### PR TITLE
fix: unblock CI, silence OTLP export noise, consolidate worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ sandbox.log
 /wiki/
 /hack/test/tb2/jobs/
 /tmp/
+/mcp
+/.tmp-adk-inspect/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,7 +82,13 @@ linters:
       # example servers (e.g. the MCP everything server). The vendored code
       # deliberately exercises APIs that the upstream SDK is deprecating
       # (SA1019) so we can detect SDK breakage early. Don't lint it.
-      - path: ^hack/
+      #
+      # Deliberately unanchored: golangci-lint caches results by content but
+      # prints the path recorded when the entry was written, so a cache hit
+      # populated from a sibling worktree surfaces as
+      # ../<other-worktree>/hack/... . An ^-anchored pattern misses those and
+      # the excluded issues resurface as hard pre-commit failures.
+      - path: hack/
         linters:
           - staticcheck
       # ADK tool handlers return errors inside result structs, not as Go errors.

--- a/hack/test/mcp/main.go
+++ b/hack/test/mcp/main.go
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // The everything server implements all supported features of an MCP server.
+//
+//lint:file-ignore SA1019 example server exercises deprecated SEP-2577 APIs (roots, sampling, logging) for demonstration.
 package main
 
 import (

--- a/hack/test/mcp/main.go
+++ b/hack/test/mcp/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -48,16 +49,23 @@ func main() {
 	}
 }
 
+// gcOnce guards the /gc registration. ServeMux.Handle panics on a duplicate
+// pattern, so registering on every pprofMux call takes the process down the
+// second time round — as `go test -count=2` on this package used to prove.
+var gcOnce sync.Once
+
 // pprofMux returns the pprof mux with a /gc endpoint added. Triggering a few GC
 // cycles before scraping /debug/pprof/heap means the heap profile reports only
 // reachable memory, which is the point when hunting a leak.
 func pprofMux() *http.ServeMux {
-	http.DefaultServeMux.Handle("/gc", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		for range 3 {
-			runtime.GC()
-		}
-		fmt.Fprintln(w, "GC'ed")
-	}))
+	gcOnce.Do(func() {
+		http.DefaultServeMux.Handle("/gc", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			for range 3 {
+				runtime.GC()
+			}
+			fmt.Fprintln(w, "GC'ed")
+		}))
+	})
 	return http.DefaultServeMux
 }
 

--- a/internal/atif/writer.go
+++ b/internal/atif/writer.go
@@ -25,7 +25,20 @@ type Writer struct {
 	filePath    string
 	trajectory  Trajectory
 	stepCounter int
-	mu          sync.Mutex
+	// flushCount is incremented on every successful flush(). Test-only:
+	// TestWriterAppendEvents_FlushedExactlyOnce reads it instead of
+	// racing a poller against os.Rename to observe temp-file appearance.
+	flushCount int
+	mu         sync.Mutex
+}
+
+// FlushCount returns the number of times flush() has completed successfully
+// since the Writer was created. It is intended for tests that need an exact
+// count of disk writes; production callers should not depend on it.
+func (w *Writer) FlushCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.flushCount
 }
 
 // NewWriter creates a Writer that will maintain an ATIF file at filePath.
@@ -177,5 +190,6 @@ func (w *Writer) flush() error {
 		os.Remove(tmpName)
 	}
 
+	w.flushCount++
 	return nil
 }

--- a/internal/atif/writer_appendevents_test.go
+++ b/internal/atif/writer_appendevents_test.go
@@ -4,11 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"google.golang.org/adk/v2/session"
 )
@@ -174,61 +171,23 @@ func TestWriterAppendEvents_MixedEmpty(t *testing.T) {
 	}
 }
 
-// countFlushTransitions spins a polling goroutine that observes how many
-// times a .atif-*.tmp file appears in dir. Each call to flush() creates
-// exactly one such temp file (via os.CreateTemp) and removes it via
-// os.Rename. So the number of "appearing" transitions is a lower bound on
-// the number of flush() calls.
-//
-// The poller is best-effort: on very fast filesystems, a single flush may
-// complete between two polls and be missed entirely. The function returns
-// the observed count plus the "currently visible" indicator so the caller
-// can also reason about duration.
-func countFlushTransitions(t *testing.T, dir string, work func()) int {
+// runAndCountFlushes runs work() against a fresh Writer and returns the number
+// of flushes the writer performed, sampled directly from Writer.FlushCount
+// before and after the call. This is race-free — it does not depend on
+// file-system polling — unlike the previous countFlushTransitions helper,
+// which raced against os.Rename and missed flushes on fast filesystems.
+func runAndCountFlushes(t *testing.T, fp string, meta SessionMeta, work func(w *Writer)) int {
 	t.Helper()
-	stop := make(chan struct{})
-	done := make(chan struct{})
-	var transitions int
-	var inTmp bool
-	go func() {
-		defer close(done)
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-			}
-			entries, _ := os.ReadDir(dir)
-			hasTmp := false
-			for _, e := range entries {
-				name := e.Name()
-				if strings.HasPrefix(name, ".atif-") && strings.HasSuffix(name, ".tmp") {
-					hasTmp = true
-					break
-				}
-			}
-			if hasTmp && !inTmp {
-				transitions++
-				inTmp = true
-			} else if !hasTmp && inTmp {
-				inTmp = false
-			}
-			runtime.Gosched()
-		}
-	}()
-	work()
-	// Allow poller to drain the dir.
-	time.Sleep(2 * time.Millisecond)
-	close(stop)
-	<-done
-	return transitions
+	w := NewWriter(fp, meta)
+	before := w.FlushCount()
+	work(w)
+	return w.FlushCount() - before
 }
 
 // TestWriterAppendEvents_FlushedExactlyOnce verifies that AppendEvents flushes
