### PR TITLE
feat: --trace-http raw request/response logging

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -95,9 +95,66 @@ func versionString() string {
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "pi [prompt]",
-		Short:   "pi-go coding agent",
-		Long:    "A Go coding agent with multi-provider LLM support, tool calling, and interactive TUI.",
+		Use:   "pi [prompt]",
+		Short: "pi-go coding agent",
+		Long: `A Go coding agent with multi-provider LLM support, tool calling, and interactive TUI.
+
+Run with no prompt for the interactive TUI; pass a prompt to answer once and exit.
+
+The provider is inferred from the model name, so --model is usually the only
+routing you need:
+
+  claude-*                 Anthropic       ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN)
+  gpt-*                    OpenAI          OPENAI_API_KEY
+  gemini-*                 Google Gemini   GEMINI_API_KEY (or GOOGLE_API_KEY)
+  mistral-*, magistral-*   Mistral         MISTRAL_API_KEY
+  ollama/<model>           Ollama, local   none; http://localhost:11434
+  <model>:cloud            Ollama Cloud    OLLAMA_API_KEY; https://api.ollama.com
+  azure/<deployment>       Azure OpenAI    AZURE_OPENAI_API_KEY
+  opencode/<model>         OpenCode        OPENCODE_API_KEY
+
+A name with no recognized prefix is rejected rather than guessed at — reach for
+the ollama/ prefix or the :cloud suffix to name an Ollama model explicitly.
+
+Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
+--smol, --slow and --plan switch between the roles configured there.`,
+		Example: `  # Anthropic
+  pi --model claude-sonnet-5 "explain what this repo does"
+
+  # OpenAI
+  pi --model gpt-5.2 "add a table-driven test for the parser"
+
+  # Google Gemini
+  pi --model gemini-3.5-pro "review the diff on this branch"
+
+  # Mistral
+  pi --model mistral-large-latest "summarize the changelog"
+
+  # Ollama against a local daemon — no API key needed
+  pi --model ollama/gemma4:e4b "rename this symbol everywhere"
+
+  # Ollama Cloud — the :cloud tag routes to api.ollama.com, needs OLLAMA_API_KEY
+  pi --model minimax-m3:cloud "port this module to generics"
+
+  # Azure OpenAI — the deployment name follows azure/
+  pi --model azure/my-gpt5-deployment "draft release notes"
+
+  # OpenCode
+  pi --model opencode/claude-sonnet-5 "find the goroutine leak"
+
+  # Any OpenAI-compatible gateway, with an extra header and a corporate CA
+  pi --url https://llm.corp.internal/v1 --model gpt-5.2 \
+     --header X-Team=platform --ca-cert /etc/ssl/corp.pem "run the tests"
+
+  # One-shot answer instead of the TUI, and resuming a session
+  pi --mode print "what changed in the last commit?"
+  pi --continue
+  pi --session 01JQ8Z... "carry on where we left off"
+
+  # Diagnosing a provider
+  pi ping                                 # DNS/TCP/TLS/HTTP trace, curl -v style
+  pi ping --model minimax-m3:cloud        # check one model end to end
+  pi --trace-http "why was that rejected?"  # full request/response in the session log`,
 		Version: versionString(),
 		Args:    cobra.ArbitraryArgs,
 		// Start pprof here rather than in runRoot: subcommands (`pi memory mine`,
@@ -108,7 +165,7 @@ func newRootCmd() *cobra.Command {
 		RunE:             runRoot,
 	}
 
-	cmd.Flags().StringVar(&flagModel, "model", "", "LLM model to use (e.g. claude-sonnet-4-6, gpt-4o, gemini-2.5-pro)")
+	cmd.Flags().StringVar(&flagModel, "model", "", "LLM model to use (e.g. claude-sonnet-5, gpt-5.2, gemini-3.5-pro, ollama/gemma4:e4b, minimax-m3:cloud)")
 	cmd.Flags().StringVar(&flagMode, "mode", "", "Output mode: interactive, print, json, socket, rpc")
 	cmd.Flags().StringVar(&flagSocket, "socket", "/tmp/pi-go.sock", "Unix socket path for socket mode")
 	// pi-acp unconditionally spawns `pi --mode rpc --no-themes`. pi-go has no
@@ -140,6 +197,18 @@ func newRootCmd() *cobra.Command {
 	// other subcommands that reach a provider all need it.
 	cmd.PersistentFlags().BoolVar(&flagTraceHTTP, "trace-http", false,
 		"Log full LLM request/response headers and bodies to the session log and OTel spans (credentials masked; prompts are not)")
+
+	// Append the resolved role table to `pi --help`. A help func set on the
+	// root is inherited by every subcommand, so this reproduces the default
+	// output and only adds the footer when help was asked for the root itself
+	// — `pi audit --help` has no use for it.
+	defaultHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		defaultHelp(c, args)
+		if c == cmd {
+			writeRoleSummary(c.OutOrStdout())
+		}
+	})
 
 	cmd.AddCommand(newPingCmd())
 	cmd.AddCommand(newAuditCmd())

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/guardrail"
+	"github.com/dimetron/pi-go/internal/httplog"
 	"github.com/dimetron/pi-go/internal/jsonrpc"
 	"github.com/dimetron/pi-go/internal/logger"
 	"github.com/dimetron/pi-go/internal/lsp"
@@ -64,6 +65,7 @@ var (
 	flagSystem    string
 	flagPprof     string
 	flagPprofPort string
+	flagTraceHTTP bool
 
 	// lastSessionFile persists the last session start metadata across invocations.
 	// Used to detect rapid restart loops (e.g. print mode crashes).
@@ -134,6 +136,10 @@ func newRootCmd() *cobra.Command {
 	// "unknown flag: --pprof" the moment a subcommand was used.
 	cmd.PersistentFlags().StringVar(&flagPprof, "pprof", "", "Enable pprof profiling (serves /debug/pprof; any non-empty value enables it)")
 	cmd.PersistentFlags().StringVar(&flagPprofPort, "pprof-port", "6060", "Port for the pprof HTTP server")
+	// Persistent for the same reason as --pprof: `pi ping --trace-http` and the
+	// other subcommands that reach a provider all need it.
+	cmd.PersistentFlags().BoolVar(&flagTraceHTTP, "trace-http", false,
+		"Log full LLM request/response headers and bodies to the session log and OTel spans (credentials masked; prompts are not)")
 
 	cmd.AddCommand(newPingCmd())
 	cmd.AddCommand(newAuditCmd())
@@ -254,7 +260,7 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 		AdvisorMaxUses: advisorMaxUses,
 		AdvisorCaching: advisorCaching,
 	}
-	applyTLSOptions(llmOpts, cfg)
+	applyTransportOptions(llmOpts, cfg)
 	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, llmOpts)
 	if err != nil {
 		return rootRuntime{}, fmt.Errorf("creating LLM provider: %w", err)
@@ -569,7 +575,14 @@ func runNonInteractive(
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pi-go: warning: could not create session log: %v\n", err)
 	}
-	defer func() { _ = sessionLog.Close() }()
+	// --trace-http entries are dropped until this point, because the transport
+	// is built well before the log file exists. In practice the only requests
+	// that precede it are the ollama health check and model listing.
+	httplog.SetSink(logger.HTTPSink(sessionLog))
+	defer func() {
+		httplog.SetSink(nil)
+		_ = sessionLog.Close()
+	}()
 
 	ag, err := agent.New(agent.Config{
 		Model:               llm,
@@ -1411,16 +1424,24 @@ func mergeExtraHeaders(cfgHeaders map[string]string, cliHeaders []string) map[st
 	return merged
 }
 
-// applyTLSOptions layers the --insecure/--ca-cert flags over the TLS trust
-// settings from config. The flags are additive: neither one can turn a
-// config-enabled setting back off, matching how --header behaves.
-func applyTLSOptions(opts *provider.LLMOptions, cfg config.Config) {
+// applyTransportOptions layers the --insecure/--ca-cert/--trace-http flags over
+// the transport settings from config. The flags are additive: none of them can
+// turn a config-enabled setting back off, matching how --header behaves.
+func applyTransportOptions(opts *provider.LLMOptions, cfg config.Config) {
 	opts.InsecureSkipTLS = cfg.InsecureSkipTLS || flagInsecure
 	opts.CACertPath = cfg.CACertPath
 	if flagCACert != "" {
 		opts.CACertPath = flagCACert
 	}
 	opts.DisableSystemCAs = cfg.DisableSystemCAs
+
+	opts.TraceHTTP = cfg.TraceHTTP || flagTraceHTTP
+	// The transport reads this through httplog rather than from opts, so that
+	// a client built before the flag was parsed still honors it. Setting it
+	// here keeps the two in step for every path that builds an LLM.
+	if opts.TraceHTTP {
+		httplog.SetEnabled(true)
+	}
 }
 
 // convertHooks converts config.HookConfig to extension.HookConfig.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/dimetron/pi-go/internal/config"
+)
+
+// roleFlags lists the roles pi can run as, in the order the footer prints them,
+// paired with the flag that selects each one.
+var roleFlags = []struct{ role, flag string }{
+	{"default", ""},
+	{"smol", "--smol"},
+	{"slow", "--slow"},
+	{"plan", "--plan"},
+}
+
+// writeRoleSummary appends the resolved role table to `pi --help`.
+//
+// The static help can only describe how a model name maps to a provider; this
+// answers the question actually being asked, which is what --smol and --slow
+// will do on *this* machine. It reads the live config, so it also surfaces a
+// role that silently falls back to default and a provider whose credential is
+// not in the environment — two things that otherwise only show up as a failure
+// at the first request.
+//
+// Help output must never fail. Every error path here degrades to a shorter
+// table or a single hint line rather than returning one.
+func writeRoleSummary(w io.Writer) {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(w, "\nConfigured roles: unavailable (%v)\n", err)
+		return
+	}
+
+	keys := config.APIKeys()
+
+	// Both paths are named because config.Load merges them and a role shown
+	// here may come from either; pointing at only the global file would send
+	// someone editing the wrong one.
+	fmt.Fprint(w, "\nConfigured roles (~/.pi-go/config.json, overridden by ./.pi-go/config.json):\n\n")
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  ROLE\tFLAG\tMODEL\tPROVIDER\tCREDENTIAL")
+
+	for _, rf := range roleFlags {
+		flag := rf.flag
+		if flag == "" {
+			flag = "-"
+		}
+
+		rc, configured := cfg.Roles[rf.role]
+		if !configured || rc.Model == "" {
+			// Not an error: ResolveRole falls back to default, so the role
+			// still works. Saying so beats printing the default's model twice
+			// and leaving the reader to infer it.
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n", rf.role, flag, "(falls back to default)")
+			continue
+		}
+
+		model, prov, _, _, _, resolveErr := cfg.ResolveRole(rf.role)
+		if resolveErr != nil {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n", rf.role, flag, "("+resolveErr.Error()+")")
+			continue
+		}
+
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\n", rf.role, flag, model, prov, credentialStatus(prov, model, keys))
+	}
+
+	_ = tw.Flush()
+
+	fmt.Fprint(w, "\n  Change these in config.json under \"roles\", or override per run with --model.\n")
+}
+
+// credentialStatus reports which environment variable authenticates prov, and
+// whether it is currently set.
+//
+// A local Ollama daemon is the one provider that needs no credential, so
+// reporting a missing OLLAMA_API_KEY there would be a false alarm — the key is
+// only required once a :cloud tag routes the request to api.ollama.com.
+func credentialStatus(prov, model string, keys map[string]string) string {
+	if prov == "ollama" && !isOllamaCloudModel(model) {
+		return "none (local daemon)"
+	}
+
+	envVar := providerEnvVar(prov)
+	if _, ok := keys[prov]; ok {
+		return envVar + " (set)"
+	}
+	return envVar + " (MISSING)"
+}
+
+// isOllamaCloudModel reports whether the model tag routes to Ollama Cloud
+// rather than a local daemon. Mirrors provider.Resolve.
+func isOllamaCloudModel(model string) bool {
+	return strings.HasSuffix(model, ":cloud") || strings.HasSuffix(model, "-cloud")
+}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeGlobalConfig points HOME at a temp dir holding the given config, so
+// writeRoleSummary reads it instead of the developer's real one.
+func writeGlobalConfig(t *testing.T, cfg map[string]any) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".pi-go")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), raw, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// config.Load also merges ./.pi-go/config.json from the process working
+	// directory, which during `go test` is the package source tree. Move to a
+	// clean dir so the repo's own config cannot alter the result.
+	t.Chdir(t.TempDir())
+}
+
+func TestWriteRoleSummaryShowsEachRole(t *testing.T) {
+	writeGlobalConfig(t, map[string]any{
+		"roles": map[string]any{
+			"default": map[string]any{"model": "claude-sonnet-5"},
+			"smol":    map[string]any{"model": "claude-haiku-4-5-20251001"},
+			"slow":    map[string]any{"model": "claude-opus-5"},
+		},
+	})
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+	var buf bytes.Buffer
+	writeRoleSummary(&buf)
+	out := buf.String()
+
+	for _, want := range []string{
+		"default", "claude-sonnet-5",
+		"smol", "claude-haiku-4-5-20251001",
+		"slow", "claude-opus-5",
+		"anthropic", "ANTHROPIC_API_KEY (set)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("role summary missing %q:\n%s", want, out)
+		}
+	}
+
+	// plan is unconfigured here and must be reported as a fallback rather than
+	// silently echoing the default's model.
+	if !strings.Contains(out, "falls back to default") {
+		t.Errorf("unconfigured plan role not reported as a fallback:\n%s", out)
+	}
+}
+
+func TestWriteRoleSummaryFlagsMissingCredential(t *testing.T) {
+	writeGlobalConfig(t, map[string]any{
+		"roles": map[string]any{"default": map[string]any{"model": "claude-sonnet-5"}},
+	})
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+
+	var buf bytes.Buffer
+	writeRoleSummary(&buf)
+
+	if !strings.Contains(buf.String(), "ANTHROPIC_API_KEY (MISSING)") {
+		t.Errorf("absent credential not flagged:\n%s", buf.String())
+	}
+}
+
+// A local Ollama daemon needs no key, so demanding one would be a false alarm;
+// a :cloud tag reaches api.ollama.com and does.
+func TestWriteRoleSummaryOllamaCredential(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{"local daemon needs no key", "ollama/gemma4:e4b", "none (local daemon)"},
+		{"cloud tag needs a key", "minimax-m3:cloud", "OLLAMA_API_KEY (MISSING)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writeGlobalConfig(t, map[string]any{
+				"roles": map[string]any{"default": map[string]any{"model": tc.model}},
+			})
+			t.Setenv("OLLAMA_API_KEY", "")
+
+			var buf bytes.Buffer
+			writeRoleSummary(&buf)
+
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("got:\n%s\nwant it to contain %q", buf.String(), tc.want)
+			}
+		})
+	}
+}
+
+// The footer belongs to the root command only; a help func set on the root is
+// inherited by every subcommand, which is exactly how it would leak.
+func TestRootHelpFooterDoesNotLeakToSubcommands(t *testing.T) {
+	writeGlobalConfig(t, map[string]any{
+		"roles": map[string]any{"default": map[string]any{"model": "claude-sonnet-5"}},
+	})
+
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("root --help: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Configured roles") {
+		t.Errorf("root help is missing the role table:\n%s", buf.String())
+	}
+
+	buf.Reset()
+	root.SetArgs([]string{"audit", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("audit --help: %v", err)
+	}
+	if strings.Contains(buf.String(), "Configured roles") {
+		t.Errorf("subcommand help inherited the root footer:\n%s", buf.String())
+	}
+}
+
+// The examples are the part of help most likely to rot, so pin the routing
+// forms they teach.
+func TestRootExampleCoversEveryProvider(t *testing.T) {
+	example := newRootCmd().Example
+	for _, want := range []string{
+		"--model claude-", "--model gpt-", "--model gemini-", "--model mistral-",
+		"--model ollama/", "--model minimax-m3:cloud", "--model azure/", "--model opencode/",
+	} {
+		if !strings.Contains(example, want) {
+			t.Errorf("root examples missing %q", want)
+		}
+	}
+}

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/guardrail"
+	"github.com/dimetron/pi-go/internal/httplog"
 	"github.com/dimetron/pi-go/internal/logger"
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/memory"
@@ -41,6 +42,9 @@ type initResources struct {
 
 func (r *initResources) cleanup() {
 	if r.sessionLog != nil {
+		// Detach before closing: a late trace from an in-flight streaming body
+		// would otherwise write into a closed file.
+		httplog.SetSink(nil)
 		_ = r.sessionLog.Close()
 	}
 	if r.memWorker != nil {
@@ -362,6 +366,10 @@ func deferredInit(
 	sessionLog, logErr := logger.New()
 	if logErr == nil {
 		res.sessionLog = sessionLog
+		// --trace-http entries are dropped until the log file exists; the
+		// transport is built before this point. See the matching note in
+		// cli.go. Detached on shutdown where sessionLog is closed.
+		httplog.SetSink(logger.HTTPSink(sessionLog))
 	}
 
 	// Create agent.
@@ -861,7 +869,7 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 	llmOpts := &provider.LLMOptions{
 		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),
 	}
-	applyTLSOptions(llmOpts, cfg)
+	applyTransportOptions(llmOpts, cfg)
 	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, llmOpts)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("creating LLM: %w", err)

--- a/internal/cli/ping.go
+++ b/internal/cli/ping.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/auth"
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/httplog"
 	"github.com/dimetron/pi-go/internal/provider"
 )
 
@@ -143,6 +146,16 @@ func runPing(cmd *cobra.Command, args []string) error {
 	w := pingWriter(func(format string, a ...any) { _, _ = fmt.Fprintf(os.Stderr, format, a...) })
 	target.printHeader(w)
 
+	// ping has no session log to write to, so --trace-http goes to the same
+	// stream as the rest of its output. Without this the flag would be
+	// accepted here and do nothing. It complements rather than duplicates the
+	// dumpPing* output: that covers only the health-check probe and never
+	// shows a body, while this covers the model API call underneath.
+	if flagTraceHTTP {
+		httplog.SetSink(pingTraceSink(w))
+		defer httplog.SetSink(nil)
+	}
+
 	u, err := url.Parse(target.targetURL)
 	if err != nil {
 		w("* ERROR: invalid URL %q: %v\n", target.targetURL, err)
@@ -252,7 +265,7 @@ func resolvePingTarget(cfg config.Config) (*pingTarget, error) {
 	opts := &provider.LLMOptions{
 		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),
 	}
-	applyTLSOptions(opts, cfg)
+	applyTransportOptions(opts, cfg)
 
 	return &pingTarget{
 		info:         info,
@@ -413,6 +426,35 @@ func setPingAuthHeaders(req *http.Request, providerName, apiKey string) {
 		q := req.URL.Query()
 		q.Set("key", apiKey)
 		req.URL.RawQuery = q.Encode()
+	}
+}
+
+// pingTraceSink renders --trace-http entries in the same curl -v style as the
+// rest of ping's output, so a full exchange reads as one continuous transcript.
+func pingTraceSink(w pingWriter) func(httplog.Entry) {
+	return func(e httplog.Entry) {
+		marker := ">"
+		if e.Direction == httplog.DirectionResponse {
+			marker = "<"
+		}
+		switch {
+		case e.Err != "":
+			w("%s%s [%d] transport error: %s%s\n", colorYellow, marker, e.Exchange, e.Err, colorReset)
+			return
+		case e.Direction == httplog.DirectionRequest:
+			w("%s%s [%d] %s %s%s\n", colorBlue, marker, e.Exchange, e.Method, e.URL, colorReset)
+		case e.Status != 0:
+			w("%s%s [%d] %s %d (%s)%s\n", colorBlue, marker, e.Exchange, e.Proto, e.Status,
+				e.Duration.Round(time.Millisecond), colorReset)
+		}
+		for _, k := range slices.Sorted(maps.Keys(e.Headers)) {
+			for _, v := range e.Headers[k] {
+				w("%s%s [%d] %s: %s%s\n", colorBlue, marker, e.Exchange, k, v, colorReset)
+			}
+		}
+		if e.Body != "" {
+			w("%s%s [%d] body: %s%s\n", colorGray, marker, e.Exchange, e.Body, colorReset)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,11 +66,18 @@ type Config struct {
 	// which turns verification off for every endpoint.
 	CACertPath string `json:"caCertPath,omitempty"`
 	// DisableSystemCAs narrows trust to caCertPath alone.
-	DisableSystemCAs bool           `json:"disableSystemCAs,omitempty"`
-	Tools            map[string]any `json:"tools,omitempty"`
-	MCP              *MCPConfig     `json:"mcp,omitempty"`
-	Hooks            []HookConfig   `json:"hooks,omitempty"`
-	MaxDailyTokens   int64          `json:"maxDailyTokens,omitempty"` // 0 = unlimited
+	DisableSystemCAs bool `json:"disableSystemCAs,omitempty"`
+	// TraceHTTP logs every LLM request and response in full — headers and
+	// bodies — to the session log and to OTel span events. Equivalent to
+	// --trace-http, which can enable it but never turn it off.
+	//
+	// The resulting log contains the entire conversation, system prompt and
+	// tool output in cleartext. Credentials are masked; nothing else is.
+	TraceHTTP      bool           `json:"traceHTTP,omitempty"`
+	Tools          map[string]any `json:"tools,omitempty"`
+	MCP            *MCPConfig     `json:"mcp,omitempty"`
+	Hooks          []HookConfig   `json:"hooks,omitempty"`
+	MaxDailyTokens int64          `json:"maxDailyTokens,omitempty"` // 0 = unlimited
 	// ContextWindow overrides the model's context window in tokens. Needed for
 	// models absent from the embedded catalog (notably the opencode ones):
 	// auto-compaction measures a percentage of the window, so it stays off

--- a/internal/httplog/httplog.go
+++ b/internal/httplog/httplog.go
@@ -1,0 +1,340 @@
+// Package httplog carries raw HTTP request/response traces from the provider
+// transports to whichever sinks are active — the JSONL session log, OpenTelemetry
+// span events, or both.
+//
+// It exists as its own package to break an ownership cycle. The provider
+// transports are built during startup, before the session logger exists
+// (internal/cli/cli.go builds the LLM at ~:251 and the logger at ~:568), so a
+// transport cannot hold a logger reference at construction time. Instead the
+// transport emits into this package unconditionally and the CLI installs a sink
+// once the logger is ready — the same late-binding idiom as auth.SetDebugLogger.
+//
+// Nothing is captured unless SetEnabled(true) has been called: Enabled() is
+// checked before a body is ever buffered, so the disabled path costs one atomic
+// load per request.
+package httplog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Direction distinguishes the two halves of an exchange.
+const (
+	DirectionRequest  = "request"
+	DirectionResponse = "response"
+)
+
+// Entry is one captured half of an HTTP exchange. Requests and responses are
+// emitted as separate entries rather than one combined record because a
+// streaming response body is not complete until long after its headers arrive —
+// a single record would have to withhold the request until the stream drained.
+// Exchange ties the pair back together.
+type Entry struct {
+	// Exchange correlates the request with its response. Monotonic per process.
+	Exchange uint64
+	// Direction is DirectionRequest or DirectionResponse.
+	Direction string
+	// Method and URL are set on both directions so a response entry is
+	// readable on its own.
+	Method string
+	URL    string
+	// Proto and Status are set on responses only.
+	Proto  string
+	Status int
+	// Headers is already redacted; see Redact.
+	Headers map[string][]string
+	// Body is the captured payload, truncated to MaxBody. Empty when the
+	// message had no body.
+	Body string
+	// BodyTruncated reports that Body was cut at the cap.
+	BodyTruncated bool
+	// Duration is the time from request write to response headers. Set on
+	// responses only.
+	Duration time.Duration
+	// Err is the transport-level failure, if the round trip never produced a
+	// response. Set on responses only.
+	Err string
+}
+
+// Default body caps. Requests carry the full conversation history, so a cap is
+// not optional — a single turn late in a long session runs to hundreds of
+// kilobytes, and the log is written on every request.
+//
+// The OTel cap is deliberately much smaller than the JSONL one. Span
+// attributes travel through the OTLP exporter, which batches in memory and is
+// bounded by the collector's own message-size limit; a megabyte-scale attribute
+// silently drops the whole span at the collector rather than truncating it.
+// The file sink has no such ceiling, so it keeps the larger cap.
+const (
+	DefaultMaxBody     = 1 << 20 // 1 MiB, JSONL sink
+	DefaultOTelMaxBody = 8 << 10 // 8 KiB, span-event attributes
+)
+
+var (
+	enabled     atomic.Bool
+	maxBody     atomic.Int64
+	otelMaxBody atomic.Int64
+
+	sinkMu sync.RWMutex
+	sink   func(Entry)
+
+	exchangeCounter atomic.Uint64
+)
+
+func init() {
+	maxBody.Store(DefaultMaxBody)
+	otelMaxBody.Store(DefaultOTelMaxBody)
+}
+
+// SetEnabled turns capture on or off. Off by default; the CLI sets it from
+// --debug.
+func SetEnabled(v bool) { enabled.Store(v) }
+
+// Enabled reports whether capture is on. Transports must check this before
+// buffering anything.
+func Enabled() bool { return enabled.Load() }
+
+// SetMaxBody overrides the JSONL body cap. A value <= 0 restores the default.
+func SetMaxBody(n int) {
+	if n <= 0 {
+		n = DefaultMaxBody
+	}
+	maxBody.Store(int64(n))
+}
+
+// MaxBody returns the current JSONL body cap.
+func MaxBody() int { return int(maxBody.Load()) }
+
+// SetOTelMaxBody overrides the span-attribute body cap. A value <= 0 restores
+// the default.
+func SetOTelMaxBody(n int) {
+	if n <= 0 {
+		n = DefaultOTelMaxBody
+	}
+	otelMaxBody.Store(int64(n))
+}
+
+// SetSink installs the destination for captured entries, replacing any previous
+// one. Passing nil detaches the sink, which is what tests and shutdown want —
+// entries emitted with no sink are dropped, not buffered.
+//
+// OTel span events are emitted independently of the sink, so tracing works even
+// when no session log exists.
+func SetSink(fn func(Entry)) {
+	sinkMu.Lock()
+	defer sinkMu.Unlock()
+	sink = fn
+}
+
+// NextExchange returns a fresh correlation ID for a request/response pair.
+func NextExchange() uint64 { return exchangeCounter.Add(1) }
+
+// Emit delivers e to the installed sink and, when ctx carries a recording span,
+// records it as a span event. It is safe to call with capture disabled or no
+// sink installed.
+//
+// ctx is the request's context, so the span picked up is the agent turn the
+// call belongs to (see internal/tui/agent_loop.go, which starts it).
+func Emit(ctx context.Context, e Entry) {
+	if !Enabled() {
+		return
+	}
+
+	sinkMu.RLock()
+	fn := sink
+	sinkMu.RUnlock()
+	if fn != nil {
+		fn(e)
+	}
+
+	emitSpanEvent(ctx, e)
+}
+
+// emitSpanEvent records the entry on the active span. A non-recording span
+// (the no-op tracer, when OTel is not configured) short-circuits here, which is
+// what makes the OTel half of this "if enabled" without a config lookup.
+func emitSpanEvent(ctx context.Context, e Entry) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.Int64("http.exchange", int64(e.Exchange)), //nolint:gosec // counter, not user input
+		attribute.String("http.direction", e.Direction),
+	}
+	if e.Method != "" {
+		attrs = append(attrs, attribute.String("http.request.method", e.Method))
+	}
+	if e.URL != "" {
+		attrs = append(attrs, attribute.String("url.full", e.URL))
+	}
+	if e.Status != 0 {
+		attrs = append(attrs, attribute.Int("http.response.status_code", e.Status))
+	}
+	if e.Duration > 0 {
+		attrs = append(attrs, attribute.Int64("http.duration_ms", e.Duration.Milliseconds()))
+	}
+	if e.Err != "" {
+		attrs = append(attrs, attribute.String("error.message", e.Err))
+	}
+
+	// Headers go on as one attribute per field rather than a single blob so a
+	// backend can filter on, say, retry-after without parsing.
+	prefix := "http.request.header."
+	if e.Direction == DirectionResponse {
+		prefix = "http.response.header."
+	}
+	for k, vs := range e.Headers {
+		attrs = append(attrs, attribute.String(prefix+strings.ToLower(k), strings.Join(vs, ", ")))
+	}
+
+	if e.Body != "" {
+		body, truncated := truncate(e.Body, int(otelMaxBody.Load()))
+		attrs = append(attrs, attribute.String(prefix+"..body", body))
+		if truncated || e.BodyTruncated {
+			attrs = append(attrs, attribute.Bool("http.body.truncated", true))
+		}
+	}
+
+	span.AddEvent("http."+e.Direction, trace.WithAttributes(attrs...))
+}
+
+// redactedHeaders are replaced with a fingerprint rather than dropped, so a log
+// still shows that a credential was sent and whether it changed between calls.
+//
+// Response headers are in here too: openai-organization and set-cookie identify
+// the account, and a session log is routinely pasted into a bug report.
+var redactedHeaders = map[string]bool{
+	"authorization":       true,
+	"proxy-authorization": true,
+	"x-api-key":           true,
+	"api-key":             true,
+	"x-goog-api-key":      true,
+	"cookie":              true,
+	"set-cookie":          true,
+	"chatgpt-account-id":  true,
+	"openai-organization": true,
+}
+
+// Redact copies h, replacing credential values with a prefix and a length so
+// the entry stays diagnostically useful without carrying the secret.
+//
+// The copy matters: http.Header is a live map owned by the request, and
+// redacting in place would strip the caller's own credentials.
+func Redact(h http.Header) map[string][]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(h))
+	for k, vs := range h {
+		if !redactedHeaders[strings.ToLower(k)] {
+			out[k] = append([]string(nil), vs...)
+			continue
+		}
+		masked := make([]string, len(vs))
+		for i, v := range vs {
+			masked[i] = mask(v)
+		}
+		out[k] = masked
+	}
+	return out
+}
+
+// mask reduces a credential to an identifiable but unusable stub.
+func mask(v string) string {
+	if v == "" {
+		return ""
+	}
+	const keep = 8
+	if len(v) <= keep {
+		return "***(" + strconv.Itoa(len(v)) + " bytes)"
+	}
+	return v[:keep] + "***(" + strconv.Itoa(len(v)) + " bytes)"
+}
+
+// truncate cuts s to n bytes, reporting whether it did.
+func truncate(s string, n int) (string, bool) {
+	if n <= 0 || len(s) <= n {
+		return s, false
+	}
+	return s[:n] + fmt.Sprintf("…(truncated, %d bytes total)", len(s)), true
+}
+
+// CaptureBody buffers up to MaxBody bytes of rc as it is read by the real
+// consumer, then calls done exactly once when the stream ends — at EOF, at a
+// read error, or at Close, whichever comes first.
+//
+// It exists because a streaming response cannot be logged the way an ordinary
+// one can. io.ReadAll on an SSE body blocks until the model finishes its turn,
+// which for a long completion means the SDK sees no tokens for minutes and the
+// TUI renders nothing; for a body that never terminates it deadlocks outright.
+// Buffering alongside the consumer keeps the stream flowing at its own pace and
+// defers the log entry to the point where there is something complete to write.
+func CaptureBody(rc io.ReadCloser, done func(body string, truncated bool)) io.ReadCloser {
+	return &bodyCapture{rc: rc, limit: MaxBody(), done: done}
+}
+
+type bodyCapture struct {
+	rc        io.ReadCloser
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+	once      sync.Once
+	done      func(string, bool)
+}
+
+func (b *bodyCapture) Read(p []byte) (int, error) {
+	n, err := b.rc.Read(p)
+	if n > 0 {
+		b.record(p[:n])
+	}
+	if err != nil {
+		// Includes io.EOF. Finishing here rather than waiting for Close means
+		// the entry lands as soon as the stream ends, even for a consumer that
+		// leaks the body.
+		b.finish()
+	}
+	return n, err
+}
+
+func (b *bodyCapture) Close() error {
+	b.finish()
+	return b.rc.Close()
+}
+
+func (b *bodyCapture) record(p []byte) {
+	room := b.limit - b.buf.Len()
+	if room <= 0 {
+		b.truncated = true
+		return
+	}
+	if len(p) > room {
+		b.buf.Write(p[:room])
+		b.truncated = true
+		return
+	}
+	b.buf.Write(p)
+}
+
+func (b *bodyCapture) finish() {
+	b.once.Do(func() {
+		body := b.buf.String()
+		if b.truncated {
+			body += fmt.Sprintf("…(truncated at %d bytes)", b.limit)
+		}
+		b.done(body, b.truncated)
+	})
+}

--- a/internal/httplog/httplog_test.go
+++ b/internal/httplog/httplog_test.go
@@ -1,0 +1,235 @@
+package httplog
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// reset returns httplog to its zero configuration. Package state is global, so
+// every test that touches it must restore it or leak into the next one.
+func reset(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		SetEnabled(false)
+		SetSink(nil)
+		SetMaxBody(0)
+		SetOTelMaxBody(0)
+	})
+	SetEnabled(false)
+	SetSink(nil)
+	SetMaxBody(0)
+	SetOTelMaxBody(0)
+}
+
+func TestEmitDroppedWhenDisabled(t *testing.T) {
+	reset(t)
+	var got int
+	SetSink(func(Entry) { got++ })
+
+	Emit(context.Background(), Entry{Direction: DirectionRequest})
+	if got != 0 {
+		t.Fatalf("sink called %d times while disabled, want 0", got)
+	}
+
+	SetEnabled(true)
+	Emit(context.Background(), Entry{Direction: DirectionRequest})
+	if got != 1 {
+		t.Fatalf("sink called %d times while enabled, want 1", got)
+	}
+}
+
+func TestEmitWithNoSinkDoesNotPanic(t *testing.T) {
+	reset(t)
+	SetEnabled(true)
+	Emit(context.Background(), Entry{Direction: DirectionResponse, Status: 200})
+}
+
+func TestRedactMasksCredentialsAndCopies(t *testing.T) {
+	reset(t)
+	h := http.Header{}
+	h.Set("Authorization", "Bearer sk-abcdefghijklmnop")
+	h.Set("X-Api-Key", "short")
+	h.Set("Content-Type", "application/json")
+	h.Set("Set-Cookie", "session=deadbeefcafe")
+
+	out := Redact(h)
+
+	if got := out["Content-Type"][0]; got != "application/json" {
+		t.Errorf("Content-Type = %q, want it passed through unchanged", got)
+	}
+	if got := out["Authorization"][0]; strings.Contains(got, "ijklmnop") {
+		t.Errorf("Authorization = %q, still contains the secret tail", got)
+	} else if !strings.HasPrefix(got, "Bearer s") {
+		t.Errorf("Authorization = %q, want an identifying prefix retained", got)
+	}
+	if got := out["X-Api-Key"][0]; strings.Contains(got, "short") {
+		t.Errorf("X-Api-Key = %q, short values must be masked entirely", got)
+	}
+	if got := out["Set-Cookie"][0]; strings.Contains(got, "deadbeefcafe") {
+		t.Errorf("Set-Cookie = %q, response credentials must be masked too", got)
+	}
+
+	// The caller's header must be untouched — redacting in place would strip
+	// the credentials off the request that is about to be sent.
+	if h.Get("Authorization") != "Bearer sk-abcdefghijklmnop" {
+		t.Errorf("Redact mutated the source header: %q", h.Get("Authorization"))
+	}
+}
+
+func TestRedactNilHeader(t *testing.T) {
+	if got := Redact(nil); got != nil {
+		t.Errorf("Redact(nil) = %v, want nil", got)
+	}
+}
+
+func TestCaptureBodyEmitsOnEOF(t *testing.T) {
+	reset(t)
+	var (
+		mu        sync.Mutex
+		body      string
+		truncated bool
+		calls     int
+	)
+	rc := CaptureBody(io.NopCloser(strings.NewReader("hello world")), func(b string, tr bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, truncated, calls = b, tr, calls+1
+	})
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("consumer read %q, want the body passed through intact", got)
+	}
+	if body != "hello world" || truncated {
+		t.Errorf("captured %q truncated=%v, want %q false", body, truncated, "hello world")
+	}
+
+	// Close after EOF must not fire the callback a second time.
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("done called %d times, want exactly 1", calls)
+	}
+}
+
+func TestCaptureBodyEmitsOnCloseWithoutFullRead(t *testing.T) {
+	reset(t)
+	var body string
+	var called bool
+	rc := CaptureBody(io.NopCloser(strings.NewReader("abcdefghij")), func(b string, _ bool) {
+		body, called = b, true
+	})
+
+	buf := make([]byte, 4)
+	if _, err := rc.Read(buf); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if called {
+		t.Fatal("done fired mid-stream; it must wait for the end")
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if body != "abcd" {
+		t.Errorf("captured %q, want the bytes actually read (%q)", body, "abcd")
+	}
+}
+
+func TestCaptureBodyTruncatesAtCap(t *testing.T) {
+	reset(t)
+	SetMaxBody(10)
+	var body string
+	var truncated bool
+	rc := CaptureBody(io.NopCloser(strings.NewReader(strings.Repeat("x", 100))), func(b string, tr bool) {
+		body, truncated = b, tr
+	})
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(got) != 100 {
+		t.Errorf("consumer got %d bytes, want all 100 — the cap must not truncate the stream itself", len(got))
+	}
+	if !truncated {
+		t.Error("truncated = false, want true")
+	}
+	if !strings.HasPrefix(body, strings.Repeat("x", 10)) || !strings.Contains(body, "truncated") {
+		t.Errorf("captured %q, want 10 bytes plus a truncation marker", body)
+	}
+}
+
+// errReader fails after handing back its payload, standing in for a connection
+// that drops mid-stream.
+type errReader struct {
+	data []byte
+	done bool
+}
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if e.done {
+		return 0, errors.New("connection reset")
+	}
+	e.done = true
+	n := copy(p, e.data)
+	return n, nil
+}
+
+func (e *errReader) Close() error { return nil }
+
+func TestCaptureBodyEmitsOnReadError(t *testing.T) {
+	reset(t)
+	var body string
+	var called bool
+	rc := CaptureBody(&errReader{data: []byte("partial")}, func(b string, _ bool) {
+		body, called = b, true
+	})
+
+	if _, err := io.ReadAll(rc); err == nil {
+		t.Fatal("ReadAll succeeded, want the underlying error surfaced")
+	}
+	if !called {
+		t.Fatal("done never fired; a broken stream must still log what it got")
+	}
+	if body != "partial" {
+		t.Errorf("captured %q, want %q", body, "partial")
+	}
+}
+
+func TestNextExchangeIsMonotonic(t *testing.T) {
+	a, b := NextExchange(), NextExchange()
+	if b <= a {
+		t.Errorf("NextExchange returned %d then %d, want strictly increasing", a, b)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got, tr := truncate("abc", 10); got != "abc" || tr {
+		t.Errorf("truncate under cap = %q,%v; want unchanged", got, tr)
+	}
+	got, tr := truncate("abcdef", 3)
+	if !tr || !strings.HasPrefix(got, "abc") {
+		t.Errorf("truncate over cap = %q,%v", got, tr)
+	}
+}
+
+func TestSetMaxBodyRestoresDefaultOnNonPositive(t *testing.T) {
+	reset(t)
+	SetMaxBody(5)
+	if MaxBody() != 5 {
+		t.Fatalf("MaxBody() = %d, want 5", MaxBody())
+	}
+	SetMaxBody(0)
+	if MaxBody() != DefaultMaxBody {
+		t.Errorf("MaxBody() = %d after SetMaxBody(0), want the default %d", MaxBody(), DefaultMaxBody)
+	}
+}

--- a/internal/logger/httpsink.go
+++ b/internal/logger/httpsink.go
@@ -1,0 +1,41 @@
+package logger
+
+import (
+	"github.com/dimetron/pi-go/internal/httplog"
+)
+
+// HTTPSink adapts a Logger to httplog's sink signature, so --trace-http entries
+// land in the same JSONL session file as everything else.
+//
+// The dependency runs one way only — httplog knows nothing about Logger — which
+// is what lets the provider transports emit traces without importing the
+// logger they cannot reach at construction time.
+//
+// Returns nil for a nil Logger so the caller can install the result
+// unconditionally; httplog.SetSink(nil) simply detaches.
+func HTTPSink(l *Logger) func(httplog.Entry) {
+	if l == nil {
+		return nil
+	}
+	return func(e httplog.Entry) {
+		entry := Entry{
+			Type:      "http_" + e.Direction,
+			Exchange:  e.Exchange,
+			Method:    e.Method,
+			URL:       e.URL,
+			Proto:     e.Proto,
+			Status:    e.Status,
+			Headers:   e.Headers,
+			Content:   e.Body,
+			Truncated: e.BodyTruncated,
+			DurationM: e.Duration.Milliseconds(),
+		}
+		if e.Err != "" {
+			// A transport-level failure never produced a response, so there is
+			// no status to report. Carrying it as the content of the response
+			// entry keeps the exchange correlated with its request.
+			entry.Content = "transport error: " + e.Err
+		}
+		l.Log(entry)
+	}
+}

--- a/internal/logger/httpsink_test.go
+++ b/internal/logger/httpsink_test.go
@@ -1,0 +1,142 @@
+package logger
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/httplog"
+)
+
+func TestHTTPSinkNilLogger(t *testing.T) {
+	if HTTPSink(nil) != nil {
+		t.Error("HTTPSink(nil) returned a non-nil sink; callers install it unconditionally")
+	}
+}
+
+func TestHTTPSinkWritesRequestAndResponse(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	sink := HTTPSink(l)
+	sink(httplog.Entry{
+		Exchange:  7,
+		Direction: httplog.DirectionRequest,
+		Method:    "POST",
+		URL:       "https://api.example.com/v1/messages",
+		Headers:   map[string][]string{"Authorization": {"Bearer ab***(20 bytes)"}},
+		Body:      `{"prompt":"hi"}`,
+	})
+	sink(httplog.Entry{
+		Exchange:      7,
+		Direction:     httplog.DirectionResponse,
+		Method:        "POST",
+		URL:           "https://api.example.com/v1/messages",
+		Proto:         "HTTP/2.0",
+		Status:        429,
+		Headers:       map[string][]string{"Retry-After": {"30"}},
+		Body:          `{"error":"rate_limit"}`,
+		BodyTruncated: true,
+		Duration:      1500 * time.Millisecond,
+	})
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries := readEntries(t, l.Path())
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(entries), entries)
+	}
+
+	req := entries[0]
+	if req.Type != "http_request" {
+		t.Errorf("request type = %q, want http_request", req.Type)
+	}
+	if req.Exchange != 7 || req.Method != "POST" {
+		t.Errorf("request = exchange %d %s, want 7 POST", req.Exchange, req.Method)
+	}
+	if req.Content != `{"prompt":"hi"}` {
+		t.Errorf("request content = %q, want the body", req.Content)
+	}
+	if got := req.Headers["Authorization"][0]; !strings.Contains(got, "***") {
+		t.Errorf("request Authorization = %q, want the masked value carried through", got)
+	}
+
+	resp := entries[1]
+	if resp.Type != "http_response" {
+		t.Errorf("response type = %q, want http_response", resp.Type)
+	}
+	if resp.Status != 429 || resp.Proto != "HTTP/2.0" {
+		t.Errorf("response = %d %s, want 429 HTTP/2.0", resp.Status, resp.Proto)
+	}
+	if resp.DurationM != 1500 {
+		t.Errorf("response duration_ms = %d, want 1500", resp.DurationM)
+	}
+	if !resp.Truncated {
+		t.Error("response truncated = false, want true")
+	}
+	if resp.Exchange != req.Exchange {
+		t.Errorf("response exchange = %d, want %d to match the request", resp.Exchange, req.Exchange)
+	}
+}
+
+func TestHTTPSinkTransportError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	HTTPSink(l)(httplog.Entry{
+		Exchange:  3,
+		Direction: httplog.DirectionResponse,
+		Method:    "GET",
+		URL:       "https://api.example.com/v1/models",
+		Err:       "dial tcp: connection refused",
+	})
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries := readEntries(t, l.Path())
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if !strings.Contains(entries[0].Content, "connection refused") {
+		t.Errorf("content = %q, want the transport error", entries[0].Content)
+	}
+	if entries[0].Status != 0 {
+		t.Errorf("status = %d, want 0 — no response arrived", entries[0].Status)
+	}
+}
+
+// TestHTTPEntriesAreNotCoalesced guards the interaction with the streaming
+// coalescer: only llm_text and thinking merge, so a run of HTTP entries must
+// stay one record each.
+func TestHTTPEntriesAreNotCoalesced(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	sink := HTTPSink(l)
+	for i := range 3 {
+		sink(httplog.Entry{
+			Exchange:  uint64(i), //nolint:gosec // small loop index
+			Direction: httplog.DirectionRequest,
+			Method:    "POST",
+			Body:      "body",
+		})
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if entries := readEntries(t, l.Path()); len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3 separate records: %+v", len(entries), entries)
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -26,13 +26,26 @@ type Logger struct {
 // Entry represents a single log entry.
 type Entry struct {
 	Time    string `json:"time"`
-	Type    string `json:"type"`              // "user", "llm_text", "thinking", "tool_call", "tool_result", "error", "info"
+	Type    string `json:"type"`              // "user", "llm_text", "thinking", "tool_call", "tool_result", "error", "info", "http_request", "http_response"
 	Agent   string `json:"agent,omitempty"`   // agent name (for subagents)
 	Tool    string `json:"tool,omitempty"`    // tool name
-	Content string `json:"content,omitempty"` // text content or error message
+	Content string `json:"content,omitempty"` // text content, error message, or HTTP body
 	Args    any    `json:"args,omitempty"`    // tool call arguments
 	Session string `json:"session,omitempty"` // session ID (logged once at start)
 	Model   string `json:"model,omitempty"`   // model name (logged once at start)
+
+	// HTTP trace fields, set only on "http_request"/"http_response" entries
+	// written under --trace-http. They are part of Entry rather than a
+	// separate record type so the transport trace interleaves with the tool
+	// calls and model output it caused, in one chronologically ordered file.
+	Exchange  uint64              `json:"exchange,omitempty"`  // correlates a request with its response
+	Method    string              `json:"method,omitempty"`    // HTTP method
+	URL       string              `json:"url,omitempty"`       // full request URL
+	Proto     string              `json:"proto,omitempty"`     // e.g. "HTTP/2.0"
+	Status    int                 `json:"status,omitempty"`    // response status code
+	Headers   map[string][]string `json:"headers,omitempty"`   // credential values already masked
+	Truncated bool                `json:"truncated,omitempty"` // body was cut at the cap
+	DurationM int64               `json:"duration_ms,omitempty"`
 }
 
 // New creates a new session logger.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,13 +25,16 @@ import (
 // HTTPS_PROXY — which is exactly the environment where a custom CA or a TLS
 // skip is needed in the first place.
 func BuildTransport(opts *LLMOptions) (http.RoundTripper, error) {
+	// TraceHTTP is checked before the nil guard: a nil opts still has to be
+	// traceable, because several callers pass one and they issue real requests.
+	traceHTTP := opts != nil && opts.TraceHTTP
 	if opts == nil {
-		return nil, nil
+		return maybeTrace(nil, traceHTTP), nil
 	}
 	hasHeaders := len(opts.ExtraHeaders) > 0
 	needsTLS := opts.InsecureSkipTLS || opts.CACertPath != ""
 	if !needsTLS && !hasHeaders && opts.ConnectTimeout <= 0 {
-		return nil, nil
+		return maybeTrace(nil, traceHTTP), nil
 	}
 
 	base := http.DefaultTransport
@@ -53,10 +56,32 @@ func BuildTransport(opts *LLMOptions) (http.RoundTripper, error) {
 		}
 		base = cloned
 	}
+	// Innermost, beneath headerTransport: the trace has to record the request
+	// as it actually goes on the wire. Wrapping the other way round would run
+	// the trace first and log a request missing every ExtraHeader the server
+	// went on to receive — the headers a proxy or gateway problem is usually
+	// about.
+	base = maybeTrace(base, traceHTTP)
 	if hasHeaders {
 		base = &headerTransport{base: base, headers: opts.ExtraHeaders}
 	}
 	return base, nil
+}
+
+// maybeTrace wraps base in the HTTP trace transport when tracing is on.
+//
+// A nil base means "no customization was needed"; that becomes
+// http.DefaultTransport rather than staying nil, because a nil RoundTripper
+// tells the caller to leave the SDK's own client alone and the trace would
+// never run.
+func maybeTrace(base http.RoundTripper, trace bool) http.RoundTripper {
+	if !trace {
+		return base
+	}
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &traceTransport{base: base}
 }
 
 // buildTLSConfig turns the TLS fields of opts into a *tls.Config.
@@ -345,6 +370,12 @@ type LLMOptions struct {
 	// not cached, with no error and no extra cost. Other providers ignore
 	// this flag today.
 	DisablePromptCaching bool
+	// TraceHTTP records every LLM request and response — method, URL, full
+	// headers and body — to the session log and to OTel span events. Set by
+	// --trace-http. Credentials are masked (see httplog.Redact), but prompts
+	// and completions are not: the log holds the entire conversation in
+	// cleartext, which is the point and also the reason it is off by default.
+	TraceHTTP bool
 }
 
 // NewLLM creates a model.LLM for the given provider info, API key, optional base URL, thinking level, and options.

--- a/internal/provider/trace_transport.go
+++ b/internal/provider/trace_transport.go
@@ -1,0 +1,159 @@
+package provider
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/httplog"
+)
+
+// traceTransport records every request and response passing through it —
+// method, URL, full headers and body — into internal/httplog, which fans them
+// out to the session log and to OpenTelemetry span events.
+//
+// It is installed by BuildTransport as the *innermost* wrapper — below
+// headerTransport — so it observes the request as it actually goes on the wire.
+// Sitting above headerTransport would log a request missing every ExtraHeader
+// the server went on to receive.
+//
+// Capture is re-checked per round trip rather than only at construction, so
+// enabling the trace does not depend on having been decided before the LLM
+// client was built.
+type traceTransport struct{ base http.RoundTripper }
+
+func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !httplog.Enabled() {
+		return t.base.RoundTrip(req)
+	}
+
+	ctx := req.Context()
+	exchange := httplog.NextExchange()
+	method, url := req.Method, req.URL.String()
+
+	body, truncated := readRequestBody(req)
+	httplog.Emit(ctx, httplog.Entry{
+		Exchange:      exchange,
+		Direction:     httplog.DirectionRequest,
+		Method:        method,
+		URL:           url,
+		Headers:       httplog.Redact(req.Header),
+		Body:          body,
+		BodyTruncated: truncated,
+	})
+
+	start := time.Now()
+	resp, err := t.base.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	if err != nil || resp == nil {
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		httplog.Emit(ctx, httplog.Entry{
+			Exchange:  exchange,
+			Direction: httplog.DirectionResponse,
+			Method:    method,
+			URL:       url,
+			Duration:  elapsed,
+			Err:       msg,
+		})
+		return resp, err
+	}
+
+	// Headers are emitted now, body when the stream ends. Waiting for the body
+	// would withhold the status code of a streaming completion for the whole
+	// duration of the turn, which is exactly when it is most wanted.
+	httplog.Emit(ctx, httplog.Entry{
+		Exchange:  exchange,
+		Direction: httplog.DirectionResponse,
+		Method:    method,
+		URL:       url,
+		Proto:     resp.Proto,
+		Status:    resp.StatusCode,
+		Headers:   httplog.Redact(resp.Header),
+		Duration:  elapsed,
+	})
+
+	if resp.Body != nil {
+		status, proto := resp.StatusCode, resp.Proto
+		resp.Body = httplog.CaptureBody(resp.Body, func(b string, bodyTruncated bool) {
+			if b == "" {
+				return
+			}
+			httplog.Emit(ctx, httplog.Entry{
+				Exchange:      exchange,
+				Direction:     httplog.DirectionResponse,
+				Method:        method,
+				URL:           url,
+				Proto:         proto,
+				Status:        status,
+				Body:          b,
+				BodyTruncated: bodyTruncated,
+			})
+		})
+	}
+
+	return resp, err
+}
+
+// readRequestBody returns a copy of the outgoing body without disturbing the
+// request the caller still owns.
+//
+// GetBody is preferred and is what the OpenAI and Anthropic SDKs set: it hands
+// back an independent reader, so the original body is never consumed and a
+// retry after a 429 still has something to send. Only when it is absent does
+// this fall back to draining and replacing the body, which is safe for the
+// single attempt but is why GetBody is tried first.
+func readRequestBody(req *http.Request) (string, bool) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return "", false
+	}
+
+	limit := httplog.MaxBody()
+
+	if req.GetBody != nil {
+		rc, err := req.GetBody()
+		if err != nil || rc == nil {
+			return "", false
+		}
+		defer func() { _ = rc.Close() }()
+		return readLimited(rc, limit)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(req.Body, int64(limit)+1))
+	if err != nil {
+		// The body is now partially drained and cannot be put back intact.
+		// Restore what was read so the request still carries as much as
+		// possible rather than being silently emptied by the act of logging it.
+		req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(raw), req.Body))
+		return "", false
+	}
+	req.Body = struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.MultiReader(bytes.NewReader(raw), req.Body),
+		Closer: req.Body,
+	}
+	return capped(raw, limit)
+}
+
+func readLimited(r io.Reader, limit int) (string, bool) {
+	raw, err := io.ReadAll(io.LimitReader(r, int64(limit)+1))
+	if err != nil {
+		return "", false
+	}
+	return capped(raw, limit)
+}
+
+// capped trims raw to limit, marking the result when it had to cut.
+func capped(raw []byte, limit int) (string, bool) {
+	if len(raw) > limit {
+		return string(raw[:limit]) + "…(truncated at " + strconv.Itoa(limit) + " bytes)", true
+	}
+	return string(raw), false
+}

--- a/internal/provider/trace_transport_test.go
+++ b/internal/provider/trace_transport_test.go
@@ -1,0 +1,319 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/httplog"
+)
+
+// stubTripper returns a canned response, recording the request body it actually
+// received so a test can prove the trace did not eat it.
+type stubTripper struct {
+	resp     *http.Response
+	err      error
+	gotBody  string
+	gotCalls int
+}
+
+func (s *stubTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.gotCalls++
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		s.gotBody = string(b)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.resp, nil
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("Set-Cookie", "sess=supersecretvalue")
+	return &http.Response{
+		StatusCode: status,
+		Proto:      "HTTP/2.0",
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// collect turns tracing on with a recording sink for the duration of a test.
+func collect(t *testing.T) *[]httplog.Entry {
+	t.Helper()
+	var mu sync.Mutex
+	entries := make([]httplog.Entry, 0, 8)
+	httplog.SetEnabled(true)
+	httplog.SetSink(func(e httplog.Entry) {
+		mu.Lock()
+		defer mu.Unlock()
+		entries = append(entries, e)
+	})
+	t.Cleanup(func() {
+		httplog.SetEnabled(false)
+		httplog.SetSink(nil)
+		httplog.SetMaxBody(0)
+	})
+	return &entries
+}
+
+func TestTraceTransportCapturesRequestAndResponse(t *testing.T) {
+	entries := collect(t)
+
+	stub := &stubTripper{resp: jsonResponse(200, `{"ok":true}`)}
+	tr := &traceTransport{base: stub}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://api.example.com/v1/messages", strings.NewReader(`{"prompt":"hi"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer sk-secretsecret")
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if string(body) != `{"ok":true}` {
+		t.Errorf("consumer read %q, want the response body intact", body)
+	}
+	if stub.gotBody != `{"prompt":"hi"}` {
+		t.Errorf("upstream received body %q, want it undisturbed by tracing", stub.gotBody)
+	}
+
+	e := *entries
+	if len(e) != 3 {
+		t.Fatalf("got %d entries, want 3 (request, response headers, response body): %+v", len(e), e)
+	}
+
+	reqEntry := e[0]
+	if reqEntry.Direction != httplog.DirectionRequest {
+		t.Errorf("entry 0 direction = %q, want request", reqEntry.Direction)
+	}
+	if reqEntry.Method != http.MethodPost || reqEntry.URL != "https://api.example.com/v1/messages" {
+		t.Errorf("entry 0 = %s %s, want POST of the full URL", reqEntry.Method, reqEntry.URL)
+	}
+	if reqEntry.Body != `{"prompt":"hi"}` {
+		t.Errorf("entry 0 body = %q, want the request payload", reqEntry.Body)
+	}
+	if got := reqEntry.Headers["Authorization"][0]; strings.Contains(got, "secretsecret") {
+		t.Errorf("entry 0 leaked the credential: %q", got)
+	}
+
+	hdrEntry := e[1]
+	if hdrEntry.Status != 200 || hdrEntry.Proto != "HTTP/2.0" {
+		t.Errorf("entry 1 = %d %s, want 200 HTTP/2.0", hdrEntry.Status, hdrEntry.Proto)
+	}
+	if hdrEntry.Body != "" {
+		t.Errorf("entry 1 body = %q, want headers only", hdrEntry.Body)
+	}
+	if got := hdrEntry.Headers["Set-Cookie"][0]; strings.Contains(got, "supersecretvalue") {
+		t.Errorf("entry 1 leaked a response credential: %q", got)
+	}
+
+	bodyEntry := e[2]
+	if bodyEntry.Body != `{"ok":true}` {
+		t.Errorf("entry 2 body = %q, want the response payload", bodyEntry.Body)
+	}
+
+	for i, entry := range e {
+		if entry.Exchange != e[0].Exchange {
+			t.Errorf("entry %d exchange = %d, want all three to share %d", i, entry.Exchange, e[0].Exchange)
+		}
+	}
+}
+
+func TestTraceTransportRecordsTransportError(t *testing.T) {
+	entries := collect(t)
+
+	tr := &traceTransport{base: &stubTripper{err: errors.New("dial tcp: refused")}}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/v1/models", nil)
+
+	if _, err := tr.RoundTrip(req); err == nil {
+		t.Fatal("RoundTrip succeeded, want the transport error propagated")
+	}
+
+	e := *entries
+	if len(e) != 2 {
+		t.Fatalf("got %d entries, want 2 (request, failed response): %+v", len(e), e)
+	}
+	if e[1].Err == "" || !strings.Contains(e[1].Err, "refused") {
+		t.Errorf("entry 1 Err = %q, want the dial failure", e[1].Err)
+	}
+	if e[1].Status != 0 {
+		t.Errorf("entry 1 status = %d, want 0 — no response was received", e[1].Status)
+	}
+}
+
+func TestTraceTransportDisabledIsPassthrough(t *testing.T) {
+	httplog.SetEnabled(false)
+	var got int
+	httplog.SetSink(func(httplog.Entry) { got++ })
+	t.Cleanup(func() { httplog.SetSink(nil) })
+
+	stub := &stubTripper{resp: jsonResponse(200, "{}")}
+	tr := &traceTransport{base: stub}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/", nil)
+
+	if _, err := tr.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("sink called %d times with tracing off, want 0", got)
+	}
+	if stub.gotCalls != 1 {
+		t.Errorf("base called %d times, want 1", stub.gotCalls)
+	}
+}
+
+func TestReadRequestBodyPrefersGetBody(t *testing.T) {
+	httplog.SetEnabled(true)
+	t.Cleanup(func() { httplog.SetEnabled(false) })
+
+	payload := `{"a":1}`
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://x/", strings.NewReader(payload))
+	if req.GetBody == nil {
+		t.Fatal("precondition: NewRequest with a *strings.Reader should set GetBody")
+	}
+
+	body, truncated := readRequestBody(req)
+	if body != payload || truncated {
+		t.Errorf("readRequestBody = %q,%v; want %q,false", body, truncated, payload)
+	}
+
+	// GetBody hands back an independent reader, so the original must still be
+	// fully readable — this is what keeps SDK retries working.
+	remaining, _ := io.ReadAll(req.Body)
+	if string(remaining) != payload {
+		t.Errorf("original body left as %q, want %q", remaining, payload)
+	}
+}
+
+func TestReadRequestBodyWithoutGetBodyRestoresStream(t *testing.T) {
+	httplog.SetEnabled(true)
+	t.Cleanup(func() { httplog.SetEnabled(false) })
+
+	payload := "raw-stream-payload"
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://x/", nil)
+	req.Body = io.NopCloser(bytes.NewReader([]byte(payload)))
+	req.GetBody = nil
+
+	body, _ := readRequestBody(req)
+	if body != payload {
+		t.Errorf("readRequestBody = %q, want %q", body, payload)
+	}
+	remaining, _ := io.ReadAll(req.Body)
+	if string(remaining) != payload {
+		t.Errorf("body left as %q, want it replayable as %q", remaining, payload)
+	}
+}
+
+func TestReadRequestBodyNil(t *testing.T) {
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", nil)
+	if body, tr := readRequestBody(req); body != "" || tr {
+		t.Errorf("readRequestBody on a bodyless request = %q,%v; want empty", body, tr)
+	}
+}
+
+func TestReadRequestBodyTruncates(t *testing.T) {
+	httplog.SetEnabled(true)
+	httplog.SetMaxBody(8)
+	t.Cleanup(func() {
+		httplog.SetEnabled(false)
+		httplog.SetMaxBody(0)
+	})
+
+	payload := strings.Repeat("y", 50)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://x/", strings.NewReader(payload))
+
+	body, truncated := readRequestBody(req)
+	if !truncated {
+		t.Error("truncated = false, want true")
+	}
+	if !strings.HasPrefix(body, strings.Repeat("y", 8)) || !strings.Contains(body, "truncated") {
+		t.Errorf("body = %q, want 8 bytes plus a marker", body)
+	}
+}
+
+func TestBuildTransportInstallsTraceBeneathHeaders(t *testing.T) {
+	// With no other customization, tracing alone must still produce a
+	// transport — the nil return that means "leave the SDK's client alone"
+	// would skip the trace entirely.
+	tr, err := BuildTransport(&LLMOptions{TraceHTTP: true})
+	if err != nil {
+		t.Fatalf("BuildTransport: %v", err)
+	}
+	tt, ok := tr.(*traceTransport)
+	if !ok {
+		t.Fatalf("BuildTransport returned %T, want *traceTransport", tr)
+	}
+	if tt.base != http.DefaultTransport {
+		t.Errorf("trace base = %T, want http.DefaultTransport", tt.base)
+	}
+
+	// With ExtraHeaders, headerTransport must be on the outside so the trace
+	// below it records the headers it injected.
+	tr, err = BuildTransport(&LLMOptions{TraceHTTP: true, ExtraHeaders: map[string]string{"X-Team": "pi"}})
+	if err != nil {
+		t.Fatalf("BuildTransport: %v", err)
+	}
+	ht, ok := tr.(*headerTransport)
+	if !ok {
+		t.Fatalf("BuildTransport returned %T, want *headerTransport outermost", tr)
+	}
+	if _, ok := ht.base.(*traceTransport); !ok {
+		t.Errorf("headerTransport wraps %T, want *traceTransport directly beneath it", ht.base)
+	}
+}
+
+func TestBuildTransportWithoutTraceUnchanged(t *testing.T) {
+	tr, err := BuildTransport(&LLMOptions{})
+	if err != nil {
+		t.Fatalf("BuildTransport: %v", err)
+	}
+	if tr != nil {
+		t.Errorf("BuildTransport with no options = %T, want nil so the SDK client is left alone", tr)
+	}
+	if tr, err = BuildTransport(nil); err != nil || tr != nil {
+		t.Errorf("BuildTransport(nil) = %v,%v; want nil,nil", tr, err)
+	}
+}
+
+// TestTraceTransportSeesInjectedHeaders is the end-to-end case the layering in
+// BuildTransport exists for: a header added by headerTransport must appear in
+// the trace, because diagnosing a gateway that rejects a request depends on
+// seeing the headers it actually got.
+func TestTraceTransportSeesInjectedHeaders(t *testing.T) {
+	entries := collect(t)
+
+	stub := &stubTripper{resp: jsonResponse(200, "{}")}
+	tr, err := BuildTransport(&LLMOptions{TraceHTTP: true, ExtraHeaders: map[string]string{"X-Team": "pi"}})
+	if err != nil {
+		t.Fatalf("BuildTransport: %v", err)
+	}
+	// Swap the real network transport underneath the trace for the stub.
+	tr.(*headerTransport).base.(*traceTransport).base = stub
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	got := (*entries)[0].Headers["X-Team"]
+	if len(got) == 0 || got[0] != "pi" {
+		t.Errorf("trace headers X-Team = %v, want [pi] — the injected header must be visible", got)
+	}
+}


### PR DESCRIPTION
Adds `--trace-http` for full LLM HTTP tracing — method, URL, headers and bodies, both directions — fanning out to the JSONL session log and to OpenTelemetry span events. Also expands `pi --help` so the model → provider routing rules (the ollama/, :cloud, azure/, opencode/ prefixes) and the per-provider credential are discoverable up front, instead of being hidden behind the error you get after guessing wrong.

Branch rebased onto current `main`; every commit has `Signed-off-by` and is cryptographically signed.