### PR TITLE
fix(tui): don't abort productive polling as a stuck loop

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -22,7 +22,10 @@ import (
 
 const (
 	// maxRepeatToolCalls is the number of identical consecutive tool calls
-	// before the loop is considered stuck and aborted.
+	// before the loop is considered stuck and aborted. A repeated call whose
+	// result changes resets the count (see observeResult): polling tools like
+	// bash_output repeat identical args by design, and only identical results
+	// make the repetition meaningless.
 	maxRepeatToolCalls = 10
 
 	// maxRepeatErrorCalls aliases maxRepeatToolCalls for callers that frame
@@ -117,7 +120,9 @@ func extractAgentType(args map[string]any) string {
 type stuckDetector struct {
 	recent      []string // ring of fingerprints (len <= recentWindowSize)
 	lastPrint   string   // fingerprint of last tool call
-	streak      int      // consecutive identical tool calls
+	lastName    string   // tool name behind lastPrint
+	lastResult  string   // fingerprint of the streak's previous result ("" = none yet)
+	streak      int      // consecutive identical tool calls with identical results
 	lastErrTool string   // name of last tool that errored
 	errStreak   int      // consecutive errors for that tool
 	outBuf      string   // rolling tail of the model's own output
@@ -171,6 +176,8 @@ func (s *stuckDetector) observe(name string, args map[string]any) (stuck bool, d
 	} else {
 		s.streak = 1
 		s.lastPrint = fp
+		s.lastName = name
+		s.lastResult = ""
 	}
 
 	// Sliding window.
@@ -189,6 +196,27 @@ func (s *stuckDetector) observe(name string, args map[string]any) (stuck bool, d
 	}
 
 	return false, ""
+}
+
+// observeResult records a tool call's response. Polling tools repeat identical
+// calls by design — bash_output on a running command sends the same handle
+// every time and gets fresh output back — so a response that differs from the
+// streak's previous response is progress, and resets the identical-call
+// streak. A response identical to the last one keeps the streak counting:
+// re-polling a finished command or re-reading an unchanged file is genuine
+// repetition. A stuck loop whose responses vary trivially (timestamps) escapes
+// this detector, but observeError and observeOutput still cover that shape.
+func (s *stuckDetector) observeResult(name string, response map[string]any) {
+	if name != s.lastName {
+		return
+	}
+	b, _ := json.Marshal(response)
+	sum := sha256.Sum256(b)
+	fp := hex.EncodeToString(sum[:])[:16]
+	if s.lastResult != "" && fp != s.lastResult {
+		s.streak = 0
+	}
+	s.lastResult = fp
 }
 
 // observeError records the outcome of a tool call by name. Consecutive errors
@@ -694,6 +722,11 @@ func (m *model) emitEventParts(
 			respJSON, _ := json.Marshal(fr.Response)
 			log.ToolResult(ev.Author, fr.Name, string(respJSON))
 			m.agentCh <- agentToolResultMsg{name: fr.Name, content: string(respJSON)}
+
+			// A changed result on a repeated call is progress, not a loop
+			// (a poll returning fresh output) — let it reset the
+			// identical-call streak before the next call is observed.
+			detector.observeResult(fr.Name, fr.Response)
 
 			// Track per-tool error streaks: ADK wraps tool errors as
 			// map[string]any{"error": ...}. Anything else (including a

--- a/internal/tui/agent_loop_stuck_test.go
+++ b/internal/tui/agent_loop_stuck_test.go
@@ -106,6 +106,62 @@ func TestStuckDetector_Observe_StreakThreshold(t *testing.T) {
 	}
 }
 
+// TestStuckDetector_ObserveResult_PollingNotStuck reproduces session
+// 260808-1813: bash_output polled a running background command with identical
+// args, but every response carried fresh progress (elapsed, streamed output).
+// Changing results must reset the identical-call streak so productive polling
+// outlives maxRepeatToolCalls.
+func TestStuckDetector_ObserveResult_PollingNotStuck(t *testing.T) {
+	s := &stuckDetector{}
+	args := map[string]any{"handle": "bg_16", "wait_ms": 1000}
+	for i := 0; i < maxRepeatToolCalls*3; i++ {
+		stuck, detail := s.observe("bash_output", args)
+		if stuck {
+			t.Fatalf("poll %d flagged stuck: %s", i, detail)
+		}
+		s.observeResult("bash_output", map[string]any{
+			"handle":  "bg_16",
+			"elapsed": i, // progress: every response differs
+			"running": true,
+		})
+	}
+}
+
+func TestStuckDetector_ObserveResult_IdenticalResultsStillStuck(t *testing.T) {
+	s := &stuckDetector{}
+	args := map[string]any{"handle": "bg_16"}
+	resp := map[string]any{"running": false, "stdout": "done"}
+	tripped := false
+	for i := 0; i < maxRepeatToolCalls; i++ {
+		stuck, _ := s.observe("bash_output", args)
+		tripped = tripped || stuck
+		s.observeResult("bash_output", resp)
+	}
+	if !tripped {
+		t.Errorf("identical calls with identical results should still trip after %d repeats", maxRepeatToolCalls)
+	}
+}
+
+func TestStuckDetector_ObserveResult_OtherToolDoesNotReset(t *testing.T) {
+	s := &stuckDetector{}
+	s.observe("read", map[string]any{"path": "/foo"})
+	s.observe("read", map[string]any{"path": "/foo"})
+	s.observeResult("write", map[string]any{"changed": 1})
+	s.observeResult("write", map[string]any{"changed": 2})
+	if s.streak != 2 {
+		t.Errorf("streak = %d, want 2: another tool's results must not reset it", s.streak)
+	}
+}
+
+func TestStuckDetector_ObserveResult_FirstResultOnlySetsBaseline(t *testing.T) {
+	s := &stuckDetector{}
+	s.observe("read", map[string]any{"path": "/foo"})
+	s.observeResult("read", map[string]any{"content": "x"})
+	if s.streak != 1 {
+		t.Errorf("streak = %d, want 1: the first result has nothing to compare against", s.streak)
+	}
+}
+
 func TestDetectCycle_ShortWindow(t *testing.T) {
 	s := &stuckDetector{}
 	// Window < 6 should return ""


### PR DESCRIPTION
The stuck detector fingerprints tool calls by name+args only, so polling a
background command — bash_output with the same handle every time — looked
identical call after call and tripped maxRepeatToolCalls after 10 polls,
aborting the turn while the command was still running and streaming output
(session 260808-1813-9766b-0fdd6, polling a 1+ minute make test-coverage).

Make the identical-call streak result-aware: a repeated call whose response
differs from the streak's previous response is progress and resets the
streak. Identical responses keep counting, so re-polling a finished command
or re-reading an unchanged file still aborts at the same threshold, and the
error-streak and output-repetition detectors are unchanged.

Signed-off-by: dimetron <dimetron@me.com>
