### PR TITLE
fix(subagent): reduce default timeout to five minutes

### DIFF
--- a/internal/subagent/timeout.go
+++ b/internal/subagent/timeout.go
@@ -8,8 +8,8 @@ import (
 
 // Default timeout values for subagent processes.
 const (
-	// DefaultAbsoluteTimeout is the maximum wall-clock time a subagent can run (10 minutes).
-	DefaultAbsoluteTimeout = 10 * time.Minute
+	// DefaultAbsoluteTimeout is the maximum wall-clock time a subagent can run (5 minutes).
+	DefaultAbsoluteTimeout = 5 * time.Minute
 
 	// DefaultInactivityTimeout is how long a subagent can go without producing output (120 seconds).
 	DefaultInactivityTimeout = 120 * time.Second


### PR DESCRIPTION
## Summary
- reduce the default subagent absolute timeout from 10 minutes to 5 minutes
- retain environment and per-agent timeout overrides

## Verification
- `make vet`
- `make lint`
- `go test ./internal/subagent`
- `make build`

`make test` was started but stalled in the sandbox after initial packages; this repository documents that listener-based tests require an unsandboxed environment.