### PR TITLE
test: isolate HOME so the suite cannot overwrite a real ~/.pi-go

### DIFF
--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain redirects HOME to a throwaway directory for every test in this
+// package.
+//
+// Code under test resolves paths through os.UserHomeDir and writes there —
+// ~/.pi-go/config.json, session history, logs. Tests that exercise those paths
+// without isolating HOME first will overwrite the developer's real
+// configuration: running "go test ./..." was enough to rewrite the default
+// model role and theme of the machine running it. Isolating at package scope
+// makes that impossible by construction, rather than relying on every future
+// test remembering to call t.Setenv("HOME", ...).
+//
+// Tests that need their own HOME can still override it; t.Setenv restores this
+// value rather than the developer's when they finish.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pi-go-test-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "isolating HOME: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+
+	code := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain redirects HOME to a throwaway directory for every test in this
+// package.
+//
+// Code under test resolves paths through os.UserHomeDir and writes there —
+// ~/.pi-go/config.json, session history, logs. Tests that exercise those paths
+// without isolating HOME first will overwrite the developer's real
+// configuration: running "go test ./..." was enough to rewrite the default
+// model role and theme of the machine running it. Isolating at package scope
+// makes that impossible by construction, rather than relying on every future
+// test remembering to call t.Setenv("HOME", ...).
+//
+// Tests that need their own HOME can still override it; t.Setenv restores this
+// value rather than the developer's when they finish.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pi-go-test-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "isolating HOME: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+
+	// lastSessionFile is a package-level var resolved from $HOME at init time,
+	// which happens before TestMain runs — setting HOME above cannot reach it.
+	// Repoint it explicitly so print-mode tests that do not already override it
+	// cannot write to the developer's real ~/.pi-go.
+	lastSessionFile = filepath.Join(dir, ".pi-go", "last-session.json")
+
+	code := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/guardrail/main_test.go
+++ b/internal/guardrail/main_test.go
@@ -1,0 +1,35 @@
+package guardrail
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain redirects HOME to a throwaway directory for every test in this
+// package.
+//
+// Code under test resolves paths through os.UserHomeDir and writes there —
+// ~/.pi-go/config.json, session history, logs. Tests that exercise those paths
+// without isolating HOME first will overwrite the developer's real
+// configuration: running "go test ./..." was enough to rewrite the default
+// model role and theme of the machine running it. Isolating at package scope
+// makes that impossible by construction, rather than relying on every future
+// test remembering to call t.Setenv("HOME", ...).
+//
+// Tests that need their own HOME can still override it; t.Setenv restores this
+// value rather than the developer's when they finish.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pi-go-test-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "isolating HOME: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+
+	code := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/sop/main_test.go
+++ b/internal/sop/main_test.go
@@ -1,0 +1,35 @@
+package sop
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain redirects HOME to a throwaway directory for every test in this
+// package.
+//
+// Code under test resolves paths through os.UserHomeDir and writes there —
+// ~/.pi-go/config.json, session history, logs. Tests that exercise those paths
+// without isolating HOME first will overwrite the developer's real
+// configuration: running "go test ./..." was enough to rewrite the default
+// model role and theme of the machine running it. Isolating at package scope
+// makes that impossible by construction, rather than relying on every future
+// test remembering to call t.Setenv("HOME", ...).
+//
+// Tests that need their own HOME can still override it; t.Setenv restores this
+// value rather than the developer's when they finish.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pi-go-test-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "isolating HOME: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+
+	code := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/tui/login_test.go
+++ b/internal/tui/login_test.go
@@ -13,11 +13,29 @@ import (
 	"github.com/dimetron/pi-go/internal/auth"
 )
 
-// TestMain globally disables real browser opens and process restart for every test in this package.
+// TestMain globally disables real browser opens and process restart for every
+// test in this package, and redirects HOME to a throwaway directory.
+//
+// The HOME isolation matters because saveThemeToConfig and SaveDefaultRole
+// resolve ~/.pi-go/config.json through os.UserHomeDir and rewrite the whole
+// file. Without it, running "go test ./..." overwrites the developer's real
+// theme and default model role.
 func TestMain(m *testing.M) {
 	openBrowser = func(string) error { return nil }
 	execRestart = func() {}
-	os.Exit(m.Run())
+
+	dir, err := os.MkdirTemp("", "pi-go-test-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "isolating HOME: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+
+	code := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(code)
 }
 
 // mockBrowser records all URLs passed to openBrowser.


### PR DESCRIPTION
Running `go test ./...` overwrites the developer's own `~/.pi-go` configuration.

Test code reaches `saveThemeToConfig` and `SaveDefaultRole`, which resolve `~/.pi-go/config.json` via `os.UserHomeDir` and marshal the **entire** `Config` back to disk. Fixture state therefore gets persisted over real configuration. On my machine the `default` role was replaced with `claude-sonnet-4-6` — a model I have no API key for — and `pi` failed to start until I repaired the file by hand:

```
Error: no API key found for provider "anthropic" (set ANTHROPIC_API_KEY)
```

The blast radius is wider than `config.json`. Running the suite under a sacrificial `HOME` shows what a full run writes:

```
$HOME/.pi-go/config.json
$HOME/.pi-go/history.jsonl
$HOME/.pi-go/last-session.json
$HOME/.pi-go/usage.json
$HOME/.pi-go/sessions/...
$HOME/.pi-go/log/...
$HOME/.pi-go/memory/claude-mem.db
$HOME/.pi-go/models/sentence-transformers_all-MiniLM-L6-v2/   (~90MB download)
```

Some tests already isolate `HOME` individually — which is why this went unnoticed. The ones that forget are the leak, and nothing enforces it.

## Change

A package-scoped `TestMain` in each package whose code can reach a `$HOME` write: `cli`, `tui`, `agent`, `sop`, `guardrail`. Isolation then holds by construction rather than by every future test remembering. Tests that need their own `HOME` still override it — `t.Setenv` restores the throwaway directory instead of the developer's.

`internal/tui` already had a `TestMain` for browser/restart stubbing, so it is extended rather than duplicated.

`lastSessionFile` needs separate handling: it is a package-level var resolved from `$HOME` at **init**, which runs before `TestMain`, so setting the environment cannot reach it. `TestMain` repoints the var directly.

## Verification

Full suite run under a sacrificial `HOME`, before and after, diffing what appeared:

| | before | after |
|---|---|---|
| paths created under `~/.pi-go/` | 8 (incl. a ~90MB model download) | **0** |

`go test ./...` passes, `gofmt -l` and `go vet ./...` clean. No production code changed — the diff is test files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)