### PR TITLE
feat(resume): restore model, transcript and context gauge on --session

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -273,7 +273,16 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 		return rootRuntime{}, err
 	}
 
+	// Resolve which session we are resuming before the model is picked: the
+	// model restore below reads that session's metadata, and --continue has to
+	// become a concrete ID for the lookup to happen at all.
+	if err := resolveResumeSession(); err != nil {
+		return rootRuntime{}, err
+	}
+
 	activeRole := resolveActiveRole()
+	applyResumedModel(&cfg, activeRole)
+
 	modelName, providerName, advisorModel, advisorMaxUses, advisorCaching, err := cfg.ResolveRole(activeRole)
 	if err != nil {
 		return rootRuntime{}, fmt.Errorf("resolving model role: %w", err)
@@ -360,23 +369,6 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 		sandboxRoot = cwd
 	}
 	worktreeDir := os.Getenv("PI_WORKTREE_ROOT")
-
-	if flagContinue {
-		homeDir, hErr := os.UserHomeDir()
-		if hErr != nil {
-			return rootRuntime{}, fmt.Errorf("getting home dir: %w", hErr)
-		}
-		sessionsDir := filepath.Join(homeDir, ".pi-go", "sessions")
-		sessionSvc, sErr := pisession.NewFileService(sessionsDir)
-		if sErr != nil {
-			return rootRuntime{}, fmt.Errorf("creating session service: %w", sErr)
-		}
-		lastID := sessionSvc.LastSessionID(agent.AppName, agent.DefaultUserID)
-		if lastID == "" {
-			return rootRuntime{}, fmt.Errorf("no previous session found to continue")
-		}
-		flagSession = lastID
-	}
 
 	checkForRapidRestartAndWarn(cwd)
 	_ = writeLastSession(cwd, info.Provider, llm.Name())
