### PR TITLE
fix: route ACP bash output and lifecycle failures

### DIFF
--- a/internal/acp/server/adapter/bash_output_test.go
+++ b/internal/acp/server/adapter/bash_output_test.go
@@ -1,0 +1,29 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestOnBashOutputDropsEmptyContentAndNilUpdater(t *testing.T) {
+	up := &fakeUpdater{}
+	if err := New(up).OnBashOutput(context.Background(), "bg_1", "heartbeat", ""); err != nil {
+		t.Fatalf("empty output: %v", err)
+	}
+	if got := len(up.updates); got != 0 {
+		t.Fatalf("empty output produced %d updates, want 0", got)
+	}
+	if err := New(nil).OnBashOutput(context.Background(), "bg_1", "output", "hello"); err != nil {
+		t.Fatalf("nil updater: %v", err)
+	}
+}
+
+func TestOnBashOutputWrapsUpdaterError(t *testing.T) {
+	want := errors.New("updater failed")
+	up := &fakeUpdater{err: want}
+	err := New(up).OnBashOutput(context.Background(), "bg_1", "stderr", "oops")
+	if !errors.Is(err, want) {
+		t.Fatalf("OnBashOutput error = %v, want wrapping %v", err, want)
+	}
+}

--- a/internal/acp/server/adapter/stream.go
+++ b/internal/acp/server/adapter/stream.go
@@ -126,6 +126,24 @@ func (s *Stream) OnEvent(ctx context.Context, ev *adksession.Event) error {
 	return nil
 }
 
+// OnBashOutput forwards live shell activity to the ACP peer without adding it
+// to the assistant's final response text.
+func (s *Stream) OnBashOutput(ctx context.Context, execID, kind, content string) error {
+	if content == "" {
+		return nil
+	}
+	s.mu.Lock()
+	updater := s.updater
+	s.mu.Unlock()
+	if updater == nil {
+		return nil
+	}
+	if err := updater.Update(ctx, acp.UpdateAgentThoughtText(content)); err != nil {
+		return fmt.Errorf("stream: bash %s update for %s: %w", kind, execID, err)
+	}
+	return nil
+}
+
 // Final returns the accumulated assistant text with surrounding whitespace
 // trimmed. Safe to call multiple times; always reflects the latest state.
 func (s *Stream) Final() string {

--- a/internal/acp/server/adapter/stream_test.go
+++ b/internal/acp/server/adapter/stream_test.go
@@ -263,3 +263,18 @@ func TestStream_FinalTrimsSurroundingWhitespace(t *testing.T) {
 		t.Fatalf("Final() = %q, want %q", got, want)
 	}
 }
+
+func TestOnBashOutputForwardsThoughtUpdate(t *testing.T) {
+	up := &fakeUpdater{}
+	s := New(up)
+	if err := s.OnBashOutput(context.Background(), "bg_1", "output", "building\\n"); err != nil {
+		t.Fatalf("OnBashOutput: %v", err)
+	}
+	if got := len(up.updates); got != 1 {
+		t.Fatalf("updates = %d, want 1", got)
+	}
+	thought := up.updates[0].AgentThoughtChunk
+	if thought == nil || thought.Content.Text == nil || thought.Content.Text.Text != "building\\n" {
+		t.Fatalf("thought update = %+v, want bash output", thought)
+	}
+}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -47,9 +47,11 @@ type RuntimeConfig struct {
 // piSessionState caches the per-ACP-session pi runtime so all turns within one
 // session share a single agent instance and its conversation history.
 type piSessionState struct {
+	mu          sync.Mutex // serializes turns, which share the agent and bash output sink
 	agent       *piagent.Agent
 	sessionID   string // ADK session ID — reused across turns for history continuity
 	streamProxy *streamProxy
+	bashSup     *tools.BashSupervisor
 	cleanup     func()
 }
 
@@ -110,10 +112,17 @@ func NewPromptHandler(rt RuntimeConfig) PromptHandler {
 			mu.Unlock()
 		}
 
+		ps.mu.Lock()
+		defer ps.mu.Unlock()
+
 		// Fresh stream per turn so tool-call IDs and text are isolated.
 		stream := adapter.New(turn.Updater)
 		ps.streamProxy.swap(stream)
+		ps.bashSup.SetSink(func(execID, kind, content string) {
+			_ = stream.OnBashOutput(ctx, execID, kind, content)
+		})
 		defer ps.streamProxy.swap(nil)
+		defer ps.bashSup.SetSink(nil)
 
 		return runPromptTurn(ctx, turn, ps, stream)
 	}
