### PR TITLE
fix(provider): omit incomplete Responses tool pairs

### DIFF
--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -187,6 +187,32 @@ func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.Genera
 	}
 	instructions := strings.TrimSpace(systemBuilder.String())
 
+	// A canceled turn can persist a function call before its tool result is
+	// emitted. Responses requires calls and outputs to be paired, so omit either
+	// half of an incomplete pair when replaying conversation history.
+	callIDs := make(map[string]struct{})
+	responseIDs := make(map[string]struct{})
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		for _, part := range content.Parts {
+			if part == nil {
+				continue
+			}
+			if part.FunctionCall != nil {
+				if id := strings.TrimSpace(part.FunctionCall.ID); id != "" {
+					callIDs[id] = struct{}{}
+				}
+			}
+			if part.FunctionResponse != nil {
+				if id := strings.TrimSpace(part.FunctionResponse.ID); id != "" {
+					responseIDs[id] = struct{}{}
+				}
+			}
+		}
+	}
+
 	// Always build a list of input items. The ChatGPT codex backend
 	// (/backend-api/codex/responses) rejects a bare string with
 	// `{"detail":"Input must be a list"}`. The platform Responses API
@@ -220,12 +246,18 @@ func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.Genera
 				if strings.TrimSpace(fc.ID) == "" {
 					continue
 				}
+				if _, ok := responseIDs[fc.ID]; !ok {
+					continue
+				}
 				argsJSON, _ := json.Marshal(fc.Args)
 				items = append(items, responses.ResponseInputItemParamOfFunctionCall(string(argsJSON), fc.ID, fc.Name))
 			case part.FunctionResponse != nil:
 				flushText()
 				fr := part.FunctionResponse
 				if strings.TrimSpace(fr.ID) == "" {
+					continue
+				}
+				if _, ok := callIDs[fr.ID]; !ok {
 					continue
 				}
 				items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(fr.ID, oaiFunctionResponseContent(fr.Response)))

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1498,7 +1498,7 @@ func TestOaiContentsToResponsesInput_WithFunctionCalls(t *testing.T) {
 	}
 }
 
-func TestOaiContentsToResponsesInput_DoesNotInventMissingFunctionOutput(t *testing.T) {
+func TestOaiContentsToResponsesInput_SkipsFunctionCallsWithoutResponse(t *testing.T) {
 	fc := genai.NewPartFromFunctionCall("find", map[string]any{"pattern": "*.go"})
 	fc.FunctionCall.ID = "call_find"
 
@@ -1512,17 +1512,37 @@ func TestOaiContentsToResponsesInput_DoesNotInventMissingFunctionOutput(t *testi
 		t.Fatalf("unexpected error: %v", err)
 	}
 	items := input.OfInputItemList
-	if len(items) != 2 {
-		t.Fatalf("expected message + function call only, got %d items", len(items))
+	if len(items) != 1 {
+		t.Fatalf("expected orphaned function call to be omitted, got %d items", len(items))
 	}
-	if items[1].OfFunctionCall == nil {
-		t.Fatalf("expected second item to be function call, got %+v", items[1])
+	if items[0].OfMessage == nil {
+		t.Fatalf("expected only the user message, got %+v", items[0])
 	}
-	if items[1].OfFunctionCall.CallID != "call_find" {
-		t.Errorf("function call CallID = %q, want call_find", items[1].OfFunctionCall.CallID)
+}
+
+func TestOaiContentsToResponsesInput_SkipsFunctionResponseWithoutCall(t *testing.T) {
+	fr := &genai.Part{
+		FunctionResponse: &genai.FunctionResponse{
+			ID:       "call_find",
+			Name:     "find",
+			Response: map[string]any{"result": "found"},
+		},
 	}
-	if items[1].OfFunctionCall.Arguments != `{"pattern":"*.go"}` {
-		t.Errorf("function call arguments = %q, want pattern JSON", items[1].OfFunctionCall.Arguments)
+	contents := []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "Search files"}}},
+		{Role: "user", Parts: []*genai.Part{fr}},
+	}
+
+	input, _, err := oaiContentsToResponsesInput(contents, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	items := input.OfInputItemList
+	if len(items) != 1 {
+		t.Fatalf("expected orphaned function response to be omitted, got %d items", len(items))
+	}
+	if items[0].OfMessage == nil {
+		t.Fatalf("expected only the user message, got %+v", items[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- omit persisted function calls that lack a matching tool result
- omit standalone tool results that lack a matching function call
- cover both malformed history shapes in the Responses serializer

## Validation
- `make lint`
- `make vet`
- `GOEXPERIMENT=simd go test ./internal/provider -count=1`
- `make build`

`make test` began passing packages but stalled under the sandbox after the TUI/listener test environment limitation; the focused provider suite passed.