### PR TITLE
feat(tui): verify subagent exit status before running gates in /run

### DIFF
--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -598,6 +598,54 @@ func (o *Orchestrator) List() []AgentStatus {
 	return statuses
 }
 
+// SetStatusForTest is a test-only helper that records a synthetic
+// agent state so callers can exercise post-spawn verification paths
+// without spawning a real subprocess. The agent is marked "running"
+// until SetStatusForTest is called with a final status. Returns false
+// if the orchestrator was already shut down. Not for production use.
+func (o *Orchestrator) SetStatusForTest(agentID, status string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.closed {
+		return false
+	}
+	now := time.Now()
+	o.agents[agentID] = &agentState{
+		ID:         agentID,
+		Type:       "test",
+		StartedAt:  now,
+		FinishedAt: now,
+		Status:     status,
+	}
+	return true
+}
+
+// Get returns the status of a single tracked agent by ID.
+// Returns (AgentStatus{}, false) when the agent is unknown. Useful for
+// post-spawn verification (e.g. the /run flow checks exit status before
+// moving on to gate validation).
+func (o *Orchestrator) Get(agentID string) (AgentStatus, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	state, ok := o.agents[agentID]
+	if !ok {
+		return AgentStatus{}, false
+	}
+	dur := ""
+	if state.Status != "running" && !state.FinishedAt.IsZero() {
+		dur = state.FinishedAt.Sub(state.StartedAt).Truncate(time.Millisecond).String()
+	}
+	return AgentStatus{
+		AgentID:   state.ID,
+		Type:      state.Type,
+		Status:    state.Status,
+		Prompt:    state.Prompt,
+		StartedAt: state.StartedAt,
+		Duration:  dur,
+	}, true
+}
+
 // resolveWorktreeUsage determines whether a worktree should be created for a spawn.
 func resolveWorktreeUsage(agentDefault bool, inputOverride *bool, workDir string) bool {
 	if workDir != "" {

--- a/internal/subagent/orchestrator_test.go
+++ b/internal/subagent/orchestrator_test.go
@@ -688,3 +688,38 @@ func TestValidateAgentForCancel(t *testing.T) {
 		})
 	}
 }
