### PR TITLE
tui: stop markdown renderer from querying the terminal

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/x/ansi"
 
 	"charm.land/lipgloss/v2"
@@ -280,6 +281,14 @@ func (c *ChatModel) MaxScroll(height int) int {
 	return max
 }
 
+func newMarkdownRenderer(width int) (*glamour.TermRenderer, error) {
+	return glamour.NewTermRenderer(
+		glamour.WithStandardStyle(styles.DarkStyle),
+		glamour.WithWordWrap(width),
+		glamour.WithEmoji(),
+	)
+}
+
 // UpdateRenderer recreates the glamour renderer for the given terminal width.
 func (c *ChatModel) UpdateRenderer(width int) {
 	c.Width = width
@@ -287,11 +296,7 @@ func (c *ChatModel) UpdateRenderer(width int) {
 	if width < 40 {
 		width = 40
 	}
-	c.Renderer, _ = glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(width),
-		glamour.WithEmoji(),
-	)
+	c.Renderer, _ = newMarkdownRenderer(width)
 	// Invalidate render caches — width changed so all cached output is stale.
 	c.invalidateRenderCaches()
 }

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -1,11 +1,27 @@
 package tui
 
 import (
+	"bytes"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/creack/pty"
+	"github.com/muesli/termenv"
 )
+
+type scriptedTerminal struct {
+	input  *bytes.Reader
+	output bytes.Buffer
+}
+
+func (t *scriptedTerminal) Read(p []byte) (int, error) { return t.input.Read(p) }
+func (t *scriptedTerminal) Write(p []byte) (int, error) {
+	return t.output.Write(p)
+}
+func (t *scriptedTerminal) Fd() uintptr { return 0 }
 
 func newTestRenderer(t *testing.T) *glamour.TermRenderer {
 	t.Helper()
@@ -14,6 +30,34 @@ func newTestRenderer(t *testing.T) *glamour.TermRenderer {
 		t.Fatalf("failed to create test renderer: %v", err)
 	}
 	return r
+}
+
+func TestUpdateRendererDoesNotQueryTerminalBackground(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	ptyMaster, ptySlave, err := pty.Open()
+	if err != nil {
+		t.Fatalf("open pty: %v", err)
+	}
+	defer ptyMaster.Close()
+	defer ptySlave.Close()
+
+	previousStdout := os.Stdout
+	os.Stdout = ptySlave
+	defer func() { os.Stdout = previousStdout }()
+
+	terminal := &scriptedTerminal{
+		input: bytes.NewReader([]byte("\x1b]11;rgb:0a0a/0e0e/1414\a\x1b[1;1R")),
+	}
+	previousOutput := termenv.DefaultOutput()
+	termenv.SetDefaultOutput(termenv.NewOutput(terminal, termenv.WithUnsafe()))
+	defer termenv.SetDefaultOutput(previousOutput)
+
+	chat := NewChatModel(nil)
+	chat.UpdateRenderer(80)
+
+	if got := terminal.output.String(); strings.Contains(got, "\x1b]11;?") {
+		t.Fatalf("renderer update queried terminal background: %q", got)
+	}
 }
 
 // --- wordWrap ---
@@ -515,8 +559,8 @@ func TestChatModel_UpdateRenderer_MinWidth(t *testing.T) {
 
 	// Renderer should still work after narrow width.
 	result := cm.RenderMarkdown("test content")
-	if !strings.Contains(result, "test content") {
-		t.Error("expected rendered content even with narrow width")
+	if !strings.Contains(ansi.Strip(result), "test content") {
+		t.Errorf("expected rendered content even with narrow width, got %q", result)
 	}
 }
 

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -206,36 +206,32 @@ func TestSelectionStaysInsideTheChatPanel(t *testing.T) {
 	}
 }
 
