### PR TITLE
test: cover the pi-acp compatibility patch

### DIFF
--- a/internal/auth/codex_device_edge_test.go
+++ b/internal/auth/codex_device_edge_test.go
@@ -1,0 +1,319 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The interval encoding is the field most likely to change upstream, and a
+// parse failure there must not be mistaken for a valid zero.
+func TestCodexIntervalUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    codexInterval
+		wantErr bool
+	}{
+		{name: "quoted number", input: `"5"`, want: 5},
+		{name: "bare number", input: `9`, want: 9},
+		{name: "empty string leaves the zero value", input: `""`},
+		{name: "null leaves the zero value", input: `null`},
+		{name: "whitespace only", input: `"  "`},
+		{name: "not a number", input: `"soon"`, wantErr: true},
+		{name: "float is rejected", input: `1.5`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got codexInterval
+			err := got.UnmarshalJSON([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("UnmarshalJSON(%s) = nil error, want a parse failure", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UnmarshalJSON(%s) error = %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("interval = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// A server that cannot be reached at all has to be reported as a start
+// failure, not as a session with empty fields.
+func TestStartCodexDeviceFlow_UnreachableServer(t *testing.T) {
+	prov := codexDeviceProvider("http://127.0.0.1:1")
+
+	_, err := StartCodexDeviceFlow(context.Background(), prov)
+	if err == nil {
+		t.Fatal("StartCodexDeviceFlow() = nil error, want a transport failure")
+	}
+	if !strings.Contains(err.Error(), "requesting device user code") {
+		t.Errorf("error = %q, want it to name the failed step", err)
+	}
+}
+
+// A 200 whose body is not the expected JSON must fail rather than yield a
+// session with an empty device id that would poll forever.
+func TestStartCodexDeviceFlow_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer srv.Close()
+
+	_, err := StartCodexDeviceFlow(context.Background(), codexDeviceProvider(srv.URL))
+	if err == nil {
+		t.Fatal("StartCodexDeviceFlow() = nil error, want a parse failure")
+	}
+	if !strings.Contains(err.Error(), "parsing device user code response") {
+		t.Errorf("error = %q, want it to name the parse step", err)
+	}
+}
+
+// A 404 means the auth server does not route /deviceauth at all and gets its
+// own message; any other non-200 has to report the server's own reason so the
+// user can tell a misconfiguration from an outage.
+func TestStartCodexDeviceFlow_ServerRejection(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{
+			name:   "not routed",
+			status: http.StatusNotFound,
+			body:   `{"error":"no such route"}`,
+			want:   "device auth is not enabled",
+		},
+		{
+			name:   "server error reports the status",
+			status: http.StatusInternalServerError,
+			body:   `{"error":"upstream unavailable"}`,
+			want:   "500",
+		},
+		{
+			name:   "unauthorized reports the status",
+			status: http.StatusUnauthorized,
+			body:   `{"error":"bad client"}`,
+			want:   "401",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			_, err := StartCodexDeviceFlow(context.Background(), codexDeviceProvider(srv.URL))
+			if err == nil {
+				t.Fatalf("StartCodexDeviceFlow() = nil error, want a rejection for status %d", tt.status)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteCodexDeviceFlow_NilSession(t *testing.T) {
+	_, err := CompleteCodexDeviceFlow(context.Background(), codexDeviceProvider("http://127.0.0.1:1"), nil)
+	if err == nil {
+		t.Fatal("CompleteCodexDeviceFlow(nil) = nil error, want a refusal")
+	}
+}
+
+// An approval that arrives without the verifier cannot be exchanged, so it has
+// to fail here rather than at the token endpoint with a confusing message.
+func TestCompleteCodexDeviceFlow_ApprovalMissingFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/usercode") {
+			_, _ = w.Write([]byte(`{"device_auth_id":"dev-1","user_code":"ABCD-EFGH","interval":"1"}`))
+			return
+		}
+		// Approved, but with no code_verifier.
+		_, _ = w.Write([]byte(`{"authorization_code":"auth-1"}`))
+	}))
+	defer srv.Close()
+
+	prov := codexDeviceProvider(srv.URL)
+	sess, err := StartCodexDeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("StartCodexDeviceFlow() error = %v", err)
+	}
+
+	result, err := CompleteCodexDeviceFlow(context.Background(), prov, sess)
+	if err != nil {
+		t.Fatalf("CompleteCodexDeviceFlow() error = %v, want the failure in Result.Err", err)
+	}
+	if result.Err == nil {
+		t.Fatal("Result.Err = nil, want the incomplete approval reported")
+	}
+	if !strings.Contains(result.Err.Error(), "code_verifier") {
+		t.Errorf("Result.Err = %v, want it to name the missing field", result.Err)
+	}
+}
+
+// An approved code whose token exchange is rejected must surface that, not the
+// approval that already succeeded.
+func TestCompleteCodexDeviceFlow_TokenExchangeRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/usercode"):
+			_, _ = w.Write([]byte(`{"device_auth_id":"dev-1","user_code":"ABCD-EFGH","interval":"1"}`))
+		case strings.HasSuffix(r.URL.Path, "/deviceauth"), strings.Contains(r.URL.Path, "deviceauth/token"):
+			_, _ = w.Write([]byte(`{"authorization_code":"auth-1","code_verifier":"verifier-1"}`))
+		default: // /oauth/token
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+		}
+	}))
+	defer srv.Close()
+
+	prov := codexDeviceProvider(srv.URL)
+	sess, err := StartCodexDeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("StartCodexDeviceFlow() error = %v", err)
+	}
+
+	result, err := CompleteCodexDeviceFlow(context.Background(), prov, sess)
+	if err != nil {
+		t.Fatalf("CompleteCodexDeviceFlow() error = %v, want the failure in Result.Err", err)
+	}
+	if result.Err == nil {
+		t.Fatal("Result.Err = nil, want the rejected exchange reported")
+	}
+	if !strings.Contains(result.Err.Error(), "device code exchange") {
+		t.Errorf("Result.Err = %v, want it to name the exchange step", result.Err)
+	}
+}
+
+// An approval body that is not JSON must fail the poll rather than be treated
+// as a pending response and retried until the deadline.
+func TestPollCodexApproval_MalformedApproval(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/usercode") {
+			_, _ = w.Write([]byte(`{"device_auth_id":"dev-1","user_code":"ABCD-EFGH","interval":"1"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{oops`))
+	}))
+	defer srv.Close()
+
+	prov := codexDeviceProvider(srv.URL)
+	sess, err := StartCodexDeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("StartCodexDeviceFlow() error = %v", err)
+	}
+
+	_, err = pollCodexApproval(context.Background(), prov, sess)
+	if err == nil {
+		t.Fatal("pollCodexApproval() = nil error, want a parse failure")
+	}
+	if !strings.Contains(err.Error(), "parsing device authorization response") {
+		t.Errorf("error = %q, want it to name the parse step", err)
+	}
+}
+
+// The poll loop must stop when its context is canceled — a user who hits Esc
+// should not leave a poller running against the auth server.
+func TestPollCodexApproval_StopsOnCanceledContext(t *testing.T) {
+	polled := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/usercode") {
+			_, _ = w.Write([]byte(`{"device_auth_id":"dev-1","user_code":"ABCD-EFGH","interval":"1"}`))
+			return
+		}
+		select {
+		case polled <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusForbidden) // never approved
+	}))
+	defer srv.Close()
+
+	prov := codexDeviceProvider(srv.URL)
+	sess, err := StartCodexDeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("StartCodexDeviceFlow() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-polled
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, pollErr := pollCodexApproval(ctx, prov, sess)
+		done <- pollErr
+	}()
+
+	select {
+	case pollErr := <-done:
+		if pollErr == nil {
+			t.Fatal("pollCodexApproval() = nil error, want the cancellation reported")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("pollCodexApproval did not stop after its context was canceled")
+	}
+}
+
+// A poll that loses the server mid-flight is a transport failure, not a
+// pending approval.
+func TestPollCodexApproval_TransportFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"device_auth_id":"dev-1","user_code":"ABCD-EFGH","interval":"1"}`))
+	}))
+	prov := codexDeviceProvider(srv.URL)
+	sess, err := StartCodexDeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("StartCodexDeviceFlow() error = %v", err)
+	}
+	srv.Close() // the poll now has nothing to talk to
+
+	_, err = pollCodexApproval(context.Background(), prov, sess)
+	if err == nil {
+		t.Fatal("pollCodexApproval() = nil error, want a transport failure")
+	}
+	if !strings.Contains(err.Error(), "polling device authorization") {
+		t.Errorf("error = %q, want it to name the polling step", err)
+	}
+}
+
+func TestPostJSON_RejectsUnencodablePayload(t *testing.T) {
+	_, _, err := postJSON(context.Background(), "http://127.0.0.1:1", make(chan int))
+	if err == nil {
+		t.Fatal("postJSON() = nil error, want the encoding failure")
+	}
+	if !strings.Contains(err.Error(), "encoding request") {
+		t.Errorf("error = %q, want it to name the encoding step", err)
+	}
+}
+
+func TestPostJSON_RejectsInvalidEndpoint(t *testing.T) {
+	// A control character cannot appear in a request URL.
+	_, _, err := postJSON(context.Background(), "http://exa\x7fmple.invalid/", map[string]string{})
+	if err == nil {
+		t.Fatal("postJSON() = nil error, want the request to be rejected")
+	}
+}

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -2,7 +2,10 @@ package browser
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -99,5 +102,63 @@ func TestOpen_NoHandler(t *testing.T) {
 
 	if err := Open("https://example.invalid/"); !errors.Is(err, ErrNoHandler) {
 		t.Errorf("Open() = %v, want ErrNoHandler", err)
+	}
+}
+
+// TestOpen_UsesBrowserEnv is the dev-container case this package exists for:
+// $BROWSER is the only handler that reaches a human, so it must be run in
+// preference to anything installed alongside it.
+//
+// The stand-in handler is a script that records its arguments, which also pins
+// that Open passes the URL through unmangled.
+func TestOpen_UsesBrowserEnv(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "opened.txt")
+	handler := filepath.Join(dir, "fake-browser")
+
+	script := "#!/bin/sh\nprintf '%s' \"$1\" > " + record + "\n"
+	if err := os.WriteFile(handler, []byte(script), 0o700); err != nil {
+		t.Fatalf("writing fake browser: %v", err)
+	}
+
+	t.Setenv("BROWSER", handler)
+
+	const url = "https://auth.openai.com/codex/device"
+	if err := Open(url); err != nil {
+		t.Fatalf("Open() = %v, want nil when $BROWSER can run", err)
+	}
+
+	// Open uses Start, not Run, so the handler may not have finished yet.
+	var got []byte
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(record); err == nil && len(b) > 0 {
+			got = b
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if string(got) != url {
+		t.Errorf("$BROWSER received %q, want %q", got, url)
+	}
+}
+
+// An entry that is not on PATH must be skipped rather than aborting the whole
+// search — that fallthrough is what makes the per-platform handler list useful.
+func TestOpen_SkipsMissingHandlers(t *testing.T) {
+	dir := t.TempDir()
+	handler := filepath.Join(dir, "fallback-browser")
+	if err := os.WriteFile(handler, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("writing fake browser: %v", err)
+	}
+
+	// An empty PATH means every platform default fails LookPath; only the
+	// absolute $BROWSER path can resolve.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BROWSER", handler)
+
+	if err := Open("https://example.invalid/"); err != nil {
+		t.Errorf("Open() = %v, want nil; the reachable handler was skipped", err)
 	}
 }

--- a/internal/cli/dispatch_server_modes_test.go
+++ b/internal/cli/dispatch_server_modes_test.go
@@ -1,0 +1,296 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/guardrail"
+)
+
+// withStdinLines replaces os.Stdin with a pipe carrying the given NDJSON lines
+// and closes it, so a server reading stdin sees the commands and then EOF.
+// dispatchMode wires the stdio server to os.Stdin directly, so this is the only
+// seam a test has.
+func withStdinLines(t *testing.T, lines ...string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+	})
+
+	go func() {
+		defer func() { _ = w.Close() }()
+		for _, line := range lines {
+			if _, err := w.WriteString(line + "\n"); err != nil {
+				return
+			}
+		}
+	}()
+}
+
+// shortSocketPath returns a socket path short enough for the 104-byte sun_path
+// limit, which t.TempDir() paths can exceed on macOS.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "pisock")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
+// withSocketChanged sets the explicit-use flag and restores it, since
+// resetGlobalFlags does not cover it.
+func withSocketChanged(t *testing.T, changed bool) {
+	t.Helper()
+	orig := flagSocketChanged
+	flagSocketChanged = changed
+	t.Cleanup(func() { flagSocketChanged = orig })
+}
+
+// "socket" is pi-go's own JSON-RPC over a Unix socket. It has to bind the path
+// from --socket, or an editor pointed at that path never connects.
+func TestDispatchModeSocketServesTheConfiguredPath(t *testing.T) {
+	resetGlobalFlags(t)
+	withSocketChanged(t, false)
+	flagSocket = shortSocketPath(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	bound := make(chan struct{})
+	go func() {
+		// The listener exists as soon as Run gets past net.Listen; poll for the
+		// socket file rather than guessing at a sleep.
+		defer close(bound)
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(flagSocket); err == nil {
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = captureStderr(t, func() {
+			err = dispatchMode(ctx, "socket", "", nil, "sid", nil, "test-model", config.Config{}, nil)
+		})
+	}()
+
+	<-bound
+	if _, statErr := os.Stat(flagSocket); statErr != nil {
+		cancel()
+		<-done
+		t.Fatalf("socket %s was never created: %v", flagSocket, statErr)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("socket server did not shut down on context cancellation")
+	}
+	if err != nil {
+		t.Errorf("dispatchMode(socket) = %v, want nil on shutdown", err)
+	}
+}
+
+// `--mode rpc --socket` was the pre-rename spelling for the Unix socket
+// server. Silently starting the stdio server instead would leave the caller's
+// socket client hanging, so the deprecated spelling must still be honored —
+// with a warning.
+func TestDispatchModeRPCWithExplicitSocketFallsBackToSocketMode(t *testing.T) {
+	resetGlobalFlags(t)
+	withSocketChanged(t, true)
+	flagSocket = shortSocketPath(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var err error
+	var stderr string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		stderr = captureStderr(t, func() {
+			err = dispatchMode(ctx, "rpc", "", nil, "sid", nil, "test-model", config.Config{}, nil)
+		})
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, statErr := os.Stat(flagSocket); statErr == nil {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	created := false
+	if _, statErr := os.Stat(flagSocket); statErr == nil {
+		created = true
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("server did not shut down on context cancellation")
+	}
+
+	if !created {
+		t.Error("`--mode rpc --socket` did not start the socket server; a socket client would hang")
+	}
+	if err != nil {
+		t.Errorf("dispatchMode = %v, want nil on shutdown", err)
+	}
+	if !strings.Contains(stderr, "deprecated") {
+		t.Errorf("stderr = %q, want a deprecation warning for `--mode rpc --socket`", stderr)
+	}
+}
+
+// Plain `--mode rpc` is the stdio NDJSON protocol pi-acp drives. Every command
+// must be answered on stdout, and the server must exit when stdin closes.
+func TestDispatchModeRPCServesTheStdioProtocol(t *testing.T) {
+	resetGlobalFlags(t)
+	withSocketChanged(t, false)
+
+	withStdinLines(t,
+		`{"type":"get_state","id":"s1"}`,
+		`{"type":"get_available_models","id":"s2"}`,
+	)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = dispatchMode(context.Background(), "rpc", "", nil, "sess-1", nil, "test-model", config.Config{}, nil)
+	})
+	if err != nil {
+		t.Fatalf("dispatchMode(rpc) = %v, want nil when stdin closes", err)
+	}
+
+	var ids []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var resp map[string]any
+		if jsonErr := json.Unmarshal([]byte(line), &resp); jsonErr != nil {
+			t.Fatalf("stdout line is not JSON: %q: %v", line, jsonErr)
+		}
+		id, _ := resp["id"].(string)
+		ids = append(ids, id)
+	}
+
+	if len(ids) != 2 || ids[0] != "s1" || ids[1] != "s2" {
+		t.Errorf("response ids = %v, want [s1 s2]; pi-acp pairs replies by id", ids)
+	}
+}
+
+// set_model reaches buildSwitchedLLM through the switcher dispatchMode wires
+// in. An unknown model must come back as an error response rather than a
+// cosmetic success, or the client renders a switch that never happened.
+//
+// A real agent is required: pirpc refuses to call the switcher at all when it
+// has no agent to rebuild, which would bypass the wiring under test.
+func TestDispatchModeRPCSetModelRejectsUnknownModels(t *testing.T) {
+	resetGlobalFlags(t)
+	withSocketChanged(t, false)
+
+	ag, sessionID := newTestAgent(t, &cliMockLLM{name: "test-model", response: "hi"})
+	// buildSwitchedLLM records the new model's context window on the tracker,
+	// so the switcher needs the real one runNonInteractive always supplies.
+	tracker := guardrail.New(0)
+	withStdinLines(t, `{"type":"set_model","id":"m1","modelId":"not-a-real-model-xyz","provider":"openai"}`)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = dispatchMode(context.Background(), "rpc", "", ag, sessionID, nil, "test-model", config.Config{}, tracker)
+	})
+	if err != nil {
+		t.Fatalf("dispatchMode(rpc) = %v, want nil when stdin closes", err)
+	}
+
+	line := strings.TrimSpace(out)
+	if line == "" {
+		t.Fatal("set_model produced no response; the client would wait forever")
+	}
+	var resp map[string]any
+	if jsonErr := json.Unmarshal([]byte(line), &resp); jsonErr != nil {
+		t.Fatalf("stdout line is not JSON: %q: %v", line, jsonErr)
+	}
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false for an unknown model", resp["success"])
+	}
+	if resp["error"] == nil {
+		t.Error("error field missing; the client cannot tell the switch failed")
+	}
+}
+
+// The provider the ACP client names has to override the default role's
+// provider. Without that substitution pi-go infers the provider from the
+// configured default, which routes e.g. an OpenAI model through Ollama.
+func TestDispatchModeRPCSetModelHonorsTheNamedProvider(t *testing.T) {
+	resetGlobalFlags(t)
+	withSocketChanged(t, false)
+
+	ag, sessionID := newTestAgent(t, &cliMockLLM{name: "test-model", response: "hi"})
+	// buildSwitchedLLM records the new model's context window on the tracker,
+	// so the switcher needs the real one runNonInteractive always supplies.
+	tracker := guardrail.New(0)
+
+	// A default role pinned to a different provider is the stale pin the
+	// substitution exists to defeat.
+	cfg := config.Config{Roles: map[string]config.RoleConfig{
+		"default": {Model: "some-ollama-model", Provider: "ollama"},
+	}}
+
+	withStdinLines(t, `{"type":"set_model","id":"m1","modelId":"gpt-5.5","provider":"openai"}`)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = dispatchMode(context.Background(), "rpc", "", ag, sessionID, nil, "test-model", cfg, tracker)
+	})
+	if err != nil {
+		t.Fatalf("dispatchMode(rpc) = %v, want nil when stdin closes", err)
+	}
+
+	var resp map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); jsonErr != nil {
+		t.Fatalf("stdout line is not JSON: %q: %v", out, jsonErr)
+	}
+
+	// The switch itself needs credentials this test does not have, so either
+	// outcome is acceptable — what must not happen is the request being routed
+	// to ollama, which would name that provider in the error.
+	if resp["success"] == true {
+		data, ok := resp["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("data has type %T, want the state map", resp["data"])
+		}
+		if data["provider"] == "ollama" {
+			t.Errorf("provider = ollama; the client's choice of openai was ignored")
+		}
+		return
+	}
+	if msg, _ := resp["error"].(string); strings.Contains(strings.ToLower(msg), "ollama") {
+		t.Errorf("error = %q; the request was routed to the default role's provider, not the named one", msg)
+	}
+
+	// The caller's config must not be mutated: the switcher clones Roles
+	// precisely so a switch cannot rewrite the session's default.
+	if cfg.Roles["default"].Provider != "ollama" {
+		t.Errorf("caller config was mutated: default provider = %q, want ollama", cfg.Roles["default"].Provider)
+	}
+}

--- a/internal/cli/login_codex_device_test.go
+++ b/internal/cli/login_codex_device_test.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/auth"
+)
+
+// newCodexDeviceServer stands in for auth.openai.com's device endpoints.
+// pollsBeforeApproval answers that many polls with 403 ("not approved yet"),
+// which is the only pending signal the protocol has.
+func newCodexDeviceServer(t *testing.T, pollsBeforeApproval int) *httptest.Server {
+	t.Helper()
+	polls := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/deviceauth/usercode":
+			fmt.Fprint(w, `{"device_auth_id":"dev-1","user_code":"ABCD-9876","interval":"1"}`)
+		case "/deviceauth/token":
+			polls++
+			if polls <= pollsBeforeApproval {
+				w.WriteHeader(http.StatusForbidden)
+				fmt.Fprint(w, `{"error":"pending"}`)
+				return
+			}
+			fmt.Fprint(w, `{"authorization_code":"auth-1","code_verifier":"verifier-1"}`)
+		case "/oauth/token":
+			fmt.Fprint(w, `{"access_token":"codex-cli-token","token_type":"bearer"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func codexDeviceProvider(srvURL string) auth.Provider {
+	return auth.Provider{
+		Name:              "codex",
+		EnvVar:            "OPENAI_API_KEY",
+		DeviceURL:         srvURL + "/deviceauth",
+		TokenURL:          srvURL + "/oauth/token",
+		ClientID:          "pi-go-cli",
+		CodexDeviceAuth:   true,
+		DeviceVerifyURL:   "https://auth.openai.com/codex/device",
+		DeviceRedirectURI: "http://localhost/callback",
+		TokenToKey:        func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	}
+}
+
+// The code and URL have to be printed before polling begins: in a headless
+// container this output is the entire user interface for the login.
+func TestRunCodexDeviceFlow_PrintsCodeThenCompletes(t *testing.T) {
+	srv := newCodexDeviceServer(t, 1)
+	defer srv.Close()
+
+	// Keep the flow from launching a real browser.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BROWSER", "")
+
+	var result *auth.Result
+	var err error
+	out := captureStdout(t, func() {
+		result, err = runCodexDeviceFlow(context.Background(), codexDeviceProvider(srv.URL))
+	})
+	if err != nil {
+		t.Fatalf("runCodexDeviceFlow() error = %v", err)
+	}
+	if result.Err != nil {
+		t.Fatalf("device auth failed: %v", result.Err)
+	}
+	if result.APIKey != "codex-cli-token" {
+		t.Errorf("APIKey = %q, want codex-cli-token", result.APIKey)
+	}
+	if result.EnvVar != "OPENAI_API_KEY" {
+		t.Errorf("EnvVar = %q, want OPENAI_API_KEY", result.EnvVar)
+	}
+
+	if !strings.Contains(out, "ABCD-9876") {
+		t.Errorf("stdout = %q, want the user code", out)
+	}
+	if !strings.Contains(out, "https://auth.openai.com/codex/device") {
+		t.Errorf("stdout = %q, want the verification URL", out)
+	}
+	if !strings.Contains(out, "Waiting for authorization") {
+		t.Errorf("stdout = %q, want the wait notice", out)
+	}
+}
+
+// A server that does not route /deviceauth is the documented failure here, and
+// the caller needs an error rather than a nil session it would dereference.
+func TestRunCodexDeviceFlow_StartFailureIsWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var result *auth.Result
+	var err error
+	_ = captureStdout(t, func() {
+		result, err = runCodexDeviceFlow(context.Background(), codexDeviceProvider(srv.URL))
+	})
+
+	if err == nil {
+		t.Fatal("runCodexDeviceFlow() = nil error, want the start failure reported")
+	}
+	if result != nil {
+		t.Errorf("result = %+v, want nil alongside the error", result)
+	}
+	if !strings.Contains(err.Error(), "codex device auth") {
+		t.Errorf("error = %q, want it to name the flow", err)
+	}
+}
+
+// A provider that does not advertise codex device auth must be refused up
+// front rather than posting to an endpoint that does not exist.
+func TestRunCodexDeviceFlow_RejectsUnsupportedProvider(t *testing.T) {
+	var err error
+	_ = captureStdout(t, func() {
+		_, err = runCodexDeviceFlow(context.Background(), auth.Provider{Name: "nope"})
+	})
+	if err == nil {
+		t.Fatal("runCodexDeviceFlow() = nil error, want a refusal")
+	}
+}
+
+// A polling failure travels in Result.Err, not as a returned error — saveResult
+// is what turns it into the user-facing message.
+func TestRunCodexDeviceFlow_PollFailureTravelsInResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/deviceauth/usercode" {
+			fmt.Fprint(w, `{"device_auth_id":"dev-1","user_code":"ABCD-9876","interval":"1"}`)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"device_code_expired"}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BROWSER", "")
+
+	var result *auth.Result
+	var err error
+	_ = captureStdout(t, func() {
+		result, err = runCodexDeviceFlow(context.Background(), codexDeviceProvider(srv.URL))
+	})
+	if err != nil {
+		t.Fatalf("runCodexDeviceFlow() error = %v, want the failure in Result.Err", err)
+	}
+	if result.Err == nil {
+		t.Fatal("Result.Err = nil, want the expired device code reported")
+	}
+	if !strings.Contains(result.Err.Error(), "device_code_expired") {
+		t.Errorf("Result.Err = %v, want it to name the server's reason", result.Err)
+	}
+}
+
+// When nothing in the environment can open a URL, login must print it and
+// carry on: the callback server is already listening, so the flow is one paste
+// away from working and failing it would be gratuitous.
+func TestOpenBrowserDefault_PrintsURLWhenNoHandlerExists(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BROWSER", "")
+
+	var err error
+	out := captureStdout(t, func() {
+		err = openBrowserDefault("https://auth.openai.com/authorize?client_id=test")
+	})
+
+	if err != nil {
+		t.Errorf("openBrowserDefault() = %v, want nil so the login can continue", err)
+	}
+	if !strings.Contains(out, "https://auth.openai.com/authorize?client_id=test") {
+		t.Errorf("stdout = %q, want the URL printed for the user to open by hand", out)
+	}
+}
+
+// With a handler available the URL is handed off silently; printing it too
+// would be noise in the middle of an interactive login.
+func TestOpenBrowserDefault_SilentWhenAHandlerExists(t *testing.T) {
+	// `true` accepts any arguments and exits 0, so it stands in for a browser
+	// launcher without opening anything.
+	t.Setenv("BROWSER", "/usr/bin/true")
+
+	var err error
+	out := captureStdout(t, func() {
+		err = openBrowserDefault("https://example.invalid/")
+	})
+
+	if err != nil {
+		t.Errorf("openBrowserDefault() = %v, want nil", err)
+	}
+	if strings.Contains(out, "Open this URL") {
+		t.Errorf("stdout = %q, want no fallback message when a handler ran", out)
+	}
+}