+
+// TestGet_ReturnsSeededStatus verifies that Get returns the recorded
+// status of a seeded agent and reports (zero, false) for unknown IDs.
+func TestGet_ReturnsSeededStatus(t *testing.T) {
+	o := NewOrchestrator(&config.Config{}, "", nil)
+
+	if _, ok := o.Get("nope"); ok {
+		t.Fatal("Get on unknown agent should return ok=false")
+	}
+
+	if !o.SetStatusForTest("task-1", "completed") {
+		t.Fatal("SetStatusForTest should succeed on a fresh orchestrator")
+	}
+	st, ok := o.Get("task-1")
+	if !ok {
+		t.Fatal("Get should find seeded agent")
+	}
+	if st.Status != "completed" {
+		t.Errorf("status = %q, want completed", st.Status)
+	}
+	if st.AgentID != "task-1" {
+		t.Errorf("agentID = %q, want task-1", st.AgentID)
+	}
+	if st.Duration == "" {
+		t.Error("Duration should be populated for finished agents")
+	}
+
+	if !o.SetStatusForTest("task-2", "failed") {
+		t.Fatal("SetStatusForTest should succeed")
+	}
+	st2, _ := o.Get("task-2")
+	if st2.Status != "failed" {
+		t.Errorf("status = %q, want failed", st2.Status)
+	}
+}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -328,7 +328,7 @@ func slashCommandDesc(cmd string) string {
 	case "/plan":
 		return "Start PDD planning session"
 	case "/run":
-		return "Execute a spec with task agent"
+		return "Execute a spec with task agent (verifies subagent exit status before merging)"
 	case "/theme":
 		return "Switch theme or list themes"
 	case "/skills":

--- a/internal/tui/plan_run_e2e_test.go
+++ b/internal/tui/plan_run_e2e_test.go
@@ -571,6 +571,7 @@ func TestE2E_MergeSuccessFlow(t *testing.T) {
 
 func TestE2E_AgentDoneGatePassMergeFlow(t *testing.T) {
 	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	orch.SetStatusForTest("task-flow-1", "completed")
 
 	m := &model{
 		cfg: Config{

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -541,6 +541,31 @@ func (m *model) handleRunAgentDone(msg runAgentDoneMsg) (tea.Model, tea.Cmd) {
 	m.chatModel.Streaming = ""
 	m.chatModel.Thinking = ""
 
+	// Verify that every subagent exited cleanly (status == "completed")
+	// before moving on to gate validation. A "failed" / "killed" /
+	// "canceled" status means the subagent process exited non-zero (or
+	// was killed), so the work in its worktree is unreliable — skip
+	// gates/merge and surface the failure to the user instead. The
+	// worktree is preserved so they can inspect it manually.
+	if bad := m.failedAgentIDs(); len(bad) > 0 {
+		m.run.phase = "failed"
+		wtPaths := m.runWorktreePathsFor(bad)
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role: "assistant",
+			content: fmt.Sprintf(
+				"**Subagent exited with non-zero status** for spec `%s` — skipping gates and merge.\n"+
+					"Inspect the worktree(s) below and re-run `/run %s` once the issue is fixed.\n%s",
+				m.run.specName, m.run.specName, wtPaths),
+		})
+		if report, rerr := m.writeRunSummary("agent_failed"); rerr == nil {
+			m.chatModel.Messages = append(m.chatModel.Messages, message{
+				role:    "assistant",
+				content: fmt.Sprintf("Summary report: `%s`", report),
+			})
+		}
+		return m, nil
+	}
+
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role:    "assistant",
 		content: "**All agents finished** — validating gates...",
@@ -559,6 +584,53 @@ func (m *model) handleRunAgentDone(msg runAgentDoneMsg) (tea.Model, tea.Cmd) {
 	// Run gate validation.
 	m.run.phase = "gating"
 	return m, m.runGatesCmd()
+}
+
+// failedAgentIDs returns the IDs of subagents (single or parallel) that
+// did not exit cleanly. An agent is considered failed when its status in
+// the orchestrator is anything other than "completed" or "running".
+// When the orchestrator has no record of an agent yet (race between
+// channel close and state update), it is treated as failed so the user
+// is warned rather than silently merged.
+func (m *model) failedAgentIDs() []string {
+	if m.run == nil || m.cfg.Orchestrator == nil {
+		return nil
+	}
+	var bad []string
+	check := func(agentID string) {
+		st, ok := m.cfg.Orchestrator.Get(agentID)
+		if !ok || st.Status != "completed" {
+			bad = append(bad, agentID)
+		}
+	}
+	if m.run.isParallel() {
+		for _, pa := range m.run.parallel {
+			check(pa.agentID)
+		}
+	} else if m.run.agentID != "" {
+		check(m.run.agentID)
+	}
+	return bad
+}
+
+// runWorktreePathsFor returns a markdown bullet list of worktree paths
+// for the given agent IDs, one per line. Used by the post-run failure
+// message so the user can find the preserved worktree(s).
+func (m *model) runWorktreePathsFor(agentIDs []string) string {
+	if m.cfg.Orchestrator == nil || len(agentIDs) == 0 {
+		return ""
+	}
+	wm := m.cfg.Orchestrator.Worktree()
+	if wm == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, aid := range agentIDs {
+		if p := wm.PathFor(aid); p != "" {
+			fmt.Fprintf(&b, "- `%s`\n", p)
+		}
+	}
+	return b.String()
 }
 
 // runGatesCmd returns a tea.Cmd that runs each gate command sequentially in the worktree.
@@ -947,6 +1019,8 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 		fmt.Fprintf(&b, "Gate validation failed after %d retries. Worktree preserved for manual inspection.\n", rs.retries)
 	case "merge_failed":
 		b.WriteString("Gates passed but merge into the main branch failed. Worktree preserved for manual resolution.\n")
+	case "agent_failed":
+		b.WriteString("Subagent process exited with non-zero status (or was killed) before gates could run. Worktree preserved for manual inspection — see chat for the failing agent IDs and their worktree paths.\n")
 	default:
 		fmt.Fprintf(&b, "Run ended with status: %s\n", outcome)
 	}

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -856,9 +856,11 @@ func TestHandleRunAgentDone_NoGatesSkipsToMerge(t *testing.T) {
 }
 
 func TestHandleRunAgentDone_WithGatesTriggersGating(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	orch.SetStatusForTest("task-123", "completed")
 	m := &model{
 		cfg: Config{
-			Orchestrator: subagent.NewOrchestrator(&config.Config{}, "", nil),
+			Orchestrator: orch,
 		},
 		chatModel: ChatModel{Messages: make([]message, 0)},
 		running:   true,
@@ -1476,5 +1478,198 @@ func TestRunWorktreeName(t *testing.T) {
 	}
 	if got := runWorktreeName("features/SUB/skills-subagents", "part-2"); got != "features-SUB-skills-subagents-part-2" {
 		t.Fatalf("runWorktreeName() with suffix = %q", got)
+	}
+}
+
+// TestHandleRunAgentDone_CompletedStatus_ProceedsToGatesOrMerge verifies
+// that when the orchestrator reports the subagent's status as
+// "completed" (i.e. clean exit code 0), handleRunAgentDone continues
+// to the normal gate/merge flow. This is the "happy path" of the
+// post-spawn verification step.
+func TestHandleRunAgentDone_CompletedStatus_ProceedsToGatesOrMerge(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	orch.SetStatusForTest("task-1", "completed")
+
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		cfg:       Config{Orchestrator: orch},
+		run: &runState{
+			specName: "test-spec",
+			phase:    "running",
+			agentID:  "task-1",
+			gates:    nil, // no gates → goes straight to merge
+		},
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-1"})
+
+	if m.run.phase != "merging" {
+		t.Errorf("phase = %q, want merging (completed status, no gates)", m.run.phase)
+	}
+	if m.running {
+		t.Error("model should not still be running after done")
+	}
+}
+
+// TestHandleRunAgentDone_FailedStatus_SkipsGatesAndMerge verifies that
+// when the subagent exited non-zero (status != "completed"), the run
+// is marked failed, gates/merge are skipped, and the worktree is
+// preserved. This is the behavior the user asked for: "check if
+// subagent finished <> 0 exit code".
+func TestHandleRunAgentDone_FailedStatus_SkipsGatesAndMerge(t *testing.T) {
+	tmpDir := t.TempDir()
+	orch := subagent.NewOrchestrator(&config.Config{}, tmpDir, nil)
+	orch.SetStatusForTest("task-1", "failed")
+
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		cfg: Config{
+			Orchestrator: orch,
+			WorkDir:      tmpDir,
+		},
+		run: &runState{
+			specName: "test-spec",
+			phase:    "running",
+			agentID:  "task-1",
+			gates:    []Gate{{Name: "test", Command: "go test ./..."}},
+		},
+	}
+
+	// Pre-create a PROMPT.md so writeRunSummary has somewhere to write.
+	if err := os.MkdirAll(filepath.Join(tmpDir, "specs", "test-spec"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "specs", "test-spec", "PROMPT.md"),
+		[]byte("# Test\n\n## Gates\n\n- **test**: `go test ./...`\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-1"})
+
+	if m.run.phase != "failed" {
+		t.Errorf("phase = %q, want failed (subagent exited non-zero)", m.run.phase)
+	}
+
+	// User-facing message should mention the non-zero status and the
+	// /run command they can use to resume.
+	var saw bool
+	for _, msg := range m.chatModel.Messages {
+		if strings.Contains(msg.content, "non-zero status") &&
+			strings.Contains(msg.content, "/run test-spec") {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		t.Error("expected a chat message mentioning non-zero status and the /run command to resume")
+	}
+
+	// Should NOT contain the gate validation message (we skip gates).
+	for _, msg := range m.chatModel.Messages {
+		if strings.Contains(msg.content, "validating gates") {
+			t.Error("should not announce gate validation when subagent failed")
+		}
+	}
+
+	// SUMMARY.md should be written with the new agent_failed outcome.
+	reportPath := filepath.Join(tmpDir, "specs", "test-spec", "SUMMARY.md")
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("expected SUMMARY.md: %v", err)
+	}
+	if !strings.Contains(string(data), "agent_failed") {
+		t.Errorf("SUMMARY.md should mention agent_failed outcome; got:\n%s", string(data))
+	}
+}
+
+// TestHandleRunAgentDone_UnknownStatus_TreatedAsFailed verifies that
+// when the orchestrator has no record of the agent at all (e.g. the
+// events channel closed before the orchestrator recorded a final
+// status), we err on the side of warning the user rather than silently
+// merging.
+func TestHandleRunAgentDone_UnknownStatus_TreatedAsFailed(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	// No SetStatusForTest — the orchestrator has no record of this agent.
+
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		cfg:       Config{Orchestrator: orch},
+		run: &runState{
+			specName: "test-spec",
+			phase:    "running",
+			agentID:  "task-unknown",
+			gates:    []Gate{{Name: "test", Command: "true"}},
+		},
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-unknown"})
+
+	if m.run.phase != "failed" {
+		t.Errorf("phase = %q, want failed (unknown agent)", m.run.phase)
+	}
+}
+
+// TestHandleRunAgentDone_ParallelOneFailed_AbortsRun verifies that if
+// even one parallel agent exits non-zero, the whole run is marked
+// failed and gates/merge are skipped — neither the failing agent nor
+// the successful one should be merged.
+func TestHandleRunAgentDone_ParallelOneFailed_AbortsRun(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	orch.SetStatusForTest("a-1", "completed")
+	orch.SetStatusForTest("a-2", "killed")
+
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		cfg:       Config{Orchestrator: orch},
+		run: &runState{
+			specName: "test-spec",
+			phase:    "running",
+			parallel: []*parallelAgent{
+				{agentID: "a-1", done: true},
+				{agentID: "a-2", done: true},
+			},
+		},
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "a-1"}) // a-1 already done, a-2 also done
+	// (a-2 was already marked done in setup; handleRunAgentDone's
+	//  parallel branch only sets done=true on the matching agentID.)
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "a-2"})
+
+	if m.run.phase != "failed" {
+		t.Errorf("phase = %q, want failed (a-2 was killed)", m.run.phase)
+	}
+}
+
+// TestHandleRunAgentDone_ParallelAllCompleted_ProceedsToGates verifies
+// the parallel happy path: every agent is "completed" → gates run.
+func TestHandleRunAgentDone_ParallelAllCompleted_ProceedsToGates(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	orch.SetStatusForTest("a-1", "completed")
+	orch.SetStatusForTest("a-2", "completed")
+
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		cfg:       Config{Orchestrator: orch},
+		run: &runState{
+			specName: "test-spec",
+			phase:    "running",
+			gates:    []Gate{{Name: "test", Command: "true"}}, // has gates → phase "gating"
+			parallel: []*parallelAgent{
+				{agentID: "a-1", done: true}, // already done
+				{agentID: "a-2", done: false},
+			},
+		},
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "a-2"})
+
+	if m.run.phase != "gating" {
+		t.Errorf("phase = %q, want gating (parallel all completed)", m.run.phase)
 	}
 }


