### PR TITLE
feat(tui): scale tool command display with terminal width

### DIFF
--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -99,11 +99,10 @@ func TestToolCallSummary_BashLongCommand(t *testing.T) {
 	long := strings.Repeat("x", 100)
 	args := map[string]any{"command": long}
 	result := toolCallSummary("bash", args)
-	if len(result) > 80 {
-		t.Errorf("expected truncated command, got len=%d", len(result))
-	}
-	if !strings.HasSuffix(result, "...") {
-		t.Error("expected '...' suffix for truncated command")
+	// toolCallSummary no longer truncates — the renderer clips to the
+	// terminal width. The full command is preserved for wide terminals.
+	if result != long {
+		t.Errorf("expected full command preserved, got len=%d", len(result))
 	}
 }
 

--- a/internal/tui/coverage_boost_test.go
+++ b/internal/tui/coverage_boost_test.go
@@ -2007,10 +2007,11 @@ func TestToolCallSummary(t *testing.T) {
 	if got := toolCallSummary("bash", map[string]any{"command": "ls"}); got != "ls" {
 		t.Errorf("expected ls, got %q", got)
 	}
-	// bash long
+	// bash long — toolCallSummary preserves the full command; the renderer
+	// clips to terminal width.
 	longCmd := strings.Repeat("x", 100)
-	if got := toolCallSummary("bash", map[string]any{"command": longCmd}); !strings.HasSuffix(got, "...") {
-		t.Errorf("expected truncation, got %q", got)
+	if got := toolCallSummary("bash", map[string]any{"command": longCmd}); got != longCmd {
+		t.Errorf("expected full command preserved, got %q", got)
 	}
 }
 

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -523,9 +523,9 @@ func TestHandleRunAgentEvent_ToolCall_PopulatesToolIn(t *testing.T) {
 	if got.tool != "bash" {
 		t.Errorf("bash tool message: tool=%q, want bash", got.tool)
 	}
-	// toolCallSummary truncates to 80 chars.
-	if len(got.toolIn) > 80 {
-		t.Errorf("bash toolIn should be truncated to 80, got %d chars: %q", len(got.toolIn), got.toolIn)
+	// toolCallSummary preserves the full command; the renderer clips to width.
+	if got.toolIn != longCmd {
+		t.Errorf("bash toolIn should preserve the full command, got %d chars: %q", len(got.toolIn), got.toolIn)
 	}
 	if got.toolIn == "" {
 		t.Error("bash toolIn should be populated from args.command")

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -121,8 +121,8 @@ func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style) st
 
 	if msg.toolIn != "" {
 		args := msg.toolIn
-		if len(args) > 60 {
-			args = args[:57] + "..."
+		if max := t.argWidth(); len(args) > max {
+			args = truncateRunes(args, max)
 		}
 		b.WriteString(dim.Render("("))
 		b.WriteString(dim.Render(args))
@@ -131,8 +131,8 @@ func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style) st
 
 	if msg.content != "" {
 		summary := toolResultSummary(msg.content)
-		if len(summary) > 60 {
-			summary = summary[:57] + "..."
+		if max := t.argWidth(); len(summary) > max {
+			summary = truncateRunes(summary, max)
 		}
 		// Show only the first line of the summary.
 		if idx := strings.IndexByte(summary, '\n'); idx >= 0 {
@@ -308,6 +308,24 @@ func (t *ToolDisplayModel) contentWidth() int {
 	return w*8/10 - 4
 }
 
+// argWidth returns the max rune count for a tool's argument/command shown in
+// the header line. It scales with the terminal width so wide terminals show
+// longer commands instead of truncating everything to a fixed 60/80 chars.
+// The header is "◉ tool(args)" — reserve room for the bullet, tool name, and
+// parens, then give the rest to the args. A floor of 60 keeps narrow
+// terminals readable.
+func (t ToolDisplayModel) argWidth() int {
+	w := t.Width
+	if w < 40 {
+		w = 80 // sensible default when width unknown
+	}
+	// Reserve ~20 chars for "◉ tool(" + ")" and the trailing summary space.
+	if w-20 < 60 {
+		return 60
+	}
+	return w - 20
+}
+
 // collapseToSingleLine replaces newlines and tabs with spaces and collapses
 // runs of whitespace, so long multi-line content renders on a single wrapped
 // line under the agent tool's "│ " gutter rather than drifting to column 0.
@@ -342,7 +360,7 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style) st
 	b.WriteString(toolBullet)
 	b.WriteString(toolStyle.Render(msg.tool))
 	if msg.toolIn != "" {
-		args := truncateRunes(msg.toolIn, 80)
+		args := truncateRunes(msg.toolIn, t.argWidth())
 		b.WriteString(dim.Render("("))
 		b.WriteString(argStyle.Render(args))
 		b.WriteString(dim.Render(")"))
@@ -428,9 +446,6 @@ func toolCallSummary(name string, args map[string]any) string {
 		}
 	case "bash":
 		if cmd, ok := args["command"].(string); ok {
-			if len(cmd) > 80 {
-				cmd = cmd[:77] + "..."
-			}
 			return cmd
 		}
 	// "ripgrep" is the name the grep tool registers under when rg is installed.

--- a/internal/tui/tool_display_test.go
+++ b/internal/tui/tool_display_test.go
@@ -149,6 +149,38 @@ func TestContentWidth_SmallWidth(t *testing.T) {
 	}
 }
 
+func TestArgWidth_ScalesWithTerminalWidth(t *testing.T) {
+	// Narrow terminal floors at 60.
+	if got := (ToolDisplayModel{Width: 40}).argWidth(); got != 60 {
+		t.Errorf("narrow width: expected 60, got %d", got)
+	}
+	// Wide terminal gives more room for the command.
+	if got := (ToolDisplayModel{Width: 200}).argWidth(); got != 180 {
+		t.Errorf("wide width: expected 180, got %d", got)
+	}
+	// Default width (0 → 80) floors at 60.
+	if got := (ToolDisplayModel{Width: 0}).argWidth(); got != 60 {
+		t.Errorf("default width: expected 60, got %d", got)
+	}
+}
+
+func TestRenderRegularTool_WideTerminalShowsLongerCommand(t *testing.T) {
+	longCmd := strings.Repeat("x", 150)
+	msg := message{role: "tool", tool: "bash", toolIn: longCmd}
+
+	// Narrow terminal truncates the command.
+	narrow := ToolDisplayModel{Width: 80}
+	if out := narrow.RenderToolMessage(msg); strings.Contains(out, longCmd) {
+		t.Error("narrow terminal should truncate the long command")
+	}
+
+	// Wide terminal shows the full command.
+	wide := ToolDisplayModel{Width: 200}
+	if out := wide.RenderToolMessage(msg); !strings.Contains(out, longCmd) {
+		t.Error("wide terminal should show the full command")
+	}
+}
+
 func TestSoftWrap_ShortLine(t *testing.T) {
 	lines := softWrap("hello world", 80)
 	if len(lines) != 1 || lines[0] != "hello world" {


### PR DESCRIPTION
toolCallSummary truncated bash commands to 80 chars at message-creation
time, and the renderers clipped args to fixed 60/80 chars regardless of
terminal width. Wide terminals showed the same short command as narrow
ones.

Preserve the full command in the message and clip at render time using a
new width-aware argWidth() that reserves room for the bullet, tool name,
and parens, then gives the rest to the args (floor 60).

Signed-off-by: dimetron <dimetron@me.com>
