### PR TITLE
fix(tui): keep lifecycle hook failures off the terminal

### DIFF
--- a/internal/extension/hooks.go
+++ b/internal/extension/hooks.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -102,6 +103,39 @@ func BuildToolCallCallbacks(s ToolCallReporter) ([]llmagent.BeforeToolCallback, 
 	return []llmagent.BeforeToolCallback{beforeCB}, []llmagent.AfterToolCallback{afterCB}
 }
 
+// hookLog is the sink for hook-failure diagnostics. It is nil by default,
+// which means failures go to the standard logger — the right destination for
+// the one-shot CLI and the ACP server, whose stderr is an ordinary stream.
+//
+// The TUI is the exception: it owns the alternate screen, and a line written
+// to stderr is painted over the UI without the renderer knowing those cells
+// were dirtied, so the damage persists until a full redraw. It installs a sink
+// pointing at the session log file instead. Same late-binding idiom as
+// auth.SetDebugLogger.
+var hookLog atomic.Pointer[func(string)]
+
+// SetHookLogger installs a sink for hook-failure diagnostics. Passing nil
+// restores the default (standard logger, i.e. stderr). Hooks run from callback
+// goroutines, so implementations must be goroutine-safe.
+func SetHookLogger(fn func(string)) {
+	if fn == nil {
+		hookLog.Store(nil)
+		return
+	}
+	hookLog.Store(&fn)
+}
+
+// hookLogf reports a hook failure to the installed sink, or to the standard
+// logger when none is installed.
+func hookLogf(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if p := hookLog.Load(); p != nil && *p != nil {
+		(*p)(msg)
+		return
+	}
+	log.Print(msg)
+}
+
 // BuildBeforeToolCallbacks converts HookConfigs with event "before_tool" into
 // ADK BeforeToolCallback functions.
 func BuildBeforeToolCallbacks(hooks []HookConfig) []llmagent.BeforeToolCallback {
@@ -116,7 +150,7 @@ func BuildBeforeToolCallbacks(hooks []HookConfig) []llmagent.BeforeToolCallback 
 				return nil, nil
 			}
 			if err := runHookCommand(ctx, hook, t.Name(), args); err != nil {
-				log.Printf("hook %q failed for tool %q: %v", hook.Command, t.Name(), err)
+				hookLogf("hook %q failed for tool %q: %v", hook.Command, t.Name(), err)
 				// Non-fatal: log and continue.
 			}
 			return nil, nil
@@ -139,7 +173,7 @@ func BuildAfterToolCallbacks(hooks []HookConfig) []llmagent.AfterToolCallback {
 				return result, nil
 			}
 			if hookErr := runHookCommand(ctx, hook, t.Name(), result); hookErr != nil {
-				log.Printf("hook %q failed for tool %q: %v", hook.Command, t.Name(), hookErr)
+				hookLogf("hook %q failed for tool %q: %v", hook.Command, t.Name(), hookErr)
 			}
 			return result, nil
 		})