@@ -621,12 +613,11 @@ func runNonInteractive(
 	loadNonInteractiveSkills(mode)
 	instruction += memoryInstructionContext(parentCtx, memStore, cfg, cwd)
 
-	homeDir, err := os.UserHomeDir()
+	sessionsPath, err := sessionsDir()
 	if err != nil {
-		return fmt.Errorf("getting home dir: %w", err)
+		return err
 	}
-	sessionsDir := filepath.Join(homeDir, ".pi-go", "sessions")
-	sessionSvc, err := pisession.NewFileService(sessionsDir)
+	sessionSvc, err := pisession.NewFileService(sessionsPath)
 	if err != nil {
 		return fmt.Errorf("creating session service: %w", err)
 	}
@@ -700,7 +691,7 @@ func runNonInteractive(
 	}
 
 	// Capture ACP subagent events (claude, gemini) under the session dir.
-	orch.SetACPLogPath(filepath.Join(sessionsDir, sessionID, "acp.jsonl"))
+	orch.SetACPLogPath(filepath.Join(sessionsPath, sessionID, "acp.jsonl"))
 
 	if memStore != nil {
 		// Arms the observation callback wired above.
@@ -751,9 +742,82 @@ func memoryInstructionContext(ctx context.Context, store memory.Store, cfg confi
 	return "\n\n" + memContext
 }
 
+// sessionsDir is the directory FileService keeps one subdirectory per session
+// in. Startup reaches for it before any session service exists, so it cannot
+// be asked of the service itself.
+func sessionsDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home dir: %w", err)
+	}
+	return filepath.Join(homeDir, ".pi-go", "sessions"), nil
+}
+
+// resolveResumeSession turns --continue into an explicit --session value, so
+// everything downstream — the model restore, the agent, the TUI's transcript
+// restore — reads one resolved session ID instead of handling two ways of
+// asking for the same thing.
+func resolveResumeSession() error {
+	if !flagContinue {
+		return nil
+	}
+	dir, err := sessionsDir()
+	if err != nil {
+		return err
+	}
+	sessionSvc, err := pisession.NewFileService(dir)
+	if err != nil {
+		return fmt.Errorf("creating session service: %w", err)
+	}
+	lastID := sessionSvc.LastSessionID(agent.AppName, agent.DefaultUserID)
+	if lastID == "" {
+		return fmt.Errorf("no previous session found to continue")
+	}
+	flagSession = lastID
+	return nil
+}
+
+// applyResumedModel restores the model a resumed session last ran under.
+//
+// Sessions record their model in meta.json, but startup used to resolve the
+// model from config alone: `pi --session <id>` continued a conversation held
+// with one model under whatever the default role happened to point at, with
+// nothing on screen admitting the swap. Since the whole transcript is replayed
+// to the new model, the switch is silent and total.
+//
+// Explicit intent still wins. --model names a model outright, and --smol /
+// --slow / --plan pick a role for a reason, so each leaves the session's
+// recorded model alone.
+func applyResumedModel(cfg *config.Config, activeRole string) {
+	if flagSession == "" || flagModel != "" || activeRole != "default" || cfg.Roles == nil {
+		return
+	}
+	dir, err := sessionsDir()
+	if err != nil {
+		return
+	}
+	name := pisession.SessionModel(dir, flagSession)
+	if name == "" {
+		return
+	}
+	rc := cfg.Roles["default"]
+	if rc.Model == name {
+		return
+	}
+	rc.Model = name
+	// The configured provider belongs to the configured model. Carrying it
+	// over would route the session's model to the wrong API — an anthropic
+	// role serving a gpt-* model — so let it be re-detected from the name.
+	rc.Provider = ""
+	cfg.Roles["default"] = rc
+}
+
 // resolveSessionID picks the session to run in: an explicit --session, the most
 // recent one under --continue, or a freshly created session.
 func resolveSessionID(ctx context.Context, ag *agent.Agent, sessionSvc *pisession.FileService) (string, error) {
+	// buildRootRuntime already resolved --continue into flagSession, but this
+	// branch stays authoritative: --continue with nothing to continue is an
+	// error, and must never fall through to opening a brand-new session.
 	if flagContinue {
 		lastID := sessionSvc.LastSessionID(agent.AppName, agent.DefaultUserID)
 		if lastID == "" {

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -332,13 +332,12 @@ func deferredInit(
 	}
 
 	// Session service.
-	homeDir, err := os.UserHomeDir()
+	sessionsPath, err := sessionsDir()
 	if err != nil {
-		fail(fmt.Errorf("getting home dir: %w", err))
+		fail(err)
 		return
 	}
-	sessionsDir := filepath.Join(homeDir, ".pi-go", "sessions")
-	sessionSvc, err := pisession.NewFileService(sessionsDir)
+	sessionSvc, err := pisession.NewFileService(sessionsPath)
 	if err != nil {
 		fail(fmt.Errorf("creating session service: %w", err))
 		return
@@ -393,6 +392,7 @@ func deferredInit(
 
 	// Resolve session (--continue is resolved in fast path, flagSession is set).
 	sessionID := flagSession
+	resumed := sessionID != ""
 	var defaultTitle string
 	if sessionID == "" {
 		sessionID, defaultTitle, err = ag.CreateSession(ctx)
@@ -400,6 +400,14 @@ func deferredInit(
 			fail(fmt.Errorf("creating session: %w", err))
 			return
 		}
+	}
+
+	// Keep the recorded model honest. meta.Model used to be written once, at
+	// creation, so a session resumed under a different model (via --model) kept
+	// advertising the old one — and the next resume would restore that instead
+	// of what the session actually last ran with.
+	if resumed {
+		_ = sessionSvc.SetSessionModel(sessionID, llm.Name()) // best-effort metadata
 	}
 
 	// Store session ID for resume hint on exit.
@@ -427,7 +435,7 @@ func deferredInit(
 	}
 
 	// Capture ACP subagent events (claude, gemini) under the session dir.
-	res.orch.SetACPLogPath(filepath.Join(sessionsDir, sessionID, "acp.jsonl"))
+	res.orch.SetACPLogPath(filepath.Join(sessionsPath, sessionID, "acp.jsonl"))
 
 	// Session logger was created above; record the session start now that the
 	// session ID is known.
@@ -447,6 +455,7 @@ func deferredInit(
 			Agent:             ag,
 			SessionID:         sessionID,
 			SessionTitle:      defaultTitle,
+			Resumed:           resumed,
 			SessionService:    sessionSvc,
 			Orchestrator:      orch,
 			Logger:            sessionLog,

--- a/internal/cli/resume_model_test.go
+++ b/internal/cli/resume_model_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+)
+
+// writeSessionMeta creates a session directory whose meta.json records model.
+func writeSessionMeta(t *testing.T, dir, sessionID, model string) {
+	t.Helper()
+	sessionDir := filepath.Join(dir, ".pi-go", "sessions", sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"id":"` + sessionID + `","appName":"pi-go","userID":"local","model":"` + model + `"}`
+	if err := os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// withFlags restores the package-level flag state the CLI resolves through.
+func withFlags(t *testing.T, session, model string) {
+	t.Helper()
+	origSession, origModel := flagSession, flagModel
+	t.Cleanup(func() { flagSession, flagModel = origSession, origModel })
+	flagSession, flagModel = session, model
+}
+
+func TestApplyResumedModel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSessionMeta(t, home, "sess-gpt", "gpt-5.6-luna")
+	writeSessionMeta(t, home, "sess-unknown", "unknown")
+
+	tests := []struct {
+		name       string
+		session    string
+		model      string
+		activeRole string
+		want       string
+	}{
+		{"restores the session's model", "sess-gpt", "", "default", "gpt-5.6-luna"},
+		{"--model wins", "sess-gpt", "gemini-3.5-pro", "default", "claude-sonnet-4-6"},
+		{"role flag wins", "sess-gpt", "", "plan", "claude-sonnet-4-6"},
+		{"unknown model is ignored", "sess-unknown", "", "default", "claude-sonnet-4-6"},
+		{"missing session is ignored", "sess-absent", "", "default", "claude-sonnet-4-6"},
+		{"no session is ignored", "", "", "default", "claude-sonnet-4-6"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withFlags(t, tc.session, tc.model)
+			cfg := config.Config{Roles: map[string]config.RoleConfig{
+				"default": {Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			}}
+
+			applyResumedModel(&cfg, tc.activeRole)
+
+			if got := cfg.Roles["default"].Model; got != tc.want {
+				t.Errorf("model = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The configured provider belongs to the configured model; carrying it over
+// would route the restored model to the wrong API.
+func TestApplyResumedModel_ClearsStaleProvider(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSessionMeta(t, home, "sess-gpt", "gpt-5.6-luna")
+	withFlags(t, "sess-gpt", "")
+
+	cfg := config.Config{Roles: map[string]config.RoleConfig{
+		"default": {Model: "claude-sonnet-4-6", Provider: "anthropic"},
+	}}
+
+	applyResumedModel(&cfg, "default")
+
+	if got := cfg.Roles["default"].Provider; got != "" {
+		t.Errorf("provider = %q, want it cleared for re-detection", got)
+	}
+}
+
+// A session already running the configured model must not have its role
+// rewritten, or an explicitly configured provider would be dropped for nothing.
+func TestApplyResumedModel_KeepsProviderWhenModelMatches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSessionMeta(t, home, "sess-same", "claude-sonnet-4-6")
+	withFlags(t, "sess-same", "")
+
+	cfg := config.Config{Roles: map[string]config.RoleConfig{
+		"default": {Model: "claude-sonnet-4-6", Provider: "anthropic"},
+	}}
+
+	applyResumedModel(&cfg, "default")
+
+	if got := cfg.Roles["default"].Provider; got != "anthropic" {
+		t.Errorf("provider = %q, want it left alone", got)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -526,7 +526,14 @@ func (s *FileService) SetSessionModel(sessionID, modelName string) error {
 
 	sess, ok := s.sessions[sessionID]
 	if !ok {
-		return fmt.Errorf("session not found: %s", sessionID)
+		// Lazy-load from disk, like SetSessionTitle: a resumed session is not
+		// in the cache until the runner first reads it, and recording the model
+		// it is resuming under has to happen before that.
+		loaded, err := s.loadSessionUnchecked(sessionID)
+		if err != nil {
+			return err
+		}
+		sess = loaded
 	}
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
@@ -803,6 +810,20 @@ func writeMeta(sessionDir string, meta *Meta) error {
 		return fmt.Errorf("marshaling meta: %w", err)
 	}
 	return os.WriteFile(filepath.Join(sessionDir, "meta.json"), data, 0o644)
+}
+
+// SessionModel returns the model recorded in a session's metadata, or an empty
+// string when the session is unknown or its model was never recorded.
+//
+// Deliberately not a FileService method: startup needs this before any session
+// is loaded, and going through the cache would parse the whole events.jsonl
+// (and rebuild the ATIF trajectory) to read a single metadata field.
+func SessionModel(baseDir, sessionID string) string {
+	meta, err := readMeta(filepath.Join(baseDir, sessionID))
+	if err != nil || meta.Model == UnknownModel {
+		return ""
+	}
+	return strings.TrimSpace(meta.Model)
 }
 
 func readMeta(sessionDir string) (*Meta, error) {

--- a/internal/tui/session_restore.go
+++ b/internal/tui/session_restore.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+
+	"google.golang.org/adk/v2/session"
+
+	"github.com/dimetron/pi-go/internal/agent"
+)
+
+// restoreTranscript rebuilds the visible chat transcript from a resumed
+// session's persisted events.
+//
+// Resuming used to start with an empty screen: the events were replayed to the
+// model, so the conversation continued correctly, but the user saw the welcome
+// splash and no sign of the history the model was answering from. This maps
+// those same events back to the messages the live agent loop would have built.
+//
+// Partial events are never persisted (FileService.AppendEvent drops them), so
+// each text part here is a whole chunk rather than a stream delta — consecutive
+// assistant chunks are merged the way streaming would have merged them.
+// Thinking is skipped: it is scratch work the live UI itself replaces with the
+// answer as soon as one arrives.
+func restoreTranscript(events []*session.Event) []message {
+	var msgs []message
+	for _, ev := range events {
+		if ev == nil || ev.Content == nil || ev.Content.Role == "thinking" {
+			continue
+		}
+		for _, part := range ev.Content.Parts {
+			switch {
+			case part.FunctionCall != nil:
+				fc := part.FunctionCall
+				msgs = append(msgs, message{
+					role:   "tool",
+					tool:   fc.Name,
+					toolIn: toolCallSummary(fc.Name, fc.Args),
+				})
+			case part.FunctionResponse != nil:
+				fr := part.FunctionResponse
+				respJSON, _ := json.Marshal(fr.Response)
+				attachToolResult(msgs, fr.Name, toolResultSummary(string(respJSON)))
+			case part.Text != "":
+				msgs = appendText(msgs, ev.Content.Role, part.Text)
+			}
+		}
+	}
+	return msgs
+}
+
+// appendText adds one text part, merging into a trailing assistant message so a
+// reply split across several persisted events reads as one answer. A tool
+// message in between ends the run, which keeps rendered order matching event
+// order — the same rule handleAgentText follows live.
+func appendText(msgs []message, role, text string) []message {
+	if role == "user" {
+		return append(msgs, message{role: "user", content: text})
+	}
+	if n := len(msgs); n > 0 && msgs[n-1].role == "assistant" {
+		msgs[n-1].content += text
+		return msgs
+	}
+	return append(msgs, message{role: "assistant", content: text})
+}
+
+// attachToolResult fills in the output of the most recent still-unanswered call
+// to the named tool, mirroring handleAgentToolResult. Results arrive in their
+// own events, and parallel calls mean the matching call is not always the last
+// message.
+func attachToolResult(msgs []message, name, content string) {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].role == "tool" && msgs[i].tool == name && msgs[i].content == "" {
+			msgs[i].content = content
+			return
+		}
+	}
+}
+
+// restoreSession loads a resumed session's transcript into the chat and seeds
+// the context gauge from it. Both are best-effort: a session that cannot be
+// read is worth continuing with an empty screen, not worth refusing to start.
+func (m *model) restoreSession() {
+	svc := m.cfg.SessionService
+	if svc == nil || m.cfg.SessionID == "" {
+		return
+	}
+	resp, err := svc.Get(context.Background(), &session.GetRequest{
+		AppName:   agent.AppName,
+		UserID:    agent.DefaultUserID,
+		SessionID: m.cfg.SessionID,
+	})
+	if err != nil || resp == nil || resp.Session == nil {
+		return
+	}
+
+	var events []*session.Event
+	for ev := range resp.Session.Events().All() {
+		events = append(events, ev)
+	}
+	if restored := restoreTranscript(events); len(restored) > 0 {
+		m.chatModel.Messages = append(restored, m.chatModel.Messages...)
+		m.chatModel.Scroll = 0
+	}
+
+	// Seed the gauge, or a resumed session reads "ctx: 0" until the first reply
+	// lands — the emptiest possible reading of a window that is already full.
+	// EstimateTokens is the same chars/4 heuristic /compact refreshes with.
+	if tt := m.cfg.TokenTracker; tt != nil {
+		if est, estErr := svc.EstimateTokens(
+			m.cfg.SessionID, agent.AppName, agent.DefaultUserID,
+		); estErr == nil && est > 0 {
+			tt.SetLastPromptTokens(int64(est))
+		}
+	}
+}

--- a/internal/tui/session_restore_test.go
+++ b/internal/tui/session_restore_test.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"testing"
+
+	adkmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+func event(role string, parts ...*genai.Part) *session.Event {
+	return &session.Event{LLMResponse: adkmodel.LLMResponse{
+		Content: &genai.Content{Role: role, Parts: parts},
+	}}
+}
+
+func textEvent(role, text string) *session.Event {
+	return event(role, &genai.Part{Text: text})
+}
+
+func callPart(name string, args map[string]any) *genai.Part {
+	return &genai.Part{FunctionCall: &genai.FunctionCall{Name: name, Args: args}}
+}
+
+func resultPart(name string, resp map[string]any) *genai.Part {
+	return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: name, Response: resp}}
+}
+
+func TestRestoreTranscript_UserAndAssistant(t *testing.T) {
+	msgs := restoreTranscript([]*session.Event{
+		textEvent("user", "hello"),
+		textEvent("model", "hi "),
+		textEvent("model", "there"),
+	})
+
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2: %+v", len(msgs), msgs)
+	}
+	if msgs[0].role != "user" || msgs[0].content != "hello" {
+		t.Errorf("first message = %+v, want user/hello", msgs[0])
+	}
+	// Consecutive assistant chunks merge, as streaming would have merged them.
+	if msgs[1].role != "assistant" || msgs[1].content != "hi there" {
+		t.Errorf("second message = %+v, want assistant/%q", msgs[1], "hi there")
+	}
+}
+
+func TestRestoreTranscript_SkipsThinking(t *testing.T) {
+	msgs := restoreTranscript([]*session.Event{
+		textEvent("thinking", "scratch work"),
+		textEvent("model", "answer"),
+	})
+
+	if len(msgs) != 1 || msgs[0].content != "answer" {
+		t.Fatalf("got %+v, want only the answer", msgs)
+	}
+}
+
+func TestRestoreTranscript_ToolCallPairsWithResult(t *testing.T) {
+	msgs := restoreTranscript([]*session.Event{
+		event("model", callPart("read", map[string]any{"path": "main.go"})),
+		event("user", resultPart("read", map[string]any{"content": "package main"})),
+	})
+
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1 tool message: %+v", len(msgs), msgs)
+	}
+	if msgs[0].role != "tool" || msgs[0].tool != "read" {
+		t.Fatalf("got %+v, want a read tool message", msgs[0])
+	}
+	if msgs[0].content == "" {
+		t.Error("tool result was not attached to its call")
+	}
+}
+
+// A result must fill in its own call, not the nearest one, or parallel calls to
+// the same tool would show each other's output.
+func TestRestoreTranscript_ResultFillsOldestOpenCall(t *testing.T) {
+	msgs := restoreTranscript([]*session.Event{
+		event("model", callPart("grep", nil)),
+		event("model", callPart("grep", nil)),
+		event("user", resultPart("grep", map[string]any{"hits": "first"})),
+		event("user", resultPart("grep", map[string]any{"hits": "second"})),
+	})
+
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2: %+v", len(msgs), msgs)
+	}
+	for i, m := range msgs {
+		if m.content == "" {
+			t.Errorf("call %d left unanswered", i)
+		}
+	}
+	if msgs[0].content == msgs[1].content {
+		t.Errorf("both calls got the same result: %q", msgs[0].content)
+	}
+}
+
+// Text after a tool call starts a new message, so rendered order matches event
+// order instead of folding the reply back above the tool card.
+func TestRestoreTranscript_TextAfterToolStartsNewMessage(t *testing.T) {
+	msgs := restoreTranscript([]*session.Event{
+		textEvent("model", "looking"),
+		event("model", callPart("ls", nil)),
+		textEvent("model", "done"),
+	})
+
+	if len(msgs) != 3 {
+		t.Fatalf("got %d messages, want 3: %+v", len(msgs), msgs)
+	}
+	if msgs[0].content != "looking" || msgs[1].role != "tool" || msgs[2].content != "done" {
+		t.Errorf("order not preserved: %+v", msgs)
+	}
+}
+
+func TestRestoreTranscript_SkipsEmptyEvents(t *testing.T) {
+	if msgs := restoreTranscript([]*session.Event{nil, {}, textEvent("model", "")}); len(msgs) != 0 {
+		t.Fatalf("got %+v, want no messages", msgs)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2034,6 +2034,12 @@ func (m *model) handleInitEvent(msg initEventMsg) (tea.Model, tea.Cmd) {
 		m.inputModel.Skills = r.Skills
 		m.inputModel.SkillDirs = r.SkillDirs
 
+		// Rebuild the transcript last: it reads the session service and token
+		// tracker that were just installed above.
+		if r.Resumed {
+			m.restoreSession()
+		}
+
 		var cmds []tea.Cmd
 		if r.AgentEventCh != nil {
 			cmds = append(cmds, waitForSubEvent(r.AgentEventCh))

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -94,7 +94,11 @@ type InitResult struct {
 	// (git repo name, or CWD basename). The TUI seeds its terminal window/tab
 	// title with it so the user sees a label before the first user prompt
 	// arrives. Empty if the agent has no title namer or no CWD to derive from.
-	SessionTitle      string
+	SessionTitle string
+	// Resumed reports that SessionID names an existing session rather than one
+	// created for this run, so the TUI knows to rebuild its transcript from the
+	// session's events instead of opening on the welcome splash.
+	Resumed           bool
 	SessionService    *pisession.FileService
 	Orchestrator      *subagent.Orchestrator
 	Logger            *logger.Logger


### PR DESCRIPTION
Resuming a session restored only its event history, and only for the model: `pi --session <id>` opened on the welcome splash with an empty chat, a context gauge reading 0, and whatever model the default role pointed at — while replaying the whole conversation to that model.

Verified against a session created under `gpt-5.6-luna`: two resumes both started under `claude-sonnet-4-6`, the config default, with nothing on screen admitting the swap.

## Three parts, each independent

**Model.** Session metadata already records the model, but startup resolved the model from config alone. `--continue` now resolves to a concrete session ID *before* the model is picked, and that session's recorded model feeds the default role. An explicit `--model`, or a role flag (`--smol`/`--slow`/`--plan`), still wins. The role's configured provider is cleared so it is re-detected from the restored model name, or an `anthropic` role would try to serve a `gpt-*` model.

**Transcript.** The TUI rebuilds its message list from the session's persisted events, mapping them the way the live agent loop does: consecutive assistant chunks merge, tool results attach to the oldest unanswered call of that tool, thinking is skipped. Partial events are never persisted, so nothing double-counts.

**Gauge.** Seeded from `EstimateTokens`, the same heuristic `/compact` refreshes with, instead of reading 0 over a window already full.

`meta.Model` was also only ever written at session creation, so a session resumed under `--model` kept advertising the old one and the next resume would restore that instead. It is now rewritten on resume, which needed `SetSessionModel` to lazy-load like `SetSessionTitle` already does.

## Verification

Resuming a copy of a `minimax-m3:cloud` session with the patched binary, driven through a real pty:

- sidebar reads `ollama / minimax-m3:clo…` — provider correctly re-detected from the `:cloud` suffix
- the prior conversation renders, in event order
- `ctx: 57.8k` and `94.5k/524.3k 25%`, previously `ctx: 0`
- `events.jsonl` byte-identical afterward

9 new test cases across the two behaviors; `internal/{tui,cli,session,agent}` green; `make lint` reports 0 issues.

Note: `make test` has one pre-existing failure unrelated to this branch — `TestNewPromptHandler_NoAPIKey` in `internal/acp/server` expects a "no API key" error, but with a real key present it issues a live call that 404s on the retired `claude-3-5-haiku-latest`. It fails identically on an untouched checkout.
