### PR TITLE
fix(agent): end canceled streams cleanly and catch runaway turns

### DIFF
--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -613,6 +613,7 @@ func antRunStreaming(ctx context.Context, client *anthropic.Client, params anthr
 
 	if err := stream.Err(); err != nil {
 		if ctx.Err() == context.Canceled {
+			_ = yield(canceledResponse(), nil)
 			return
 		}
 		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
@@ -748,6 +749,7 @@ func antRunStreamingBeta(ctx context.Context, client *anthropic.BetaService, par
 
 	if err := stream.Err(); err != nil {
 		if ctx.Err() == context.Canceled {
+			_ = yield(canceledResponse(), nil)
 			return
 		}
 		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -99,6 +100,13 @@ func (m *ollamaModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 			Messages: messages,
 		}
 
+		if n := ollamaNumPredict(); n > 0 {
+			if chatReq.Options == nil {
+				chatReq.Options = map[string]any{}
+			}
+			chatReq.Options["num_predict"] = n
+		}
+
 		// No num_ctx for cloud models. api.ollama.com already serves each model
 		// at its native window, and sending a fixed value caps it instead of
 		// raising it: deepseek-v4-flash:0731-cloud has 1M, so the 256K that
@@ -149,6 +157,30 @@ func ollamaThinkingConfig(level string) *ollamaapi.ThinkValue {
 }
 
 // ollamaFinishReasonToGenai maps Ollama done_reason to genai.FinishReason.
+// defaultOllamaNumPredict bounds the output of a single Ollama turn.
+//
+// Ollama defaults to no client-side limit, so a model that falls into a
+// repetition loop streams until the server's own ceiling: one
+// deepseek-v4-flash:0731:cloud turn emitted 148 KB of the same sentence over 87
+// seconds before it stopped. The cap matches what the Anthropic path already
+// allows a thinking turn (16K), which is far above a normal coding reply.
+const defaultOllamaNumPredict = 16384
+
+// ollamaNumPredict returns the per-turn output cap in tokens.
+// PI_OLLAMA_NUM_PREDICT overrides the default; a value <= 0 removes the cap,
+// restoring the old unbounded behavior for anyone who needs it.
+func ollamaNumPredict() int {
+	raw := strings.TrimSpace(os.Getenv("PI_OLLAMA_NUM_PREDICT"))
+	if raw == "" {
+		return defaultOllamaNumPredict
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultOllamaNumPredict
+	}
+	return n
+}
+
 func ollamaFinishReasonToGenai(reason string) genai.FinishReason {
 	switch reason {
 	case "length":
@@ -444,6 +476,7 @@ func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *
 
 	if err != nil {
 		if ctx.Err() == context.Canceled {
+			_ = yield(canceledResponse(), nil)
 			return
 		}
 		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -277,6 +277,7 @@ func oaiRunStreaming(ctx context.Context, client *openai.Client, params openai.C
 
 	if err := stream.Err(); err != nil {
 		if ctx.Err() == context.Canceled {
+			_ = yield(canceledResponse(), nil)
 			return
 		}
 		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -413,6 +413,7 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 
 	if err := stream.Err(); err != nil {
 		if ctx.Err() == context.Canceled {
+			_ = yield(canceledResponse(), nil)
 			return emitted, nil
 		}
 		// Hand the error back to generateResponses: it owns the stale-id

--- a/internal/provider/stream_cancel.go
+++ b/internal/provider/stream_cancel.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// canceledResponse is the terminal event a streaming path yields when the turn
+// is canceled mid-stream.
+//
+// Returning without yielding anything leaves ADK holding the last *partial*
+// chunk it received. Its flow then takes the "not final" branch and aborts the
+// run with `TODO: last event is not final`
+// (google.golang.org/adk/v2/internal/llminternal/base_flow.go), which pi-go
+// renders verbatim — so pressing Esc showed the user an unfinished TODO string
+// from a dependency instead of a canceled turn.
+//
+// The event deliberately carries no parts: cancellation drops the half-written
+// reply rather than committing it to the transcript. The Content is non-nil
+// only because ADK skips responses that have neither content nor an error code,
+// and a skipped response cannot become the final event.
+func canceledResponse() *model.LLMResponse {
+	return &model.LLMResponse{
+		Partial:      false,
+		TurnComplete: true,
+		FinishReason: genai.FinishReasonOther,
+		Content:      &genai.Content{Role: string(genai.RoleModel)},
+	}
+}

--- a/internal/provider/stream_cancel_test.go
+++ b/internal/provider/stream_cancel_test.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+func TestCanceledResponse_IsTerminal(t *testing.T) {
+	resp := canceledResponse()
+	if resp.Partial {
+		t.Error("a cancellation event must not be Partial: ADK reports a partial last event as \"TODO: last event is not final\"")
+	}
+	if !resp.TurnComplete {
+		t.Error("expected TurnComplete = true")
+	}
+	if resp.Content == nil {
+		t.Error("Content must be non-nil or ADK skips the event before it can be the final one")
+	}
+	if len(resp.Content.Parts) != 0 {
+		t.Errorf("expected no parts, got %d", len(resp.Content.Parts))
+	}
+	if resp.FinishReason == genai.FinishReasonStop {
+		t.Error("a canceled turn must not report STOP")
+	}
+}
+
+// TestOllamaRunStreaming_CancelYieldsTerminalEvent covers the regression
+// directly: the stream is canceled after the first chunk, and the last thing
+// the caller sees must be a non-partial event. Leaving a partial chunk as the
+// last event is what made a canceled turn surface as ADK's internal
+// "TODO: last event is not final" string.
+func TestOllamaRunStreaming_CancelYieldsTerminalEvent(t *testing.T) {
+	srv := newMockOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		writeNDJSON(w, []any{
+			ollamaChatLine("test", "assistant", "thinking out loud", "", "", false, 0, 0, nil),
+		})
+		// Hold the connection open so the cancellation, not EOF, ends the stream.
+		<-r.Context().Done()
+	})
+
+	llm := newOllamaModelFromServer(t, srv, "test", "none")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+	}
+
+	var last *model.LLMResponse
+	for resp, err := range llm.GenerateContent(ctx, req, true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		last = resp
+		cancel() // cancel as soon as the first chunk lands
+	}
+
+	if last == nil {
+		t.Fatal("expected at least one response")
+	}
+	if last.Partial {
+		t.Error("last event after cancellation is still Partial -- ADK will abort with \"TODO: last event is not final\"")
+	}
+	if !last.TurnComplete {
+		t.Error("expected the cancellation event to complete the turn")
+	}
+}
+
+func TestOllamaNumPredict_DefaultAndOverride(t *testing.T) {
+	if got := ollamaNumPredict(); got != defaultOllamaNumPredict {
+		t.Errorf("default = %d, want %d", got, defaultOllamaNumPredict)
+	}
+	t.Setenv("PI_OLLAMA_NUM_PREDICT", "512")
+	if got := ollamaNumPredict(); got != 512 {
+		t.Errorf("override = %d, want 512", got)
+	}
+	t.Setenv("PI_OLLAMA_NUM_PREDICT", "0")
+	if got := ollamaNumPredict(); got != 0 {
+		t.Errorf("0 must disable the cap, got %d", got)
+	}
+	t.Setenv("PI_OLLAMA_NUM_PREDICT", "not-a-number")
+	if got := ollamaNumPredict(); got != defaultOllamaNumPredict {
+		t.Errorf("garbage must fall back to the default, got %d", got)
+	}
+}
+
+func TestOllamaChatRequest_CarriesNumPredict(t *testing.T) {
+	var gotOptions map[string]any
+	srv := newMockOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotOptions, _ = body["options"].(map[string]any)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		writeNDJSON(w, []any{
+			ollamaChatLine("test", "assistant", "hi", "", "stop", true, 1, 1, nil),
+		})
+	})
+
+	llm := newOllamaModelFromServer(t, srv, "test", "none")
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+	}
+	for range llm.GenerateContent(context.Background(), req, true) { //nolint:revive // drain
+	}
+
+	if gotOptions == nil {
+		t.Fatal("request carried no options: the output cap was not sent")
+	}
+	if got, ok := gotOptions["num_predict"].(float64); !ok || int(got) != defaultOllamaNumPredict {
+		t.Errorf("num_predict = %v, want %d", gotOptions["num_predict"], defaultOllamaNumPredict)
+	}
+}

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -13,6 +13,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/agent"
 	"github.com/dimetron/pi-go/internal/extension"
@@ -39,6 +40,33 @@ const (
 	// recentWindowSize is the sliding window of tool-call fingerprints kept
 	// for repetition detection.
 	recentWindowSize = 12
+
+	// maxOutputRepeats is the number of back-to-back copies of one phrase in
+	// the model's own output before the turn is called degenerate.
+	maxOutputRepeats = 12
+
+	// outputWindowBytes is the rolling tail of streamed output kept for
+	// repetition detection. It has to hold maxOutputRepeats copies of the
+	// longest phrase worth catching (~680 bytes).
+	outputWindowBytes = 8192
+
+	// outputProbeBytes is the suffix matched against earlier output to find
+	// the length of the phrase being repeated.
+	outputProbeBytes = 48
+
+	// minOutputPeriod is the shortest phrase treated as a repetition unit.
+	// Below this, ordinary output (indentation, ASCII art) is periodic often
+	// enough to matter.
+	minOutputPeriod = 16
+
+	// minPeriodVariety is how many distinct bytes the repeating phrase must
+	// contain. A rule of dashes or a run of spaces is perfectly periodic and
+	// perfectly harmless; a sentence the model cannot stop restating is not.
+	minPeriodVariety = 8
+
+	// outputCheckEvery is how much new output accumulates between scans.
+	// Scanning per token would put a linear search in the streaming path.
+	outputCheckEvery = 512
 )
 
 // extractAgentType returns a label for the subagent tool call by inspecting
@@ -93,15 +121,45 @@ type stuckDetector struct {
 	streak      int      // consecutive identical tool calls
 	lastErrTool string   // name of last tool that errored
 	errStreak   int      // consecutive errors for that tool
+	outBuf      string   // rolling tail of the model's own output
+	outSince    int      // bytes of output since the last repetition scan
+}
+
+// volatileToolArgs address a slice of a target rather than the target itself.
+// A model paging through one file — read(x, offset 1), read(x, offset 230),
+// read(x, offset 240) — is repeating itself, but hashing the raw args makes
+// every one of those calls unique and hides the loop from the detector.
+var volatileToolArgs = map[string]bool{
+	"offset":     true,
+	"limit":      true,
+	"head_limit": true,
+	"start_line": true,
+	"end_line":   true,
 }
 
 // toolFingerprint produces a short hash of a tool call for comparison.
+// Pagination arguments are dropped first, so re-reading one file region by
+// region collapses to a single fingerprint. json.Marshal sorts map keys, so
+// the hash does not depend on argument order.
 func toolFingerprint(name string, args map[string]any) string {
 	h := sha256.New()
 	h.Write([]byte(name))
-	b, _ := json.Marshal(args)
+	b, _ := json.Marshal(stableToolArgs(args))
 	h.Write(b)
 	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// stableToolArgs returns args without the volatile keys. The input map belongs
+// to the event being streamed, so it is copied rather than filtered in place.
+func stableToolArgs(args map[string]any) map[string]any {
+	stable := make(map[string]any, len(args))
+	for k, v := range args {
+		if volatileToolArgs[k] {
+			continue
+		}
+		stable[k] = v
+	}
+	return stable
 }
 
 // observe records a tool call and returns true if the loop appears stuck.
@@ -149,6 +207,88 @@ func (s *stuckDetector) observeError(name string, isError bool) (stuck bool, det
 		return true, fmt.Sprintf("tool %q failed %d times in a row", name, s.errStreak)
 	}
 	return false, ""
+}
+
+// observeOutput records a chunk of the model's own output — reply text or
+// thinking — and reports whether the turn has collapsed into repetition.
+//
+// The detectors above watch tool calls, so a turn that makes no calls at all is
+// invisible to them. That is exactly the shape of a degenerate turn: one
+// sentence restated until the output cap is hit, with nothing else emitted.
+// This scans the tail of the stream for a repeating period instead.
+func (s *stuckDetector) observeOutput(text string) (stuck bool, detail string) {
+	if text == "" {
+		return false, ""
+	}
+	s.outBuf += text
+	if len(s.outBuf) > outputWindowBytes {
+		s.outBuf = s.outBuf[len(s.outBuf)-outputWindowBytes:]
+	}
+
+	s.outSince += len(text)
+	if s.outSince < outputCheckEvery {
+		return false, ""
+	}
+	s.outSince = 0
+
+	period := repeatPeriod(s.outBuf)
+	if period < minOutputPeriod || !isPeriodic(s.outBuf, period, maxOutputRepeats) {
+		return false, ""
+	}
+	if !hasVariety(s.outBuf[len(s.outBuf)-period:]) {
+		return false, ""
+	}
+	return true, fmt.Sprintf("model repeated a %d-character phrase %d times", period, maxOutputRepeats)
+}
+
+// repeatPeriod returns the distance between the tail of buf and the previous
+// occurrence of that same tail — the length of the phrase the model may be
+// cycling on — or 0 when the tail does not recur.
+func repeatPeriod(buf string) int {
+	if len(buf) < outputProbeBytes*2 {
+		return 0
+	}
+	probe := buf[len(buf)-outputProbeBytes:]
+	prev := strings.LastIndex(buf[:len(buf)-outputProbeBytes], probe)
+	if prev < 0 {
+		return 0
+	}
+	return len(buf) - outputProbeBytes - prev
+}
+
+// hasVariety reports whether unit contains enough distinct bytes to be a
+// phrase rather than filler.
+func hasVariety(unit string) bool {
+	var seen [256]bool
+	distinct := 0
+	for i := range len(unit) {
+		if seen[unit[i]] {
+			continue
+		}
+		seen[unit[i]] = true
+		distinct++
+		if distinct >= minPeriodVariety {
+			return true
+		}
+	}
+	return false
+}
+
+// isPeriodic reports whether the last period*repeats bytes of buf are one
+// period-long phrase repeated back to back. Comparing bytes is safe for UTF-8
+// here: a byte-exact repeat is a rune-exact repeat.
+func isPeriodic(buf string, period, repeats int) bool {
+	span := period * repeats
+	if period <= 0 || span > len(buf) {
+		return false
+	}
+	tail := buf[len(buf)-span:]
+	for i := period; i < len(tail); i++ {
+		if tail[i] != tail[i-period] {
+			return false
+		}
+	}
+	return true
 }
 
 // detectCycle checks the recent window for repeating subsequences.
@@ -211,6 +351,11 @@ type agentToolResultMsg struct {
 }
 type agentDoneMsg struct{ err error }
 
+// agentWarningMsg carries a non-fatal problem with the turn into the
+// transcript. The turn keeps running; the user just needs to know the reply
+// they are reading is not the whole reply.
+type agentWarningMsg struct{ text string }
+
 // agentSubEventMsg carries a streamed event from a running subagent to the TUI.
 type agentSubEventMsg struct {
 	agentID       string // which subagent
@@ -227,6 +372,7 @@ func (agentThinkingMsg) agentMsg()   {}
 func (agentToolCallMsg) agentMsg()   {}
 func (agentToolResultMsg) agentMsg() {}
 func (agentDoneMsg) agentMsg()       {}
+func (agentWarningMsg) agentMsg()    {}
 func (agentSubEventMsg) agentMsg()   {}
 
 // waitForAgent returns a Cmd that waits for the next message on the agent channel.
@@ -436,6 +582,9 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string) {
 	// the query set and emit each search exactly once per turn.
 	groundedSeen := map[string]bool{}
 
+	// Warn once per turn, however many events carry the finish reason.
+	truncated := false
+
 	// Start a top-level OTEL span for the entire agent run, inheriting the
 	// per-response context so Esc/Ctrl+C can interrupt it without quitting the TUI.
 	tracer := otel.Tracer("pi-go")
@@ -476,6 +625,16 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string) {
 			return
 		}
 
+		// A turn cut short at the output cap is otherwise indistinguishable
+		// from a complete one: the finish reason was mapped by every provider
+		// and then read by nobody, so a truncated reply just looked short.
+		if ev.FinishReason == genai.FinishReasonMaxTokens && !truncated {
+			truncated = true
+			m.agentCh <- agentWarningMsg{
+				text: "Response truncated: the model hit its output-token limit.",
+			}
+		}
+
 		if ev.Content == nil {
 			continue
 		}
@@ -501,6 +660,9 @@ func (m *model) emitEventParts(
 		case part.Text != "" && ev.Content.Role == "thinking":
 			log.Thinking(ev.Author, part.Text)
 			m.agentCh <- agentThinkingMsg{text: part.Text}
+			if err := stuckErr(detector.observeOutput(part.Text)); err != nil {
+				return err
+			}
 
 		case part.Text != "":
 			if dedup.SkipText(ev) {
@@ -508,6 +670,9 @@ func (m *model) emitEventParts(
 			}
 			log.LLMText(ev.Author, part.Text)
 			m.agentCh <- agentTextMsg{text: part.Text}
+			if err := stuckErr(detector.observeOutput(part.Text)); err != nil {
+				return err
+			}
 		}
 
 		if fc := part.FunctionCall; fc != nil {
@@ -564,6 +729,12 @@ func (m *model) handleAgentThinking(msg agentThinkingMsg) (tea.Model, tea.Cmd) {
 		})
 	}
 	m.chatModel.Scroll = 0
+	return m, waitForAgent(m.agentCh)
+}
+
+// handleAgentWarning processes an agentWarningMsg.
+func (m *model) handleAgentWarning(msg agentWarningMsg) (tea.Model, tea.Cmd) {
+	m.chatModel.AppendWarning(msg.text)
 	return m, waitForAgent(m.agentCh)
 }
 

--- a/internal/tui/agent_loop_runaway_test.go
+++ b/internal/tui/agent_loop_runaway_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"context"
+	"iter"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	llmmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+const runawayPhrase = "Let me look at how the TUI renders messages and whether hook output surfaces. "
+
+func TestStuckDetector_ObserveOutput_TripsOnRepeatedPhrase(t *testing.T) {
+	s := &stuckDetector{}
+	var stuck bool
+	var detail string
+	for range maxOutputRepeats * 4 {
+		if stuck, detail = s.observeOutput(runawayPhrase); stuck {
+			break
+		}
+	}
+	if !stuck {
+		t.Fatal("expected the repeated phrase to trip the detector")
+	}
+	if !strings.Contains(detail, "repeated") {
+		t.Errorf("detail = %q, want it to mention repetition", detail)
+	}
+}
+
+func TestStuckDetector_ObserveOutput_AllowsProse(t *testing.T) {
+	s := &stuckDetector{}
+	// Distinct sentences, well past the byte volume that trips a repeat.
+	for i := range 400 {
+		text := strings.Repeat("x", i%37) + " unique sentence number " + strings.Repeat("y", i%29) + ". "
+		if stuck, detail := s.observeOutput(text); stuck {
+			t.Fatalf("non-repeating output tripped the detector at chunk %d: %s", i, detail)
+		}
+	}
+}
+
+func TestStuckDetector_ObserveOutput_IgnoresShortPeriods(t *testing.T) {
+	// A horizontal rule is periodic with period 1; it must not count.
+	s := &stuckDetector{}
+	for range 40 {
+		if stuck, _ := s.observeOutput(strings.Repeat("-", 80) + "\n"); stuck {
+			t.Fatal("a run of dashes must not be treated as a repetition loop")
+		}
+	}
+}
+
+func TestToolFingerprint_IgnoresPagination(t *testing.T) {
+	base := map[string]any{"file_path": "/repo/chat.go"}
+	paged := map[string]any{"file_path": "/repo/chat.go", "offset": 230, "limit": 40}
+	if toolFingerprint("read", base) != toolFingerprint("read", paged) {
+		t.Error("pagination args must not change the fingerprint")
+	}
+	other := map[string]any{"file_path": "/repo/other.go", "offset": 230, "limit": 40}
+	if toolFingerprint("read", paged) == toolFingerprint("read", other) {
+		t.Error("a different file must change the fingerprint")
+	}
+}
+
+func TestStuckDetector_Observe_TripsOnPagedRereads(t *testing.T) {
+	s := &stuckDetector{}
+	var stuck bool
+	for i := range maxRepeatToolCalls {
+		stuck, _ = s.observe("read", map[string]any{"file_path": "/repo/chat.go", "offset": i * 40})
+	}
+	if !stuck {
+		t.Fatalf("re-reading one file %d times must trip the detector", maxRepeatToolCalls)
+	}
+}
+
+// runawayLLM streams one sentence over and over and never calls a tool,
+// reproducing the deepseek-v4-flash:0731:cloud turn that emitted 148 KB of the
+// same text before the output cap stopped it.
+type runawayLLM struct {
+	name string
+	mu   sync.Mutex
+	n    int
+}
+
+func (m *runawayLLM) Name() string { return m.name }
+
+func (m *runawayLLM) GenerateContent(_ context.Context, _ *llmmodel.LLMRequest, _ bool) iter.Seq2[*llmmodel.LLMResponse, error] {
+	m.mu.Lock()
+	m.n++
+	m.mu.Unlock()
+	return func(yield func(*llmmodel.LLMResponse, error) bool) {
+		for range 4096 {
+			if !yield(&llmmodel.LLMResponse{
+				Partial: true,
+				Content: &genai.Content{
+					Role:  "thinking",
+					Parts: []*genai.Part{{Text: runawayPhrase}},
+				},
+			}, nil) {
+				return
+			}
+		}
+		yield(&llmmodel.LLMResponse{
+			TurnComplete: true,
+			FinishReason: genai.FinishReasonMaxTokens,
+			Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: "done"}},
+			},
+		}, nil)
+	}
+}
+
+// TestRunAgentLoop_AbortsRunawayOutput drives the whole pipeline against a
+// model that has collapsed into repeating itself with no tool calls at all —
+// the case both tool-call detectors are blind to.
+func TestRunAgentLoop_AbortsRunawayOutput(t *testing.T) {
+	dir := t.TempDir()
+	sb, err := tools.NewSandbox(dir)
+	if err != nil {
+		t.Fatalf("NewSandbox: %v", err)
+	}
+	coreTools, err := tools.CoreTools(sb)
+	if err != nil {
+		t.Fatalf("CoreTools: %v", err)
+	}
+	a, err := agent.New(agent.Config{Model: &runawayLLM{name: "runaway"}, Tools: coreTools, Instruction: "test"})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	ctx := context.Background()
+	sid, _, err := a.CreateSession(ctx)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	m := &model{cfg: Config{Agent: a, SessionID: sid}, ctx: ctx}
+	m.agentCh = make(chan agentMsg, 8192)
+
+	done := make(chan struct{})
+	var doneErr error
+	go func() {
+		defer close(done)
+		for msg := range m.agentCh {
+			if v, ok := msg.(agentDoneMsg); ok {
+				doneErr = v.err
+			}
+		}
+	}()
+
+	go m.runAgentLoop(ctx, "why is the hook message visible")
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runAgentLoop did not terminate -- runaway output was not detected")
+	}
+
+	if doneErr == nil || !strings.Contains(doneErr.Error(), "aborted") {
+		t.Fatalf("expected loop-aborted error, got: %v", doneErr)
+	}
+}
+
+// truncatedLLM ends its turn at the output cap, the finish reason nothing used
+// to act on.
+type truncatedLLM struct{ name string }
+
+func (m *truncatedLLM) Name() string { return m.name }
+
+func (m *truncatedLLM) GenerateContent(_ context.Context, _ *llmmodel.LLMRequest, _ bool) iter.Seq2[*llmmodel.LLMResponse, error] {
+	return func(yield func(*llmmodel.LLMResponse, error) bool) {
+		yield(&llmmodel.LLMResponse{
+			TurnComplete: true,
+			FinishReason: genai.FinishReasonMaxTokens,
+			Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: "a reply that stops mid-sen"}},
+			},
+		}, nil)
+	}
+}
+
+func TestRunAgentLoop_WarnsOnTruncatedTurn(t *testing.T) {
+	dir := t.TempDir()
+	sb, err := tools.NewSandbox(dir)
+	if err != nil {
+		t.Fatalf("NewSandbox: %v", err)
+	}
+	coreTools, err := tools.CoreTools(sb)
+	if err != nil {
+		t.Fatalf("CoreTools: %v", err)
+	}
+	a, err := agent.New(agent.Config{Model: &truncatedLLM{name: "truncated"}, Tools: coreTools, Instruction: "test"})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	ctx := context.Background()
+	sid, _, err := a.CreateSession(ctx)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	m := &model{cfg: Config{Agent: a, SessionID: sid}, ctx: ctx}
+	m.agentCh = make(chan agentMsg, 256)
+
+	done := make(chan struct{})
+	var warnings []string
+	go func() {
+		defer close(done)
+		for msg := range m.agentCh {
+			if v, ok := msg.(agentWarningMsg); ok {
+				warnings = append(warnings, v.text)
+			}
+		}
+	}()
+
+	go m.runAgentLoop(ctx, "write something long")
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runAgentLoop did not terminate")
+	}
+
+	if len(warnings) != 1 {
+		t.Fatalf("got %d truncation warnings, want exactly 1: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "truncated") {
+		t.Errorf("warning = %q, want it to say the reply was truncated", warnings[0])
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -657,6 +657,9 @@ func (m *model) updateAgentStream(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case agentSubEventMsg:
 		model, cmd := m.handleAgentSubEvent(msg)
 		return model, cmd, true
+	case agentWarningMsg:
+		model, cmd := m.handleAgentWarning(msg)
+		return model, cmd, true
 	case systemNoticeMsg:
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role:    "assistant",


### PR DESCRIPTION
A deepseek-v4-flash:0731:cloud session degenerated into repeating one
sentence for 87 seconds — 148 KB, ~37k tokens, no tool calls — and then
reported `Error: TODO: last event is not final`. Nothing in the loop was
in a position to stop it, and the error the user saw came from a TODO
string inside a dependency. Five gaps, fixed here.

1. Canceling mid-stream left ADK holding the last partial chunk, so its
   flow aborted with `TODO: last event is not final`
   (adk/v2/internal/llminternal/base_flow.go) instead of ending the turn.
   Every provider returned silently on context.Canceled; they now yield a
   terminal non-partial event via the shared canceledResponse helper.
   Five call sites: ollama, anthropic (both streaming paths), and the
   OpenAI completions and responses paths.

2. FinishReasonMaxTokens was mapped by every provider and read by nobody,
   so a reply cut off at the output cap looked merely short. The agent
   loop now warns once per turn that the response was truncated.

3. The Ollama path sent no num_predict, so a repeating model streamed
   until the server's own ceiling. Capped at 16384 tokens — what the
   Anthropic path already allows a thinking turn — overridable with
   PI_OLLAMA_NUM_PREDICT, where <= 0 restores unbounded output.

4. The stuck detector hashed raw tool args, so read(x, offset 1) and
   read(x, offset 230) were different calls and paging through one file
   in a loop stayed invisible. Pagination args are dropped from the
   fingerprint.

5. Nothing watched the model's own output: a turn with no tool calls
   could not trip either detector, which is exactly the shape of the
   runaway. A repetition guard now aborts the turn when the tail of the
   stream is one phrase repeated maxOutputRepeats times. Filler with too
   few distinct bytes (rules, indentation) is excluded so ordinary
   formatting cannot trip it.

Tests cover each: the ollama cancel path yields a non-partial last event,
num_predict reaches the wire, paged re-reads trip the detector, and
runAgentLoop aborts a no-tool-call runaway and warns on a truncated turn.

Signed-off-by: dimetron <dimetron@me.com>
