### PR TITLE
feat(provider): catalog 1M context window for opencode/deepseek-v4-flash

### DIFF
--- a/internal/provider/coverage_boost_test.go
+++ b/internal/provider/coverage_boost_test.go
@@ -35,6 +35,7 @@ func TestContextWindowSize(t *testing.T) {
 		{"mistral-large tag variant", "mistral-large-2512", 256_000},
 		{"qwen custom model defaults to 4k", "qwen-3.6-27b-q4", 4_096},
 		{"ollama phi4 14b context", "ollama/phi4:14b", 16_384},
+		{"opencode deepseek-v4-flash resolves to 1M", "deepseek-v4-flash", 1_000_000},
 		{"unknown returns 0", "nonexistent-model-xyz", 0},
 	}
 	for _, tt := range tests {

--- a/internal/provider/modeldata/context-windows.json
+++ b/internal/provider/modeldata/context-windows.json
@@ -118,5 +118,8 @@
     "qwen": 4096,
     "phi4:14b": 16384,
     "glm-5.2": 976000
+  },
+  "opencode": {
+    "deepseek-v4-flash": 1000000
   }
 }

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -148,6 +148,15 @@ func TestNewOpenCode_AnthropicBaseURLStripped(t *testing.T) {
 	}
 }
 
+// The opencode/ prefix is stripped before the provider-aware lookup
+// (provider.go), so the cataloged window must resolve for the bare model name
+// under the opencode provider.
+func TestContextWindowSizeForOpenCode(t *testing.T) {
+	if got := ContextWindowSizeFor("opencode", "deepseek-v4-flash"); got != 1_000_000 {
+		t.Errorf("ContextWindowSizeFor(opencode, deepseek-v4-flash) = %d, want 1000000", got)
+	}
+}
+
 func TestNewOpenCode_AllCatalogModels(t *testing.T) {
 	// Verify every model in the catalog can be constructed without error.
 	for modelID, family := range opencodeGoModelCatalog {


### PR DESCRIPTION
The opencode catalog (opencode.go) only maps model IDs to API families;
context windows live in modeldata/context-windows.json, which had no
opencode section. opencode/deepseek-v4-flash therefore resolved to 0
tokens, disabling auto-compaction and the context gauge baseline.

Add an opencode section cataloging deepseek-v4-flash at 1M tokens,
matching the native window the cloud model serves (the num_ctx cap was
already removed in 6a9d5aa). Cover the flattened prefix lookup and the
provider-aware ContextWindowSizeFor path.

Signed-off-by: dimetron <dimetron@me.com>
