### PR TITLE
fix(tui): thread theme palette into renderers so light themes render

### DIFF
--- a/internal/tui/agent_loop_error_e2e_test.go
+++ b/internal/tui/agent_loop_error_e2e_test.go
@@ -119,7 +119,7 @@ func TestChatRender_ErrorMessageIsDistinct(t *testing.T) {
 	plain := message{role: "assistant", content: "boom"}
 	errMsg := message{role: "assistant", content: "boom", isError: true}
 
-	if plain.renderKey(80, false, false, false) == errMsg.renderKey(80, false, false, false) {
+	if plain.renderKey(80, false, false, false, 0) == errMsg.renderKey(80, false, false, false, 0) {
 		t.Fatal("renderKey collides for plain and error messages -- cached render would leak")
 	}
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -54,10 +54,10 @@ func wordWrap(text string, maxWidth int) []string {
 }
 
 // renderWelcome builds the startup welcome screen, constrained to available width.
-func (c *ChatModel) renderWelcome() string {
-	accent := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	cmd := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+func (c *ChatModel) renderWelcome(p Palette) string {
+	accent := lipgloss.NewStyle().Foreground(p.Primary).Bold(true)
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
+	cmd := lipgloss.NewStyle().Foreground(p.Cyan)
 
 	// ASCII diagonals, matching the sidebar mascot: ╱ ╲ are East Asian Ambiguous
 	// and widen the row in CJK-configured terminals. See face.go.
@@ -157,7 +157,7 @@ func fnvInt(h uint64, v int) uint64 {
 // (and re-syntax-highlighted) the entire scrollback, several times a second.
 // Keying on the inputs gets the same safety without the cost: a mutated message
 // simply gets a different key and re-renders.
-func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlaceholder bool) uint64 {
+func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlaceholder bool, themeKey uint64) uint64 {
 	h := fnvOffset64
 	h = fnvStr(h, m.role)
 	h = fnvStr(h, m.content)
@@ -175,6 +175,7 @@ func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlac
 	h = fnvInt(h, width)
 	h = fnvInt(h, m.pipelineStep)
 	h = fnvInt(h, m.pipelineTotal)
+	h = fnvInt(h, int(themeKey))
 
 	var flags byte
 	if m.isWarning {
@@ -219,6 +220,9 @@ type ChatModel struct {
 	TraceLog    []traceEntry
 	Width       int
 	ToolDisplay ToolDisplayModel
+	// Palette is the resolved theme palette, set each frame by the model before
+	// rendering. Zero means the dark default.
+	Palette Palette
 }
 
 // NewChatModel creates a ChatModel with the given markdown renderer.
@@ -434,13 +438,16 @@ func (c *ChatModel) RenderMessages(running bool) string {
 // lines it opened, and collapseBlankLines then drops entries from both together,
 // so kinds[i] always describes the i-th line of the returned string.
 func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
+	p := paletteOrDark(c.Palette)
+	themeKey := paletteKey(p)
+
 	if len(c.Messages) == 0 {
-		welcome := c.renderWelcome()
+		welcome := c.renderWelcome(p)
 		return welcome, make([]blockKind, strings.Count(welcome, "\n")+1)
 	}
 
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	bullet := lipgloss.NewStyle().Foreground(lipgloss.Color("63")).Bold(true).Render("◉ ")
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
+	bullet := lipgloss.NewStyle().Foreground(p.Accent).Bold(true).Render("◉ ")
 	sepWidth := c.Width
 	if sepWidth < 20 {
 		sepWidth = 20
@@ -454,7 +461,7 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 		msg := &c.Messages[i]
 
 		isLastAndStreaming := running && i == lastIdx
-		key := msg.renderKey(c.Width, c.ToolDisplay.CompactTools, i > 0, isLastAndStreaming)
+		key := msg.renderKey(c.Width, c.ToolDisplay.CompactTools, i > 0, isLastAndStreaming, themeKey)
 		if msg.renderCached && msg.renderCacheKey == key {
 			b.WriteString(msg.renderCache)
 			kinds = appendKind(kinds, kindOf(msg), strings.Count(msg.renderCache, "\n"))
@@ -469,7 +476,7 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 				msgBuf.WriteString("\n")
 			}
 			label := lipgloss.NewStyle().
-				Foreground(lipgloss.Color("39")).
+				Foreground(p.Primary).
 				Bold(true).
 				Render("> ")
 			msgBuf.WriteString(label)
@@ -492,8 +499,8 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 
 		case "thinking":
 			if msg.content != "" {
-				thinkStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Italic(true)
-				thinkBullet := lipgloss.NewStyle().Foreground(lipgloss.Color("243")).Render("💭 ")
+				thinkStyle := lipgloss.NewStyle().Foreground(p.Faint).Italic(true)
+				thinkBullet := lipgloss.NewStyle().Foreground(p.Faint).Render("💭 ")
 				msgBuf.WriteString("\n")
 				msgBuf.WriteString(thinkBullet)
 				// Show last few lines of thinking to keep it compact.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -558,7 +558,7 @@ func (m *model) formatContextUsage() string {
 		}
 		b.WriteString("*Context usage*\n\n")
 		b.WriteString(RenderContextBreakdown(
-			bd.withConversationFrom(used), window, min(m.chatWidth()-4, 64)))
+			bd.withConversationFrom(used), window, min(m.chatWidth()-4, 64), m.palette))
 		b.WriteString("\n\n")
 	}
 

--- a/internal/tui/context_breakdown.go
+++ b/internal/tui/context_breakdown.go
@@ -58,26 +58,26 @@ func (k ContextSegmentKind) Label() string {
 }
 
 // Color returns the segment's swatch. The palette is chosen so adjacent
-// segments never share a hue and the whole set stays legible on the Mocha
+// segments never share a hue and the whole set stays legible on the theme's
 // background; Conversation is warmest because it is the one that grows.
-func (k ContextSegmentKind) Color() color.Color {
+func (k ContextSegmentKind) Color(p Palette) color.Color {
 	switch k {
 	case SegSystemPrompt:
-		return lipgloss.Color("#9399b2") // overlay2 — inert overhead
+		return p.Overlay2 // inert overhead
 	case SegToolDefs:
-		return lipgloss.Color("#89b4fa") // blue
+		return p.Blue
 	case SegRules:
-		return lipgloss.Color("#a6e3a1") // green
+		return p.Green
 	case SegSkills:
-		return lipgloss.Color("#f9e2af") // yellow
+		return p.Yellow
 	case SegMCPTools:
-		return lipgloss.Color("#cba6f7") // mauve
+		return p.Mauve
 	case SegSubagents:
-		return lipgloss.Color("#89dceb") // sky
+		return p.Sky
 	case SegConversation:
-		return lipgloss.Color("#fab387") // peach — the part that grows
+		return p.Peach // the part that grows
 	default:
-		return lipgloss.Color("#585b70")
+		return p.Surface
 	}
 }
 
@@ -226,7 +226,7 @@ func segmentWidths(b ContextBreakdown, cells int) [segCount]int {
 
 // renderSegmentedGauge draws the proportional bar across exactly `cells`
 // columns, using the rule glyph so the row still reads as a rule.
-func renderSegmentedGauge(b ContextBreakdown, cells int) string {
+func renderSegmentedGauge(b ContextBreakdown, cells int, p Palette) string {
 	if cells <= 0 {
 		return ""
 	}
@@ -239,13 +239,13 @@ func renderSegmentedGauge(b ContextBreakdown, cells int) string {
 		if n <= 0 {
 			continue
 		}
-		style := lipgloss.NewStyle().Foreground(k.Color())
+		style := lipgloss.NewStyle().Foreground(k.Color(p))
 		sb.WriteString(style.Render(strings.Repeat(string(gaugeEmptyGlyph), n)))
 		drawn += n
 	}
 	// Unused remainder of the window, in the dim rule color.
 	if drawn < cells {
-		dim := lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70"))
+		dim := lipgloss.NewStyle().Foreground(p.Surface)
 		sb.WriteString(dim.Render(strings.Repeat(string(gaugeEmptyGlyph), cells-drawn)))
 	}
 	return sb.String()
@@ -253,7 +253,7 @@ func renderSegmentedGauge(b ContextBreakdown, cells int) string {
 
 // RenderContextBreakdown renders the legend panel: a header with the headline
 // percentage, the segmented bar, then one row per section.
-func RenderContextBreakdown(b ContextBreakdown, window int64, width int) string {
+func RenderContextBreakdown(b ContextBreakdown, window int64, width int, p Palette) string {
 	if width < 24 {
 		width = 24
 	}
@@ -278,8 +278,8 @@ func RenderContextBreakdown(b ContextBreakdown, window int64, width int) string 
 	if gap < 1 {
 		gap = 1
 	}
-	headStyle := lipgloss.NewStyle().Foreground(contextSeverityColor(pct)).Bold(true)
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9399b2"))
+	headStyle := lipgloss.NewStyle().Foreground(contextSeverityColor(pct, p)).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(p.Overlay2)
 	sb.WriteString(headStyle.Render(head) + strings.Repeat(" ", gap) + dimStyle.Render(tail))
 	sb.WriteString("\n\n")
 
@@ -289,9 +289,9 @@ func RenderContextBreakdown(b ContextBreakdown, window int64, width int) string 
 	if window > 0 && total < window {
 		barCells = int(float64(total) / float64(window) * float64(width))
 	}
-	sb.WriteString(renderSegmentedGauge(b, barCells))
+	sb.WriteString(renderSegmentedGauge(b, barCells, p))
 	if barCells < width {
-		dim := lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70"))
+		dim := lipgloss.NewStyle().Foreground(p.Surface)
 		sb.WriteString(dim.Render(strings.Repeat(string(gaugeEmptyGlyph), width-barCells)))
 	}
 	sb.WriteString("\n\n")
@@ -301,7 +301,7 @@ func RenderContextBreakdown(b ContextBreakdown, window int64, width int) string 
 		if tok <= 0 {
 			continue
 		}
-		swatch := lipgloss.NewStyle().Foreground(k.Color()).Render("███")
+		swatch := lipgloss.NewStyle().Foreground(k.Color(p)).Render("███")
 		label := k.Label()
 		count := formatTokenCount(tok)
 		pad := width - ansi.StringWidth(swatch) - 1 - ansi.StringWidth(label) - ansi.StringWidth(count)
@@ -309,7 +309,7 @@ func RenderContextBreakdown(b ContextBreakdown, window int64, width int) string 
 			pad = 1
 		}
 		sb.WriteString(swatch + " " +
-			lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4")).Render(label) +
+			lipgloss.NewStyle().Foreground(p.Text).Render(label) +
 			strings.Repeat(" ", pad) +
 			dimStyle.Render(count))
 		sb.WriteString("\n")

--- a/internal/tui/context_breakdown_test.go
+++ b/internal/tui/context_breakdown_test.go
@@ -41,7 +41,7 @@ func TestSegmentWidths_SumExactly(t *testing.T) {
 func TestRenderSegmentedGauge_ExactWidth(t *testing.T) {
 	b := realisticBreakdown()
 	for _, cells := range []int{1, 3, 7, 20, 40, 76, 120, 200} {
-		if got := ansi.StringWidth(renderSegmentedGauge(b, cells)); got != cells {
+		if got := ansi.StringWidth(renderSegmentedGauge(b, cells, darkPalette)); got != cells {
 			t.Errorf("cells=%d: rendered %d", cells, got)
 		}
 	}
@@ -146,7 +146,7 @@ func TestContextSegmentKind_LabelsAndColorsAreDistinct(t *testing.T) {
 		}
 		seenLabel[l] = true
 
-		c := truecolorFragment(k.Color())
+		c := truecolorFragment(k.Color(darkPalette))
 		if seenColor[c] {
 			t.Errorf("%s reuses another segment's color", l)
 		}
@@ -162,7 +162,7 @@ func TestContextRule_SegmentedKeepsExactWidth(t *testing.T) {
 		for _, used := range []int64{1_000, 85_000, 200_000, 400_000, 1_000_000} {
 			out := renderContextRule(contextRuleInput{
 				Width: width, UsedTokens: used, Breakdown: &b,
-			})
+			}, darkPalette)
 			if got := ansi.StringWidth(out); got != width {
 				t.Errorf("width=%d used=%d: rule is %d cells", width, used, got)
 			}
@@ -172,9 +172,9 @@ func TestContextRule_SegmentedKeepsExactWidth(t *testing.T) {
 
 func TestContextRule_SegmentedUsesSegmentColors(t *testing.T) {
 	b := realisticBreakdown()
-	out := renderContextRule(contextRuleInput{Width: 160, UsedTokens: 85_000, Breakdown: &b})
+	out := renderContextRule(contextRuleInput{Width: 160, UsedTokens: 85_000, Breakdown: &b}, darkPalette)
 	for _, k := range []ContextSegmentKind{SegToolDefs, SegRules, SegMCPTools, SegConversation} {
-		if !strings.Contains(out, truecolorFragment(k.Color())) {
+		if !strings.Contains(out, truecolorFragment(k.Color(darkPalette))) {
 			t.Errorf("segmented rule missing %s color", k.Label())
 		}
 	}
@@ -182,7 +182,7 @@ func TestContextRule_SegmentedUsesSegmentColors(t *testing.T) {
 
 func TestRenderContextBreakdown_ListsEveryNonZeroSection(t *testing.T) {
 	b := realisticBreakdown()
-	out := ansi.Strip(RenderContextBreakdown(b, 200_000, 60))
+	out := ansi.Strip(RenderContextBreakdown(b, 200_000, 60, darkPalette))
 	for k := ContextSegmentKind(0); k < segCount; k++ {
 		if b.Tokens(k) <= 0 {
 			continue
@@ -198,7 +198,7 @@ func TestRenderContextBreakdown_ListsEveryNonZeroSection(t *testing.T) {
 
 func TestRenderContextBreakdown_OmitsZeroSections(t *testing.T) {
 	b := ContextBreakdown{SystemPrompt: 500, Conversation: 5_000}
-	out := ansi.Strip(RenderContextBreakdown(b, 200_000, 60))
+	out := ansi.Strip(RenderContextBreakdown(b, 200_000, 60, darkPalette))
 	if strings.Contains(out, "MCP & dynamic tools") {
 		t.Error("a zero section must not be listed")
 	}
@@ -209,7 +209,7 @@ func TestRenderContextBreakdown_OmitsZeroSections(t *testing.T) {
 
 func TestRenderContextBreakdown_NarrowWidthDoesNotPanic(t *testing.T) {
 	for _, w := range []int{0, 1, 10, 24, 40} {
-		out := RenderContextBreakdown(realisticBreakdown(), 200_000, w)
+		out := RenderContextBreakdown(realisticBreakdown(), 200_000, w, darkPalette)
 		if out == "" {
 			t.Errorf("width=%d produced nothing", w)
 		}

--- a/internal/tui/context_rule.go
+++ b/internal/tui/context_rule.go
@@ -211,8 +211,8 @@ func layoutContextRule(in contextRuleInput) (contextRuleLayout, bool) {
 //
 // The result is always exactly Width display cells, so it satisfies the frame's
 // width invariant on its own and needs no padding by the caller.
-func renderContextRule(in contextRuleInput) string {
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70")) // Mocha surface2
+func renderContextRule(in contextRuleInput, p Palette) string {
+	dim := lipgloss.NewStyle().Foreground(p.Surface)
 
 	if in.Width <= 0 {
 		return ""
@@ -233,7 +233,7 @@ func renderContextRule(in contextRuleInput) string {
 		filled = 1
 	}
 
-	fg := contextSeverityColor(lay.Pct)
+	fg := contextSeverityColor(lay.Pct, p)
 	labelStyle := lipgloss.NewStyle().Foreground(fg)
 
 	// The filled run is either one severity-colored block or, when a breakdown
@@ -241,7 +241,7 @@ func renderContextRule(in contextRuleInput) string {
 	// produce exactly `filled` cells, so width is invariant to which is used.
 	var filledRun string
 	if in.Breakdown != nil && in.Breakdown.Total() > 0 {
-		filledRun = renderSegmentedGauge(in.Breakdown.withConversationFrom(lay.Used), filled)
+		filledRun = renderSegmentedGauge(in.Breakdown.withConversationFrom(lay.Used), filled, p)
 	} else {
 		filledRun = lipgloss.NewStyle().Foreground(fg).
 			Render(strings.Repeat(string(gaugeFilledGlyph), filled))
@@ -253,7 +253,7 @@ func renderContextRule(in contextRuleInput) string {
 	// the measurement. White belongs to no zone and so is legible as a control.
 	clear := ""
 	if lay.ShowClear {
-		clear = lipgloss.NewStyle().Foreground(lipgloss.Color("#ffffff")).
+		clear = lipgloss.NewStyle().Foreground(p.White).
 			Render(gaugeClearButton)
 	}
 
@@ -276,14 +276,14 @@ func renderContextRule(in contextRuleInput) string {
 // used/window ratio. That keeps the color picker testable by the same number
 // the bar prints, so a user who sees "100%" sees red — the bar reaches 100
 // only at the dumb-zone boundary.
-func contextSeverityColor(pct float64) color.Color {
+func contextSeverityColor(pct float64, p Palette) color.Color {
 	switch {
 	case pct >= 100:
-		return lipgloss.Color("#f38ba8") // Mocha red — dumb zone
+		return p.Red // dumb zone
 	case pct >= warmZoneFraction/dumbZoneFraction*100:
-		return lipgloss.Color("#fab387") // Mocha peach — warm zone
+		return p.Peach // warm zone
 	default:
-		return lipgloss.Color("#a6e3a1") // Mocha green — smart zone
+		return p.Green // smart zone
 	}
 }
 

--- a/internal/tui/context_rule_test.go
+++ b/internal/tui/context_rule_test.go
@@ -16,7 +16,7 @@ var sgrSegment = regexp.MustCompile(`\x1b\[(38;2;\d+;\d+;\d+)m([^\x1b]*)\x1b\[m`
 // filledCells counts the leading run drawn in the severity color. The gauge
 // encodes usage in color, not glyph, so this is what "filled" means.
 func filledCells(out string, pct float64) int {
-	want := truecolorFragment(contextSeverityColor(pct))
+	want := truecolorFragment(contextSeverityColor(pct, darkPalette))
 	for _, m := range sgrSegment.FindAllStringSubmatch(out, -1) {
 		if m[1] == want {
 			return ansi.StringWidth(m[2])
@@ -28,7 +28,7 @@ func filledCells(out string, pct float64) int {
 // hasSeverityColor reports whether the gauge drew any run in a severity color,
 // i.e. whether it is showing a reading at all.
 func hasSeverityColor(out string, pct float64) bool {
-	return strings.Contains(out, truecolorFragment(contextSeverityColor(pct)))
+	return strings.Contains(out, truecolorFragment(contextSeverityColor(pct, darkPalette)))
 }
 
 // I1: the gauge is a frame row, so it must be exactly the terminal width at
@@ -38,7 +38,7 @@ func TestContextRule_ExactWidth(t *testing.T) {
 	for _, width := range []int{20, 40, 60, 80, 120, 200} {
 		for _, used := range []int64{0, 1, 1_000, 50_000, 128_000, 255_999, 256_000, 999_999} {
 			in := contextRuleInput{Width: width, UsedTokens: used, WindowSize: defaultContextWindow}
-			got := ansi.StringWidth(renderContextRule(in))
+			got := ansi.StringWidth(renderContextRule(in, darkPalette))
 			if got != width {
 				t.Errorf("width=%d used=%d: rule is %d cells, want %d", width, used, got, width)
 			}
@@ -50,7 +50,7 @@ func TestContextRule_ExactWidth(t *testing.T) {
 func TestContextRule_NoEscapeLeak(t *testing.T) {
 	out := renderContextRule(contextRuleInput{
 		Width: 120, UsedTokens: 150_000, WindowSize: defaultContextWindow,
-	})
+	}, darkPalette)
 	if strings.Contains(ansi.Strip(out), "38;5;") || strings.Contains(ansi.Strip(out), "[0m") {
 		t.Errorf("escape leaked into visible text: %q", ansi.Strip(out))
 	}
@@ -74,7 +74,7 @@ func TestContextRule_SeverityLadder(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := contextSeverityColor(tc.pct)
+			got := contextSeverityColor(tc.pct, darkPalette)
 			if got == nil {
 				t.Fatal("nil color")
 			}
@@ -114,7 +114,7 @@ func TestContextRule_DumbZoneEntryTurnsRed(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			out := renderContextRule(contextRuleInput{
 				Width: 120, UsedTokens: tc.used, WindowSize: tc.window,
-			})
+			}, darkPalette)
 			if !hasSeverityColor(out, 100) {
 				t.Errorf("used=%d window=%d: gauge at dumb-zone entry should be red, got %q",
 					tc.used, tc.window, out)
@@ -137,7 +137,7 @@ func TestContextRule_FillGrowsWithUsage(t *testing.T) {
 		}
 		out := renderContextRule(contextRuleInput{
 			Width: width, UsedTokens: used, WindowSize: defaultContextWindow,
-		})
+		}, darkPalette)
 		filled := filledCells(out, pct)
 		if filled <= prev {
 			t.Errorf("used=%d: filled=%d did not grow past %d", used, filled, prev)
@@ -153,13 +153,13 @@ func TestContextRule_PegsAtDumbZoneEntry(t *testing.T) {
 	const width = 120
 	atBoundary := renderContextRule(contextRuleInput{
 		Width: width, UsedTokens: 179_200, WindowSize: defaultContextWindow,
-	})
+	}, darkPalette)
 	pastBoundary := renderContextRule(contextRuleInput{
 		Width: width, UsedTokens: 200_000, WindowSize: defaultContextWindow,
-	})
+	}, darkPalette)
 	wellPast := renderContextRule(contextRuleInput{
 		Width: width, UsedTokens: 256_000, WindowSize: defaultContextWindow,
-	})
+	}, darkPalette)
 	atFill := filledCells(atBoundary, 100)
 	pastFill := filledCells(pastBoundary, 100)
 	wellPastFill := filledCells(wellPast, 100)
@@ -173,7 +173,7 @@ func TestContextRule_PegsAtDumbZoneEntry(t *testing.T) {
 }
 
 func TestContextRule_UnmeasuredRendersPlainRule(t *testing.T) {
-	out := renderContextRule(contextRuleInput{Width: 80})
+	out := renderContextRule(contextRuleInput{Width: 80}, darkPalette)
 	if hasSeverityColor(out, 0) {
 		t.Error("an unmeasured context must not render a filled gauge")
 	}
@@ -190,7 +190,7 @@ func TestContextRule_AnyUsageShowsAtLeastOneCell(t *testing.T) {
 	// still read as a gauge rather than an empty rule.
 	out := renderContextRule(contextRuleInput{
 		Width: 120, UsedTokens: 1, WindowSize: defaultContextWindow,
-	})
+	}, darkPalette)
 	if got := filledCells(out, 0); got < 1 {
 		t.Errorf("measured usage must show at least one filled cell, got %d", got)
 	}
@@ -202,7 +202,7 @@ func TestContextRule_FallsBackToDefaultWindow(t *testing.T) {
 	//
 	// 128k of a 256k window sits at 50% of the window, which under the dumb-zone
 	// calibration equals 50/70 ≈ 71.4% of the bar (100 = dumb-zone entry).
-	out := renderContextRule(contextRuleInput{Width: 120, UsedTokens: 128_000})
+	out := renderContextRule(contextRuleInput{Width: 120, UsedTokens: 128_000}, darkPalette)
 	plain := ansi.Strip(out)
 	if !strings.Contains(plain, "256.0k") {
 		t.Errorf("expected the assumed 256k denominator, got %q", plain)
@@ -269,7 +269,7 @@ func TestContextRule_ReadoutNamesTheScaleInUse(t *testing.T) {
 		{800_000, "1.0M", "100%"},
 	}
 	for _, tc := range tests {
-		out := ansi.Strip(renderContextRule(contextRuleInput{Width: 120, UsedTokens: tc.used}))
+		out := ansi.Strip(renderContextRule(contextRuleInput{Width: 120, UsedTokens: tc.used}, darkPalette))
 		if !strings.Contains(out, tc.wantScale) {
 			t.Errorf("used=%d: readout %q does not name scale %s", tc.used, out, tc.wantScale)
 		}
@@ -290,8 +290,8 @@ func TestContextRule_StepUpRescalesDownward(t *testing.T) {
 	var belowUsed int64 = midScaleThreshold - 1
 	atUsed := int64(midScaleThreshold)
 
-	below := renderContextRule(contextRuleInput{Width: width, UsedTokens: belowUsed})
-	at := renderContextRule(contextRuleInput{Width: width, UsedTokens: atUsed})
+	below := renderContextRule(contextRuleInput{Width: width, UsedTokens: belowUsed}, darkPalette)
+	at := renderContextRule(contextRuleInput{Width: width, UsedTokens: atUsed}, darkPalette)
 
 	belowPct := float64(belowUsed) / (float64(defaultContextWindow) * dumbZoneFraction) * 100
 	if belowPct > 100 {
@@ -317,7 +317,7 @@ func TestContextRule_ExactWidthAcrossScales(t *testing.T) {
 		for _, used := range []int64{
 			0, 199_999, 200_000, 399_999, 400_000, 999_999, 1_000_000, 2_000_000,
 		} {
-			out := renderContextRule(contextRuleInput{Width: width, UsedTokens: used})
+			out := renderContextRule(contextRuleInput{Width: width, UsedTokens: used}, darkPalette)
 			if got := ansi.StringWidth(out); got != width {
 				t.Errorf("width=%d used=%d: rule is %d cells", width, used, got)
 			}
@@ -327,7 +327,7 @@ func TestContextRule_ExactWidthAcrossScales(t *testing.T) {
 
 // Usage past the top scale pegs at 100% rather than overflowing the rule.
 func TestContextRule_BeyondTopScalePegs(t *testing.T) {
-	out := ansi.Strip(renderContextRule(contextRuleInput{Width: 120, UsedTokens: 5_000_000}))
+	out := ansi.Strip(renderContextRule(contextRuleInput{Width: 120, UsedTokens: 5_000_000}, darkPalette))
 	if !strings.Contains(out, "100%") {
 		t.Errorf("usage beyond the top scale should peg at 100%%, got %q", out)
 	}
@@ -336,7 +336,7 @@ func TestContextRule_BeyondTopScalePegs(t *testing.T) {
 func TestContextRule_RealWindowWins(t *testing.T) {
 	out := renderContextRule(contextRuleInput{
 		Width: 120, UsedTokens: 100_000, WindowSize: 200_000,
-	})
+	}, darkPalette)
 	plain := ansi.Strip(out)
 	if !strings.Contains(plain, "200.0k") {
 		t.Errorf("a known window must override the assumed one, got %q", plain)
@@ -345,7 +345,7 @@ func TestContextRule_RealWindowWins(t *testing.T) {
 
 func TestContextRule_EstimateUsedBeforeFirstResponse(t *testing.T) {
 	pct := 40_000.0 / float64(defaultContextWindow) * 100
-	out := renderContextRule(contextRuleInput{Width: 120, FallbackEst: 40_000})
+	out := renderContextRule(contextRuleInput{Width: 120, FallbackEst: 40_000}, darkPalette)
 	if filledCells(out, pct) < 1 {
 		t.Error("the pre-response estimate should still drive the gauge")
 	}
@@ -355,15 +355,15 @@ func TestContextRule_NarrowTerminalDegradesGracefully(t *testing.T) {
 	for _, width := range []int{1, 2, 5, 10, 15} {
 		out := renderContextRule(contextRuleInput{
 			Width: width, UsedTokens: 128_000, WindowSize: defaultContextWindow,
-		})
+		}, darkPalette)
 		if got := ansi.StringWidth(out); got != width {
 			t.Errorf("width=%d: got %d cells", width, got)
 		}
 	}
-	if renderContextRule(contextRuleInput{Width: 0}) != "" {
+	if renderContextRule(contextRuleInput{Width: 0}, darkPalette) != "" {
 		t.Error("zero width must render nothing")
 	}
-	if renderContextRule(contextRuleInput{Width: -5}) != "" {
+	if renderContextRule(contextRuleInput{Width: -5}, darkPalette) != "" {
 		t.Error("negative width must render nothing")
 	}
 }

--- a/internal/tui/highlight_test.go
+++ b/internal/tui/highlight_test.go
@@ -74,7 +74,7 @@ func TestHighlightReadOutput_BasicGoFile(t *testing.T) {
 		"     2\t",
 		"     3\tfunc main() {}",
 	}
-	result := highlightReadOutput(lines, "main.go")
+	result := highlightReadOutput(lines, "main.go", darkPalette)
 
 	if len(result) != 3 {
 		t.Fatalf("expected 3 lines, got %d", len(result))
@@ -98,7 +98,7 @@ func TestHighlightReadOutput_NoTabSeparator(t *testing.T) {
 		"     1\tpackage main",
 		"... (truncated)",
 	}
-	result := highlightReadOutput(lines, "main.go")
+	result := highlightReadOutput(lines, "main.go", darkPalette)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(result))
@@ -111,7 +111,7 @@ func TestHighlightReadOutput_NoTabSeparator(t *testing.T) {
 
 func TestHighlightReadOutput_EmptyLines(t *testing.T) {
 	lines := []string{}
-	result := highlightReadOutput(lines, "main.go")
+	result := highlightReadOutput(lines, "main.go", darkPalette)
 	if len(result) != 0 {
 		t.Errorf("expected 0 lines for empty input, got %d", len(result))
 	}
@@ -122,7 +122,7 @@ func TestHighlightReadOutput_PreservesLineNumberFormat(t *testing.T) {
 		"    42\tx := 1",
 		"    43\ty := 2",
 	}
-	result := highlightReadOutput(lines, "test.go")
+	result := highlightReadOutput(lines, "test.go", darkPalette)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(result))
@@ -143,7 +143,7 @@ func TestHighlightGrepOutput_BasicMatch(t *testing.T) {
 		"main.go:10: func main() {}",
 		"utils.go:25: var x = 42",
 	}
-	result := highlightGrepOutput(lines)
+	result := highlightGrepOutput(lines, darkPalette)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(result))
@@ -167,7 +167,7 @@ func TestHighlightGrepOutput_TruncationNote(t *testing.T) {
 		"file.go:1: x := 1",
 		"... (200 total matches, truncated)",
 	}
-	result := highlightGrepOutput(lines)
+	result := highlightGrepOutput(lines, darkPalette)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(result))
@@ -178,7 +178,7 @@ func TestHighlightGrepOutput_TruncationNote(t *testing.T) {
 }
 
 func TestHighlightGrepOutput_EmptyLines(t *testing.T) {
-	result := highlightGrepOutput([]string{})
+	result := highlightGrepOutput([]string{}, darkPalette)
 	if len(result) != 0 {
 		t.Errorf("expected 0 lines, got %d", len(result))
 	}
@@ -186,7 +186,7 @@ func TestHighlightGrepOutput_EmptyLines(t *testing.T) {
 
 func TestHighlightGrepOutput_NoColonLine(t *testing.T) {
 	lines := []string{"just a line without colons"}
-	result := highlightGrepOutput(lines)
+	result := highlightGrepOutput(lines, darkPalette)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 line, got %d", len(result))
 	}
@@ -200,7 +200,7 @@ func TestHighlightGrepOutput_SyntaxHighlightedContent(t *testing.T) {
 	lines := []string{
 		"main.go:5: func main() {}",
 	}
-	result := highlightGrepOutput(lines)
+	result := highlightGrepOutput(lines, darkPalette)
 
 	// Content portion should have chroma highlighting (ANSI codes).
 	if len(result) != 1 {
@@ -216,7 +216,7 @@ func TestHighlightGrepOutput_PythonFile(t *testing.T) {
 	lines := []string{
 		"script.py:3: def hello():",
 	}
-	result := highlightGrepOutput(lines)
+	result := highlightGrepOutput(lines, darkPalette)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 line, got %d", len(result))
 	}
@@ -233,7 +233,7 @@ func TestHighlightFindOutput_FileList(t *testing.T) {
 		"internal/tools/write.go",
 		"internal/tui/tui.go",
 	}
-	result := highlightFindOutput(lines)
+	result := highlightFindOutput(lines, darkPalette)
 
 	if len(result) != 3 {
 		t.Fatalf("expected 3 lines, got %d", len(result))
@@ -254,7 +254,7 @@ func TestHighlightFindOutput_WithDirectories(t *testing.T) {
 		"src/",
 		"src/main.go",
 	}
-	result := highlightFindOutput(lines)
+	result := highlightFindOutput(lines, darkPalette)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(result))
@@ -270,7 +270,7 @@ func TestHighlightFindOutput_TruncationNote(t *testing.T) {
 		"file1.go",
 		"... (500 total files, truncated)",
 	}
-	result := highlightFindOutput(lines)
+	result := highlightFindOutput(lines, darkPalette)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(result))
@@ -281,7 +281,7 @@ func TestHighlightFindOutput_TruncationNote(t *testing.T) {
 }
 
 func TestHighlightFindOutput_EmptyLines(t *testing.T) {
-	result := highlightFindOutput([]string{})
+	result := highlightFindOutput([]string{}, darkPalette)
 	if len(result) != 0 {
 		t.Errorf("expected 0 lines, got %d", len(result))
 	}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -66,6 +66,10 @@ type InputModel struct {
 	SkillDirs []string
 	WorkDir   string
 
+	// Palette is the resolved theme palette, set each frame by the model before
+	// rendering. Zero means the dark default.
+	Palette Palette
+
 	input textinput.Model
 }
 
@@ -150,11 +154,12 @@ func (im *InputModel) SetWidth(width int) {
 func (im *InputModel) View(running bool) string {
 	im.ensureInput()
 	if running {
+		p := paletteOrDark(im.Palette)
 		prefix := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("39")).
+			Foreground(p.Primary).
 			Bold(true).
 			Render("> ")
-		dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+		dim := lipgloss.NewStyle().Foreground(p.Dim)
 		return prefix + dim.Render("(waiting for response...)")
 	}
 	return im.input.View()
@@ -223,13 +228,14 @@ func (im *InputModel) Cursor() *tea.Cursor {
 func (im *InputModel) ensureInput() {
 	if im.input.KeyMap.CharacterForward.Keys() == nil {
 		im.input = textinput.New()
+		p := paletteOrDark(im.Palette)
 		promptStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("39")).
+			Foreground(p.Primary).
 			Bold(true)
 		styles := im.input.Styles()
 		styles.Focused.Prompt = promptStyle
 		styles.Blurred.Prompt = promptStyle
-		styles.Cursor.Color = lipgloss.Color("39")
+		styles.Cursor.Color = p.Primary
 		styles.Cursor.Shape = tea.CursorBar
 		im.input.SetStyles(styles)
 		im.input.Prompt = "> "

--- a/internal/tui/matrix.go
+++ b/internal/tui/matrix.go
@@ -60,6 +60,7 @@ type matrixState struct {
 	fullWidth int                       // full terminal width for centering
 	seed      int64                     // accumulated entropy from token bytes
 	active    bool
+	palette   Palette // resolved theme palette for the rain gradient
 }
 
 // randCell generates a random cell using the current RNG.
@@ -107,7 +108,8 @@ func (ms *matrixState) renderLine(row int) string {
 	if n == 0 {
 		return ""
 	}
-	maxShade := len(matrixColors) - 1
+	colors := matrixGradient(ms.palette)
+	maxShade := len(colors) - 1
 	mid := float64(n) / 2.0
 
 	var sb strings.Builder
@@ -138,10 +140,33 @@ func (ms *matrixState) renderLine(row int) string {
 		if shade > maxShade {
 			shade = maxShade
 		}
-		style := lipgloss.NewStyle().Foreground(matrixColors[shade])
+		style := lipgloss.NewStyle().Foreground(colors[shade])
 		sb.WriteString(style.Render(string(cell.ch)))
 	}
 	return sb.String()
+}
+
+// matrixGradient returns the rain gradient for a palette: a ramp from the
+// background through the surface shades up to the bright accent hues, so the
+// rain stays legible on both dark and light themes.
+func matrixGradient(p Palette) []color.Color {
+	if !p.Valid {
+		return matrixColors
+	}
+	return []color.Color{
+		p.Background, // base (nearly invisible)
+		p.Surface0,
+		p.Surface1,
+		p.Surface,
+		p.Overlay0,
+		p.Overlay1,
+		p.Blue,
+		p.Sapphire,
+		p.Teal,
+		p.Lavender,
+		p.Mauve,
+		p.Pink,
+	}
 }
 
 // feed mixes token text into the entropy and shifts characters left.

--- a/internal/tui/minimap.go
+++ b/internal/tui/minimap.go
@@ -57,10 +57,6 @@ func thumbRange(start, end, total, rows int) (lo, hi int) {
 	return lo, lo + thumbRows
 }
 
-// separatorColor matches the sidebar's old border (Mocha surface1), so rows with
-// no conversation behind them still read as a plain divider.
-const separatorColor = "#45475a"
-
 // railCell renders one rail cell: glyph repeated to fill railWidth, in color.
 func railCell(glyph, color string) string {
 	return lipgloss.NewStyle().
@@ -70,20 +66,16 @@ func railCell(glyph, color string) string {
 
 // separatorCell is the rail outside the message viewport — above and below the
 // chat, where there is nothing to map.
-func separatorCell() string {
-	return railCell(railGlyph, separatorColor)
+func separatorCell(p Palette) string {
+	return railCell(railGlyph, colorString(p.Surface1))
 }
-
-// ruleColor is the color of the horizontal rules that close the panel and frame
-// the input (Mocha surface2).
-const ruleColor = "#585b70"
 
 // railFootCell is the rail's last cell, the one that sits on the panel's closing
 // rule. A vertical glyph there cuts the rule in half where the panel meets the
 // sidebar; the joint carries the line through instead, so the panel's rule, this
 // cell and the sidebar's rule read as one line across the terminal.
-func railFootCell() string {
-	return railCell(railFoot, ruleColor)
+func railFootCell(p Palette) string {
+	return railCell(railFoot, colorString(p.Surface))
 }
 
 // blockKind classifies a rendered line by the kind of message it came from.
@@ -104,23 +96,36 @@ const (
 	blockTool    // any other tool, incl. MCP
 )
 
-// minimapColors maps each block kind to its bar color, as an ANSI 256 index.
+// minimapColor maps a block kind to its rail color, resolved from the palette.
 // Mutations and commands — the lines a reader most often scrolls back to find —
 // get the warm, high-contrast end of the palette; passive content stays cool
 // and recessive. Colors echo the ones each block already uses in the chat, so
 // the strip reads as a scaled-down copy rather than a separate legend.
-var minimapColors = map[blockKind]string{
-	blockUser:      "39",  // blue, matches the "> " prompt label
-	blockAssistant: "63",  // violet, matches the reply bullet
-	blockWarning:   "226", // yellow, matches the warning bullet
-	blockError:     "203", // red, matches the error bullet
-	blockThinking:  "243", // gray, matches the thinking style
-	blockRead:      "45",  // cyan
-	blockEdit:      "208", // orange
-	blockExecute:   "76",  // green
-	blockAgent:     "141", // purple
-	blockTool:      "102", // muted slate
-	blockNone:      "237", // near-background track
+func minimapColor(kind blockKind, p Palette) string {
+	switch kind {
+	case blockUser:
+		return colorString(p.Primary)
+	case blockAssistant:
+		return colorString(p.Accent)
+	case blockWarning:
+		return colorString(p.Warning)
+	case blockError:
+		return colorString(p.Error)
+	case blockThinking:
+		return colorString(p.Faint)
+	case blockRead:
+		return colorString(p.Cyan)
+	case blockEdit:
+		return colorString(p.Peach)
+	case blockExecute:
+		return colorString(p.Green)
+	case blockAgent:
+		return colorString(p.Mauve)
+	case blockTool:
+		return colorString(p.Overlay)
+	default:
+		return colorString(p.Surface1)
+	}
 }
 
 // kindOf classifies a message for the minimap.
@@ -168,7 +173,7 @@ func toolBlockKind(tool string) blockKind {
 //
 // kinds is the per-line classification of the full rendered chat; start and end
 // bound the slice of it currently visible.
-func renderMinimap(kinds []blockKind, start, end, rows int) []string {
+func renderMinimap(kinds []blockKind, start, end, rows int, p Palette) []string {
 	if rows <= 0 {
 		return nil
 	}
@@ -178,7 +183,7 @@ func renderMinimap(kinds []blockKind, start, end, rows int) []string {
 	if total == 0 {
 		// No content yet: draw the empty track, so the column never appears or
 		// disappears from under the user.
-		empty := railCell(railGlyph, minimapColors[blockNone])
+		empty := railCell(railGlyph, colorString(p.Surface1))
 		for i := range cells {
 			cells[i] = empty
 		}
@@ -199,14 +204,14 @@ func renderMinimap(kinds []blockKind, start, end, rows int) []string {
 
 		kind := dominantKind(kinds[lo:hi])
 
-		glyph, color := railGlyph, minimapColors[kind]
+		glyph, color := railGlyph, minimapColor(kind, p)
 		if row >= thumbLo && row < thumbHi {
 			glyph = railThumb
 			if kind == blockNone {
 				// A thumb over a run of blank lines still has to read as "you
 				// are here", so brighten the track rather than leaving a hole
 				// in it.
-				color = "244"
+				color = colorString(p.Subtext)
 			}
 		}
 		cells[row] = railCell(glyph, color)
@@ -247,8 +252,8 @@ func dominantKind(kinds []blockKind) blockKind {
 //
 // rows is the panel's height; msgStart is the row the message viewport begins
 // on; cells are the minimap cells for it, one per row.
-func railColumn(rows, msgStart int, cells []string) string {
-	sep := separatorCell()
+func railColumn(rows, msgStart int, cells []string, p Palette) string {
+	sep := separatorCell(p)
 
 	out := make([]string, rows)
 	for i := range out {
@@ -258,7 +263,7 @@ func railColumn(rows, msgStart int, cells []string) string {
 		}
 	}
 	if rows > 0 {
-		out[rows-1] = railFootCell()
+		out[rows-1] = railFootCell(p)
 	}
 	return strings.Join(out, "\n")
 }

--- a/internal/tui/minimap_test.go
+++ b/internal/tui/minimap_test.go
@@ -55,7 +55,7 @@ func TestRenderMinimapCompressesWholeConversation(t *testing.T) {
 		kinds[i] = blockEdit
 	}
 
-	cells := renderMinimap(kinds, 0, 10, 10)
+	cells := renderMinimap(kinds, 0, 10, 10, darkPalette)
 
 	if len(cells) != 10 {
 		t.Fatalf("got %d cells, want one per row (10)", len(cells))
@@ -72,9 +72,9 @@ func TestRenderMinimapCompressesWholeConversation(t *testing.T) {
 // The minimap and the separator are the same rail, so they must be the same
 // width — otherwise the rule appears to change thickness as you scroll.
 func TestMinimapWidthMatchesSeparator(t *testing.T) {
-	sep := ansi.StringWidth(separatorCell())
+	sep := ansi.StringWidth(separatorCell(darkPalette))
 
-	for _, cell := range renderMinimap([]blockKind{blockUser, blockEdit}, 0, 1, 2) {
+	for _, cell := range renderMinimap([]blockKind{blockUser, blockEdit}, 0, 1, 2, darkPalette) {
 		if got := ansi.StringWidth(cell); got != sep {
 			t.Errorf("minimap cell width = %d, separator width = %d; they must match", got, sep)
 		}
@@ -108,7 +108,7 @@ func TestScrollThumbIsThreeDots(t *testing.T) {
 
 	// Whatever the viewport size, the thumb stays three rows.
 	for _, view := range [][2]int{{0, 10}, {0, 100}, {95, 105}, {190, 200}} {
-		cells := renderMinimap(kinds, view[0], view[1], 20)
+		cells := renderMinimap(kinds, view[0], view[1], 20, darkPalette)
 		if n, _ := countThumb(cells); n != thumbRows {
 			t.Errorf("viewport %v: thumb is %d rows, want %d", view, n, thumbRows)
 		}
@@ -116,8 +116,8 @@ func TestScrollThumbIsThreeDots(t *testing.T) {
 
 	// And it rides the track: top of the conversation puts it at the top, the
 	// bottom puts it at the bottom.
-	_, atTop := countThumb(renderMinimap(kinds, 0, 10, 20))
-	_, atBottom := countThumb(renderMinimap(kinds, 190, 200, 20))
+	_, atTop := countThumb(renderMinimap(kinds, 0, 10, 20, darkPalette))
+	_, atBottom := countThumb(renderMinimap(kinds, 190, 200, 20, darkPalette))
 	if atTop != 0 {
 		t.Errorf("scrolled to the top, thumb starts at row %d, want 0", atTop)
 	}
@@ -132,7 +132,7 @@ func TestScrollThumbIsThreeDots(t *testing.T) {
 // A rail shorter than the thumb is filled, rather than showing a thumb longer
 // than its track.
 func TestScrollThumbOnShortRail(t *testing.T) {
-	cells := renderMinimap([]blockKind{blockUser, blockEdit}, 0, 2, 2)
+	cells := renderMinimap([]blockKind{blockUser, blockEdit}, 0, 2, 2, darkPalette)
 	for i, c := range cells {
 		if !strings.Contains(c, railThumb) {
 			t.Errorf("row %d of a 2-row rail has no thumb", i)
@@ -143,7 +143,7 @@ func TestScrollThumbOnShortRail(t *testing.T) {
 // Always visible: an empty chat still gets a track, so the column never appears
 // or disappears under the user.
 func TestRenderMinimapAlwaysDrawsATrack(t *testing.T) {
-	cells := renderMinimap(nil, 0, 0, 5)
+	cells := renderMinimap(nil, 0, 0, 5, darkPalette)
 	if len(cells) != 5 {
 		t.Fatalf("got %d cells for an empty chat, want 5", len(cells))
 	}
@@ -184,9 +184,9 @@ func TestPanelBodyTruncatesOverlongLines(t *testing.T) {
 // gutter this replaces.
 func TestRailIsContinuousAndSingleColumn(t *testing.T) {
 	// Two header rows, three message rows, two footer rows.
-	cells := renderMinimap([]blockKind{blockUser, blockEdit, blockAssistant}, 0, 3, 3)
+	cells := renderMinimap([]blockKind{blockUser, blockEdit, blockAssistant}, 0, 3, 3, darkPalette)
 
-	out := railColumn(7, 2, cells)
+	out := railColumn(7, 2, cells, darkPalette)
 	lines := strings.Split(out, "\n")
 
 	if len(lines) != 7 {

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -1,0 +1,196 @@
+package tui
+
+import (
+	"fmt"
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Palette is the resolved set of colors the renderers draw with. It is the
+// bridge between the theme system and the renderers: the theme manager picks a
+// Theme, and paletteFor turns it into a Palette the renderers can read.
+//
+// Before this existed every renderer hardcoded Catppuccin Mocha (dark) hex
+// values, so switching to a light theme changed nothing on screen — the dark
+// foregrounds were invisible on a light terminal background. Threading a
+// Palette through the render inputs is what makes light themes actually render.
+//
+// Valid distinguishes a real palette from the zero value, so renderers that
+// receive an unset Palette (e.g. in tests) fall back to the dark palette and
+// keep their existing output byte-for-byte.
+type Palette struct {
+	Valid bool
+
+	// Text roles.
+	Text    color.Color // primary text
+	Subtext color.Color // secondary text
+	Dim     color.Color // muted text (thinking, separators)
+	Faint   color.Color // faintest (line numbers, very muted)
+
+	// Semantic accents.
+	Primary color.Color // blue — prompts, user labels, links
+	Accent  color.Color // violet — reply bullets
+	Tool    color.Color // green — tool names
+	Success color.Color // green
+	Error   color.Color // red
+	Warning color.Color // yellow
+
+	// Extended hues.
+	Blue     color.Color
+	Cyan     color.Color
+	Teal     color.Color
+	Green    color.Color
+	Yellow   color.Color
+	Peach    color.Color // orange
+	Red      color.Color
+	Pink     color.Color
+	Mauve    color.Color
+	Sky      color.Color
+	Sapphire color.Color
+	Lavender color.Color
+
+	// Surfaces.
+	Surface     color.Color // rules, separators (surface2)
+	Surface1    color.Color
+	Overlay     color.Color
+	Overlay2    color.Color
+	Background  color.Color
+	Surface0    color.Color
+	Overlay0    color.Color
+	Overlay1    color.Color
+	White       color.Color // deliberately outside the gauge vocabulary
+	Transparent color.Color
+}
+
+// darkPalette is the Catppuccin Mocha palette the renderers used before theming
+// existed. It is the default so existing dark output is unchanged.
+var darkPalette = Palette{
+	Valid:       true,
+	Text:        lipgloss.Color("#cdd6f4"),
+	Subtext:     lipgloss.Color("#a6adc8"),
+	Dim:         lipgloss.Color("#a6adc8"),
+	Faint:       lipgloss.Color("#7f849c"),
+	Primary:     lipgloss.Color("#89b4fa"),
+	Accent:      lipgloss.Color("#cba6f7"),
+	Tool:        lipgloss.Color("#a6e3a1"),
+	Success:     lipgloss.Color("#a6e3a1"),
+	Error:       lipgloss.Color("#f38ba8"),
+	Warning:     lipgloss.Color("#f9e2af"),
+	Blue:        lipgloss.Color("#89b4fa"),
+	Cyan:        lipgloss.Color("#89dceb"),
+	Teal:        lipgloss.Color("#94e2d5"),
+	Green:       lipgloss.Color("#a6e3a1"),
+	Yellow:      lipgloss.Color("#f9e2af"),
+	Peach:       lipgloss.Color("#fab387"),
+	Red:         lipgloss.Color("#f38ba8"),
+	Pink:        lipgloss.Color("#f5c2e7"),
+	Mauve:       lipgloss.Color("#cba6f7"),
+	Sky:         lipgloss.Color("#89dceb"),
+	Sapphire:    lipgloss.Color("#74c7ec"),
+	Lavender:    lipgloss.Color("#b4befe"),
+	Surface:     lipgloss.Color("#585b70"),
+	Surface1:    lipgloss.Color("#45475a"),
+	Overlay:     lipgloss.Color("#6c7086"),
+	Overlay2:    lipgloss.Color("#9399b2"),
+	Background:  lipgloss.Color("#1e1e2e"),
+	Surface0:    lipgloss.Color("#313244"),
+	Overlay0:    lipgloss.Color("#6c7086"),
+	Overlay1:    lipgloss.Color("#7f849c"),
+	White:       lipgloss.Color("#ffffff"),
+	Transparent: lipgloss.Color("#00000000"),
+}
+
+// lightPalette is the Catppuccin Latte palette, chosen so every role stays
+// legible on a light terminal background. The extended hues are the Latte
+// equivalents of the Mocha hues the renderers used, so the light theme reads as
+// the same UI, just on a light background.
+var lightPalette = Palette{
+	Valid:       true,
+	Text:        lipgloss.Color("#4c4f69"),
+	Subtext:     lipgloss.Color("#6c6f85"),
+	Dim:         lipgloss.Color("#7c7f93"),
+	Faint:       lipgloss.Color("#8c8fa1"),
+	Primary:     lipgloss.Color("#1e66f5"),
+	Accent:      lipgloss.Color("#8839ef"),
+	Tool:        lipgloss.Color("#40a02b"),
+	Success:     lipgloss.Color("#40a02b"),
+	Error:       lipgloss.Color("#d20f39"),
+	Warning:     lipgloss.Color("#df8e1d"),
+	Blue:        lipgloss.Color("#1e66f5"),
+	Cyan:        lipgloss.Color("#04a5e5"),
+	Teal:        lipgloss.Color("#179299"),
+	Green:       lipgloss.Color("#40a02b"),
+	Yellow:      lipgloss.Color("#df8e1d"),
+	Peach:       lipgloss.Color("#fe640b"),
+	Red:         lipgloss.Color("#d20f39"),
+	Pink:        lipgloss.Color("#ea76cb"),
+	Mauve:       lipgloss.Color("#8839ef"),
+	Sky:         lipgloss.Color("#04a5e5"),
+	Sapphire:    lipgloss.Color("#209fb5"),
+	Lavender:    lipgloss.Color("#7287fd"),
+	Surface:     lipgloss.Color("#acb0be"),
+	Surface1:    lipgloss.Color("#bcc0cc"),
+	Overlay:     lipgloss.Color("#9ca0b0"),
+	Overlay2:    lipgloss.Color("#8c8fa1"),
+	Background:  lipgloss.Color("#eff1f5"),
+	Surface0:    lipgloss.Color("#ccd0da"),
+	Overlay0:    lipgloss.Color("#9ca0b0"),
+	Overlay1:    lipgloss.Color("#8c8fa1"),
+	White:       lipgloss.Color("#ffffff"),
+	Transparent: lipgloss.Color("#00000000"),
+}
+
+// paletteFor resolves a Palette from a Theme. Dark themes keep the Mocha
+// palette the renderers used before theming, so existing dark output is
+// byte-for-byte unchanged; light themes get the Catppuccin Latte palette, which
+// is legible on a light terminal background. This is what makes a light theme
+// actually render instead of drawing dark-theme foregrounds on a light screen.
+func paletteFor(t Theme) Palette {
+	if t.ThemeType == "light" {
+		return lightPalette
+	}
+	return darkPalette
+}
+
+// paletteOrDark returns p when it is a real palette, otherwise the dark
+// default. Renderers call this so an unset Palette (tests, zero-value inputs)
+// renders exactly as before.
+func paletteOrDark(p Palette) Palette {
+	if p.Valid {
+		return p
+	}
+	return darkPalette
+}
+
+// paletteKey fingerprints a palette so the chat render cache can invalidate
+// when the theme changes. It folds the palette's distinguishing colors into a
+// single uint64; two palettes that render identically share a key.
+func paletteKey(p Palette) uint64 {
+	h := fnvOffset64
+	for _, c := range []color.Color{
+		p.Text, p.Primary, p.Accent, p.Tool, p.Success, p.Error,
+		p.Warning, p.Dim, p.Faint, p.Surface, p.Background,
+	} {
+		if c == nil {
+			continue
+		}
+		r, g, b, a := c.RGBA()
+		h = fnvByte(h, byte(r>>8))
+		h = fnvByte(h, byte(g>>8))
+		h = fnvByte(h, byte(b>>8))
+		h = fnvByte(h, byte(a>>8))
+	}
+	return h
+}
+
+// colorString returns the hex form of a color.Color, or the empty string when
+// it is nil. Used where a renderer needs the raw color token (e.g. the
+// minimap's rail cells).
+func colorString(c color.Color) string {
+	if c == nil {
+		return ""
+	}
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)
+}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"cmp"
 	"fmt"
+	"image/color"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -55,6 +56,7 @@ type SidebarRenderInput struct {
 	MCPTools     []extension.MCPToolEntry // MCP tools section; nil = hidden
 	MemoryStatus *palace.PalaceStatus     // memory palace status; nil = hidden
 	Artifacts    []ArtifactEntry          // artifacts section; nil/empty = hidden
+	Palette      Palette                  // resolved theme palette; zero = dark default
 }
 
 // ArtifactEntry is one row in the Artifacts sidebar section.
@@ -68,34 +70,37 @@ type ArtifactEntry struct {
 	Mime     string
 }
 
-// Catppuccin Mocha slice used across the sidebar sections.
-const (
-	sidebarTextHex     = "#cdd6f4" // text
-	sidebarSubtextHex  = "#a6adc8" // subtext0
-	sidebarBlueHex     = "#89b4fa" // blue
-	sidebarSapphireHex = "#74c7ec" // sapphire
-	sidebarYellowHex   = "#f9e2af" // yellow
-	sidebarPeachHex    = "#fab387" // peach
-	sidebarGreenHex    = "#a6e3a1" // green
-	sidebarRedHex      = "#f38ba8" // red
-	sidebarTealHex     = "#94e2d5" // teal
-	sidebarPinkHex     = "#f5c2e7" // pink
-	sidebarMauveHex    = "#cba6f7" // mauve
-	sidebarOverlayHex  = "#6c7086" // overlay0
-	sidebarSurfaceHex  = "#585b70" // surface2, same as the panel rule
-	// crust with alpha, for dark transparency
-	sidebarBgHex = "#11111bcc"
-)
+// sidebarStyles bundles the resolved styles the sidebar draws with, derived
+// from the active theme's palette. It is built once per frame in RenderSidebar
+// and threaded through the section renderers so a light theme actually renders.
+type sidebarStyles struct {
+	dim     lipgloss.Style
+	heading lipgloss.Style
+	bg      color.Color
+	// per-role foreground styles
+	text, subtext, blue, sapphire, yellow, peach, green, red, teal, pink, mauve, overlay, surface lipgloss.Style
+}
 
-var (
-	sidebarBg      = lipgloss.Color(sidebarBgHex)
-	sidebarDim     = lipgloss.NewStyle().Foreground(lipgloss.Color(sidebarSubtextHex))
-	sidebarHeading = lipgloss.NewStyle().Foreground(lipgloss.Color(sidebarBlueHex)).Bold(true)
-)
-
-// sidebarStyle is shorthand for a plain foreground style in the Mocha palette.
-func sidebarStyle(hex string) lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(hex))
+// newSidebarStyles resolves a sidebarStyles from a palette.
+func newSidebarStyles(p Palette) sidebarStyles {
+	return sidebarStyles{
+		dim:      lipgloss.NewStyle().Foreground(p.Subtext),
+		heading:  lipgloss.NewStyle().Foreground(p.Blue).Bold(true),
+		bg:       p.Background,
+		text:     lipgloss.NewStyle().Foreground(p.Text),
+		subtext:  lipgloss.NewStyle().Foreground(p.Subtext),
+		blue:     lipgloss.NewStyle().Foreground(p.Blue),
+		sapphire: lipgloss.NewStyle().Foreground(p.Sapphire),
+		yellow:   lipgloss.NewStyle().Foreground(p.Yellow),
+		peach:    lipgloss.NewStyle().Foreground(p.Peach),
+		green:    lipgloss.NewStyle().Foreground(p.Green),
+		red:      lipgloss.NewStyle().Foreground(p.Red),
+		teal:     lipgloss.NewStyle().Foreground(p.Teal),
+		pink:     lipgloss.NewStyle().Foreground(p.Pink),
+		mauve:    lipgloss.NewStyle().Foreground(p.Mauve),
+		overlay:  lipgloss.NewStyle().Foreground(p.Overlay),
+		surface:  lipgloss.NewStyle().Foreground(p.Surface),
+	}
 }
 
 // RenderSidebar renders the right sidebar panel.
@@ -107,33 +112,35 @@ func RenderSidebar(in SidebarRenderInput) string {
 	w := max(in.Width, 10)
 	innerW := w - 3 // padding + border
 
+	st := newSidebarStyles(paletteOrDark(in.Palette))
+
 	var lines []string
 	for _, section := range [][]string{
-		sidebarMoodLines(in),
-		sidebarModelLines(in, innerW),
-		sidebarArtifactLines(in, innerW),
-		sidebarGitLines(in, innerW),
-		sidebarModeLines(in, innerW),
-		sidebarAgentLines(in, innerW),
-		sidebarSkillLines(in),
-		sidebarMemoryLines(in),
-		sidebarMCPLines(in, innerW),
-		sidebarLoadingLines(in),
+		sidebarMoodLines(in, st),
+		sidebarModelLines(in, innerW, st),
+		sidebarArtifactLines(in, innerW, st),
+		sidebarGitLines(in, innerW, st),
+		sidebarModeLines(in, innerW, st),
+		sidebarAgentLines(in, innerW, st),
+		sidebarSkillLines(in, st),
+		sidebarMemoryLines(in, st),
+		sidebarMCPLines(in, innerW, st),
+		sidebarLoadingLines(in, st),
 	} {
 		lines = append(lines, section...)
 	}
 
-	return sidebarFrame(in, lines, w)
+	return sidebarFrame(in, lines, w, st)
 }
 
 // sidebarMoodLines renders the mascot face or the eyes at the top of the
 // sidebar. The two are mutually exclusive; the mascot wins if both are set.
-func sidebarMoodLines(in SidebarRenderInput) []string {
+func sidebarMoodLines(in SidebarRenderInput, st sidebarStyles) []string {
 	face := cmp.Or(in.Mascot, in.Eyes)
 	if face == "" {
 		return nil
 	}
-	return []string{"", sidebarStyle(sidebarSapphireHex).Render(fmt.Sprintf("  %s", face)), ""}
+	return []string{"", st.sapphire.Render(fmt.Sprintf("  %s", face)), ""}
 }
 
 // sidebarContextLines / sidebarOTELLines were removed: the bottom context rule
@@ -141,24 +148,24 @@ func sidebarMoodLines(in SidebarRenderInput) []string {
 // OTEL indicator adds nothing the user cannot already see via the run status.
 
 // sidebarModelLines shows the active provider and model name.
-func sidebarModelLines(in SidebarRenderInput, innerW int) []string {
-	lines := []string{sidebarHeading.Render("  Model")}
+func sidebarModelLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
+	lines := []string{st.heading.Render("  Model")}
 	if in.ProviderName != "" {
-		lines = append(lines, sidebarStyle(sidebarTextHex).Render("  "+in.ProviderName))
+		lines = append(lines, st.text.Render("  "+in.ProviderName))
 	}
 	if in.ModelName != "" {
-		lines = append(lines, sidebarStyle(sidebarYellowHex).
+		lines = append(lines, st.yellow.
 			Render("  "+truncateLabel(in.ModelName, innerW)))
 	}
 	return append(lines, "")
 }
 
 // sidebarArtifactLines lists stored session artifacts with an icon and size.
-func sidebarArtifactLines(in SidebarRenderInput, innerW int) []string {
+func sidebarArtifactLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
 	if len(in.Artifacts) == 0 {
 		return nil
 	}
-	lines := []string{sidebarStyle(sidebarPeachHex).Bold(true).
+	lines := []string{st.peach.Bold(true).
 		Render(fmt.Sprintf("  Artifacts [%d]", len(in.Artifacts)))}
 
 	for _, a := range in.Artifacts {
@@ -170,62 +177,62 @@ func sidebarArtifactLines(in SidebarRenderInput, innerW int) []string {
 		// Reserve 10 chars for the size column so 2.1 MB lines align, and one
 		// spare cell so a truncated name never butts against the size column.
 		name := truncateLabel(a.Filename, max(innerW-2-2-10, 6)-1)
-		lines = append(lines, sidebarDim.Render(
+		lines = append(lines, st.dim.Render(
 			fmt.Sprintf("  %s %s  %s", icon, name, formatBytes(a.Size))))
 	}
 	return append(lines, "")
 }
 
 // sidebarGitLines shows the current branch and the working-tree diff counts.
-func sidebarGitLines(in SidebarRenderInput, innerW int) []string {
+func sidebarGitLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
 	if in.GitBranch == "" {
 		return nil
 	}
 	// Line 1: "Git" heading + "+N -M" counts.
-	gitLine := sidebarHeading.Render("  Git")
+	gitLine := st.heading.Render("  Git")
 	if in.DiffAdded > 0 || in.DiffRemoved > 0 {
 		gitLine += " " +
-			sidebarStyle(sidebarGreenHex).Render(fmt.Sprintf("+%d", in.DiffAdded)) +
-			sidebarDim.Render(" ") +
-			sidebarStyle(sidebarRedHex).Render(fmt.Sprintf("-%d", in.DiffRemoved))
+			st.green.Render(fmt.Sprintf("+%d", in.DiffAdded)) +
+			st.dim.Render(" ") +
+			st.red.Render(fmt.Sprintf("-%d", in.DiffRemoved))
 	}
 
 	// Line 2: branch with ⎇ prefix, truncated to fit inner width.
 	// Prefix "  ⎇ " is 5 visible cells, plus one spare cell at the right edge.
 	branch := truncateLabel(in.GitBranch, max(innerW-5, 4)-1)
-	return []string{gitLine, "  " + sidebarStyle(sidebarTealHex).Render("⎇ "+branch), ""}
+	return []string{gitLine, "  " + st.teal.Render("⎇ "+branch), ""}
 }
 
 // sidebarModeLines renders the /run checklist while a run is active, and the
 // plain mode indicator otherwise.
-func sidebarModeLines(in SidebarRenderInput, innerW int) []string {
+func sidebarModeLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
 	if len(in.RunChecklist) > 0 && in.RunPhase != "" {
-		return append(sidebarRunLines(in, innerW), "")
+		return append(sidebarRunLines(in, innerW, st), "")
 	}
 
-	lines := []string{sidebarHeading.Render("  Mode")}
+	lines := []string{st.heading.Render("  Mode")}
 	mode := cmp.Or(in.Mode, "chat")
 	if mode == "plan" {
-		lines = append(lines, sidebarStyle(sidebarPeachHex).Render("  [plan]"))
+		lines = append(lines, st.peach.Render("  [plan]"))
 	} else {
-		lines = append(lines, sidebarDim.Render("  ["+mode+"]"))
+		lines = append(lines, st.dim.Render("  ["+mode+"]"))
 	}
-	lines = append(lines, sidebarActivityLines(in)...)
+	lines = append(lines, sidebarActivityLines(in, st)...)
 	return append(lines, "")
 }
 
 // sidebarRunLines renders the spec name, cycle/phase and step checklist of an
 // in-progress /run.
-func sidebarRunLines(in SidebarRenderInput, innerW int) []string {
+func sidebarRunLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
 	lines := []string{
-		sidebarHeading.Render(truncateLabel(fmt.Sprintf("  Run: %s", in.RunSpec), innerW+2)),
-		sidebarStyle(sidebarPeachHex).Render(fmt.Sprintf("  cycle %d/%d ∙ %s",
+		st.heading.Render(truncateLabel(fmt.Sprintf("  Run: %s", in.RunSpec), innerW+2)),
+		st.peach.Render(fmt.Sprintf("  cycle %d/%d ∙ %s",
 			in.RunCycle, in.RunMaxCycle, in.RunPhase)),
 		"",
 	}
 
-	doneStyle := sidebarStyle(sidebarGreenHex)
-	todoStyle := sidebarStyle(sidebarOverlayHex)
+	doneStyle := st.green
+	todoStyle := st.overlay
 	for _, step := range in.RunChecklist {
 		title := truncateLabel(step.Title, max(innerW-5, 10)) // room for "  [x] " prefix
 		if step.Done {
@@ -237,25 +244,25 @@ func sidebarRunLines(in SidebarRenderInput, innerW int) []string {
 
 	if in.Running {
 		lines = append(lines, "")
-		lines = append(lines, sidebarActivityLines(in)...)
+		lines = append(lines, sidebarActivityLines(in, st)...)
 	}
 	return lines
 }
 
 // sidebarActivityLines shows the running tool, or a thinking indicator when the
 // agent is busy without a named tool. Empty when idle.
-func sidebarActivityLines(in SidebarRenderInput) []string {
+func sidebarActivityLines(in SidebarRenderInput, st sidebarStyles) []string {
 	if !in.Running {
 		return nil
 	}
 	if in.ActiveTool != "" {
-		return []string{sidebarDim.Render("  ⚡ " + in.ActiveTool)}
+		return []string{st.dim.Render("  ⚡ " + in.ActiveTool)}
 	}
-	return []string{sidebarDim.Render("  thinking...")}
+	return []string{st.dim.Render("  thinking...")}
 }
 
 // sidebarAgentLines lists spawned subagents, running ones first.
-func sidebarAgentLines(in SidebarRenderInput, innerW int) []string {
+func sidebarAgentLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
 	if in.Orchestrator == nil {
 		return nil
 	}
@@ -265,10 +272,10 @@ func sidebarAgentLines(in SidebarRenderInput, innerW int) []string {
 	}
 	sortAgentsForDisplay(agents)
 
-	lines := []string{agentHeadingStyle(agents).Render(fmt.Sprintf("  Agents [%d]", len(agents)))}
+	lines := []string{agentHeadingStyle(agents, st).Render(fmt.Sprintf("  Agents [%d]", len(agents)))}
 	names := agentDisplayNames(agents, innerW)
 	for i, a := range agents {
-		lines = append(lines, agentRow(a.Status, names[i]))
+		lines = append(lines, agentRow(a.Status, names[i], st))
 	}
 	return append(lines, "")
 }
@@ -289,7 +296,7 @@ func sortAgentsForDisplay(agents []subagent.AgentStatus) {
 
 // agentHeadingStyle colors the Agents heading by the worst status present:
 // red if anything failed, orange while any agent runs, green otherwise.
-func agentHeadingStyle(agents []subagent.AgentStatus) lipgloss.Style {
+func agentHeadingStyle(agents []subagent.AgentStatus, st sidebarStyles) lipgloss.Style {
 	var running, failed int
 	for _, a := range agents {
 		switch a.Status {
@@ -299,14 +306,14 @@ func agentHeadingStyle(agents []subagent.AgentStatus) lipgloss.Style {
 			failed++
 		}
 	}
-	hex := sidebarGreenHex
+	style := st.green
 	if running > 0 {
-		hex = sidebarPeachHex
+		style = st.peach
 	}
 	if failed > 0 {
-		hex = sidebarRedHex
+		style = st.red
 	}
-	return sidebarStyle(hex).Bold(true)
+	return style.Bold(true)
 }
 
 // agentDisplayNames labels each agent by type, appending an incrementing
@@ -331,52 +338,52 @@ func agentDisplayNames(agents []subagent.AgentStatus, innerW int) []string {
 }
 
 // agentRow renders one agent line with a status icon and matching color.
-func agentRow(status, name string) string {
+func agentRow(status, name string, st sidebarStyles) string {
 	switch status {
 	case "running":
-		return sidebarStyle(sidebarPeachHex).Render("  ⚡ " + name)
+		return st.peach.Render("  ⚡ " + name)
 	case "done":
-		return sidebarStyle(sidebarGreenHex).Render("  ✓ " + name)
+		return st.green.Render("  ✓ " + name)
 	case "failed":
-		return sidebarStyle(sidebarRedHex).Render("  ✗ " + name)
+		return st.red.Render("  ✗ " + name)
 	case "killed":
-		return sidebarStyle(sidebarOverlayHex).Render("  ⊘ " + name)
+		return st.overlay.Render("  ⊘ " + name)
 	default:
-		return sidebarDim.Render("  ∙ " + name)
+		return st.dim.Render("  ∙ " + name)
 	}
 }
 
 // sidebarSkillLines shows how many skills are loaded.
-func sidebarSkillLines(in SidebarRenderInput) []string {
+func sidebarSkillLines(in SidebarRenderInput, st sidebarStyles) []string {
 	if len(in.Skills) == 0 {
 		return nil
 	}
-	return []string{sidebarStyle(sidebarYellowHex).Bold(true).
+	return []string{st.yellow.Bold(true).
 		Render(fmt.Sprintf("  Skills [%d]", len(in.Skills))), ""}
 }
 
 // sidebarMemoryLines summarizes memory palace state: drawers, model readiness,
 // knowledge-graph entities and rooms.
-func sidebarMemoryLines(in SidebarRenderInput) []string {
+func sidebarMemoryLines(in SidebarRenderInput, st sidebarStyles) []string {
 	if in.MemoryStatus == nil {
 		return nil
 	}
-	lines := []string{sidebarStyle(sidebarPinkHex).Bold(true).
+	lines := []string{st.pink.Bold(true).
 		Render(fmt.Sprintf("  Memory [%d]", in.MemoryStatus.DrawerCount))}
 	if in.MemoryStatus.ModelLoaded {
-		lines = append(lines, sidebarDim.Render("  ⬡ model ready"))
+		lines = append(lines, st.dim.Render("  ⬡ model ready"))
 	}
 	if in.MemoryStatus.KG != nil {
-		lines = append(lines, sidebarDim.Render(
+		lines = append(lines, st.dim.Render(
 			fmt.Sprintf("  ⬡ %d entities", in.MemoryStatus.KG.EntityCount)))
 	}
-	lines = append(lines, sidebarDim.Render(fmt.Sprintf("  ⬡ %d rooms", in.MemoryStatus.RoomCount)))
+	lines = append(lines, st.dim.Render(fmt.Sprintf("  ⬡ %d rooms", in.MemoryStatus.RoomCount)))
 	return append(lines, "")
 }
 
 // sidebarMCPLines counts MCP tools per server rather than listing every tool,
 // keeping the section a fixed handful of rows.
-func sidebarMCPLines(in SidebarRenderInput, innerW int) []string {
+func sidebarMCPLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
 	if len(in.MCPTools) == 0 {
 		return nil
 	}
@@ -389,28 +396,28 @@ func sidebarMCPLines(in SidebarRenderInput, innerW int) []string {
 		toolCounts[e.Server]++
 	}
 
-	lines := []string{sidebarStyle(sidebarMauveHex).Bold(true).
+	lines := []string{st.mauve.Bold(true).
 		Render(fmt.Sprintf("  MCP Tools [%d]", len(in.MCPTools)))}
 	for _, srv := range seenOrder {
 		countLabel := fmt.Sprintf(" [%d]", toolCounts[srv])
 		srvLabel := truncateLabel(srv, max(innerW-4-len(countLabel), 1))
-		lines = append(lines, sidebarDim.Render("  ⬡ "+srvLabel+countLabel))
+		lines = append(lines, st.dim.Render("  ⬡ "+srvLabel+countLabel))
 	}
 	return append(lines, "")
 }
 
 // sidebarLoadingLines tracks startup subsystems, ticking each off as it loads.
-func sidebarLoadingLines(in SidebarRenderInput) []string {
+func sidebarLoadingLines(in SidebarRenderInput, st sidebarStyles) []string {
 	if in.LoadingItems == nil {
 		return nil
 	}
-	lines := []string{sidebarHeading.Render("  Loading")}
+	lines := []string{st.heading.Render("  Loading")}
 	for _, name := range sortedKeys(in.LoadingItems) {
 		if in.LoadingItems[name] {
-			lines = append(lines, sidebarStyle(sidebarGreenHex).Render("  ✓ "+name))
+			lines = append(lines, st.green.Render("  ✓ "+name))
 			continue
 		}
-		lines = append(lines, sidebarStyle(sidebarPeachHex).Render("  ◌ "+name+"..."))
+		lines = append(lines, st.peach.Render("  ◌ "+name+"..."))
 	}
 	return append(lines, "")
 }
@@ -418,7 +425,7 @@ func sidebarLoadingLines(in SidebarRenderInput) []string {
 // sidebarFrame pads the section lines to fill the panel height, appends the
 // token status line and matrix rain when active, closes with the rule, and
 // boxes the result at a fixed width.
-func sidebarFrame(in SidebarRenderInput, lines []string, w int) string {
+func sidebarFrame(in SidebarRenderInput, lines []string, w int, st sidebarStyles) string {
 	// Reserve rows for the matrix rain and its status separator.
 	hasMatrix := in.MatrixLines != ""
 	matrixH, statusH := 0, 0
@@ -440,7 +447,7 @@ func sidebarFrame(in SidebarRenderInput, lines []string, w int) string {
 	targetH := max(0, in.Height-matrixH-statusH-ruleH)
 	// Fill remaining space with subtle dim separators.
 	for len(contentLines) < targetH {
-		contentLines = append(contentLines, sidebarDim.Render("  ∙∙∙"))
+		contentLines = append(contentLines, st.dim.Render("  ∙∙∙"))
 	}
 	if len(contentLines) > targetH {
 		contentLines = contentLines[:targetH]
@@ -451,12 +458,12 @@ func sidebarFrame(in SidebarRenderInput, lines []string, w int) string {
 		if maxStatusW := w - 4; runewidth.StringWidth(statusText) > maxStatusW {
 			statusText = runewidth.Truncate(statusText, maxStatusW-1, "─")
 		}
-		contentLines = append(contentLines, sidebarDim.Render(statusText))
+		contentLines = append(contentLines, st.dim.Render(statusText))
 		contentLines = append(contentLines, strings.Split(in.MatrixLines, "\n")...)
 	}
 	if ruleH > 0 {
 		contentLines = append(contentLines,
-			sidebarStyle(sidebarSurfaceHex).Render(strings.Repeat("─", w)))
+			st.surface.Render(strings.Repeat("─", w)))
 	}
 
 	// A fixed-size box, flush to the right edge of the terminal. Width alone only
@@ -470,7 +477,7 @@ func sidebarFrame(in SidebarRenderInput, lines []string, w int) string {
 	box := lipgloss.NewStyle().
 		Width(w).
 		MaxWidth(w).
-		Background(sidebarBg)
+		Background(st.bg)
 	if in.Height > 0 {
 		box = box.Height(in.Height).MaxHeight(in.Height)
 	}

--- a/internal/tui/sidebar_sections_test.go
+++ b/internal/tui/sidebar_sections_test.go
@@ -19,6 +19,12 @@ func plain(lines []string) string {
 	return ansi.Strip(strings.Join(lines, "\n"))
 }
 
+// testSidebarStyles returns the dark sidebar styles for tests that call the
+// section renderers directly.
+func testSidebarStyles() sidebarStyles {
+	return newSidebarStyles(darkPalette)
+}
+
 func TestTruncateLabel(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -78,7 +84,7 @@ func TestSidebarMoodLines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := sidebarMoodLines(tt.in)
+			got := sidebarMoodLines(tt.in, testSidebarStyles())
 			if len(got) != tt.wantLen {
 				t.Fatalf("sidebarMoodLines() returned %d lines, want %d", len(got), tt.wantLen)
 			}
@@ -97,13 +103,13 @@ func TestSidebarHiddenSections(t *testing.T) {
 		name string
 		got  []string
 	}{
-		{"no artifacts", sidebarArtifactLines(empty, 27)},
-		{"no git branch", sidebarGitLines(empty, 27)},
-		{"no orchestrator", sidebarAgentLines(empty, 27)},
-		{"no skills", sidebarSkillLines(empty)},
-		{"no memory status", sidebarMemoryLines(empty)},
-		{"no mcp tools", sidebarMCPLines(empty, 27)},
-		{"no loading items", sidebarLoadingLines(empty)},
+		{"no artifacts", sidebarArtifactLines(empty, 27, testSidebarStyles())},
+		{"no git branch", sidebarGitLines(empty, 27, testSidebarStyles())},
+		{"no orchestrator", sidebarAgentLines(empty, 27, testSidebarStyles())},
+		{"no skills", sidebarSkillLines(empty, testSidebarStyles())},
+		{"no memory status", sidebarMemoryLines(empty, testSidebarStyles())},
+		{"no mcp tools", sidebarMCPLines(empty, 27, testSidebarStyles())},
+		{"no loading items", sidebarLoadingLines(empty, testSidebarStyles())},
 	}
 
 	for _, tt := range tests {
@@ -145,7 +151,7 @@ func TestSidebarGitLines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out := plain(sidebarGitLines(tt.in, 27))
+			out := plain(sidebarGitLines(tt.in, 27, testSidebarStyles()))
 			for _, want := range tt.wantParts {
 				if !strings.Contains(out, want) {
 					t.Errorf("expected %q in:\n%s", want, out)
@@ -175,7 +181,7 @@ func TestSidebarModeLines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out := plain(sidebarModeLines(tt.in, 27))
+			out := plain(sidebarModeLines(tt.in, 27, testSidebarStyles()))
 			if !strings.Contains(out, tt.want) {
 				t.Errorf("expected %q in:\n%s", tt.want, out)
 			}
@@ -196,7 +202,7 @@ func TestSidebarModeLinesRunChecklist(t *testing.T) {
 		},
 	}
 
-	out := plain(sidebarModeLines(in, 27))
+	out := plain(sidebarModeLines(in, 27, testSidebarStyles()))
 	for _, want := range []string{"Run: my-spec", "cycle 2/5 ∙ implement", "[x] write tests", "[ ] make them pass"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in:\n%s", want, out)
@@ -267,7 +273,7 @@ func TestAgentRowIcons(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
 			t.Parallel()
-			got := ansi.Strip(agentRow(tt.status, "worker"))
+			got := ansi.Strip(agentRow(tt.status, "worker", testSidebarStyles()))
 			if !strings.Contains(got, tt.want) {
 				t.Errorf("agentRow(%q) = %q, want icon %q", tt.status, got, tt.want)
 			}
@@ -301,7 +307,7 @@ func TestSidebarMCPLinesCountsPerServer(t *testing.T) {
 		{Server: "alpha", Tool: "two"},
 		{Server: "beta", Tool: "three"},
 	}}
-	out := plain(sidebarMCPLines(in, 27))
+	out := plain(sidebarMCPLines(in, 27, testSidebarStyles()))
 
 	if !strings.Contains(out, "MCP Tools [3]") {
 		t.Errorf("expected a total of 3 tools, got:\n%s", out)
@@ -317,7 +323,7 @@ func TestSidebarMCPLinesCountsPerServer(t *testing.T) {
 func TestSidebarLoadingLines(t *testing.T) {
 	t.Parallel()
 	in := SidebarRenderInput{LoadingItems: map[string]bool{"mcp": true, "skills": false}}
-	out := plain(sidebarLoadingLines(in))
+	out := plain(sidebarLoadingLines(in, testSidebarStyles()))
 
 	if !strings.Contains(out, "✓ mcp") {
 		t.Errorf("expected a tick for the loaded item, got:\n%s", out)
@@ -331,7 +337,7 @@ func TestSidebarLoadingLinesEmptyMapStillShowsHeading(t *testing.T) {
 	t.Parallel()
 	// A non-nil but empty map means "loading started, nothing reported yet",
 	// which is different from nil (hidden).
-	got := sidebarLoadingLines(SidebarRenderInput{LoadingItems: map[string]bool{}})
+	got := sidebarLoadingLines(SidebarRenderInput{LoadingItems: map[string]bool{}}, testSidebarStyles())
 	if len(got) == 0 {
 		t.Fatal("an empty (non-nil) loading map should still render the heading")
 	}

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -40,6 +40,7 @@ type StatusRenderInput struct {
 	HostName     string          // local hostname
 	LoadingItems map[string]bool // item -> done; nil means not loading
 	Flash        string          // transient notice ("Copied!"); empty when none
+	Palette      Palette         // resolved theme palette; zero = dark default
 }
 
 // runCycleInfo carries /run state for the status bar.
@@ -54,7 +55,7 @@ const contextBarWidth = 10
 
 // renderContextBar returns a color-coded visual bar like "████░░░░░░ 42%".
 // Colors: green < 60%, orange 60-80%, red > 80%.
-func renderContextBar(pct float64, bg color.Color) string {
+func renderContextBar(pct float64, bg color.Color, p Palette) string {
 	if pct < 0 {
 		pct = 0
 	}
@@ -71,15 +72,15 @@ func renderContextBar(pct float64, bg color.Color) string {
 	var fg color.Color
 	switch {
 	case pct >= 80:
-		fg = lipgloss.Color("#f38ba8") // Mocha red
+		fg = p.Red
 	case pct >= 60:
-		fg = lipgloss.Color("#fab387") // Mocha peach
+		fg = p.Peach
 	default:
-		fg = lipgloss.Color("#a6e3a1") // Mocha green
+		fg = p.Green
 	}
 
 	filledStyle := lipgloss.NewStyle().Background(bg).Foreground(fg)
-	emptyStyle := lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color("#585b70")) // Mocha surface2
+	emptyStyle := lipgloss.NewStyle().Background(bg).Foreground(p.Surface)
 	pctStyle := lipgloss.NewStyle().Background(bg).Foreground(fg)
 
 	return filledStyle.Render(strings.Repeat("█", filled)) +
@@ -89,12 +90,12 @@ func renderContextBar(pct float64, bg color.Color) string {
 
 // Render renders the status bar string.
 func (s *StatusModel) Render(in StatusRenderInput) string {
-	dimFg := lipgloss.Color("#bac2de") // Mocha subtext1
+	p := paletteOrDark(in.Palette)
 
-	dim := lipgloss.NewStyle().Foreground(dimFg)
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
 	bar := lipgloss.NewStyle().Width(s.Width)
 
-	sepStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70")) // Mocha surface2
+	sepStyle := lipgloss.NewStyle().Foreground(p.Surface)
 	sep := sepStyle.Render("  │  ")
 
 	var parts []string
@@ -113,16 +114,16 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	}
 	switch {
 	case in.Flash != "":
-		flashStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")).Bold(true) // Mocha green
+		flashStyle := lipgloss.NewStyle().Foreground(p.Green).Bold(true)
 		parts = append(parts, flashStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(in.Flash))))
 	case mode == "plan":
-		modeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#fab387")) // Mocha peach
+		modeStyle := lipgloss.NewStyle().Foreground(p.Peach)
 		parts = append(parts, modeStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode))))
 	case in.Running && s.ActiveTool == "":
-		verbStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")) // Mocha blue
+		verbStyle := lipgloss.NewStyle().Foreground(p.Blue)
 		parts = append(parts, verbStyle.Render(fmt.Sprintf(" [%s]", spinnerVerb())))
 	default:
-		verbStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")) // Mocha blue
+		verbStyle := lipgloss.NewStyle().Foreground(p.Blue)
 		parts = append(parts, verbStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode))))
 	}
 
@@ -131,10 +132,10 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 		var items []string
 		for _, name := range sortedKeys(in.LoadingItems) {
 			if in.LoadingItems[name] {
-				okStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")) // Mocha green
+				okStyle := lipgloss.NewStyle().Foreground(p.Green)
 				items = append(items, okStyle.Render(name+" \u2713"))
 			} else {
-				loadStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#fab387")) // Mocha peach
+				loadStyle := lipgloss.NewStyle().Foreground(p.Peach)
 				items = append(items, loadStyle.Render(name+"..."))
 			}
 		}
@@ -143,10 +144,10 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	}
 
 	// Context % bar (visual bar with color coding).
-	noBg := lipgloss.Color("#00000000") // transparent for context bar
+	noBg := p.Transparent
 	if tt := in.TokenTracker; tt != nil && tt.Limit() > 0 {
 		pct := tt.PercentUsed()
-		parts = append(parts, renderContextBar(pct, noBg))
+		parts = append(parts, renderContextBar(pct, noBg, p))
 	} else {
 		// Fallback: rough context size estimate (~4 chars per token).
 		ctxChars := 0
@@ -171,9 +172,9 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 			var tokenStyle lipgloss.Style
 			switch {
 			case pct >= 100:
-				tokenStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f38ba8")) // Mocha red
+				tokenStyle = lipgloss.NewStyle().Foreground(p.Red)
 			case pct >= 80:
-				tokenStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#fab387")) // Mocha peach
+				tokenStyle = lipgloss.NewStyle().Foreground(p.Peach)
 			default:
 				tokenStyle = dim
 			}
@@ -186,8 +187,8 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 
 	// Directory | host.
 	if in.FolderName != "" || in.HostName != "" {
-		dirStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#cba6f7"))  // Mocha mauve
-		hostStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#89dceb")) // Mocha sky
+		dirStyle := lipgloss.NewStyle().Foreground(p.Mauve)
+		hostStyle := lipgloss.NewStyle().Foreground(p.Sky)
 
 		var locationParts []string
 		if in.FolderName != "" {
@@ -200,7 +201,7 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	}
 
 	// Active tools or thinking status.
-	toolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#74c7ec")) // Mocha sapphire
+	toolStyle := lipgloss.NewStyle().Foreground(p.Sapphire)
 	if len(s.ActiveTools) > 1 {
 		var toolNames []string
 		for name := range s.ActiveTools {
@@ -216,7 +217,7 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	// /run cycle indicator. The spec name is omitted: it is long enough to wrap
 	// the status bar onto a second line, and it is already shown in the sidebar.
 	if in.RunCycle != nil {
-		runStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#fab387")) // Mocha peach
+		runStyle := lipgloss.NewStyle().Foreground(p.Peach)
 		parts = append(parts, runStyle.Render(fmt.Sprintf("cycle %d/%d",
 			in.RunCycle.Cycle, in.RunCycle.MaxRetries)))
 	}

--- a/internal/tui/teatest_test.go
+++ b/internal/tui/teatest_test.go
@@ -951,7 +951,7 @@ func TestRenderContextBar(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			bg := lipgloss.Color("236")
-			result := renderContextBar(tc.pct, bg)
+			result := renderContextBar(tc.pct, bg, darkPalette)
 			if !strings.Contains(result, tc.want) {
 				t.Errorf("renderContextBar(%.0f) = %q, want substring %q", tc.pct, result, tc.want)
 			}

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -244,3 +244,43 @@ func TestNewThemeManagerFromJSON(t *testing.T) {
 		t.Error("NewThemeManagerFromJSON should error on invalid JSON")
 	}
 }
+
+// TestPaletteForLightThemeRendersDifferently pins the fix for light themes:
+// before the palette was threaded into the renderers, switching to a light
+// theme changed nothing on screen because every renderer hardcoded dark Mocha
+// colors. paletteFor must produce a palette whose key differs from the dark
+// default, so the render cache and the renderers actually pick up the change.
+func TestPaletteForLightThemeRendersDifferently(t *testing.T) {
+	tm := NewThemeManager()
+	if err := tm.SetTheme("github-light"); err != nil {
+		t.Fatalf("SetTheme(github-light) error: %v", err)
+	}
+	light := paletteFor(tm.Current())
+	if !light.Valid {
+		t.Fatal("light palette should be valid")
+	}
+	if paletteKey(light) == paletteKey(darkPalette) {
+		t.Error("light palette key equals dark palette key; light theme would not re-render")
+	}
+	// The light palette's text must be dark (legible on a light background),
+	// not the dark theme's light text.
+	if colorString(light.Text) == colorString(darkPalette.Text) {
+		t.Errorf("light theme text %q should differ from dark theme text %q",
+			colorString(light.Text), colorString(darkPalette.Text))
+	}
+}
+
+// TestPaletteForDarkThemeMatchesDefault ensures the default (dark) theme
+// resolves to the same Mocha palette the renderers used before theming, so
+// existing dark output is byte-for-byte unchanged.
+func TestPaletteForDarkThemeMatchesDefault(t *testing.T) {
+	tm := NewThemeManager()
+	dark := paletteFor(tm.Current())
+	if !dark.Valid {
+		t.Fatal("dark palette should be valid")
+	}
+	if paletteKey(dark) != paletteKey(darkPalette) {
+		t.Errorf("default theme palette key %d != dark default %d",
+			paletteKey(dark), paletteKey(darkPalette))
+	}
+}

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -91,6 +91,9 @@ type ToolDisplayModel struct {
 	Width int
 	// CompactTools when true shows one-line summaries instead of full output.
 	CompactTools bool
+	// Palette is the resolved theme palette, set each frame by the model before
+	// rendering. Zero means the dark default.
+	Palette Palette
 }
 
 // RenderToolMessage renders a tool message (role=="tool") into a styled string.
@@ -98,22 +101,23 @@ type ToolDisplayModel struct {
 // (with syntax-highlighted output). When CompactTools is true, renders a
 // one-line summary instead of full output.
 func (t *ToolDisplayModel) RenderToolMessage(msg message) string {
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	p := paletteOrDark(t.Palette)
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
 
 	if t.CompactTools {
-		return t.renderCompactTool(msg, dim)
+		return t.renderCompactTool(msg, dim, p)
 	}
 	if msg.tool == "agent" || msg.tool == "subagent" {
-		return t.renderAgentTool(msg, dim)
+		return t.renderAgentTool(msg, dim, p)
 	}
-	return t.renderRegularTool(msg, dim)
+	return t.renderRegularTool(msg, dim, p)
 }
 
 // renderCompactTool renders a one-line tally for a tool message.
-func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style) string {
-	toolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("35")).Bold(true)
-	checkStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("35"))
-	toolBullet := lipgloss.NewStyle().Foreground(lipgloss.Color("35")).Bold(true).Render("◉ ")
+func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style, p Palette) string {
+	toolStyle := lipgloss.NewStyle().Foreground(p.Tool).Bold(true)
+	checkStyle := lipgloss.NewStyle().Foreground(p.Tool)
+	toolBullet := lipgloss.NewStyle().Foreground(p.Tool).Bold(true).Render("◉ ")
 
 	var b strings.Builder
 	b.WriteString(toolBullet)
@@ -149,7 +153,7 @@ func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style) st
 
 // renderAgentTool renders an agent/subagent tool message with type, title,
 // event stream, and result summary.
-func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style) string {
+func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style, p Palette) string {
 	agentBullet := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true).Render("◉ ")
 	typeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true)
 	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
@@ -173,7 +177,7 @@ func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style) stri
 	// renderable remainder, keep the newest maxAgentOutputLines so the user
 	// always sees the latest activity — not a stream truncated into silence.
 	if len(msg.agentEvents) > 0 {
-		evStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+		evStyle := lipgloss.NewStyle().Foreground(p.Dim)
 		evToolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(agentToolColor(msg.agentType)))
 
 		renderable := make([]agentEv, 0, len(msg.agentEvents))
@@ -261,11 +265,11 @@ const maxLiveOutputLines = 5
 // nothing is indistinguishable from a hung one, and that ambiguity is what let
 // two sessions sit wedged for an hour without anyone noticing. "1m30s — no
 // output" removes it.
-func (t *ToolDisplayModel) renderLiveOutput(msg message, dim lipgloss.Style) string {
+func (t *ToolDisplayModel) renderLiveOutput(msg message, dim lipgloss.Style, p Palette) string {
 	cw := t.contentWidth()
-	outStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("173"))
-	stateStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	outStyle := lipgloss.NewStyle().Foreground(p.Dim)
+	errStyle := lipgloss.NewStyle().Foreground(p.Error)
+	stateStyle := lipgloss.NewStyle().Foreground(p.Warning)
 
 	var (
 		lines []string
@@ -408,7 +412,7 @@ func softWrap(s string, width int) []string {
 
 // renderRegularTool renders a standard tool message with name, args, and
 // syntax-highlighted output.
-func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style) string {
+func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p Palette) string {
 	toolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("35")).Bold(true)
 	argStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 	toolBullet := lipgloss.NewStyle().Foreground(lipgloss.Color("35")).Bold(true).Render("◉ ")
@@ -427,7 +431,7 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style) st
 		// Still running: show the live tail instead of an empty card. Once the
 		// result arrives, msg.content takes over and the final output replaces
 		// this window — the stream is a progress indicator, not a transcript.
-		b.WriteString(t.renderLiveOutput(msg, dim))
+		b.WriteString(t.renderLiveOutput(msg, dim, p))
 	}
 	if msg.content != "" {
 		lines := strings.Split(msg.content, "\n")
@@ -449,7 +453,7 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style) st
 		var styled []string
 		switch {
 		case msg.tool == "read" && msg.toolIn != "":
-			styled = highlightReadOutput(lines, msg.toolIn)
+			styled = highlightReadOutput(lines, msg.toolIn, p)
 		case msg.tool == "bash":
 			// Bash output is plain text most of the time but frequently contains
 			// runnable snippets (`cat file`, `curl ...`, `go test` output). Run it
@@ -464,9 +468,9 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style) st
 		// "grep" here meant grep output was never highlighted in practice and
 		// fell through to the dim default.
 		case msg.tool == "grep" || msg.tool == "ripgrep":
-			styled = highlightGrepOutput(lines)
+			styled = highlightGrepOutput(lines, p)
 		case msg.tool == "find":
-			styled = highlightFindOutput(lines)
+			styled = highlightFindOutput(lines, p)
 		default:
 			styled = make([]string, len(lines))
 			for i, line := range lines {
@@ -720,8 +724,8 @@ func formatToolResult(data map[string]any) string {
 
 // highlightReadOutput applies syntax highlighting to read tool output lines.
 // Each line has format "     1\tcontent" — line numbers are styled separately.
-func highlightReadOutput(lines []string, filename string) []string {
-	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+func highlightReadOutput(lines []string, filename string, p Palette) []string {
+	numStyle := lipgloss.NewStyle().Foreground(p.Faint)
 
 	// Separate line numbers from code
 	var codeLines []string
@@ -864,10 +868,10 @@ func highlightBashOutput(lines []string) []string {
 }
 
 // highlightGrepOutput styles grep result lines of the form "file:line: content".
-func highlightGrepOutput(lines []string) []string {
-	fileStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39"))     // blue
-	lineNumStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240")) // gray
-	sepStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+func highlightGrepOutput(lines []string, p Palette) []string {
+	fileStyle := lipgloss.NewStyle().Foreground(p.Blue)     // blue
+	lineNumStyle := lipgloss.NewStyle().Foreground(p.Faint) // gray
+	sepStyle := lipgloss.NewStyle().Foreground(p.Faint)
 
 	result := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -875,12 +879,12 @@ func highlightGrepOutput(lines []string) []string {
 		first := strings.IndexByte(line, ':')
 		if first < 0 {
 			// Not a match line (e.g. truncation note) — dim it.
-			result = append(result, lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(line))
+			result = append(result, lipgloss.NewStyle().Foreground(p.Faint).Render(line))
 			continue
 		}
 		second := strings.IndexByte(line[first+1:], ':')
 		if second < 0 {
-			result = append(result, lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(line))
+			result = append(result, lipgloss.NewStyle().Foreground(p.Faint).Render(line))
 			continue
 		}
 		second += first + 1 // absolute index of second colon
@@ -907,10 +911,10 @@ func highlightGrepOutput(lines []string) []string {
 }
 
 // highlightFindOutput styles find/glob result lines as file paths.
-func highlightFindOutput(lines []string) []string {
-	fileStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39")) // blue
-	dirStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Bold(true)
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+func highlightFindOutput(lines []string, p Palette) []string {
+	fileStyle := lipgloss.NewStyle().Foreground(p.Blue) // blue
+	dirStyle := lipgloss.NewStyle().Foreground(p.Cyan).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(p.Faint)
 
 	result := make([]string, 0, len(lines))
 	for _, line := range lines {

--- a/internal/tui/tool_name_alias_test.go
+++ b/internal/tui/tool_name_alias_test.go
@@ -29,11 +29,11 @@ func TestGrepAliasIsRecognized(t *testing.T) {
 			// And the rendered block must be colored, not the dim default.
 			out := td.renderRegularTool(message{
 				role: "tool", tool: name, toolIn: "grepHandler", content: content,
-			}, dim)
+			}, dim, darkPalette)
 
-			// highlightGrepOutput colors the filename blue (39) and the line
-			// number gray (240); the dim default branch emits neither.
-			if !strings.Contains(out, "38;5;39") {
+			// highlightGrepOutput colors the filename blue and the line number
+			// gray; the dim default branch emits neither.
+			if !strings.Contains(out, truecolorFragment(darkPalette.Blue)) {
 				t.Errorf("%q output not highlighted (no grep file color); got %q", name, out)
 			}
 		})

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -41,6 +41,10 @@ type model struct {
 	// Theme manager.
 	themeManager *ThemeManager
 
+	// palette is the resolved color palette for the active theme, recomputed
+	// each frame in View so a /theme switch takes effect immediately.
+	palette Palette
+
 	// Agent state.
 	running     bool
 	mode        string             // "chat" or "plan" — shown in status bar
@@ -1277,9 +1281,21 @@ func (m *model) View() tea.View {
 		return tea.NewView("Goodbye!\n")
 	}
 
+	// Resolve the active theme's palette once per frame so a /theme switch
+	// takes effect on the next render. A nil manager (tests) falls back to the
+	// dark palette, keeping existing output unchanged.
+	m.palette = darkPalette
+	if m.themeManager != nil {
+		m.palette = paletteFor(m.themeManager.Current())
+	}
+	m.chatModel.Palette = m.palette
+	m.chatModel.ToolDisplay.Palette = m.palette
+	m.inputModel.Palette = m.palette
+	m.matrix.palette = m.palette
+
 	if m.width == 0 {
 		// Show matrix-style startup text before the first terminal size arrives.
-		matrixLine := renderStartupMatrixLine(m.loadingDots, m.cfg.AppVersion, m.loadingItems, m.loadingTotal)
+		matrixLine := renderStartupMatrixLine(m.loadingDots, m.cfg.AppVersion, m.loadingItems, m.loadingTotal, m.palette)
 		if m.loadingItems != nil {
 			var lines []string
 			lines = append(lines, matrixLine)
@@ -1356,7 +1372,7 @@ func (m *model) View() tea.View {
 
 	// Horizontal rule for separating sections. The panel hr is bodyWidth; the
 	// full-width hr spans the entire terminal (used below the sidebar).
-	hrStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70")) // Catppuccin Mocha surface2
+	hrStyle := lipgloss.NewStyle().Foreground(m.palette.Surface)
 	hr := hrStyle.Render(strings.Repeat("─", bodyWidth))
 	fullHr := hrStyle.Render(strings.Repeat("─", m.width))
 
@@ -1410,7 +1426,7 @@ func (m *model) View() tea.View {
 	// full terminal width underneath.
 	body := padLinesTo(b.String(), bodyWidth)
 	panelRows := strings.Count(body, "\n") + 1
-	rail := railColumn(panelRows, msgStart, renderMinimap(lineKinds, startLine, endLine, msgRows))
+	rail := railColumn(panelRows, msgStart, renderMinimap(lineKinds, startLine, endLine, msgRows, m.palette), m.palette)
 	leftPanel := lipgloss.JoinHorizontal(lipgloss.Top, body, rail)
 
 	var topSection string
@@ -1444,6 +1460,7 @@ func (m *model) View() tea.View {
 			MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
 			MemoryStatus: m.memoryStatus,
 			Artifacts:    m.artifactList(),
+			Palette:      m.palette,
 		}
 		if m.run != nil && m.run.phase != "" {
 			sidebarInput.RunChecklist = m.run.checklist
@@ -1472,7 +1489,7 @@ func (m *model) View() tea.View {
 	bottom.WriteString("\n")
 	// The closing rule doubles as the session context gauge — same row, same
 	// width, now carrying a reading instead of only closing the frame.
-	bottom.WriteString(renderContextRule(m.contextRuleFor(m.width)))
+	bottom.WriteString(renderContextRule(m.contextRuleFor(m.width), m.palette))
 
 	// Pad the bottom section to the full terminal width so no row is wider or
 	// narrower than m.width. The status bar's Width style handles it for that
@@ -1544,7 +1561,7 @@ func drainTerminalResponses() {
 
 const startupProgressBarWidth = 8
 
-func renderStartupMatrixLine(phase int, appVersion string, loadingItems map[string]bool, loadingTotal int) string {
+func renderStartupMatrixLine(phase int, appVersion string, loadingItems map[string]bool, loadingTotal int, p Palette) string {
 	versionSuffix := ""
 	if appVersion != "" {
 		versionSuffix = " " + appVersion
@@ -1555,10 +1572,10 @@ func renderStartupMatrixLine(phase int, appVersion string, loadingItems map[stri
 	if width < 1 || len(matrixRunes) == 0 {
 		return "Loading Pi" + versionSuffix + progress + detail + " .."
 	}
-	bright := lipgloss.NewStyle().Foreground(lipgloss.Color("#94e2d5")).Bold(true)
-	mid := lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa"))
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("#45475a"))
-	accent := lipgloss.NewStyle().Foreground(lipgloss.Color("#cba6f7")).Bold(true)
+	bright := lipgloss.NewStyle().Foreground(p.Teal).Bold(true)
+	mid := lipgloss.NewStyle().Foreground(p.Blue)
+	dim := lipgloss.NewStyle().Foreground(p.Surface1)
+	accent := lipgloss.NewStyle().Foreground(p.Mauve).Bold(true)
 
 	dotCount := 2 + phase%3
 	wave := phase % (2 * (width - 1))
@@ -1871,6 +1888,7 @@ func (m *model) statusRenderInput() StatusRenderInput {
 		HostName:     hostName,
 		LoadingItems: m.loadingItems,
 		Flash:        m.flash,
+		Palette:      m.palette,
 	}
 }
 
@@ -2147,41 +2165,41 @@ func (m *model) renderSearchPopup(width int) string {
 	}
 
 	sp := m.searchPopup
-	bg := lipgloss.Color("236")
+	bg := m.palette.Surface0
 
 	// Get colors based on mode.
 	popupStyle := lipgloss.NewStyle().Background(bg)
 	headerStyle := lipgloss.NewStyle().Background(bg).Bold(true)
 	searchStyle := lipgloss.NewStyle().Background(bg)
 	itemStyle := lipgloss.NewStyle().Background(bg)
-	selectedItemStyle := lipgloss.NewStyle().Background(lipgloss.Color("15"))
+	selectedItemStyle := lipgloss.NewStyle().Background(m.palette.White)
 
 	var header string
 
 	switch sp.mode {
 	case searchModeCommands:
-		border := lipgloss.Color("33") // cyan for commands
+		border := m.palette.Cyan // cyan for commands
 		popupStyle = popupStyle.
-			Foreground(lipgloss.Color("252")).
+			Foreground(m.palette.Subtext).
 			Border(lipgloss.RoundedBorder(), true, true, true, true).
 			BorderForeground(border).
 			Width(width)
-		headerStyle = headerStyle.Foreground(lipgloss.Color("252")).Width(width)
-		searchStyle = searchStyle.Foreground(lipgloss.Color("245"))
-		itemStyle = itemStyle.Foreground(lipgloss.Color("81")) // teal
-		selectedItemStyle = selectedItemStyle.Background(lipgloss.Color("33"))
+		headerStyle = headerStyle.Foreground(m.palette.Subtext).Width(width)
+		searchStyle = searchStyle.Foreground(m.palette.Dim)
+		itemStyle = itemStyle.Foreground(m.palette.Teal) // teal
+		selectedItemStyle = selectedItemStyle.Background(m.palette.Cyan)
 		header = "Commands"
 	case searchModeHistory:
-		border := lipgloss.Color("208") // orange for history
+		border := m.palette.Peach // orange for history
 		popupStyle = popupStyle.
-			Foreground(lipgloss.Color("252")).
+			Foreground(m.palette.Subtext).
 			Border(lipgloss.RoundedBorder(), true, true, true, true).
 			BorderForeground(border).
 			Width(width)
-		headerStyle = headerStyle.Foreground(lipgloss.Color("252")).Width(width)
-		searchStyle = searchStyle.Foreground(lipgloss.Color("245"))
-		itemStyle = itemStyle.Foreground(lipgloss.Color("208")) // orange
-		selectedItemStyle = selectedItemStyle.Background(lipgloss.Color("208"))
+		headerStyle = headerStyle.Foreground(m.palette.Subtext).Width(width)
+		searchStyle = searchStyle.Foreground(m.palette.Dim)
+		itemStyle = itemStyle.Foreground(m.palette.Peach) // orange
+		selectedItemStyle = selectedItemStyle.Background(m.palette.Peach)
 		header = "History"
 	}
 
@@ -2328,15 +2346,15 @@ func (m *model) renderBranchPopup() string {
 	}
 
 	popup := m.branchPopup
-	bg := lipgloss.Color("236")
-	border := lipgloss.Color("240")
-	selected := lipgloss.Color("33")
-	activeFg := lipgloss.Color("35")
-	dimFg := lipgloss.Color("243")
+	bg := m.palette.Surface0
+	border := m.palette.Surface
+	selected := m.palette.Primary
+	activeFg := m.palette.Green
+	dimFg := m.palette.Faint
 
 	style := lipgloss.NewStyle().
 		Background(bg).
-		Foreground(lipgloss.Color("252")).
+		Foreground(m.palette.Subtext).
 		Border(lipgloss.ThickBorder(), true, true, true, true).
 		BorderForeground(border).
 		Width(m.width - 10)
@@ -2350,7 +2368,7 @@ func (m *model) renderBranchPopup() string {
 	// Header
 	header := lipgloss.NewStyle().
 		Background(bg).
-		Foreground(lipgloss.Color("252")).
+		Foreground(m.palette.Subtext).
 		Bold(true).
 		Width(popupWidth).
 		Align(lipgloss.Center).
@@ -2386,7 +2404,7 @@ func (m *model) renderBranchPopup() string {
 		var lineStyle lipgloss.Style
 		switch {
 		case isSelected:
-			lineStyle = lipgloss.NewStyle().Background(selected).Foreground(lipgloss.Color("15"))
+			lineStyle = lipgloss.NewStyle().Background(selected).Foreground(m.palette.White)
 		case isActive:
 			lineStyle = lipgloss.NewStyle().Background(bg).Foreground(activeFg)
 		default:

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2092,7 +2092,7 @@ func TestFormatHistoryOutput(t *testing.T) {
 func TestRenderWelcome(t *testing.T) {
 	renderer, _ := glamour.NewTermRenderer(glamour.WithAutoStyle(), glamour.WithWordWrap(80))
 	cm := ChatModel{Renderer: renderer}
-	got := cm.renderWelcome()
+	got := cm.renderWelcome(darkPalette)
 	// Check for key content (some words may be split by ANSI style codes).
 	checks := []string{
 		"Welcome to pi-go",

--- a/internal/tui/tui_update_test.go
+++ b/internal/tui/tui_update_test.go
@@ -72,7 +72,7 @@ func TestUpdateWindowSizeClampsScrollAndInvalidatesWidth(t *testing.T) {
 	}
 	// The cache must have been repopulated at the new width, keyed to it.
 	got := &mm.chatModel.Messages[0]
-	wantKey := got.renderKey(wantChat, mm.chatModel.ToolDisplay.CompactTools, false, false)
+	wantKey := got.renderKey(wantChat, mm.chatModel.ToolDisplay.CompactTools, false, false, paletteKey(paletteOrDark(mm.chatModel.Palette)))
 	if !got.renderCached || got.renderCacheKey != wantKey {
 		t.Fatalf("render cache not repopulated for width %d: cached=%v key=%d want %d",
 			wantChat, got.renderCached, got.renderCacheKey, wantKey)

--- a/internal/tui/url_nav_test.go
+++ b/internal/tui/url_nav_test.go
@@ -85,7 +85,10 @@ func TestURLArrowNavigation_DoesNotRewriteCursorCellInline(t *testing.T) {
 	}
 
 	view := im.View(false)
-	reverseVideo := regexp.MustCompile(`\x1b\[[0-9;]*7[0-9;]*m`)
+	// Reverse video is the standalone SGR parameter 7. The \b guards keep this
+	// from matching a truecolor sequence like 38;2;137;180;250, whose 137
+	// contains a 7 but is not reverse video.
+	reverseVideo := regexp.MustCompile(`\x1b\[[0-9;]*\b7\b[0-9;]*m`)
 	if reverseVideo.MatchString(view) {
 		t.Fatalf("input view should not render an inline reverse-video cursor in URL text: %q", view)
 	}


### PR DESCRIPTION
The theme system could select a light theme but nothing on screen changed:
every renderer hardcoded Catppuccin Mocha (dark) hex values, so a light theme
drew dark-theme foregrounds on a light terminal background and was invisible.

Introduce a Palette abstraction (palette.go) that resolves the active theme
into a set of colors the renderers read. Dark themes keep the exact Mocha
palette, so existing dark output is byte-for-byte unchanged; light themes get
the Catppuccin Latte palette, which is legible on a light background.

Thread the palette through the status bar, sidebar, chat/tool display, input,
minimap/rail, context rule and breakdown, matrix rain, and the frame rules.
The chat render cache now keys on the palette so a /theme switch re-renders
cached messages instead of showing stale colors.

Signed-off-by: dimetron <dimetron@me.com>