-// the trajectory to disk once at the end, not once per event. The test
-// counts how many times a .atif-*.tmp file is observed in the dir during
-// the call, and compares against the same count for N per-event AppendEvent
-// calls. AppendEvents must produce strictly fewer flushes.
+// the trajectory to disk exactly once, not once per event. The number of
+// flushes is read directly from Writer.FlushCount (no filesystem polling),
+// so the assertions are exact on every filesystem.
 func TestWriterAppendEvents_FlushedExactlyOnce(t *testing.T) {
 	const N = 30
 
@@ -240,8 +199,7 @@ func TestWriterAppendEvents_FlushedExactlyOnce(t *testing.T) {
 	}
 
 	// Batch path: one AppendEvents call.
-	batchCount := countFlushTransitions(t, dir, func() {
-		w := NewWriter(fp, SessionMeta{SessionID: "sess-batch", AgentName: "pi-go"})
+	batchCount := runAndCountFlushes(t, fp, SessionMeta{SessionID: "sess-batch", AgentName: "pi-go"}, func(w *Writer) {
 		if err := w.AppendEvents(events); err != nil {
 			t.Errorf("AppendEvents: %v", err)
 		}
@@ -250,8 +208,7 @@ func TestWriterAppendEvents_FlushedExactlyOnce(t *testing.T) {
 	// Live path: N AppendEvent calls in a fresh dir.
 	dirLive := t.TempDir()
 	fpLive := filepath.Join(dirLive, "trajectory.atif.json")
-	liveCount := countFlushTransitions(t, dirLive, func() {
-		w := NewWriter(fpLive, SessionMeta{SessionID: "sess-live", AgentName: "pi-go"})
+	liveCount := runAndCountFlushes(t, fpLive, SessionMeta{SessionID: "sess-live", AgentName: "pi-go"}, func(w *Writer) {
 		for _, ev := range events {
 			if err := w.AppendEvent(ev); err != nil {
 				t.Errorf("AppendEvent: %v", err)
@@ -259,19 +216,11 @@ func TestWriterAppendEvents_FlushedExactlyOnce(t *testing.T) {
 		}
 	})
 
-	if batchCount == 0 {
-		t.Errorf("poller did not observe any flush; test is not reliable on this filesystem")
+	if batchCount != 1 {
+		t.Errorf("AppendEvents produced %d flushes; want exactly 1 (one batch flush at the end)", batchCount)
 	}
-	if liveCount == 0 {
-		t.Errorf("poller did not observe any live flush; test is not reliable on this filesystem")
-	}
-	if batchCount >= liveCount {
-		t.Errorf("AppendEvents should produce fewer flushes than N per-event AppendEvent calls: batch=%d live=%d (N=%d)", batchCount, liveCount, N)
-	}
-	// AppendEvents should be roughly 1; allow a small slack for the
-	// os.Rename-close race in the poller.
-	if batchCount > 3 {
-		t.Errorf("AppendEvents produced %d flush observations; want <= 3 (single flush, with poller race slack)", batchCount)
+	if liveCount != N {
+		t.Errorf("AppendEvent x%d produced %d flushes; want exactly %d (one per event)", N, liveCount, N)
 	}
 }
 

--- a/internal/cli/cli_coverage_test.go
+++ b/internal/cli/cli_coverage_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dimetron/pi-go/internal/logger"
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/memory"
-	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/subagent"
 	"github.com/dimetron/pi-go/internal/tools"
 	"github.com/dimetron/pi-go/internal/webserver"
@@ -665,78 +664,6 @@ func TestFindMemoryDB_EmptyProject(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
-// runMemoryMine — project files
-// -----------------------------------------------------------------------
-
-// skipWithoutEmbedder skips tests that need a real embedding backend.
-//
-// These are integration tests wearing unit-test clothing: they call the same
-// code paths `pi memory mine` does, which embed for real. With the default
-// config that means a local Ollama daemon, and without one they either fail
-// outright ("cannot reach daemon at http://localhost:11434") or — worse — fall
-// through to downloading a ~100 MB model, which blew past the 10-minute test
-// timeout and took the whole package down with a panic rather than a failure.
-//
-// Probing is cheap: EmbedderAvailability is a loopback request with a 3-second
-// deadline. So this skips in CI, where no daemon runs, and still exercises the
-// code locally where one does — which is better than a build tag that would
-// make these dead weight everywhere.
-func skipWithoutEmbedder(t *testing.T) {
-	t.Helper()
-	cfg := palace.DefaultConfig()
-	cfg.ModelPath = defaultPalaceModelPath()
-	if err := palace.EmbedderAvailability(cfg); err != nil {
-		t.Skipf("no embedding backend available: %v", err)
-	}
-}
-
-func TestRunMemoryMine_ProjectFiles(t *testing.T) {
-	// Skip race detection due to race in third-party go-huggingface library
-	// (hugot.DownloadModel → gomlx/go-huggingface hub.(*Repo).DownloadFiles).
-	if raceEnabled {
-		t.Skip("skipping: go-huggingface has race condition")
-	}
-	skipWithoutEmbedder(t)
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "main.go"),
-		[]byte("package main\n\nfunc main() { println(\"hello world test content for chunk threshold minimum\") }"), 0o644)
-
-	output := captureStdout(t, func() {
-		err := runMemoryMine(dir, "testproject", false)
-		if err != nil {
-			t.Fatalf("runMemoryMine: %v", err)
-		}
-	})
-	if output == "" {
-		t.Error("expected mining output")
-	}
-}
-
-func TestRunMemoryMine_Conversations(t *testing.T) {
-	// Skip race detection due to race in third-party go-huggingface library
-	// (hugot.DownloadModel → gomlx/go-huggingface hub.(*Repo).DownloadFiles).
-	if raceEnabled {
-		t.Skip("skipping: go-huggingface has race condition")
-	}
-	skipWithoutEmbedder(t)
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "chat.jsonl"),
-		[]byte(`{"role":"user","content":"question"}
-{"role":"assistant","content":"answer"}
-`), 0o644)
-
-	output := captureStdout(t, func() {
-		err := runMemoryMine(dir, "testconv", true)
-		if err != nil {
-			t.Fatalf("runMemoryMine convos: %v", err)
-		}
-	})
-	if output == "" {
-		t.Error("expected mining output")
-	}
-}
-
-// -----------------------------------------------------------------------
 // runMemoryModelStatus
 // -----------------------------------------------------------------------
 
@@ -794,38 +721,6 @@ func TestRunMemoryStatus_NoDB(t *testing.T) {
 	})
 	if output == "" {
 		t.Error("expected 'no palace' message")
-	}
-}
-
-func TestRunMemoryStatus_WithDB(t *testing.T) {
-	// AddDrawer embeds its content, so this needs a backend like the mine tests
-	// do. This is the test that hung for 10 minutes and panicked the package.
-	skipWithoutEmbedder(t)
-
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "palace.db")
-
-	// Create a real palace with some data
-	p, err := palace.New(palace.WithDBPath(dbPath))
-	if err != nil {
-		t.Fatalf("palace.New: %v", err)
-	}
-	p.AddDrawer(context.Background(), palace.DrawerInput{
-		Wing: "test", Room: "api", Content: "test content",
-	})
-	p.KGAdd(context.Background(), palace.TripleInput{
-		Subject: "Alice", Predicate: "works_on", Object: "api",
-	})
-	p.Close()
-
-	output := captureStdout(t, func() {
-		err := runMemoryStatus(dbPath)
-		if err != nil {
-			t.Fatalf("runMemoryStatus: %v", err)
-		}
-	})
-	if output == "" {
-		t.Error("expected status output")
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -183,9 +183,13 @@ func TestCLI_SmolFlag(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("OPENAI_API_KEY", "test-key")
 
-	// Write a config with smol role.
+	// Write a config with smol role. Run inside the tmpDir so the
+	// loadDotEnv walk-up from cwd doesn't reach this machine's real
+	// ~/.pi-go/.env — on a dev box with a saved codex OAuth token,
+	// that walk-up would override OPENAI_API_KEY=test-key with the
+	// JWT and trip "model not supported by the ChatGPT codex
+	// backend" in NewOpenAI for non-codex-listed models.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{
@@ -194,6 +198,8 @@ func TestCLI_SmolFlag(t *testing.T) {
 			"smol": {"model": "gpt-5.4-mini", "provider": "openai"}
 		}
 	}`), 0o644)
+	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"--smol", "--mode", "print"})
@@ -252,7 +258,14 @@ func TestRootCmdDefaultModelNoPrompt(t *testing.T) {
 
 func TestRootCmdMissingAPIKey(t *testing.T) {
 	// Isolate HOME so loadDotEnv cannot pull credentials from the real machine.
-	t.Setenv("HOME", t.TempDir())
+	// Also chdir into the same tmpDir so findNearestDotEnv cannot walk up
+	// from cwd and reach the real ~/.pi-go/.env above this repo — without
+	// that chdir the walk-up re-introduces the host's saved OPENAI_API_KEY
+	// (or, worse, a codex OAuth token) and the test's "no key set" intent
+	// never reaches buildRootRuntime.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	// Ensure no provider API keys are set.
 	for _, key := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"} {

--- a/internal/cli/memory_mine_integration_test.go
+++ b/internal/cli/memory_mine_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/palace"
+)
+
+// Tests in this file require a live Ollama daemon and embedding model. They
+// run only under `go test -tags integration ./internal/cli/...`; the regular
+// `go test` build excludes them entirely.
+//
+// Run locally:
+//
+//	ollama serve
+//	ollama pull embeddinggemma
+//	make test-integration
+//
+// Or directly:
+//
+//	go test -tags integration -run 'TestRunMemoryMine|TestRunMemoryStatus_WithDB' ./internal/cli/...
+
+func TestRunMemoryMine_ProjectFiles(t *testing.T) {
+	// Skip race detection due to race in third-party go-huggingface library
+	// (hugot.DownloadModel → gomlx/go-huggingface hub.(*Repo).DownloadFiles).
+	if raceEnabled {
+		t.Skip("skipping: go-huggingface has race condition")
+	}
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\n\nfunc main() { println(\"hello world test content for chunk threshold minimum\") }"), 0o644)
+
+	output := captureStdout(t, func() {
+		err := runMemoryMine(dir, "testproject", false)
+		if err != nil {
+			t.Fatalf("runMemoryMine: %v", err)
+		}
+	})
+	if output == "" {
+		t.Error("expected mining output")
+	}
+}
+
+func TestRunMemoryMine_Conversations(t *testing.T) {
+	// Skip race detection due to race in third-party go-huggingface library
+	// (hugot.DownloadModel → gomlx/go-huggingface hub.(*Repo).DownloadFiles).
+	if raceEnabled {
+		t.Skip("skipping: go-huggingface has race condition")
+	}
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "chat.jsonl"),
+		[]byte(`{"role":"user","content":"question"}
+{"role":"assistant","content":"answer"}
+`), 0o644)
+
+	output := captureStdout(t, func() {
+		err := runMemoryMine(dir, "testconv", true)
+		if err != nil {
+			t.Fatalf("runMemoryMine convos: %v", err)
+		}
+	})
+	if output == "" {
+		t.Error("expected mining output")
+	}
+}
+
+func TestRunMemoryStatus_WithDB(t *testing.T) {
+	// AddDrawer embeds its content, so this needs a backend like the mine tests.
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "palace.db")
+
+	// Create a real palace with some data
+	p, err := palace.New(palace.WithDBPath(dbPath))
+	if err != nil {
+		t.Fatalf("palace.New: %v", err)
+	}
+	p.AddDrawer(context.Background(), palace.DrawerInput{
+		Wing: "test", Room: "api", Content: "test content",
+	})
+	p.KGAdd(context.Background(), palace.TripleInput{
+		Subject: "Alice", Predicate: "works_on", Object: "api",
+	})
+	p.Close()
+
+	output := captureStdout(t, func() {
+		err := runMemoryStatus(dbPath)
+		if err != nil {
+			t.Fatalf("runMemoryStatus: %v", err)
+		}
+	})
+	if output == "" {
+		t.Error("expected status output")
+	}
+}

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -38,7 +39,39 @@ import (
 var (
 	tracerProvider *sdktrace.TracerProvider
 	initOnce       sync.Once
+
+	// exportErrCount and lastExportErr capture what the OTel SDK would
+	// otherwise print to stderr. See captureExportError.
+	exportErrCount atomic.Int64
+	lastExportErr  atomic.Pointer[string]
 )
+
+// captureExportError is the global OTel ErrorHandler. The SDK's default
+// handler writes to stderr with a plain log.Logger, so an unreachable
+// collector paints lines like
+//
+//	2026/08/05 09:54:16 traces export: exporter export timeout: rpc error: ...
+//
+// straight over whatever the TUI had drawn. Every batch retry repeats it.
+// pi owns the screen, so these are recorded here instead of printed; read
+// them back with ExportErrors when diagnosing a silent collector.
+func captureExportError(err error) {
+	if err == nil {
+		return
+	}
+	exportErrCount.Add(1)
+	msg := err.Error()
+	lastExportErr.Store(&msg)
+}
+
+// ExportErrors returns how many telemetry export errors have been swallowed
+// since start, and the most recent one ("" if there has been none).
+func ExportErrors() (count int64, last string) {
+	if p := lastExportErr.Load(); p != nil {
+		last = *p
+	}
+	return exportErrCount.Load(), last
+}
 
 // ResetForTest resets the lazy-initialized tracer provider. It is intended
 // for tests that need to re-read the OTEL configuration from the current
@@ -69,6 +102,9 @@ func initProvider() {
 		// SDK messages (URL parse errors, etc.) ever reach the user's terminal.
 		// The SDK default is stdr→os.Stderr which pollutes ACP/TUI stdout streams.
 		otel.SetLogger(logr.Discard())
+		// Same reasoning for the error handler: batch export failures reach
+		// the terminal through otel.Handle, not through the logger.
+		otel.SetErrorHandler(otel.ErrorHandlerFunc(captureExportError))
 
 		ctx := context.Background()
 

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -2,10 +2,12 @@ package otel
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -192,6 +194,42 @@ func TestIsAvailable_SetsExporterNoneIfNotAvailable(t *testing.T) {
 		t.Skip("a collector is running on port 4317 — skipping test")
 	}
 	// If we get here, no collector is running, which is the expected state.
+}
+
+func TestCaptureExportError(t *testing.T) {
+	before, _ := ExportErrors()
+
+	captureExportError(nil) // must not count
+	if got, _ := ExportErrors(); got != before {
+		t.Fatalf("captureExportError(nil) changed count: %d, want %d", got, before)
+	}
+
+	captureExportError(errors.New("traces export: connection refused"))
+	count, last := ExportErrors()
+	if count != before+1 {
+		t.Fatalf("count = %d, want %d", count, before+1)
+	}
+	if last != "traces export: connection refused" {
+		t.Fatalf("last = %q, want the recorded error", last)
+	}
+}
+
+// TestGlobalErrorHandlerIsInstalled guards the actual bug: an unreachable
+// collector made the SDK's default handler print export failures over the TUI.
+// After init, otel.Handle must reach captureExportError instead of stderr.
+func TestGlobalErrorHandlerIsInstalled(t *testing.T) {
+	_ = Tracer("error-handler-test") // drives initProvider
+
+	before, _ := ExportErrors()
+	otel.Handle(errors.New("exporter export timeout"))
+
+	count, last := ExportErrors()
+	if count != before+1 {
+		t.Fatalf("otel.Handle did not reach captureExportError: count = %d, want %d", count, before+1)
+	}
+	if last != "exporter export timeout" {
+		t.Fatalf("last = %q, want %q", last, "exporter export timeout")
+	}
 }
 
 func TestShutdown(t *testing.T) {

--- a/specs/features/TOO/018-goal-command/PROMPT.md
+++ b/specs/features/TOO/018-goal-command/PROMPT.md
@@ -1,0 +1,171 @@
+# `/goal` Slash Command
+
+## Objective
+
+Add a `/goal` slash command to pi-go's interactive TUI, modeled on Codex CLI's
+`/goal`. Users declare a persistent per-session objective that the agent
+pursues across turns, with a status lifecycle (Active / Paused / Blocked /
+Complete), a footer indicator, system-prompt injection, and round-trip
+persistence through `meta.json` (so it survives `--continue`).
+
+## Key Requirements
+
+1. **Persistent per-session objective** — A single text field per session,
+   persisted in `session.Meta.GoalContext`, parallel to `PlanContext`.
+2. **Six sub-commands** — bare `/goal` (summary), `/goal <text>` (set),
+   `/goal edit` (overlay editor), `/goal pause`, `/goal resume`,
+   `/goal clear`.
+3. **Status lifecycle** — `Active | Paused | Blocked | Complete`. Only
+   `Active` injects into the agent prompt; `Paused | Blocked | Complete`
+   leave the prompt unchanged.
+4. **System-prompt injection** — A `# Current Goal` block appended after
+   `Base + Rules + Skills` (parallel to `# Active Skill`).
+5. **Footer indicator** — A short status line in the bottom bar showing
+   the goal state and the (truncated) objective.
+6. **Resume across `--continue` / `--session`** — A loaded session
+   rehydrates the goal; if `Paused | Blocked`, a chat hint suggests
+   `/goal resume`.
+7. **Validation** — 4 000-byte cap on objective length; empty rejected.
+8. **No silent overwrite protection** — `/goal <text>` replaces any
+   existing goal silently.
+
+## Acceptance Criteria
+
+### Goal set
+
+- Given no goal set, when `/goal keep tests green`, then chat shows
+  `Goal set: keep tests green`, footer reads `Goal: keep tests green`,
+  next turn sees the `# Current Goal` block, meta.json contains
+  `GoalContext{objective: "keep tests green", status: active}`.
+
+### Goal pause / resume
+
+- Given a goal with `status: paused`, when `/goal resume`, then chat shows
+  `Goal resumed`, footer flips from `Goal paused: <obj>` to `Goal: <obj>`,
+  the `# Current Goal` block returns to the prompt.
+
+### Goal edit
+
+- Given an active goal with text `x`, when `/goal edit` then Enter then
+  `y\nEnter`, then meta.json holds the new text and prompt rebuilds.
+
+### Goal clear
+
+- Given any goal, when `/goal clear`, then chat shows `Goal cleared.`,
+  footer disappears, meta.json `GoalContext` is nil, no `# Current Goal`
+  block.
+
+### Validation cap
+
+- Given no goal, when `/goal <4100-char string>`, then chat shows
+  `goal objective must be at most 4000 characters (got 4100)`, state
+  unchanged.
+
+### Resume from paused session
+
+- Given meta.json with `GoalContext{status: paused, objective: x}`, when
+  `pi --continue`, then chat shows the resume hint
+  (`Loaded … paused state …`), footer shows `Goal paused: x`, no
+  `# Current Goal` block in prompt.
+
+## Implementation Slices
+
+1. **Slice 1 — Schema + persistence** — `GoalStatus`, `GoalContext`,
+   `Meta.GoalContext` field, `UpdateGoalContext`, `GetGoalContext` in
+   `internal/session/store.go`. Round-trip tests in `store_test.go`.
+   verify: `go build ./internal/session/... && go test ./internal/session/...`
+
+2. **Slice 2 — Agent validation + injection** — `MaxGoalObjectiveChars`,
+   `ValidateGoalObjective`, `AppendActiveGoal` in `internal/agent/agent.go`.
+   Tests for empty / 4 001 / 4 000 cases and exact block wording.
+   verify: `go build ./internal/agent/... && go test ./internal/agent/...`
+
+3. **Slice 3 — TUI dispatch + summary card** — `handleGoalCommand`,
+   `printGoalSummary`, `setGoalFromInput`, `transitionGoal`, `clearGoal`,
+   `persistGoal`, `truncate` in `internal/tui/goal.go` (new); model field
+   `goal *session.GoalContext` in `internal/tui/types.go`; `case "/goal"`
+   in `internal/tui/commands.go`. One test per sub-command in
+   `commands_test.go`.
+   verify: `go build ./internal/tui/... && go test -run TestHandleSlashCommandGoal ./internal/tui/...`
+
+4. **Slice 4 — Prompt rebuild + edit overlay** — implement
+   `applyGoalToPrompt` in `goal.go` (calls
+   `m.cfg.Agent.RebuildWithInstruction`); add `beginGoalEdit` /
+   `commitGoalEdit` reusing the `create_skill.go` overlay pattern. Test
+   that `RebuildWithInstruction` is called on state change.
+   verify: `go build ./internal/tui/... && go test ./internal/tui/...`
+
+5. **Slice 5 — Footer indicator** — extend `StatusRenderInput` with
+   `GoalIndicator string` in `internal/tui/status.go`; implement
+   `goalIndicatorText()` in `internal/tui/tui.go`; populate in
+   `statusRenderInput()`. Five-case table test.
+   verify: `go test -run TestGoalIndicatorText ./internal/tui/...`
+
+6. **Slice 6 — Resume across `--continue` / `--session`** — in
+   `internal/cli/interactive.go:~298`, call `AppendActiveGoal` when the
+   loaded goal is Active; prepend the resume-hint message when Paused or
+   Blocked. Tests in `cli_test.go` / new `interactive_test.go`.
+   verify: `go test -run TestResumeGoal ./internal/cli/...`
+
+7. **Slice 7 — Autocomplete + help table** — append `"/goal"` to
+   `slashCommands`; add `slashCommandDesc` case in
+   `internal/tui/input.go`; add `**Long-running tasks:**` section to
+   `formatHelp` in `internal/tui/commands.go`. Tests for both.
+   verify: `go test -run "TestSlashCommands|TestFormatHelp" ./internal/tui/...`
+
+8. **Slice 8 — Compact / reload resilience** — `TestGoalContext_AfterCompactReload`
+   and `TestGoalContext_SurvivesUpdateTwice` in
+   `internal/session/store_test.go`. Confirms `meta.json` round-trip
+   survives `Compact()` and that `UpdatedAt` advances.
+   verify:
+   `go test -run "TestGoalContext_AfterCompactReload|TestGoalContext_SurvivesUpdateTwice" ./internal/session/...`
+
+## Gates
+
+- **build**: `go build ./...`
+- **test**: `go test ./internal/session/... ./internal/agent/... ./internal/tui/... ./internal/cli/...`
+- **vet**: `go vet ./...`
+- **race (manual, optional)**:
+  `go test -race ./internal/tui/... ./internal/session/... ./internal/agent/... ./internal/cli/...`
+
+Run the slice-specific verify command at the end of each slice.
+Run all gates plus `go test ./...` at the end of Slice 8 (the final
+slice). No `go.mod` change; no new module dependency.
+
+## Reference
+
+- Design: `specs/features/TOO/018-goal-command/design.md`
+- Outline: `specs/features/TOO/018-goal-command/outline.md`
+- Plan: `specs/features/TOO/018-goal-command/plan.md`
+- Requirements: `specs/features/TOO/018-goal-command/requirements.md`
+- Research: `specs/features/TOO/018-goal-command/research/`
+    - `codex-goal-reference.md` — codex port anatomy
+    - `pi-go-integration-points.md` — where the implementation lands
+
+## Constraints
+
+- **No new module dependency.** Stick to the existing dependencies; no
+  `go.mod` change.
+- **One objective per session.** No list of goals, no sub-goals.
+- **Interactive TUI mode only.** `print`, `json`, `rpc` modes honor a
+  loaded goal in the prompt but do not expose a `/goal` command
+  surface. CLI/RPC parity is a follow-up spec.
+- **`len` is byte length** for the 4 000-char cap, not rune count. The
+  purpose is to bound prompt cost; bytes are the right unit.
+- **`/goal <text>` replaces any existing goal silently.** No confirmation
+  step (Q4 decision).
+- **Byte cap = 4 000.** Matches codex's `MAX_THREAD_GOAL_OBJECTIVE_CHARS`
+  (Q3).
+- **Status enum is `Active | Paused | Blocked | Complete`.** No
+  `UsageLimited` / `BudgetLimited` in v1 — token-budget accounting is a
+  follow-up spec.
+- **Slice ordering is fixed.** Slices 1 and 2 are independent; Slice 3
+  depends on both; Slices 4–8 depend on Slice 3. Do not reorder.
+- **Do not edit `internal/agent/agent.go:46` (`SystemInstruction` constant).**
+  The `# Current Goal` block goes through `AppendActiveGoal`, not by
+  editing the constant.
+- **Do not change `session.Meta` keys other than adding `goalContext`.**
+  Existing keys (`planContext`, `title`, `model`, etc.) must remain stable.
+- **Existing `AppendActiveSkill` shape is the precedent for `AppendActiveGoal`.**
+  Match the docstring style, the `\n\n` separators, and the placement
+  after `Base + Rules + Skills`.

--- a/specs/features/TOO/018-goal-command/design.md
+++ b/specs/features/TOO/018-goal-command/design.md
@@ -1,0 +1,393 @@
+# Design — `/goal` Slash Command
+
+## Overview
+
+A `/goal` slash command in pi-go's interactive TUI, modeled on Codex CLI's
+`/goal`. Users declare a persistent per-session objective that the agent
+pursues across turns, with a status lifecycle (`Active | Paused | Blocked |
+Complete`) and a footer indicator. Ported shape, not a port of codex's
+implementation — pi-go uses JSONL session metadata, not SQLite.
+
+## End state
+
+Typing `/goal keep tests green after every refactor`:
+
+1. Chat shows `Goal set: keep tests green after every refactor`.
+2. Footer reads `… gpt-5.4  Goal: keep tests green after every refactor  …`.
+3. Next turn's system prompt includes a `# Current Goal` block (per Q8).
+4. Goal persists in `meta.json`. Re-applied on every turn of the session.
+5. `/goal pause` → footer becomes `Goal paused: …`, prompt no longer injects.
+6. `/goal resume` → restores.
+7. `/goal clear` → wipes the entry.
+8. `--continue` rehydrates from disk; if `Paused | Blocked`, prepends a
+   one-line chat hint suggesting `/goal resume`.
+
+## Architecture
+
+```
+internal/tui/commands.go      handleSlashCommand dispatches /goal
+                               -> handleGoalCommand(args)
+                                  -> printGoalSummary / setGoalFromInput /
+                                     beginGoalEdit / transitionGoal / clearGoal
+
+internal/tui/goal.go          NEW — owns the goal-command state machine,
+                               summary-card renderer, edit overlay, and the
+                               footer status fragment.
+
+internal/tui/status.go        StatusRenderInput.GoalIndicator field.
+internal/tui/tui.go           statusRenderInput populates GoalIndicator
+                               via goalIndicatorText().
+
+internal/session/store.go     NEW: GoalContext, GoalStatus,
+                               Meta.GoalContext, UpdateGoalContext,
+                               GetGoalContext. (Mirror PlanContext; the
+                               schemas are disjoint.)
+
+internal/agent/agent.go       NEW: AppendActiveGoal, ValidateGoalObjective,
+                               MaxGoalObjectiveChars. Sit next to
+                               AppendActiveSkill (line 727).
+
+internal/cli/interactive.go   After instruction = instructionParts.String()
+                               (line 297), call AppendActiveGoal when the
+                               loaded session has Status=Active.
+```
+
+### State machine
+
+```
+                  /goal <text>          /goal edit (commit)
+                  /goal <text-resend>   /goal resume
+     (none) ─── /goal ──► Active ──/goal pause──► Paused
+                                              ▲   │
+                                              │   ▼
+                                   /goal resume│
+                                              ▼
+                                          Blocked ── /goal clear ──► (none)
+                                              │
+                                              ▼
+                                          Complete ── /goal clear ──► (none)
+```
+
+`Paused | Blocked | Complete` are terminal "off" states for prompt-injection
+(no `# Current Goal` block). `Active` is the only "on" state. `/goal
+resume` moves `Paused | Blocked` → `Active`; emits `Goal already active.`
+if already `Active`. `Complete` is one-way in v1.
+
+## Session metadata schema (`internal/session/store.go`)
+
+```go
+type GoalStatus string
+
+const (
+    GoalStatusActive   GoalStatus = "active"
+    GoalStatusPaused   GoalStatus = "paused"
+    GoalStatusBlocked  GoalStatus = "blocked"
+    GoalStatusComplete GoalStatus = "complete"
+)
+
+type GoalContext struct {
+    Objective       string     `json:"objective,omitempty"`
+    Status          GoalStatus `json:"status,omitempty"`
+    CreatedAt       int64      `json:"createdAt,omitempty"`        // unix seconds
+    UpdatedAt       int64      `json:"updatedAt,omitempty"`
+    TimeUsedSeconds int64      `json:"timeUsedSeconds,omitempty"`
+}
+
+// Meta (line 47):
+//   GoalContext *GoalContext `json:"goalContext,omitempty"`
+```
+
+`UpdateGoalContext(sessionID, *GoalContext)` and `GetGoalContext(sessionID)`
+mirror `UpdatePlanContext` / `GetPlanContext` (store.go:620, 638) byte-for-
+byte; only the field name and struct type differ.
+
+## Agent prompt injection (`internal/agent/agent.go`)
+
+```go
+const MaxGoalObjectiveChars = 4_000
+
+func ValidateGoalObjective(objective string) error {
+    if objective == "" {
+        return errors.New("goal objective must not be empty")
+    }
+    if len(objective) > MaxGoalObjectiveChars {
+        return fmt.Errorf(
+            "goal objective must be at most %d characters (got %d)",
+            MaxGoalObjectiveChars, len(objective),
+        )
+    }
+    return nil
+}
+
+func AppendActiveGoal(prompt, objective string) string {
+    return prompt + fmt.Sprintf(
+        "\n\n# Current Goal\n\nThe user's active session goal is:\n\n> %s\n\n"+
+            "Stay focused on this objective across turns. "+
+            "If it is no longer the user's intent, surface that "+
+            "and suggest /goal edit before pursuing other work.\n",
+        objective,
+    )
+}
+```
+
+`len` is **byte length**, not rune count. Codex's purpose is to bound the
+*cost* of the objective in the prompt; bytes are the right unit for a cost
+bound. Rune-counting would let 4 000 Han characters consume four times the
+budget.
+
+### Injection points
+
+1. **At session start** — `internal/cli/interactive.go:289-300`. After
+   `instruction = instructionParts.String()`, if the loaded session has
+   `Status=Active`, call `AppendActiveGoal`.
+2. **On user-driven updates** — from `/goal edit` and
+   `/goal pause → resume`. Same call:
+   `m.cfg.Agent.RebuildWithInstruction(instructionWithGoal)`. The pattern
+   exists at `create_skill.go:69` (skill rebuild) and `plan.go:245` (plan
+   rebuild).
+
+Both share one helper:
+
+```go
+// in internal/tui/goal.go
+func (m *model) applyGoalToPrompt() {
+    if m.cfg.Agent == nil || m.cfg.SessionService == nil { return }
+    if m.goal == nil || m.goal.Status != session.GoalStatusActive { return }
+    base := agent.LoadInstruction(agent.SystemInstruction)
+    full := agent.AppendActiveGoal(base, m.goal.Objective)
+    if err := m.cfg.Agent.RebuildWithInstruction(full); err != nil {
+        m.chatModel.Messages = append(m.chatModel.Messages, message{
+            role:    "assistant",
+            content: fmt.Sprintf("Error reapplying goal to prompt: %v", err),
+        })
+    }
+}
+```
+
+## TUI model fields
+
+```go
+// in internal/tui/types.go
+type model struct {
+    // ...existing fields...
+    goal *session.GoalContext  // nil when no goal
+    goalEditing bool           // /goal edit overlay
+    goalDraft   []rune         // /goal edit buffer
+}
+```
+
+A pointer so a fresh-from-disk load and a freshly-set goal share one code
+path. `m.goal == nil` ⇒ no indicator, no `# Current Goal` injection.
+
+## Slash-command surface (`internal/tui/commands.go`)
+
+```go
+// in handleSlashCommand, between /run and /login
+case "/goal":
+    return m.handleGoalCommand(parts[1:])
+
+// one entry point; sub-commands route through it
+func (m *model) handleGoalCommand(args []string) (tea.Model, tea.Cmd) {
+    if len(args) == 0 {
+        m.printGoalSummary()
+        return m, nil
+    }
+    sub := strings.ToLower(args[0])
+    switch sub {
+    case "edit":       m.beginGoalEdit()
+    case "pause":      m.transitionGoal(session.GoalStatusPaused, "Goal paused")
+    case "resume":     m.transitionGoal(session.GoalStatusActive, "Goal resumed")
+    case "clear":      m.clearGoal()
+    case "":           m.printGoalSummary()
+    default:
+        text := strings.TrimSpace(strings.Join(args, " "))
+        m.setGoalFromInput(text)
+    }
+    return m, nil
+}
+```
+
+The `default` branch joins all of `args` (including the first non-keyword
+token) as the objective — same convention as `/skills create` and
+`/rename`. So `/goal keep tests green` sets the objective to
+`keep tests green`.
+
+### Summary card (`printGoalSummary`)
+
+```go
+func (m *model) printGoalSummary() {
+    if m.goal == nil {
+        m.chatModel.Messages = append(m.chatModel.Messages, message{
+            role: "assistant",
+            content: "No goal is currently set. `/goal <objective>` to set.",
+        })
+        return
+    }
+    obj := truncate(m.goal.Objective, 200)
+    var line string
+    switch m.goal.Status {
+    case session.GoalStatusActive:
+        line = fmt.Sprintf("Goal: %s   [/goal edit | /goal pause | /goal clear]", obj)
+    case session.GoalStatusPaused:
+        line = fmt.Sprintf("Goal paused: %s   [/goal resume | /goal edit | /goal clear]", obj)
+    case session.GoalStatusBlocked:
+        line = fmt.Sprintf("Goal blocked: %s   [/goal resume | /goal edit | /goal clear]", obj)
+    case session.GoalStatusComplete:
+        line = fmt.Sprintf("Goal complete: %s   [/goal clear]", obj)
+    }
+    m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: line})
+}
+```
+
+`truncate(s, n)` is a tiny local helper. No need for a package.
+
+### Set / edit / pause / resume / clear
+
+```go
+func (m *model) setGoalFromInput(text string) {
+    if err := agent.ValidateGoalObjective(text); err != nil {
+        m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: err.Error()})
+        return
+    }
+    now := time.Now().Unix()
+    m.goal = &session.GoalContext{Objective: text, Status: session.GoalStatusActive, CreatedAt: now, UpdatedAt: now}
+    if err := m.persistGoal(); err != nil {
+        m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: "Failed to persist goal: " + err.Error()})
+        return
+    }
+    m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: "Goal set: " + text})
+    m.applyGoalToPrompt()
+}
+```
+
+`transitionGoal`, `clearGoal`, `beginGoalEdit`, `commitGoalEdit` are
+analogous. The *edit* path uses the existing `create_skill.go` overlay
+pattern — captures key events into `m.goalDraft`; Enter commits via
+`setGoalFromInput`; Esc drops the overlay and clears the draft.
+
+## Footer indicator (`internal/tui/status.go`)
+
+```go
+type StatusRenderInput struct {
+    // ...existing fields...
+    GoalIndicator string  // empty when no goal
+}
+
+func (m *model) goalIndicatorText() string {
+    if m.goal == nil { return "" }
+    obj := truncate(m.goal.Objective, 32)
+    switch m.goal.Status {
+    case session.GoalStatusActive:    return "Goal: " + obj
+    case session.GoalStatusPaused:    return "Goal paused: " + obj
+    case session.GoalStatusBlocked:   return "Goal blocked: " + obj
+    case session.GoalStatusComplete:  return "Goal complete: " + obj
+    }
+    return ""
+}
+```
+
+`status.go` renders it via a new `(s Status).renderGoal()` call inside the
+existing inline-rendering loop, placed next to (left of) the token counter.
+Empty input renders nothing.
+
+## Autocomplete + help text
+
+`slashCommands` (input.go:272) gains `"/goal"` and `slashCommandDesc`
+(line 297) gains `case "/goal": return "Set or view the current session goal"`.
+
+`formatHelp` (commands.go:794) gains a new section between `**Git &
+Planning:**` and `**Display:**`:
+
+```
+**Long-running tasks:**
+
+| Command | Description |
+|---------|-------------|
+| `/goal` | Set or view the session goal |
+| `/goal <text>` | Set the goal |
+| `/goal edit` | Edit the current goal |
+| `/goal pause` | Pause pursuing the goal |
+| `/goal resume` | Resume pursuing the goal |
+| `/goal clear` | Clear the goal |
+```
+
+## Resume across `--continue` / `--session`
+
+```go
+// internal/cli/interactive.go:~298 — after instructionParts.String()
+ctx, _ := sessionSvc.GetGoalContext(loadedSessionID)
+if ctx != nil && ctx.Status == session.GoalStatusActive {
+    instruction = agent.AppendActiveGoal(instruction, ctx.Objective)
+}
+```
+
+For the post-resume hint, prepend one assistant message if
+`m.goal != nil && m.goal.Status ∈ {paused, blocked}` after load:
+`"Loaded a previously-set goal in `<status>` state. Type `/goal resume`
+to keep pursuing it."` This uses the same program-prepend route used by
+`/plan resume` (plan.go:200ish).
+
+## Patterns to follow (existing codebase)
+
+- Slash-command dispatch shape — `internal/tui/commands.go:31-104`.
+- Sub-command `strings.ToLower(args[0])` — `internal/tui/plan.go`.
+- `m.cfg.SessionService.UpdatePlanContext(...)` — `plan.go:282`.
+- `agent.AppendActiveSkill` — `internal/agent/agent.go:727`.
+- `m.cfg.Agent.RebuildWithInstruction(full)` — `create_skill.go:69`,
+  `plan.go:245`.
+- `m.chatModel.Messages = append(...)` for assistant messages — used by
+  every existing command.
+
+## Error handling
+
+| Case                                                | Action                                                                                                                                                      |
+|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `validateGoalObjective` fails                       | Error message appended to chat. Model state unchanged.                                                                                                      |
+| `UpdateGoalContext` returns error                   | Goal stays in memory; "Error persisting goal: <err>" appended. Model and prompt not rebuilt. meta.json write is the source of truth for the *next* session. |
+| `RebuildWithInstruction` fails                      | Error appended to chat. Stored goal is intact but prompt does not include it. Next `/goal <text>` retries.                                                  |
+| `m.cfg.SessionService == nil` (e.g. `--memory-off`) | Append "Goal tracking requires the session service." Goal is not stored across sessions; lives only in `m.goal` for this run.                               |
+| `m.cfg.Agent == nil`                                | Skip `applyGoalToPrompt`; goal is persisted but no prompt injection. Footer indicator still renders.                                                        |
+
+## Acceptance Criteria
+
+```
+Given no goal set, when "/goal keep tests green" → chat "Goal set: …",
+    footer "Goal: …", next turn sees "# Current Goal", meta.json correct.
+
+Given goal {status: paused}, when "/goal resume" → chat "Goal resumed",
+    footer "Goal: …", next turn sees "# Current Goal" again.
+
+Given no goal, when "/goal <4100-char>" → chat "…at most 4000 characters
+    (got 4100)", state unchanged.
+
+Given goal {status: active}, when "/goal clear" → chat "Goal cleared.",
+    footer disappears, meta.json GoalContext nil, no "# Current Goal".
+
+Given meta.json with paused goal, when "pi --continue" → chat hint
+    "Loaded … paused state … `/goal resume`", footer "Goal paused: …",
+    no "# Current Goal" in prompt.
+```
+
+## Testing strategy
+
+| Layer        | Location                                    | Coverage                                                                                               |
+|--------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| Schema       | `internal/session/store_test.go`            | `TestGoalContext_RoundTrip` — all four statuses + 4 000-char boundary.                                 |
+| Validation   | `internal/agent/agent_test.go`              | `TestValidateGoalObjective` — empty/4001/4000 cases.                                                   |
+| Injection    | `internal/agent/agent_test.go`              | `TestAppendActiveGoal` — block matches Q8 wording; empty input returns input unchanged.                |
+| Dispatch     | `internal/tui/commands_test.go`             | One test per sub-command: bare, set, edit, pause, resume, clear. Mirrors `TestHandleSlashCommandPlan`. |
+| Edit overlay | `internal/tui/goal_test.go`                 | Pre-fills; Enter commits; Esc cancels.                                                                 |
+| Footer       | `internal/tui/tui_test.go`                  | `goalIndicatorText()` truth table over five inputs (no-goal + four statuses).                          |
+| Resume       | `internal/cli/interactive_test.go` (or new) | `--continue` with paused goal injects the resume hint.                                                 |
+
+## Out of scope (v1)
+
+- `token_budget` / `tokens_used` — codex's accounting machinery; pi-go's
+  token tracker is per-turn.
+- `UsageLimited` / `BudgetLimited` statuses — pi-go has no quota concept yet.
+- `--goal <text>` CLI flag, `pi-go-rpc.SetGoal` — follow-up spec.
+- Composer-button shortcut — pi-go's TUI is a single-line input.
+- Cross-session memory palace persistence — single-session scope.
+- Multi-objective / sub-goals — one objective per session.
+
+These match the `out of scope` block in `requirements.md`.

--- a/specs/features/TOO/018-goal-command/outline.md
+++ b/specs/features/TOO/018-goal-command/outline.md
@@ -1,0 +1,111 @@
+# Outline — `/goal` Slash Command
+
+Vertical slices. Each builds, tests, and is a checkpoint on its own.
+
+## Slice 1 — Session schema + persistence
+
+Add `GoalContext`, `GoalStatus`, `Meta.GoalContext *GoalContext`,
+`UpdateGoalContext`, `GetGoalContext` to `internal/session/store.go`. Round-trip
+test in `store_test.go`. (No TUI, no agent changes.)
+
+## Slice 2 — Agent validation + injection
+
+Add `MaxGoalObjectiveChars`, `ValidateGoalObjective`, `AppendActiveGoal` to
+`internal/agent/agent.go`. Tests for empty / 4 001 / 4 000 cases and for the
+exact wording of the injected block. (No TUI, no session-store wiring.)
+
+## Slice 3 — TUI dispatch + summary card
+
+In `internal/tui/goal.go` (new): `handleGoalCommand(args)` wired from
+`commands.go`. Implement: bare `/goal` (summary), `/goal <text>` (set), `/goal
+pause`, `/goal resume`, `/goal clear`. Persist each via Slice 1. Drop
+validation through Slice 2. Stub `applyGoalToPrompt` so it builds but doesn't
+rebuild yet. Tests in `commands_test.go` per sub-command.
+
+## Slice 4 — Prompt rebuild on edit / pause / resume
+
+Wire `applyGoalToPrompt` to actually call `m.cfg.Agent.RebuildWithInstruction`.
+Add `m.goal *session.GoalContext` and `goalEditing/goalDraft` overlay state.
+Add `/goal edit` using the `create_skill.go` overlay pattern. Tests: prompt
+contains block when active, doesn't when paused.
+
+## Slice 5 — Footer indicator
+
+Add `GoalIndicator string` to `StatusRenderInput`. Implement
+`goalIndicatorText()`. Render in `status.go`. `statusRenderInput` wires it.
+Five-case test in `tui_test.go`.
+
+## Slice 6 — Resume across `--continue` / `--session`
+
+In `internal/cli/interactive.go:~298`, after `instructionParts.String()`,
+call `AppendActiveGoal` when `GetGoalContext` returns a goal with
+`Status=Active`. Prepend the resume-hint message when the loaded goal is
+`Paused` or `Blocked`. Test in `interactive_test.go` (or extend
+`cli_test.go`).
+
+## Slice 7 — Autocomplete + help table
+
+Append `/goal` to `slashCommands` (`input.go:272`). Add case to
+`slashCommandDesc`. Add the `**Long-running tasks:**` section to `formatHelp`
+between `**Git & Planning:**` and `**Display:**`. Test in `input_test.go`.
+
+## Slice 8 — Session-resume rebuild via RebuildWithInstruction
+
+Cover the case where a prompt was rebuilt by `/goal` mid-session and the
+session is later resumed across a process restart. Confirms
+`UpdateGoalContext` survives a `compact` + re-load cycle. Test asserts no
+double-prefix when `Status=Paused`.
+
+## Order of changes
+
+1 → 2 → 3 → 4 → 5 → 6 → 7 → 8. Each slice compiles and tests in isolation.
+Slices 1–3 are forced; 4–8 are follow-ups that depend on 3.
+
+## Key new symbols
+
+```go
+// session/store.go
+type GoalStatus string
+type GoalContext struct { /* … see design */ }
+func (s *FileService) UpdateGoalContext(id string, ctx *GoalContext) error
+func (s *FileService) GetGoalContext(id string) (*GoalContext, error)
+
+// agent/agent.go
+const MaxGoalObjectiveChars = 4_000
+func ValidateGoalObjective(string) error
+func AppendActiveGoal(prompt, objective string) string
+
+// tui/goal.go  (new)
+func (m *model) handleGoalCommand(args []string) (tea.Model, tea.Cmd)
+func (m *model) printGoalSummary()
+func (m *model) setGoalFromInput(text string)
+func (m *model) beginGoalEdit()
+func (m *model) commitGoalEdit()
+func (m *model) transitionGoal(to GoalStatus, notice string)
+func (m *model) clearGoal()
+func (m *model) applyGoalToPrompt()
+func (m *model) persistGoal() error
+func (m *model) goalIndicatorText() string
+func truncate(s string, n int) string
+
+// tui/types.go — extend model
+goal        *session.GoalContext
+goalEditing bool
+goalDraft   []rune
+
+// tui/status.go — extend StatusRenderInput
+GoalIndicator string
+
+// tui/input.go — append "/goal" + desc case
+```
+
+## Gates (per-slice verification)
+
+```bash
+go build ./...
+go vet ./...
+go test ./internal/session/...
+go test ./internal/agent/...
+go test ./internal/tui/...
+go test ./internal/cli/...
+```

--- a/specs/features/TOO/018-goal-command/plan.md
+++ b/specs/features/TOO/018-goal-command/plan.md
@@ -1,0 +1,313 @@
+# Plan — `/goal` Slash Command
+
+Eight vertical slices. Each compiles and tests independently before the
+next begins. Gate commands at the bottom apply at every slice end.
+
+---
+
+## Slice 1 — Session schema + persistence
+
+**Goal:** The session metadata layer can store and retrieve a goal,
+round-tripping through `meta.json`.
+
+Files:
+
+- `internal/session/store.go` — add `GoalStatus` type and constants,
+  `GoalContext` struct, `Meta.GoalContext *GoalContext` field after
+  `PlanContext`, `UpdateGoalContext`, `GetGoalContext` mirroring the
+  `PlanContext` pair (store.go:620, 638) byte-for-byte.
+- `internal/session/store_test.go` — add `TestGoalContext_RoundTrip`:
+  marshal an instance with each of the four statuses, unmarshal, assert
+  equality. Add a 4 000-byte exact-cap case and a 4 001-byte rejection
+  (rejection happens at validation, not here — this is just round-trip).
+- `internal/session/store_test.go` — add `TestGoalContext_NilClear`:
+  `UpdateGoalContext(id, nil)` drops the field on disk, subsequent
+  `GetGoalContext` returns `(nil, nil)`.
+
+Verify:
+
+```bash
+go build ./internal/session/... && go test ./internal/session/...
+```
+
+Dependencies: none. This slice stands alone.
+
+---
+
+## Slice 2 — Agent validation + injection
+
+**Goal:** The agent package owns the 4 000-char validator and the
+`# Current Goal` block builder.
+
+Files:
+
+- `internal/agent/agent.go` — add `MaxGoalObjectiveChars = 4_000`,
+  `ValidateGoalObjective(string) error` (empty + over-cap rejection),
+  `AppendActiveGoal(prompt, objective string) string` returning exactly
+  the Q8 block. Place immediately after `AppendActiveSkill` (line 727).
+- `internal/agent/agent.go` — add a docstring comment on
+  `AppendActiveGoal` noting the byte-vs-rune choice (`len`, not rune count).
+- `internal/agent/agent_test.go` — add `TestValidateGoalObjective`
+  table-driven for empty / 4001 / 4000 cases.
+- `internal/agent/agent_test.go` — add `TestAppendActiveGoal` asserting
+  exact block wording (snapshot-style string equality) and that
+  empty/over-cap inputs return the prompt unchanged.
+
+Verify:
+
+```bash
+go build ./internal/agent/... && go test ./internal/agent/...
+```
+
+Dependencies: none.
+
+---
+
+## Slice 3 — TUI dispatch + summary card
+
+**Goal:** All six sub-commands route through `handleGoalCommand`. State
+persists. Prompt rebuild is stubbed.
+
+Files:
+
+- `internal/tui/commands.go` — add `case "/goal": return m.handleGoalCommand(parts[1:])`
+  between `/run` (line 75) and `/login` (line 77).
+- `internal/tui/goal.go` (new) — define `handleGoalCommand(args)`,
+  `printGoalSummary()`, `setGoalFromInput(text)`,
+  `transitionGoal(to session.GoalStatus, notice string)`,
+  `clearGoal()`, `persistGoal() error`, `truncate(s string, n int) string`.
+  Stub `applyGoalToPrompt()` to a no-op (logged note that it lands in
+  slice 4).
+- `internal/tui/types.go` — extend `model` with `goal *session.GoalContext`,
+  `goalEditing bool`, `goalDraft []rune`. Initialize `goal: nil` in
+  `newM()` and any other constructors (verify with `grep "newM\|&model{"`).
+- `internal/tui/commands_test.go` — add a `TestHandleSlashCommandGoal_*`
+  test per sub-command:
+    - bare on no goal → `No goal is currently set` chat message
+    - bare on active goal → `Goal: <obj>   [/goal edit | /goal pause | /goal clear]` line
+    - `/goal <text>` → `Goal set: <text>` chat message, `m.goal != nil`
+    - `/goal pause` → status flips, footer text shape matches
+    - `/goal resume` → status flips, no-op message when already active
+    - `/goal clear` → `m.goal == nil`
+    - over-cap input (4100 chars) → validation error message, no state change
+
+Verify:
+
+```bash
+go build ./internal/tui/... && go test -run TestHandleSlashCommandGoal ./internal/tui/...
+```
+
+Dependencies: Slices 1, 2 (calls `ValidateGoalObjective`, calls
+`UpdateGoalContext`).
+
+---
+
+## Slice 4 — Prompt rebuild on edit / pause / resume
+
+**Goal:** A status change re-applies the `# Current Goal` block to the
+agent prompt; `/goal edit` has an editor.
+
+Files:
+
+- `internal/tui/goal.go` — implement `applyGoalToPrompt()` per design
+  §"Injection points"`. Call from `transitionGoal`, `setGoalFromInput`,
+  `commitGoalEdit`. Skip when `m.goal == nil` or `Status != Active`.
+- `internal/tui/goal.go` — implement `beginGoalEdit` and
+  `commitGoalEdit`. Pre-fill `m.goalDraft` from current objective when
+  entering; on Enter commit, on Esc drop. Reuse the overlay pattern from
+  `internal/tui/create_skill.go:50-90` (no new package).
+- `internal/tui/goal_test.go` (new) — `TestGoalEdit_Overlay_*`:
+    - entering edit pre-fills the draft from current objective
+    - Enter replaces goal and rebuilds prompt
+    - Esc drops overlay and leaves goal unchanged
+- `internal/tui/commands_test.go` — extend `TestHandleSlashCommandGoal`
+  to assert `RebuildWithInstruction` was called when state changed from
+  Paused to Active (mock the agent if necessary; if the test harness
+  already constructs an `Agent`, capture its last instruction).
+
+Verify:
+
+```bash
+go build ./internal/tui/... && go test ./internal/tui/...
+```
+
+Dependencies: Slice 3.
+
+---
+
+## Slice 5 — Footer indicator
+
+**Goal:** The status bar shows a one-line goal indicator.
+
+Files:
+
+- `internal/tui/status.go` — extend `StatusRenderInput` with
+  `GoalIndicator string`. Hook into the existing render loop so that
+  when `GoalIndicator != ""` it renders, else nothing. Match the
+  placement rules of the existing token counter (right-aligned side of
+  the bar; left of token usage).
+- `internal/tui/tui.go` — extend `statusRenderInput()` (line 1836) to
+  populate `GoalIndicator: m.goalIndicatorText()`.
+- `internal/tui/tui_test.go` — `TestGoalIndicatorText` table-driven
+  over five inputs: `nil` goal, Active, Paused, Blocked, Complete.
+  Assert exact strings.
+
+Verify:
+
+```bash
+go build ./internal/tui/... && go test -run TestGoalIndicatorText ./internal/tui/...
+```
+
+Dependencies: Slice 3 (model field), Slice 4 (`applyGoalToPrompt` not
+strictly required, but a coherent story).
+
+---
+
+## Slice 6 — Resume across `--continue` / `--session`
+
+**Goal:** A loaded session rehydrates the goal into the prompt and a
+one-line hint when the loaded goal is Paused/Blocked.
+
+Files:
+
+- `internal/cli/interactive.go` — after `instruction = instructionParts.String()`
+  (line 297), look up `sessionSvc.GetGoalContext(loadedSessionID)`. If
+  non-nil and `Status == Active`, call `AppendActiveGoal` on `instruction`.
+- `internal/cli/interactive.go` — find the model-construction site
+  (search for `&model{` / `tea.NewProgram`). If a goal is loaded with
+  `Status ∈ {Paused, Blocked}`, set `m.goal` and prepend one assistant
+  message: `Loaded a previously-set goal in '<status>' state. Type
+  '/goal resume' to keep pursuing it.`
+- `internal/cli/cli_test.go` or new `interactive_test.go` — add
+  `TestResumeGoal_HintShown`:
+    - Given `meta.json` with a paused goal,
+    - When `InteractiveCLI(loadedSessionID)` is built,
+    - Then the model's chat messages start with the resume hint and the
+      model field `goal` is non-nil.
+- Same file — add `TestResumeGoal_ActiveInjected`:
+    - Given `meta.json` with an active goal,
+    - When the instruction is assembled,
+    - Then `strings.Contains(instruction, "# Current Goal")` is true.
+
+Verify:
+
+```bash
+go build ./internal/cli/... && go test -run TestResumeGoal ./internal/cli/...
+```
+
+Dependencies: Slices 1, 2, 3.
+
+---
+
+## Slice 7 — Autocomplete + help table
+
+**Goal:** `/goal` is in autocomplete and `/help`.
+
+Files:
+
+- `internal/tui/input.go` — append `"/goal"` to `slashCommands` (line 272-295).
+  Add `case "/goal": return "Set or view the current session goal"`
+  to `slashCommandDesc` (line 297-351).
+- `internal/tui/commands.go` — extend `formatHelp()` (line 794-820) with
+  the `**Long-running tasks:**` section between `**Git & Planning:**`
+  and `**Display:**` per design.
+- `internal/tui/input_test.go` (if exists) or `commands_test.go` — add
+  `TestSlashCommands_IncludesGoal` asserting `"/goal"` is in the list.
+  Add `TestFormatHelp_GoalSection` asserting the new section appears in
+  the rendered help output.
+
+Verify:
+
+```bash
+go test -run "TestSlashCommands|TestFormatHelp" ./internal/tui/...
+```
+
+Dependencies: Slice 3 (handler exists).
+
+---
+
+## Slice 8 — Session-resume rebuild across compact/reload
+
+**Goal:** A `compact` mid-session followed by `--continue` lands the
+prompt in the right state. Catches double-prefix / stale-cache bugs.
+
+Files:
+
+- `internal/session/store_test.go` — add `TestGoalContext_AfterCompactReload`:
+    - Create session, `UpdateGoalContext(id, &GoalContext{…, Status: Paused, …})`,
+    - `Compact`, close, reopen,
+    - Assert `GetGoalContext` returns the same `Status: Paused` value.
+    - Assert `instruction = AppendActiveGoal(base, "")` returns `base` unchanged
+      on the empty objective path (no leaked block).
+- `internal/session/store_test.go` — add `TestGoalContext_SurvivesUpdateTwice`:
+    - Set Active, update to Paused, reload, flip to Active again, reload.
+    - No fields are dropped; `UpdatedAt` advances each time.
+
+Verify:
+
+```bash
+go test -run "TestGoalContext_AfterCompactReload|TestGoalContext_SurvivesUpdateTwice" ./internal/session/...
+```
+
+Dependencies: Slice 1.
+
+---
+
+## Order of execution
+
+1. Slice 1 — schema + persistence
+2. Slice 2 — agent validation + injection
+3. Slice 3 — TUI dispatch + summary card
+4. Slice 4 — prompt rebuild + edit overlay
+5. Slice 5 — footer indicator
+6. Slice 6 — `--continue` / `--session` rehydration
+7. Slice 7 — autocomplete + help table
+8. Slice 8 — compact/reload resilience
+
+Slices 1 and 2 are independent. Slice 3 depends on both. Slices 4–8
+depend on Slice 3.
+
+## Gates (run after every slice)
+
+```bash
+# Always
+go build ./...
+go vet ./...
+
+# Touched-by-slice subset (faster feedback than full test)
+go test ./internal/session/...
+go test ./internal/agent/...
+go test ./internal/tui/...
+go test ./internal/cli/...
+```
+
+Full test (run after plan completion, optional per-slice):
+
+```bash
+go test ./...
+```
+
+No race detector is enforced by CI today, but the work must remain safe
+under:
+
+```bash
+go test -race ./internal/tui/... ./internal/session/... ./internal/agent/... ./internal/cli/...
+```
+
+(no new goroutines, no shared mutable state across the slash-command
+paths).
+
+## Constraints
+
+- No new module dependency, no `go.mod` change.
+- `len(byte)` based cap on objective length (not rune count).
+- One objective per session, full stop.
+- `/goal <text>` overwrites any existing goal silently (Q4).
+- Footer indicator slot: same placement as token usage, model name (Q5).
+- Interactive TUI mode only — `print`/`json`/`rpc` honor the loaded goal
+  but expose no `/goal` command (Q6).
+- Status enum: `Active | Paused | Blocked | Complete` (no
+  `UsageLimited` / `BudgetLimited` in v1 — defer to token-budget spec).
+- 4 000-byte cap (Q3).
+- Q8 wording for the prompt block.
+- Q7 wording for the summary card per status.

--- a/specs/features/TOO/018-goal-command/requirements.md
+++ b/specs/features/TOO/018-goal-command/requirements.md
@@ -1,0 +1,141 @@
+# Requirements — `/goal` Slash Command
+
+## Task Scope
+
+Add a `/goal` slash command to pi-go's TUI, modeled on Codex CLI's `/goal`,
+that lets the user set, view, edit, pause, resume, and clear a **persistent
+per-session objective** the agent pursues across turns. The objective is
+persisted in `session.Meta` (parallel to `PlanContext`), surfaced in the
+status footer (e.g. `Goal: keep tests green`), injected into the agent
+system prompt (parallel to `# Active Skill`), and survives `--continue` /
+`--session` resume.
+
+Non-goals (deliberately cut from v1; see
+`research/codex-goal-reference.md` for what codex does, deferred):
+
+- Token-budget tracking (`token_budget`, `tokens_used`) — pi-go's token
+  tracker is per-turn, not per-thread goal; matching codex would require
+  plumbing the entire `SessionService` through the goal API. Tracked as a
+  follow-up spec.
+- `UsageLimited` and `BudgetLimited` statuses — folded away in v1; the
+  only statuses are `Active | Paused | Blocked | Complete`.
+- Composer-button shortcut — pi-go's TUI is a single-line `inputModel`;
+  the slash command is the only entry point.
+- Cross-session memory palace persistence. Goals are per-thread.
+- Multi-objective / sub-goals. One objective per session.
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] `/goal` with no args: prints the summary card if a goal exists,
+  otherwise prints the usage line and a hint ("No goal is currently set").
+- [ ] `/goal <objective text>`: creates a goal with `Status=Active`; if a
+  goal already exists (any status), replaces it silently and appends
+  a chat-log entry `Goal set: <new objective>`. No confirmation step.
+- [ ] `/goal edit`: opens the editor over the current objective (text-area
+  pre-filled with current text); on commit, replaces the objective and
+  sets `UpdatedAt`.
+- [ ] `/goal pause`: sets `Status=Paused`. Bare `/goal` shows the
+  `Commands: /goal resume, /goal edit, /goal clear` footer.
+- [ ] `/goal resume`: sets `Status=Active` if currently `Paused`, or
+  `Blocked`. No-op if already `Active`.
+- [ ] `/goal clear`: deletes the goal (NULL the `*GoalContext` slot);
+  restores the no-indicator state.
+- [ ] When `Status=Active`, the agent's system prompt includes a
+  `# Current Goal` block with the objective text. The objective is
+  capped at 4 000 characters (Q3).
+- [ ] When `Status != Active`, no `# Current Goal` block is injected.
+- [ ] `--continue` and `--session <id>` rehydrate the goal from disk;
+  if the loaded goal is `Paused` or `Blocked`, a one-line info message in
+  the chat suggests `/goal resume`.
+
+### Non-functional
+
+- [ ] No new module dependency, no `go.mod` change.
+- [ ] Goal serializes cleanly through `session.Meta` JSON round-trip
+  (`UpdateGoalContext` / `GetGoalContext` mirror `PlanContext`).
+- [ ] The TUI status footer reads `Goal: <truncated>` when `Status=Active`,
+  `Goal paused` when `Paused`, `Goal blocked` when `Blocked`,
+  `Goal complete` (dim) when `Complete`, and nothing when no goal set.
+- [ ] No goroutines, no shared mutable state across the slash-command paths
+  (passes `go test -race`).
+- [ ] Each sub-command has a unit test in
+  `internal/tui/commands_test.go`; the round-trip test in
+  `internal/session/store_test.go` covers `*GoalContext` JSON
+  serialization.
+
+### Commands / Help / Autocomplete
+
+- [ ] `/goal` is in the `slashCommands` autocomplete list
+  (`internal/tui/input.go`).
+- [ ] `slashCommandDesc("/goal")` returns "Set or view the current session
+  goal".
+- [ ] `formatHelp()` lists `/goal` under a new **Long-running tasks**
+  group, sibling to `/plan` and `/run`.
+
+## Questions & Answers
+
+**Q1 — What does "goal-command" actually mean here?**
+A: Full Codex-style `/goal` slash command — persistent per-session
+objective with set / view / edit / pause / resume / clear sub-commands,
+persisted in `session.Meta`, surfaced in the footer.
+
+**Q2 — Where in the system prompt is the objective injected?**
+A: Appended *after* `Base + Rules + Skills` (parallel to how `# Active
+Skill` is appended via `AppendActiveSkill` in `agent.go:758`).
+Implemented by a sibling `AppendActiveGoal(prompt, objective) string`
+called once at session start if a goal is loaded with `Status=Active`.
+Re-applied on `/goal edit`, `/goal pause → /goal resume` only if the
+prompt assembly is rebuilt for that turn. The agent prompt's pre-existing
+"keep working context focused: … restate the current goal" line is left
+untouched as a general principle.
+
+**Q3 — Validation/size cap on the objective text?**
+A: **4 000 characters**, matching codex's
+`MAX_THREAD_GOAL_OBJECTIVE_CHARS`. Empty string is rejected. The check
+lives next to `AppendActiveGoal` so callers cannot bypass it.
+
+**Q4 — When `/goal <text>` is invoked and an active goal already exists?**
+A: Always replace silently. No confirmation step. The next bare `/goal`
+shows the new objective. The TUI message log records the change as
+`Goal set: <new objective>`.
+
+**Q5 — Where does the goal indicator live in the TUI layout?**
+A: Footer line only, alongside the model name and token usage (same
+placement codex uses for "Pursuing goal"). Single-line `inputModel`
+composer means there is no in-composer button; the slash command is
+the only entry point.
+
+**Q6 — Which modes support `/goal`?**
+A: Interactive TUI only. `print`, `json`, and `rpc` modes load the goal
+from the session if present and inject it into the system prompt, but
+provide no `/goal` interface. CLI/RPC parity (e.g. `pi --goal <text>`,
+`pi-go-rpc.SetGoal`) is a follow-up spec.
+
+**Q7 — What does the bare `/goal` summary card show per status?**
+A: One-line summary card with objective + status-aware action hint:
+
+- `Active`:    `Goal: <objective>   [/goal edit | /goal pause | /goal clear]`
+- `Paused`:    `Goal paused: <objective>   [/goal resume | /goal edit | /goal clear]`
+- `Blocked`:   `Goal blocked: <objective>   [/goal resume | /goal edit | /goal clear]`
+- `Complete`:  dim `Goal complete: <objective>   [/goal clear]`
+- none:        `No goal set.   /goal <objective> to set.`
+
+**Q8 — How is the goal worded in the system prompt?**
+A: A full block (matching codex's tone) appended after `Base + Rules +
+Skills`:
+
+```
+# Current Goal
+
+The user's active session goal is:
+
+> <objective text>
+
+Stay focused on this objective across turns. If it is no longer the user's
+intent, surface that and suggest /goal edit before pursuing other work.
+```
+
+Only present when `Status=Active`. `Paused` / `Blocked` / `Complete`
+goals inject nothing.

--- a/specs/features/TOO/018-goal-command/research/codex-goal-reference.md
+++ b/specs/features/TOO/018-goal-command/research/codex-goal-reference.md
@@ -1,0 +1,166 @@
+# Research — Codex `/goal` Reference
+
+Codex (OpenAI's CLI coding agent) ships a fully realized `/goal` concept. The
+repository keeps a snapshot at `tmp/codex/codex-rs/`. This file compresses the
+shape so the implementer does not need to read codex source.
+
+## 1. Slash command definition
+
+`tmp/codex/codex-rs/tui/src/slash_command.rs:122`:
+
+```
+SlashCommand::Goal => "set or view the goal for a long-running task",
+```
+
+The same file lists `Goal` immediately after `Plan` in the enum.
+
+`supports_inline_args` returns true for `Goal` — `/goal foo bar baz` parses
+the trailing text as a possible objective. Sub-control commands take
+precedence over the positional objective argument.
+
+`available_during_task` returns true for `Goal` — usable while an agent turn
+runs.
+
+## 2. Usage string
+
+`tmp/codex/codex-rs/tui/src/goal_display.rs:7`:
+
+```rust
+pub(crate) const GOAL_USAGE: &str =
+    "Usage: /goal [<objective>|clear|edit|pause|resume]";
+```
+
+Bare `/goal` (no args) when no goal is set → shows this string with hint
+`"No goal is currently set."`. When a goal exists → opens a summary card
+(see §5).
+
+## 3. Sub-command dispatch
+
+From `tmp/codex/codex-rs/tui/src/app/thread_goal_actions.rs`:
+
+| Sub-command    | Side effect                                                 |
+|----------------|-------------------------------------------------------------|
+| `/goal <text>` | Set objective (create or replace; confirm prompt if active) |
+| `/goal edit`   | Open editor over the current objective                      |
+| `/goal pause`  | Status → Paused (system prompt hides the objective)         |
+| `/goal resume` | Status → Active                                             |
+| `/goal clear`  | Drop the goal entry (no confirmation)                       |
+
+When `/goal <text>` is invoked with `mode == ConfirmIfExists` and an existing
+goal status is `Paused | Blocked | Complete`, the UI shows a confirmation
+prompt before replacing ("Replace the current goal with the new one?").
+
+## 4. Status enum
+
+`tmp/codex/codex-rs/protocol/src/protocol.rs:4067`:
+
+```rust
+pub enum ThreadGoalStatus {
+    Active,
+    Paused,
+    Blocked,
+    UsageLimited,    // pi-go v1: drop
+    BudgetLimited,   // pi-go v1: drop (folded with token budget)
+    Complete,
+}
+```
+
+pi-go v1 keeps: `Active | Paused | Blocked | Complete`.
+
+`Blocked` is set by codex when the agent decides the goal is unattainable in
+its current form (e.g. external dep missing). pi-go does not auto-derive this;
+the user marks it manually.
+
+## 5. Summary card render (bare `/goal` when goal exists)
+
+```
+Goal
+Status: active
+Objective: Keep improving the bare goal command until it feels calm and useful.
+Time used: 1m
+Tokens used: 12.5K
+Token budget: 80K
+
+Commands: /goal edit, /goal pause, /goal clear
+```
+
+Snapshot source:
+`tmp/codex/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__goal_menu_active.snap`.
+
+## 6. Footer status indicator
+
+`tmp/codex/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_line_goal_active_token_budget_footer.snap`:
+
+```
+gpt-5.4                                            Pursuing goal (40K / 50K)
+```
+
+pi-go v1 simplifies to: when `status == Active`, the footer shows
+`Goal: <truncated objective>` (32 chars, ellipsis). When `Paused` shows
+`Goal paused`. When `Blocked` shows `Goal blocked`. When `Complete` shows
+`Goal complete` (dim). When no goal set → no indicator.
+
+## 7. Time and token display
+
+`format_goal_elapsed_seconds` (same file, lines 9-33):
+
+```
+0s            < 60s
+59s           < 1 minute
+1m            exact
+30m
+1h 30m
+2h
+1d 0h 0m      exactly 24h
+2d 23h 42m
+```
+
+Compact token format from `format_tokens_compact`:
+`63.9K / 50K` style.
+
+## 8. Validation
+
+`validate_thread_goal_objective` (`protocol.rs:4083`):
+
+- Must not be empty.
+- Must not exceed `MAX_THREAD_GOAL_OBJECTIVE_CHARS` = 4 000.
+
+## 9. SQL storage (excluded from pi-go port)
+
+codex persists in `thread_goals` (`state/migrations/0029_thread_goals.sql`) with
+columns:
+
+- `goal_id TEXT PRIMARY KEY`
+- `thread_id TEXT NOT NULL`
+- `objective TEXT NOT NULL`
+- `status TEXT NOT NULL`
+- `token_budget INTEGER` (nullable)
+- `tokens_used INTEGER NOT NULL DEFAULT 0`
+- `time_used_seconds INTEGER NOT NULL DEFAULT 0`
+- `created_at INTEGER NOT NULL`
+- `updated_at INTEGER NOT NULL`
+
+Indexed on `thread_id` and `updated_at`.
+
+pi-go's storage is JSONL via `internal/session/store.go`. A `*GoalContext` in
+`Meta` parallels `*PlanContext` (same file:27-33).
+
+## 10. After-resume hook
+
+`maybe_prompt_resume_paused_goal_after_resume` (`thread_goal_actions.rs:64-93`):
+after a session is resumed from disk, if the goal status is
+`Paused | Blocked | UsageLimited`, the TUI prompts the user to resume it.
+pi-go equivalent: when `--continue` or `--session` loads a session with a
+paused goal, a one-line status notice appears (no modal) suggesting
+`/goal resume`.
+
+## 11. Files in codex that the pi-go port does not need to mirror
+
+- `goal_files.rs` — codex materializes objectives to a temp dir, lets the agent
+  read them via a filesystem entry. pi-go passes the objective through the
+  system prompt directly.
+- `ThreadGoalSetMode` — codex is a stateful app server protocol; pi-go is a
+  CLI, so the mode/replace distinction collapses into a simpler TUI-side
+  prompt.
+- The `guardian_goal_continuation_drops_stale_reviews` snapshot is codex's
+  auto-review machinery — irrelevant in pi-go.

--- a/specs/features/TOO/018-goal-command/research/pi-go-integration-points.md
+++ b/specs/features/TOO/018-goal-command/research/pi-go-integration-points.md
@@ -1,0 +1,151 @@
+# Research — pi-go Integration Points for `/goal`
+
+## Existing mechanisms to imitate (NOT invent)
+
+### 1. Slash-command dispatch layer
+
+`internal/tui/commands.go:31-104` — the `handleSlashCommand` switch is the only
+place to register a new command. Pattern from `/plan`:
+
+```go
+case "/plan":
+    return m.handlePlanCommand(parts[1:])
+```
+
+For `/goal`, every sub-command is processed in one entry point because the
+arg-less variants share the "show summary" code path:
+
+```go
+case "/goal":
+    return m.handleGoalCommand(parts[1:])
+```
+
+### 2. Autocomplete list and help table
+
+`internal/tui/input.go:272-295` — `slashCommands` slice.
+`internal/tui/input.go:297-351` — `slashCommandDesc` lookup table.
+`internal/tui/commands.go:794-820` — `formatHelp` table (group: "**Git & Planning:**").
+
+### 3. The plan command itself — closest existing analogue
+
+`internal/tui/plan.go` contains the entire `handlePlanCommand` implementation
+and is the file we pattern after for stateful TUI side-effects.
+
+Key patterns from `plan.go`:
+
+- Multi-step command (resume / arg-less / subarg) — uses `strings.ToLower(subcmd)`.
+- Writing to session state via `m.cfg.SessionService.UpdatePlanContext(...)`
+  (`plan.go:282`).
+- Sending an info message back to chat: appending to `m.chatModel.Messages`
+  with `role: "assistant"`.
+
+### 4. Session metadata schema
+
+`internal/session/store.go:27-33`:
+
+```go
+type PlanContext struct {
+    TaskName   string `json:"taskName,omitempty"`
+    RoughIdea  string `json:"roughIdea,omitempty"`
+    Phase      string `json:"phase,omitempty"`
+}
+```
+
+And `Meta` (lines ~50-60) embeds `*PlanContext` with the JSON tag
+`"planContext,omitempty"`.
+
+For `/goal`, mirror with:
+
+```go
+type GoalContext struct {
+    Objective      string `json:"objective,omitempty"`
+    Status         string `json:"status,omitempty"`            // active | paused | blocked | complete
+    CreatedAt      int64  `json:"createdAt,omitempty"`         // unix seconds
+    UpdatedAt      int64  `json:"updatedAt,omitempty"`
+    TimeUsedSeconds int64 `json:"timeUsedSeconds,omitempty"`    // for v1 display
+}
+```
+
+`UpdatePlanContext` / `GetPlanContext` (store.go:~620-650) provide the read/write
+API to copy.
+
+### 5. System-prompt injection
+
+`internal/agent/agent.go:687-695` shows `LoadInstructionParts(base)` returns
+`{Base, Rules, Skills}`. `agent.go:758-765` shows `AppendActiveSkill(prompt,
+skill, body)` as the precedent for "append a context block for one turn".
+
+For `/goal`, add a thin `AppendActiveGoal(prompt, objective string) string` next
+to `AppendActiveSkill`. Call it from `interactive.go:289-300` (the runRoot /
+interactive build path) after `LoadInstructionParts(agent.SystemInstruction)`
+when `m.cfg.SessionService` has an active goal.
+
+### 6. Status / footer
+
+The status bar lives in `m.statusModel` (status.go / tui.go:1670-1700). The
+goal indicator slots into the same line as the model name and the token
+usage counter. The simplest extension is to give `statusRenderInput` an extra
+field on the `model` struct — `goalIndicator string` — populated by a new
+`buildGoalIndicator()` function called once per render tick from the
+existing render-input builder.
+
+The exact existing function to extend during design is found via:
+
+```
+grep -n "statusRenderInput\|statusModel" internal/tui/*.go
+```
+
+### 7. Tests
+
+Pattern from `internal/tui/commands_test.go` (TestHandleSlashCommandHelp,
+TestHandleSlashCommandClear, TestHandleSlashCommandModel — lines 37-220). Each
+test constructs a `model`, calls `m.handleSlashCommand("/foo <args>")`, and
+asserts on the resulting messages / cmds. The `/goal` tests follow this shape.
+
+`internal/tui/teatest_test.go:1132-1187` is the secondary e2e harness
+(`handleSlashCommand("/session")`, `/branch`, `/compact`, `/nonexistent`). A
+matching `handleSlashCommand("/goal <variants>")` block sits in the same file.
+
+## Things this work will touch but should NOT redesign
+
+- `session.Meta` JSON keys: add `goalContext,omitempty`; do not change
+  `planContext` or any other key.
+- The agent system prompt lives at `internal/agent/agent.go:46`. Do not edit
+  it as part of this spec — prompt injection goes through `AppendActiveGoal`
+  in `agent.go` next to `AppendActiveSkill` (line 758), preserving the
+  assembly rule "Base + Rules + Skills" set by `InstructionParts.String()`
+  (line 677).
+- The CLI's `runRoot` and `runPrint` paths: add wiring via the same
+  `setupSessionService` already used by `/plan`, do not introduce a new
+  constructor.
+
+## Confirmed non-goals
+
+- No new persistence layer (no SQLite). JSONL via `session.Meta` is enough.
+- No new dependency in `go.mod`.
+- No changes to the memory palace.
+- No MCP-server integration of `/goal`.
+- No changes to the `/run` task agent.
+
+## Build / test commands discovered
+
+Gates that the slice verification must pass at the end of every implemented
+slice:
+
+```bash
+go build ./...                # compiles
+go vet ./...                  # static checks
+go test ./internal/tui/...    # unit + commands_test + teatest_test
+go test ./internal/session/... # store round-trip
+go test ./internal/agent/...  # AppendActiveGoal surfaces objective
+```
+
+Full repo test (run after plan completion, optional per-slice):
+
+```bash
+go test ./...
+```
+
+No race detector is enforced today, but the work must be safe under
+`go test -race ./internal/tui/... ./internal/session/...` (no new
+goroutines, no shared mutation).

--- a/specs/features/TOO/018-goal-command/rough-idea.md
+++ b/specs/features/TOO/018-goal-command/rough-idea.md
@@ -1,0 +1,79 @@
+# Rough Idea — `/goal` Slash Command
+
+## One-line
+
+Add a `/goal` slash command to pi-go's TUI for setting, viewing, editing, pausing,
+resuming, and clearing a **persistent per-session objective** that the agent pursues
+across turns — modeled on Codex CLI's `/goal` (see `tmp/codex/codex-rs/`).
+
+## Why now
+
+- pi-go already has `/plan` (planning) and `/run` (execution of a spec) but no
+  concept of a long-lived per-session objective. Users hitting `/plan` repeatedly
+  on related turns have no machine-readable way to say "stay on this".
+- The existing `session.Meta` carries an `AGENTS.md`-style `Rules` block, but no
+  per-session state owned by the user.
+- Codex (the closest sibling tool) shipped this end-to-end and explicitly tracks the
+  concept in `ThreadGoal { objective, status, token_budget, tokens_used,
+  time_used_seconds }` plus a SQL table. pi-go can port the shape without copying
+  the implementation; the store is local JSONL, not SQLite.
+
+## What Codex's `/goal` looks like (reference)
+
+`/goal` (bare) → opens a summary card:
+
+```
+Goal
+Status: active
+Objective: Keep improving the bare goal command until it feels calm and useful.
+Time used: 1m
+Tokens used: 12.5K
+Token budget: 80K
+
+Commands: /goal edit, /goal pause, /goal clear
+```
+
+Status footer when active with budget:
+
+```
+gpt-5.4                                            Pursuing goal (40K / 50K)
+```
+
+Statuses (from `tmp/codex/codex-rs/protocol/src/protocol.rs:4067`):
+`Active | Paused | Blocked | UsageLimited | BudgetLimited | Complete`
+
+Usage line (from `tmp/codex/codex-rs/tui/src/goal_display.rs:7`):
+`Usage: /goal [<objective>|clear|edit|pause|resume]`
+
+Objective validated to ≤ 4 000 chars (from `MAX_THREAD_GOAL_OBJECTIVE_CHARS`).
+
+## Out of scope for v1 (deliberate cuts)
+
+- **Token budget tracking** — drop the `token_budget` / `tokens_used` fields for v1.
+  pi-go's token tracker is per-turn, not goal-scoped; matching codex's accounting
+  would require plumbing the entire `SessionService` through the goal API. Tracked
+  as a follow-up spec.
+- **Goal-button keyboard shortcut** — codex has a button in its composer to open
+  the goal menu. pi-go's TUI is a single-line `inputModel`, so the slash command
+  is the only entry point; a button is not meaningful here.
+- **Cross-session memory palace persistence** — out of scope. Goals are per-thread
+  (per-session-id), not cross-session.
+- **Multi-objective / sub-goals** — one objective per session, full stop.
+
+## Status enum for pi-go v1
+
+Drop `UsageLimited` (no quota concept in pi-go yet). Keep:
+`Active | Paused | Blocked | Complete`.
+
+`BudgetLimited` is folded into the deferred token-budget feature.
+
+## Open questions for requirements
+
+- Persistence: confirm we extend `session.Meta` with a new `*GoalContext` field
+  alongside the existing `*PlanContext`.
+- Inject objective into system prompt: prepend a `# Current Goal` block to the
+  assembled instruction, the same way `# Active Skill` is appended.
+- Resume across `--continue` and `--session`: goal must round-trip through the
+  session store, not just live in TUI memory.
+- Tests: each subcommand has its own table-driven test in
+  `internal/tui/commands_test.go` (matches the `/plan`, `/skills` pattern).

--- a/specs/features/TOO/018-goal-command/summary.md
+++ b/specs/features/TOO/018-goal-command/summary.md
@@ -1,0 +1,59 @@
+# Summary — `/goal` Slash Command Spec
+
+## Outcome
+
+Spec authored for `/goal` slash command — a port of Codex CLI's
+`/goal` concept into pi-go's interactive TUI. All seven planning
+artifacts produced; no code written. Ready for an executor agent
+running `PROMPT.md`.
+
+## Artifacts
+
+| Phase           | File                                   | Lines | Status                        |
+|-----------------|----------------------------------------|-------|-------------------------------|
+| 1. Idea         | `rough-idea.md`                        | 50    | Rewritten with codex context  |
+| 2. Requirements | `requirements.md`                      | 142   | 8 Q&A, full AC                |
+| 3a. Research    | `research/codex-goal-reference.md`     | 117   | Compression of codex source   |
+| 3b. Research    | `research/pi-go-integration-points.md` | 134   | Where it lands in pi-go       |
+| 4. Design       | `design.md`                            | 393   | Architecture, schema, wire-up |
+| 5. Outline      | `outline.md`                           | 79    | 8-slice index                 |
+| 6. Plan         | `plan.md`                              | 294   | Per-slice files + verify      |
+| 7. Prompt       | `PROMPT.md`                            | 184   | Executable briefing           |
+
+## Resolved decisions
+
+1. **Shape** — Full Codex port: set / view / edit / pause / resume / clear.
+2. **Prompt injection** — Appended after `Base + Rules + Skills`, parallel to `# Active Skill`.
+3. **Cap** — 4 000 bytes (matches codex's `MAX_THREAD_GOAL_OBJECTIVE_CHARS`).
+4. **Replace on set** — Always silently overwrite any existing goal.
+5. **Footer placement** — Same line as model + token usage (single-line input).
+6. **Modes** — Interactive TUI only. `print` / `json` / `rpc` load the goal but expose no command.
+7. **Status surface** — One-line summary card with status-aware action hint (Q7 specific text in design).
+8. **Block wording** — Full `# Current Goal` block with "stay focused + suggest /goal edit" guidance.
+
+## Non-goals (deferred)
+
+- Token-budget tracking (`token_budget`, `tokens_used`) — out of v1.
+- `UsageLimited` / `BudgetLimited` statuses — folded away in v1.
+- `--goal <text>` CLI flag, `pi-go-rpc.SetGoal` — follow-up spec.
+- Composer-button shortcut — N/A in single-line TUI.
+- Cross-session memory palace persistence — single-session scope.
+- Multi-objective / sub-goals — one objective per session.
+
+## Risks noted in design
+
+- The `default:` branch in `handleGoalCommand` swallows the first
+  argument so `/goal keep tests green` parses as a single objective.
+  Tested explicitly.
+- `applyGoalToPrompt` calls `RebuildWithInstruction` which is also used
+  by skill activation; ensure both call-sites coexist.
+- `session.Meta.GoalContext` adds a JSON field; existing sessions
+  without it must continue to work.
+- `/goal clear` and a fresh load both yield `nil`; both must round-trip
+  identically.
+
+## Next action
+
+`PROMPT.md` is the briefing for an executor agent. It enumerates the
+eight slices with their verification commands and gates. Pass it to a
+fresh agent along with the `design.md` reference.

--- a/specs/memory/001-session-memory/requirements.md
+++ b/specs/memory/001-session-memory/requirements.md
@@ -1,0 +1,50 @@
+# Requirements: PiGoMemoryService
+
+## Background
+
+Reference: https://adk.dev/sessions/memory/ — Google's ADK defines a
+`memory.Service` interface that ingests sessions into long-term, searchable
+memory and exposes them via `SearchMemory` for use across user-scoped
+sessions. ADK ships an `InMemoryService` reference implementation; this spec
+defines a production-grade, persistent **`PiGoMemoryService`** that conforms
+to the same `google.golang.org/adk/v2/memory.Service` interface.
+
+## Interface (from ADK — non-negotiable contract)
+
+```go
+// google.golang.org/adk/v2/memory.Service
+type Service interface {
+    AddSessionToMemory(ctx context.Context, s session.Session) error
+    SearchMemory(ctx context.Context, req *SearchRequest) (*SearchResponse, error)
+}
+
+type SearchRequest  struct { Query, UserID, AppName string }
+type SearchResponse struct { Memories []Entry }
+type Entry struct {
+    ID             string
+    Content        *genai.Content
+    Author         string
+    Timestamp      time.Time
+    CustomMetadata map[string]any
+}
+```
+
+## Questions & Answers
+
+### Q1 — Scope confirmation
+
+**Q:** Is the goal to implement `PiGoMemoryService` — a persistent
+implementation of `google.golang.org/adk/v2/memory.Service` — backed by
+pi-go's existing `internal/memory` SQLite store (not the ADK-shipped
+`InMemoryService`)? Ingest events from `session.Session`, make them
+searchable by `(AppName, UserID, query)`, and wire it into `agent.Config`?
+**A:** Yes — same idea as the ADK `InMemoryService` but a `PiGoMemoryService`
+backed by the pi-go memory SQLite store (or a new sub-store inside it),
+wirable via `agent.New(...)` and used across sessions.
+
+### Q2 — Storage strategy
+
+**Q:** Reuse existing `internal/memory` palace store, add a new sub-store,
+wrap palace as backing, or something else?
+**A:** d) Other (TBD — needs more discussion).
+

--- a/specs/memory/001-session-memory/rough-idea.md
+++ b/specs/memory/001-session-memory/rough-idea.md
@@ -1,0 +1,3 @@
+# Rough Idea
+
+session-memory

--- a/specs/memory/002-temporal-knowledge-session-memory-prd-temporal/requirements.md
+++ b/specs/memory/002-temporal-knowledge-session-memory-prd-temporal/requirements.md
@@ -1,0 +1,35 @@
+# Requirements
+
+## Questions & Answers
+
+### Q1 — Target scope
+
+**Q:** What is the target scope for this implementation?
+*Options: (a) Go library within pi-go, (b) Full runtime integration, (c) Standalone service, (d) Library + minimal reference agent.*
+
+**A:** (a) Go library within pi-go.
+
+**Implication:** The deliverable is a package (likely in `internal/memory/` or a new sibling package) that any pi-go agent or CLI can import. No HTTP server, no external service. Storage local. Extraction/embedding are pluggable interfaces that the host wires up.
+
+**Critical context discovered:** `internal/memory/` already exists in pi-go with a working subsystem covering `Session`, `Observation` (typed: decision/bugfix/feature/refactor/discovery/change), and `SessionSummary`. It already does compression, search, context loading, privacy filtering, and worker-based extraction. The new PRD's `Observation` and `Summary` types overlap. The new work must **extend** the existing package, not replace it — adding `Fact/Decision/Constraint/Procedure/Lesson/Question` knowledge nodes with temporal supersession, provenance, confidence, and a validation state machine on top of the existing observation/summary machinery.
+
+### Q2 — Relationship to existing `internal/memory`
+
+**Q:** How should the new system relate to the existing `internal/memory` package?
+*Options: (a) Extend in place, (b) New sibling package, (c) Both with knowledge as a thin layer.*
+
+**A:** (a) Extend in place — new knowledge tables live alongside `Observation`/`Summary` in the same package, sharing the existing SQLite DB and worker pool.
+
+### Q3 — Storage backend
+
+**Q:** What is the storage backend for the knowledge graph?
+*Options: (a) Same SQLite, simple tables, (b) SQLite + dedicated graph tables with proper indexes and adjacency representation, (c) SQLite + in-memory graph layer.*
+
+**A:** (b) SQLite + dedicated graph tables with proper indexes. Edges in an `edge(from_id, to_id, kind)` table with indexes so the PRD's `supersedes / based_on / learned_from / prevents / derived_from / uses / resolved_by` traversals are fast via recursive CTE.
+
+### Q4 — Node identity
+
+**Q:** How should knowledge nodes be addressed and merged?
+*Options: (a) Content-derived ID, (b) Caller-supplied ID, (c) Hybrid caller-supplied ID + content hash for dedup.*
+
+**A:** (c) Hybrid. Every node carries (1) a caller-supplied `node_id` (stable string used as primary key and referenced by edges), and (2) a `content_hash = sha256(canonical_text)` used only for de-dup detection. Identical hash + identical type produces a `MergedInto` event against the existing node (history preserved per PRD principle 3 — "nothing is deleted"). Edges always reference `node_id`, never `content_hash`.

--- a/specs/memory/002-temporal-knowledge-session-memory-prd-temporal/rough-idea.md
+++ b/specs/memory/002-temporal-knowledge-session-memory-prd-temporal/rough-idea.md
@@ -1,0 +1,64 @@
+# Rough Idea
+
+temporal-knowledge-session-memory - # PRD: Temporal Knowledge Memory for Coding Agents **Status:** Draft v0.1 **Author:
+** Dmytro Rashko + ChatGPT Discussion **Purpose:** Design a long-term memory subsystem for coding agents (Codex, Py, Go
+ADK agents, etc.) that continuously learns from execution while preventing hallucinations and preserving engineering
+knowledge. --- # Vision Traditional coding agents remember conversations. This system remembers **knowledge**. Rather
+than storing raw conversations, tool calls, or execution traces forever, the system continuously extracts engineering
+knowledge and builds a temporal knowledge graph. Every future session starts with accumulated project knowledge instead
+of raw chat history. --- # Goals - Learn continuously from coding sessions - Preserve engineering decisions - Capture
+reusable knowledge - Track temporal evolution of knowledge - Record provenance for every fact - Prevent hallucinations
+from entering long-term memory - Support self-improvement of coding agents - Produce explainable reasoning ("Why do we
+believe this?") --- # Non-Goals The memory is **not** intended to permanently store: - AST - Source code - Tool call
+history - Execution traces - LLM conversations - Complete session logs - Embeddings of everything These artifacts can
+always be reconstructed. Only knowledge that cannot easily be regenerated should survive. --- # High-Level Architecture
+```text Coding Session User │ ▼ +----------------------+ | Conversation | | Tool Calls | | Execution Graph | | Traces | +----------------------+ │ ▼ +--------------------------------------+ | Knowledge Consolidation Pipeline | |--------------------------------------| | Extract candidate knowledge | | Merge duplicates | | Resolve conflicts | | Validate | | Score confidence | | Apply temporal updates | +--------------------------------------+ │ ▼ +--------------------------------------+ | Persistent Temporal Knowledge Memory | +--------------------------------------+ ``` --- #
+Core Ontology The ontology intentionally remains minimal. ## Fact Something believed to be true. Examples: - Repository
+uses Go modules - User prefers Minimax M3 - CI runs GitHub Actions --- ## Decision An engineering decision. Examples: -
+Adopt Event Sourcing - Switch to Tree-sitter - Use SQLite instead of PostgreSQL --- ## Constraint Something limiting
+future work. Examples: - Pure Go only - No CGO - Docker deployment required --- ## Procedure Reusable engineering
+workflow. Examples: - Release process - Build pipeline - Evaluation workflow --- ## Lesson Knowledge learned after
+success or failure. Examples: - DeepSeek loses instructions in long sessions - Graph reranking performs better than LLM
+reranking --- ## Observation Temporary finding. May later become: - Fact - Lesson - Decision --- ## Question Unresolved
+knowledge. Examples: - Should we use Temporal? - Is graph reranking enough? Questions can later become Facts or
+Decisions. --- ## Summary Compressed summary of completed work. Useful for onboarding and context loading. --- #
+Relationships
+```text Decision ├── based_on → Fact ├── supersedes → Decision └── introduces → Constraint Lesson ├── learned_from → Session └── prevents → Problem Procedure ├── derived_from → Lesson └── uses → Decision Question └── resolved_by → Decision ``` --- #
+Temporal Model Every node has its own timeline.
+```yaml created_at: valid_from: last_confirmed: superseded_at: expires_at: ``` Knowledge is **never overwritten**.
+Instead: ```text Decision A ↓ Decision B ↓ Decision B supersedes Decision A ``` Complete history remains
+available. --- # Provenance Every knowledge node stores its origin. ```yaml source_type: ``` Possible values: - USER -
+CODE - TEST - DOCUMENT - TOOL - AGENT - SYSTEM --- # Source Priority Not all sources are equally trustworthy. | Source |
+Priority | |---------|---------:| | User | 100 | | Successful Tests | 95 | | Source Code | 90 | | Build Results | 85 | |
+Documentation | 80 | | Tool Output | 70 | | Agent Reasoning | 50 | | LLM Speculation | 20 | Higher-priority evidence
+wins during conflicts. --- # Confidence Every knowledge node contains: ```yaml confidence: 0.97 ``` Confidence evolves
+over time. Increase when: - user confirms - tests pass - repeated observations match Decrease when: - conflicts appear -
+assumptions fail - user corrects the agent --- # Validation State Machine
+```text Candidate ↓ Pending Validation ↓ Confirmed ↓ Deprecated ↓ Rejected ``` Rejected knowledge is never deleted. It
+becomes valuable evaluation and training data. --- # Candidate Knowledge Extraction The consolidation pipeline
+extracts: - Facts - Decisions - Constraints - Procedures - Lessons - Questions - Summaries Everything else is
+discarded. --- # Conflict Resolution Example: ```text Fact: Database = PostgreSQL ↓ Later Fact: Database = SQLite ```
+Result: ```text Fact(PostgreSQL) status = Superseded Fact(SQLite) status = Active ``` History remains intact. --- #
+Consolidation Triggers ## 1. End of Session Primary consolidation. Highest-quality knowledge extraction. --- ## 2. Ask
+User Boundary Whenever the workflow pauses for user input.
+```text Agent ↓ Ask User ↓ Pause ↓ Extract Candidate Knowledge ↓ Wait for User ``` User feedback can immediately
+validate or reject candidate knowledge. --- ## 3. Long-Running Tasks Periodic checkpoints. Possible triggers: - every N
+workflow steps - after successful test suite - after completing a subtask - after merge - after deployment Checkpoint
+memories remain **Pending Validation** until confirmed. --- # Knowledge Lifecycle
+```text Observation ↓ Candidate ↓ Pending Validation ↓ Confirmed ↓ Fact / Decision / Lesson ↓ Deprecated ↓ Archived ``` --- #
+Hallucination Protection Agent-generated knowledge is never immediately promoted.
+```text Agent generates assumption ↓ Candidate ↓ Needs validation ↓ Confirmed by: • User • Tests • Code • Documentation ↓ Stored permanently ```
+This prevents memory pollution. --- # Feedback Loop Incorrect memories become learning signals.
+```text Wrong Decision ↓ Conflict Detected ↓ Correction Recorded ↓ Evaluation Dataset ↓ Prompt Improvement ↓ Better Agent ```
+The memory system becomes a self-improving feedback mechanism. --- # Query Examples Examples of supported semantic
+queries: - What decisions were made this week? - Why do we use SQLite? - Which constraints apply to this project? - What
+lessons were learned from the last session? - Which decisions superseded previous ones? - Which candidate memories still
+require validation? - What facts originated only from agent reasoning? - Show unresolved questions. - Show deprecated
+engineering decisions. - Show all knowledge confirmed by the user. --- # Future Extensions - Multi-agent shared memory -
+Team-wide organizational memory - Repository-scoped knowledge graphs - Cross-project knowledge reuse - Automatic PR
+summaries - Architectural Decision Record (ADR) generation - Retrieval-Augmented Agent Memory (RAM) - Memory quality
+scoring - Knowledge aging and decay - Automatic memory pruning - Reinforcement learning from corrected memories --- #
+Design Principles 1. Store knowledge, not conversations. 2. Everything is temporal. 3. Nothing is deleted. 4. Provenance
+is mandatory. 5. User always has the highest authority. 6. Agent reasoning is never trusted without validation. 7.
+Memory continuously improves the agent. 8. The ontology remains intentionally small and extensible. 9. Long-term memory
+must be explainable. 10. Knowledge should outlive individual coding sessions.


### PR DESCRIPTION
Consolidates the parallel-worktree work from the PR #66 session. PR #66 is closed; this supersedes it and carries its fix.

## CI fixes

- **`test(cli)`** (3de14d5) — `TestCLI_SmolFlag` and `TestRootCmdMissingAPIKey` walked up from cwd to the host's real `~/.pi-go/.env`. On a box with a saved codex OAuth JWT that overrode `OPENAI_API_KEY`, tripping "model not supported by the ChatGPT codex backend". Isolates both HOME and cwd. This is PR #66's fix.
- **`test(atif)`** (dad2a9f) — `TestWriterAppendEvents_FlushedExactlyOnce` polled `ReadDir` to count flushes, which races the filesystem. Replaced with a race-free `Writer.FlushCount()`; the test now asserts exact counts instead of probabilistic slack. 200/200 green locally.
- **`test(cli)`** (d541870) — three memory tests needed a live Ollama daemon and embedding model, so they failed on any host without one. Moved behind `//go:build integration`.

## OTLP export noise

`fix(otel)` (5912270) — with `OTEL_TRACES_EXPORTER=otlp` and no collector listening, the SDK printed a line per batch retry straight onto the TUI:

```
2026/08/05 09:54:16 traces export: exporter export timeout: rpc error: code = Unavailable ... connection refused
```

`initProvider` already discarded the SDK *logger*, but batch export errors don't travel through it — `BatchSpanProcessor` calls `otel.Handle`, whose default global `ErrorHandler` writes to stderr with a plain `log.Logger`. Installs a global `ErrorHandler`. Rather than dropping the errors it records a count and the last message, so a silent collector stays diagnosable via `ExportErrors()`.

## Lint

`build(lint)` (28edd43) — golangci-lint caches by content but prints the path recorded when the entry was written. With several worktrees checked out, a run in one tree serves entries written by another and prints `../<other-worktree>/hack/test/mcp/main.go`. The anchored `^hack/` exclusion stopped matching, so the `SA1019` issues it exists to suppress resurfaced as hard pre-commit failures on branches that never touched `hack/`. Dropping the anchor fixes it; a `//lint:file-ignore` directive in the file covers it from the other side too.

## Latent bug

`fix(hack/mcp)` (39495df) — `pprofMux()` re-registered `/gc` on `DefaultServeMux` on every call, and `ServeMux.Handle` panics on a duplicate pattern. One call per process hid it; `go test -count=2 ./hack/test/mcp/` panicked. Guarded with a `sync.Once`, now green at `-count=3`.

## Verification

Every CI job type run locally against this branch:

- `go build ./...` — green
- `go test -count=1 ./...` — all packages green
- `GOEXPERIMENT=simd go test -race -count=1 $(go list ./... | grep -v '/internal/acp/server$')` — green
- `go test -coverprofile=... -coverpkg=./internal/... ./internal/...` — green, 86.5% total
- `golangci-lint run ./...` — 0 issues (local v2.12.2; CI pins v2.11)
- cross-compile matrix linux/windows/darwin × amd64/arm64 — all build

All commits carry `Signed-off-by` and an SSH `gpgsig`.