### PR TITLE
test(agent): cover the cancel and runaway guards left untested

### DIFF
--- a/internal/provider/stream_cancel_paths_test.go
+++ b/internal/provider/stream_cancel_paths_test.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// sseHangingServer streams one chunk of an event stream and then holds the
+// connection open, so the only thing that can end the stream is the client
+// canceling it. That is the shape that produced the ADK
+// "TODO: last event is not final" abort.
+func sseHangingServer(t *testing.T, chunks ...string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		for _, c := range chunks {
+			_, _ = fmt.Fprint(w, c)
+			if ok {
+				flusher.Flush()
+			}
+		}
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// assertCancelTerminates drains a stream, canceling as soon as the first
+// response arrives, and asserts the caller was left with a terminal event
+// rather than a dangling partial one.
+func assertCancelTerminates(ctx context.Context, t *testing.T, llm model.LLM, cancel context.CancelFunc) {
+	t.Helper()
+	var last *model.LLMResponse
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+	}
+	for resp, err := range llm.GenerateContent(ctx, req, true) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		last = resp
+		cancel()
+	}
+	if last == nil {
+		t.Fatal("expected at least one response before cancellation")
+	}
+	if last.Partial {
+		t.Error("last event after cancellation is Partial -- ADK aborts such a turn with \"TODO: last event is not final\"")
+	}
+	if !last.TurnComplete {
+		t.Error("expected the cancellation event to complete the turn")
+	}
+	if last.FinishReason == genai.FinishReasonStop {
+		t.Error("a canceled turn must not report STOP")
+	}
+}
+
+const antSSEPrelude = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"thinking out loud"}}
+
+`
+
+func TestAnthropicStreaming_CancelYieldsTerminalEvent(t *testing.T) {
+	srv := sseHangingServer(t, antSSEPrelude)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	llm, err := NewAnthropic(ctx, "claude-sonnet-4-6", "sk-test", srv.URL, "none", nil)
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	assertCancelTerminates(ctx, t, llm, cancel)
+}
+
+// The beta path is a separate streaming implementation with its own copy of
+// the cancellation branch, so it needs its own regression test. Configuring an
+// advisor model is what routes the request through the beta API.
+func TestAnthropicBetaStreaming_CancelYieldsTerminalEvent(t *testing.T) {
+	srv := sseHangingServer(t, antSSEPrelude)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := &LLMOptions{AdvisorModel: "claude-opus-4-7"}
+	llm, err := NewAnthropic(ctx, "claude-sonnet-4-6", "sk-test", srv.URL, "high", opts)
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	assertCancelTerminates(ctx, t, llm, cancel)
+}
+
+func TestOpenAICompletions_CancelYieldsTerminalEvent(t *testing.T) {
+	chunk := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"thinking out loud"},"finish_reason":null}]}` + "\n\n"
+	srv := sseHangingServer(t, chunk)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	llm, err := NewOpenAI(ctx, "gpt-4o", "sk-test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewOpenAI: %v", err)
+	}
+	assertCancelTerminates(ctx, t, llm, cancel)
+}
+
+func TestOpenAIResponses_CancelYieldsTerminalEvent(t *testing.T) {
+	chunk := `event: response.output_text.delta
+data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_1","content_index":0,"delta":"thinking out loud","sequence_number":1}
+
+`
+	srv := sseHangingServer(t, chunk)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// gpt-5-codex routes through the Responses endpoint.
+	llm, err := NewOpenAI(ctx, "gpt-5-codex", "sk-test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewOpenAI: %v", err)
+	}
+	assertCancelTerminates(ctx, t, llm, cancel)
+}