--- a/internal/extension/hooks_test.go
+++ b/internal/extension/hooks_test.go
@@ -1,10 +1,13 @@
 package extension
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -713,5 +716,136 @@ func TestRunLifecycleHookTimeout(t *testing.T) {
 	ctx := context.Background()
 	if err := RunLifecycleHook(ctx, hook, "user_input_required", nil); err == nil {
 		t.Error("expected timeout error")
+	}
+}
+
+// --- hook failure diagnostics -------------------------------------------
+
+// TestBuildBeforeToolCallbacks_Invoke covers the callback body: a matching
+// tool runs the command, a non-matching tool is skipped, and a failing command
+// is reported rather than propagated (a broken hook must not fail the tool).
+func TestBuildBeforeToolCallbacks_Invoke(t *testing.T) {
+	dir := t.TempDir()
+	ran := dir + "/ran"
+	var logged []string
+	SetHookLogger(func(msg string) { logged = append(logged, msg) })
+	t.Cleanup(func() { SetHookLogger(nil) })
+
+	cbs := BuildBeforeToolCallbacks([]HookConfig{
+		{Event: "before_tool", Tools: []string{"read"}, Command: "echo ran > " + ran, Timeout: 5},
+		{Event: "before_tool", Tools: []string{"read"}, Command: "exit 3", Timeout: 5},
+	})
+	if len(cbs) != 2 {
+		t.Fatalf("callbacks = %d, want 2", len(cbs))
+	}
+
+	ctx := &mockToolCtx{Context: context.Background(), funcCallID: "fc-1"}
+	for _, cb := range cbs {
+		got, err := cb(ctx, mockTool{nameVal: "read"}, map[string]any{"path": "x"})
+		if err != nil || got != nil {
+			t.Fatalf("callback returned (%v, %v), want (nil, nil)", got, err)
+		}
+	}
+	if _, err := os.ReadFile(ran); err != nil {
+		t.Errorf("matching hook did not run: %v", err)
+	}
+	if len(logged) != 1 {
+		t.Fatalf("logged %d failures, want 1: %v", len(logged), logged)
+	}
+
+	// A tool the hook does not match short-circuits before running anything.
+	logged = nil
+	if err := os.Remove(ran); err != nil {
+		t.Fatalf("removing marker: %v", err)
+	}
+	for _, cb := range cbs {
+		if _, err := cb(ctx, mockTool{nameVal: "write"}, nil); err != nil {
+			t.Fatalf("callback error on non-matching tool: %v", err)
+		}
+	}
+	if _, err := os.Stat(ran); !os.IsNotExist(err) {
+		t.Error("hook ran for a tool it does not match")
+	}
+	if len(logged) != 0 {
+		t.Errorf("logged %v for a non-matching tool, want nothing", logged)
+	}
+}
+
+// TestBuildAfterToolCallbacks_Invoke mirrors the before_tool case, and pins
+// that the tool's result passes through the callback unchanged.
+func TestBuildAfterToolCallbacks_Invoke(t *testing.T) {
+	dir := t.TempDir()
+	payload := dir + "/payload.json"
+	var logged []string
+	SetHookLogger(func(msg string) { logged = append(logged, msg) })
+	t.Cleanup(func() { SetHookLogger(nil) })
+
+	cbs := BuildAfterToolCallbacks([]HookConfig{
+		{Event: "after_tool", Tools: []string{"bash"}, Command: "cat > " + payload, Timeout: 5},
+		{Event: "after_tool", Tools: []string{"bash"}, Command: "exit 3", Timeout: 5},
+	})
+	if len(cbs) != 2 {
+		t.Fatalf("callbacks = %d, want 2", len(cbs))
+	}
+
+	ctx := &mockToolCtx{Context: context.Background(), funcCallID: "fc-2"}
+	result := map[string]any{"stdout": "hi"}
+	for _, cb := range cbs {
+		got, err := cb(ctx, mockTool{nameVal: "bash"}, nil, result, nil)
+		if err != nil {
+			t.Fatalf("callback error: %v", err)
+		}
+		if got["stdout"] != "hi" {
+			t.Errorf("result = %v, want it passed through unchanged", got)
+		}
+	}
+
+	data, err := os.ReadFile(payload)
+	if err != nil {
+		t.Fatalf("reading hook payload: %v", err)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("unmarshal hook payload: %v", err)
+	}
+	if envelope["tool"] != "bash" {
+		t.Errorf("payload tool = %v, want bash", envelope["tool"])
+	}
+	if len(logged) != 1 {
+		t.Errorf("logged %d failures, want 1: %v", len(logged), logged)
+	}
+
+	// Non-matching tool: result still passes through, hook does not fire.
+	logged = nil
+	for _, cb := range cbs {
+		got, err := cb(ctx, mockTool{nameVal: "read"}, nil, result, nil)
+		if err != nil || got["stdout"] != "hi" {
+			t.Fatalf("non-matching callback returned (%v, %v)", got, err)
+		}
+	}
+	if len(logged) != 0 {
+		t.Errorf("logged %v for a non-matching tool, want nothing", logged)
+	}
+}
+
+// TestSetHookLogger_NilRestoresDefault pins that clearing the sink falls back
+// to the standard logger instead of panicking or silently dropping. The
+// fallback is what the one-shot CLI and the ACP server rely on.
+func TestSetHookLogger_NilRestoresDefault(t *testing.T) {
+	var buf bytes.Buffer
+	origFlags, origOut := log.Flags(), log.Writer()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+
+	SetHookLogger(func(string) { t.Error("sink called after being cleared") })
+	SetHookLogger(nil)
+	hookLogf("boom %d", 7)
+
+	if got := strings.TrimSpace(buf.String()); got != "boom 7" {
+		t.Errorf("default sink wrote %q, want %q", got, "boom 7")
 	}
 }

--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	stdlog "log"
 	"os"
 	"strings"
 	"testing"
