### PR TITLE
fix(tools): stop leaking process trees, stream shell output, let the agent cancel

### DIFF
--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -327,15 +327,25 @@ func buildSessionResources(rt RuntimeConfig, cfg config.Config, turn PromptTurn,
 		_ = sandbox.AddExtraDir(filepath.Join(home, ".pi-go"))
 	}
 
-	coreTools, err := tools.CoreTools(sandbox)
+	bashSup := tools.NewBashSupervisor()
+	coreTools, err := tools.CoreTools(sandbox, tools.WithBashSupervisor(bashSup))
 	if err != nil {
 		_ = sandbox.Close()
 		return nil, fmt.Errorf("creating core tools: %w", err)
 	}
+	bashCtlTools, err := tools.BashControlTools(bashSup)
+	if err != nil {
+		_ = sandbox.Close()
+		return nil, fmt.Errorf("creating bash control tools: %w", err)
+	}
+	coreTools = append(coreTools, bashCtlTools...)
 
 	orch := newSessionOrchestrator(rt, cfg, cwd)
 	lspMgr := lsp.NewManager(nil)
 	cleanup := func() {
+		// Backgrounded commands outlive the turn by design, so the session
+		// teardown is the only thing that will ever reap them.
+		bashSup.KillAll()
 		lspMgr.Shutdown()
 		orch.Shutdown()
 		_ = sandbox.Close()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -465,6 +465,7 @@ type nonInteractiveRuntime struct {
 	coreTools    []adktool.Tool
 	orch         *subagent.Orchestrator
 	agentEventCh chan tui.AgentSubEvent
+	bashSup      *tools.BashSupervisor
 }
 
 func initNonInteractiveRuntime(ctx context.Context, cfg *config.Config, cwd, sandboxRoot, worktreeDir string) (*nonInteractiveRuntime, error) {
@@ -479,11 +480,18 @@ func initNonInteractiveRuntime(ctx context.Context, cfg *config.Config, cwd, san
 		}
 	}
 
-	coreTools, err := tools.CoreTools(sandbox)
+	bashSup := tools.NewBashSupervisor()
+	coreTools, err := tools.CoreTools(sandbox, tools.WithBashSupervisor(bashSup))
 	if err != nil {
 		_ = sandbox.Close()
 		return nil, fmt.Errorf("creating core tools: %w", err)
 	}
+	bashCtlTools, err := tools.BashControlTools(bashSup)
+	if err != nil {
+		_ = sandbox.Close()
+		return nil, fmt.Errorf("creating bash control tools: %w", err)
+	}
+	coreTools = append(coreTools, bashCtlTools...)
 
 	repoRoot := detectGitRoot(ctx, cwd)
 	discovery, err := subagent.DiscoverAgents(cwd, subagent.ScopeBoth)
@@ -512,17 +520,27 @@ func initNonInteractiveRuntime(ctx context.Context, cfg *config.Config, cwd, san
 	}
 	coreTools = append(coreTools, agentTools...)
 
+	bashSup.SetSink(func(execID, kind, content string) {
+		agentEventCB(execID, tui.BashEventKind(kind), content)
+	})
+
 	return &nonInteractiveRuntime{
 		sandbox:      sandbox,
 		coreTools:    coreTools,
 		orch:         orch,
 		agentEventCh: agentEventCh,
+		bashSup:      bashSup,
 	}, nil
 }
 
 func (r *nonInteractiveRuntime) close() {
 	if r == nil {
 		return
+	}
+	// Backgrounded commands have no owner but this supervisor; leaving them
+	// running past the run is a leaked process tree.
+	if r.bashSup != nil {
+		r.bashSup.KillAll()
 	}
 	if r.orch != nil {
 		r.orch.Shutdown()

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -38,9 +38,16 @@ type initResources struct {
 	memWorker  *memory.Worker
 	sessionLog *logger.Logger
 	sessionID  string // captured for resume hint on exit
+	bashSup    *tools.BashSupervisor
 }
 
 func (r *initResources) cleanup() {
+	// Stop backgrounded shell commands first. Nothing else owns them, so a
+	// command still running when the session ends is a leaked process — the
+	// exact failure this supervisor was introduced to prevent.
+	if r.bashSup != nil {
+		r.bashSup.KillAll()
+	}
 	if r.sessionLog != nil {
 		// Detach before closing: a late trace from an in-flight streaming body
 		// would otherwise write into a closed file.
@@ -155,11 +162,23 @@ func deferredInit(
 		_ = sandbox.AddExtraDir(filepath.Join(home, ".pi-go"))
 	}
 
-	coreTools, err := tools.CoreTools(sandbox)
+	// The supervisor is built here, before the UI event channel exists, because
+	// the bash tool needs it at construction time. Its sink is attached later,
+	// once there is somewhere to stream to.
+	bashSup := tools.NewBashSupervisor()
+	res.bashSup = bashSup
+
+	coreTools, err := tools.CoreTools(sandbox, tools.WithBashSupervisor(bashSup))
 	if err != nil {
 		fail(fmt.Errorf("creating core tools: %w", err))
 		return
 	}
+	bashCtlTools, err := tools.BashControlTools(bashSup)
+	if err != nil {
+		fail(fmt.Errorf("creating bash control tools: %w", err))
+		return
+	}
+	coreTools = append(coreTools, bashCtlTools...)
 
 	send("tools", true)
 
@@ -269,6 +288,13 @@ func deferredInit(
 	}
 	agentTools, _ := tools.AgentTools(orch, agentEventCB)
 	coreTools = append(coreTools, agentTools...)
+
+	// Stream live shell output to the same channel the subagent cards use. The
+	// prefix keeps the two streams apart; the non-blocking send in agentEventCB
+	// is what keeps a slow UI from stalling a running command.
+	bashSup.SetSink(func(execID, kind, content string) {
+		agentEventCB(execID, tui.BashEventKind(kind), content)
+	})
 
 	// Append LSP tools.
 	if ps.lspTools != nil {

--- a/internal/extension/hooks.go
+++ b/internal/extension/hooks.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os/exec"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -24,6 +23,7 @@ import (
 	"google.golang.org/adk/v2/tool"
 
 	"github.com/dimetron/pi-go/internal/otel"
+	"github.com/dimetron/pi-go/internal/procs"
 )
 
 // HookConfig defines a shell command hook that runs before or after tool calls.
@@ -403,7 +403,7 @@ func RunLifecycleHook(ctx context.Context, hook HookConfig, event string, data m
 	hookCtx, cancel := context.WithTimeout(ctx, hook.timeout())
 	defer cancel()
 
-	cmd := exec.CommandContext(hookCtx, "sh", "-c", hook.Command)
+	cmd := procs.CommandContext(hookCtx, "sh", "-c", hook.Command)
 
 	input := map[string]any{
 		"event": event,
@@ -429,7 +429,7 @@ func runHookCommand(ctx context.Context, hook HookConfig, toolName string, data 
 	hookCtx, cancel := context.WithTimeout(ctx, hook.timeout())
 	defer cancel()
 
-	cmd := exec.CommandContext(hookCtx, "sh", "-c", hook.Command)
+	cmd := procs.CommandContext(hookCtx, "sh", "-c", hook.Command)
 
 	// Pass context as JSON on stdin.
 	input := map[string]any{

--- a/internal/procs/procs.go
+++ b/internal/procs/procs.go
@@ -1,0 +1,90 @@
+// Package procs runs child processes so that canceling them actually stops
+// them.
+//
+// The default exec.CommandContext contract is weaker than it looks. On
+// cancellation it signals only the direct child, and it waits for the
+// stdout/stderr pipes to reach EOF. A shell command like
+//
+//	find / -name '*.go' | grep foo
+//
+// forks grandchildren that inherit those pipes. Killing the shell leaves them
+// running, reparented to init, still holding the write end — so Wait blocks
+// forever and the caller hangs long past its own timeout. That is not
+// theoretical: it wedged two pi sessions for over an hour, with the orphaned
+// find processes still burning CPU.
+//
+// Isolate closes both halves of that gap: the child leads its own process
+// group so cancellation reaches every descendant, and WaitDelay caps how long
+// Wait will wait on pipes that something is still holding open.
+package procs
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// DefaultWaitDelay bounds how long Wait may block after cancellation before
+// the runtime force-closes the child's pipes and gives up on them.
+//
+// It is a backstop, not the main mechanism — group termination should already
+// have reaped every writer. It exists for the cases group termination cannot
+// reach: a process stopped in the kernel, a descendant that escaped into a new
+// session, or a platform without process groups at all.
+const DefaultWaitDelay = 5 * time.Second
+
+// DefaultKillGrace is how long a canceled group has to exit on SIGTERM before
+// it is sent SIGKILL. Long enough for a shell to run its traps and for a
+// compiler to remove its temporary files; short enough that no caller notices.
+const DefaultKillGrace = 2 * time.Second
+
+// CommandContext builds an isolated command. Prefer it over calling
+// exec.CommandContext and Isolate separately: Isolate installs a Cancel func,
+// and os/exec rejects that at Start time on a command built without a context,
+// so the two-step form is easy to get wrong in a way that only fails at
+// runtime.
+func CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	Isolate(cmd)
+	return cmd
+}
+
+// Isolate prepares cmd so that canceling its context terminates the whole
+// process tree it spawns, and so that Wait cannot block indefinitely
+// afterwards.
+//
+// cmd must have been created by exec.CommandContext. Isolate sets Cancel, and
+// os/exec refuses to start a command that has one without a context; use
+// CommandContext to avoid the trap entirely.
+//
+// Call it after building cmd and before starting it. Isolate sets SysProcAttr,
+// Cancel and WaitDelay; a caller that overwrites any of those afterwards gets
+// the old broken behavior back.
+//
+// On platforms without process groups it still sets WaitDelay, which alone is
+// enough to prevent the indefinite hang, and falls back to killing the direct
+// child.
+func Isolate(cmd *exec.Cmd) {
+	IsolateWithDelay(cmd, DefaultWaitDelay, DefaultKillGrace)
+}
+
+// IsolateWithDelay is Isolate with explicit timings. waitDelay bounds the wait
+// on lingering pipes; killGrace is how long the group has to honor SIGTERM
+// before SIGKILL follows.
+func IsolateWithDelay(cmd *exec.Cmd, waitDelay, killGrace time.Duration) {
+	setGroup(cmd)
+	cmd.WaitDelay = waitDelay
+	cmd.Cancel = func() error {
+		return terminate(cmd, killGrace)
+	}
+}
+
+// Kill terminates cmd's process group immediately, without the SIGTERM grace
+// period. It is safe to call on a process that has already exited, and safe to
+// call more than once.
+//
+// Use it to stop a process that is not tied to a cancellable context — a
+// backgrounded command being killed on request, for instance.
+func Kill(cmd *exec.Cmd) error {
+	return kill(cmd)
+}

--- a/internal/procs/procs_fallback_test.go
+++ b/internal/procs/procs_fallback_test.go
@@ -1,0 +1,124 @@
+//go:build unix
+
+package procs
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSignalGroup_NilAndUnstartedAreNoOps: terminate runs on Wait's goroutine
+// and must never panic or error on a command that never started, or the
+// cancellation path itself becomes the failure.
+func TestSignalGroup_NilAndUnstartedAreNoOps(t *testing.T) {
+	if err := signalGroup(nil, syscall.SIGKILL); err != nil {
+		t.Errorf("signalGroup(nil) = %v, want nil", err)
+	}
+
+	unstarted := exec.Command("bash", "-c", "true") // never started: Process is nil
+	if err := signalGroup(unstarted, syscall.SIGKILL); err != nil {
+		t.Errorf("signalGroup(unstarted) = %v, want nil", err)
+	}
+	if err := Kill(unstarted); err != nil {
+		t.Errorf("Kill(unstarted) = %v, want nil", err)
+	}
+}
+
+// TestSignalGroup_WithoutSetpgidSignalsTheChildOnly is the safety property that
+// matters most in this file.
+//
+// The negative-PID form of kill(2) addresses a process group, and pi runs as an
+// ordinary user process — so kill(-pid) without a group of our own could name
+// the group pi itself is in and take down the session. When Setpgid was not
+// applied, the code must fall back to signaling the direct child and nothing
+// else.
+func TestSignalGroup_WithoutSetpgidSignalsTheChildOnly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", "sleep 30")
+	// Deliberately no setGroup: this is the no-process-group path.
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	if err := signalGroup(cmd, syscall.SIGKILL); err != nil {
+		t.Fatalf("signalGroup: %v", err)
+	}
+	_ = cmd.Wait()
+
+	if alive(pid) {
+		t.Errorf("child %d survived the fallback signal", pid)
+	}
+	// The test process must still be here — the whole point of the guard.
+	if err := syscall.Kill(syscall.Getpid(), 0); err != nil {
+		t.Fatalf("the test process was signaled by a group kill: %v", err)
+	}
+}
+
+// TestTerminate_EscalatesToKill covers the SIGTERM-then-SIGKILL path against a
+// process that ignores SIGTERM. Group termination has to be able to insist,
+// otherwise a shell trapping TERM would leak exactly as before.
+func TestTerminate_EscalatesToKill(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// trap '' TERM makes the shell immune to SIGTERM.
+	cmd := CommandContext(ctx, "bash", "-c", "trap '' TERM; sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	if err := terminate(cmd, 100*time.Millisecond); err != nil {
+		t.Fatalf("terminate: %v", err)
+	}
+	_ = cmd.Wait()
+
+	if alive(pid) {
+		t.Errorf("process %d ignored SIGTERM and was never escalated to SIGKILL", pid)
+	}
+}
+
+// TestIsolateWithDelay_AppliesTimings checks the explicit-timing entry point
+// wires WaitDelay through, since that is the backstop against the original
+// indefinite hang.
+func TestIsolateWithDelay_AppliesTimings(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", "true")
+	IsolateWithDelay(cmd, 3*time.Second, time.Second)
+
+	if cmd.WaitDelay != 3*time.Second {
+		t.Errorf("WaitDelay = %v, want 3s", cmd.WaitDelay)
+	}
+	if cmd.Cancel == nil {
+		t.Error("Cancel was not installed")
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Error("Setpgid was not applied")
+	}
+}
+
+// TestIsolate_PreservesExistingSysProcAttr: a caller that set its own
+// attributes (credentials, for instance) must keep them.
+func TestIsolate_PreservesExistingSysProcAttr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", "true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Foreground: false, Noctty: true}
+	Isolate(cmd)
+
+	if !cmd.SysProcAttr.Setpgid {
+		t.Error("Setpgid was not applied on top of existing attributes")
+	}
+	if !cmd.SysProcAttr.Noctty {
+		t.Error("Isolate clobbered a caller-set attribute")
+	}
+}

--- a/internal/procs/procs_other.go
+++ b/internal/procs/procs_other.go
@@ -1,0 +1,30 @@
+//go:build !unix
+
+package procs
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// setGroup is a no-op off Unix. Windows has an equivalent in job objects, but
+// wiring one up is a separate piece of work; until then WaitDelay carries the
+// load, which is enough to keep Wait from blocking forever even when a
+// grandchild survives.
+func setGroup(*exec.Cmd) {}
+
+func terminate(cmd *exec.Cmd, _ time.Duration) error {
+	return kill(cmd)
+}
+
+func kill(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}

--- a/internal/procs/procs_test.go
+++ b/internal/procs/procs_test.go
@@ -1,0 +1,159 @@
+//go:build unix
+
+package procs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestIsolate_KillsGrandchildAndReturnsPromptly reproduces the failure this
+// package exists for.
+//
+// The command backgrounds a child and then waits. The child inherits the
+// stdout pipe, so under plain exec.CommandContext two things go wrong at once:
+// cancellation signals only the shell, leaving the child running and reparented
+// to init, and Wait then blocks forever because that child still holds the pipe
+// open. Two pi sessions hung for over an hour this way with orphaned `find`
+// processes still burning CPU.
+//
+// Both halves are asserted here: Wait must return quickly, and the grandchild
+// must be gone.
+func TestIsolate_KillsGrandchildAndReturnsPromptly(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	// `sleep` inherits stdout; `wait` keeps the shell alive alongside it.
+	cmd := CommandContext(ctx, "bash", "-c",
+		"sleep 60 & echo $! > "+pidFile+"; wait")
+
+	// A non-*os.File writer is what makes os/exec allocate a pipe and copy
+	// through a goroutine — which is the code path that blocks. Handing it an
+	// *os.File would let exec pass the fd straight through and the bug would
+	// not reproduce.
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	childPID := waitForPIDFile(t, pidFile)
+
+	start := time.Now()
+	_ = cmd.Wait()
+	elapsed := time.Since(start)
+
+	// Generous bound: the point is "returns", not "returns in exactly N ms".
+	// The old behavior did not return at all.
+	if elapsed > 10*time.Second {
+		t.Fatalf("Wait blocked for %s after cancellation; the pipe is still held open", elapsed)
+	}
+
+	if alive(childPID) {
+		t.Errorf("grandchild %d survived cancellation", childPID)
+	}
+}
+
+// TestIsolate_NormalExitIsUnaffected guards the common case: the overwhelming
+// majority of commands finish long before anything here fires, and must be
+// reported exactly as before.
+func TestIsolate_NormalExitIsUnaffected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := CommandContext(ctx, "bash", "-c", "echo hi; exit 3")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %v", err)
+	}
+	if got := exitErr.ExitCode(); got != 3 {
+		t.Errorf("exit code = %d, want 3", got)
+	}
+	if strings.TrimSpace(out.String()) != "hi" {
+		t.Errorf("stdout = %q, want %q", out.String(), "hi")
+	}
+}
+
+// TestKill_TerminatesGroup covers the explicit-kill path used when a
+// backgrounded command is stopped on request rather than by cancellation.
+func TestKill_TerminatesGroup(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+
+	cmd := CommandContext(context.Background(), "bash", "-c", "sleep 60 & echo $! > "+pidFile+"; wait")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	childPID := waitForPIDFile(t, pidFile)
+
+	if err := Kill(cmd); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	_ = cmd.Wait()
+
+	if alive(childPID) {
+		t.Errorf("grandchild %d survived Kill", childPID)
+	}
+}
+
+// TestKill_AfterExitIsHarmless: killing a reaped process must not error, and
+// must not signal whatever inherited its PID.
+func TestKill_AfterExitIsHarmless(t *testing.T) {
+	cmd := CommandContext(context.Background(), "bash", "-c", "true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if err := Kill(cmd); err != nil {
+		t.Errorf("Kill after exit: %v", err)
+	}
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child never wrote its pid to %s", path)
+	return 0
+}
+
+// alive reports whether pid still exists, allowing a moment for the kernel to
+// reap it. Signal 0 performs the permission and existence checks without
+// delivering anything.
+func alive(pid int) bool {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return true
+}

--- a/internal/procs/procs_unix.go
+++ b/internal/procs/procs_unix.go
@@ -1,0 +1,84 @@
+//go:build unix
+
+package procs
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// setGroup makes the child the leader of a new process group, so its own PID
+// doubles as the group ID. Every process it forks inherits that group unless it
+// deliberately leaves, which is what makes a single kill reach the whole tree.
+func setGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// terminate asks the group to exit, then insists.
+//
+// SIGTERM first: a shell gets to run its EXIT trap, a compiler gets to unlink
+// its temporary files, and a test binary gets to flush. SIGKILL follows after
+// grace for anything that ignored it — including the case that matters most
+// here, a descendant blocked in a syscall that will never return on its own.
+//
+// The SIGKILL is scheduled rather than awaited because Cancel runs on Wait's
+// own goroutine: blocking here would delay exactly the return we are trying to
+// guarantee.
+func terminate(cmd *exec.Cmd, grace time.Duration) error {
+	if err := signalGroup(cmd, syscall.SIGTERM); err != nil {
+		return err
+	}
+	time.AfterFunc(grace, func() {
+		_ = signalGroup(cmd, syscall.SIGKILL)
+	})
+	return nil
+}
+
+func kill(cmd *exec.Cmd) error {
+	return signalGroup(cmd, syscall.SIGKILL)
+}
+
+// signalGroup sends sig to the child's process group, falling back to the lone
+// child when no group was established.
+//
+// The negative-PID form of kill(2) addresses a group, and getting the sign
+// wrong here is unusually costly: pi runs as a normal user process, so
+// kill(-pid) against our own group would take down the session. The Setpgid
+// check is what rules that out — without it there is no guarantee the child
+// leads a group of its own, and -pid could name the group pi itself is in.
+func signalGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	pid := cmd.Process.Pid
+	if pid <= 0 {
+		return nil
+	}
+
+	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Setpgid {
+		// Resolve the group rather than assuming it equals the PID. They are
+		// the same for a group leader, but a child that called setpgid itself
+		// has moved on, and signaling a stale group would miss it entirely.
+		pgid, err := syscall.Getpgid(pid)
+		if err == nil && pgid > 1 {
+			if err := syscall.Kill(-pgid, sig); err == nil || errors.Is(err, syscall.ESRCH) {
+				return nil
+			}
+		}
+	}
+
+	// No group, or the group signal failed: reach the direct child at least.
+	if err := cmd.Process.Signal(sig); err != nil {
+		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -1,11 +1,8 @@
 package tools
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -15,14 +12,22 @@ import (
 	"github.com/dimetron/pi-go/internal/otel"
 )
 
-const defaultBashTimeout = 120 * time.Second
+const (
+	defaultBashTimeout = 120 * time.Second
+	maxBashTimeout     = 10 * time.Minute
+)
 
 // BashInput defines the parameters for the bash tool.
 type BashInput struct {
 	// The shell command to execute.
 	Command string `json:"command"`
 	// Optional timeout in milliseconds. Default: 120000 (2 minutes). Max: 600000 (10 minutes).
+	// On expiry the command is moved to the background, not killed.
 	Timeout int `json:"timeout,omitempty"`
+	// Optional idle timeout in milliseconds. A command that produces no output
+	// at all for this long is moved to the background. Default: 90000.
+	// Set it higher for commands that are legitimately quiet for a long time.
+	IdleTimeout int `json:"idle_timeout,omitempty"`
 }
 
 // BashOutput contains the result of executing a shell command.
@@ -31,33 +36,74 @@ type BashOutput struct {
 	Stdout string `json:"stdout"`
 	// Standard error from the command.
 	Stderr string `json:"stderr"`
-	// Exit code of the command.
+	// Exit code of the command. -1 when the command has not exited.
 	ExitCode int `json:"exit_code"`
+	// Running is true when the command outlived its timeout and is still
+	// executing in the background.
+	Running bool `json:"running,omitempty"`
+	// Handle identifies a still-running command for bash_output and bash_kill.
+	Handle string `json:"handle,omitempty"`
+	// Note explains a non-obvious outcome in terms the model can act on.
+	Note string `json:"note,omitempty"`
 }
 
-func newBashTool(sb *Sandbox) (tool.Tool, error) {
-	return newTool("bash", "Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, running tests, building code, git operations, etc.", func(ctx agent.Context, input BashInput) (BashOutput, error) {
-		return bashHandler(sb, ctx, input)
+// BashStatus is the result of inspecting or stopping a backgrounded command.
+type BashStatus struct {
+	Handle  string `json:"handle"`
+	Command string `json:"command"`
+	// Running reports whether the command is still executing.
+	Running bool `json:"running"`
+	// ExitCode is meaningful only once Running is false.
+	ExitCode int `json:"exit_code,omitempty"`
+	// Stdout and Stderr carry only what was produced since the previous read.
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+	// Elapsed is how long the command has been running in total.
+	Elapsed string `json:"elapsed,omitempty"`
+	// Idle is how long it has been since the command last produced output.
+	Idle string `json:"idle,omitempty"`
+	Note string `json:"note,omitempty"`
+}
+
+// BashOutputInput asks for output accumulated by a backgrounded command.
+type BashOutputInput struct {
+	// Handle returned by a previous bash call.
+	Handle string `json:"handle"`
+	// WaitMs blocks up to this long for new output or for the command to exit,
+	// instead of returning immediately. Max 60000. Prefer waiting over polling
+	// in a loop.
+	WaitMs int `json:"wait_ms,omitempty"`
+}
+
+// BashKillInput identifies a backgrounded command to stop.
+type BashKillInput struct {
+	// Handle returned by a previous bash call.
+	Handle string `json:"handle"`
+}
+
+const maxBashOutputWait = 60 * time.Second
+
+const bashDescription = `Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, running tests, building code, git operations, etc.
+
+A command that runs past its timeout, or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Use bash_output to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.`
+
+func newBashTool(sb *Sandbox, sup *BashSupervisor) (tool.Tool, error) {
+	return newTool("bash", bashDescription, func(ctx agent.Context, input BashInput) (BashOutput, error) {
+		return bashHandler(sb, sup, ctx, input)
 	})
 }
 
-func bashHandler(sb *Sandbox, ctx agent.Context, input BashInput) (BashOutput, error) {
+func bashHandler(sb *Sandbox, sup *BashSupervisor, ctx agent.Context, input BashInput) (BashOutput, error) {
 	if input.Command == "" {
 		return BashOutput{}, fmt.Errorf("command is required")
 	}
 
-	timeout := defaultBashTimeout
-	if input.Timeout > 0 {
-		timeout = time.Duration(input.Timeout) * time.Millisecond
-		if timeout > 10*time.Minute {
-			timeout = 10 * time.Minute
-		}
-	}
-
 	// Use background context if agent.Context is nil (e.g. in unit tests)
-	var parentCtx = context.Background()
+	var parentCtx context.Context
 	if ctx != nil {
 		parentCtx = ctx
+	} else {
+		parentCtx = context.Background()
 	}
 
 	parentCtx, span := otel.Tracer("pi-go").Start(parentCtx, "tool.bash")
@@ -67,53 +113,69 @@ func bashHandler(sb *Sandbox, ctx agent.Context, input BashInput) (BashOutput, e
 	)
 	defer span.End()
 
-	cmdCtx, cancel := context.WithTimeout(parentCtx, timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(cmdCtx, "bash", "-c", input.Command)
-	cmd.Dir = sb.Dir()
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-
-	exitCode := 0
+	out, err := sup.Run(parentCtx, runRequest{
+		dir:         sb.Dir(),
+		command:     input.Command,
+		timeout:     clampDuration(input.Timeout, defaultBashTimeout, maxBashTimeout),
+		idleTimeout: clampDuration(input.IdleTimeout, 0, maxBashTimeout),
+	})
 	if err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			exitCode = exitErr.ExitCode()
-		} else if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
-			span.SetAttributes(
-				attribute.Int("bash.exit_code", -1),
-				attribute.Int("bash.stdout_len", stdout.Len()),
-				attribute.Int("bash.stderr_len", stderr.Len()),
-			)
-			return BashOutput{
-				Stdout:   redactSecrets(truncateOutput(stdout.String())),
-				Stderr:   redactSecrets(truncateOutput("command timed out\n" + stripRuntimeNoise(stderr.String()))),
-				ExitCode: -1,
-			}, nil
-		} else {
-			span.RecordError(err)
-			return BashOutput{}, fmt.Errorf("executing command: %w", err)
-		}
-	}
-
-	// SIGPIPE (exit 141 = signal 13 + 128) is benign — the consumer closed the pipe
-	// before the producer finished writing. Treat it as success.
-	if exitCode == 141 {
-		exitCode = 0
+		span.RecordError(err)
+		return BashOutput{}, fmt.Errorf("executing command: %w", err)
 	}
 
 	span.SetAttributes(
-		attribute.Int("bash.exit_code", exitCode),
-		attribute.Int("bash.stdout_len", stdout.Len()),
-		attribute.Int("bash.stderr_len", stderr.Len()),
+		attribute.Int("bash.exit_code", out.ExitCode),
+		attribute.Int("bash.stdout_len", len(out.Stdout)),
+		attribute.Int("bash.stderr_len", len(out.Stderr)),
+		attribute.Bool("bash.backgrounded", out.Running),
 	)
-	return BashOutput{
-		Stdout:   redactSecrets(truncateOutput(stdout.String())),
-		Stderr:   redactSecrets(truncateOutput(stripRuntimeNoise(stderr.String()))),
-		ExitCode: exitCode,
-	}, nil
+	return out, nil
+}
+
+// clampDuration converts a millisecond input to a duration, substituting
+// fallback when unset and capping at maxDur.
+func clampDuration(ms int, fallback, maxDur time.Duration) time.Duration {
+	if ms <= 0 {
+		return fallback
+	}
+	d := time.Duration(ms) * time.Millisecond
+	if d > maxDur {
+		return maxDur
+	}
+	return d
+}
+
+// BashControlTools returns the tools for inspecting and stopping commands that
+// the bash tool moved to the background.
+//
+// They are separate from CoreTools because they are only worth advertising to
+// the model when something can actually background a command — a caller that
+// builds its own supervisor and never streams need not carry the extra schema.
+func BashControlTools(sup *BashSupervisor) ([]tool.Tool, error) {
+	outputTool, err := newTool("bash_output",
+		"Read output produced by a backgrounded shell command since the last read. Returns running=false and the exit code once it finishes, after which the handle is spent. Set wait_ms to block for new output instead of polling in a loop.",
+		func(_ agent.Context, input BashOutputInput) (BashStatus, error) {
+			if input.Handle == "" {
+				return BashStatus{}, fmt.Errorf("handle is required (running: %v)", sup.Handles())
+			}
+			return sup.readOutput(input.Handle, clampDuration(input.WaitMs, 0, maxBashOutputWait))
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	killTool, err := newTool("bash_kill",
+		"Stop a backgrounded shell command and every process it spawned. Returns any output produced since the last read.",
+		func(_ agent.Context, input BashKillInput) (BashStatus, error) {
+			if input.Handle == "" {
+				return BashStatus{}, fmt.Errorf("handle is required (running: %v)", sup.Handles())
+			}
+			return sup.killHandle(input.Handle)
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return []tool.Tool{outputTool, killTool}, nil
 }

--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -1,0 +1,431 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/tool"
+)
+
+// TestBashControlTools_Registered checks the two control tools exist under the
+// names the bash tool's own description tells the model to call. A mismatch
+// here is invisible until a model follows the instruction and gets "no such
+// tool".
+func TestBashControlTools_Registered(t *testing.T) {
+	sup := testSupervisor(t)
+
+	ts, err := BashControlTools(sup)
+	if err != nil {
+		t.Fatalf("BashControlTools: %v", err)
+	}
+	if len(ts) != 2 {
+		t.Fatalf("got %d tools, want 2", len(ts))
+	}
+
+	names := map[string]bool{}
+	for _, tool := range ts {
+		names[tool.Name()] = true
+	}
+	for _, want := range []string{"bash_output", "bash_kill"} {
+		if !names[want] {
+			t.Errorf("missing tool %q; got %v", want, names)
+		}
+		if !strings.Contains(bashDescription, want) {
+			t.Errorf("bash description should point the model at %q", want)
+		}
+	}
+}
+
+// runNamedTool invokes one of a tool set by name through the same Run path the
+// ADK runner uses. Driving the tools this way — rather than calling the
+// supervisor directly — is what covers argument decoding, which is where a
+// schema mistake would actually bite.
+func runNamedTool(t *testing.T, ts []tool.Tool, name string, args map[string]any) (map[string]any, error) {
+	t.Helper()
+	for _, candidate := range ts {
+		if candidate.Name() != name {
+			continue
+		}
+		r, ok := candidate.(runnableTool)
+		if !ok {
+			t.Fatalf("tool %q is not runnable", name)
+		}
+		return r.Run(mockToolCtx{Context: context.Background()}, args)
+	}
+	t.Fatalf("tool %q not found", name)
+	return nil, nil
+}
+
+// TestBashControlTools_RoundTrip drives a backgrounded command through the two
+// tools the way a model would: read, then kill.
+func TestBashControlTools_RoundTrip(t *testing.T) {
+	sup := fastSupervisor(t)
+	sb := testSandbox(t, t.TempDir())
+	ts, err := BashControlTools(sup)
+	if err != nil {
+		t.Fatalf("BashControlTools: %v", err)
+	}
+
+	out, err := bashHandler(sb, sup, nil, BashInput{Command: "sleep 0.3; echo hello; sleep 30"})
+	if err != nil {
+		t.Fatalf("bashHandler: %v", err)
+	}
+	if !out.Running || out.Handle == "" {
+		t.Fatalf("expected a backgrounded command, got %+v", out)
+	}
+
+	// wait_ms means one call, not a polling loop — the whole reason it exists.
+	res, err := runNamedTool(t, ts, "bash_output", map[string]any{
+		"handle":  out.Handle,
+		"wait_ms": 3000,
+	})
+	if err != nil {
+		t.Fatalf("bash_output: %v", err)
+	}
+	if !strings.Contains(fmtAny(res["stdout"]), "hello") {
+		t.Fatalf("bash_output did not deliver the line: %v", res)
+	}
+	if running, _ := res["running"].(bool); !running {
+		t.Errorf("command should still be running, got %v", res)
+	}
+
+	res, err = runNamedTool(t, ts, "bash_kill", map[string]any{"handle": out.Handle})
+	if err != nil {
+		t.Fatalf("bash_kill: %v", err)
+	}
+	if running, _ := res["running"].(bool); running {
+		t.Error("command still running after bash_kill")
+	}
+	if fmtAny(res["command"]) == "" {
+		t.Error("status should echo the command so the model knows what it stopped")
+	}
+
+	// A spent handle must not resolve again.
+	if _, err := runNamedTool(t, ts, "bash_output", map[string]any{"handle": out.Handle}); err == nil {
+		t.Error("expected an error reading a killed handle")
+	}
+}
+
+// TestBashTool_RunEndToEnd invokes the bash tool the way the ADK runner does,
+// covering the factory closure and the argument decoding around it.
+func TestBashTool_RunEndToEnd(t *testing.T) {
+	sb := testSandbox(t, t.TempDir())
+	bt, err := newBashTool(sb, testSupervisor(t))
+	if err != nil {
+		t.Fatalf("newBashTool: %v", err)
+	}
+
+	res, err := runNamedTool(t, []tool.Tool{bt}, "bash", map[string]any{
+		"command": "echo through-the-runner",
+	})
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	if !strings.Contains(fmtAny(res["stdout"]), "through-the-runner") {
+		t.Errorf("stdout = %v", res)
+	}
+}
+
+// TestCoreTools_UsesSuppliedSupervisor confirms the option actually reaches the
+// bash tool. Without it the CLI would attach its sink to a supervisor nothing
+// runs through, and streaming would silently never appear.
+func TestCoreTools_UsesSuppliedSupervisor(t *testing.T) {
+	sb := testSandbox(t, t.TempDir())
+	sup := testSupervisor(t)
+
+	var started int
+	sup.SetSink(func(_, kind, _ string) {
+		if kind == "start" {
+			started++
+		}
+	})
+
+	ts, err := CoreTools(sb, WithBashSupervisor(sup))
+	if err != nil {
+		t.Fatalf("CoreTools: %v", err)
+	}
+
+	if _, err := runNamedTool(t, ts, "bash", map[string]any{"command": "echo wired"}); err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	if started != 1 {
+		t.Errorf("supplied supervisor saw %d starts, want 1 — the option did not reach the tool", started)
+	}
+}
+
+// TestBashControlTools_RejectMissingHandle covers the argument guard in each
+// tool closure.
+func TestBashControlTools_RejectMissingHandle(t *testing.T) {
+	sup := fastSupervisor(t)
+	ts, err := BashControlTools(sup)
+	if err != nil {
+		t.Fatalf("BashControlTools: %v", err)
+	}
+
+	for _, name := range []string{"bash_output", "bash_kill"} {
+		if _, err := runNamedTool(t, ts, name, map[string]any{}); err == nil {
+			t.Errorf("%s accepted a call with no handle", name)
+		}
+	}
+}
+
+func fmtAny(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// TestBashControlTools_EmptyHandleNamesLiveOnes: the model sometimes calls
+// these with no handle at all. The error has to be recoverable — it must say
+// what is actually running.
+func TestBashControlTools_EmptyHandleNamesLiveOnes(t *testing.T) {
+	sup := fastSupervisor(t)
+	live := run(t, sup, "sleep 30", 10*time.Second)
+
+	if _, err := sup.readOutput("", 0); err == nil || !strings.Contains(err.Error(), live.Handle) {
+		t.Errorf("readOutput with no handle should name live handles, got %v", err)
+	}
+	if _, err := sup.killHandle("nope"); err == nil || !strings.Contains(err.Error(), live.Handle) {
+		t.Errorf("killHandle with a bad handle should name live handles, got %v", err)
+	}
+}
+
+// TestBashHandler_EmptyCommandRejected covers the guard that keeps an empty
+// tool call from spawning a shell that does nothing.
+func TestBashHandler_EmptyCommandRejected(t *testing.T) {
+	sb := testSandbox(t, t.TempDir())
+	if _, err := bashHandler(sb, testSupervisor(t), nil, BashInput{}); err == nil {
+		t.Error("expected an error for an empty command")
+	}
+}
+
+// TestBashHandler_IdleTimeoutIsHonored proves the per-call knob works: a
+// command well inside the default idle window is backgrounded early when the
+// caller asks for it.
+func TestBashHandler_IdleTimeoutIsHonored(t *testing.T) {
+	sb := testSandbox(t, t.TempDir())
+	sup := testSupervisor(t)
+	sup.heartbeat = 20 * time.Millisecond
+
+	out, err := bashHandler(sb, sup, nil, BashInput{
+		Command:     "sleep 30",
+		IdleTimeout: 150, // ms — far below the 90s default
+	})
+	if err != nil {
+		t.Fatalf("bashHandler: %v", err)
+	}
+	if !out.Running {
+		t.Fatalf("idle_timeout was ignored, got %+v", out)
+	}
+	if _, err := sup.killHandle(out.Handle); err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
+}
+
+// TestSupervisor_StartFailureIsReported covers the path where the shell never
+// runs at all — a working directory that does not exist. It must surface as an
+// error, not as a silent empty success.
+func TestSupervisor_StartFailureIsReported(t *testing.T) {
+	sup := testSupervisor(t)
+
+	_, err := sup.Run(t.Context(), runRequest{
+		dir:     "/definitely/not/a/directory",
+		command: "echo hi",
+		timeout: 5 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error when the working directory does not exist")
+	}
+}
+
+// TestSupervisor_IdleTimeoutClampedToTimeout: a caller asking for a 10s budget
+// does not want a 90s idle check silently overriding it.
+func TestSupervisor_IdleTimeoutClampedToTimeout(t *testing.T) {
+	sup := testSupervisor(t)
+	sup.heartbeat = 20 * time.Millisecond
+
+	start := time.Now()
+	out, err := sup.Run(t.Context(), runRequest{
+		dir:         t.TempDir(),
+		command:     "sleep 30",
+		timeout:     200 * time.Millisecond,
+		idleTimeout: time.Hour, // longer than the timeout; must be clamped
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Run took %s; the idle timeout was not clamped to the timeout", elapsed)
+	}
+	if !out.Running {
+		t.Errorf("expected handoff, got %+v", out)
+	}
+	if _, err := sup.killHandle(out.Handle); err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
+}
+
+// TestSupervisor_LifetimeLimitKillsBackgroundCommand covers the last-resort
+// reaper. Without it, a forgotten background command is precisely the leak this
+// change set out to remove.
+func TestSupervisor_LifetimeLimitKillsBackgroundCommand(t *testing.T) {
+	sup := fastSupervisor(t)
+	sup.maxLifetime = 200 * time.Millisecond
+
+	out := run(t, sup, "sleep 30", 10*time.Second)
+	if !out.Running {
+		t.Fatalf("expected handoff, got %+v", out)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		st, err := sup.readOutput(out.Handle, 100*time.Millisecond)
+		if err != nil {
+			t.Fatalf("readOutput: %v", err)
+		}
+		if !st.Running {
+			return // reaped by the lifetime limit, as intended
+		}
+	}
+	t.Fatal("background command outlived its lifetime limit")
+}
+
+// TestSupervisor_EvictionPrefersFinishedCommands: evicting a finished command
+// costs nothing, evicting a live one destroys work. The cap must take the free
+// one first even when a live command is older.
+func TestSupervisor_EvictionPrefersFinishedCommands(t *testing.T) {
+	sup := fastSupervisor(t)
+	sup.maxProcs = 2
+
+	// Oldest, and still running.
+	live := run(t, sup, "sleep 30", 10*time.Second)
+	// Younger, but exits almost immediately after being handed off.
+	shortLived := run(t, sup, "sleep 0.2", 10*time.Second)
+
+	waitUntilExited(t, sup, shortLived.Handle)
+
+	// A third command forces an eviction.
+	third := run(t, sup, "sleep 30", 10*time.Second)
+
+	if _, err := sup.readOutput(live.Handle, 0); err != nil {
+		t.Errorf("the live command was evicted in preference to a finished one: %v", err)
+	}
+	if _, err := sup.readOutput(third.Handle, 0); err != nil {
+		t.Errorf("the new command should be registered: %v", err)
+	}
+}
+
+// waitUntilExited blocks until the handle's command is no longer running,
+// without consuming the handle.
+func waitUntilExited(t *testing.T, sup *BashSupervisor, handle string) {
+	t.Helper()
+	p, ok := sup.lookup(handle)
+	if !ok {
+		t.Fatalf("unknown handle %q", handle)
+	}
+	select {
+	case <-p.done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("command %q never exited", handle)
+	}
+}
+
+// TestSinkWriter_FlushesLinelessOutput covers the guard against a command that
+// never emits a newline — `printf` with no trailing newline, a progress bar
+// using carriage returns. Without the flush the UI would show nothing at all.
+func TestSinkWriter_FlushesLinelessOutput(t *testing.T) {
+	sup := NewBashSupervisor()
+	t.Cleanup(sup.KillAll)
+
+	var got []string
+	sup.SetSink(func(_, _, content string) { got = append(got, content) })
+
+	p := &bashProc{sup: sup, id: "bg_test", stdout: newStream(1 << 20)}
+	w := &sinkWriter{proc: p, stream: p.stdout, kind: "output"}
+
+	w.Write([]byte(strings.Repeat("x", 9000))) // no newline anywhere
+
+	if len(got) == 0 {
+		t.Fatal("a command that never emits a newline produced no events at all")
+	}
+	if len(got[0]) < 8192 {
+		t.Errorf("flushed chunk was %d bytes, want the full buffered run", len(got[0]))
+	}
+}
+
+func TestExitCodeOf(t *testing.T) {
+	if got := exitCodeOf(nil); got != 0 {
+		t.Errorf("exitCodeOf(nil) = %d, want 0", got)
+	}
+	// A non-ExitError failure (the process never ran) has no exit status.
+	if got := exitCodeOf(errors.New("fork/exec: no such file")); got != -1 {
+		t.Errorf("exitCodeOf(plain error) = %d, want -1", got)
+	}
+
+	cmd := exec.Command("bash", "-c", "exit 9")
+	err := cmd.Run()
+	if got := exitCodeOf(err); got != 9 {
+		t.Errorf("exitCodeOf(ExitError) = %d, want 9", got)
+	}
+}
+
+func TestRoundDur(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{1500 * time.Microsecond, "2ms"},
+		{2500 * time.Millisecond, "2.5s"},
+		{90*time.Second + 4*time.Millisecond, "1m30s"},
+	}
+	for _, tt := range tests {
+		if got := roundDur(tt.in).String(); got != tt.want {
+			t.Errorf("roundDur(%v) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestClampDuration(t *testing.T) {
+	const fallback = 7 * time.Second
+	const maxDur = 10 * time.Second
+
+	if got := clampDuration(0, fallback, maxDur); got != fallback {
+		t.Errorf("unset input = %v, want the fallback %v", got, fallback)
+	}
+	if got := clampDuration(-5, fallback, maxDur); got != fallback {
+		t.Errorf("negative input = %v, want the fallback %v", got, fallback)
+	}
+	if got := clampDuration(2000, fallback, maxDur); got != 2*time.Second {
+		t.Errorf("2000ms = %v, want 2s", got)
+	}
+	if got := clampDuration(999999, fallback, maxDur); got != maxDur {
+		t.Errorf("oversized input = %v, want the cap %v", got, maxDur)
+	}
+}
+
+// TestNewStream_DefaultsWhenLimitUnset guards against a zero limit silently
+// producing a buffer that discards everything.
+func TestNewStream_DefaultsWhenLimitUnset(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		s := newStream(limit)
+		s.Write([]byte("kept"))
+		if got := s.String(); got != "kept" {
+			t.Errorf("newStream(%d) dropped its content: %q", limit, got)
+		}
+	}
+}
+
+// TestSupervisorDefaults covers the zero-value fallbacks, which only fire if a
+// supervisor is built by hand rather than by the constructor.
+func TestSupervisorDefaults(t *testing.T) {
+	s := &BashSupervisor{}
+	if got := s.heartbeatInterval(); got != heartbeatInterval {
+		t.Errorf("heartbeatInterval() = %v, want %v", got, heartbeatInterval)
+	}
+	if got := s.capacity(); got != maxBackgroundProcs {
+		t.Errorf("capacity() = %d, want %d", got, maxBackgroundProcs)
+	}
+}

--- a/internal/tools/bash_stream.go
+++ b/internal/tools/bash_stream.go
@@ -1,0 +1,101 @@
+package tools
+
+import (
+	"sync"
+)
+
+// streamCap bounds how much of one output channel is retained. A command that
+// prints a gigabyte still runs to completion; only its tail is kept, because
+// the tail is what the model is given and what the user is shown.
+const streamCap = maxOutputBytes
+
+// stream is the retained tail of one output channel of a running command,
+// addressed by absolute byte offset.
+//
+// Absolute offsets are what make incremental reads honest under a bounded
+// buffer. A reader that asks for "everything after offset N" can be told that
+// bytes it never saw were discarded, instead of silently receiving a later
+// chunk as though it followed directly on from N. Without that distinction a
+// slow reader of a noisy command would be handed a plausible, wrong transcript.
+type stream struct {
+	mu    sync.Mutex
+	data  []byte // retained tail, at most cap bytes
+	base  int64  // absolute offset of data[0]
+	end   int64  // absolute offset one past the last byte written
+	limit int
+	// notify is closed and replaced on every write, so any number of readers
+	// can wait for "something changed" without a per-reader channel.
+	notify chan struct{}
+}
+
+func newStream(limit int) *stream {
+	if limit <= 0 {
+		limit = streamCap
+	}
+	return &stream{limit: limit, notify: make(chan struct{})}
+}
+
+// Write appends p to the tail, discarding the oldest bytes past the limit.
+// It never returns an error: dropping old output is the designed behavior, not
+// a failure, and returning one would make the copying goroutine tear down a
+// command that is running perfectly well.
+func (s *stream) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	s.mu.Lock()
+	s.data = append(s.data, p...)
+	s.end += int64(len(p))
+	if over := len(s.data) - s.limit; over > 0 {
+		s.data = s.data[over:]
+		s.base += int64(over)
+	}
+	// Wake every waiter by closing the current notify channel and installing a
+	// fresh one for the next write.
+	close(s.notify)
+	s.notify = make(chan struct{})
+	s.mu.Unlock()
+	return len(p), nil
+}
+
+// since returns the retained bytes at or after off, the offset to pass next
+// time, and how many bytes between off and the returned data were dropped
+// because they aged out of the buffer.
+func (s *stream) since(off int64) (data string, next int64, dropped int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if off < s.base {
+		dropped = s.base - off
+		off = s.base
+	}
+	if off >= s.end {
+		return "", s.end, dropped
+	}
+	return string(s.data[off-s.base:]), s.end, dropped
+}
+
+// String returns the whole retained tail.
+func (s *stream) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.data)
+}
+
+// Len reports the total number of bytes ever written, including bytes since
+// discarded. Callers use it to detect progress, so it must not shrink when the
+// buffer trims.
+func (s *stream) Len() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.end
+}
+
+// wait returns a channel closed on the next write. Taking it under the same
+// lock that publishes writes is what makes the check-then-wait sequence safe:
+// a reader that saw offset N and then waits on this channel cannot miss a write
+// that lands in between.
+func (s *stream) wait() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notify
+}

--- a/internal/tools/bash_stream_test.go
+++ b/internal/tools/bash_stream_test.go
@@ -1,0 +1,108 @@
+package tools
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestStream_SinceIsIncremental(t *testing.T) {
+	s := newStream(1024)
+
+	if data, next, dropped := s.since(0); data != "" || next != 0 || dropped != 0 {
+		t.Fatalf("empty stream: got (%q, %d, %d)", data, next, dropped)
+	}
+
+	s.Write([]byte("alpha\n"))
+	data, next, dropped := s.since(0)
+	if data != "alpha\n" || dropped != 0 {
+		t.Fatalf("first read: got (%q, %d)", data, dropped)
+	}
+
+	// A read from the returned offset must see only what arrived afterwards.
+	s.Write([]byte("beta\n"))
+	data, next, dropped = s.since(next)
+	if data != "beta\n" || dropped != 0 {
+		t.Fatalf("second read: got (%q, %d)", data, dropped)
+	}
+
+	if data, _, _ := s.since(next); data != "" {
+		t.Errorf("caught-up read should be empty, got %q", data)
+	}
+}
+
+// TestStream_ReportsDroppedBytes is the honesty requirement. A bounded buffer
+// must not hand a reader a later chunk as though it followed directly on from
+// the offset it asked for — a slow reader of a noisy command would otherwise
+// assemble a plausible, wrong transcript.
+func TestStream_ReportsDroppedBytes(t *testing.T) {
+	s := newStream(16)
+
+	s.Write([]byte("0123456789"))
+	s.Write([]byte("abcdefghij")) // total 20 bytes, 4 must age out
+
+	data, next, dropped := s.since(0)
+	if dropped != 4 {
+		t.Errorf("dropped = %d, want 4", dropped)
+	}
+	if data != "456789abcdefghij" {
+		t.Errorf("data = %q, want the retained tail", data)
+	}
+	if next != 20 {
+		t.Errorf("next = %d, want 20 (absolute offset, not buffer length)", next)
+	}
+}
+
+// TestStream_LenCountsEverythingEverWritten: Len drives the idle clock and the
+// progress checks, so it must not shrink when the buffer trims.
+func TestStream_LenCountsEverythingEverWritten(t *testing.T) {
+	s := newStream(8)
+	s.Write([]byte("aaaaaaaaaaaaaaaa")) // 16 bytes into an 8-byte buffer
+	if got := s.Len(); got != 16 {
+		t.Errorf("Len() = %d, want 16", got)
+	}
+	if got := len(s.String()); got != 8 {
+		t.Errorf("retained tail = %d bytes, want 8", got)
+	}
+}
+
+// TestStream_WaitWakesOnWrite covers the blocking read used by bash_output, and
+// specifically the check-then-wait ordering: a waiter that took the channel
+// before a write must still be woken by it.
+func TestStream_WaitWakesOnWrite(t *testing.T) {
+	s := newStream(1024)
+
+	ch := s.wait()
+	select {
+	case <-ch:
+		t.Fatal("wait channel fired before any write")
+	default:
+	}
+
+	go s.Write([]byte("x"))
+	<-ch // blocks until the write lands; the test times out if it never does
+}
+
+func TestStream_ConcurrentWritesAreSerialized(t *testing.T) {
+	s := newStream(1 << 20)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				s.Write([]byte("0123456789"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	const want = 50 * 20 * 10
+	if got := s.Len(); got != want {
+		t.Errorf("Len() = %d, want %d", got, want)
+	}
+	if got := strings.Count(s.String(), "0123456789"); got != want/10 {
+		t.Errorf("found %d intact chunks, want %d — writes interleaved", got, want/10)
+	}
+}

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -1,0 +1,640 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/procs"
+)
+
+const (
+	// defaultIdleTimeout is how long a command may produce no output at all
+	// before it is handed off to the background.
+	//
+	// The value is calibrated against real quiet commands rather than picked
+	// round: a cold `go build ./...` on this repo prints nothing for ~28s, and
+	// a cold test run is worse. A threshold near that would background ordinary
+	// builds and cost a round trip every time. Ninety seconds clears them while
+	// still reacting long before a hopeless command would otherwise sit there —
+	// which matters most when the model sets a generous timeout, since the idle
+	// check then fires minutes before the hard limit.
+	//
+	// Nothing is killed at the threshold, so erring low is cheap; erring low
+	// enough to trip on every build is merely annoying.
+	defaultIdleTimeout = 90 * time.Second
+
+	// heartbeatInterval is how often a running command reports that it is still
+	// alive. It drives the "45s, no output" line in the UI, which is the whole
+	// point of streaming — a stall you can see is not a hang.
+	heartbeatInterval = 5 * time.Second
+
+	// maxBackgroundProcs caps concurrently backgrounded commands. Handing off
+	// instead of killing means nothing reaps a forgotten command, so the cap is
+	// what stops a confused model from accumulating them without bound.
+	maxBackgroundProcs = 8
+
+	// backgroundMaxLifetime is the longest a backgrounded command may run
+	// before it is killed outright. It is the last line of defense against the
+	// exact leak this package exists to prevent.
+	backgroundMaxLifetime = 30 * time.Minute
+)
+
+// OutputSink receives live activity from running shell commands.
+//
+// kind is one of "start", "output", "stderr", "heartbeat", "stall",
+// "background" or "exit". Implementations must not block: the sink is called
+// from the goroutines copying the command's pipes, and blocking there stalls
+// the command itself. The TUI's implementation drops events when its channel
+// is full, which is the correct trade — a dropped progress line costs nothing,
+// a stalled pipe costs the command.
+type OutputSink func(execID, kind, content string)
+
+// BashSupervisor runs shell commands, streams their output while they run, and
+// owns any command that outlives its foreground call.
+//
+// The unit of work is a process group, not a process. A shell command is a tree
+// — pipelines, subshells, whatever the model wrote — and every operation here
+// (cancel, timeout, kill) acts on the whole tree. That is the difference
+// between a timeout that works and one that leaves orphans holding pipes.
+type BashSupervisor struct {
+	mu    sync.Mutex
+	sink  OutputSink
+	procs map[string]*bashProc
+	seq   uint64
+
+	// Tunables, overridable in tests.
+	idleTimeout time.Duration
+	heartbeat   time.Duration
+	maxProcs    int
+	maxLifetime time.Duration
+}
+
+// NewBashSupervisor returns a supervisor with no sink attached. Output is still
+// captured and still streamed internally; it just goes nowhere visible until
+// SetSink is called.
+func NewBashSupervisor() *BashSupervisor {
+	return &BashSupervisor{
+		procs:       make(map[string]*bashProc),
+		idleTimeout: defaultIdleTimeout,
+		heartbeat:   heartbeatInterval,
+		maxProcs:    maxBackgroundProcs,
+		maxLifetime: backgroundMaxLifetime,
+	}
+}
+
+// SetSink attaches a live-output destination. It may be called after tools are
+// built, which matters because the UI channel the sink writes to is created
+// later in startup than the tool registry.
+func (s *BashSupervisor) SetSink(sink OutputSink) {
+	s.mu.Lock()
+	s.sink = sink
+	s.mu.Unlock()
+}
+
+func (s *BashSupervisor) emit(id, kind, content string) {
+	s.mu.Lock()
+	sink := s.sink
+	s.mu.Unlock()
+	if sink != nil {
+		sink(id, kind, content)
+	}
+}
+
+func (s *BashSupervisor) nextID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seq++
+	return fmt.Sprintf("bg_%d", s.seq)
+}
+
+// bashProc is one running (or finished) shell command.
+type bashProc struct {
+	sup     *BashSupervisor
+	id      string
+	command string
+	dir     string
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+
+	stdout *stream
+	stderr *stream
+
+	started time.Time
+	lastOut atomic.Int64 // UnixNano of the most recent byte of output
+
+	done     chan struct{} // closed once the process has been reaped
+	exitCode int
+	waitErr  error
+	killed   atomic.Bool
+
+	// Read cursors for incremental reads by the model. Guarded by curMu rather
+	// than by the streams' own locks: they belong to the reader, not the writer.
+	curMu  sync.Mutex
+	outCur int64
+	errCur int64
+}
+
+func (p *bashProc) markOutput() {
+	p.lastOut.Store(time.Now().UnixNano())
+}
+
+func (p *bashProc) idleFor() time.Duration {
+	last := p.lastOut.Load()
+	if last == 0 {
+		return time.Since(p.started)
+	}
+	return time.Since(time.Unix(0, last))
+}
+
+func (p *bashProc) running() bool {
+	select {
+	case <-p.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// runRequest is one call into the supervisor.
+type runRequest struct {
+	dir         string
+	command     string
+	timeout     time.Duration
+	idleTimeout time.Duration
+}
+
+// Run executes command and blocks until it finishes, stalls, or exceeds its
+// timeout.
+//
+// It returns without killing anything. A command that outruns either limit is
+// handed to the background and reported with a handle, because the alternative
+// — killing it — throws away work the model may still want and tells it nothing
+// about why. The model then chooses: read more output, or kill it.
+//
+// Canceling ctx (the user pressing Esc, the turn ending) does kill the command
+// and everything it spawned, but only while it is still in the foreground. Once
+// handed off it is the supervisor's, and outlives the turn.
+func (s *BashSupervisor) Run(ctx context.Context, req runRequest) (BashOutput, error) {
+	if req.timeout <= 0 {
+		req.timeout = defaultBashTimeout
+	}
+	if req.idleTimeout <= 0 {
+		req.idleTimeout = s.idleTimeout
+	}
+	// Never stall out before the hard limit would have fired anyway; a caller
+	// asking for a 10s timeout does not want a 30s idle check.
+	if req.idleTimeout > req.timeout {
+		req.idleTimeout = req.timeout
+	}
+
+	p, err := s.start(ctx, req)
+	if err != nil {
+		return BashOutput{}, err
+	}
+
+	return s.supervise(ctx, p, req)
+}
+
+// start launches the command and the goroutine that reaps it.
+//
+// The command's own context is detached from ctx on purpose. Foreground
+// cancellation is handled explicitly in supervise, which stops watching once
+// the command is handed off — a command that survives its turn must not be
+// killed by that turn ending.
+func (s *BashSupervisor) start(ctx context.Context, req runRequest) (*bashProc, error) {
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+
+	p := &bashProc{
+		sup:     s,
+		id:      s.nextID(),
+		command: req.command,
+		dir:     req.dir,
+		cancel:  cancel,
+		stdout:  newStream(streamCap),
+		stderr:  newStream(streamCap),
+		started: time.Now(),
+		done:    make(chan struct{}),
+	}
+
+	cmd := exec.CommandContext(runCtx, "bash", "-c", req.command)
+	cmd.Dir = req.dir
+	cmd.Stdout = &sinkWriter{proc: p, stream: p.stdout, kind: "output"}
+	cmd.Stderr = &sinkWriter{proc: p, stream: p.stderr, kind: "stderr"}
+	procs.Isolate(cmd)
+	p.cmd = cmd
+
+	s.emit(p.id, "start", req.command)
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("starting command: %w", err)
+	}
+
+	go func() {
+		p.waitErr = cmd.Wait()
+		p.exitCode = exitCodeOf(p.waitErr)
+		close(p.done)
+	}()
+
+	return p, nil
+}
+
+// supervise waits for the command on behalf of the caller, reporting progress
+// and deciding what to do when it takes too long.
+func (s *BashSupervisor) supervise(ctx context.Context, p *bashProc, req runRequest) (BashOutput, error) {
+	deadline := time.NewTimer(req.timeout)
+	defer deadline.Stop()
+	tick := time.NewTicker(s.heartbeatInterval())
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-p.done:
+			return s.finish(p), nil
+
+		case <-ctx.Done():
+			// The turn was canceled while this command was still in the
+			// foreground. Kill the whole group and let the caller report the
+			// cancellation; nothing is backgrounded, because nobody is left to
+			// ask about it.
+			p.terminate()
+			<-p.done
+			return BashOutput{}, ctx.Err()
+
+		case <-deadline.C:
+			return s.background(p, fmt.Sprintf("still running after %s", roundDur(time.Since(p.started)))), nil
+
+		case <-tick.C:
+			idle := p.idleFor()
+			s.emit(p.id, "heartbeat", fmt.Sprintf("%s elapsed, %s without output",
+				roundDur(time.Since(p.started)), roundDur(idle)))
+			if idle >= req.idleTimeout {
+				s.emit(p.id, "stall", fmt.Sprintf("no output for %s", roundDur(idle)))
+				return s.background(p, fmt.Sprintf("no output for %s", roundDur(idle))), nil
+			}
+		}
+	}
+}
+
+func (s *BashSupervisor) heartbeatInterval() time.Duration {
+	if s.heartbeat > 0 {
+		return s.heartbeat
+	}
+	return heartbeatInterval
+}
+
+// finish builds the result for a command that ran to completion.
+func (s *BashSupervisor) finish(p *bashProc) BashOutput {
+	p.cancel()
+	elapsed := roundDur(time.Since(p.started))
+	s.emit(p.id, "exit", fmt.Sprintf("exit %d in %s", p.exitCode, elapsed))
+
+	stdout := p.stdout.String()
+	stderr := p.stderr.String()
+
+	// SIGPIPE (exit 141 = signal 13 + 128) is benign — the consumer closed the
+	// pipe before the producer finished writing. Treat it as success.
+	exitCode := p.exitCode
+	if exitCode == 141 {
+		exitCode = 0
+	}
+
+	out := BashOutput{
+		Stdout:   redactSecrets(truncateOutput(stdout)),
+		Stderr:   redactSecrets(truncateOutput(stripRuntimeNoise(stderr))),
+		ExitCode: exitCode,
+	}
+	// A failure to start at all (bad interpreter, missing cwd) surfaces through
+	// waitErr rather than an exit status, and would otherwise read as a silent
+	// success with no output.
+	if p.waitErr != nil && exitCode == 0 {
+		var exitErr *exec.ExitError
+		if !errors.As(p.waitErr, &exitErr) {
+			out.ExitCode = -1
+			out.Stderr = strings.TrimSpace(out.Stderr + "\n" + p.waitErr.Error())
+		}
+	}
+	return out
+}
+
+// background hands a still-running command to the supervisor and returns what
+// it has produced so far.
+//
+// The reason string is written for the model, not for a log: it has to be
+// specific enough to act on, since "no output for 30s" and "still running after
+// 2m0s" call for different responses.
+func (s *BashSupervisor) background(p *bashProc, reason string) BashOutput {
+	s.register(p)
+	s.emit(p.id, "background", reason)
+
+	stdout, outCur, _ := p.stdout.since(0)
+	stderr, errCur, _ := p.stderr.since(0)
+	p.curMu.Lock()
+	p.outCur, p.errCur = outCur, errCur
+	p.curMu.Unlock()
+
+	note := fmt.Sprintf(
+		"Command %s and was moved to the background; it is still running. "+
+			"Read more with bash_output(handle=%q) or stop it with bash_kill(handle=%q). "+
+			"Output above is everything produced so far.",
+		reason, p.id, p.id)
+	if strings.TrimSpace(stdout) == "" && strings.TrimSpace(stderr) == "" {
+		note += " It has produced no output at all — if that is unexpected, the command is probably too broad (a filesystem-wide scan, or a prompt waiting for input) and should be killed and narrowed."
+	}
+
+	return BashOutput{
+		Stdout:   redactSecrets(truncateOutput(stdout)),
+		Stderr:   redactSecrets(truncateOutput(stripRuntimeNoise(stderr))),
+		ExitCode: -1,
+		Running:  true,
+		Handle:   p.id,
+		Note:     note,
+	}
+}
+
+// register adds p to the background set, enforcing the cap and arming the
+// lifetime backstop.
+func (s *BashSupervisor) register(p *bashProc) {
+	s.mu.Lock()
+	if len(s.procs) >= s.capacity() {
+		if victim := oldestLocked(s.procs); victim != nil {
+			delete(s.procs, victim.id)
+			// Kill outside the lock; terminate can block briefly on signaling.
+			defer func() {
+				victim.terminate()
+				s.emit(victim.id, "exit", "killed: too many background commands")
+			}()
+		}
+	}
+	s.procs[p.id] = p
+	lifetime := s.maxLifetime
+	s.mu.Unlock()
+
+	if lifetime <= 0 {
+		lifetime = backgroundMaxLifetime
+	}
+	go s.reap(p, lifetime)
+}
+
+func (s *BashSupervisor) capacity() int {
+	if s.maxProcs > 0 {
+		return s.maxProcs
+	}
+	return maxBackgroundProcs
+}
+
+// reap kills a background command that overstays, and releases its slot when it
+// exits on its own.
+func (s *BashSupervisor) reap(p *bashProc, lifetime time.Duration) {
+	timer := time.NewTimer(lifetime)
+	defer timer.Stop()
+	select {
+	case <-p.done:
+		p.cancel()
+		s.emit(p.id, "exit", fmt.Sprintf("exit %d in %s", p.exitCode, roundDur(time.Since(p.started))))
+	case <-timer.C:
+		p.terminate()
+		s.emit(p.id, "exit", fmt.Sprintf("killed after %s (background lifetime limit)", roundDur(lifetime)))
+	}
+}
+
+// oldestLocked returns the longest-running entry, preferring one that has
+// already exited — evicting a finished command costs nothing, evicting a live
+// one destroys work.
+func oldestLocked(m map[string]*bashProc) *bashProc {
+	var oldestDone, oldestLive *bashProc
+	for _, p := range m {
+		if p.running() {
+			if oldestLive == nil || p.started.Before(oldestLive.started) {
+				oldestLive = p
+			}
+			continue
+		}
+		if oldestDone == nil || p.started.Before(oldestDone.started) {
+			oldestDone = p
+		}
+	}
+	if oldestDone != nil {
+		return oldestDone
+	}
+	return oldestLive
+}
+
+// terminate stops the command and everything it spawned, and does not return
+// until it has been reaped or the wait delay has elapsed.
+func (p *bashProc) terminate() {
+	p.killed.Store(true)
+	_ = procs.Kill(p.cmd)
+	// cancel() also runs the exec cancellation path, which is what enforces
+	// WaitDelay and force-closes pipes a grandchild is still holding.
+	p.cancel()
+}
+
+func (s *BashSupervisor) lookup(handle string) (*bashProc, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.procs[handle]
+	return p, ok
+}
+
+func (s *BashSupervisor) forget(handle string) {
+	s.mu.Lock()
+	delete(s.procs, handle)
+	s.mu.Unlock()
+}
+
+// Handles lists the background commands the supervisor currently knows about,
+// oldest first.
+func (s *BashSupervisor) Handles() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.procs))
+	for id := range s.procs {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// KillAll stops every background command. Call it when the session ends: a
+// backgrounded command has no other owner, and leaving it running is precisely
+// the leak this supervisor exists to prevent.
+func (s *BashSupervisor) KillAll() {
+	s.mu.Lock()
+	all := make([]*bashProc, 0, len(s.procs))
+	for _, p := range s.procs {
+		all = append(all, p)
+	}
+	s.procs = make(map[string]*bashProc)
+	s.mu.Unlock()
+
+	for _, p := range all {
+		p.terminate()
+	}
+}
+
+// readOutput returns everything produced since the caller's last read.
+//
+// A finished command is forgotten once its exit status has been reported, so a
+// handle is good for exactly one final read. Holding finished commands
+// indefinitely would turn the cap into a queue of corpses.
+func (s *BashSupervisor) readOutput(handle string, wait time.Duration) (BashStatus, error) {
+	p, ok := s.lookup(handle)
+	if !ok {
+		return BashStatus{}, fmt.Errorf("unknown handle %q (running: %s)", handle, strings.Join(s.Handles(), ", "))
+	}
+
+	if wait > 0 {
+		p.awaitChange(wait)
+	}
+
+	p.curMu.Lock()
+	outStr, outNext, outDropped := p.stdout.since(p.outCur)
+	errStr, errNext, errDropped := p.stderr.since(p.errCur)
+	p.outCur, p.errCur = outNext, errNext
+	p.curMu.Unlock()
+
+	st := BashStatus{
+		Handle:  handle,
+		Command: p.command,
+		Running: p.running(),
+		Stdout:  redactSecrets(truncateOutput(outStr)),
+		Stderr:  redactSecrets(truncateOutput(stripRuntimeNoise(errStr))),
+		Elapsed: roundDur(time.Since(p.started)).String(),
+	}
+	if dropped := outDropped + errDropped; dropped > 0 {
+		st.Note = fmt.Sprintf("%d bytes of earlier output were discarded (buffer limit).", dropped)
+	}
+	if st.Running {
+		st.Idle = roundDur(p.idleFor()).String()
+		if outStr == "" && errStr == "" {
+			st.Note = strings.TrimSpace(st.Note + " No new output since the last read.")
+		}
+		return st, nil
+	}
+
+	st.ExitCode = p.exitCode
+	if p.killed.Load() {
+		st.Note = strings.TrimSpace(st.Note + " The command was killed.")
+	}
+	s.forget(handle)
+	return st, nil
+}
+
+// awaitChange blocks until the command produces output, exits, or the wait
+// elapses. Waiting on the streams' notify channels means a poll costs one
+// round trip instead of a spin.
+func (p *bashProc) awaitChange(wait time.Duration) {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-p.done:
+	case <-p.stdout.wait():
+	case <-p.stderr.wait():
+	case <-timer.C:
+	}
+}
+
+// killHandle stops a background command and returns its final state.
+func (s *BashSupervisor) killHandle(handle string) (BashStatus, error) {
+	p, ok := s.lookup(handle)
+	if !ok {
+		return BashStatus{}, fmt.Errorf("unknown handle %q (running: %s)", handle, strings.Join(s.Handles(), ", "))
+	}
+	p.terminate()
+
+	// Give the reaper a moment so the reported exit status is the real one
+	// rather than "still running".
+	select {
+	case <-p.done:
+	case <-time.After(procs.DefaultWaitDelay):
+	}
+
+	p.curMu.Lock()
+	outStr, outNext, _ := p.stdout.since(p.outCur)
+	errStr, errNext, _ := p.stderr.since(p.errCur)
+	p.outCur, p.errCur = outNext, errNext
+	p.curMu.Unlock()
+
+	st := BashStatus{
+		Handle:   handle,
+		Command:  p.command,
+		Running:  false,
+		ExitCode: p.exitCode,
+		Stdout:   redactSecrets(truncateOutput(outStr)),
+		Stderr:   redactSecrets(truncateOutput(stripRuntimeNoise(errStr))),
+		Elapsed:  roundDur(time.Since(p.started)).String(),
+		Note:     "Killed, along with every process it spawned.",
+	}
+	s.forget(handle)
+	return st, nil
+}
+
+// sinkWriter fans one output channel into the retained buffer, the idle clock,
+// and the live sink.
+//
+// It splits on newlines before emitting because the sink feeds a UI that
+// renders one event per row: forwarding raw pipe chunks would put half-lines in
+// the display and split words across rows at arbitrary boundaries.
+type sinkWriter struct {
+	proc    *bashProc
+	stream  *stream
+	kind    string
+	partial []byte
+}
+
+func (w *sinkWriter) Write(b []byte) (int, error) {
+	n, _ := w.stream.Write(b)
+	w.proc.markOutput()
+
+	w.partial = append(w.partial, b...)
+	for {
+		i := bytes.IndexByte(w.partial, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.partial[:i]), "\r")
+		w.partial = w.partial[i+1:]
+		if strings.TrimSpace(line) != "" {
+			w.proc.sup.emit(w.proc.id, w.kind, line)
+		}
+	}
+	// Don't let a command that never emits a newline grow this without bound.
+	if len(w.partial) > 8192 {
+		w.proc.sup.emit(w.proc.id, w.kind, string(w.partial))
+		w.partial = w.partial[:0]
+	}
+	return n, nil
+}
+
+func exitCodeOf(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// roundDur trims durations to something a human reads at a glance: "1m30s",
+// not "1m30.004283ms".
+func roundDur(d time.Duration) time.Duration {
+	switch {
+	case d >= time.Minute:
+		return d.Round(time.Second)
+	case d >= time.Second:
+		return d.Round(100 * time.Millisecond)
+	default:
+		return d.Round(time.Millisecond)
+	}
+}

--- a/internal/tools/bash_supervisor_test.go
+++ b/internal/tools/bash_supervisor_test.go
@@ -1,0 +1,349 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fastSupervisor is tuned so stall handling happens in milliseconds. The
+// thresholds are the only thing scaled down; every code path under test is the
+// production one.
+func fastSupervisor(t *testing.T) *BashSupervisor {
+	t.Helper()
+	sup := NewBashSupervisor()
+	sup.idleTimeout = 150 * time.Millisecond
+	sup.heartbeat = 25 * time.Millisecond
+	t.Cleanup(sup.KillAll)
+	return sup
+}
+
+func run(t *testing.T, sup *BashSupervisor, command string, timeout time.Duration) BashOutput {
+	t.Helper()
+	out, err := sup.Run(context.Background(), runRequest{
+		dir:     t.TempDir(),
+		command: command,
+		timeout: timeout,
+	})
+	if err != nil {
+		t.Fatalf("Run(%q): %v", command, err)
+	}
+	return out
+}
+
+// TestSupervisor_SilentCommandIsBackgrounded is the case that wedged two
+// sessions: a command that produces nothing and never finishes. It must come
+// back promptly with a handle, still running.
+func TestSupervisor_SilentCommandIsBackgrounded(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	out := run(t, sup, "sleep 30", 10*time.Second)
+
+	if !out.Running {
+		t.Fatalf("expected the silent command to be backgrounded, got %+v", out)
+	}
+	if out.Handle == "" {
+		t.Fatal("expected a handle")
+	}
+	if out.ExitCode != -1 {
+		t.Errorf("ExitCode = %d, want -1 while running", out.ExitCode)
+	}
+	// The note has to be actionable: a model that cannot tell "produced nothing"
+	// from "produced something slowly" cannot decide whether to kill it.
+	if !strings.Contains(out.Note, "no output at all") {
+		t.Errorf("Note should call out the total absence of output, got %q", out.Note)
+	}
+
+	st, err := sup.killHandle(out.Handle)
+	if err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
+	if st.Running {
+		t.Error("still running after kill")
+	}
+}
+
+// TestSupervisor_ChattyCommandIsNotBackgrounded is the guard against an overly
+// eager idle check. A command that keeps talking is making progress, however
+// long it takes, and must be left alone.
+func TestSupervisor_ChattyCommandIsNotBackgrounded(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	// Runs for ~500ms, well past the 150ms idle threshold, but never silent
+	// for longer than 50ms.
+	out := run(t, sup, "for i in $(seq 1 10); do echo tick-$i; sleep 0.05; done", 30*time.Second)
+
+	if out.Running {
+		t.Fatalf("a command producing steady output must not be backgrounded: %+v", out)
+	}
+	if out.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", out.ExitCode)
+	}
+	if !strings.Contains(out.Stdout, "tick-10") {
+		t.Errorf("stdout missing the last line: %q", out.Stdout)
+	}
+}
+
+// TestSupervisor_BackgroundOutputIsIncremental verifies that reads pick up
+// where the previous one stopped, and that the final read carries the exit
+// status.
+func TestSupervisor_BackgroundOutputIsIncremental(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	// Silent long enough to be handed off, then produces output and exits.
+	out := run(t, sup, "sleep 0.4; echo first; sleep 0.2; echo second", 10*time.Second)
+	if !out.Running {
+		t.Fatalf("expected handoff, got %+v", out)
+	}
+
+	first := readUntil(t, sup, out.Handle, "first")
+	if strings.Contains(first, "second") {
+		t.Fatalf("first read raced ahead of the command: %q", first)
+	}
+
+	// The second read must not repeat what the first already returned.
+	second := readUntil(t, sup, out.Handle, "second")
+	if strings.Contains(second, "first") {
+		t.Errorf("second read repeated already-delivered output: %q", second)
+	}
+}
+
+// readUntil polls a handle until want appears, returning the read that carried
+// it. It fails the test rather than looping forever.
+func readUntil(t *testing.T, sup *BashSupervisor, handle, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		st, err := sup.readOutput(handle, 200*time.Millisecond)
+		if err != nil {
+			t.Fatalf("readOutput: %v", err)
+		}
+		if strings.Contains(st.Stdout, want) {
+			return st.Stdout
+		}
+		if !st.Running {
+			t.Fatalf("command exited before producing %q", want)
+		}
+	}
+	t.Fatalf("timed out waiting for %q", want)
+	return ""
+}
+
+// TestSupervisor_FinalReadReportsExitAndSpendsHandle covers the end of a
+// backgrounded command's life: the exit code is delivered once, and the handle
+// is then gone so finished commands cannot pile up.
+func TestSupervisor_FinalReadReportsExitAndSpendsHandle(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	out := run(t, sup, "sleep 0.3; echo done; exit 5", 10*time.Second)
+	if !out.Running {
+		t.Fatalf("expected handoff, got %+v", out)
+	}
+
+	// Reads are incremental, so the output and the exit status may arrive in
+	// different reads: whichever read observes the last write delivers the
+	// bytes, and the exit code lands on the first read taken after the process
+	// is reaped. What must hold is that nothing is lost across the sequence.
+	var (
+		final     BashStatus
+		collected strings.Builder
+	)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		st, err := sup.readOutput(out.Handle, 500*time.Millisecond)
+		if err != nil {
+			t.Fatalf("readOutput: %v", err)
+		}
+		collected.WriteString(st.Stdout)
+		if !st.Running {
+			final = st
+			break
+		}
+	}
+	if final.Handle == "" {
+		t.Fatal("command never reported completion")
+	}
+	if final.ExitCode != 5 {
+		t.Errorf("ExitCode = %d, want 5", final.ExitCode)
+	}
+	if !strings.Contains(collected.String(), "done") {
+		t.Errorf("output was lost across the read sequence: %q", collected.String())
+	}
+	if _, err := sup.readOutput(out.Handle, 0); err == nil {
+		t.Error("a spent handle should no longer resolve")
+	}
+}
+
+// TestSupervisor_ForegroundCancellationKillsCommand covers Esc during a turn:
+// a command still in the foreground dies with its whole tree and is not
+// silently promoted to the background.
+func TestSupervisor_ForegroundCancellationKillsCommand(t *testing.T) {
+	sup := fastSupervisor(t)
+	sup.idleTimeout = time.Hour // keep it foreground until we cancel
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := sup.Run(ctx, runRequest{dir: t.TempDir(), command: "sleep 30 | cat", timeout: time.Hour})
+	if err == nil {
+		t.Fatal("expected a cancellation error")
+	}
+	if elapsed := time.Since(start); elapsed > 15*time.Second {
+		t.Fatalf("Run blocked for %s after cancellation", elapsed)
+	}
+	if got := sup.Handles(); len(got) != 0 {
+		t.Errorf("canceled command should not be backgrounded, got handles %v", got)
+	}
+}
+
+// TestSupervisor_KillAllStopsEverything covers session shutdown. A
+// backgrounded command has no other owner, so anything left here is a leak of
+// exactly the kind this change removes.
+func TestSupervisor_KillAllStopsEverything(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	var handles []string
+	for range 3 {
+		out := run(t, sup, "sleep 30", 10*time.Second)
+		if !out.Running {
+			t.Fatalf("expected handoff, got %+v", out)
+		}
+		handles = append(handles, out.Handle)
+	}
+	if got := len(sup.Handles()); got != 3 {
+		t.Fatalf("Handles() = %d, want 3", got)
+	}
+
+	sup.KillAll()
+
+	if got := sup.Handles(); len(got) != 0 {
+		t.Errorf("Handles() = %v, want empty after KillAll", got)
+	}
+	for _, h := range handles {
+		if _, err := sup.readOutput(h, 0); err == nil {
+			t.Errorf("handle %s still resolves after KillAll", h)
+		}
+	}
+}
+
+// TestSupervisor_CapEvictsOldest keeps a confused model from accumulating
+// background commands without bound.
+func TestSupervisor_CapEvictsOldest(t *testing.T) {
+	sup := fastSupervisor(t)
+	sup.maxProcs = 2
+
+	first := run(t, sup, "sleep 30", 10*time.Second)
+	second := run(t, sup, "sleep 30", 10*time.Second)
+	third := run(t, sup, "sleep 30", 10*time.Second)
+
+	handles := sup.Handles()
+	if len(handles) != 2 {
+		t.Fatalf("Handles() = %v, want 2 entries", handles)
+	}
+	if _, err := sup.readOutput(first.Handle, 0); err == nil {
+		t.Error("oldest handle should have been evicted")
+	}
+	for _, h := range []string{second.Handle, third.Handle} {
+		if _, err := sup.readOutput(h, 0); err != nil {
+			t.Errorf("handle %s should have survived eviction: %v", h, err)
+		}
+	}
+}
+
+// TestSupervisor_SinkStreamsOutput covers the live view: the UI has to receive
+// output while the command runs, not after it finishes. Without that, a stall
+// is indistinguishable from a hang.
+func TestSupervisor_SinkStreamsOutput(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	var mu sync.Mutex
+	kinds := map[string][]string{}
+	sup.SetSink(func(_, kind, content string) {
+		mu.Lock()
+		kinds[kind] = append(kinds[kind], content)
+		mu.Unlock()
+	})
+
+	out := run(t, sup, "echo alpha; echo beta >&2; exit 0", 10*time.Second)
+	if out.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d", out.ExitCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !contains(kinds["output"], "alpha") {
+		t.Errorf("stdout was not streamed: %v", kinds["output"])
+	}
+	if !contains(kinds["stderr"], "beta") {
+		t.Errorf("stderr was not streamed: %v", kinds["stderr"])
+	}
+	if len(kinds["start"]) != 1 {
+		t.Errorf("expected exactly one start event, got %v", kinds["start"])
+	}
+	if len(kinds["exit"]) != 1 {
+		t.Errorf("expected exactly one exit event, got %v", kinds["exit"])
+	}
+}
+
+// TestSupervisor_SinkReportsStall is the timer hook: silence must be visible
+// while it is happening.
+func TestSupervisor_SinkReportsStall(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	var mu sync.Mutex
+	var heartbeats, stalls int
+	sup.SetSink(func(_, kind, _ string) {
+		mu.Lock()
+		switch kind {
+		case "heartbeat":
+			heartbeats++
+		case "stall":
+			stalls++
+		}
+		mu.Unlock()
+	})
+
+	out := run(t, sup, "sleep 30", 10*time.Second)
+	if !out.Running {
+		t.Fatalf("expected handoff, got %+v", out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if heartbeats == 0 {
+		t.Error("no heartbeat reached the sink; a stall would be invisible")
+	}
+	if stalls != 1 {
+		t.Errorf("stall events = %d, want 1", stalls)
+	}
+}
+
+// TestSupervisor_UnknownHandleNamesTheLiveOnes: an error the model can recover
+// from beats one it can only apologize for.
+func TestSupervisor_UnknownHandleNamesTheLiveOnes(t *testing.T) {
+	sup := fastSupervisor(t)
+	live := run(t, sup, "sleep 30", 10*time.Second)
+
+	_, err := sup.readOutput("bg_nope", 0)
+	if err == nil {
+		t.Fatal("expected an error for an unknown handle")
+	}
+	if !strings.Contains(err.Error(), live.Handle) {
+		t.Errorf("error should list live handles, got %q", err)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if strings.Contains(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -9,13 +9,24 @@ import (
 	"testing"
 )
 
+// testSupervisor returns a supervisor that stops everything it started when the
+// test ends. Background handoff means a test can leave a live process behind,
+// and a leaked `sleep` outliving the run is exactly the failure mode this whole
+// change exists to remove.
+func testSupervisor(t *testing.T) *BashSupervisor {
+	t.Helper()
+	sup := NewBashSupervisor()
+	t.Cleanup(sup.KillAll)
+	return sup
+}
+
 // TestNewBashTool ensures newBashTool constructs successfully and is registered
 // with the correct name and description.
 func TestNewBashTool(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
 
-	tool, err := newBashTool(sb)
+	tool, err := newBashTool(sb, testSupervisor(t))
 	if err != nil {
 		t.Fatalf("newBashTool: %v", err)
 	}
@@ -36,7 +47,7 @@ func TestBashHandler_TimeoutCappedAtTenMinutes(t *testing.T) {
 
 	// Timeout of 20 minutes should be capped at 10 minutes.
 	// The command itself completes in a fraction of a second.
-	out, err := bashHandler(sb, nil, BashInput{Command: "echo capped", Timeout: 20 * 60 * 1000})
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "echo capped", Timeout: 20 * 60 * 1000})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
@@ -54,7 +65,7 @@ func TestBashHandler_TimeoutZeroUsesDefault(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
 
-	out, err := bashHandler(sb, nil, BashInput{Command: "echo default", Timeout: 0})
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "echo default", Timeout: 0})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
@@ -72,7 +83,7 @@ func TestBashHandler_SigpipeTreatedAsSuccess(t *testing.T) {
 	// yes will receive SIGPIPE when head closes the pipe after 1 line.
 	// Bash reports the producer exit status as 141 (128 + SIGPIPE=13).
 	// The `pipefail` option surfaces SIGPIPE to the shell's exit code.
-	out, err := bashHandler(sb, nil, BashInput{
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
 		Command: "set -o pipefail; yes | head -n 1",
 	})
 	if err != nil {
@@ -93,7 +104,7 @@ func TestBashHandler_SecretsRedacted(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
 
-	out, err := bashHandler(sb, nil, BashInput{
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
 		Command: "echo export API_KEY=sk-abcdefghijklmnopqrstuvwxyz1234",
 	})
 	if err != nil {
@@ -119,7 +130,7 @@ func TestBashHandler_RunsInSandboxDir(t *testing.T) {
 		t.Fatalf("write marker: %v", err)
 	}
 
-	out, err := bashHandler(sb, nil, BashInput{Command: "cat marker.txt"})
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "cat marker.txt"})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
@@ -131,15 +142,16 @@ func TestBashHandler_RunsInSandboxDir(t *testing.T) {
 	}
 }
 
-// TestBashHandler_TimeoutExact confirms a command that runs longer than the
-// given timeout reports a non-zero exit code. Depending on the system,
-// timed-out bash may surface as either ExitCode=-1 (DeadlineExceeded branch)
-// or the SIGKILL exit status via ExitError, so we only assert non-zero.
-func TestBashHandler_TimeoutExact(t *testing.T) {
+// TestBashHandler_TimeoutHandsOffToBackground confirms a command that outruns
+// its timeout is reported as still running, with a handle, rather than killed.
+// Killing it would discard whatever it had produced and tell the model nothing
+// about why it stopped.
+func TestBashHandler_TimeoutHandsOffToBackground(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
+	sup := testSupervisor(t)
 
-	out, err := bashHandler(sb, nil, BashInput{
+	out, err := bashHandler(sb, sup, nil, BashInput{
 		Command: "sleep 5",
 		Timeout: 200, // 200 ms
 	})
@@ -148,6 +160,23 @@ func TestBashHandler_TimeoutExact(t *testing.T) {
 	}
 	if out.ExitCode == 0 {
 		t.Errorf("expected non-zero ExitCode for timeout, got %d", out.ExitCode)
+	}
+	if !out.Running {
+		t.Error("expected Running=true after the timeout")
+	}
+	if out.Handle == "" {
+		t.Fatal("expected a handle for the backgrounded command")
+	}
+	if !strings.Contains(out.Note, out.Handle) {
+		t.Errorf("Note should name the handle so the model can act on it, got %q", out.Note)
+	}
+
+	st, err := sup.killHandle(out.Handle)
+	if err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
+	if st.Running {
+		t.Error("command still running after kill")
 	}
 }
 
@@ -160,7 +189,7 @@ func TestBashHandler_StdoutAndStderrAreSeparated(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
 
-	out, err := bashHandler(sb, nil, BashInput{
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
 		Command: "echo stdout-marker; echo stderr-marker >&2",
 	})
 	if err != nil {
@@ -193,7 +222,7 @@ func TestBashHandler_OutputIsNotInput(t *testing.T) {
 	sb := testSandbox(t, dir)
 
 	cmd := "echo unique-output-value-xyz"
-	out, err := bashHandler(sb, nil, BashInput{Command: cmd})
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: cmd})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
@@ -213,6 +242,7 @@ func TestBashHandler_ConcurrentCallsProduceIndependentOutput(t *testing.T) {
 	const workers = 20
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
+	sup := testSupervisor(t)
 
 	type result struct {
 		id  int
@@ -225,7 +255,7 @@ func TestBashHandler_ConcurrentCallsProduceIndependentOutput(t *testing.T) {
 	for i := 0; i < workers; i++ {
 		go func() {
 			defer wg.Done()
-			out, err := bashHandler(sb, nil, BashInput{
+			out, err := bashHandler(sb, sup, nil, BashInput{
 				Command: fmt.Sprintf("echo worker-%d-stdout; echo worker-%d-stderr >&2", i, i),
 			})
 			results[i] = result{id: i, out: out, err: err}
@@ -269,7 +299,7 @@ func TestBashHandler_BothStreamsAndExitCode(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
 
-	out, err := bashHandler(sb, nil, BashInput{
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
 		Command: "echo out-line; echo err-line >&2; exit 7",
 	})
 	if err != nil {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -14,15 +14,39 @@ import (
 	"google.golang.org/genai"
 )
 
+// CoreOption customizes the core tool set.
+type CoreOption func(*coreConfig)
+
+type coreConfig struct {
+	bashSupervisor *BashSupervisor
+}
+
+// WithBashSupervisor makes the bash tool use a caller-owned supervisor, so the
+// caller can attach a live-output sink and stop backgrounded commands at
+// shutdown. Without it CoreTools builds a private supervisor: commands still
+// get process-group isolation and background handoff, but nothing outside the
+// tool can see or reap them.
+func WithBashSupervisor(sup *BashSupervisor) CoreOption {
+	return func(c *coreConfig) { c.bashSupervisor = sup }
+}
+
 // CoreTools returns the core coding agent tools as ADK FunctionTools.
 // The sandbox restricts file-system access to the given root directory.
-func CoreTools(sandbox *Sandbox) ([]tool.Tool, error) {
+func CoreTools(sandbox *Sandbox, opts ...CoreOption) ([]tool.Tool, error) {
+	cfg := coreConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.bashSupervisor == nil {
+		cfg.bashSupervisor = NewBashSupervisor()
+	}
+
 	builders := []func(*Sandbox) (tool.Tool, error){
 		newReadTool,
 		newReadImageTool,
 		newWriteTool,
 		newEditTool,
-		newBashTool,
+		func(sb *Sandbox) (tool.Tool, error) { return newBashTool(sb, cfg.bashSupervisor) },
 		newGrepTool,
 		newFindTool,
 		newLsTool,

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -253,7 +253,7 @@ func TestBashHandler(t *testing.T) {
 	sb := testSandbox(t, dir)
 
 	t.Run("simple command", func(t *testing.T) {
-		out, err := bashHandler(sb, nil, BashInput{Command: "echo hello"})
+		out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "echo hello"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -266,7 +266,7 @@ func TestBashHandler(t *testing.T) {
 	})
 
 	t.Run("nonzero exit", func(t *testing.T) {
-		out, err := bashHandler(sb, nil, BashInput{Command: "exit 42"})
+		out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "exit 42"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -276,7 +276,7 @@ func TestBashHandler(t *testing.T) {
 	})
 
 	t.Run("empty command", func(t *testing.T) {
-		_, err := bashHandler(sb, nil, BashInput{})
+		_, err := bashHandler(sb, testSupervisor(t), nil, BashInput{})
 		if err == nil {
 			t.Error("expected error for empty command")
 		}
@@ -405,19 +405,26 @@ func TestLsHandler(t *testing.T) {
 func TestBashTimeout(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
-	out, err := bashHandler(sb, nil, BashInput{Command: "sleep 10", Timeout: 500})
+	sup := testSupervisor(t)
+	out, err := bashHandler(sb, sup, nil, BashInput{Command: "sleep 10", Timeout: 500})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if out.ExitCode == 0 {
 		t.Error("expected non-zero exit code for timed-out command")
 	}
+	if !out.Running || out.Handle == "" {
+		t.Fatalf("timed-out command should be backgrounded with a handle, got %+v", out)
+	}
+	if _, err := sup.killHandle(out.Handle); err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
 }
 
 func TestBashStderr(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
-	out, err := bashHandler(sb, nil, BashInput{Command: "echo error >&2; exit 1"})
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "echo error >&2; exit 1"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -947,8 +947,71 @@ func (m *model) handleAgentToolResult(msg agentToolResultMsg) (tea.Model, tea.Cm
 	return m, waitForAgent(m.agentCh)
 }
 
+// bashEventPrefix namespaces live shell-command events on the same channel the
+// subagent stream uses, so a command's output cannot be mistaken for a
+// subagent's.
+const bashEventPrefix = "bash:"
+
+// maxLiveBashEvents caps the events retained per running command. Only the last
+// few are ever drawn, and a command that prints for two minutes would otherwise
+// grow this without bound behind a window that shows five lines.
+const maxLiveBashEvents = 64
+
+// handleBashEvent routes one live event from a running shell command to its
+// card.
+//
+// Binding is by command text on the "start" event, not by position: the model
+// can issue several bash calls in one turn, and matching "the most recent bash
+// card" would interleave two commands' output into one card.
+func (m *model) handleBashEvent(msg agentSubEventMsg) (tea.Model, tea.Cmd) {
+	kind := strings.TrimPrefix(msg.kind, bashEventPrefix)
+
+	if kind == "start" {
+		if idx := findUnassignedBashCard(m.chatModel.Messages, msg.content); idx >= 0 {
+			m.chatModel.Messages[idx].agentID = msg.agentID
+		}
+		return m, waitForSubEvent(m.cfg.AgentEventCh)
+	}
+
+	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
+		if m.chatModel.Messages[i].tool != "bash" || m.chatModel.Messages[i].agentID != msg.agentID {
+			continue
+		}
+		evs := append(m.chatModel.Messages[i].agentEvents, agentEv{kind: kind, content: msg.content})
+		if len(evs) > maxLiveBashEvents {
+			evs = evs[len(evs)-maxLiveBashEvents:]
+		}
+		m.chatModel.Messages[i].agentEvents = evs
+		break
+	}
+	m.chatModel.Scroll = 0
+	return m, waitForSubEvent(m.cfg.AgentEventCh)
+}
+
+// findUnassignedBashCard returns the newest bash card still waiting for a
+// command to claim it, preferring an exact command match.
+func findUnassignedBashCard(messages []message, command string) int {
+	fallback := -1
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.tool != "bash" || msg.agentID != "" || msg.content != "" {
+			continue
+		}
+		if msg.toolIn == command {
+			return i
+		}
+		if fallback == -1 {
+			fallback = i
+		}
+	}
+	return fallback
+}
+
 // handleAgentSubEvent processes an agentSubEventMsg.
 func (m *model) handleAgentSubEvent(msg agentSubEventMsg) (tea.Model, tea.Cmd) {
+	if strings.HasPrefix(msg.kind, bashEventPrefix) {
+		return m.handleBashEvent(msg)
+	}
 	m.matrix.feed(msg.kind+msg.content, m.mainWidth())
 	if msg.kind == "spawn" {
 		// Agent IDs from the orchestrator are "<agent-name>-<unix-nano>".

--- a/internal/tui/bash_stream_test.go
+++ b/internal/tui/bash_stream_test.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func bashCard(command string) message {
+	return message{role: "tool", tool: "bash", toolIn: command}
+}
+
+// TestHandleBashEvent_BindsByCommand is the guard against interleaving. The
+// model routinely issues several bash calls in one turn; binding to "the most
+// recent bash card" would pour two commands' output into one card and leave the
+// other blank.
+func TestHandleBashEvent_BindsByCommand(t *testing.T) {
+	m := &model{}
+	m.chatModel.Messages = []message{
+		bashCard("go build ./..."),
+		bashCard("go test ./..."),
+	}
+
+	m.handleBashEvent(agentSubEventMsg{agentID: "bg_2", kind: "bash:start", content: "go test ./..."})
+	m.handleBashEvent(agentSubEventMsg{agentID: "bg_1", kind: "bash:start", content: "go build ./..."})
+
+	if got := m.chatModel.Messages[0].agentID; got != "bg_1" {
+		t.Errorf("first card bound to %q, want bg_1", got)
+	}
+	if got := m.chatModel.Messages[1].agentID; got != "bg_2" {
+		t.Errorf("second card bound to %q, want bg_2", got)
+	}
+
+	m.handleBashEvent(agentSubEventMsg{agentID: "bg_1", kind: "bash:output", content: "build line"})
+	m.handleBashEvent(agentSubEventMsg{agentID: "bg_2", kind: "bash:output", content: "test line"})
+
+	if len(m.chatModel.Messages[0].agentEvents) != 1 ||
+		m.chatModel.Messages[0].agentEvents[0].content != "build line" {
+		t.Errorf("first card events = %+v", m.chatModel.Messages[0].agentEvents)
+	}
+	if len(m.chatModel.Messages[1].agentEvents) != 1 ||
+		m.chatModel.Messages[1].agentEvents[0].content != "test line" {
+		t.Errorf("second card events = %+v", m.chatModel.Messages[1].agentEvents)
+	}
+}
+
+// TestHandleBashEvent_IgnoresFinishedCards: a card that already has its result
+// must not be reopened by a late event from a reused card slot.
+func TestHandleBashEvent_IgnoresFinishedCards(t *testing.T) {
+	m := &model{}
+	finished := bashCard("echo done")
+	finished.content = "done"
+	m.chatModel.Messages = []message{finished, bashCard("echo done")}
+
+	m.handleBashEvent(agentSubEventMsg{agentID: "bg_1", kind: "bash:start", content: "echo done"})
+
+	if m.chatModel.Messages[0].agentID != "" {
+		t.Error("a completed card was rebound to a new command")
+	}
+	if m.chatModel.Messages[1].agentID != "bg_1" {
+		t.Errorf("pending card not bound, got %q", m.chatModel.Messages[1].agentID)
+	}
+}
+
+// TestHandleBashEvent_CapsRetainedEvents keeps a chatty command from growing
+// the message unboundedly behind a five-line window.
+func TestHandleBashEvent_CapsRetainedEvents(t *testing.T) {
+	m := &model{}
+	m.chatModel.Messages = []message{bashCard("noisy")}
+	m.handleBashEvent(agentSubEventMsg{agentID: "bg_1", kind: "bash:start", content: "noisy"})
+
+	for range maxLiveBashEvents * 3 {
+		m.handleBashEvent(agentSubEventMsg{agentID: "bg_1", kind: "bash:output", content: "line"})
+	}
+
+	if got := len(m.chatModel.Messages[0].agentEvents); got != maxLiveBashEvents {
+		t.Errorf("retained %d events, want the cap of %d", got, maxLiveBashEvents)
+	}
+}
+
+// TestRenderLiveOutput_ShowsStallState is the reason the stream exists: a
+// command that prints nothing must still show that it is alive and stuck,
+// rather than rendering as an empty card indistinguishable from a hang.
+func TestRenderLiveOutput_ShowsStallState(t *testing.T) {
+	td := &ToolDisplayModel{Width: 100}
+	msg := bashCard("find / -name '*.go'")
+	msg.agentEvents = []agentEv{
+		{kind: "heartbeat", content: "5s elapsed, 5s without output"},
+		{kind: "heartbeat", content: "30s elapsed, 30s without output"},
+		{kind: "stall", content: "no output for 30s"},
+	}
+
+	out := td.RenderToolMessage(msg)
+
+	if !strings.Contains(out, "no output for 30s") {
+		t.Errorf("live card should show the current stall state, got:\n%s", out)
+	}
+	// Only the latest state line belongs on screen; earlier heartbeats are
+	// stale by definition and would push the output window off the card.
+	if strings.Contains(out, "5s elapsed, 5s without output") {
+		t.Errorf("stale heartbeat should have been superseded, got:\n%s", out)
+	}
+}
+
+// TestRenderLiveOutput_ResultReplacesStream confirms the live window is a
+// progress indicator, not a second copy of the output.
+func TestRenderLiveOutput_ResultReplacesStream(t *testing.T) {
+	td := &ToolDisplayModel{Width: 100}
+	msg := bashCard("echo hi")
+	msg.agentEvents = []agentEv{{kind: "output", content: "streamed-line"}}
+	msg.content = "final-output"
+
+	out := td.RenderToolMessage(msg)
+
+	if !strings.Contains(out, "final-output") {
+		t.Errorf("finished card should show the result, got:\n%s", out)
+	}
+	if strings.Contains(out, "streamed-line") {
+		t.Errorf("finished card should drop the live stream, got:\n%s", out)
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/dimetron/pi-go/internal/procs"
 	"github.com/dimetron/pi-go/internal/subagent"
 
 	tea "charm.land/bubbletea/v2"
@@ -673,7 +673,7 @@ func runGates(ctx context.Context, workDir string, gates []Gate) runGateResultMs
 	allPassed := true
 
 	for _, gate := range gates {
-		cmd := exec.CommandContext(ctx, "sh", "-c", gate.Command)
+		cmd := procs.CommandContext(ctx, "sh", "-c", gate.Command)
 		cmd.Dir = workDir
 
 		var stdout, stderr bytes.Buffer

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -248,6 +248,63 @@ func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style) stri
 	return b.String()
 }
 
+// maxLiveOutputLines bounds the rolling window shown under a running command.
+// It is smaller than the finished-output window on purpose: while a command
+// runs, what matters is that it is alive and roughly where it has got to, not
+// the content.
+const maxLiveOutputLines = 5
+
+// renderLiveOutput draws the tail of a running command's output, plus its
+// current state.
+//
+// The state line is the point of the whole exercise. A command that prints
+// nothing is indistinguishable from a hung one, and that ambiguity is what let
+// two sessions sit wedged for an hour without anyone noticing. "1m30s — no
+// output" removes it.
+func (t *ToolDisplayModel) renderLiveOutput(msg message, dim lipgloss.Style) string {
+	cw := t.contentWidth()
+	outStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("173"))
+	stateStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+
+	var (
+		lines []string
+		state string
+	)
+	for _, ev := range msg.agentEvents {
+		switch ev.kind {
+		case "heartbeat", "stall", "background":
+			// Only the latest state matters; earlier ones are stale by
+			// definition.
+			state = ev.content
+		case "stderr":
+			lines = append(lines, errStyle.Render("▎ "+collapseToSingleLine(ev.content)))
+		case "output":
+			lines = append(lines, outStyle.Render("│ "+collapseToSingleLine(ev.content)))
+		}
+	}
+	if len(lines) > maxLiveOutputLines {
+		lines = lines[len(lines)-maxLiveOutputLines:]
+	}
+
+	var b strings.Builder
+	for _, l := range lines {
+		for _, sl := range softWrap(l, cw) {
+			b.WriteString("  ")
+			b.WriteString(dim.Render("│ "))
+			b.WriteString(sl)
+			b.WriteString("\n")
+		}
+	}
+	if state != "" {
+		b.WriteString("  ")
+		b.WriteString(dim.Render("│ "))
+		b.WriteString(stateStyle.Render("⏳ " + state))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
 // maxAgentOutputLines bounds a subagent card's live output window. The card is
 // a progress indicator, not a transcript: the agent's full answer arrives in the
 // result summary and in the parent's own reply, so the stream only has to show
@@ -366,6 +423,12 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style) st
 		b.WriteString(dim.Render(")"))
 	}
 	b.WriteString("\n")
+	if msg.content == "" && len(msg.agentEvents) > 0 {
+		// Still running: show the live tail instead of an empty card. Once the
+		// result arrives, msg.content takes over and the final output replaces
+		// this window — the stream is a progress indicator, not a transcript.
+		b.WriteString(t.renderLiveOutput(msg, dim))
+	}
 	if msg.content != "" {
 		lines := strings.Split(msg.content, "\n")
 

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -160,6 +160,14 @@ type TokenTracker interface {
 	CachePrefixTokens() int64   // stable cached prefix for this window
 }
 
+// BashEventKind namespaces a live shell-command event so it can share the
+// subagent event channel without being mistaken for subagent activity.
+// Producers outside this package must route bash events through it rather than
+// hard-coding the prefix.
+func BashEventKind(kind string) string {
+	return bashEventPrefix + kind
+}
+
 // AgentSubEvent carries a subagent event from the agent tool to the TUI.
 type AgentSubEvent struct {
 	AgentID    string


### PR DESCRIPTION
## What broke

A `bash` tool call could hang forever.

`exec.CommandContext` signals only the **direct child** on cancellation, and `cmd.Wait()` blocks until the stdout/stderr pipes reach EOF. A compound command — a pipeline, or anything with `;` — forks grandchildren that inherit those pipes. Killing the shell leaves them running, reparented to init, still holding the write end. `Wait` then never returns, and `WaitDelay` was zero so nothing forced it.

Two sessions sat wedged for over an hour this way:

| Session | Command | Stuck |
|---|---|---|
| `260808-0714-51211-aff55` | `find / -path '*genai*' -name '*.go' \| grep -i live` | 1h20m |
| `260808-0714-de8bc-c1017` | `find / -type d -path '*adk/v2*'` | 1h20m |

`lsof` confirmed the mechanism: `find` (PPID 1) still owned fd 1 of pi's pipe. Neither session ever received a tool result, so neither could advance. The 2-minute timeout was unreachable.

**Not a regression.** `git log --follow internal/tools/bash.go` shows the same shape in all 11 commits back to the initial version — `Setpgid`, `cmd.Cancel` and `WaitDelay` have never been set. Only the trigger is new: the hang needs a grandchild that outlives the shell *and* a command slow enough to hit the timeout.

## The fix

**`internal/procs`** — every child leads its own process group; `Cancel` sends `SIGTERM` to the group and `SIGKILL` after a grace period; `WaitDelay` is a backstop for anything group termination cannot reach (a stopped process, a descendant that escaped into a new session, a platform without process groups). `procs.CommandContext` is the constructor, because `Isolate` on a non-context command fails only at `Start` time.

The same defect existed in two more places, fixed here as well:
- `internal/extension/hooks.go` — both hook exec paths
- `internal/tui/run.go` — `/run` gate commands

**Timeouts no longer kill.** A command that outruns its deadline, or that goes fully silent past the idle threshold, is handed to a supervisor and reported with a handle while it keeps running:

```
bash("find / -name '*.go'")
  → { running: true, handle: "bg_3", stdout: "<partial>",
      note: "Command no output for 90s and was moved to the background; it is
             still running. Read more with bash_output(handle=\"bg_3\") or stop
             it with bash_kill(handle=\"bg_3\"). It has produced no output at
             all — if that is unexpected, the command is probably too broad …" }
```

Two new tools: `bash_output` (incremental read, optional blocking wait) and `bash_kill` (stops the whole tree). Killing on timeout threw away work and explained nothing; handing off loses neither.

**Idle threshold: 90s**, calibrated rather than picked round — a cold `go build ./...` on this repo prints nothing for **28s**, so a 30s threshold would background ordinary builds. Tunable per call via `idle_timeout`.

**Live output.** Command output streams to the main window as it is produced, with a state line that makes a stall visible rather than indistinguishable from a hang:

```
◉ bash(find / -name '*.go')
  │ /usr/local/go/src/…
  │ ⏳ no output for 90s
```

Events share the subagent channel under a `bash:` prefix and bind to their card **by command text**, not by position — the model routinely issues several bash calls per turn, and position matching would interleave them.

**The handoff cannot become a new leak:** background commands are capped (8, evicting finished ones first), lifetime-limited (30 min), killed by `bash_kill`, and killed at session shutdown via `KillAll` in both CLI paths. Foreground cancellation (Esc) still kills immediately and never backgrounds.

## Tests

- `procs`: reproduces the exact wedge — a command that backgrounds a pipe-holding child, cancelled; asserts `Wait` returns **and** the grandchild is dead. Plus normal-exit, explicit-kill, and kill-after-exit paths.
- `tools`: silent command backgrounds; **chatty command does not** (the guard against an over-eager idle check); incremental reads don't repeat or lose output; handle spent after exit; foreground cancel kills without backgrounding; `KillAll`; cap eviction; sink streams stdout/stderr/heartbeat/stall.
- `tui`: binding by command text across concurrent calls, finished cards not rebound, event cap, stall state rendered, result replaces the live stream.
- Stream buffer: absolute offsets, dropped-byte reporting, wake-on-write, concurrent writers.

`go test ./...` clean, `-race` clean on all touched packages, `make lint` 0 issues.

## Note

The three orphans from those two sessions were killed manually while diagnosing.