### PR TITLE
fix(provider): add gemini-3.5-flash and gemini-3.1-flash-lite to know…

### DIFF
--- a/internal/provider/coverage_boost_test.go
+++ b/internal/provider/coverage_boost_test.go
@@ -27,6 +27,8 @@ func TestContextWindowSize(t *testing.T) {
 		{"exact claude-opus-4-7", "claude-opus-4-7", 1_000_000},
 		{"claude-3-5-sonnet prefix", "claude-3-5-sonnet-20241022", 200_000},
 		{"case-insensitive GEMINI-2.5", "GEMINI-2.5-PRO", 1_048_576},
+		{"gemini-3.5-flash stable", "gemini-3.5-flash", 1_048_576},
+		{"gemini-3.1-flash-lite stable beats -preview prefix", "gemini-3.1-flash-lite", 1_048_576},
 		{"gpt-5.5 latest frontier", "gpt-5.5", 1_050_000},
 		{"gpt-5.4-mini has longer prefix", "gpt-5.4-mini", 400_000},
 		{"mistral-large tag variant", "mistral-large-2512", 256_000},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -144,7 +144,13 @@ var KnownModels = map[string][]string{
 		"gpt-5.1-codex-max",
 	},
 	"gemini": {
-		// Latest Gemini tiers: 3.1 Pro, 3 Flash, and 3.1 Flash-Lite.
+		// Latest stable Gemini tier: 3.5 Flash.
+		"gemini-3.5-flash",
+
+		// Stable Gemini 3.1 Flash-Lite (no -preview suffix).
+		"gemini-3.1-flash-lite",
+
+		// Gemini 3.x preview tiers: 3.1 Pro, 3 Flash, and 3.1 Flash-Lite.
 		"gemini-3.1-pro-preview",
 		"gemini-3.1-pro-preview-customtools",
 		"gemini-3-flash-preview",
@@ -208,6 +214,8 @@ var contextWindowSizes = map[string]int64{
 	"gpt-5.1-codex": 1_050_000,
 	"gpt-5":         400_000,
 	// Gemini
+	"gemini-3.5-flash":              1_048_576,
+	"gemini-3.1-flash-lite":         1_048_576,
 	"gemini-3.1-pro-preview":        1_048_576,
 	"gemini-3-flash-preview":        1_048_576,
 	"gemini-3.1-flash-lite-preview": 1_048_576,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -22,6 +22,8 @@ func TestResolve(t *testing.T) {
 		{"gpt-4o", "openai", false},
 		{"gpt-5.5", "openai", false},
 		{"gemini-2.5-pro", "gemini", false},
+		{"gemini-3.5-flash", "gemini", false},
+		{"gemini-3.1-flash-lite", "gemini", false},
 		{"", "", true},
 	}
 
@@ -238,6 +240,8 @@ func TestValidateModel(t *testing.T) {
 		{Info{Provider: "openai", Model: "gpt-5.4"}, false},
 		{Info{Provider: "gemini", Model: "gemini-2.5-pro"}, false},
 		{Info{Provider: "gemini", Model: "gemini-2.5-flash"}, false},
+		{Info{Provider: "gemini", Model: "gemini-3.5-flash"}, false},
+		{Info{Provider: "gemini", Model: "gemini-3.1-flash-lite"}, false},
 		{Info{Provider: "mistral", Model: "mistral-large-latest"}, false},
 		{Info{Provider: "mistral", Model: "codestral"}, false},
 		{Info{Provider: "mistral", Model: "pixtral"}, false},
@@ -338,6 +342,8 @@ func TestResolveKnownProviders(t *testing.T) {
 		{"claude-opus-4-7", "anthropic"},
 		{"gpt-5.5", "openai"},
 		{"gemini-2.5-flash", "gemini"},
+		{"gemini-3.5-flash", "gemini"},
+		{"gemini-3.1-flash-lite", "gemini"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {


### PR DESCRIPTION
…n models (#39)

- gemini-3.5-flash: current stable tier (1M tokens, fast, balanced, multimodal) — fixes the model name being rejected by ValidateModel.
- gemini-3.1-flash-lite: stable tier that the prefix-match validator was missing. The existing entry was the longer `gemini-3.1-flash-lite-preview` variant, so the stable name (shorter, no -preview suffix) failed HasPrefix and was rejected even though the model is already used elsewhere in the repo (e.g. .scratch/adk-v2 examples).

Both models get 1,048,576 input-token context, matching the official docs (https://ai.google.dev/gemini-api/docs/models.md.txt) and the gemini-api-dev skill.