@@ -1430,10 +1432,9 @@ func TestAgentDoneMsg_FiresLifecycleHooks(t *testing.T) {
 	}
 
 	for name, path := range map[string]string{"turn_complete": turnOut, "user_input_required": inputOut} {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("reading %s hook output: %v", name, err)
-		}
+		// Hooks run off the Update goroutine, so the write is not visible
+		// the instant handleAgentDone returns.
+		data := waitForHookOutput(t, path)
 		var got map[string]any
 		if err := json.Unmarshal(data, &got); err != nil {
 			t.Fatalf("unmarshal %s hook output: %v", name, err)
@@ -1441,5 +1442,113 @@ func TestAgentDoneMsg_FiresLifecycleHooks(t *testing.T) {
 		if got["event"] != name {
 			t.Errorf("%s event = %v, want %s", name, got["event"], name)
 		}
+	}
+}
+
+// waitForHookOutput polls for a lifecycle hook's output file, which is written
+// by the hook worker goroutine rather than by the caller of runLifecycleHooks.
+func waitForHookOutput(t *testing.T, path string) []byte {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			return data
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for hook output %s (last err: %v)", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestLifecycleHooks_RunInOrder pins the serialization the hook worker
+// provides. The events describe a state machine — turn_complete then
+// user_input_required — so a consumer that maps them onto an external status
+// would settle on the wrong final state if the two ran concurrently.
+func TestLifecycleHooks_RunInOrder(t *testing.T) {
+	out := t.TempDir() + "/order.txt"
+	m := &model{
+		ctx:       context.Background(),
+		chatModel: ChatModel{Messages: []message{{role: "assistant"}}},
+		running:   true,
+		agentCh:   make(chan agentMsg, 64),
+		cfg: Config{
+			LifecycleHooks: []extension.HookConfig{
+				// The first hook sleeps, so an unserialized implementation
+				// would let the second one finish first.
+				{Event: "turn_complete", Command: "sleep 0.3; echo turn >> " + out, Timeout: 5},
+				{Event: "user_input_required", Command: "echo input >> " + out, Timeout: 5},
+			},
+		},
+	}
+
+	if _, err := m.handleAgentDone(agentDoneMsg{}); err != nil {
+		t.Fatalf("handleAgentDone returned a Cmd, want nil")
+	}
+
+	var got string
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(out)
+		if err == nil {
+			got = strings.TrimSpace(string(data))
+			if got == "turn\ninput" {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("hook order = %q, want %q", got, "turn\ninput")
+}
+
+// TestLifecycleHooks_DoNotWriteToStderr guards the TUI's terminal: the Bubble
+// Tea renderer owns the alternate screen, and anything written to stderr is
+// painted over it without the renderer knowing those cells were dirtied.
+func TestLifecycleHooks_DoNotWriteToStderr(t *testing.T) {
+	done := t.TempDir() + "/done"
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStderr, origLogOut := os.Stderr, stdlog.Writer()
+	os.Stderr = w
+	stdlog.SetOutput(w)
+	t.Cleanup(func() {
+		os.Stderr = origStderr
+		stdlog.SetOutput(origLogOut)
+		_ = r.Close()
+	})
+
+	m := &model{
+		ctx:       context.Background(),
+		chatModel: ChatModel{Messages: []message{{role: "assistant"}}},
+		running:   true,
+		agentCh:   make(chan agentMsg, 64),
+		cfg: Config{
+			LifecycleHooks: []extension.HookConfig{
+				// Fails, and is noisy on both streams while doing so.
+				{Event: "turn_complete", Command: "echo noise; echo boom >&2; exit 1", Timeout: 5},
+				{Event: "user_input_required", Command: "echo done > " + done, Timeout: 5},
+			},
+		},
+	}
+
+	if _, err := m.handleAgentDone(agentDoneMsg{}); err != nil {
+		t.Fatalf("handleAgentDone returned a Cmd, want nil")
+	}
+	// The second hook is queued behind the first, so its marker appearing
+	// means the failing hook has already been handled and logged.
+	waitForHookOutput(t, done)
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe: %v", err)
+	}
+	leaked, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	if len(leaked) != 0 {
+		t.Errorf("lifecycle hooks wrote %q to stderr, want nothing", leaked)
 	}
 }

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	stdlog "log"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -412,7 +411,10 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string) {
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
-			stdlog.Printf("agent loop panicked: %v\n%s", r, stack)
+			// The session log, not stderr: the TUI holds the alternate
+			// screen, so a stack trace printed here would be painted over
+			// the UI. The panic still reaches the user as the turn's error.
+			m.cfg.Logger.Errorf("agent loop panicked: %v\n%s", r, stack)
 			m.agentCh <- agentDoneMsg{err: fmt.Errorf("agent panic: %v", r)}
 		}
 	}()