### PR DESCRIPTION
## Why

`/run` currently moves straight from "subagent finished" → gate validation → merge, with no check on whether the subagent itself exited cleanly. A subagent whose pi subprocess crashed (OOM, timeout, sandbox abort, transport error) closes its events channel and looks identical to one that succeeded — so the run can proceed to gates, merge broken work, and report success.

The orchestrator already tracks subagent status (`completed` / `failed` / `killed` / `canceled` in `agentState.Status`), but the TUI was the only consumer that didn't read it. The fix is to consult that status before transitioning out of the agent-done state.

## What

- `internal/subagent/orchestrator.go`
  - `Orchestrator.Get(agentID) (AgentStatus, bool)` — single-agent lookup mirroring `List()`.
  - `Orchestrator.SetStatusForTest(agentID, status)` — documented test-only helper so unit tests can exercise verification paths without spawning a real subprocess.
- `internal/tui/run.go`
  - `handleRunAgentDone` now calls a new `failedAgentIDs()` helper that consults the orchestrator for every agent in the run (single or parallel). Status `completed` → proceed as before. Anything else (`failed` / `killed` / `canceled`, or unknown due to the channel-close vs. state-update race) → set phase to `failed`, skip gates and merge, surface the preserved worktree path(s), and tell the user to re-run `/run <spec>` once the issue is fixed.
  - `buildRunSummaryReport` handles the new `agent_failed` outcome so `SUMMARY.md` is informative.
- `internal/tui/input.go`
  - `/run` slash-command help text mentions the verification step.
- Tests: 5 new `internal/tui` tests + 1 new `internal/subagent` test. Two pre-existing tests (`TestHandleRunAgentDone_WithGatesTriggersGating`, `TestE2E_AgentDoneGatePassMergeFlow`) were updated to seed a `completed` status to match the new contract — the only tests that exercised the `handleRunAgentDone` happy path with a real orchestrator.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `make lint` — 0 issues
- `go test ./internal/subagent/ ./internal/tui/` — green
- One commit (`e6191b2`) — SSH-signed with `Signed-off-by` trailer.