--- a/internal/pirpc/turn_test.go
+++ b/internal/pirpc/turn_test.go
@@ -1,0 +1,790 @@
+package pirpc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	adkagent "google.golang.org/adk/v2/agent"
+	adkmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/functiontool"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/logger"
+)
+
+// scriptedLLM is an adkmodel.LLM whose reply depends on which invocation it is.
+// A turn that calls a tool reaches the model twice — once to request the call,
+// once with the result — so a single canned response cannot drive those paths.
+type scriptedLLM struct {
+	mu     sync.Mutex
+	calls  int
+	script func(call int) ([]*adkmodel.LLMResponse, error)
+}
+
+func (m *scriptedLLM) Name() string { return "scripted-model" }
+
+func (m *scriptedLLM) GenerateContent(_ context.Context, _ *adkmodel.LLMRequest, _ bool) iter.Seq2[*adkmodel.LLMResponse, error] {
+	m.mu.Lock()
+	call := m.calls
+	m.calls++
+	m.mu.Unlock()
+
+	return func(yield func(*adkmodel.LLMResponse, error) bool) {
+		resps, err := m.script(call)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		for _, r := range resps {
+			if !yield(r, nil) {
+				return
+			}
+		}
+	}
+}
+
+// textResponse builds a plain assistant reply.
+func textResponse(text string) *adkmodel.LLMResponse {
+	return &adkmodel.LLMResponse{Content: genai.NewContentFromText(text, genai.RoleModel)}
+}
+
+// partsResponse builds a reply from explicit parts, for roles and part kinds
+// NewContentFromText cannot express.
+func partsResponse(role string, parts ...*genai.Part) *adkmodel.LLMResponse {
+	return &adkmodel.LLMResponse{Content: &genai.Content{Role: role, Parts: parts}}
+}
+
+// syncBuf is an io.Writer safe for the turn goroutine and the read loop to
+// share, which is exactly the contention Server.writeMu exists to handle.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *syncBuf) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *syncBuf) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// waitForType blocks until an emitted object carries the given "type", so tests
+// synchronize on the protocol rather than on a sleep.
+func (w *syncBuf) waitForType(t *testing.T, typ string) []map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if out := w.String(); strings.Contains(out, `"`+typ+`"`) {
+			got := decodeLines(t, out)
+			for _, ev := range got {
+				if ev["type"] == typ {
+					return got
+				}
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for a %q event; got:\n%s", typ, w.String())
+	return nil
+}
+
+// echoArgs is the argument struct of the test tool.
+type echoArgs struct {
+	Text string `json:"text"`
+}
+
+// echoResult is what the test tool returns.
+type echoResult struct {
+	Echoed string `json:"echoed"`
+}
+
+// echoTool is a tool with no side effects, so a turn can exercise the
+// tool_execution_start/_end path without touching the filesystem or network.
+func echoTool(t *testing.T) tool.Tool {
+	t.Helper()
+	tl, err := functiontool.New(functiontool.Config{
+		Name:        "echo",
+		Description: "Echoes the text back.",
+	}, func(_ adkagent.Context, a echoArgs) (echoResult, error) {
+		return echoResult{Echoed: a.Text}, nil
+	})
+	if err != nil {
+		t.Fatalf("building echo tool: %v", err)
+	}
+	return tl
+}
+
+// newTurnServer wires a Server around a real Agent driven by llm, which is the
+// only way to reach runTurn: the streaming path runs through the ADK runner.
+func newTurnServer(t *testing.T, llm adkmodel.LLM, tools ...tool.Tool) (*Server, *syncBuf) {
+	t.Helper()
+
+	a, err := agent.New(agent.Config{
+		Model:          llm,
+		Tools:          tools,
+		Instruction:    "You are a test agent.",
+		SessionService: session.InMemoryService(),
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	sessionID, _, err := a.CreateSession(context.Background())
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	out := &syncBuf{}
+	return NewServer(Config{
+		Agent:     a,
+		SessionID: sessionID,
+		Model:     "scripted-model",
+		Out:       out,
+	}), out
+}
+
+// eventTypes lists the "type" field of every emitted object, in order.
+func eventTypes(events []map[string]any) []string {
+	types := make([]string, 0, len(events))
+	for _, ev := range events {
+		s, _ := ev["type"].(string)
+		types = append(types, s)
+	}
+	return types
+}
+
+// assistantDeltas collects the streamed chunks of one kind from message_update
+// events.
+func assistantDeltas(events []map[string]any, kind string) []string {
+	var deltas []string
+	for _, ev := range events {
+		if ev["type"] != "message_update" {
+			continue
+		}
+		ame, ok := ev["assistantMessageEvent"].(map[string]any)
+		if !ok || ame["type"] != kind {
+			continue
+		}
+		d, _ := ame["delta"].(string)
+		deltas = append(deltas, d)
+	}
+	return deltas
+}
+
+// pi-acp resolves the ACP session/prompt request on agent_settled and on
+// nothing else, so a turn that omits it hangs the client forever.
+func TestRunTurnStreamsTextAndSettles(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{textResponse("Hello there")}, nil
+	}}
+	s, out := newTurnServer(t, llm)
+
+	s.runTurn(context.Background(), "hi")
+
+	events := decodeLines(t, out.String())
+	types := eventTypes(events)
+	if len(types) < 2 {
+		t.Fatalf("got %v, want at least a start and a settle", types)
+	}
+	if types[0] != "agent_start" {
+		t.Errorf("first event = %q, want agent_start", types[0])
+	}
+	if got := types[len(types)-1]; got != "agent_settled" {
+		t.Errorf("last event = %q, want agent_settled", got)
+	}
+	if got := types[len(types)-2]; got != "agent_end" {
+		t.Errorf("second-to-last event = %q, want agent_end", got)
+	}
+
+	deltas := assistantDeltas(events, "text_delta")
+	if len(deltas) == 0 {
+		t.Fatal("no text_delta emitted; the client would render an empty reply")
+	}
+	if joined := strings.Join(deltas, ""); !strings.Contains(joined, "Hello there") {
+		t.Errorf("text deltas = %q, want them to contain the model reply", joined)
+	}
+}
+
+func TestRunTurnEmitsThinkingSeparatelyFromText(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{
+			partsResponse("thinking", &genai.Part{Text: "weighing options"}),
+			textResponse("the answer"),
+		}, nil
+	}}
+	s, out := newTurnServer(t, llm)
+
+	s.runTurn(context.Background(), "think first")
+
+	events := decodeLines(t, out.String())
+	thinking := strings.Join(assistantDeltas(events, "thinking_delta"), "")
+	text := strings.Join(assistantDeltas(events, "text_delta"), "")
+
+	if !strings.Contains(thinking, "weighing options") {
+		t.Errorf("thinking_delta = %q, want the reasoning text", thinking)
+	}
+	if strings.Contains(text, "weighing options") {
+		t.Errorf("reasoning leaked into text_delta = %q", text)
+	}
+	if !strings.Contains(text, "the answer") {
+		t.Errorf("text_delta = %q, want the assistant reply", text)
+	}
+}
+
+// tool_execution_start and _end must carry the same toolCallId or pi-acp
+// cannot pair them into one tool card.
+func TestRunTurnPairsToolExecutionEvents(t *testing.T) {
+	llm := &scriptedLLM{script: func(call int) ([]*adkmodel.LLMResponse, error) {
+		if call == 0 {
+			return []*adkmodel.LLMResponse{partsResponse(string(genai.RoleModel), &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					ID:   "call_1",
+					Name: "echo",
+					Args: map[string]any{"text": "ping"},
+				},
+			})}, nil
+		}
+		return []*adkmodel.LLMResponse{textResponse("done")}, nil
+	}}
+	s, out := newTurnServer(t, llm, echoTool(t))
+
+	s.runTurn(context.Background(), "use the tool")
+
+	events := decodeLines(t, out.String())
+	var startID, endID string
+	var startName string
+	for _, ev := range events {
+		switch ev["type"] {
+		case "tool_execution_start":
+			startID, _ = ev["toolCallId"].(string)
+			startName, _ = ev["toolName"].(string)
+		case "tool_execution_end":
+			endID, _ = ev["toolCallId"].(string)
+		}
+	}
+
+	if startID == "" {
+		t.Fatalf("no tool_execution_start emitted; events = %v", eventTypes(events))
+	}
+	if startName != "echo" {
+		t.Errorf("toolName = %q, want echo", startName)
+	}
+	if endID == "" {
+		t.Fatalf("no tool_execution_end emitted; the tool card would never close")
+	}
+	if startID != endID {
+		t.Errorf("toolCallId start = %q, end = %q; they must match to pair", startID, endID)
+	}
+}
+
+// pi has no error event pi-acp renders, so a failed run has to reach the user
+// as assistant text — and the turn must still settle.
+func TestRunTurnReportsErrorsAsAssistantText(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return nil, errors.New("model exploded")
+	}}
+	s, out := newTurnServer(t, llm)
+
+	s.runTurn(context.Background(), "boom")
+
+	events := decodeLines(t, out.String())
+	text := strings.Join(assistantDeltas(events, "text_delta"), "")
+	if !strings.Contains(text, "model exploded") {
+		t.Errorf("text deltas = %q, want the failure surfaced to the user", text)
+	}
+	if got := eventTypes(events); got[len(got)-1] != "agent_settled" {
+		t.Errorf("last event = %q, want agent_settled even after a failure", got[len(got)-1])
+	}
+}
+
+// An aborted turn must not report the cancellation as a model error, but it
+// must still settle or the client waits forever.
+func TestRunTurnCanceledContextSettlesWithoutError(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return nil, context.Canceled
+	}}
+	s, out := newTurnServer(t, llm)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.runTurn(ctx, "never mind")
+
+	events := decodeLines(t, out.String())
+	types := eventTypes(events)
+	if got := types[len(types)-1]; got != "agent_settled" {
+		t.Errorf("last event = %q, want agent_settled after an abort", got)
+	}
+	if text := strings.Join(assistantDeltas(events, "text_delta"), ""); strings.Contains(text, "Error:") {
+		t.Errorf("abort rendered as a model error: %q", text)
+	}
+}
+
+// runTurn clears s.cancel on the way out; leaving it set would make every
+// later set_model believe a turn was still running.
+func TestRunTurnClearsCancelOnExit(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{textResponse("ok")}, nil
+	}}
+	s, _ := newTurnServer(t, llm)
+
+	s.runTurn(context.Background(), "hi")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		t.Error("s.cancel still set after the turn; set_model would refuse forever")
+	}
+}
+
+// The prompt command is acknowledged before the turn runs, so abort stays
+// readable while the model streams.
+func TestPromptCommandAcksThenStreamsTurn(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{textResponse("streamed reply")}, nil
+	}}
+	s, out := newTurnServer(t, llm)
+	s.in = strings.NewReader(`{"type":"prompt","id":"p1","message":"hello"}` + "\n")
+
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	events := out.waitForType(t, "agent_settled")
+
+	if events[0]["type"] != "response" || events[0]["id"] != "p1" {
+		t.Errorf("first object = %v, want the prompt acknowledgement", events[0])
+	}
+	if events[0]["success"] != true {
+		t.Errorf("prompt ack success = %v, want true", events[0]["success"])
+	}
+	if text := strings.Join(assistantDeltas(events, "text_delta"), ""); !strings.Contains(text, "streamed reply") {
+		t.Errorf("text deltas = %q, want the model reply", text)
+	}
+}
+
+// blockingLLM stalls until the turn's context is canceled, standing in for a
+// model that is still streaming when the user hits abort.
+type blockingLLM struct{ entered chan struct{} }
+
+func (m *blockingLLM) Name() string { return "blocking-model" }
+
+func (m *blockingLLM) GenerateContent(ctx context.Context, _ *adkmodel.LLMRequest, _ bool) iter.Seq2[*adkmodel.LLMResponse, error] {
+	return func(yield func(*adkmodel.LLMResponse, error) bool) {
+		select {
+		case m.entered <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		yield(nil, ctx.Err())
+	}
+}
+
+// abort has to cancel the in-flight turn, not merely answer politely — and the
+// canceled turn must still settle or pi-acp waits forever.
+func TestAbortCancelsRunningTurn(t *testing.T) {
+	llm := &blockingLLM{entered: make(chan struct{}, 1)}
+	s, out := newTurnServer(t, llm)
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.runTurn(ctx, "long one")
+	}()
+
+	select {
+	case <-llm.entered:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the model was never reached; the turn did not start")
+	}
+
+	s.dispatch(ctx, command{Type: "abort", ID: "a1"})
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("abort did not cancel the running turn")
+	}
+
+	events := decodeLines(t, out.String())
+	types := eventTypes(events)
+	if got := types[len(types)-1]; got != "agent_settled" {
+		t.Errorf("last event = %q, want agent_settled after abort", got)
+	}
+	// The cancellation is the user's doing, not a model failure.
+	if text := strings.Join(assistantDeltas(events, "text_delta"), ""); strings.Contains(text, "Error:") {
+		t.Errorf("abort rendered as a model error: %q", text)
+	}
+}
+
+// A successful switch has to be visible in get_state, since that is what the
+// client renders as the active model.
+func TestSetModelSuccessUpdatesState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	log, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{textResponse("ok")}, nil
+	}}
+	s, _ := newTurnServer(t, llm)
+	s.log = log
+
+	var gotHint string
+	s.modelSwitcher = func(_ context.Context, name, providerHint string) (adkmodel.LLM, string, string, error) {
+		gotHint = providerHint
+		return &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+			return []*adkmodel.LLMResponse{textResponse("new model")}, nil
+		}}, name, "openai", nil
+	}
+
+	if err := s.setModel(context.Background(), "gpt-5.6-luna", "openai"); err != nil {
+		t.Fatalf("setModel() error = %v", err)
+	}
+
+	// The hint is load-bearing: without it pi-go infers the provider from the
+	// default role and can route an OpenAI model through Ollama.
+	if gotHint != "openai" {
+		t.Errorf("providerHint = %q, want it forwarded to the switcher", gotHint)
+	}
+
+	st := s.state()
+	if st["model"] != "gpt-5.6-luna" {
+		t.Errorf("state model = %v, want gpt-5.6-luna", st["model"])
+	}
+	if st["provider"] != "openai" {
+		t.Errorf("state provider = %v, want openai", st["provider"])
+	}
+
+	// The switch is invisible in the RPC stream, so the session log is the only
+	// place a later debugging pass can see which model actually ran.
+	if err := log.Close(); err != nil {
+		t.Fatalf("closing log: %v", err)
+	}
+	contents, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	if !bytes.Contains(contents, []byte("switched model to gpt-5.6-luna")) {
+		t.Errorf("session log does not record the switch:\n%s", contents)
+	}
+}
+
+func TestSetModelCommandSuccessReportsNewState(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{textResponse("ok")}, nil
+	}}
+	s, out := newTurnServer(t, llm)
+	s.modelSwitcher = func(_ context.Context, name, _ string) (adkmodel.LLM, string, string, error) {
+		return &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+			return []*adkmodel.LLMResponse{textResponse("x")}, nil
+		}}, name, "anthropic", nil
+	}
+	s.in = strings.NewReader(`{"type":"set_model","id":"m1","modelId":"claude-x","provider":"anthropic"}` + "\n")
+
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	events := decodeLines(t, out.String())
+	if len(events) != 1 {
+		t.Fatalf("got %d responses, want 1: %v", len(events), events)
+	}
+	if events[0]["success"] != true {
+		t.Fatalf("success = %v, want true (error=%v)", events[0]["success"], events[0]["error"])
+	}
+	data, ok := events[0]["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data has type %T, want the state map", events[0]["data"])
+	}
+	if data["model"] != "claude-x" {
+		t.Errorf("state model = %v, want claude-x", data["model"])
+	}
+}
+
+// A switcher that succeeds but whose agent rebuild fails must still report a
+// failure, or the client shows a model that is not actually in use.
+func TestSetModelRebuildFailureIsReported(t *testing.T) {
+	s := NewServer(Config{
+		Agent: &agent.Agent{}, // zero agent: RebuildWithModel has no runner to rebuild
+		ModelSwitcher: func(_ context.Context, name, _ string) (adkmodel.LLM, string, string, error) {
+			return nil, name, "openai", nil
+		},
+	})
+
+	err := s.setModel(context.Background(), "gpt-5.6-luna", "openai")
+	if err == nil {
+		t.Fatal("setModel() = nil, want an error when the rebuild cannot succeed")
+	}
+	if !strings.Contains(err.Error(), "rebuilding agent") {
+		t.Errorf("error = %q, want it to name the rebuild failure", err)
+	}
+}
+
+// The log is optional, but when present every channel of a turn should reach
+// it — that log is the only record of a headless RPC session.
+func TestRunTurnWritesToTheSessionLog(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	log, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+
+	llm := &scriptedLLM{script: func(call int) ([]*adkmodel.LLMResponse, error) {
+		if call == 0 {
+			return []*adkmodel.LLMResponse{
+				partsResponse("thinking", &genai.Part{Text: "pondering"}),
+				partsResponse(string(genai.RoleModel), &genai.Part{FunctionCall: &genai.FunctionCall{
+					ID: "call_1", Name: "echo", Args: map[string]any{"text": "ping"},
+				}}),
+			}, nil
+		}
+		return []*adkmodel.LLMResponse{textResponse("all done")}, nil
+	}}
+	s, _ := newTurnServer(t, llm, echoTool(t))
+	s.log = log
+
+	s.runTurn(context.Background(), "log this")
+
+	// Streamed assistant text is coalesced in memory and only flushed on Close,
+	// so the log is incomplete until then.
+	if err := log.Close(); err != nil {
+		t.Fatalf("closing log: %v", err)
+	}
+
+	contents, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	for _, want := range []string{"log this", "pondering", "echo", "all done"} {
+		if !bytes.Contains(contents, []byte(want)) {
+			t.Errorf("log is missing %q; got:\n%s", want, contents)
+		}
+	}
+}
+
+func TestEmitErrorIsLoggedAndSurfaced(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	log, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+
+	out := &syncBuf{}
+	s := NewServer(Config{Out: out, Log: log})
+	s.emitError(errors.New("upstream refused"))
+
+	if text := strings.Join(assistantDeltas(decodeLines(t, out.String()), "text_delta"), ""); !strings.Contains(text, "upstream refused") {
+		t.Errorf("text delta = %q, want the error surfaced as assistant text", text)
+	}
+
+	if err := log.Close(); err != nil {
+		t.Fatalf("closing log: %v", err)
+	}
+
+	contents, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	if !bytes.Contains(contents, []byte("upstream refused")) {
+		t.Errorf("error missing from the session log:\n%s", contents)
+	}
+}
+
+// pi-acp persists sessionFile into its session map, so advertising a path that
+// does not exist makes a later session/load unresolvable.
+func TestStateAdvertisesSessionFileOnlyWhenItExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	s := NewServer(Config{SessionID: "sess-file", Model: "m"})
+	if _, ok := s.state()["sessionFile"]; ok {
+		t.Error("sessionFile advertised for a session with no file on disk")
+	}
+
+	dir := filepath.Join(home, ".pi-go", "sessions")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("creating session dir: %v", err)
+	}
+	path := filepath.Join(dir, "sess-file.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("writing session file: %v", err)
+	}
+
+	if got := s.state()["sessionFile"]; got != path {
+		t.Errorf("sessionFile = %v, want %s", got, path)
+	}
+}
+
+// Run must stop when the context is canceled, even with input still pending,
+// or a shutdown would block on a client that keeps writing.
+func TestRunStopsOnCanceledContext(t *testing.T) {
+	out := &syncBuf{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s := NewServer(Config{
+		SessionID: "sess",
+		In:        strings.NewReader(strings.Repeat(`{"type":"get_state","id":"x"}`+"\n", 5)),
+		Out:       out,
+	})
+	if err := s.Run(ctx); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("Run() served commands after cancellation: %q", out.String())
+	}
+}
+
+// errReader fails partway through, standing in for a broken stdin.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestRunReportsReadFailures(t *testing.T) {
+	s := NewServer(Config{
+		In:  errReader{err: errors.New("stdin died")},
+		Out: &syncBuf{},
+	})
+	err := s.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run() = nil, want the read failure reported")
+	}
+	if !strings.Contains(err.Error(), "stdin died") {
+		t.Errorf("error = %q, want it to wrap the read failure", err)
+	}
+}
+
+// A line larger than bufio.Scanner's 64KiB default is ordinary here: prompts
+// carry whole files.
+func TestRunAcceptsPromptsLargerThanTheDefaultScannerBuffer(t *testing.T) {
+	llm := &scriptedLLM{script: func(int) ([]*adkmodel.LLMResponse, error) {
+		return []*adkmodel.LLMResponse{textResponse("got it")}, nil
+	}}
+	s, out := newTurnServer(t, llm)
+
+	big := strings.Repeat("x", 256<<10)
+	s.in = strings.NewReader(fmt.Sprintf(`{"type":"prompt","id":"big","message":%q}`+"\n", big))
+
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	events := out.waitForType(t, "agent_settled")
+	if events[0]["id"] != "big" || events[0]["success"] != true {
+		t.Errorf("large prompt was rejected: %v", events[0])
+	}
+}
+
+func TestRunSkipsBlankLines(t *testing.T) {
+	out := &syncBuf{}
+	s := NewServer(Config{
+		SessionID: "sess",
+		In:        strings.NewReader("\n   \n" + `{"type":"get_state","id":"only"}` + "\n\n"),
+		Out:       out,
+	})
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	events := decodeLines(t, out.String())
+	if len(events) != 1 {
+		t.Fatalf("got %d responses, want 1 (blank lines must not be answered): %v", len(events), events)
+	}
+}
+
+// Interleaved NDJSON would be unparseable, so emit has to serialize writes
+// across the turn goroutine and the read loop.
+func TestEmitSerializesConcurrentWrites(t *testing.T) {
+	out := &syncBuf{}
+	s := NewServer(Config{Out: out})
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.emit(map[string]any{"type": "message_update", "n": i})
+		}()
+	}
+	wg.Wait()
+
+	events := decodeLines(t, out.String()) // fails the test if any line is not valid JSON
+	if len(events) != 50 {
+		t.Errorf("got %d lines, want 50", len(events))
+	}
+}
+
+// A value json.Marshal rejects must not produce a truncated or empty line that
+// would desynchronize the client's parser.
+func TestEmitDropsUnmarshalableValues(t *testing.T) {
+	out := &syncBuf{}
+	s := NewServer(Config{Out: out})
+
+	s.emit(make(chan int))
+
+	if out.String() != "" {
+		t.Errorf("emit wrote %q for an unmarshalable value, want nothing", out.String())
+	}
+}
+
+// reply must never claim success alongside an error; the client reads only one
+// of the two fields.
+func TestReplyMarksErroredResponsesUnsuccessful(t *testing.T) {
+	out := &syncBuf{}
+	s := NewServer(Config{Out: out})
+
+	s.reply(response{ID: "r1", Command: "prompt", Success: true, Error: "it failed"})
+
+	events := decodeLines(t, out.String())
+	if len(events) != 1 {
+		t.Fatalf("got %d responses, want 1", len(events))
+	}
+	if events[0]["success"] != false {
+		t.Errorf("success = %v, want false when an error is set", events[0]["success"])
+	}
+	if events[0]["type"] != "response" {
+		t.Errorf("type = %v, want response", events[0]["type"])
+	}
+}
+
+// These commands exist so the adapter's slash menu does not error; each must
+// still answer with the current state.
+func TestAcceptedNoOpCommandsReturnState(t *testing.T) {
+	for _, cmd := range []string{
+		"set_follow_up_mode", "set_steering_mode", "set_auto_compaction",
+		"set_session_name", "switch_session", "compact",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := runCommands(t, `{"type":"`+cmd+`","id":"c1"}`)
+			if len(got) != 1 {
+				t.Fatalf("got %d responses, want 1", len(got))
+			}
+			if got[0]["success"] != true {
+				t.Errorf("success = %v, want true (error=%v)", got[0]["success"], got[0]["error"])
+			}
+			if _, ok := got[0]["data"].(map[string]any); !ok {
+				t.Errorf("data has type %T, want the state map", got[0]["data"])
+			}
+		})
+	}
+}

