### PR TITLE
feat(mcp): support custom HTTP headers for URL-based MCP servers

### DIFF
--- a/.pi-go/mcp-example.json
+++ b/.pi-go/mcp-example.json
@@ -17,6 +17,13 @@
     "tavily": {
       "url": "https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}"
     },
+    "jira": {
+      "url": "https://atlassian.example.corp/api/v1/mcp/jira/mcp/",
+      "headers": {
+        "X-Username": "dimetron",
+        "X-Api-Key": "${JIRA_API_KEY}"
+      }
+    },
     "exa": {
       "url": "https://mcp.exa.ai/mcp?exaApiKey=${EXA_API_KEY}"
     },

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -407,6 +407,7 @@ func buildMCPToolsetsFromCfg(cfg config.Config) []adktool.Toolset {
 			Command: s.Command,
 			Args:    s.Args,
 			URL:     s.URL,
+			Headers: s.Headers,
 		}
 	}
 	ts, _ := extension.BuildMCPToolsets(servers)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -604,6 +604,7 @@ func runNonInteractive(
 				Command: s.Command,
 				Args:    s.Args,
 				URL:     s.URL,
+				Headers: s.Headers,
 			}
 		}
 		mcpToolsets, _ = extension.BuildMCPToolsets(mcpServers)

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -225,6 +225,7 @@ func deferredInit(
 				Command: s.Command,
 				Args:    s.Args,
 				URL:     s.URL,
+				Headers: s.Headers,
 			}
 		}
 		ts, _ := extension.BuildMCPToolsets(mcpServers)
