### PR TITLE
test(tools): improve helper coverage

### DIFF
--- a/internal/tools/find_helpers_test.go
+++ b/internal/tools/find_helpers_test.go
@@ -1,0 +1,36 @@
+package tools
+
+import "testing"
+
+func TestMatchDoublestar(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"src/**/*.go", "src/pkg/main.go", true},
+		{"src/**/*.go", "other/pkg/main.go", false},
+		{"src/**/*.go", "src/main.go", true},
+		{"**/*.go", "pkg/main.go", true},
+		{"*.go", "pkg/main.go", false},
+		{"src/**/", "src/pkg/main.go", true},
+		{"src/**/", "other/main.go", false},
+	}
+	for _, tt := range tests {
+		if got := matchDoublestar(tt.pattern, tt.path); got != tt.want {
+			t.Errorf("matchDoublestar(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeGlobPattern(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{"**/*.go", "*.go"},
+		{"**/**/*.go", "*.go"},
+		{"src/*.go", "src/*.go"},
+	} {
+		if got := normalizeGlobPattern(tt.input); got != tt.want {
+			t.Errorf("normalizeGlobPattern(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/tools/stderr_noise_test.go
+++ b/internal/tools/stderr_noise_test.go
@@ -76,3 +76,22 @@ func TestStripRuntimeNoise(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRuntimeNoise(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"MallocStackLogging: warning", true},
+		{"x(123) MallocStackLogging: warning", true},
+		{"malloc: nano zone abandoned due to pressure", true},
+		{"x(123) malloc: nano zone abandoned due to pressure", true},
+		{"malloc allocation failed", false},
+		{"ordinary stderr", false},
+	}
+	for _, tt := range tests {
+		if got := isRuntimeNoise(tt.line); got != tt.want {
+			t.Errorf("isRuntimeNoise(%q) = %v, want %v", tt.line, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- cover runtime stderr noise classification paths
- cover doublestar glob matching and normalization helpers

## Verification
- `go test ./internal/tools` ✅
- `go test -cover ./internal/tools` ✅ (86.5%)
- repository-wide `make test-coverage` started but did not complete within the available run; baseline profile was 31.6%, so this PR does not claim 90% repository coverage.