### PR TITLE
feat(hooks): add turn_complete and user_input_required lifecycle hooks

### DIFF
--- a/docs/AGENTS-HOWTO.md
+++ b/docs/AGENTS-HOWTO.md
@@ -256,11 +256,46 @@ Hooks run shell commands before or after tool calls. They are configured in `con
 
 | Field | Description |
 |---|---|
-| `event` | `before_tool` or `after_tool` |
-| `tool` | Tool name to match (e.g., `write`, `edit`, `bash`) |
+| `event` | `before_tool`, `after_tool`, `turn_complete`, or `user_input_required` |
+| `tool` | Tool name to match (e.g., `write`, `edit`, `bash`) — tool hooks only |
 | `command` | Shell command; tool args passed as JSON on stdin |
 
 The LSP integration uses `after_tool` hooks internally: after `write` or `edit`, gopls formats the file and collects diagnostics automatically.
+
+### Lifecycle hooks
+
+Beyond tool events, pi-go fires two lifecycle hooks that let you signal the
+host terminal (e.g. agterm) when the agent's state changes:
+
+- `turn_complete` — a turn finished (success or error). Payload: `{"event":"turn_complete","data":{"error":false}}`.
+- `user_input_required` — the agent finished and is now waiting for your next prompt. Payload: `{"event":"user_input_required","data":{}}`.
+
+Both fire together at the end of a turn, so a hook can subscribe to either.
+They are best-effort: a failure or timeout is logged and never interrupts the
+agent loop.
+
+**agterm example** — set the session's agent-status indicator to `completed`
+when a turn finishes, and to `blocked` when it needs your input. agterm injects
+`AGTERM_SESSION_ID` and `AGTERM_SOCKET` into every shell it spawns, so the hook
+targets the right session:
+
+```json
+{
+  "hooks": [
+    {
+      "event": "turn_complete",
+      "command": "agtermctl session status completed --target '$AGTERM_SESSION_ID' --socket '$AGTERM_SOCKET'"
+    },
+    {
+      "event": "user_input_required",
+      "command": "agtermctl session status blocked --target '$AGTERM_SESSION_ID' --socket '$AGTERM_SOCKET'"
+    }
+  ]
+}
+```
+
+For a one-shot desktop banner instead of the persistent indicator, use
+`agtermctl notify "pi finished" --target "$AGTERM_SESSION_ID" --socket "$AGTERM_SOCKET"`.
 
 ---
 

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -91,17 +91,18 @@ func runInteractive(
 	}()
 
 	tuiErr := tui.Run(ctx, tui.Config{
-		LLM:           llm,
-		AppVersion:    versionString(),
-		ModelName:     llm.Name(),
-		ProviderName:  info.Provider,
-		ThinkingLevel: cfg.ThinkingLevel,
-		ActiveRole:    activeRole,
-		Roles:         cfg.Roles,
-		WorkDir:       cwd,
-		ThemeName:     cfg.Theme,
-		TokenTracker:  tokenTracker,
-		DeferredInit:  initCh,
+		LLM:            llm,
+		AppVersion:     versionString(),
+		ModelName:      llm.Name(),
+		ProviderName:   info.Provider,
+		ThinkingLevel:  cfg.ThinkingLevel,
+		ActiveRole:     activeRole,
+		Roles:          cfg.Roles,
+		WorkDir:        cwd,
+		ThemeName:      cfg.Theme,
+		TokenTracker:   tokenTracker,
+		LifecycleHooks: convertHooks(cfg.Hooks),
+		DeferredInit:   initCh,
 		ModelSwitcher: func(switchCtx context.Context, modelName string) (adkmodel.LLM, string, string, error) {
 			return buildSwitchedLLM(switchCtx, cfg, tokenTracker, modelName)
 		},

--- a/internal/extension/hooks.go
+++ b/internal/extension/hooks.go
@@ -361,6 +361,35 @@ func genAIProviderAttr(providerName string) attribute.KeyValue {
 	}
 }
 
+// RunLifecycleHook executes a lifecycle hook's shell command with the event
+// name and data as JSON on stdin. Lifecycle hooks (turn_complete,
+// user_input_required) have no tool, so the payload carries the event instead.
+// A non-zero exit or timeout is logged by the caller, never fatal.
+func RunLifecycleHook(ctx context.Context, hook HookConfig, event string, data map[string]any) error {
+	hookCtx, cancel := context.WithTimeout(ctx, hook.timeout())
+	defer cancel()
+
+	cmd := exec.CommandContext(hookCtx, "sh", "-c", hook.Command)
+
+	input := map[string]any{
+		"event": event,
+		"data":  data,
+	}
+	jsonBytes, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Errorf("marshaling hook input: %w", err)
+	}
+	cmd.Stdin = bytes.NewReader(jsonBytes)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command %q: %w (stderr: %s)", hook.Command, err, stderr.String())
+	}
+	return nil
+}
+
 // runHookCommand executes a hook's shell command with the tool name and data as JSON on stdin.
 func runHookCommand(ctx context.Context, hook HookConfig, toolName string, data map[string]any) error {
 	hookCtx, cancel := context.WithTimeout(ctx, hook.timeout())

--- a/internal/extension/hooks_test.go
+++ b/internal/extension/hooks_test.go
@@ -2,7 +2,9 @@ package extension
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -671,3 +673,45 @@ func (c *mockReadonlyContext) WithDelta(*agent.CommonContextDelta) agent.Context
 }
 
 var _ agent.Context = (*mockReadonlyContext)(nil)
+
+func TestRunLifecycleHook(t *testing.T) {
+	dir := t.TempDir()
+	out := dir + "/out.json"
+	hook := HookConfig{
+		Event:   "turn_complete",
+		Command: "cat > " + out,
+		Timeout: 5,
+	}
+	ctx := context.Background()
+
+	err := RunLifecycleHook(ctx, hook, "turn_complete", map[string]any{"error": false})
+	if err != nil {
+		t.Fatalf("RunLifecycleHook() error = %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading hook output: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal hook output: %v", err)
+	}
+	if got["event"] != "turn_complete" {
+		t.Errorf("event = %v, want turn_complete", got["event"])
+	}
+	if d, ok := got["data"].(map[string]any); !ok || d["error"] != false {
+		t.Errorf("data = %v, want {error:false}", got["data"])
+	}
+}
+
+func TestRunLifecycleHookTimeout(t *testing.T) {
+	hook := HookConfig{
+		Event:   "user_input_required",
+		Command: "sleep 10",
+		Timeout: 1,
+	}
+	ctx := context.Background()
+	if err := RunLifecycleHook(ctx, hook, "user_input_required", nil); err == nil {
+		t.Error("expected timeout error")
+	}
+}

--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -1,11 +1,15 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/extension"
 )
 
 // --- toolCallSummary for agent ---
@@ -1402,5 +1406,41 @@ func TestAgentToolResultMsg_ClearsActiveTool(t *testing.T) {
 	}
 	if mm.chatModel.Messages[0].content == "" {
 		t.Error("expected message content to be updated")
+	}
+}
+
+func TestAgentDoneMsg_FiresLifecycleHooks(t *testing.T) {
+	dir := t.TempDir()
+	turnOut := dir + "/turn.json"
+	inputOut := dir + "/input.json"
+	m := &model{
+		ctx:       context.Background(),
+		chatModel: ChatModel{Messages: []message{{role: "assistant"}}},
+		running:   true,
+		agentCh:   make(chan agentMsg, 64),
+		cfg: Config{
+			LifecycleHooks: []extension.HookConfig{
+				{Event: "turn_complete", Command: "cat > " + turnOut, Timeout: 5},
+				{Event: "user_input_required", Command: "cat > " + inputOut, Timeout: 5},
+			},
+		},
+	}
+
+	if _, err := m.handleAgentDone(agentDoneMsg{}); err != nil {
+		t.Fatalf("handleAgentDone returned a Cmd, want nil")
+	}
+
+	for name, path := range map[string]string{"turn_complete": turnOut, "user_input_required": inputOut} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s hook output: %v", name, err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal %s hook output: %v", name, err)
+		}
+		if got["event"] != name {
+			t.Errorf("%s event = %v, want %s", name, got["event"], name)
+		}
 	}
 }

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/adk/v2/session"
 
 	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/logger"
 	"github.com/dimetron/pi-go/internal/otel"
 )
@@ -840,5 +841,26 @@ func (m *model) handleAgentDone(msg agentDoneMsg) (tea.Model, tea.Cmd) {
 	m.chatModel.Thinking = ""
 	m.agentCh = nil
 	m.refreshDiffStats()
+	// A finished turn hands control back to the user, so both lifecycle
+	// events fire here: the turn is complete, and the agent is now waiting
+	// for the next user input. A hook can subscribe to either.
+	m.runLifecycleHooks("turn_complete", map[string]any{
+		"error": msg.err != nil,
+	})
+	m.runLifecycleHooks("user_input_required", map[string]any{})
 	return m, nil
+}
+
+// runLifecycleHooks fires every configured lifecycle hook for the given event,
+// passing the event name and data as JSON on stdin. Hooks are best-effort: a
+// failure or timeout is logged and never interrupts the agent loop.
+func (m *model) runLifecycleHooks(event string, data map[string]any) {
+	for _, h := range m.cfg.LifecycleHooks {
+		if h.Event != event {
+			continue
+		}
+		if err := extension.RunLifecycleHook(m.ctx, h, event, data); err != nil {
+			stdlog.Printf("lifecycle hook %q failed for event %q: %v", h.Command, event, err)
+		}
+	}
 }

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -54,6 +54,10 @@ type Config struct {
 	CompactMetrics CompactStatsProvider
 	// ThemeName is the configured theme name from config. Empty or "default" uses tokyo-night.
 	ThemeName string
+	// LifecycleHooks are shell-command hooks fired on agent lifecycle events
+	// (turn_complete, user_input_required). Each carries the event name and a
+	// small data payload as JSON on stdin. Nil disables lifecycle hooks.
+	LifecycleHooks []extension.HookConfig
 
 	// DeferredInit, if non-nil, is a channel of InitEvent messages.
 	// When set, the TUI starts immediately in loading state and receives


### PR DESCRIPTION
Fire shell-command lifecycle hooks when a turn finishes and when the agent
is waiting for the next user input. Both events fire together at the end of
a turn, so a hook can subscribe to either. Hooks are best-effort: a failure
or timeout is logged and never interrupts the agent loop.

Wired through the global config (hooks[].event) and passed to the TUI via
Config.LifecycleHooks. Documented with an agterm example that sets the
session agent-status indicator to completed/blocked.

Signed-off-by: dimetron <dimetron@me.com>