@@ -754,6 +755,8 @@ func buildMCPServerConfigs(cfg config.Config) []extension.MCPServerConfig {
 			Name:    s.Name,
 			Command: s.Command,
 			Args:    s.Args,
+			URL:     s.URL,
+			Headers: s.Headers,
 		}
 	}
 	return out

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,10 +91,11 @@ type MCPConfig struct {
 }
 
 type MCPServer struct {
-	Name    string   `json:"name"`
-	Command string   `json:"command,omitempty"`
-	Args    []string `json:"args,omitempty"`
-	URL     string   `json:"url,omitempty"` // HTTP transport (e.g., cloudflare-api)
+	Name    string            `json:"name"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	URL     string            `json:"url,omitempty"`     // HTTP transport (e.g., cloudflare-api)
+	Headers map[string]string `json:"headers,omitempty"` // Custom HTTP headers for the URL (Streamable HTTP) transport
 }
 
 // A2AAgentConfig defines a single A2A-capable agent endpoint.
@@ -318,6 +319,9 @@ func substituteEnvVarsFrom(cwd string, servers []MCPServer) []MCPServer {
 		if servers[i].URL != "" {
 			servers[i].URL = substituteEnv(env, servers[i].URL)
 		}
+		for k, v := range servers[i].Headers {
+			servers[i].Headers[k] = substituteEnv(env, v)
+		}
 	}
 	return servers
 }
@@ -385,6 +389,9 @@ func parseMCPServers(v any) []MCPServer {
 				if url, ok := m["url"].(string); ok {
 					srv.URL = url
 				}
+				if headers, ok := m["headers"].(map[string]any); ok {
+					srv.Headers = toStringMap(headers)
+				}
 			}
 			// Skip servers that have neither command nor URL (e.g., disabled servers).
 			if srv.Command == "" && srv.URL == "" {
@@ -411,6 +418,9 @@ func parseMCPServers(v any) []MCPServer {
 				if url, ok := m["url"].(string); ok {
 					srv.URL = url
 				}
+				if headers, ok := m["headers"].(map[string]any); ok {
+					srv.Headers = toStringMap(headers)
+				}
 				// Skip servers that have neither command nor URL.
 				if srv.Command == "" && srv.URL == "" {
 					continue
@@ -436,6 +446,24 @@ func toStringSlice(v []any) []string {
 		}
 	}
 	return s
+}
+
+// toStringMap converts map[string]any to map[string]string, keeping only
+// string values. Non-string header values are skipped.
+func toStringMap(v map[string]any) map[string]string {
+	if len(v) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(v))
+	for k, x := range v {
+		if str, ok := x.(string); ok {
+			m[k] = str
+		}
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 func loadFile(path string, cfg *Config) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -888,6 +888,74 @@ func TestParseMCPServers_URLOnly(t *testing.T) {
 	}
 }
 
+// TestParseMCPServers_Headers_ObjectFormat verifies that custom HTTP headers
+// are parsed for the Claude Desktop object format.
+func TestParseMCPServers_Headers_ObjectFormat(t *testing.T) {
+	objJSON := `{"mcpServers": {"jira": {
+		"url": "https://atlassian.example/api/v1/mcp/jira/mcp/",
+		"headers": {"X-Username": "dmitriyr", "X-Api-Key": "abc-123"}
+	}}}`
+
+	var f mcpServerFile
+	if err := json.Unmarshal([]byte(objJSON), &f); err != nil {
+		t.Fatal(err)
+	}
+	servers := parseMCPServers(f.MCPServers)
+
+	if len(servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(servers))
+	}
+	if got := servers[0].Headers["X-Username"]; got != "dmitriyr" {
+		t.Errorf("expected X-Username=dmitriyr, got %q", got)
+	}
+	if got := servers[0].Headers["X-Api-Key"]; got != "abc-123" {
+		t.Errorf("expected X-Api-Key=abc-123, got %q", got)
+	}
+}
+
+// TestParseMCPServers_Headers_ArrayFormat verifies that custom HTTP headers
+// are parsed for the legacy array format.
+func TestParseMCPServers_Headers_ArrayFormat(t *testing.T) {
+	arrJSON := `{"mcpServers": [
+		{"name": "jira", "url": "https://atlassian.example/mcp", "headers": {"X-Api-Key": "abc-123"}}
+	]}`
+
+	var f mcpServerFile
+	if err := json.Unmarshal([]byte(arrJSON), &f); err != nil {
+		t.Fatal(err)
+	}
+	servers := parseMCPServers(f.MCPServers)
+
+	if len(servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(servers))
+	}
+	if got := servers[0].Headers["X-Api-Key"]; got != "abc-123" {
+		t.Errorf("expected X-Api-Key=abc-123, got %q", got)
+	}
+}
+
+// TestSubstituteEnvVars_Headers verifies that ${VAR} placeholders in header
+// values are expanded from the environment.
+func TestSubstituteEnvVars_Headers(t *testing.T) {
+	t.Setenv("JIRA_API_KEY", "secret-key-123")
+	servers := []MCPServer{
+		{
+			Name:    "jira",
+			URL:     "https://atlassian.example/mcp",
+			Headers: map[string]string{"X-Api-Key": "${JIRA_API_KEY}", "X-Username": "dmitriyr"},
+		},
+	}
+
+	result := substituteEnvVars(servers)
+
+	if got := result[0].Headers["X-Api-Key"]; got != "secret-key-123" {
+		t.Errorf("expected expanded X-Api-Key, got %q", got)
+	}
+	if got := result[0].Headers["X-Username"]; got != "dmitriyr" {
+		t.Errorf("expected unchanged X-Username, got %q", got)
+	}
+}
+
 func TestSubstituteEnvVars(t *testing.T) {
 	// substituteEnvVars loads from .env file, so we test it indirectly
 	// by ensuring it handles servers with no variables correctly.

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -3,6 +3,7 @@ package extension
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"sync"
@@ -18,10 +19,11 @@ var mcpConnectTimeout = 15 * time.Second
 
 // MCPServerConfig matches the config.MCPServer structure.
 type MCPServerConfig struct {
-	Name    string   `json:"name"`
-	Command string   `json:"command,omitempty"`
-	Args    []string `json:"args,omitempty"`
-	URL     string   `json:"url,omitempty"` // HTTP transport (Streamable HTTP)
+	Name    string            `json:"name"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	URL     string            `json:"url,omitempty"`     // HTTP transport (Streamable HTTP)
+	Headers map[string]string `json:"headers,omitempty"` // Custom HTTP headers for the URL transport
 }
 
 // BuildMCPToolsets creates ADK Toolsets from MCP server configurations.
