### PR TITLE
fix(tui): context-aware window title + popup scroll clamp

### DIFF
--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -49,6 +49,18 @@ type SidebarRenderInput struct {
 	MCPTools     []extension.MCPToolEntry // MCP tools section; nil = hidden
 	MemoryStatus *palace.PalaceStatus     // memory palace status; nil = hidden
 	OTELEnabled  bool                     // OTEL tracing is active
+	Artifacts    []ArtifactEntry          // artifacts section; nil/empty = hidden
+}
+
+// ArtifactEntry is one row in the Artifacts sidebar section.
+// Filename is the ADK artifact key (e.g. "screenshot.png").
+// Size is the byte count of the stored part.
+// Mime is optional; entries with an "image/*" MIME get a frame icon,
+// everything else gets a paperclip.
+type ArtifactEntry struct {
+	Filename string
+	Size     int64
+	Mime     string
 }
 
 // RenderSidebar renders the right sidebar panel.
@@ -135,6 +147,35 @@ func RenderSidebar(in SidebarRenderInput) string {
 		lines = append(lines, modelStyle.Render("  "+name))
 	}
 	lines = append(lines, "")
+
+	// --- Artifacts section ---
+	if len(in.Artifacts) > 0 {
+		artHeading := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#fab387")).Bold(true) // Mocha peach
+		lines = append(lines,
+			artHeading.Render(fmt.Sprintf("  Artifacts [%d]", len(in.Artifacts))))
+
+		for _, a := range in.Artifacts {
+			icon := "📎"
+			if strings.HasPrefix(a.Mime, "image/") {
+				icon = "🖼"
+			}
+			size := formatBytes(a.Size)
+			// Layout: "  ICON NAME  SIZE" with a 2-space gap before size.
+			// Reserve 10 chars for the size column so 2.1 MB lines align.
+			maxName := innerW - 2 - 2 - 10
+			if maxName < 6 {
+				maxName = 6
+			}
+			name := a.Filename
+			if runewidth.StringWidth(name) > maxName {
+				name = runewidth.Truncate(name, maxName-1, "…")
+			}
+			lines = append(lines, dim.Render(
+				fmt.Sprintf("  %s %s  %s", icon, name, size)))
+		}
+		lines = append(lines, "")
+	}
 
 	// --- Git section ---
 	if in.GitBranch != "" {
@@ -465,6 +506,20 @@ func sidebarFolderName(workDir string) string {
 		return ""
 	}
 	return filepath.Base(filepath.Clean(workDir))
+}
+
+// formatBytes renders a byte count as "812 B" / "124 KB" / "2.1 MB".
+// No GB tier — session artifacts won't hit that scale, and the
+// sidebar column is only ~10 chars wide.
+func formatBytes(n int64) string {
+	switch {
+	case n < 1024:
+		return fmt.Sprintf("%d B", n)
+	case n < 1024*1024:
+		return fmt.Sprintf("%d KB", n/1024)
+	default:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1024*1024))
+	}
 }
 
 // agentStatusPriority returns a sort key for agent status.

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -557,3 +557,76 @@ func TestRenderSidebar_MemoryStatus_Nil(t *testing.T) {
 		t.Error("did not expect Memory section when MemoryStatus is nil")
 	}
 }
+
+func TestRenderSidebar_Artifacts_EmptyHidden(t *testing.T) {
+	baseline := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 30,
+	})
+	nilList := RenderSidebar(SidebarRenderInput{
+		Width:     30,
+		Height:    30,
+		Artifacts: nil,
+	})
+	emptyList := RenderSidebar(SidebarRenderInput{
+		Width:     30,
+		Height:    30,
+		Artifacts: []ArtifactEntry{},
+	})
+	for name, got := range map[string]string{
+		"baseline": baseline,
+		"nil":      nilList,
+		"empty":    emptyList,
+	} {
+		if strings.Contains(got, "Artifacts [") {
+			t.Errorf("case %s: did not expect Artifacts section when list is empty", name)
+		}
+	}
+}
+
+func TestRenderSidebar_Artifacts_Populated(t *testing.T) {
+	// Sizes picked so each tier renders distinctly:
+	// 124_000 bytes → "124 KB" (just under the 128 KB boundary? no — 124_000/1024 = 121 → "121 KB")
+	// Actually 124*1024 = 126976 → 126976/1024 = 124 → "124 KB". Good.
+	// 2_200_000 → 2_200_000/1024 = 2148 KB, /1024 = 2.098 → "2.1 MB"
+	// 812 → "812 B"
+	result := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 30,
+		Artifacts: []ArtifactEntry{
+			{Filename: "screenshot.png", Size: 124 * 1024, Mime: "image/png"},
+			{Filename: "error.jpg", Size: 2_200_000, Mime: "image/jpeg"},
+			{Filename: "notes.txt", Size: 812, Mime: "text/plain"},
+		},
+	})
+	if !strings.Contains(result, "Artifacts [3]") {
+		t.Error("expected Artifacts [3] heading")
+	}
+	// image/* entries get the framed-picture icon, others get the paperclip.
+	if !strings.Contains(result, "🖼") {
+		t.Error("expected image icon for image/* entries")
+	}
+	if !strings.Contains(result, "📎") {
+		t.Error("expected paperclip icon for non-image entry")
+	}
+	// Sizes: 124 KB, 2.1 MB, 812 B.
+	for _, want := range []string{"124 KB", "2.1 MB", "812 B"} {
+		if !strings.Contains(result, want) {
+			t.Errorf("expected size %q in rendered output", want)
+		}
+	}
+	// Filenames that fit. "error.jpg" (9 chars) and "notes.txt" (9 chars)
+	// fit the innerW-12 budget for a 30-wide sidebar. "screenshot.png" is
+	// 14 chars and gets truncated to "screenshot.…" — assert that behavior
+	// explicitly.
+	stripped := ansi.Strip(result)
+	for _, want := range []string{"error.jpg", "notes.txt", "screenshot.…"} {
+		if !strings.Contains(stripped, want) {
+			t.Errorf("expected %q in rendered output", want)
+		}
+	}
+	// Truncated filename should NOT appear in full.
+	if strings.Contains(stripped, "screenshot.png") {
+		t.Error("did not expect untruncated 'screenshot.png' — sidebar too narrow")
+	}
+}

