### PR TITLE
fix(ci): resolve lint and GitGuardian findings on PR 79

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -661,16 +661,16 @@ func runNonInteractive(
 	}()
 
 	ag, err := agent.New(agent.Config{
-		Model:               llm,
-		Tools:               coreTools,
-		Toolsets:            allToolsets,
-		Instruction:         instruction,
-		SessionService:      sessionSvc,
-		BeforeToolCallbacks: beforeCBs,
-		AfterToolCallbacks:  afterCBs,
+		Model:                llm,
+		Tools:                coreTools,
+		Toolsets:             allToolsets,
+		Instruction:          instruction,
+		SessionService:       sessionSvc,
+		BeforeToolCallbacks:  beforeCBs,
+		AfterToolCallbacks:   afterCBs,
 		BeforeModelCallbacks: llmBefore,
 		AfterModelCallbacks:  llmAfter,
-		Logger: sessionLog,
+		Logger:               sessionLog,
 	})
 	if err != nil {
 		return fmt.Errorf("creating agent: %w", err)

--- a/internal/cli/ping_test.go
+++ b/internal/cli/ping_test.go
@@ -205,7 +205,7 @@ func (m *streamAwareMockLLM) GenerateContent(_ context.Context, _ *model.LLMRequ
 }
 
 // TestModelPingAzureNonStreamSoftContinue verifies Azure soft-fails non-stream
-// and still reports alive when stream=true succeeds (Autox Responses behaviour).
+// and still reports alive when stream=true succeeds (Autox Responses behavior).
 func TestModelPingAzureNonStreamSoftContinue(t *testing.T) {
 	llm := &streamAwareMockLLM{
 		name:     "azure-autox",
@@ -1263,9 +1263,9 @@ func TestDumpPingRequestMasksAzureKey(t *testing.T) {
 		t.Fatalf("NewRequest: %v", err)
 	}
 	secrets := map[string]string{
-		"Api-Key":       "b38a5a7c-9c76-44ed-bfe6-8dd98296d6af",
-		"X-Api-Key":     "sk-ant-secretvalue-abcdef",
-		"Authorization": "Bearer sk-secretvalue-abcdef",
+		"Api-Key":       "azure-fake-key-for-test",
+		"X-Api-Key":     "anthropic-fake-header-value",
+		"Authorization": "Bearer fake-bearer-token",
 	}
 	for k, v := range secrets {
 		req.Header.Set(k, v)
@@ -1293,13 +1293,13 @@ func TestDumpPingResponseMasksSetCookie(t *testing.T) {
 	resp := &http.Response{
 		ProtoMajor: 2,
 		Status:     "200 OK",
-		Header:     http.Header{"Set-Cookie": {"session=supersecretvalue"}, "Content-Type": {"application/json"}},
+		Header:     http.Header{"Set-Cookie": {"session=fake-cookie-value"}, "Content-Type": {"application/json"}},
 	}
 	var sb strings.Builder
 	dumpPingResponse(func(format string, a ...any) { fmt.Fprintf(&sb, format, a...) }, resp, time.Second)
 	out := sb.String()
 
-	if strings.Contains(out, "supersecretvalue") {
+	if strings.Contains(out, "fake-cookie-value") {
 		t.Errorf("dumpPingResponse leaked Set-Cookie:\n%s", out)
 	}
 	if !strings.Contains(out, "application/json") {


### PR DESCRIPTION
Two issues, both caught by CI on the PR but pre-existing in the source commits:
- gofmt: adding the new BeforeModelCallbacks/AfterModelCallbacks fields to agent.Config{} widened the longest key, so existing column alignment in runNonInteractive drifted. gofmt re-aligns.
- misspell: ping_test.go used British 'behaviour' where the linter wants 'behavior'.
- GitGuardian: TestDumpPingRequestMasksAzureKey fixtures carried strings shaped like real credentials (an Azure-format GUID, 'sk-ant-...', 'sk-...') and the Set-Cookie test used 'supersecretvalue' as a substring, all of which tripped secret-pattern scanning on the diff. Replaced with obviously-fake placeholders that still let the masking assertion stand.