### PR TITLE
test: cover config mapping, error paths and the failed-run iterator

### DIFF
--- a/internal/acp/stringify_test.go
+++ b/internal/acp/stringify_test.go
@@ -1,0 +1,89 @@
+package acp
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestStringifyRawValue covers every branch of the raw-value coercion used
+// when pulling display strings out of untyped ACP tool-call payloads. The
+// default branch returning "" rather than a Go-syntax dump is the point: an
+// unexpected type must render as nothing, not as "map[foo:bar]" in the UI.
+func TestStringifyRawValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		desc string
+		in   any
+		want string
+	}{
+		{"string is trimmed", "  hello  ", "hello"},
+		{"string of only spaces collapses to empty", "   ", ""},
+		{"empty string stays empty", "", ""},
+		{"multiline string is trimmed at both ends", "\n\tgo test ./...\n", "go test ./..."},
+
+		// time.Duration is a fmt.Stringer, so it takes the Stringer branch
+		// rather than the numeric one despite having an integer kind.
+		{"fmt.Stringer uses String()", 90 * time.Second, "1m30s"},
+
+		{"float64 renders via %v", float64(2.5), "2.5"},
+		{"float64 whole number drops the decimal", float64(7), "7"},
+		{"int renders via %v", 42, "42"},
+		{"int64 renders via %v", int64(-9), "-9"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+
+		// Everything else must be dropped, not stringified.
+		{"nil yields empty", nil, ""},
+		{"map yields empty rather than a Go dump", map[string]int{"a": 1}, ""},
+		{"slice yields empty", []string{"a"}, ""},
+		{"struct yields empty", struct{ A int }{1}, ""},
+		{"uint is not in the numeric branch", uint(3), ""},
+		{"float32 is not in the numeric branch", float32(1.5), ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := stringifyRawValue(tc.in); got != tc.want {
+				t.Fatalf("stringifyRawValue(%#v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidationError covers the string-backed error type. It carries its
+// message as its own underlying value, so Error must round-trip it verbatim.
+func TestValidationError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Error returns the message verbatim", func(t *testing.T) {
+		t.Parallel()
+		if got := ValidationError("missing session id").Error(); got != "missing session id" {
+			t.Fatalf("Error() = %q, want %q", got, "missing session id")
+		}
+	})
+
+	t.Run("empty message round-trips", func(t *testing.T) {
+		t.Parallel()
+		if got := ValidationError("").Error(); got != "" {
+			t.Fatalf("Error() = %q, want empty", got)
+		}
+	})
+
+	t.Run("validationError constructs a usable error", func(t *testing.T) {
+		t.Parallel()
+		err := validationError("bad input")
+		if err == nil {
+			t.Fatal("validationError returned nil")
+		}
+		if err.Error() != "bad input" {
+			t.Fatalf("Error() = %q, want %q", err.Error(), "bad input")
+		}
+		var ve ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("error is not a ValidationError: %T", err)
+		}
+	})
+}

--- a/internal/agent/failedrun_test.go
+++ b/internal/agent/failedrun_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+)
+
+// TestFailedRun covers the pre-turn failure path. Run returns an iterator, so
+// a setup error cannot simply be returned — it has to reach the caller as the
+// sequence's first and only yield, with a nil event alongside it. A sequence
+// that yielded nothing would look to `for ev, err := range ...` exactly like a
+// turn that succeeded and produced no events, silently swallowing the failure.
+func TestFailedRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("yields the error once with a nil event", func(t *testing.T) {
+		t.Parallel()
+		want := errors.New("pre-turn setup failed")
+
+		var (
+			events []*session.Event
+			errs   []error
+		)
+		for ev, err := range failedRun(want) {
+			events = append(events, ev)
+			errs = append(errs, err)
+		}
+
+		if len(errs) != 1 {
+			t.Fatalf("yielded %d times, want exactly 1", len(errs))
+		}
+		if !errors.Is(errs[0], want) {
+			t.Fatalf("yielded error = %v, want %v", errs[0], want)
+		}
+		if events[0] != nil {
+			t.Fatalf("yielded event = %+v, want nil", events[0])
+		}
+	})
+
+	t.Run("respects an early break from the consumer", func(t *testing.T) {
+		t.Parallel()
+		// yield's return value must actually be honored; ignoring it would
+		// keep pushing after the consumer has stopped listening.
+		calls := 0
+		for range failedRun(errors.New("boom")) {
+			calls++
+			break
+		}
+		if calls != 1 {
+			t.Fatalf("consumer ran %d times, want 1", calls)
+		}
+	})
+
+	t.Run("nil error still yields so the turn terminates", func(t *testing.T) {
+		t.Parallel()
+		got := 0
+		for range failedRun(nil) {
+			got++
+		}
+		if got != 1 {
+			t.Fatalf("yielded %d times, want 1", got)
+		}
+	})
+}