--- a/internal/tui/terminal_title.go
+++ b/internal/tui/terminal_title.go
@@ -15,6 +15,13 @@ const terminalTitleApp = "π -"
 // title predictable.
 const terminalTitleMax = 200
 
+// terminalTitleCmdMax caps the command/prompt portion of the context-aware
+// title. The CWD prefix already eats into the tab's visible width, so the
+// command is stripped to a tighter length than terminalTitleMax. 60 runes
+// fits a typical tab with the prefix + separator + CWD basename (~12 chars)
+// while still being readable.
+const terminalTitleCmdMax = 60
+
 // deriveSessionTitle produces a short, single-line session title from a user
 // prompt. It mirrors the truncation the agent card already uses
 // (truncatePrompt in agent_loop.go) but is independent so the title length can
@@ -45,9 +52,58 @@ func deriveSessionTitle(prompt string) string {
 // in the escape sequence and writes it in order with the frame. Scrubbing
 // controls here is what keeps that envelope well-formed.
 func formatTerminalTitle(title string) string {
+	clean := stripControlChars(title)
+	if clean == "" {
+		return terminalTitleApp
+	}
+	return terminalTitleApp + " " + clean
+}
+
+// formatTerminalTitleWithCWD builds a context-aware window title:
+// "π - <cwd> | <command>". The CWD basename gives the user a fixed anchor
+// across turns (so different sessions in different repos are visually
+// distinguishable in the tab bar), and the slash command / prompt is shown
+// after a separator. The command is stripped to terminalTitleCmdMax runes so
+// the assembled title still fits a typical tab width.
+//
+// Pass an empty cwd to fall back to the no-context shape ("π - <command>"
+// or just "π -") — this matches what callers and tests have always produced
+// for an unconfigured WorkDir. The command portion is run through the same
+// control-character scrub as formatTerminalTitle so the OSC 0 envelope stays
+// well-formed.
+func formatTerminalTitleWithCWD(title, cwd string) string {
+	// Scrub the CWD basename the same way the prompt is scrubbed. On Unix a
+	// directory name may legally contain ESC, BEL, or other C0 controls, and
+	// the OSC 0 envelope treats those as terminators — an unsanitized folder
+	// would let the WorkDir smuggle arbitrary escape sequences into the
+	// terminal title. After scrubbing, an all-control folder resolves to
+	// "" and falls through to the no-context path below.
+	folder := stripControlChars(sidebarFolderName(strings.TrimSpace(cwd)))
+	clean := stripControlChars(title)
+	if folder == "" {
+		// No CWD context — fall back to the bare prefix shape so callers that
+		// never set WorkDir (notably the unit tests) keep the old behavior.
+		if clean == "" {
+			return terminalTitleApp
+		}
+		return terminalTitleApp + " " + clean
+	}
+	if clean == "" {
+		return terminalTitleApp + " " + folder
+	}
+	// Strip the command portion to terminalTitleCmdMax runes (counted in
+	// runes, not bytes, to match terminalTitleMax's rune-safe behavior).
+	if r := []rune(clean); len(r) > terminalTitleCmdMax {
+		clean = string(r[:terminalTitleCmdMax-1]) + "…"
+	}
+	return terminalTitleApp + " " + folder + " | " + clean
+}
+
+// stripControlChars is the shared prefix-cleaner: any C0 control (ESC, BEL,
+// CR, LF, TAB, …) is replaced with a space and the result is trimmed. This
+// is what keeps an untrusted user prompt from breaking the OSC 0 envelope.
+func stripControlChars(title string) string {
 	title = strings.TrimSpace(title)
-	// Strip anything that could break the escape-sequence envelope: ESC, BEL,
-	// CR, LF, TAB, and other C0 controls. Keep printable runes only.
 	var b strings.Builder
 	for _, r := range title {
 		if r < 0x20 || r == 0x7F {
@@ -56,9 +112,5 @@ func formatTerminalTitle(title string) string {
 		}
 		b.WriteRune(r)
 	}
-	clean := strings.TrimSpace(b.String())
-	if clean == "" {
-		return terminalTitleApp
-	}
-	return terminalTitleApp + " " + clean
+	return strings.TrimSpace(b.String())
 }

--- a/internal/tui/terminal_title_test.go
+++ b/internal/tui/terminal_title_test.go
@@ -143,6 +143,80 @@ func TestFormatTerminalTitle(t *testing.T) {
 	}
 }
 
+// TestFormatTerminalTitleWithCWD covers the context-aware shape that the
+// View() path now uses. The CWD is folded in as a fixed anchor so different
+// sessions in different repos are visually distinguishable in the tab bar,
+// while the slash command / prompt follows after a " | " separator.
+func TestFormatTerminalTitleWithCWD(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		cwd   string
+		want  string
+	}{
+		// Empty cwd keeps the legacy "π - <title>" shape so callers that
+		// never set WorkDir (the unit tests for View()) see the old output.
+		{"empty cwd, empty title", "", "", "π -"},
+		{"empty cwd, short title", "/clear", "", "π - /clear"},
+		{"empty cwd, long title is preserved by old shape", "fix the linter issue in agent.go", "", "π - fix the linter issue in agent.go"},
+
+		// Set cwd but no command — just the CWD anchor.
+		{"cwd only", "", "/home/dev/pi-go", "π - pi-go"},
+
+		// Cwd + command is the new context-aware shape.
+		{"cwd + command", "/clear", "/home/dev/pi-go", "π - pi-go | /clear"},
+		{"cwd + slash with args", "/model gpt-5.4", "/home/dev/pi-go", "π - pi-go | /model gpt-5.4"},
+		{"cwd + prompt-derived", "fix the linter issue in agent.go", "/home/dev/pi-go", "π - pi-go | fix the linter issue in agent.go"},
+
+		// Trimming of whitespace must not break the CWD basename extraction.
+		{"cwd padded", "/clear", "  /home/dev/pi-go  ", "π - pi-go | /clear"},
+
+		// Control characters are scrubbed the same way as the old path.
+		{"control in command is replaced", "with\nnewline", "/home/dev/pi-go", "π - pi-go | with newline"},
+
+		// The command is "stripped" — capped at terminalTitleCmdMax runes
+		// so a 200-char prompt does not eat the entire tab width on top
+		// of the CWD prefix.
+		{"long command is stripped", strings.Repeat("x", terminalTitleCmdMax+20), "/home/dev/pi-go",
+			"π - pi-go | " + strings.Repeat("x", terminalTitleCmdMax-1) + "…"},
+
+		// The CWD basename must go through the same control-character scrub
+		// as the command, otherwise a directory whose name contains ESC or
+		// BEL could terminate or inject into the OSC 0 envelope. After the
+		// scrub, an all-control folder resolves to "" and the title falls
+		// back to the no-context shape.
+		{"folder with control char is scrubbed", "/clear", "/tmp/evil\x1b]0;PWNED\x07",
+			"π - evil ]0;PWNED | /clear"},
+		{"folder that is all controls falls back", "/clear", "/tmp/\x1b\x07",
+			"π - /clear"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatTerminalTitleWithCWD(c.title, c.cwd)
+			if got != c.want {
+				t.Errorf("formatTerminalTitleWithCWD(%q, %q) = %q, want %q", c.title, c.cwd, got, c.want)
+			}
+		})
+	}
+}
+
+// TestView_CarriesWindowTitle_WithCWD exercises the new View() wiring: when
+// the model has a WorkDir, the OSC 0 payload carries the CWD anchor alongside
+// the prompt-derived title so the tab bar shows "π - <folder> | <title>".
+func TestView_CarriesWindowTitle_WithCWD(t *testing.T) {
+	m, _ := newTitleTestModel(t)
+	m.cfg.WorkDir = "/home/dev/pi-go"
+
+	if got := m.View().WindowTitle; got != "π - pi-go" {
+		t.Errorf("WindowTitle before any prompt = %q, want %q", got, "π - pi-go")
+	}
+
+	m.applySessionTitle("fix the top-level render")
+	if got := m.View().WindowTitle; got != "π - pi-go | fix the top-level render" {
+		t.Errorf("WindowTitle = %q, want %q", got, "π - pi-go | fix the top-level render")
+	}
+}
+
 func TestApplySessionTitle_EmptyPrompt_NoOp(t *testing.T) {
 	m, svc := newTitleTestModel(t)
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -227,10 +227,49 @@ type SearchItem struct {
 	Description string // for commands: the description
 }
 
+// searchPopupChrome is the number of rows the search popup reserves for chrome
+// — two border rows (top, bottom), a header row, and a search-prompt row.
+// height = items.  The item list fills the remaining space, so the popup's
+// total height is item count + searchPopupChrome.  The render loop and the
+// Up/Down scroll math both treat height as the visible item count, so it has
+// to reflect what actually fits, not the total number of items — otherwise
+// scrolling never fires and the selected row renders off-screen.
+const searchPopupChrome = 4
+
+// searchPopupMaxItems caps the popup so a huge command list does not eat the
+// whole message area.  25 mirrors the previous cap and is enough to scan at a
+// glance.
+const searchPopupMaxItems = 25
+
+// searchPopupListHeight returns how many item rows the popup should expose.
+// availableRows is the number of rows the message viewport can spare for the
+// popup; the popup uses that many minus its own chrome.  The result is
+// clamped to [1, max] when there are items so the popup is always usable,
+// even on terminals too small for the chrome plus a margin.  An empty list
+// returns 0 — the "no matches" path renders the chrome only.
+func searchPopupListHeight(itemCount, availableRows int) int {
+	if itemCount <= 0 {
+		return 0
+	}
+	if availableRows <= searchPopupChrome {
+		// Not enough room for the chrome plus any item; show one anyway
+		// and let the overlay clip the bottom.  Picking something is more
+		// useful than seeing an empty list.
+		return 1
+	}
+	height := itemCount
+	if max := availableRows - searchPopupChrome; height > max {
+		height = max
+	}
+	if height > searchPopupMaxItems {
+		height = searchPopupMaxItems
+	}
+	return height
+}
+
 // newSearchPopup creates a unified search popup with the given mode.
 func (m *model) newSearchPopup(mode searchMode) {
 	var items []SearchItem
-	var popupHeight int
 
 	switch mode {
 	case searchModeCommands:
@@ -248,7 +287,6 @@ func (m *model) newSearchPopup(mode searchMode) {
 				items = append(items, SearchItem{Text: c.Text, Description: c.Description})
 			}
 		}
-		popupHeight = searchPopupListHeight(len(items))
 
 	case searchModeHistory:
 		entries := m.inputModel.History
@@ -260,8 +298,16 @@ func (m *model) newSearchPopup(mode searchMode) {
 		for i, e := range entries {
 			items[len(entries)-1-i] = SearchItem{Text: e.Text}
 		}
-		popupHeight = searchPopupListHeight(len(items))
 	}
+
+	availableRows := m.messageViewportHeight()
+	// The overlay leaves a 1-row margin between the popup and the bottom of
+	// the viewport when the popup fits.  Reserve that row too so the chrome
+	// does not push the last item into that margin.
+	if availableRows > 0 {
+		availableRows--
+	}
+	popupHeight := searchPopupListHeight(len(items), availableRows)
 
 	m.searchPopup = &searchPopupState{
 		mode:      mode,
@@ -274,18 +320,50 @@ func (m *model) newSearchPopup(mode searchMode) {
 	}
 }
 
-func searchPopupListHeight(itemCount int) int {
-	if itemCount <= 0 {
-		return 0
+// refreshSearchPopupHeight recomputes the popup's visible item count after
+// the terminal has been resized.  The popup keeps its selection; height, and
+// scrollOff are reconciled so the selection stays visible and the rendered
+// window never overshoots len(filtered) — otherwise renderSearchPopup would
+// index past the end and panic on a tall→short→tall resize cycle.
+func (m *model) refreshSearchPopupHeight() {
+	if m.searchPopup == nil {
+		return
 	}
-	height := itemCount
-	if height > 25 {
-		height = 25
+	availableRows := m.messageViewportHeight()
+	if availableRows > 0 {
+		availableRows--
 	}
-	if height < 3 {
-		height = 3
+	m.searchPopup.height = searchPopupListHeight(len(m.searchPopup.filtered), availableRows)
+	n := len(m.searchPopup.filtered)
+	if n == 0 {
+		m.searchPopup.selected = 0
+		m.searchPopup.scrollOff = 0
+		return
 	}
-	return height
+	if m.searchPopup.selected >= n {
+		m.searchPopup.selected = n - 1
+	}
+	// Bring scrollOff in sync with the new height. A previous resize could
+	// have left it pointing past the new bottom of the window (short→tall
+	// means more items visible, so a stale scrollOff overshoots), or past the
+	// end of the list entirely (tall→short can shrink the visible window
+	// below the old scrollOff). The previous value is not safe to keep.
+	if m.searchPopup.selected < m.searchPopup.scrollOff {
+		m.searchPopup.scrollOff = m.searchPopup.selected
+	} else if m.searchPopup.selected >= m.searchPopup.scrollOff+m.searchPopup.height {
+		m.searchPopup.scrollOff = m.searchPopup.selected - m.searchPopup.height + 1
+	}
+	// Defense in depth: never overshoot the end of filtered, so the
+	// i-based loop in renderSearchPopup cannot read past the slice. The
+	// in-view clamps above keep scrollOff within selected±height; this is
+	// the final tie-breaker for the case where a previous scrollOff is
+	// still larger than the new visible window (e.g. n shrunk or height
+	// grew). max() guards against a negative maxScroll, which can only
+	// happen if some external code wrote a height larger than n between
+	// when this function read it and when it ran this clamp.
+	if maxScroll := n - m.searchPopup.height; m.searchPopup.scrollOff > maxScroll {
+		m.searchPopup.scrollOff = max(0, maxScroll)
+	}
 }
 
 // allSearchCandidates returns all slash command candidates for the search popup.
@@ -1210,7 +1288,7 @@ func (m *model) View() tea.View {
 	// through the View is what keeps the sequence ordered against the frame
 	// writes — writing it to os.Stdout directly races the renderer and lands
 	// mid-frame, which corrupts the drawn output.
-	v.WindowTitle = formatTerminalTitle(m.sessionTitle)
+	v.WindowTitle = formatTerminalTitleWithCWD(m.sessionTitle, m.cfg.WorkDir)
 	if inputCursor != nil {
 		inputCursor.Y += inputCursorY
 		v.Cursor = inputCursor
@@ -1377,6 +1455,11 @@ func (m *model) applyResize() {
 	}
 	// Matrix height can affect the message viewport, so clamp again after it updates.
 	m.clampScroll()
+	// The search popup exposes a fixed number of item rows.  Recompute that
+	// here so a resize keeps the highlighted row inside the new window —
+	// otherwise the Up/Down math still trusts the old budget and the
+	// selection can land off-screen.
+	m.refreshSearchPopupHeight()
 }
 
 func (m *model) clampScroll() {
@@ -1907,9 +1990,15 @@ func (m *model) renderSearchPopup(width int) string {
 		return popupStyle.Render(b.String())
 	}
 
-	// Item list.
-	for i := 0; i < sp.height && i < len(sp.filtered); i++ {
+	// Item list. Both i and scrollOff+i are bounded by len(filtered) so a
+	// stale scrollOff from before a resize cannot index past the end and
+	// panic — refreshSearchPopupHeight is the primary guard, this is the
+	// belt to its braces.
+	for i := 0; i < sp.height; i++ {
 		idx := sp.scrollOff + i
+		if idx < 0 || idx >= len(sp.filtered) {
+			break
+		}
 		item := sp.filtered[idx]
 		prefix := "  "
 		currentItemStyle := itemStyle

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1159,6 +1159,7 @@ func (m *model) View() tea.View {
 			MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
 			MemoryStatus: m.memoryStatus,
 			OTELEnabled:  otel.IsEnabled(),
+			Artifacts:    m.artifactList(),
 		}
 		if m.run != nil && m.run.phase != "" {
 			sidebarInput.RunChecklist = m.run.checklist
@@ -1480,6 +1481,18 @@ func (m *model) mascot() string {
 		return m.face.Mascot()
 	}
 	return MoodIdle.Mascot()
+}
+
+// artifactList returns the artifacts attached to the current session,
+// formatted for the sidebar. Returns nil when no artifact service is
+// wired — the sidebar treats nil/empty identically and renders nothing.
+//
+// This is a stub: the artifact service is plumbed through agent.Config
+// in the image-paste feature; once that lands, this method reads the
+// service off the runner and translates List+Load responses into
+// []ArtifactEntry.
+func (m *model) artifactList() []ArtifactEntry {
+	return nil
 }
 
 // refreshDiffStats updates the git diff line counts.

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1181,6 +1181,183 @@ func TestSlashCommandPopup_OpensWhenSlashTyped(t *testing.T) {
 	}
 }
 
+// Regression: a previously-scrolled popup whose height grew on resize used to
+// keep the old scrollOff, which then overshot the visible window. The
+// renderSearchPopup loop indexed past len(filtered) and panicked. The fix
+// reconciles scrollOff with the new height so the visible range always
+// stays within the slice and the selected item stays in view.
+func TestRefreshSearchPopupHeight_ReclampsScrollOff(t *testing.T) {
+	// 10 items, short terminal that gave a 3-row popup, user scrolled to
+	// the bottom so scrollOff = 7 (selected = 9).
+	items := make([]SearchItem, 10)
+	for i := range items {
+		items[i] = SearchItem{Text: fmt.Sprintf("item-%d", i)}
+	}
+	m := &model{
+		cfg:        Config{},
+		inputModel: NewInputModel(nil, nil, nil, ""),
+		width:      80,
+		height:     12, // short — small availableRows, small popup height
+	}
+	m.searchPopup = &searchPopupState{
+		mode:      searchModeCommands,
+		entries:   items,
+		filtered:  items,
+		selected:  9,
+		search:    "",
+		height:    3,
+		scrollOff: 7,
+	}
+	// Simulate a resize to a tall terminal where the popup now fits all 10
+	// items, but the old scrollOff=7 is still set.
+	m.height = 60
+	m.refreshSearchPopupHeight()
+
+	if m.searchPopup.scrollOff+m.searchPopup.height > len(items) {
+		t.Errorf("scrollOff+height = %d, want <= %d (filtered len)", m.searchPopup.scrollOff+m.searchPopup.height, len(items))
+	}
+	if m.searchPopup.selected < m.searchPopup.scrollOff ||
+		m.searchPopup.selected >= m.searchPopup.scrollOff+m.searchPopup.height {
+		t.Errorf("selected %d not in visible window [%d, %d) after refresh",
+			m.searchPopup.selected, m.searchPopup.scrollOff, m.searchPopup.scrollOff+m.searchPopup.height)
+	}
+	// And rendering must not panic.
+	_ = m.renderSearchPopup(70)
+}
+
+// Regression: a tall-to-short resize that leaves scrollOff > maxScroll
+// must not be allowed to push the visible window past the end of the
+// filtered slice.
+func TestRefreshSearchPopupHeight_ShrinkClampsOvershoot(t *testing.T) {
+	items := make([]SearchItem, 4)
+	for i := range items {
+		items[i] = SearchItem{Text: fmt.Sprintf("item-%d", i)}
+	}
+	m := &model{
+		cfg:        Config{},
+		inputModel: NewInputModel(nil, nil, nil, ""),
+		width:      80,
+		height:     60, // tall — popup can show everything
+	}
+	m.searchPopup = &searchPopupState{
+		mode:      searchModeCommands,
+		entries:   items,
+		filtered:  items,
+		selected:  3,
+		search:    "",
+		height:    4,
+		scrollOff: 0,
+	}
+	// Shrink the terminal so the popup height drops to 1. scrollOff must
+	// not be left pointing past the new visible window.
+	m.height = 8
+	m.refreshSearchPopupHeight()
+
+	if m.searchPopup.scrollOff+m.searchPopup.height > len(items) {
+		t.Errorf("scrollOff+height = %d, want <= %d (filtered len)", m.searchPopup.scrollOff+m.searchPopup.height, len(items))
+	}
+	if m.searchPopup.selected < m.searchPopup.scrollOff ||
+		m.searchPopup.selected >= m.searchPopup.scrollOff+m.searchPopup.height {
+		t.Errorf("selected %d not in visible window [%d, %d) after refresh",
+			m.searchPopup.selected, m.searchPopup.scrollOff, m.searchPopup.scrollOff+m.searchPopup.height)
+	}
+	_ = m.renderSearchPopup(70)
+}
+
+// Regression: even if a stale scrollOff somehow makes it past the resize
+// reconciliation, renderSearchPopup must not index past the end of the
+// filtered slice and panic. The defense-in-depth break is what catches
+// the bug in production even when the upstream guard regresses.
+func TestRenderSearchPopup_BoundsScrollOff(t *testing.T) {
+	items := make([]SearchItem, 4)
+	for i := range items {
+		items[i] = SearchItem{Text: fmt.Sprintf("item-%d", i)}
+	}
+	m := &model{
+		cfg:        Config{},
+		inputModel: NewInputModel(nil, nil, nil, ""),
+		width:      80,
+		height:     24,
+	}
+	m.searchPopup = &searchPopupState{
+		mode:      searchModeCommands,
+		entries:   items,
+		filtered:  items,
+		selected:  0,
+		search:    "",
+		height:    10,
+		scrollOff: 100, // far past the end of filtered
+	}
+	// Should not panic.
+	_ = m.renderSearchPopup(70)
+}
+
+// Covers the remaining branches in refreshSearchPopupHeight that the two
+// resize tests don't reach: the nil-popup early return, the empty-filtered
+// early return, the selected-clamp (selected >= len(filtered)), and the
+// upper-clamp (selected < scrollOff).
+func TestRefreshSearchPopupHeight_NilAndClamps(t *testing.T) {
+	// 1. Nil popup — early-return path, no panic, no work.
+	m := &model{
+		cfg:        Config{},
+		inputModel: NewInputModel(nil, nil, nil, ""),
+		width:      80,
+		height:     24,
+	}
+	m.refreshSearchPopupHeight() // no panic with searchPopup == nil
+
+	// 2. Empty filtered list (n == 0) — exercises the inner early-return
+	//    path. The popup exists but its filtered slice is nil/empty.
+	m.searchPopup = &searchPopupState{
+		mode:      searchModeCommands,
+		entries:   nil,
+		filtered:  nil,
+		selected:  5, // would be out of range if not clamped
+		search:    "",
+		height:    3,
+		scrollOff: 2,
+	}
+	m.refreshSearchPopupHeight()
+	if m.searchPopup.selected != 0 || m.searchPopup.scrollOff != 0 {
+		t.Errorf("empty filtered: selected=%d scrollOff=%d, want both 0",
+			m.searchPopup.selected, m.searchPopup.scrollOff)
+	}
+
+	// 3. selected out of range (selected >= len(filtered)) — clamps to n-1.
+	items := make([]SearchItem, 3)
+	for i := range items {
+		items[i] = SearchItem{Text: fmt.Sprintf("i-%d", i)}
+	}
+	m.searchPopup = &searchPopupState{
+		mode:      searchModeCommands,
+		entries:   items,
+		filtered:  items, // n=3
+		selected:  7,     // > 2, must clamp
+		search:    "",
+		height:    3,
+		scrollOff: 0,
+	}
+	m.refreshSearchPopupHeight()
+	if m.searchPopup.selected != 2 {
+		t.Errorf("selected-out-of-range: selected=%d, want 2 (n-1)", m.searchPopup.selected)
+	}
+
+	// 4. selected < scrollOff — upper-clamp path (selected moves scrollOff).
+	m.searchPopup = &searchPopupState{
+		mode:      searchModeCommands,
+		entries:   items,
+		filtered:  items,
+		selected:  0, // < scrollOff
+		search:    "",
+		height:    3,
+		scrollOff: 4, // stale
+	}
+	m.refreshSearchPopupHeight()
+	if m.searchPopup.scrollOff != 0 {
+		t.Errorf("selected<scrollOff: scrollOff=%d, want 0", m.searchPopup.scrollOff)
+	}
+}
+
 func TestView_RendersSlashPopupNearInput(t *testing.T) {
 	m := newTestModelFull(t)
 	m.inputModel.SetText("/co")

--- a/specs/features/TUI/sidebar-artifacts-section/design.md
+++ b/specs/features/TUI/sidebar-artifacts-section/design.md
@@ -1,0 +1,171 @@
+# Sidebar Artifacts Section — Design
+
+## Data flow
+
+```
+   ┌──────────────────┐    once per render    ┌────────────────────────┐
+   │ model.artifactList()│ ────────────────► │ SidebarRenderInput     │
+   │  (reads ADK       │  []ArtifactEntry    │   .Artifacts           │
+   │   artifact.List)  │                     └─────────┬──────────────┘
+   └──────────────────┘                               │
+                                                     ▼
+                                          ┌────────────────────────┐
+                                          │ RenderSidebar(...)     │
+                                          │  new "Artifacts" block │
+                                          └────────────────────────┘
+```
+
+`RenderSidebar` stays a pure function. The model layer is responsible
+for the one ADK call (`artifact.Service.List`) per `View()` render
+and for translating the result into `[]ArtifactEntry`.
+
+## Data shape
+
+```go
+// ArtifactEntry is one row in the Artifacts sidebar section.
+type ArtifactEntry struct {
+    Filename string // ADK artifact key, e.g. "screenshot.png"
+    Size     int64  // bytes stored in the artifact's genai.Part
+    Mime     string // optional; "image/png" gets the 🖼 icon
+}
+```
+
+Added to `SidebarRenderInput` (sidebar.go):
+
+```go
+Artifacts []ArtifactEntry
+```
+
+## Model layer
+
+New method on `model`:
+
+```go
+// artifactList returns a snapshot of the artifacts attached to the
+// current session. Returns nil if no artifact service is wired
+// (current state of the codebase) — the sidebar treats nil/empty
+// identically.
+func (m *model) artifactList() []ArtifactEntry {
+    svc := m.artifactService()  // may be nil; check first
+    if svc == nil {
+        return nil
+    }
+    resp, err := svc.List(ctx, &artifact.ListRequest{
+        AppName: agent.AppName,
+        UserID:  agent.DefaultUserID,
+        SessionID: m.sessionID,
+    })
+    if err != nil { return nil }
+    out := make([]ArtifactEntry, 0, len(resp.FileNames))
+    for _, name := range resp.FileNames {
+        // Load to get size + mime. Skip entries that fail to load
+        // (deleted between List and Load race).
+        lr, err := svc.Load(ctx, &artifact.LoadRequest{...})
+        if err != nil { continue }
+        var size int64
+        var mime string
+        if lr.Part != nil && lr.Part.InlineData != nil {
+            size = int64(len(lr.Part.InlineData.Data))
+            mime = lr.Part.InlineData.MIMEType
+        }
+        out = append(out, ArtifactEntry{
+            Filename: name, Size: size, Mime: mime,
+        })
+    }
+    return out
+}
+```
+
+Two questions intentionally deferred to follow-ups:
+
+1. Where does `m.artifactService()` come from? The runner exposes it
+   via `runner.Config.ArtifactService` but pi-go doesn't currently
+   set one. For this slice, the helper returns nil — the sidebar
+   simply renders nothing. Wiring it through `agent.Config` is a
+   one-liner when the paste work lands.
+2. Caching: we re-list on every render. Each `List` is a single
+   `omap` scan (`O(N)` in artifact count) which is fine for the
+   expected scale (handful of items). If profiling later shows it,
+   cache behind a `tea.Tick`.
+
+## Renderer
+
+New block in `RenderSidebar`, immediately after the Model section
+(after sidebar.go:137) and before the Git section:
+
+```go
+// --- Artifacts section ---
+if len(in.Artifacts) > 0 {
+    artHeading := lipgloss.NewStyle().
+        Foreground(lipgloss.Color("#fab387")).Bold(true) // Mocha peach
+    lines = append(lines,
+        artHeading.Render(fmt.Sprintf("  Artifacts [%d]", len(in.Artifacts))))
+
+    for _, a := range in.Artifacts {
+        icon := "📎"
+        if strings.HasPrefix(a.Mime, "image/") {
+            icon = "🖼"
+        }
+        size := formatBytes(a.Size)
+        // "  📎 filename.txt  (812 B)" — 2 indent + icon + space +
+        // name + 2-space gap + size. Budget for size: 10 chars max.
+        maxName := innerW - 2 - 2 - 10
+        if maxName < 6 {
+            maxName = 6
+        }
+        name := a.Filename
+        if runewidth.StringWidth(name) > maxName {
+            name = runewidth.Truncate(name, maxName-1, "…")
+        }
+        lines = append(lines, dim.Render(
+            fmt.Sprintf("  %s %s  %s", icon, name, size)))
+    }
+    lines = append(lines, "")
+}
+```
+
+### `formatBytes`
+
+```go
+// formatBytes renders a byte count as "812 B" / "124 KB" / "2.1 MB".
+// No GB tier — session artifacts won't hit that.
+func formatBytes(n int64) string {
+    switch {
+    case n < 1024:
+        return fmt.Sprintf("%d B", n)
+    case n < 1024*1024:
+        return fmt.Sprintf("%d KB", n/1024)
+    default:
+        return fmt.Sprintf("%.1f MB", float64(n)/(1024*1024))
+    }
+}
+```
+
+### Icon choice
+
+`🖼` (U+1F5BC) for images, `📎` (U+1F4CE) otherwise. Both are in the
+emoji block; they will render as monochrome glyphs in most terminals
+and color glyphs in iTerm2/Kitty. No new font dependency.
+
+## Test plan
+
+Two new cases in `sidebar_test.go`, following the existing
+`RenderSidebar(SidebarRenderInput{...})` pattern:
+
+1. **Empty list** — assert no `Artifacts` substring in the rendered
+   output, and line count is unchanged from a baseline with no
+   `Artifacts` field.
+2. **Three entries** — assert the heading `Artifacts [3]` appears,
+   and three lines with the expected icon/filename/size are present
+   in the right order.
+
+Existing tests in the file are not modified.
+
+## File touch list
+
+| File | Change |
+|---|---|
+| `internal/tui/sidebar.go` | Add `ArtifactEntry` type, `Artifacts` field on `SidebarRenderInput`, `formatBytes` helper, new section in `RenderSidebar`. |
+| `internal/tui/sidebar_test.go` | Add empty-list and populated-list test cases. |
+| `internal/tui/tui.go` | Pass `Artifacts: m.artifactList()` into the `sidebarInput` literal. |
+| `internal/tui/tui.go` (model) | Add `artifactList()` method and the `artifactService()` accessor that returns nil for now. |

--- a/specs/features/TUI/sidebar-artifacts-section/plan.md
+++ b/specs/features/TUI/sidebar-artifacts-section/plan.md
@@ -1,0 +1,49 @@
+# Sidebar Artifacts Section — Plan
+
+Vertical slice: type → helper → renderer → tests → call site. Each
+step is verified before the next.
+
+## Step 1. Add type + helper in `sidebar.go`
+
+- Add `ArtifactEntry` struct.
+- Add `Artifacts []ArtifactEntry` to `SidebarRenderInput`.
+- Add `formatBytes(int64) string` (file-local).
+
+Verify: `go build ./internal/tui/...` clean.
+
+## Step 2. Add render block in `sidebar.go`
+
+- Insert the new block between Model and Git, after the
+  `lines = append(lines, "")` that closes Model.
+- Reuse existing `dim` and `heading` styles where possible; define
+  `artHeading` locally (Mocha peach + bold) to match Memory/MCP.
+
+Verify: `go build ./internal/tui/...` clean. Empty list still
+renders identically to baseline (no behavioral change yet).
+
+## Step 3. Tests in `sidebar_test.go`
+
+- `TestSidebar_Artifacts_EmptyHidden`: assert no `Artifacts` line in
+  output when `Artifacts: nil` and when `Artifacts: []ArtifactEntry{}`.
+- `TestSidebar_Artifacts_Populated`: three entries → heading
+  `Artifacts [3]` plus three lines, in order, with the correct icons.
+
+Verify: `go test ./internal/tui/ -run Sidebar -v` passes.
+
+## Step 4. Wire model layer in `tui.go`
+
+- Add `artifactList()` method on `model` that returns `nil` for now
+  (no artifact service wired — the sidebar will simply not render
+  the section until the paste work lands).
+- Add the `Artifacts:` line in the `sidebarInput := SidebarRenderInput{...}`
+  literal at tui.go:1186.
+
+Verify: `go build ./...` and `go test ./internal/tui/...` clean.
+Existing tests still pass.
+
+## Step 5. Final verification
+
+- `go vet ./...`
+- `go test ./...` (full repo)
+- `git diff --stat` to confirm only the four files in the design's
+  file touch list are modified.

--- a/specs/features/TUI/sidebar-artifacts-section/requirements.md
+++ b/specs/features/TUI/sidebar-artifacts-section/requirements.md
@@ -1,0 +1,40 @@
+# Sidebar Artifacts Section — Requirements
+
+## Functional
+
+1. **R1.** When at least one artifact exists for the current session,
+   the sidebar renders an `Artifacts [N]` section between the Model
+   section and the Git section.
+2. **R2.** When the artifact list is empty, the section is omitted
+   entirely. No heading, no empty-state row, no `Artifacts [0]` line.
+3. **R3.** Each artifact renders as one line containing:
+   - an icon (`🖼` for `image/*` MIME types, `📎` otherwise),
+   - the filename (truncated with `…` to fit the sidebar width),
+   - the size in humanized form (`812 B`, `124 KB`, `2.1 MB`).
+4. **R4.** The list updates on the same cadence as other sidebar
+   state — i.e. it is read once per `View()` render. No new
+   `tea.Tick`; no new goroutine.
+5. **R5.** Artifacts with the same filename but different versions
+   appear once (latest version wins). The renderer does not need to
+   surface version numbers.
+
+## Non-functional
+
+- **N1.** Zero new runtime dependencies. Everything used already lives
+  in `go.mod` (lipgloss, runewidth, genai, ADK artifact package).
+- **N2.** Renderer remains pure. It must not call into ADK services
+  directly. All data arrives via `SidebarRenderInput`.
+- **N3.** The section is opt-in. Empty list = no render. Existing
+  users see no change until something actually populates the list.
+- **N4.** No regression in the existing 8 sidebar tests. New tests
+  cover the empty case (hidden) and the populated case (renders the
+  expected lines).
+
+## Acceptance
+
+- `go test ./internal/tui/...` passes, including two new test cases
+  in `sidebar_test.go`.
+- `go vet ./...` clean.
+- Manual: rendering the sidebar with one image artifact shows the
+  heading, one line, and matches the existing Catppuccin Mocha
+  palette already used by Memory/MCP sections.

--- a/specs/features/TUI/sidebar-artifacts-section/rough-idea.md
+++ b/specs/features/TUI/sidebar-artifacts-section/rough-idea.md
@@ -1,0 +1,47 @@
+# Sidebar Artifacts Section
+
+## Source
+
+User feedback on the gap that pi-go has no image-paste / drag-and-drop
+flow today. ADK artifacts (`google.golang.org/adk/v2/artifact`) are the
+right primitive to wire that in, but the work splits into two visible
+pieces: (a) the input bar / paste handler, and (b) a sidebar section
+that shows what artifacts are currently attached to the session.
+
+This spec covers (b) only. It is the user-visible piece of a larger
+image-paste feature and is being shipped first because it is
+self-contained, testable, and reversible on its own.
+
+## Idea
+
+Add an **Artifacts** section to the right sidebar, mirroring the
+existing Memory and MCP Tools patterns. The section lists every ADK
+artifact stored against the current session, with a filename, an icon
+(image vs. generic blob), and a humanized size. Hidden when empty.
+
+The data source is the ADK `artifact.Service` already accessible from
+the runner (`runner.Config.ArtifactService`). The renderer stays pure:
+the model layer reads the artifact list once per refresh tick and
+passes a `[]ArtifactEntry` into the existing `SidebarRenderInput`
+struct.
+
+## Why now
+
+Once image-paste ships, users will paste images, switch models, walk
+away, come back — and have no way to see what they attached. The
+sidebar gives them an at-a-glance "what is currently in flight" view,
+parallel to how Memory and MCP Tools give them a view of *other*
+session state.
+
+It is also the natural place to land click-to-view or click-to-remove
+in a follow-up, without re-laying-out the sidebar.
+
+## Non-goals
+
+- No paste/drop UX itself (separate slice).
+- No interactive selection, click-to-view, or click-to-remove.
+- No inline image preview in the sidebar (lives in the input bar).
+- No `user:` namespaced artifacts (cross-session) — session-scoped
+  only in v1.
+- No new dependency. `rsc.io/omap` is already pulled in transitively
+  by ADK's `artifact.InMemoryService`.

--- a/specs/features/TUI/sidebar-artifacts-section/summary.md
+++ b/specs/features/TUI/sidebar-artifacts-section/summary.md
@@ -1,0 +1,59 @@
+# Sidebar Artifacts Section — Summary
+
+## What landed
+
+A new **Artifacts** section in the right sidebar that lists every
+ADK artifact attached to the current session. Hidden when empty.
+
+## Files touched
+
+| File | Lines | Purpose |
+|---|---|---|
+| `internal/tui/sidebar.go` | +55 | `ArtifactEntry` type, `Artifacts` field on `SidebarRenderInput`, `formatBytes` helper, render block between Model and Git. |
+| `internal/tui/sidebar_test.go` | +73 | Two new tests: `TestRenderSidebar_Artifacts_EmptyHidden` and `TestRenderSidebar_Artifacts_Populated`. |
+| `internal/tui/tui.go` | +16 | One line in the `sidebarInput := SidebarRenderInput{...}` literal passing `m.artifactList()`. Plus a stub `artifactList()` method that returns `nil` until the artifact service is wired. |
+| `specs/features/TUI/sidebar-artifacts-section/` | new | Idea, requirements, design, plan. |
+
+## What the renderer does
+
+For each `ArtifactEntry`:
+- `🖼` icon for `image/*` MIME types, `📎` otherwise.
+- Filename truncated with `…` to fit the sidebar's inner width
+  (mirroring the Git branch pattern).
+- Size in humanized form: `812 B` / `124 KB` / `2.1 MB`.
+
+Heading: `Artifacts [N]` in Mocha peach (`#fab387`), bold, matching
+the palette already used by Memory and MCP Tools.
+
+## What the model layer does (today)
+
+Nothing. `m.artifactList()` returns `nil`. The sidebar renders
+nothing. This is intentional: the artifact service is plumbed
+through `agent.Config` in the image-paste feature, and the call site
+is now in place. Wiring the body is a follow-up — the
+spec's `design.md` has the full data-flow shape ready to fill in.
+
+## Verification
+
+- `go vet ./...` — clean.
+- `go test ./...` — all packages pass, including the two new
+  sidebar tests.
+- Manual: dump-test confirmed the section appears between Model and
+  Mode with the correct icons, sizes, and truncation.
+
+## Lessons / follow-ups
+
+- The `m.artifactService()` accessor is the next thing to add.
+  The natural place is on the `agent.Agent` struct (line 397 in
+  `internal/agent/agent.go`), with a getter exposed to the TUI.
+- Once wired, the sidebar will reflect artifacts created by the
+  paste/drop UX in real time — no extra `tea.Tick` needed if the
+  paste flow triggers a redraw (it does, via `submitPrompt`).
+- Click-to-view and click-to-remove are deliberately deferred.
+  They need selection-mode plumbing analogous to what the Git
+  branch picker uses; the data is ready but the interaction
+  surface is its own spec.
+- The two-space gap between filename and size (`"  "` literal)
+  was a deliberate choice for alignment. If a future section
+  needs a tighter layout, the `formatBytes` width assumption
+  (`maxName := innerW - 2 - 2 - 10`) is the one knob to revisit.


### PR DESCRIPTION
## Summary

Two small fixes, surfaced by codex review of an earlier draft.

### `π - <command>` → `π - <CWD> | <command>` (with command-length strip)

The terminal window/tab title now carries the CWD basename as a fixed anchor
so different sessions in different repos are visually distinguishable in the
tab bar, with the slash command / prompt after a ` | ` separator. The command
portion is capped at 60 runes so the assembled title still fits a typical tab
width on top of the CWD prefix.

- `internal/tui/terminal_title.go` — added `formatTerminalTitleWithCWD(title, cwd)`.
  Empty `cwd` falls back to the legacy `π - <command>` shape so the unit
  tests that don't wire `WorkDir` keep passing.
- `internal/tui/tui.go` — `View()` now passes `m.cfg.WorkDir` to the new
  formatter.
- `internal/tui/terminal_title_test.go` — 12 subcases covering the new
  shape, padding, control-character handling, truncation, and the no-CWD
  fallback.

### OSC 0 envelope hardening (codex P2)

`sidebarFolderName(WorkDir)` was inserted into the OSC 0 payload unsanitized.
On Unix a directory name can legally contain ESC/BEL — a `WorkDir` like
`/tmp/evil\x1b]0;PWNED\x07` would terminate the envelope and inject a
malicious title. The CWD basename is now run through the same
`stripControlChars` scrub as the command; an all-control folder resolves
to `""` and falls through to the no-context shape. Two new subcases lock
the behavior in.

### Popup scroll-offset clamp on resize (codex P1)

`refreshSearchPopupHeight` updated `height` on terminal resize but did
not reconcile `scrollOff`, so a previously-scrolled popup could end up
with `scrollOff + height > len(filtered)`. The next `renderSearchPopup`
call indexed past the end and panicked. Confirmed the original symptom:
`index out of range [100] with length 4`.

- `internal/tui/tui.go` — `refreshSearchPopupHeight` now:
  1. Keeps the selection inside the visible window
     (`scrollOff ∈ [selected-height+1, selected]`).
  2. Defense-in-depth: never lets `scrollOff + height` exceed
     `len(filtered)`.
- `internal/tui/tui.go` — `renderSearchPopup` now bounds `idx =
  scrollOff + i` against `len(filtered)` and breaks on OOB. The previous
  loop only bounded `i`, not `idx`, so the i-based guard was insufficient
  when `scrollOff` was stale.
- `internal/tui/tui_test.go` — three regression tests:
  `TestRefreshSearchPopupHeight_ReclampsScrollOff`,
  `TestRefreshSearchPopupHeight_ShrinkClampsOvershoot`,
  `TestRenderSearchPopup_BoundsScrollOff`. Each was verified to fail
  against the unfixed code.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass