### PR TITLE
perf(tui): drop per-line ansi.Strip from the render hot path

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/styles"
-	"github.com/charmbracelet/x/ansi"
 
 	"charm.land/lipgloss/v2"
 )
@@ -620,7 +619,7 @@ func collapseBlankLines(s string, kinds []blockKind) (string, []blockKind) {
 	outKinds := make([]blockKind, 0, len(lines))
 	prevBlank := false
 	for i, line := range lines {
-		if strings.TrimSpace(ansi.Strip(line)) == "" {
+		if blankFast(line) {
 			if prevBlank {
 				continue
 			}

--- a/internal/tui/collapse.go
+++ b/internal/tui/collapse.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// collapseBlankLines runs over the entire rendered history on every frame, and
+// bubbletea calls View() once per message with no frame coalescing — so during
+// streaming this executes once per token. The blank test is therefore the
+// hottest line in the render path: profiling a live session attributed 24% of
+// all CPU to the ansi.Strip call this replaces.
+//
+// blankFast reports whether line contains no non-whitespace content once ANSI
+// escape sequences are ignored — the allocation-free equivalent of
+// strings.TrimSpace(ansi.Strip(line)) == "".
+//
+// It fast-paths CSI only. CSI (SGR colors, cursor moves) is the entire
+// vocabulary lipgloss, glamour, and our own renderers emit, so the fast path
+// covers 100% of real frames. Anything else — OSC, DCS, SOS, PM, APC, or a
+// malformed escape — falls back to ansi.Strip for that one line.
+//
+// The fallback is not defensive padding; it is load-bearing. Two rounds of
+// FuzzBlankFast killed hand-rolled attempts to reproduce ansi.Strip's behavior
+// on exotic sequences: "\x1bX0" (SOS, which Strip swallows) and "\x1bX\xd0"
+// (unterminated SOS with invalid UTF-8, which Strip emits as content). Matching
+// a parser's edge-case quirks by hand is a losing game. Deferring to it for the
+// ~0% of lines that need it costs nothing and is correct by construction.
+func blankFast(line string) bool {
+	for i := 0; i < len(line); {
+		c := line[i]
+		if c == 0x1b { // ESC
+			if i+1 >= len(line) || line[i+1] != '[' {
+				return slowBlank(line) // not CSI: defer to the parser
+			}
+			// Fast-path ONLY the exact CSI grammar lipgloss/glamour emit:
+			//   ESC [ <param bytes 0x30-0x3f> <final byte 0x40-0x7e>
+			// Intermediate bytes (0x20-0x2f) are deliberately excluded: they are
+			// legal CSI but order-sensitive, and ansi.Strip aborts on bad order
+			// (FuzzBlankFast: "\x1b[ 0A"). C0 controls abort too ("\x1b[\x1c").
+			// Every deviation defers to the parser instead of guessing.
+			j := i + 2
+			for j < len(line) && line[j] >= 0x30 && line[j] <= 0x3f {
+				j++
+			}
+			if j >= len(line) || line[j] < 0x40 || line[j] > 0x7e {
+				return slowBlank(line)
+			}
+			i = j + 1 // consume final byte
+			continue
+		}
+		if c < utf8.RuneSelf { // ASCII fast path — the overwhelmingly common case
+			if !isASCIISpace(c) {
+				return false
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(line[i:])
+		if r == utf8.RuneError && size <= 1 {
+			// Invalid UTF-8. ansi.Strip has its own opinion about these bytes
+			// (FuzzBlankFast: "\xa0" is blank to Strip but not to a naive
+			// decoder), so defer rather than guess. Valid multi-byte runes —
+			// the ▌ gutter, box drawing, emoji — take the fast path above.
+			return slowBlank(line)
+		}
+		if !unicode.IsSpace(r) {
+			return false
+		}
+		i += size
+	}
+	return true
+}
+
+// slowBlank is the reference implementation blankFast must agree with, and the
+// fallback blankFast defers to for escape sequences outside the CSI fast path.
+func slowBlank(line string) bool {
+	return strings.TrimSpace(ansi.Strip(line)) == ""
+}
+
+func isASCIISpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r'
+}

--- a/internal/tui/collapse_bench_test.go
+++ b/internal/tui/collapse_bench_test.go
@@ -4,96 +4,21 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi"
 )
 
-// This file quantifies TODO.md ## PPROF item 25 and de-risks its proposed fix.
-//
-// collapseBlankLines calls ansi.Strip on every line of the entire rendered
-// history on every frame, purely to answer "is this line blank?". ansi.Strip
-// runs a full ANSI state-machine parse and allocates a new string. The question
-// it is being asked can be answered by a single non-allocating pass.
-//
-// blankFast is the candidate: walk the bytes, skip escape sequences, and bail
-// on the first non-whitespace rune. It answers the same question with no
-// allocation and no parser.
+// This file guards the blank-line fast path in collapse.go and quantifies what
+// it bought. blankFast replaced a per-line ansi.Strip call inside
+// collapseBlankLines, which runs over the whole rendered history on every
+// frame — and bubbletea calls View() once per message, so during streaming that
+// is once per token. A live CPU profile attributed 24% of all CPU to the Strip
+// call that blankFast removes.
 
-// blankFast reports whether line contains no non-whitespace content once ANSI
-// escape sequences are ignored — the allocation-free equivalent of
-// strings.TrimSpace(ansi.Strip(line)) == "".
-//
-// It fast-paths CSI only. CSI (SGR colors, cursor moves) is the entire
-// vocabulary lipgloss, glamour, and our own renderers emit, so the fast path
-// covers 100% of real frames. Anything else — OSC, DCS, SOS, PM, APC, or a
-// malformed escape — falls back to ansi.Strip for that one line.
-//
-// The fallback is not defensive padding; it is load-bearing. Two rounds of
-// FuzzBlankFast killed hand-rolled attempts to reproduce ansi.Strip's behavior
-// on exotic sequences: "\x1bX0" (SOS, which Strip swallows) and "\x1bX\xd0"
-// (unterminated SOS with invalid UTF-8, which Strip emits as content). Matching
-// a parser's edge-case quirks by hand is a losing game. Deferring to it for the
-// ~0% of lines that need it costs nothing and is correct by construction.
-func blankFast(line string) bool {
-	for i := 0; i < len(line); {
-		c := line[i]
-		if c == 0x1b { // ESC
-			if i+1 >= len(line) || line[i+1] != '[' {
-				return slowBlank(line) // not CSI: defer to the parser
-			}
-			// Fast-path ONLY the exact CSI grammar lipgloss/glamour emit:
-			//   ESC [ <param bytes 0x30-0x3f> <final byte 0x40-0x7e>
-			// Intermediate bytes (0x20-0x2f) are deliberately excluded: they are
-			// legal CSI but order-sensitive, and ansi.Strip aborts on bad order
-			// (FuzzBlankFast: "\x1b[ 0A"). C0 controls abort too ("\x1b[\x1c").
-			// Every deviation defers to the parser instead of guessing.
-			j := i + 2
-			for j < len(line) && line[j] >= 0x30 && line[j] <= 0x3f {
-				j++
-			}
-			if j >= len(line) || line[j] < 0x40 || line[j] > 0x7e {
-				return slowBlank(line)
-			}
-			i = j + 1 // consume final byte
-			continue
-		}
-		if c < utf8.RuneSelf { // ASCII fast path — the overwhelmingly common case
-			if !isASCIISpace(c) {
-				return false
-			}
-			i++
-			continue
-		}
-		r, size := utf8.DecodeRuneInString(line[i:])
-		if r == utf8.RuneError && size <= 1 {
-			// Invalid UTF-8. ansi.Strip has its own opinion about these bytes
-			// (FuzzBlankFast: "\xa0" is blank to Strip but not to a naive
-			// decoder), so defer rather than guess. Valid multi-byte runes —
-			// the ▌ gutter, box drawing, emoji — take the fast path above.
-			return slowBlank(line)
-		}
-		if !unicode.IsSpace(r) {
-			return false
-		}
-		i += size
-	}
-	return true
-}
-
-// slowBlank is the reference implementation blankFast must agree with.
-func slowBlank(line string) bool {
-	return strings.TrimSpace(ansi.Strip(line)) == ""
-}
-
-func isASCIISpace(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r'
-}
-
-// collapseBlankLinesFast is collapseBlankLines with only the blank test swapped.
-// Everything else is identical, so the benchmark isolates the ansi.Strip cost.
-func collapseBlankLinesFast(s string, kinds []blockKind) (string, []blockKind) {
+// collapseBlankLinesStrip is the original implementation: collapseBlankLines
+// with the ansi.Strip blank test it used before blankFast. Kept as the
+// benchmark baseline and as an independent reference for the correctness gate.
+func collapseBlankLinesStrip(s string, kinds []blockKind) (string, []blockKind) {
 	if s == "" {
 		return s, nil
 	}
@@ -105,7 +30,7 @@ func collapseBlankLinesFast(s string, kinds []blockKind) (string, []blockKind) {
 	outKinds := make([]blockKind, 0, len(lines))
 	prevBlank := false
 	for i, line := range lines {
-		if blankFast(line) {
+		if strings.TrimSpace(ansi.Strip(line)) == "" {
 			if prevBlank {
 				continue
 			}
@@ -176,18 +101,18 @@ func FuzzBlankFast(f *testing.F) {
 func BenchmarkCollapseBlankLines(b *testing.B) {
 	for _, n := range []int{10, 100, 500} {
 		h := history(n)
-		b.Run(fmt.Sprintf("current/msgs=%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("strip/msgs=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(h)))
 			for b.Loop() {
-				collapseBlankLines(h, nil)
+				collapseBlankLinesStrip(h, nil)
 			}
 		})
 		b.Run(fmt.Sprintf("fast/msgs=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(h)))
 			for b.Loop() {
-				collapseBlankLinesFast(h, nil)
+				collapseBlankLines(h, nil)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

Keyboard input in the TUI lags and keypresses get dropped. Profiling a live session (`pi --pprof true`) found the cause in the render path, not the input path.

`collapseBlankLines` answered *"is this line blank?"* with `strings.TrimSpace(ansi.Strip(line))` — a full ANSI state-machine parse plus an allocation, per line. Critically, that call sits **outside** the per-message render cache, at the tail of `renderMessages`:

```go
return collapseBlankLines(b.String(), kinds)
```

so it re-scanned the *entire* conversation on every frame. And bubbletea v2 calls `View()` once per message with no frame coalescing (`tea.go:880`), while the streaming message re-keys on every token (`chat.go:577`) — so during streaming this ran **once per token**.

Profile evidence from a live session:

| measurement | value |
|---|---|
| event-loop time inside `View()` | **98.7%** (750ms of 760ms) |
| all process CPU in `ansi.Strip` | **24.3%** |
| allocation churn attributed to `View()` | **86%** (1.76 GB of 2.04 GB over ~3 min) |

The bubbletea event loop is the same goroutine that services keypresses, so keys queue behind render work — and because the cost is linear in history length, it gets steadily worse over a session.

## What

`blankFast` answers the same question in a single non-allocating pass: walk the bytes, skip escape sequences, bail on the first non-whitespace rune.

It fast-paths **CSI only** — the entire vocabulary lipgloss, glamour, and our own renderers emit. Anything else (OSC, DCS, SOS, PM, APC, malformed escapes) defers to `ansi.Strip` for that one line. That fallback is load-bearing, not defensive padding: two rounds of `FuzzBlankFast` killed hand-rolled attempts to reproduce `Strip`'s behavior on `"\x1bX0"` (SOS, which Strip swallows) and `"\x1bX\xd0"` (unterminated SOS with invalid UTF-8, which Strip emits as content).

The implementation and its fuzz gate **already existed** in `collapse_bench_test.go` from a prior investigation but were never wired into production. This moves them into `collapse.go` and swaps the blank test. The old `ansi.Strip` version is retained in the test file as `collapseBlankLinesStrip`, so the benchmark still compares baseline against production.

## Result

```
BenchmarkCollapseBlankLines/strip/msgs=500-10   1976724 ns/op   1077160 B/op   10015 allocs/op
BenchmarkCollapseBlankLines/fast/msgs=500-10     312387 ns/op    555604 B/op      15 allocs/op
```

**6.3x faster, 667x fewer allocations.** Both are linear in history, so the gap widens over a session.

## Verification

- `go build ./...` clean
- `go vet ./internal/tui/` clean
- full `internal/tui` suite passes
- `FuzzBlankFast` — 103k execs, zero mismatches against the `ansi.Strip` reference
- `TestBlankFastMatchesStrip` correctness gate retained

## Scope / follow-up

This fixes the single hottest line, not the whole problem. The larger remaining win is **coalescing streaming tokens**: because bubbletea renders per message, each token still triggers one full-history render. Batching `agentCh` drains into one `agentTextMsg` per ~16ms would cut render count by 10-50x during streaming. Not in this PR.

One measurement caveat worth stating plainly: the 20s CPU profile was captured during a relatively idle window (7% total CPU). It establishes *where* event-loop time goes, not the absolute saturation level at the moment keys were dropped.

https://claude.ai/code/session_01CqpBszVZrpgDzAKEWrCjx8