### PR TITLE
fix(agent): safe instruction provider fails open per placeholder

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -19,9 +20,11 @@ import (
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/util/instructionutil"
 	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/logger"
 )
 
 // re-export callback types for use by CLI without importing llmagent directly.
@@ -264,6 +267,12 @@ type Config struct {
 
 	// AfterModelCallbacks run after each LLM invocation.
 	AfterModelCallbacks []AfterModelCallback
+
+	// Logger, if non-nil, receives non-fatal diagnostics such as unresolved
+	// instruction placeholders. These are written to the session log rather
+	// than stderr: stderr would paint over the TUI alt-screen. Its methods
+	// are nil-safe, so a nil Logger silently discards.
+	Logger *logger.Logger
 }
 
 // Agent wraps an ADK Runner and session management for the coding agent.
@@ -275,12 +284,69 @@ type Agent struct {
 
 const maxInstructionFileSize = 128 * 1024
 
+// placeholderRegex matches `{...}` runs in the instruction template. Kept
+// in sync with the regex used by ADK's internal instruction processor
+// (google.golang.org/adk/v2/internal/llminternal/instruction_processor.go)
+// so that we slice the template on the same boundaries.
+var placeholderRegex = regexp.MustCompile(`\{+[^{}]*\}+`)
+
+// safeInstructionProvider returns an ADK InstructionProvider that
+// substitutes {state_var} placeholders in template via the session state,
+// but fails open per placeholder: if a particular placeholder cannot be
+// resolved (missing key, artifact not found, etc.) the original literal
+// substring is left in place rather than aborting the whole turn.
+//
+// Why: the instruction may contain text loaded from project context files
+// (AGENTS.md / CLAUDE.md / AGENT.md / .pi-go/AGENTS.md) and skill
+// descriptions. Those files are user-authored prose and can legitimately
+// contain {identifier}-shaped substrings (e.g. documentation about
+// `{AGT_X}` placeholder tokens in a keymap system) that are NOT session
+// state references. With the default Instruction: <string> wiring, ADK
+// treats every such substring as a state key and aborts the turn with
+// "state key does not exist". By owning the provider we keep substitution
+// for legitimate keys while leaving stray prose alone, and we do it on a
+// per-placeholder basis so a single missing key never cancels every other
+// legitimate substitution in the same template.
+func safeInstructionProvider(template string, log *logger.Logger) llmagent.InstructionProvider {
+	return func(ctx adkagent.ReadonlyContext) (string, error) {
+		return injectWithFailOpen(ctx, template, log), nil
+	}
+}
+
+// injectWithFailOpen walks template, resolving each {placeholder} via
+// instructionutil.InjectSessionState and keeping the original literal
+// when resolution fails. Literal segments (between matches) are copied
+// unchanged.
+func injectWithFailOpen(ctx adkagent.ReadonlyContext, template string, log *logger.Logger) string {
+	var b strings.Builder
+	last := 0
+	for _, loc := range placeholderRegex.FindAllStringIndex(template, -1) {
+		b.WriteString(template[last:loc[0]])
+		match := template[loc[0]:loc[1]]
+		resolved, err := instructionutil.InjectSessionState(ctx, match)
+		if err != nil {
+			// Record to the session log (not stderr — that corrupts the TUI)
+			// so a developer who intended {app:foo} to resolve but typoed the
+			// name still has a trace. User-authored prose containing literal
+			// {tokens} produces one entry per unmatched placeholder, which is
+			// acceptable signal-to-noise in an on-disk log.
+			log.Info(fmt.Sprintf("instruction placeholder %q not resolved; left as literal: %v", match, err))
+			b.WriteString(match)
+		} else {
+			b.WriteString(resolved)
+		}
+		last = loc[1]
+	}
+	b.WriteString(template[last:])
+	return b.String()
+}
+
 func buildRunner(cfg Config, instruction string, sessionSvc session.Service) (*runner.Runner, error) {
 	llmAgent, err := llmagent.New(llmagent.Config{
 		Name:                 "pi",
 		Description:          "A coding agent that helps with software engineering tasks.",
 		Model:                cfg.Model,
-		Instruction:          instruction,
+		InstructionProvider:  safeInstructionProvider(instruction, cfg.Logger),
 		Tools:                cfg.Tools,
 		Toolsets:             cfg.Toolsets,
 		BeforeToolCallbacks:  cfg.BeforeToolCallbacks,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1298,3 +1298,264 @@ func TestDefaultRetryConfig(t *testing.T) {
 		t.Errorf("MaxDelay = %v, want 30s", cfg.MaxDelay)
 	}
 }
+
+// capturingLLM records the LLMRequest it receives, then returns a fixed
+// response. Used to assert what the runner actually sent to the model —
+// in particular, what the instruction looked like after our
+// InstructionProvider ran.
+type capturingLLM struct {
+	name     string
+	response string
+
+	mu          sync.Mutex
+	lastRequest *model.LLMRequest
+}
+
+func (m *capturingLLM) Name() string { return m.name }
+
+func (m *capturingLLM) GenerateContent(_ context.Context, req *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	m.mu.Lock()
+	m.lastRequest = req
+	m.mu.Unlock()
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(&model.LLMResponse{
+			Content: genai.NewContentFromText(m.response, genai.RoleModel),
+		}, nil)
+	}
+}
+
+func (m *capturingLLM) capturedSystemInstruction() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lastRequest == nil || m.lastRequest.Config == nil {
+		return ""
+	}
+	sc := m.lastRequest.Config.SystemInstruction
+	if sc == nil {
+		return ""
+	}
+	// Flatten all text parts into a single string for substring checks.
+	var sb strings.Builder
+	for _, p := range sc.Parts {
+		if p != nil && p.Text != "" {
+			sb.WriteString(p.Text)
+		}
+	}
+	return sb.String()
+}
+
+// TestSafeInstructionProvider_UnknownStateKeyDoesNotFail is the regression
+// test for the {AGT_X}-in-CLAUDE.md bug. Before the fix, an instruction
+// containing a {state_var} placeholder whose key is not in session state
+// caused the whole turn to abort with "failed to append instructions:
+// failed to inject session state into instruction: state key does not
+// exist". The safe provider must fail open: the literal {state_var}
+// substring passes through, the LLM is called, and the turn completes.
+func TestSafeInstructionProvider_UnknownStateKeyDoesNotFail(t *testing.T) {
+	llm := &capturingLLM{name: "test-model", response: "ok"}
+
+	a, err := New(Config{
+		Model:       llm,
+		Instruction: "before {unknown_xyz_placeholder} after",
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	ctx := context.Background()
+	sessionID, _, err := a.CreateSession(ctx)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+
+	var runErr error
+	for _, err := range a.Run(ctx, sessionID, "hi") {
+		if err != nil {
+			runErr = err
+			break
+		}
+	}
+	if runErr != nil {
+		t.Fatalf("Run() yielded error (regression: {state_var} should not abort): %v", runErr)
+	}
+
+	// Sanity check: the literal {unknown_xyz_placeholder} was passed through.
+	if got := llm.capturedSystemInstruction(); !strings.Contains(got, "{unknown_xyz_placeholder}") {
+		t.Errorf("system instruction should contain the literal placeholder, got %q", got)
+	}
+}
+
+// TestSafeInstructionProvider_KnownStateKeyIsSubstituted asserts the
+// positive case still works: a {app:foo} placeholder whose key IS set in
+// session state must be substituted into the instruction.
+func TestSafeInstructionProvider_KnownStateKeyIsSubstituted(t *testing.T) {
+	llm := &capturingLLM{name: "test-model", response: "ok"}
+
+	svc := session.InMemoryService()
+	a, err := New(Config{
+		Model:          llm,
+		SessionService: svc,
+		Instruction:    "hello {app:user_name}",
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	ctx := context.Background()
+	sessionID, _, err := a.CreateSession(ctx)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+
+	// Set the state key the placeholder references. ADK's in-memory
+	// service persists state via AppendEvent(StateDelta), not by
+	// mutating the session returned from Get (which is a copy).
+	seedResp, err := svc.Get(ctx, &session.GetRequest{
+		AppName:   AppName,
+		UserID:    DefaultUserID,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		t.Fatalf("Get() session: %v", err)
+	}
+	if err := svc.AppendEvent(ctx, seedResp.Session, &session.Event{
+		Author: "test",
+		Actions: session.EventActions{
+			StateDelta: map[string]any{"app:user_name": "world"},
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent(StateDelta): %v", err)
+	}
+
+	var runErr error
+	for _, err := range a.Run(ctx, sessionID, "hi") {
+		if err != nil {
+			runErr = err
+			break
+		}
+	}
+	if runErr != nil {
+		t.Fatalf("Run() yielded error: %v", runErr)
+	}
+
+	got := llm.capturedSystemInstruction()
+	if !strings.Contains(got, "hello world") {
+		t.Errorf("system instruction should contain substituted value, got %q", got)
+	}
+	if strings.Contains(got, "{app:user_name}") {
+		t.Errorf("placeholder should have been substituted, got %q", got)
+	}
+}
+
+// TestSafeInstructionProvider_DirectCallMissingKey covers the fail-open
+// path of the provider in isolation: calling the closure with a context
+// that triggers an injection error must return the original template
+// without surfacing the error.
+func TestSafeInstructionProvider_DirectCallMissingKey(t *testing.T) {
+	// A nil ReadonlyContext is not a *icontext.ReadonlyContext, so
+	// instructionutil.InjectSessionState returns an "unexpected context
+	// type" error. The provider must swallow it and return the template.
+	got, err := safeInstructionProvider("before {foo} after", nil)(nil)
+	if err != nil {
+		t.Fatalf("safeInstructionProvider returned error: %v", err)
+	}
+	if got != "before {foo} after" {
+		t.Errorf("safeInstructionProvider returned %q, want original template", got)
+	}
+}
+
+// TestSafeInstructionProvider_MixedPlaceholders is the regression test for
+// the all-or-nothing fallback: when a single template contains both a
+// real state placeholder and a stray prose token, the real one must still
+// be substituted. A naive "if any error then return the original template"
+// implementation would drop the legitimate substitution; the per-placeholder
+// walk in injectWithFailOpen must keep both behaviors independently.
+func TestSafeInstructionProvider_MixedPlaceholders(t *testing.T) {
+	llm := &capturingLLM{name: "test-model", response: "ok"}
+
+	svc := session.InMemoryService()
+	a, err := New(Config{
+		Model:          llm,
+		SessionService: svc,
+		// One real key (app:user_name) and one stray token ({AGT_X})
+		// that looks like a state key but isn't.
+		Instruction: "real={app:user_name}, stray={AGT_X}",
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	ctx := context.Background()
+	sessionID, _, err := a.CreateSession(ctx)
+	if err != nil {
+		t.Fatalf("CreateSession() error: %v", err)
+	}
+
+	// Set only the real key.
+	seedResp, err := svc.Get(ctx, &session.GetRequest{
+		AppName:   AppName,
+		UserID:    DefaultUserID,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		t.Fatalf("Get() session: %v", err)
+	}
+	if err := svc.AppendEvent(ctx, seedResp.Session, &session.Event{
+		Author: "test",
+		Actions: session.EventActions{
+			StateDelta: map[string]any{"app:user_name": "world"},
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent(StateDelta): %v", err)
+	}
+
+	var runErr error
+	for _, err := range a.Run(ctx, sessionID, "hi") {
+		if err != nil {
+			runErr = err
+			break
+		}
+	}
+	if runErr != nil {
+		t.Fatalf("Run() yielded error: %v", runErr)
+	}
+
+	got := llm.capturedSystemInstruction()
+	if !strings.Contains(got, "real=world") {
+		t.Errorf("real placeholder should have been substituted, got %q", got)
+	}
+	if !strings.Contains(got, "stray={AGT_X}") {
+		t.Errorf("stray placeholder should have been left as literal, got %q", got)
+	}
+	if strings.Contains(got, "{app:user_name}") {
+		t.Errorf("real placeholder should not appear unsubstituted, got %q", got)
+	}
+}
+
+// TestInjectWithFailOpen_PerPlaceholder exercises the slicing logic
+// directly. It is the unit-level complement to the e2e mixed-placeholder
+// test: here we don't need a real session because every per-placeholder
+// call returns an error (nil ctx triggers the type-assertion failure in
+// instructionutil.InjectSessionState), so every match falls back to its
+// literal form.
+func TestInjectWithFailOpen_PerPlaceholder(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{"no placeholders", "plain text", "plain text"},
+		{"one stray placeholder", "x {foo} y", "x {foo} y"},
+		{"two stray placeholders", "{a} and {b}", "{a} and {b}"},
+		{"literal-looking but invalid name", "{a-b} and {a b}", "{a-b} and {a b}"},
+		{"braces in non-placeholder context", "shell {echo $1} style", "shell {echo $1} style"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := injectWithFailOpen(nil, tc.template, nil)
+			if got != tc.want {
+				t.Errorf("injectWithFailOpen(%q) = %q, want %q", tc.template, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -684,6 +684,16 @@ func runNonInteractive(
 		coreTools = append(coreTools, gTool)
 	}
 
+	// Session logger. Created before the agent so it can capture the agent's
+	// non-fatal diagnostics (e.g. unresolved instruction placeholders) in the
+	// session log instead of leaking them to stderr. SessionStart is recorded
+	// below once the session ID is resolved.
+	sessionLog, err := logger.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pi-go: warning: could not create session log: %v\n", err)
+	}
+	defer func() { _ = sessionLog.Close() }()
+
 	ag, err := agent.New(agent.Config{
 		Model:               llm,
 		Tools:               coreTools,
@@ -692,6 +702,7 @@ func runNonInteractive(
 		SessionService:      sessionSvc,
 		BeforeToolCallbacks: beforeCBs,
 		AfterToolCallbacks:  afterCBs,
+		Logger:              sessionLog,
 	})
 	if err != nil {
 		return fmt.Errorf("creating agent: %w", err)
@@ -729,11 +740,6 @@ func runNonInteractive(
 		})
 	}
 
-	sessionLog, err := logger.New()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "pi-go: warning: could not create session log: %v\n", err)
-	}
-	defer func() { _ = sessionLog.Close() }()
 	sessionLog.SessionStart(sessionID, llm.Name(), mode)
 
 	switch mode {

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -367,6 +367,15 @@ func deferredInit(
 		coreTools = append(coreTools, gTool)
 	}
 
+	// Session logger. Created before the agent so it can capture the agent's
+	// non-fatal diagnostics (e.g. unresolved instruction placeholders) in the
+	// session log instead of leaking them to stderr and corrupting the TUI.
+	// SessionStart is deferred until the session ID is resolved below.
+	sessionLog, logErr := logger.New()
+	if logErr == nil {
+		res.sessionLog = sessionLog
+	}
+
 	// Create agent.
 	ag, err := agent.New(agent.Config{
 		Model:                llm,
@@ -378,6 +387,7 @@ func deferredInit(
 		AfterToolCallbacks:   afterCBs,
 		BeforeModelCallbacks: llmBefore,
 		AfterModelCallbacks:  llmAfter,
+		Logger:               sessionLog,
 	})
 	if err != nil {
 		fail(fmt.Errorf("creating agent: %w", err))
@@ -401,10 +411,9 @@ func deferredInit(
 	// Capture ACP subagent events (claude, gemini) under the session dir.
 	res.orch.SetACPLogPath(filepath.Join(sessionsDir, sessionID, "acp.jsonl"))
 
-	// Session logger.
-	sessionLog, logErr := logger.New()
+	// Session logger was created above; record the session start now that the
+	// session ID is known.
 	if logErr == nil {
-		res.sessionLog = sessionLog
 		sessionLog.SessionStart(sessionID, llm.Name(), "interactive")
 	}
 


### PR DESCRIPTION
## Summary

Replace the default ADK `InstructionProvider` with a custom one that resolves each `{placeholder}` independently. When a placeholder cannot be resolved against session state, the original literal substring is left in place rather than aborting the entire turn.

## Why

The default ADK instruction processor aborts the whole turn with `state key does not exist` if any single `{placeholder}` in the template cannot be resolved. That is too strict for our setup because the instruction string is composed from:

- project context files: `AGENTS.md` / `CLAUDE.md` / `AGENT.md` / `.pi-go/AGENTS.md`
- skill descriptions

These are user-authored prose and can legitimately contain `{identifier}`-shaped substrings — e.g. documentation about `{AGT_X}` placeholder tokens in a keymap system — that are **not** session state references. With the default wiring, ADK treats every such substring as a state key and aborts the turn, even though the rest of the template would have been fine.

## Changes

- **`internal/agent/agent.go`** — new `safeInstructionProvider` returns an `llmagent.InstructionProvider` that:
  - walks the template on the same `{+}…{+}` boundaries as ADK's internal processor (`placeholderRegex`), so we slice identically;
  - resolves each match via `instructionutil.InjectSessionState`;
  - on resolution failure, leaves the original literal substring in place instead of aborting — a single bad key never cancels every other legitimate substitution in the same template;
  - records each unresolved placeholder to the session logger (`logger.Logger` on `Config`) so a developer who typoed a `{app:foo}` reference still has a trace, without painting diagnostics over the TUI alt-screen.
- **`agent.Config`** — gains a `Logger` field. Nil-safe (nil discards).
- **`internal/cli/cli.go`** / **`internal/cli/interactive.go`** — create the session logger **before** `agent.New` so it is available to the agent, and defer `SessionStart` until the session ID is resolved.
- The regex is documented as kept in sync with ADK's internal `llminternal.InstructionProcessor`.

## Tests

`internal/agent/agent_test.go` — new `TestSafeInstructionProvider_*` cases:

- all-resolved placeholders substitute correctly;
- single unresolved placeholder is kept literal;
- multiple unresolved placeholders all kept literal;
- mixed: legitimate `{app:foo}` resolves while stray prose `{AGT_X}` is kept literal;
- empty template is a no-op;
- plain text without placeholders is unchanged;
- double-brace edge cases: `{}`, `{{}`, `{{x}}`.

## Verification

```
go build ./...                     # clean
go test ./internal/agent/...       # ok
go test ./internal/cli/...         # ok
golangci-lint                      # 0 issues
```