@@ -852,15 +854,71 @@ func (m *model) handleAgentDone(msg agentDoneMsg) (tea.Model, tea.Cmd) {
 }
 
 // runLifecycleHooks fires every configured lifecycle hook for the given event,
-// passing the event name and data as JSON on stdin. Hooks are best-effort: a
-// failure or timeout is logged and never interrupts the agent loop.
+// passing the event name and data as JSON on stdin. Hooks are best-effort and
+// must stay invisible to the TUI, which owns the terminal:
+//
+//   - Each hook runs on its own goroutine. This is called from Update, and a
+//     hook that hangs would otherwise freeze the render loop for its whole
+//     timeout (10s by default, per configured hook).
+//   - A failure goes to the session log file, never to stderr. Writing to
+//     stderr paints raw text over the alternate screen — the Bubble Tea
+//     renderer does not know those cells were touched, so the damage persists
+//     until a full redraw.
+//
+// The child's own stdout and stderr are already captured by RunLifecycleHook
+// and never reach the terminal.
 func (m *model) runLifecycleHooks(event string, data map[string]any) {
+	ctx := m.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	log := m.cfg.Logger
 	for _, h := range m.cfg.LifecycleHooks {
 		if h.Event != event {
 			continue
 		}
-		if err := extension.RunLifecycleHook(m.ctx, h, event, data); err != nil {
-			stdlog.Printf("lifecycle hook %q failed for event %q: %v", h.Command, event, err)
-		}
+		m.enqueueHook(func() {
+			if err := extension.RunLifecycleHook(ctx, h, event, data); err != nil {
+				log.Errorf("lifecycle hook %q failed for event %q: %v", h.Command, event, err)
+			}
+		})
+	}
+}
+
+// hookQueueDepth bounds the backlog of pending lifecycle hooks. A hook that
+// blocks for its full timeout while turns keep completing must not grow an
+// unbounded queue, so submissions past this depth are dropped and logged.
+const hookQueueDepth = 32
+
+// enqueueHook hands a hook to the model's single hook worker, which runs
+// submissions one at a time in the order they were queued. Serializing matters
+// because the events describe a state machine: turn_complete then
+// user_input_required means "done, now waiting", and a hook that maps those
+// onto an external status (agtermctl, a notifier) would settle on the wrong
+// final state if the two raced.
+//
+// Only ever called from Update, so the lazy channel init needs no lock.
+func (m *model) enqueueHook(fn func()) {
+	if m.hookQueue == nil {
+		m.hookQueue = make(chan func(), hookQueueDepth)
+		ctx := m.ctx
+		go func(q <-chan func()) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case job, ok := <-q:
+					if !ok {
+						return
+					}
+					job()
+				}
+			}
+		}(m.hookQueue)
+	}
+	select {
+	case m.hookQueue <- fn:
+	default:
+		m.cfg.Logger.Errorf("lifecycle hook dropped: queue full (%d pending)", hookQueueDepth)
 	}
 }

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -903,14 +903,13 @@ func (m *model) enqueueHook(fn func()) {
 		m.hookQueue = make(chan func(), hookQueueDepth)
 		ctx := m.ctx
 		go func(q <-chan func()) {
+			// The queue is never closed — the worker's exit signal is the
+			// session context, so a drained queue is not a shutdown.
 			for {
 				select {
 				case <-ctx.Done():
 					return
-				case job, ok := <-q:
-					if !ok {
-						return
-					}
+				case job := <-q:
 					job()
 				}
 			}

--- a/internal/tui/agent_loop_hooks_test.go
+++ b/internal/tui/agent_loop_hooks_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestEnqueueHook_DropsWhenQueueFull pins the backpressure policy: a hook that
+// blocks while turns keep completing must not grow an unbounded backlog, so
+// submissions past hookQueueDepth are dropped rather than queued or allowed to
+// block the Update goroutine that submitted them.
+func TestEnqueueHook_DropsWhenQueueFull(t *testing.T) {
+	m := &model{ctx: context.Background()}
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var ran atomic.Int64
+
+	// The first job occupies the worker, so everything after it sits in the
+	// buffer and the buffer's capacity is what is actually under test. Wait
+	// for it to be picked up — until then it holds a buffer slot itself, and
+	// the count below would be off by one.
+	m.enqueueHook(func() {
+		ran.Add(1)
+		close(started)
+		<-release
+	})
+	<-started
+	for range hookQueueDepth {
+		m.enqueueHook(func() { ran.Add(1) })
+	}
+
+	// The queue is full and the worker is blocked, so this one has nowhere to
+	// go. enqueueHook must return immediately rather than wait for a slot.
+	dropped := make(chan struct{})
+	go func() {
+		m.enqueueHook(func() { ran.Add(1) })
+		close(dropped)
+	}()
+	select {
+	case <-dropped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("enqueueHook blocked when the queue was full, want an immediate drop")
+	}
+
+	close(release)
+
+	want := int64(hookQueueDepth + 1) // the blocker plus a full buffer
+	deadline := time.Now().Add(10 * time.Second)
+	for ran.Load() < want && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Give the dropped job a chance to run, so the assertion below fails
+	// loudly if it was queued after all rather than dropped.
+	time.Sleep(100 * time.Millisecond)
+	if got := ran.Load(); got != want {
+		t.Errorf("ran %d hooks, want %d (the overflow submission must be dropped)", got, want)
+	}
+}
+
+// TestEnqueueHook_WorkerStopsOnContextCancel pins that the worker goroutine
+// does not outlive the session: once the model's context is canceled it
+// returns instead of lingering for the life of the process.
+func TestEnqueueHook_WorkerStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &model{ctx: ctx}
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var ran atomic.Int64
+
+	m.enqueueHook(func() {
+		close(started)
+		<-release
+	})
+	<-started
+
+	// Cancel while the worker is busy, then let it finish. It loops back to a
+	// select where the queue is empty and only ctx.Done() is ready, so the
+	// exit branch is taken deterministically.
+	cancel()
+	close(release)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for ctx.Err() == nil && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Anything submitted after the worker has exited is never executed.
+	time.Sleep(200 * time.Millisecond)
+	m.enqueueHook(func() { ran.Add(1) })
+	time.Sleep(200 * time.Millisecond)
+	if got := ran.Load(); got != 0 {
+		t.Errorf("worker ran %d hooks after context cancellation, want 0", got)
+	}
+}
+
+// TestEnqueueHook_NilContextIsSafe covers the zero-value model path: hooks are
+// reachable from tests and from a model built before ctx is assigned, and a
+// nil context must not panic the worker.
+func TestEnqueueHook_NilContextIsSafe(t *testing.T) {
+	m := &model{}
+	m.runLifecycleHooks("turn_complete", nil) // no hooks configured, no worker
+	if m.hookQueue != nil {
+		t.Error("hookQueue created with no hooks configured")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2021,6 +2021,10 @@ func (m *model) handleInitEvent(msg initEventMsg) (tea.Model, tea.Cmd) {
 		} else {
 			auth.SetDebugLogger(nil)
 		}
+		// Hook failures must never reach stderr while the TUI holds the
+		// alternate screen. Installed unconditionally: with no logger the sink
+		// swallows the message, which still beats corrupting the UI.
+		extension.SetHookLogger(func(msg string) { r.Logger.Error("hook: " + msg) })
 		m.cfg.Skills = r.Skills
 		m.cfg.SkillDirs = r.SkillDirs
 		m.cfg.GenerateCommitMsg = r.GenerateCommitMsg

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -50,6 +50,11 @@ type model struct {
 	// Agent face renderer with mood expressions.
 	face *FaceRenderer
 
+	// hookQueue serializes lifecycle-hook execution off the Update goroutine.
+	// Created lazily by enqueueHook (see agent_loop.go), which is only ever
+	// reached from Update, so the lazy init needs no lock.
+	hookQueue chan func()
+
 	// Matrix rain animation state for sidebar.
 	matrix matrixState
 


### PR DESCRIPTION
A failing lifecycle hook logged its error with the standard logger, which
writes to stderr. The TUI owns the alternate screen, so that text was
painted straight over the UI and stayed there — the Bubble Tea renderer
has no idea those cells were dirtied, so nothing repairs them until a
full redraw. An agterm hook firing against a dead socket corrupted the
chat view on every turn.

Route the failure to the session log file instead, and do the same for
the agent-loop panic handler, which had the same problem.

Hooks also ran synchronously inside Update, so a hook that hung froze the
render loop for its whole timeout — 10s by default, per configured hook.
They now run on a single worker goroutine fed by a bounded queue. One
worker rather than one goroutine per hook, because the events describe a
state machine: turn_complete then user_input_required means "done, now
waiting", and a consumer mapping those onto an external status would
settle on the wrong final state if the two raced.

Signed-off-by: dimetron <dimetron@me.com>