--- a/internal/tui/login_flows_test.go
+++ b/internal/tui/login_flows_test.go
@@ -1,0 +1,647 @@
+package tui
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/auth"
+	"github.com/dimetron/pi-go/internal/logger"
+)
+
+// newMockCodexDeviceServer stands in for auth.openai.com's device endpoints.
+// approvalsBeforeOK controls how many polls answer 403 ("not approved yet")
+// before the approval lands, which is the only signal that path gets.
+func newMockCodexDeviceServer(t *testing.T, approvalsBeforeOK int) *httptest.Server {
+	t.Helper()
+	polls := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/deviceauth/usercode":
+			// The interval arrives as a JSON string upstream, so exercise that
+			// encoding rather than the more obvious number.
+			fmt.Fprint(w, `{"device_auth_id":"dev-1","user_code":"WXYZ-1234","interval":"1"}`)
+		case "/deviceauth/token":
+			polls++
+			if polls <= approvalsBeforeOK {
+				w.WriteHeader(http.StatusForbidden)
+				fmt.Fprint(w, `{"error":"pending"}`)
+				return
+			}
+			fmt.Fprint(w, `{"authorization_code":"auth-code-1","code_verifier":"verifier-1"}`)
+		case "/oauth/token":
+			fmt.Fprint(w, `{"access_token":"codex-device-token","token_type":"bearer"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// codexDeviceProvider wires a Provider at a mock server.
+func codexDeviceProvider(srvURL string) auth.Provider {
+	return auth.Provider{
+		Name:              "codex",
+		EnvVar:            "OPENAI_API_KEY",
+		DeviceURL:         srvURL + "/deviceauth",
+		TokenURL:          srvURL + "/oauth/token",
+		ClientID:          "pi-go-cli",
+		CodexDeviceAuth:   true,
+		DeviceVerifyURL:   "https://auth.openai.com/codex/device",
+		DeviceRedirectURI: "http://localhost/callback",
+		TokenToKey:        func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	}
+}
+
+// loggedModel returns a model wired to a real session log in an isolated HOME,
+// plus a func returning the log's contents. The async login commands take a
+// separate branch when a logger is configured, and that branch carries the only
+// record of what a failed authentication did.
+func loggedModel(t *testing.T) (*model, func() string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	log, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = log.Close() })
+
+	return &model{cfg: Config{Logger: log}}, func() string {
+		t.Helper()
+		if err := log.Close(); err != nil {
+			t.Fatalf("closing log: %v", err)
+		}
+		contents, err := os.ReadFile(log.Path())
+		if err != nil {
+			t.Fatalf("reading log: %v", err)
+		}
+		return string(contents)
+	}
+}
+
+// The device code has to reach the chat pane before polling starts, or the
+// user is left staring at a spinner with no code to enter.
+func TestLoginStartCodexDeviceFlow_PromptsThenPolls(t *testing.T) {
+	mb := withMockBrowser(t)
+	srv := newMockCodexDeviceServer(t, 1)
+	defer srv.Close()
+
+	m, logContents := loggedModel(t)
+	_, cmd := m.loginStartCodexDeviceFlow(codexDeviceProvider(srv.URL))
+
+	if m.login == nil || m.login.phase != "device" {
+		t.Fatalf("login state = %+v, want device phase", m.login)
+	}
+	if cmd == nil {
+		t.Fatal("expected a polling command")
+	}
+
+	last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content
+	if !strings.Contains(last, "WXYZ-1234") {
+		t.Errorf("prompt is missing the user code, got: %s", last)
+	}
+	// The verification URL is the one the user opens; the device endpoint is
+	// pi's own business and must not be shown.
+	if !strings.Contains(last, "https://auth.openai.com/codex/device") {
+		t.Errorf("prompt is missing the verification URL, got: %s", last)
+	}
+	if mb.lastURL() != "https://auth.openai.com/codex/device" {
+		t.Errorf("browser opened %q, want the verification URL", mb.lastURL())
+	}
+
+	msg := cmd()
+	result, ok := msg.(loginSSOResultMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want loginSSOResultMsg", msg)
+	}
+	if result.result.Err != nil {
+		t.Fatalf("device auth failed: %v", result.result.Err)
+	}
+	if result.result.APIKey != "codex-device-token" {
+		t.Errorf("APIKey = %q, want codex-device-token", result.result.APIKey)
+	}
+
+	if got := logContents(); !strings.Contains(got, "codex device auth ok") {
+		t.Errorf("session log does not record the successful device auth:\n%s", got)
+	}
+}
+
+// A failed start must clear the login state, or the TUI stays wedged in a
+// device phase that nothing will ever complete.
+func TestLoginStartCodexDeviceFlow_StartFailureClearsState(t *testing.T) {
+	withMockBrowser(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":"boom"}`)
+	}))
+	defer srv.Close()
+
+	m := &model{}
+	_, cmd := m.loginStartCodexDeviceFlow(codexDeviceProvider(srv.URL))
+
+	if m.login != nil {
+		t.Errorf("login state = %+v, want nil after a failed start", m.login)
+	}
+	if cmd != nil {
+		t.Error("expected no polling command after a failed start")
+	}
+	if len(m.chatModel.Messages) == 0 {
+		t.Fatal("expected an error message")
+	}
+	if last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content; !strings.Contains(last, "Login error") {
+		t.Errorf("message = %q, want a login error", last)
+	}
+}
+
+// A device auth that fails during polling still has to produce a result the
+// TUI can render, rather than leaving the command hanging.
+func TestLoginStartCodexDeviceFlow_PollFailureReportsResult(t *testing.T) {
+	withMockBrowser(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/deviceauth/usercode":
+			fmt.Fprint(w, `{"device_auth_id":"dev-1","user_code":"WXYZ-1234","interval":"1"}`)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"device_code_expired"}`)
+		}
+	}))
+	defer srv.Close()
+
+	m, logContents := loggedModel(t)
+	_, cmd := m.loginStartCodexDeviceFlow(codexDeviceProvider(srv.URL))
+	if cmd == nil {
+		t.Fatal("expected a polling command")
+	}
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err == nil {
+		t.Fatal("expected the poll failure to be reported")
+	}
+	if !strings.Contains(result.result.Err.Error(), "device_code_expired") {
+		t.Errorf("error = %v, want it to name the server's reason", result.result.Err)
+	}
+	if got := logContents(); !strings.Contains(got, "codex device auth failed") {
+		t.Errorf("session log does not record the failure:\n%s", got)
+	}
+}
+
+// manualCodeProvider wires an Anthropic-style paste-the-code provider.
+func manualCodeProvider(srvURL string) auth.Provider {
+	return auth.Provider{
+		Name:              "manual",
+		EnvVar:            "MANUAL_API_KEY",
+		AuthURL:           srvURL + "/oauth/authorize",
+		TokenURL:          srvURL + "/oauth/token",
+		ClientID:          "pi-go-cli",
+		Scopes:            []string{"api"},
+		ManualCode:        true,
+		ManualRedirectURI: "https://example.invalid/callback",
+		TokenToKey:        func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	}
+}
+
+func TestLoginStartManualCode_PromptsForPaste(t *testing.T) {
+	mb := withMockBrowser(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"manual-token","token_type":"bearer"}`)
+	}))
+	defer srv.Close()
+
+	m := &model{}
+	m.loginStartManualCode(manualCodeProvider(srv.URL))
+
+	if m.login == nil || m.login.phase != "manual-code" {
+		t.Fatalf("login state = %+v, want manual-code phase", m.login)
+	}
+	if m.login.manualCode == nil {
+		t.Fatal("manual-code session was not retained; the paste would have nothing to exchange")
+	}
+	if mb.called() != 1 {
+		t.Errorf("browser called %d times, want 1", mb.called())
+	}
+	if last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content; !strings.Contains(last, "redirect URL") {
+		t.Errorf("prompt does not explain what to paste, got: %s", last)
+	}
+}
+
+// A provider not configured for the manual-code flow must surface the error
+// rather than leave the user at a prompt with no session behind it.
+func TestLoginStartManualCode_StartFailureIsReported(t *testing.T) {
+	withMockBrowser(t)
+	m := &model{}
+
+	// ManualCode is set but ManualRedirectURI is not, which StartManualCodeFlow
+	// rejects.
+	m.loginStartManualCode(auth.Provider{Name: "broken", ManualCode: true})
+
+	if m.login != nil {
+		t.Errorf("login state = %+v, want nil", m.login)
+	}
+	if len(m.chatModel.Messages) == 0 {
+		t.Fatal("expected an error message")
+	}
+	if last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content; !strings.Contains(last, "Login error") {
+		t.Errorf("message = %q, want a login error", last)
+	}
+}
+
+func TestHandleLoginCodeSubmit_ExchangesPastedCode(t *testing.T) {
+	withMockBrowser(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"manual-token","token_type":"bearer"}`)
+	}))
+	defer srv.Close()
+
+	sess, err := auth.StartManualCodeFlow(manualCodeProvider(srv.URL))
+	if err != nil {
+		t.Fatalf("StartManualCodeFlow() error = %v", err)
+	}
+
+	m, logContents := loggedModel(t)
+	m.login = &loginState{phase: "manual-code", provider: "manual", manualCode: sess}
+	_, cmd := m.handleLoginCodeSubmit("auth-code-123")
+	if cmd == nil {
+		t.Fatal("expected an exchange command")
+	}
+	if last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content; !strings.Contains(last, "Exchanging code") {
+		t.Errorf("message = %q, want progress feedback", last)
+	}
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err != nil {
+		t.Fatalf("exchange failed: %v", result.result.Err)
+	}
+	if result.result.APIKey != "manual-token" {
+		t.Errorf("APIKey = %q, want manual-token", result.result.APIKey)
+	}
+	if result.result.EnvVar != "MANUAL_API_KEY" {
+		t.Errorf("EnvVar = %q, want MANUAL_API_KEY", result.result.EnvVar)
+	}
+	if got := logContents(); !strings.Contains(got, "manual-code exchange ok") {
+		t.Errorf("session log does not record the exchange:\n%s", got)
+	}
+}
+
+// A paste with no code in it must come back as a result the TUI renders, not
+// as a silent no-op.
+func TestHandleLoginCodeSubmit_UnusablePasteIsReported(t *testing.T) {
+	withMockBrowser(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"unused","token_type":"bearer"}`)
+	}))
+	defer srv.Close()
+
+	sess, err := auth.StartManualCodeFlow(manualCodeProvider(srv.URL))
+	if err != nil {
+		t.Fatalf("StartManualCodeFlow() error = %v", err)
+	}
+
+	m, logContents := loggedModel(t)
+	m.login = &loginState{phase: "manual-code", provider: "manual", manualCode: sess}
+	_, cmd := m.handleLoginCodeSubmit("")
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err == nil {
+		t.Fatal("expected an error for a paste with no authorization code")
+	}
+	if got := logContents(); !strings.Contains(got, "manual-code exchange aborted") {
+		t.Errorf("session log does not record the aborted exchange:\n%s", got)
+	}
+}
+
+func TestHandleLoginCodeSubmit_WithoutSession(t *testing.T) {
+	m := &model{login: &loginState{phase: "manual-code", provider: "manual"}}
+	_, cmd := m.handleLoginCodeSubmit("anything")
+
+	if cmd != nil {
+		t.Error("expected no command when there is no session to exchange against")
+	}
+	if m.login != nil {
+		t.Errorf("login state = %+v, want nil", m.login)
+	}
+	if last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content; !strings.Contains(last, "Internal error") {
+		t.Errorf("message = %q, want an internal error", last)
+	}
+}
+
+// TestLoginStartPKCEFlow_CompletesViaCallback drives the whole PKCE round trip:
+// the mock browser plays the user, fetching the callback URL that the real
+// browser would have been redirected to.
+func TestLoginStartPKCEFlow_CompletesViaCallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"pkce-token","token_type":"bearer"}`)
+	}))
+	defer srv.Close()
+
+	orig := openBrowser
+	t.Cleanup(func() { openBrowser = orig })
+	// PKCEFlow builds the redirect URI from the port its listener actually got,
+	// so the callback address is only knowable from the authorize URL.
+	openBrowser = func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		redirect, err := url.Parse(q.Get("redirect_uri"))
+		if err != nil {
+			return err
+		}
+		cb := *redirect
+		cb.RawQuery = url.Values{
+			"code":  {"pkce-code"},
+			"state": {q.Get("state")},
+		}.Encode()
+
+		resp, err := http.Get(cb.String())
+		if err != nil {
+			return err
+		}
+		return resp.Body.Close()
+	}
+
+	m, logContents := loggedModel(t)
+	_, cmd := m.loginStartPKCEFlow(auth.Provider{
+		Name:       "pkce",
+		EnvVar:     "PKCE_API_KEY",
+		AuthURL:    srv.URL + "/oauth/authorize",
+		TokenURL:   srv.URL + "/oauth/token",
+		ClientID:   "pi-go-cli",
+		Scopes:     []string{"api"},
+		TokenToKey: func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	})
+	if cmd == nil {
+		t.Fatal("expected a PKCE command")
+	}
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err != nil {
+		t.Fatalf("PKCE flow failed: %v", result.result.Err)
+	}
+	if result.result.APIKey != "pkce-token" {
+		t.Errorf("APIKey = %q, want pkce-token", result.result.APIKey)
+	}
+	if got := logContents(); !strings.Contains(got, "pkce callback/exchange ok") {
+		t.Errorf("session log does not record the exchange:\n%s", got)
+	}
+}
+
+// A PKCE round trip whose token exchange is rejected comes back as a result
+// carrying the error, not as a transport failure.
+func TestLoginStartPKCEFlow_TokenExchangeFailureIsLogged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant"}`)
+	}))
+	defer srv.Close()
+
+	orig := openBrowser
+	t.Cleanup(func() { openBrowser = orig })
+	openBrowser = func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		redirect, err := url.Parse(q.Get("redirect_uri"))
+		if err != nil {
+			return err
+		}
+		cb := *redirect
+		cb.RawQuery = url.Values{"code": {"pkce-code"}, "state": {q.Get("state")}}.Encode()
+		resp, err := http.Get(cb.String())
+		if err != nil {
+			return err
+		}
+		return resp.Body.Close()
+	}
+
+	m, logContents := loggedModel(t)
+	_, cmd := m.loginStartPKCEFlow(auth.Provider{
+		Name:       "pkce",
+		EnvVar:     "PKCE_API_KEY",
+		AuthURL:    srv.URL + "/oauth/authorize",
+		TokenURL:   srv.URL + "/oauth/token",
+		ClientID:   "pi-go-cli",
+		TokenToKey: func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	})
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err == nil {
+		t.Fatal("expected the rejected token exchange to be reported")
+	}
+	if got := logContents(); !strings.Contains(got, "pkce callback/exchange failed") {
+		t.Errorf("session log does not record the failed exchange:\n%s", got)
+	}
+}
+
+// A browser that cannot be opened aborts PKCE, since nothing will ever reach
+// the callback — the failure has to come back as a renderable result.
+func TestLoginStartPKCEFlow_BrowserFailureIsReported(t *testing.T) {
+	mb := withMockBrowser(t)
+	mb.err = fmt.Errorf("no browser handler")
+
+	m, logContents := loggedModel(t)
+	_, cmd := m.loginStartPKCEFlow(auth.Provider{
+		Name:       "pkce",
+		EnvVar:     "PKCE_API_KEY",
+		AuthURL:    "http://127.0.0.1:1/authorize",
+		TokenURL:   "http://127.0.0.1:1/token",
+		ClientID:   "pi-go-cli",
+		TokenToKey: func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	})
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err == nil {
+		t.Fatal("expected the browser failure to be reported")
+	}
+	if got := logContents(); !strings.Contains(got, "pkce flow aborted") {
+		t.Errorf("session log does not record the aborted flow:\n%s", got)
+	}
+}
+
+// The RFC 8628 device flow is the other headless path; its async poll takes a
+// separate logging branch from the codex variant.
+func TestLoginStartDeviceFlow_LogsPollOutcome(t *testing.T) {
+	withMockBrowser(t)
+	attempt := 0
+	srv := newMockDeviceServer(t, &attempt)
+	defer srv.Close()
+
+	m, logContents := loggedModel(t)
+	_, cmd := m.loginStartDeviceFlow(auth.Provider{
+		Name:          "test-device",
+		EnvVar:        "TEST_KEY",
+		DeviceURL:     srv.URL + "/device/code",
+		TokenURL:      srv.URL + "/oauth/token",
+		UseDeviceFlow: true,
+		ClientID:      "test",
+		Scopes:        []string{"api"},
+		TokenToKey:    func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	})
+	if cmd == nil {
+		t.Fatal("expected a polling command")
+	}
+
+	result, ok := cmd().(loginSSOResultMsg)
+	if !ok {
+		t.Fatal("cmd did not return a loginSSOResultMsg")
+	}
+	if result.result.Err != nil {
+		t.Fatalf("device flow failed: %v", result.result.Err)
+	}
+
+	got := logContents()
+	if !strings.Contains(got, "device flow prompt") {
+		t.Errorf("session log does not record the prompt:\n%s", got)
+	}
+	if !strings.Contains(got, "device flow ok") {
+		t.Errorf("session log does not record the successful poll:\n%s", got)
+	}
+}
+
+// The Codex variant renames the prompt; the wording is what tells the user
+// which credential they are about to hand over.
+func TestLoginStartPKCEFlow_CodexOAuthWording(t *testing.T) {
+	withMockBrowser(t)
+	m := &model{}
+	m.loginStartPKCEFlow(auth.Provider{
+		Name:       "codex",
+		EnvVar:     "OPENAI_API_KEY",
+		AuthURL:    "http://127.0.0.1:1/authorize",
+		TokenURL:   "http://127.0.0.1:1/token",
+		ClientID:   "pi-go-cli",
+		CodexOAuth: true,
+		TokenToKey: func(tok *auth.TokenResponse) string { return tok.AccessToken },
+	})
+
+	last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content
+	if !strings.Contains(last, "codex OAuth") {
+		t.Errorf("message = %q, want it to name Codex OAuth", last)
+	}
+}
+
+// loginStart routes on provider capability; the codex device path is the one
+// that exists so a dev container with no browser and no callback can log in.
+func TestLoginStart_RoutesCodexDeviceAuth(t *testing.T) {
+	withMockBrowser(t)
+	srv := newMockCodexDeviceServer(t, 0)
+	defer srv.Close()
+
+	m := &model{}
+	m.loginStart(codexDeviceProvider(srv.URL))
+
+	if m.login == nil || m.login.phase != "device" {
+		t.Fatalf("login state = %+v, want the device phase", m.login)
+	}
+	if last := m.chatModel.Messages[len(m.chatModel.Messages)-1].content; !strings.Contains(last, "WXYZ-1234") {
+		t.Errorf("message = %q, want the device code", last)
+	}
+}
+
+func TestLoginStart_RoutesManualCode(t *testing.T) {
+	withMockBrowser(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+
+	m := &model{}
+	m.loginStart(manualCodeProvider(srv.URL))
+
+	if m.login == nil || m.login.phase != "manual-code" {
+		t.Fatalf("login state = %+v, want the manual-code phase", m.login)
+	}
+}
+
+// Login events are the only trace a failed authentication leaves, so they have
+// to reach the session log when one is configured.
+func TestLogLogin_WritesToTheSessionLog(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	log, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+
+	m := &model{cfg: Config{Logger: log}}
+	m.logLogin("selected %s flow for %s", "device", "codex")
+
+	if err := log.Close(); err != nil {
+		t.Fatalf("closing log: %v", err)
+	}
+	contents, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	if !strings.Contains(string(contents), "login: selected device flow for codex") {
+		t.Errorf("log is missing the login entry:\n%s", contents)
+	}
+}
+
+// A nil model or a session with no logger must not panic — logLogin is called
+// from paths that run before the logger is wired.
+func TestLogLogin_WithoutLoggerIsSafe(t *testing.T) {
+	var nilModel *model
+	nilModel.logLogin("no panic please")
+	(&model{}).logLogin("still no panic")
+}
+
+// The status view is what `/login` with no argument shows; it must report each
+// provider's real state rather than a fixed string.
+func TestLoginShowStatus_ReflectsConfiguredKeys(t *testing.T) {
+	m := &model{}
+	m.loginShowStatus()
+
+	if len(m.chatModel.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(m.chatModel.Messages))
+	}
+	content := m.chatModel.Messages[0].content
+	for _, want := range []string{"API Key Status", "codex", "/login <provider>"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("status output is missing %q, got:\n%s", want, content)
+		}
+	}
+	if !strings.Contains(content, "configured") && !strings.Contains(content, "not set") {
+		t.Errorf("status output reports no state at all, got:\n%s", content)
+	}
+}
+
+// openBrowserDefault is the real handler behind the openBrowser var that every
+// other test replaces, so it needs its own exercise.
+func TestOpenBrowserDefault_ReportsNoHandler(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BROWSER", "")
+
+	if err := openBrowserDefault("https://example.invalid/"); err == nil {
+		t.Error("openBrowserDefault() = nil, want an error when nothing can open a URL")
+	}
+}