@@ -183,6 +192,7 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		agent:       ag,
 		sessionID:   sessionID,
 		streamProxy: res.proxy,
+		bashSup:     res.bashSup,
 		cleanup:     res.cleanup,
 	}, nil
 }
@@ -306,6 +316,7 @@ type sessionResources struct {
 	afterCBs       []llmagent.AfterToolCallback
 	beforeModelCBs []llmagent.BeforeModelCallback
 	proxy          *streamProxy
+	bashSup        *tools.BashSupervisor
 	cleanup        func()
 }
 
@@ -389,6 +400,7 @@ func buildSessionResources(rt RuntimeConfig, cfg config.Config, turn PromptTurn,
 		afterCBs:       afterCBs,
 		beforeModelCBs: beforeModelCBs,
 		proxy:          proxy,
+		bashSup:        bashSup,
 		cleanup:        cleanup,
 	}, nil
 }

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -89,6 +89,19 @@ func (p *streamProxy) OnToolEnd(ctx context.Context, callID string, args map[str
 	return s.OnToolEnd(ctx, callID, args, result, runErr)
 }
 
+// beginTurnStream connects the session's shared callbacks to one active ACP
+// turn. Call the returned function before releasing the session turn lock.
+func (p *piSessionState) beginTurnStream(ctx context.Context, stream *adapter.Stream) func() {
+	p.streamProxy.swap(stream)
+	p.bashSup.SetSink(func(execID, kind, content string) {
+		_ = stream.OnBashOutput(ctx, execID, kind, content)
+	})
+	return func() {
+		p.bashSup.SetSink(nil)
+		p.streamProxy.swap(nil)
+	}
+}
+
 // NewPromptHandler returns a real pi-backed ACP prompt handler. It maintains a
 // per-ACP-session cache so the pi agent (and its ADK session history) is reused
 // across turns rather than re-created on every prompt.
@@ -117,12 +130,8 @@ func NewPromptHandler(rt RuntimeConfig) PromptHandler {
 
 		// Fresh stream per turn so tool-call IDs and text are isolated.
 		stream := adapter.New(turn.Updater)
-		ps.streamProxy.swap(stream)
-		ps.bashSup.SetSink(func(execID, kind, content string) {
-			_ = stream.OnBashOutput(ctx, execID, kind, content)
-		})
-		defer ps.streamProxy.swap(nil)
-		defer ps.bashSup.SetSink(nil)
+		finishTurn := ps.beginTurnStream(ctx, stream)
+		defer finishTurn()
 
 		return runPromptTurn(ctx, turn, ps, stream)
 	}

--- a/internal/acp/server/session_helpers_test.go
+++ b/internal/acp/server/session_helpers_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/dimetron/pi-go/internal/acp/server/adapter"
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/tools"
 )
 
 func TestLoadSessionConfig(t *testing.T) {
@@ -131,5 +134,21 @@ func TestStreamProxyIsSafeWhenUnset(t *testing.T) {
 	p.swap(nil)
 	if _, err := p.OnToolStart(t.Context(), "grep", nil); err != nil {
 		t.Errorf("OnToolStart after swap(nil) = %v, want nil", err)
+	}
+}
+
+func TestBeginTurnStreamDetachesSharedCallbacks(t *testing.T) {
+	state := &piSessionState{
+		streamProxy: &streamProxy{},
+		bashSup:     tools.NewBashSupervisor(),
+	}
+	finish := state.beginTurnStream(context.Background(), adapter.New(nil))
+
+	if id, err := state.streamProxy.OnToolStart(context.Background(), "read", nil); err != nil || id == "" {
+		t.Fatalf("tool start while active = (%q, %v), want a call ID", id, err)
+	}
+	finish()
+	if id, err := state.streamProxy.OnToolStart(context.Background(), "read", nil); err != nil || id != "" {
+		t.Fatalf("tool start after cleanup = (%q, %v), want empty ID", id, err)
 	}
 }

--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -1550,5 +1551,38 @@ func TestLifecycleHooks_DoNotWriteToStderr(t *testing.T) {
 	}
 	if len(leaked) != 0 {
 		t.Errorf("lifecycle hooks wrote %q to stderr, want nothing", leaked)
+	}
+}
+
+func TestAgentDoneMsg_ErrorDoesNotFireUserInputHook(t *testing.T) {
+	dir := t.TempDir()
+	turnOut := dir + "/turn.json"
+	inputOut := dir + "/input.json"
+	m := &model{
+		ctx:       context.Background(),
+		chatModel: ChatModel{Messages: []message{{role: "assistant"}}},
+		running:   true,
+		agentCh:   make(chan agentMsg, 64),
+		cfg: Config{LifecycleHooks: []extension.HookConfig{
+			{Event: "turn_complete", Command: "cat > " + turnOut, Timeout: 5},
+			{Event: "user_input_required", Command: "cat > " + inputOut, Timeout: 5},
+		}},
+	}
+
+	m.handleAgentDone(agentDoneMsg{err: errors.New("request canceled")})
+	data := waitForHookOutput(t, turnOut)
+	var payload struct {
+		Event string         `json:"event"`
+		Data  map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal turn_complete output: %v", err)
+	}
+	if payload.Data["error"] != true {
+		t.Errorf("turn_complete error = %v, want true", payload.Data["error"])
+	}
+	time.Sleep(200 * time.Millisecond)
+	if _, err := os.Stat(inputOut); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("user_input_required hook ran after an error, stat err = %v", err)
 	}
 }

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -1077,13 +1077,15 @@ func (m *model) handleAgentDone(msg agentDoneMsg) (tea.Model, tea.Cmd) {
 	m.chatModel.Thinking = ""
 	m.agentCh = nil
 	m.refreshDiffStats()
-	// A finished turn hands control back to the user, so both lifecycle
-	// events fire here: the turn is complete, and the agent is now waiting
-	// for the next user input. A hook can subscribe to either.
+	// Every terminal outcome completes the turn, but only a successful turn has
+	// returned to an input-ready state. Do not tell lifecycle consumers that a
+	// failed or canceled run is awaiting input.
 	m.runLifecycleHooks("turn_complete", map[string]any{
 		"error": msg.err != nil,
 	})
-	m.runLifecycleHooks("user_input_required", map[string]any{})
+	if msg.err == nil {
+		m.runLifecycleHooks("user_input_required", map[string]any{})
+	}
 	return m, nil
 }
 