@@ -191,7 +193,13 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 	var transport mcp.Transport
 	switch {
 	case srv.URL != "":
-		transport = &mcp.StreamableClientTransport{Endpoint: srv.URL}
+		t := &mcp.StreamableClientTransport{Endpoint: srv.URL}
+		if len(srv.Headers) > 0 {
+			t.HTTPClient = &http.Client{
+				Transport: &headerRoundTripper{headers: srv.Headers},
+			}
+		}
+		transport = t
 	case srv.Command != "":
 		transport = &respawnTransport{
 			command: srv.Command,
@@ -208,4 +216,26 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 		return nil, fmt.Errorf("creating MCP toolset: %w", err)
 	}
 	return &resilientToolset{inner: ts, name: srv.Name}, nil
+}
+
+// headerRoundTripper injects static HTTP headers (e.g., API keys, usernames)
+// into every request sent by the Streamable HTTP MCP transport. The base
+// RoundTripper defaults to http.DefaultTransport when nil.
+type headerRoundTripper struct {
+	headers map[string]string
+	base    http.RoundTripper
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request so we never mutate the caller's headers, which the
+	// transport may reuse across retries.
+	r := req.Clone(req.Context())
+	for k, v := range h.headers {
+		r.Header.Set(k, v)
+	}
+	base := h.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(r)
 }

--- a/internal/extension/mcp_test.go
+++ b/internal/extension/mcp_test.go
@@ -3,6 +3,8 @@ package extension
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -219,12 +221,16 @@ func TestMCPServerConfigFromConfigStruct(t *testing.T) {
 		Name:    "test-server",
 		Command: "echo",
 		Args:    []string{"test"},
+		URL:     "https://example.com/mcp",
+		Headers: map[string]string{"X-Api-Key": "abc-123"},
 	}
 
 	extCfg := MCPServerConfig{
 		Name:    cfg.Name,
 		Command: cfg.Command,
 		Args:    cfg.Args,
+		URL:     cfg.URL,
+		Headers: cfg.Headers,
 	}
 
 	if extCfg.Name != "test-server" {
@@ -235,6 +241,9 @@ func TestMCPServerConfigFromConfigStruct(t *testing.T) {
 	}
 	if len(extCfg.Args) != 1 || extCfg.Args[0] != "test" {
 		t.Errorf("expected args ['test'], got %v", extCfg.Args)
+	}
+	if extCfg.Headers["X-Api-Key"] != "abc-123" {
+		t.Errorf("expected header X-Api-Key=abc-123, got %q", extCfg.Headers["X-Api-Key"])
 	}
 }
 
@@ -333,6 +342,59 @@ func TestToolsetStatuses_Failed(t *testing.T) {
 	}
 	if result[0].Status != "failed" {
 		t.Errorf("expected status 'failed', got %q", result[0].Status)
+	}
+}
+
+// --- headerRoundTripper tests ---
+
+func TestHeaderRoundTripper_InjectsHeaders(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Transport: &headerRoundTripper{
+			headers: map[string]string{"X-Username": "dmitriyr", "X-Api-Key": "abc-123"},
+		},
+	}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if v := got.Get("X-Username"); v != "dmitriyr" {
+		t.Errorf("expected X-Username=dmitriyr, got %q", v)
+	}
+	if v := got.Get("X-Api-Key"); v != "abc-123" {
+		t.Errorf("expected X-Api-Key=abc-123, got %q", v)
+	}
+}
+
+// TestHeaderRoundTripper_DoesNotMutateOriginalRequest verifies the round
+// tripper clones the request before adding headers.
+func TestHeaderRoundTripper_DoesNotMutateOriginalRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt := &headerRoundTripper{headers: map[string]string{"X-Api-Key": "abc-123"}}
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if req.Header.Get("X-Api-Key") != "" {
+		t.Errorf("original request was mutated: %q", req.Header.Get("X-Api-Key"))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a `headers` map to MCP server config so Streamable HTTP (`url`) transports can send custom headers such as `X-Username` / `X-Api-Key`.
- Header values support `${VAR}` substitution from `.pi-go/.env`, keeping secrets out of `mcp.json`.
- Headers are parsed for both the Claude Desktop object format and the legacy array format, propagated through all `config` → `extension` converters, and injected per-request via an `http.RoundTripper` that clones the request so retries stay safe.
- Also fixes `buildMCPServerConfigs` which was silently dropping the server `URL`.

### Example
```json
{
  "mcpServers": {
    "jira": {
      "url": "https://atlassian.example.corp/api/v1/mcp/jira/mcp/",
      "headers": {
        "X-Username": "dmitriyr",
        "X-Api-Key": "${JIRA_API_KEY}"
      }
    }
  }
}
```

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/extension/... ./internal/cli/... ./internal/acp/server/...`
- [x] New tests: object/array header parsing, `${VAR}` substitution in header values, header injection over an `httptest` server, and the no-mutation (retry-safe) guarantee.
- [x] golangci-lint clean (via pre-commit hook).