-// The reported bug: the selection landed several rows below the mouse.
-//
-// The UI is on the normal screen, so the frame is drawn under whatever the
-// terminal already had on it (a shell prompt, a "pprof listening" line), and
-// Bubble Tea reports the mouse in absolute terminal rows. Indexing the frame
-// with a raw mouse Y therefore lands exactly that many rows too low.
-func TestSelectionFollowsTheMouseWhenFrameIsOffset(t *testing.T) {
+// A full-height frame has a stable screen origin: terminal row Y is frame row Y.
+// Leaving even one unused row makes an inline renderer's origin depend on prior
+// output and terminal reflow, which intermittently shifts selection by one row.
+func TestSelectionFollowsMouseInFullHeightFrame(t *testing.T) {
 	m := selectionModel(t)
 	m.View()
 
-	top := m.frameTop()
-	if top == 0 {
-		t.Skip("frame is flush with the top of the screen; nothing to translate")
+	if m.frameRows != m.height {
+		t.Fatalf("frame has %d rows for terminal height %d; origin is not stable", m.frameRows, m.height)
+	}
+	if top := m.frameTop(); top != 0 {
+		t.Fatalf("full-height frame starts at terminal row %d, want 0", top)
 	}
 
 	row, col := findRow(t, m, "SELECT-ME-ONE")
 
-	// Press where the text actually is on screen: frame row + the frame's origin.
-	next, _ := m.Update(tea.MouseClickMsg(tea.Mouse{X: col, Y: row + top, Button: tea.MouseLeft}))
+	next, _ := m.Update(tea.MouseClickMsg(tea.Mouse{X: col, Y: row, Button: tea.MouseLeft}))
 	m = next.(*model)
 
 	if m.sel.anchorY != row {
-		t.Fatalf("clicking terminal row %d selected frame row %d, want %d — the selection is %d rows off",
-			row+top, m.sel.anchorY, row, m.sel.anchorY-row)
+		t.Fatalf("clicking terminal row %d selected frame row %d", row, m.sel.anchorY)
 	}
 
-	// And the text under the mouse is what gets copied.
-	next, _ = m.Update(tea.MouseMotionMsg(tea.Mouse{X: col + len("SELECT-ME-ONE") - 1, Y: row + top, Button: tea.MouseLeft}))
+	next, _ = m.Update(tea.MouseMotionMsg(tea.Mouse{X: col + len("SELECT-ME-ONE") - 1, Y: row, Button: tea.MouseLeft}))
 	m = next.(*model)
-	next, _ = m.Update(tea.MouseReleaseMsg(tea.Mouse{X: col + len("SELECT-ME-ONE") - 1, Y: row + top, Button: tea.MouseLeft}))
+	next, _ = m.Update(tea.MouseReleaseMsg(tea.Mouse{X: col + len("SELECT-ME-ONE") - 1, Y: row, Button: tea.MouseLeft}))
 	m = next.(*model)
 
 	if got := selectedText(m.lastFrame, m.sel, m.chatWidth()); got != "SELECT-ME-ONE" {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/glamour"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -326,11 +325,7 @@ func Run(ctx context.Context, cfg Config) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	renderer, _ := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(100),
-		glamour.WithEmoji(),
-	)
+	renderer, _ := newMarkdownRenderer(100)
 
 	// Load persistent command history from ~/.pi-go/history.jsonl.
 	history := loadHistory()
@@ -1060,7 +1055,10 @@ func (m *model) View() tea.View {
 	// rows that inset the block from the rules are budgeted separately.
 	visibleLineCount := strings.Count(visibleMessages, "\n") + 1
 	for visibleLineCount < availableHeight {
-		visibleMessages += "\n"
+		// Keep the final padding row materialized. A trailing newline only
+		// terminates the preceding row; treating its trailing empty string as a
+		// row made the composed frame one line shorter than the terminal.
+		visibleMessages += "\n "
 		visibleLineCount++
 	}
 	visibleMessages = m.overlaySearchPopup(visibleMessages, bodyWidth)


### PR DESCRIPTION
## Summary

The chat markdown renderer was created with `glamour.WithAutoStyle()`, which
issues an OSC 11 query (`ESC ] 11 ; ? BEL`) to discover the terminal's
background color. In an inline Bubble Tea program that query is visible in the
PTY stream and is hostile to test harnesses that treat stdin/stdout as a
deterministic stream. It also makes the rendered output depend on a value the
test cannot observe without spawning a real terminal.

Switch both renderer construction sites to `glamour.WithStandardStyle(styles.DarkStyle)`
via a new `newMarkdownRenderer` helper. The Dark style was already the rendered
output in CI / headless runs, so this is a behavior change only for terminals
that previously detected a light background.

While here, fix a one-row off-by-one in `View()`: the final padding newline
terminated the previous row instead of producing an empty row, so the composed
frame was always one line shorter than the terminal. Padding rows now carry a
single space so the row is materialized. With the frame now reaching the
bottom of the screen, mouse hit-testing in the selection test no longer needs
to translate by `frameTop()`.

## Changes

- `internal/tui/chat.go` — add `newMarkdownRenderer` helper; use it from
  `UpdateRenderer` instead of inlining `WithAutoStyle`.
- `internal/tui/tui.go` — use the same helper at startup; fix the trailing
  padding row in `View()`.
- `internal/tui/chat_test.go` — add `TestUpdateRendererDoesNotQueryTerminalBackground`
  using a PTY and scripted terminal; tighten the narrow-width test with `ansi.Strip`.
- `internal/tui/selection_test.go` — assert the frame is full-height and
  drop the `frameTop()` translation; rename for the new invariant.

## Verification

- `golangci-lint run ./...`: clean (0 issues)
- `go test ./...`: pass
- `go test -tags integration ./...`: pass
- `go test -tags e2e ./...`: pass
- `make test-coverage`: **87.6%** (gate: >80%)
- `go build ./cmd/pi`: ok

Signed-off-by: dimetron <dimetron@me.com>