--- a/internal/tui/agent_loop_runaway_units_test.go
+++ b/internal/tui/agent_loop_runaway_units_test.go
@@ -1,0 +1,168 @@
+package tui
+
+import (
+	"context"
+	"iter"
+	"strings"
+	"testing"
+	"time"
+
+	llmmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+func TestStuckDetector_ObserveOutput_EmptyChunkIsNoop(t *testing.T) {
+	s := &stuckDetector{}
+	if stuck, _ := s.observeOutput(""); stuck {
+		t.Error("an empty chunk must not trip the detector")
+	}
+	if s.outBuf != "" || s.outSince != 0 {
+		t.Errorf("an empty chunk must not change detector state: buf=%q since=%d", s.outBuf, s.outSince)
+	}
+}
+
+func TestRepeatPeriod(t *testing.T) {
+	if got := repeatPeriod("short"); got != 0 {
+		t.Errorf("a buffer shorter than two probes has no period, got %d", got)
+	}
+	// The unit must not be periodic within itself, or the probe legitimately
+	// matches at the shorter inner period instead.
+	unit := "the model keeps restating this one sentence, verbatim. "
+	if got := repeatPeriod(strings.Repeat(unit, 4)); got != len(unit) {
+		t.Errorf("repeatPeriod = %d, want %d", got, len(unit))
+	}
+	if got := repeatPeriod(strings.Repeat("q", 200) + "no repetition of the tail whatsoever here!"); got != 0 {
+		t.Errorf("a tail that never recurs has no period, got %d", got)
+	}
+}
+
+func TestIsPeriodic(t *testing.T) {
+	unit := "the same phrase again. "
+	if !isPeriodic(strings.Repeat(unit, 12), len(unit), 12) {
+		t.Error("12 back-to-back copies must read as periodic")
+	}
+	if isPeriodic(strings.Repeat(unit, 12)+"different tail", len(unit), 12) {
+		t.Error("a broken tail must not read as periodic")
+	}
+	if isPeriodic(unit, len(unit), 12) {
+		t.Error("a buffer shorter than period*repeats cannot be periodic")
+	}
+	if isPeriodic(strings.Repeat(unit, 12), 0, 12) {
+		t.Error("a zero period must be rejected")
+	}
+}
+
+func TestHasVariety(t *testing.T) {
+	if hasVariety(strings.Repeat("-", 80)) {
+		t.Error("a rule of dashes is filler, not a phrase")
+	}
+	if !hasVariety("a sentence with plenty of distinct letters") {
+		t.Error("ordinary prose must count as a phrase")
+	}
+}
+
+func TestHandleAgentWarning_AppendsWarning(t *testing.T) {
+	m := newHandlerModel()
+	m.handleAgentWarning(agentWarningMsg{text: "Response truncated: the model hit its output-token limit."})
+
+	if len(m.chatModel.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(m.chatModel.Messages))
+	}
+	last := m.chatModel.Messages[0]
+	if !last.isWarning {
+		t.Error("a truncation notice must render as a warning, not as ordinary reply text")
+	}
+	if !strings.Contains(last.content, "truncated") {
+		t.Errorf("content = %q, want it to say the reply was truncated", last.content)
+	}
+}
+
+func TestUpdateAgentStream_DispatchesWarning(t *testing.T) {
+	m := newHandlerModel()
+	_, _, handled := m.updateAgentStream(agentWarningMsg{text: "Response truncated."})
+	if !handled {
+		t.Fatal("agentWarningMsg must be handled by updateAgentStream")
+	}
+	if len(m.chatModel.Messages) != 1 || !m.chatModel.Messages[0].isWarning {
+		t.Fatalf("expected the warning to reach the transcript, got %+v", m.chatModel.Messages)
+	}
+}
+
+// replyRunawayLLM repeats itself in the reply stream rather than in thinking,
+// covering the other branch of the streaming guard.
+type replyRunawayLLM struct{ name string }
+
+func (m *replyRunawayLLM) Name() string { return m.name }
+
+func (m *replyRunawayLLM) GenerateContent(_ context.Context, _ *llmmodel.LLMRequest, _ bool) iter.Seq2[*llmmodel.LLMResponse, error] {
+	return func(yield func(*llmmodel.LLMResponse, error) bool) {
+		for range 4096 {
+			if !yield(&llmmodel.LLMResponse{
+				Partial: true,
+				Content: &genai.Content{
+					Role:  genai.RoleModel,
+					Parts: []*genai.Part{{Text: runawayPhrase}},
+				},
+			}, nil) {
+				return
+			}
+		}
+		yield(&llmmodel.LLMResponse{
+			TurnComplete: true,
+			FinishReason: genai.FinishReasonMaxTokens,
+			Content: &genai.Content{
+				Role:  genai.RoleModel,
+				Parts: []*genai.Part{{Text: "done"}},
+			},
+		}, nil)
+	}
+}
+
+func TestRunAgentLoop_AbortsRunawayReplyText(t *testing.T) {
+	dir := t.TempDir()
+	sb, err := tools.NewSandbox(dir)
+	if err != nil {
+		t.Fatalf("NewSandbox: %v", err)
+	}
+	coreTools, err := tools.CoreTools(sb)
+	if err != nil {
+		t.Fatalf("CoreTools: %v", err)
+	}
+	a, err := agent.New(agent.Config{Model: &replyRunawayLLM{name: "runaway-reply"}, Tools: coreTools, Instruction: "test"})
+	if err != nil {
+		t.Fatalf("agent.New: %v", err)
+	}
+	ctx := context.Background()
+	sid, _, err := a.CreateSession(ctx)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	m := &model{cfg: Config{Agent: a, SessionID: sid}, ctx: ctx}
+	m.agentCh = make(chan agentMsg, 8192)
+
+	done := make(chan struct{})
+	var doneErr error
+	go func() {
+		defer close(done)
+		for msg := range m.agentCh {
+			if v, ok := msg.(agentDoneMsg); ok {
+				doneErr = v.err
+			}
+		}
+	}()
+
+	go m.runAgentLoop(ctx, "explain the hook")
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runAgentLoop did not terminate -- runaway reply text was not detected")
+	}
+	if doneErr == nil || !strings.Contains(doneErr.Error(), "aborted") {
+		t.Fatalf("expected loop-aborted error, got: %v", doneErr)
+	}
+}


### PR DESCRIPTION
Patch coverage on #90 came in at 79.12% against an 82.77% target. The
gaps were the branches hardest to reach and most worth pinning: four of
the five provider cancellation paths, and the helpers behind the output
repetition guard.

- Cancellation regression tests for the anthropic streaming and beta
  streaming paths and for both OpenAI endpoints, each driven by an SSE
  server that sends one chunk and then holds the connection open, so
  cancellation — not EOF — is what ends the stream. Each asserts the
  last event the caller sees is non-partial and turn-complete, which is
  exactly the condition ADK reports as "TODO: last event is not final".
- Unit tests for repeatPeriod, isPeriodic and hasVariety, including the
  boundaries the detector depends on: a buffer shorter than two probes,
  a broken tail, a zero period, and filler with too few distinct bytes.
- A runaway whose repetition arrives as reply text rather than thinking,
  covering the second call site of the guard.
- handleAgentWarning and its updateAgentStream dispatch, so the
  truncation notice is pinned as a warning rather than reply text.

Patch coverage on the #90 diff goes from 79.12% to 98%; the remainder is
the zero-statement agentMsg marker method.

Signed-off-by: dimetron <dimetron@me.com>