### PR DESCRIPTION
Patch coverage on this branch was 54.4% against an 82.2% target. The bulk of the gap was internal/pirpc, whose turn loop had no test at all: runTurn, emitDelta and emitError were entirely uncovered because reaching them needs a real agent.Agent driven through the ADK runner, not a stub.

Adds a scripted adkmodel.LLM so a Server can be wired to a real Agent, which makes the streaming path testable end to end. What that buys, beyond the number, is coverage of the protocol invariants pi-acp depends on:

  - every turn ends in agent_settled, including after a model error and after an abort — pi-acp resolves session/prompt on nothing else, so missing it hangs the client forever;
  - tool_execution_start and _end carry the same toolCallId;
  - reasoning goes to thinking_delta, never to text_delta;
  - emit serializes concurrent writes, since interleaved NDJSON would be unparseable.

Also covers the new server-mode routing in dispatchMode, including the deprecated `--mode rpc --socket` fallback and the ModelSwitcher closure that substitutes the client's named provider (a stale default-role pin would otherwise route an OpenAI model through Ollama), the codex device auth flow in both the CLI and the TUI, and browser.Open's handler search.

Patch coverage 54.4% -> 95.9%; internal/pirpc 52.7% -> 95.9%, internal/browser 84.6% -> 100%, internal/auth 87.9% -> 90.9%.

Test-only change; no production code is modified.