@@ -1136,6 +1138,9 @@ func (m *model) enqueueHook(fn func()) {
 	if m.hookQueue == nil {
 		m.hookQueue = make(chan func(), hookQueueDepth)
 		ctx := m.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		go func(q <-chan func()) {
 			// The queue is never closed — the worker's exit signal is the
 			// session context, so a drained queue is not a shutdown.

--- a/internal/tui/agent_loop_hooks_test.go
+++ b/internal/tui/agent_loop_hooks_test.go
@@ -107,3 +107,15 @@ func TestEnqueueHook_NilContextIsSafe(t *testing.T) {
 		t.Error("hookQueue created with no hooks configured")
 	}
 }
+
+func TestEnqueueHook_NilContextRunsHook(t *testing.T) {
+	m := &model{}
+	ran := make(chan struct{})
+	m.enqueueHook(func() { close(ran) })
+
+	select {
+	case <-ran:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hook did not run with a nil model context")
+	}
+}


### PR DESCRIPTION
## Summary
- stream ACP background-command output through the active turn updater
- serialize per-session turns while the shared agent and bash sink are active
- prevent lifecycle hooks from reporting input-ready after failed turns
- make lifecycle-hook workers safe for models without a context

## Verification
- `go test ./internal/tui`
- `go test ./internal/acp/server/adapter ./internal/acp/server`
- `make build`
- `make vet`
- `make lint`