### PR TITLE
test(cli): isolate cwd in --smol and missing-API-key tests

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -183,9 +183,13 @@ func TestCLI_SmolFlag(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("OPENAI_API_KEY", "test-key")
 
-	// Write a config with smol role.
+	// Write a config with smol role. Run inside the tmpDir so the
+	// loadDotEnv walk-up from cwd doesn't reach this machine's real
+	// ~/.pi-go/.env — on a dev box with a saved codex OAuth token,
+	// that walk-up would override OPENAI_API_KEY=test-key with the
+	// JWT and trip "model not supported by the ChatGPT codex
+	// backend" in NewOpenAI for non-codex-listed models.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{
@@ -194,6 +198,8 @@ func TestCLI_SmolFlag(t *testing.T) {
 			"smol": {"model": "gpt-5.4-mini", "provider": "openai"}
 		}
 	}`), 0o644)
+	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"--smol", "--mode", "print"})
@@ -252,7 +258,14 @@ func TestRootCmdDefaultModelNoPrompt(t *testing.T) {
 
 func TestRootCmdMissingAPIKey(t *testing.T) {
 	// Isolate HOME so loadDotEnv cannot pull credentials from the real machine.
-	t.Setenv("HOME", t.TempDir())
+	// Also chdir into the same tmpDir so findNearestDotEnv cannot walk up
+	// from cwd and reach the real ~/.pi-go/.env above this repo — without
+	// that chdir the walk-up re-introduces the host's saved OPENAI_API_KEY
+	// (or, worse, a codex OAuth token) and the test's "no key set" intent
+	// never reaches buildRootRuntime.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	// Ensure no provider API keys are set.
 	for _, key := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"} {


### PR DESCRIPTION
## Summary

Two `internal/cli` unit tests broke on hosts that have a saved codex OAuth token in `~/.pi-go/.env` (`TestCLI_SmolFlag` and `TestRootCmdMissingAPIKey`). The CI Test job from run `30960271876`/job `92162461618` failed on `main` with:

- `TestCLI_SmolFlag`: `model "gpt-5.4-mini" is not supported by the ChatGPT codex backend…`
- `TestRootCmdMissingAPIKey`: `expected error for missing API key` — the test never sees a missing key because the host's real `OPENAI_API_KEY` (a codex JWT) is loaded during `loadDotEnv`.

Root cause: both tests set `HOME=t.TempDir()` but never `chdir` into it. `loadDotEnv` calls `findNearestDotEnv(cwd)`, which walks up from the current working directory until it finds a `.pi-go/.env`. Because the project's test cwd sits inside the repo, the walk reaches the developer's real `~/.pi-go/.env` above the repo and reloads the host's credential with `os.Setenv`, clobbering the test's `t.Setenv("OPENAI_API_KEY", "test-key")` (or empty value).

## Fix

Add `t.Chdir(tmpDir)` after `t.Setenv("HOME", tmpDir)` in the two failing tests. `t.Chdir` (Go 1.24+) auto-restores cwd at test end via `t.Cleanup`. No production code touched; no behavior change for users.

The pattern matches `TestLoadDotEnvProjectOverridesGlobal` (also in `cli_test.go`), which already pairs `os.Chdir` with a `t.Setenv("HOME", …)`.

## Verification

On a dev host with the saving codex JWT:

```
$ go test -count=1 -run 'TestCLI_SmolFlag|TestRootCmdMissingAPIKey' ./internal/cli/
ok  	github.com/dimetron/pi-go/internal/cli
```

Full `make test-unit` (the CI Test job's `go test -count=1 ./...`): **all 35 packages green.**

| Check             | Result          |
|-------------------|-----------------|
| `go test -count=1 ./...` | 35 packages pass |
| `go test -race` (excluding `/internal/acp/server`) | green |
| `make test-coverage` | 87.3% statements covered |
| `go build` (linux/amd64) | green |
| `golangci-lint run` | 0 issues |
| `go vet ./...` | clean |
| SSH signature on commit `3de14d5` | intact (`git cat-file commit HEAD \| grep gpgsig`) |

## Out of scope

The same cwd-leak pattern exists in `TestRootCmdNoPromptExitsCleanly`, `TestCLI_ModelFlagOverridesDefault`, `TestCLI_RoleFlagsMutuallyExclusive`, and `TestContinueNoSessionError` (and several tests in `cli_coverage_test.go`, `run_modes_test.go`, `root_cmd_test.go`). These currently pass CI by luck — the model names used (`gpt-5.6-sol`, etc.) happen to be in the codex backend allowlist, so a host JWT doesn't trigger the rejection. A codex review pass flagged them as "must fix" for cleanliness, but that's a follow-up PR. This PR is scoped to the two tests that were actually breaking CI.

Refs:
- Failing run: https://github.com/dimetron/pi-go/actions/runs/30960271876/job/92162461618
- Head of `main` at the failure: `f9dd72c` ("Fix/pr 64 mcp everything")

🤖 Generated with [Claude Code](https://claude.com/claude-code)