--- a/internal/cli/autocompact_config_test.go
+++ b/internal/cli/autocompact_config_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/logger"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// TestAutoCompactConfigFrom covers the config.Config -> AutoCompactConfig
+// mapping. Every field is guarded by its own zero-check, so a wrong guard
+// silently keeps the default and the user's setting is dropped without any
+// error — exactly the failure this table is here to catch.
+func TestAutoCompactConfigFrom(t *testing.T) {
+	t.Parallel()
+
+	defaults := pisession.DefaultAutoCompactConfig()
+	enabled, disabled := true, false
+
+	cases := []struct {
+		desc string
+		in   config.Config
+		want pisession.AutoCompactConfig
+	}{
+		{
+			desc: "nil AutoCompact yields untouched defaults",
+			in:   config.Config{},
+			want: defaults,
+		},
+		{
+			desc: "empty AutoCompact yields untouched defaults",
+			in:   config.Config{AutoCompact: &config.AutoCompactConfig{}},
+			want: defaults,
+		},
+		{
+			desc: "Enabled=false is honored, not treated as unset",
+			in:   config.Config{AutoCompact: &config.AutoCompactConfig{Enabled: &disabled}},
+			want: withEnabled(defaults, false),
+		},
+		{
+			desc: "Enabled=true is honored",
+			in:   config.Config{AutoCompact: &config.AutoCompactConfig{Enabled: &enabled}},
+			want: withEnabled(defaults, true),
+		},
+		{
+			desc: "every numeric field overrides its default",
+			in: config.Config{AutoCompact: &config.AutoCompactConfig{
+				Enabled:               &enabled,
+				ShedPercent:           41,
+				SummarizePercent:      77,
+				KeepUserMessageTokens: 1234,
+				KeepRecentEvents:      9,
+			}},
+			want: pisession.AutoCompactConfig{
+				Enabled:               true,
+				ShedPercent:           41,
+				SummarizePercent:      77,
+				KeepUserMessageTokens: 1234,
+				KeepRecentEvents:      9,
+			},
+		},
+		{
+			desc: "zero numerics fall back to defaults rather than zeroing the config",
+			in: config.Config{AutoCompact: &config.AutoCompactConfig{
+				ShedPercent:           0,
+				SummarizePercent:      0,
+				KeepUserMessageTokens: 0,
+				KeepRecentEvents:      0,
+			}},
+			want: defaults,
+		},
+		{
+			desc: "negative numerics are ignored like zero",
+			in: config.Config{AutoCompact: &config.AutoCompactConfig{
+				ShedPercent:      -5,
+				KeepRecentEvents: -1,
+			}},
+			want: defaults,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			got := autoCompactConfigFrom(tc.in)
+			if got != tc.want {
+				t.Fatalf("autoCompactConfigFrom() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func withEnabled(c pisession.AutoCompactConfig, v bool) pisession.AutoCompactConfig {
+	c.Enabled = v
+	return c
+}
+
+// newTempLogger builds a logger rooted in a temp HOME so the test never
+// appends to the developer's real ~/.pi-go/log tree.
+func newTempLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	l, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l
+}
+
+// TestAutoCompactDepsReport covers the notification fan-out. Both sinks are
+// optional, and compaction discarding history silently is the outcome the
+// Notify hook exists to prevent, so the nil cases matter as much as the
+// wired ones.
+//
+// Not parallel: the Log cases need t.Setenv to redirect HOME, which panics if
+// this test or any parent has called t.Parallel.
+func TestAutoCompactDepsReport(t *testing.T) {
+	t.Run("both sinks nil does not panic", func(t *testing.T) {
+		autoCompactDeps{}.report("no sinks")
+	})
+
+	t.Run("Notify receives the message verbatim", func(t *testing.T) {
+		var got []string
+		d := autoCompactDeps{Notify: func(m string) { got = append(got, m) }}
+		d.report("shed 3 results")
+		if len(got) != 1 || got[0] != "shed 3 results" {
+			t.Fatalf("Notify got %q, want exactly [\"shed 3 results\"]", got)
+		}
+	})
+
+	// The Log sink writes to ~/.pi-go/log, so these point HOME at a temp dir.
+	t.Run("Log alone does not panic and does not need Notify", func(t *testing.T) {
+		d := autoCompactDeps{Log: newTempLogger(t)}
+		d.report("logged only")
+	})
+
+	t.Run("both sinks each receive the message", func(t *testing.T) {
+		var got []string
+		d := autoCompactDeps{
+			Log:    newTempLogger(t),
+			Notify: func(m string) { got = append(got, m) },
+		}
+		d.report("both")
+		if len(got) != 1 || got[0] != "both" {
+			t.Fatalf("Notify got %q, want exactly [\"both\"]", got)
+		}
+	})
+}

--- a/internal/cli/memory_mine_error_test.go
+++ b/internal/cli/memory_mine_error_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/palace"
+)
+
+// TestOllamaSetupError covers the one command that cannot degrade: an
+// unembedded drawer is invisible to semantic search forever after, and the
+// failure is silent at query time. Both branches must keep wrapping the cause
+// so callers can still errors.Is it, and the ErrOllamaUnavailable branch must
+// name both fixes (daemon down / model not pulled) rather than dumping the
+// raw error.
+func TestOllamaSetupError(t *testing.T) {
+	cfg := palace.PalaceConfig{
+		OllamaURL:   "http://localhost:9999",
+		OllamaModel: "test-embed-model",
+	}
+
+	t.Run("unrelated cause is wrapped without instructions", func(t *testing.T) {
+		cause := errors.New("disk on fire")
+
+		var err error
+		out := captureStderr(t, func() { err = ollamaSetupError(cfg, cause) })
+
+		if err == nil {
+			t.Fatal("ollamaSetupError returned nil, want an error")
+		}
+		if !errors.Is(err, cause) {
+			t.Fatalf("err does not wrap cause: %v", err)
+		}
+		if out != "" {
+			t.Fatalf("non-ollama cause printed guidance to stderr:\n%s", out)
+		}
+	})
+
+	t.Run("ErrOllamaUnavailable prints both fixes and still wraps", func(t *testing.T) {
+		cause := fmt.Errorf("dial tcp: %w", palace.ErrOllamaUnavailable)
+
+		var err error
+		out := captureStderr(t, func() { err = ollamaSetupError(cfg, cause) })
+
+		if err == nil {
+			t.Fatal("ollamaSetupError returned nil, want an error")
+		}
+		// The wrap must survive, or errors.Is at the call site stops
+		// recognizing this as the recoverable case.
+		if !errors.Is(err, palace.ErrOllamaUnavailable) {
+			t.Fatalf("err no longer wraps ErrOllamaUnavailable: %v", err)
+		}
+
+		for _, want := range []string{
+			"ollama serve",      // fix 1: daemon down
+			"ollama pull",       // fix 2: model not pulled
+			cfg.OllamaModel,     // which model to pull
+			cfg.OllamaURL,       // where the daemon was expected
+			"palace.ollama_url", // how to change it
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("stderr guidance missing %q; got:\n%s", want, out)
+			}
+		}
+	})
+}

--- a/internal/cli/session_dispatch_test.go
+++ b/internal/cli/session_dispatch_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// TestResolveSessionID covers the two flag-driven branches. Both run before
+// any agent call, so they are reachable without a live model — and the
+// --continue miss is the one a user hits on a fresh machine, where a wrong
+// answer means silently starting a new session instead of saying so.
+func TestResolveSessionID(t *testing.T) {
+	t.Run("--session wins and is returned verbatim", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagSession = "explicit-session-id"
+
+		// The agent and service are never touched on this path; nil proves it.
+		got, err := resolveSessionID(t.Context(), nil, nil)
+		if err != nil {
+			t.Fatalf("resolveSessionID: %v", err)
+		}
+		if got != "explicit-session-id" {
+			t.Fatalf("got %q, want %q", got, "explicit-session-id")
+		}
+	})
+
+	t.Run("--continue with no prior session is an error, not a silent new one", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagContinue = true
+
+		svc, err := pisession.NewFileService(t.TempDir())
+		if err != nil {
+			t.Fatalf("NewFileService: %v", err)
+		}
+
+		got, err := resolveSessionID(t.Context(), nil, svc)
+		if err == nil {
+			t.Fatalf("resolveSessionID returned %q, want an error", got)
+		}
+		if !strings.Contains(err.Error(), "no previous session") {
+			t.Fatalf("err = %v, want it to name the missing previous session", err)
+		}
+		if got != "" {
+			t.Fatalf("got %q alongside the error, want empty", got)
+		}
+	})
+
+	t.Run("--continue takes precedence over --session", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagContinue = true
+		flagSession = "ignored-because-continue-wins"
+
+		svc, err := pisession.NewFileService(t.TempDir())
+		if err != nil {
+			t.Fatalf("NewFileService: %v", err)
+		}
+
+		// An empty store means --continue fails; if --session were checked
+		// first this would succeed instead, which is the regression to catch.
+		if _, err := resolveSessionID(t.Context(), nil, svc); err == nil {
+			t.Fatal("--session shadowed --continue; want the --continue error")
+		}
+	})
+}
+
+// TestDispatchModeNoPrompt covers the empty-prompt guard. Every mode except
+// rpc needs a prompt, and the guard has to report that rather than handing an
+// empty turn to the model.
+func TestDispatchModeNoPrompt(t *testing.T) {
+	for _, mode := range []string{"print", "json", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			resetGlobalFlags(t)
+
+			var err error
+			out := captureStderr(t, func() {
+				err = dispatchMode(context.Background(), mode, "", nil, "sid", nil, "test-model")
+			})
+
+			if err != nil {
+				t.Fatalf("dispatchMode with no prompt = %v, want nil", err)
+			}
+			if !strings.Contains(out, "no prompt provided") {
+				t.Fatalf("stderr = %q, want it to mention the missing prompt", out)
+			}
+			// The message exists so the user can tell which model/mode was
+			// about to run; dropping either makes it useless.
+			if !strings.Contains(out, "test-model") {
+				t.Errorf("stderr %q omits the model name", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Raises statement coverage **86.4% → 86.6%** by testing eight functions that carried little or no coverage.

Targets were chosen for being reachable without a live model, daemon or terminal, so they stay stable in CI rather than skipping or flaking.

| Function | Before | After |
|---|---|---|
| `cli.autoCompactConfigFrom` | 21.4% | **100%** |
| `cli.ollamaSetupError` | 0% | **100%** |
| `cli.autoCompactDeps.report` | 0% | **100%** |
| `acp.stringifyRawValue` | 40% | **100%** |
| `acp.ValidationError.Error` | 0% | **100%** |
| `agent.failedRun` | 0% | **100%** |
| `cli.resolveSessionID` | 41.7% | 75% |
| `cli.dispatchMode` | — | no-prompt path pinned |

## What each test is actually guarding

These aren't line-count padding — each covers a path where the failure mode is silence:

- **`autoCompactConfigFrom`** — every field is guarded by its own zero-check. A wrong guard keeps the default and drops the user's setting with no error at all. The table pins each field independently, including `Enabled=false` (which must not read as "unset") and negative values.
- **`ollamaSetupError`** — mining is the one command that cannot degrade: an unembedded drawer is invisible to semantic search forever after, and the failure is silent at query time. Both branches must keep wrapping the cause so `errors.Is` still works at the call site, and the `ErrOllamaUnavailable` branch must name both fixes rather than dumping the raw error.
- **`failedRun`** — `Run` returns an iterator, so a pre-turn error can't just be returned; it has to arrive as the sequence's first and only yield. A sequence that yielded nothing would look to `for ev, err := range …` exactly like a turn that succeeded with no events, swallowing the failure.
- **`stringifyRawValue`** — the default branch must render `""`, not `map[foo:bar]`, in the UI. Also pins that `time.Duration` takes the `fmt.Stringer` branch rather than the numeric one despite its integer kind.
- **`resolveSessionID`** — `--continue` on a fresh machine must report that there's no prior session, not quietly open a new one. Includes a precedence case: `--continue` must win over `--session`.
- **`autoCompactDeps.report`** — both sinks are optional; compaction discarding history silently is exactly what `Notify` exists to prevent, so the nil cases matter as much as the wired ones.

## On the coverage numbers

Measured with the embedding backend pointed at a dead port, so the figures reflect CI rather than a dev box with ollama running. That distinction matters here: on a machine with ollama up, the integration-tagged memory tests execute and inflate the total by ~0.9pp, which makes a local before/after comparison misleading.

## Verification

- `go build ./...` — green
- `GOEXPERIMENT=simd go test -count=1 ./...` — all packages green
- `GOEXPERIMENT=simd go test -race -count=1 $(go list ./... | grep -v '/internal/acp/server$')` — green
- `golangci-lint run` on the touched packages — 0 issues

Test-only change; no production code is touched.