### PR TITLE
fix(tools): close the exit-status race in killHandle; unblock git fixture tests

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -319,6 +319,11 @@ func TestDefaultSessionTitle_RealGitRepo(t *testing.T) {
 	runGit("init", "-q")
 	runGit("config", "user.email", "t@t")
 	runGit("config", "user.name", "t")
+	// commit.gpgsign is set globally in this repo and signs through 1Password,
+	// which a temp repo inherits; without this the commit blocks on the agent
+	// and fails after a 60s timeout.
+	runGit("config", "commit.gpgsign", "false")
+	runGit("config", "tag.gpgsign", "false")
 	runGit("commit", "--allow-empty", "-q", "-m", "init")
 
 	// A fresh repo on the default branch should produce

--- a/internal/cli/interactive_test.go
+++ b/internal/cli/interactive_test.go
@@ -10,10 +10,19 @@ import (
 
 // runGit is a helper that executes a git command in the given directory
 // and ignores the error (git may not be available in all environments).
+// runGit runs a git command in dir, ignoring failures: these tests set up
+// fixture repos and care about the end state, not each step.
+//
+// Signing is forced off for every invocation. This repo sets commit.gpgsign
+// globally and signs through 1Password's op-ssh-sign, which a temp repo
+// inherits — so an unguarded `commit` here blocks on the 1Password agent for
+// 60s and then fails. Because this helper discards errors, that failure was
+// invisible: the fixture repo silently ended up with no commits and the tests
+// asserted against a weaker world than they meant to.
 func runGit(dir string, args ...string) {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)...)
 	cmd.Dir = dir
-	cmd.Run()
+	_ = cmd.Run()
 }
 
 // -----------------------------------------------------------------------

--- a/internal/cli/mine_progress_units_test.go
+++ b/internal/cli/mine_progress_units_test.go
@@ -1,0 +1,274 @@
+package cli
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a bytes.Buffer safe for the heartbeat goroutine to write to
+// while the test reads it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestFormatETA(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"sub-second rounds up to 1s, never 0s", 200 * time.Millisecond, "1s"},
+		{"seconds", 45 * time.Second, "45s"},
+		{"just under a minute", 59 * time.Second, "59s"},
+		{"a minute is minutes and padded seconds", 60 * time.Second, "1m00s"},
+		{"minutes and seconds", 80 * time.Second, "1m20s"},
+		{"just under an hour", 59*time.Minute + 59*time.Second, "59m59s"},
+		{"an hour is hours and padded minutes", time.Hour, "1h00m"},
+		{"hours and minutes", 2*time.Hour + 5*time.Minute, "2h05m"},
+		{"zero still reads as 1s", 0, "1s"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatETA(tc.in); got != tc.want {
+				t.Errorf("formatETA(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClipRight(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		w    int
+		want string
+	}{
+		{"fits untouched", "abc", 10, "abc"},
+		{"exact fit untouched", "abc", 3, "abc"},
+		{"clipped from the right", "abcdef", 3, "abc"},
+		{"zero width is empty", "abc", 0, ""},
+		{"negative width is empty", "abc", -1, ""},
+		{"empty input", "", 5, ""},
+		// The bar glyphs are three bytes each, so a byte-based clip would cut a
+		// glyph in half and emit a replacement character.
+		{"clips on a rune boundary, not a byte one", "███", 2, "██"},
+		{"a single wide rune that does not fit yields empty", "日", 1, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clipRight(tc.in, tc.w)
+			if got != tc.want {
+				t.Errorf("clipRight(%q, %d) = %q, want %q", tc.in, tc.w, got, tc.want)
+			}
+			if w := dispWidth(got); tc.w > 0 && w > tc.w {
+				t.Errorf("clipRight(%q, %d) = %q with width %d, exceeds max", tc.in, tc.w, got, w)
+			}
+			if strings.ContainsRune(got, '�') {
+				t.Errorf("clipRight split a rune and produced a replacement character: %q", got)
+			}
+		})
+	}
+}
+
+func TestClipLeft(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		w    int
+		want string
+	}{
+		{"fits untouched", "abc", 10, "abc"},
+		{"keeps the tail", "abcdef", 3, "def"},
+		{"zero width is empty", "abc", 0, ""},
+		{"a single wide rune that does not fit yields empty", "日", 1, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clipLeft(tc.in, tc.w); got != tc.want {
+				t.Errorf("clipLeft(%q, %d) = %q, want %q", tc.in, tc.w, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTerminalWidth_NonFileFallsBackTo80(t *testing.T) {
+	if got := terminalWidth(&bytes.Buffer{}); got != 80 {
+		t.Errorf("terminalWidth(non-file) = %d, want the 80-column fallback", got)
+	}
+}
+
+func TestTerminalWidth_NonTTYFileFallsBackTo80(t *testing.T) {
+	// A regular file is an *os.File but has no window size, so GetSize errors
+	// and the fallback must still apply.
+	f, err := os.CreateTemp(t.TempDir(), "width")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer f.Close()
+
+	if got := terminalWidth(f); got != 80 {
+		t.Errorf("terminalWidth(regular file) = %d, want the 80-column fallback", got)
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	if isTerminal(&bytes.Buffer{}) {
+		t.Error("a bytes.Buffer is not a terminal")
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "tty")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer f.Close()
+	if isTerminal(f) {
+		t.Error("a regular file is not a character device")
+	}
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("cannot open %s: %v", os.DevNull, err)
+	}
+	defer devNull.Close()
+	if !isTerminal(devNull) {
+		t.Errorf("%s is a character device and should report as one", os.DevNull)
+	}
+}
+
+func TestIsTerminal_ClosedFileReportsFalse(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "closed")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Stat on a closed descriptor errors; that must read as "not a terminal"
+	// rather than panicking.
+	if isTerminal(f) {
+		t.Error("a closed file reported as a terminal")
+	}
+}
+
+func TestMineProgress_StatusAnnouncesIndeterminateWork(t *testing.T) {
+	var buf bytes.Buffer
+	p := newMineProgress(&buf)
+	p.tty = true // drawLocked only emits to a terminal
+
+	p.status("scan", "walking the tree")
+
+	got := buf.String()
+	for _, want := range []string{"scan", "walking the tree"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status output %q missing %q", got, want)
+		}
+	}
+	// An indeterminate step has no countable units, so there is no honest bar
+	// or percentage to draw — only the step and how long it has run.
+	if strings.Contains(got, "%") {
+		t.Errorf("indeterminate status showed a percentage: %q", got)
+	}
+}
+
+func TestMineProgress_NonTTYRecordsTheLineWithoutDrawingIt(t *testing.T) {
+	var buf bytes.Buffer
+	p := newMineProgress(&buf) // a buffer is never a TTY
+
+	p.status("scan", "walking the tree")
+
+	if buf.Len() != 0 {
+		t.Errorf("non-TTY writer received %q, want nothing drawn", buf.String())
+	}
+	// The line is still retained so a later log record can replay it.
+	if !strings.Contains(p.last, "walking the tree") {
+		t.Errorf("retained line = %q, want it to name the step", p.last)
+	}
+}
+
+func TestMineProgress_HeartbeatIsANoOpWithoutATTY(t *testing.T) {
+	var buf bytes.Buffer
+	p := newMineProgress(&buf) // a buffer is never a TTY
+
+	p.startHeartbeat()
+	if p.beat != nil {
+		t.Error("startHeartbeat armed a ticker for a non-TTY writer")
+	}
+
+	// stopHeartbeat must tolerate never having been started.
+	p.stopHeartbeat()
+}
+
+func TestMineProgress_StopHeartbeatIsIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	p := newMineProgress(&buf)
+	p.tty = true // force the animated path without needing a real terminal
+
+	p.startHeartbeat()
+	if p.beat == nil {
+		t.Fatal("startHeartbeat did not arm a ticker on a TTY")
+	}
+
+	p.stopHeartbeat()
+	if p.beat != nil {
+		t.Error("stopHeartbeat left the channel armed")
+	}
+	p.stopHeartbeat() // must not panic or block on a second call
+}
+
+func TestMineProgress_HeartbeatRedrawsActiveLine(t *testing.T) {
+	var buf syncBuffer
+	p := newMineProgress(&buf)
+	p.tty = true
+
+	p.show("embed", "internal/cli/cli.go", 10, 100, "chunks")
+	p.startHeartbeat()
+	t.Cleanup(p.stopHeartbeat)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if strings.Count(buf.String(), "internal/cli/cli.go") >= 2 {
+			return // redrawn at least once by the heartbeat
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("heartbeat never redrew the line; output: %q", buf.String())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func TestProgressAwareHandler_WithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	p := newMineProgress(&buf)
+	base := slog.NewTextHandler(&buf, nil)
+	h := &progressAwareHandler{Handler: base, p: p}
+
+	// An empty group name is a documented no-op in slog and must not rewrap.
+	if got := h.WithGroup(""); got != slog.Handler(h) {
+		t.Error("WithGroup(\"\") should return the same handler")
+	}
+
+	grouped := h.WithGroup("mine")
+	if _, ok := grouped.(*progressAwareHandler); !ok {
+		// Unwrapping here would lose the bar-interleaving protection.
+		t.Fatalf("WithGroup returned %T, want it to stay wrapped", grouped)
+	}
+}

--- a/internal/cli/ping_trace_test.go
+++ b/internal/cli/ping_trace_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/httplog"
+)
+
+// captureSink returns a pingWriter that accumulates into a builder, plus the
+// builder, so a test can assert on the rendered transcript.
+func captureSink() (pingWriter, *strings.Builder) {
+	var b strings.Builder
+	return func(format string, a ...any) {
+		fmt.Fprintf(&b, format, a...)
+	}, &b
+}
+
+func TestPingTraceSink_RendersRequestWithOutMarker(t *testing.T) {
+	w, out := captureSink()
+
+	pingTraceSink(w)(httplog.Entry{
+		Exchange:  1,
+		Direction: httplog.DirectionRequest,
+		Method:    "POST",
+		URL:       "https://api.anthropic.com/v1/messages",
+		Headers:   map[string][]string{"Content-Type": {"application/json"}},
+		Body:      `{"model":"claude"}`,
+	})
+
+	got := out.String()
+	for _, want := range []string{
+		"> [1] POST https://api.anthropic.com/v1/messages",
+		"> [1] Content-Type: application/json",
+		`> [1] body: {"model":"claude"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("trace missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+func TestPingTraceSink_RendersResponseWithInMarker(t *testing.T) {
+	w, out := captureSink()
+
+	pingTraceSink(w)(httplog.Entry{
+		Exchange:  2,
+		Direction: httplog.DirectionResponse,
+		Proto:     "HTTP/2.0",
+		Status:    200,
+		Duration:  1234 * time.Millisecond,
+		Headers:   map[string][]string{"Content-Type": {"text/event-stream"}},
+	})
+
+	got := out.String()
+	for _, want := range []string{
+		"< [2] HTTP/2.0 200 (1.234s)",
+		"< [2] Content-Type: text/event-stream",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("trace missing %q\ngot:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "> [2]") {
+		t.Errorf("response used the request marker:\n%s", got)
+	}
+}
+
+func TestPingTraceSink_TransportErrorShortCircuits(t *testing.T) {
+	w, out := captureSink()
+
+	pingTraceSink(w)(httplog.Entry{
+		Exchange:  3,
+		Direction: httplog.DirectionResponse,
+		Err:       "connection reset by peer",
+		// Headers and body must not be printed once an error is reported.
+		Headers: map[string][]string{"X-Should-Not": {"appear"}},
+		Body:    "should not appear",
+	})
+
+	got := out.String()
+	if !strings.Contains(got, "< [3] transport error: connection reset by peer") {
+		t.Errorf("transport error not rendered:\n%s", got)
+	}
+	if strings.Contains(got, "X-Should-Not") || strings.Contains(got, "should not appear") {
+		t.Errorf("an errored exchange printed headers or body:\n%s", got)
+	}
+}
+
+func TestPingTraceSink_HeadersAreSortedForStableOutput(t *testing.T) {
+	w, out := captureSink()
+
+	pingTraceSink(w)(httplog.Entry{
+		Exchange:  4,
+		Direction: httplog.DirectionRequest,
+		Method:    "GET",
+		URL:       "https://example.com",
+		Headers: map[string][]string{
+			"Zeta":  {"z"},
+			"Alpha": {"a"},
+			"Mid":   {"m"},
+		},
+	})
+
+	got := out.String()
+	ai, mi, zi := strings.Index(got, "Alpha:"), strings.Index(got, "Mid:"), strings.Index(got, "Zeta:")
+	if ai < 0 || mi < 0 || zi < 0 {
+		t.Fatalf("not all headers rendered:\n%s", got)
+	}
+	if ai >= mi || mi >= zi {
+		t.Errorf("headers not sorted (Alpha=%d Mid=%d Zeta=%d):\n%s", ai, mi, zi, got)
+	}
+}
+
+func TestPingTraceSink_RepeatedHeaderValuesEachGetALine(t *testing.T) {
+	w, out := captureSink()
+
+	pingTraceSink(w)(httplog.Entry{
+		Exchange:  5,
+		Direction: httplog.DirectionRequest,
+		Method:    "GET",
+		URL:       "https://example.com",
+		Headers:   map[string][]string{"Accept": {"text/event-stream", "application/json"}},
+	})
+
+	got := out.String()
+	if n := strings.Count(got, "Accept:"); n != 2 {
+		t.Errorf("got %d Accept lines, want one per value:\n%s", n, got)
+	}
+}
+
+func TestPingTraceSink_ResponseWithoutStatusPrintsNoStatusLine(t *testing.T) {
+	// Status 0 means the response line was never seen; only headers follow.
+	w, out := captureSink()
+
+	pingTraceSink(w)(httplog.Entry{
+		Exchange:  6,
+		Direction: httplog.DirectionResponse,
+		Headers:   map[string][]string{"X-Trailer": {"1"}},
+	})
+
+	got := out.String()
+	if strings.Contains(got, "HTTP/") {
+		t.Errorf("a status-less response printed a status line:\n%s", got)
+	}
+	if !strings.Contains(got, "X-Trailer: 1") {
+		t.Errorf("headers not rendered:\n%s", got)
+	}
+}
+
+func TestPingTraceSink_EmptyEntryRendersNothingHarmful(t *testing.T) {
+	w, out := captureSink()
+	pingTraceSink(w)(httplog.Entry{})
+	if got := out.String(); strings.TrimSpace(got) != "" {
+		t.Errorf("empty entry rendered %q, want nothing", got)
+	}
+}

--- a/internal/guardrail/cache_metrics_test.go
+++ b/internal/guardrail/cache_metrics_test.go
@@ -1,0 +1,176 @@
+package guardrail
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUsage_FreshInputTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage Usage
+		want  int64
+	}{
+		{"no cache means every prompt token is fresh", Usage{InputTokens: 1000}, 1000},
+		{"partial cache", Usage{InputTokens: 1000, CachedInputTokens: 400}, 600},
+		{"fully cached", Usage{InputTokens: 1000, CachedInputTokens: 1000}, 0},
+		{"cached exceeding input never goes negative", Usage{InputTokens: 100, CachedInputTokens: 500}, 0},
+		{"zero value", Usage{}, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.usage.FreshInputTokens(); got != tc.want {
+				t.Errorf("FreshInputTokens() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUsage_CacheHitRate(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage Usage
+		want  float64
+	}{
+		{"half cached", Usage{InputTokens: 1000, CachedInputTokens: 500}, 50},
+		{"fully cached", Usage{InputTokens: 200, CachedInputTokens: 200}, 100},
+		{"no hits", Usage{InputTokens: 200}, 0},
+		{"no prompt tokens returns 0 rather than dividing by zero", Usage{CachedInputTokens: 50}, 0},
+		{"zero value", Usage{}, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.usage.CacheHitRate(); got != tc.want {
+				t.Errorf("CacheHitRate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTracker_CachedTokensAndHitRateToday(t *testing.T) {
+	tr := NewWithPath(0, "")
+
+	if got := tr.CachedTokensToday(); got != 0 {
+		t.Errorf("fresh tracker CachedTokensToday() = %d, want 0", got)
+	}
+	if got := tr.CacheHitRateToday(); got != 0 {
+		t.Errorf("fresh tracker CacheHitRateToday() = %v, want 0", got)
+	}
+
+	if err := tr.AddWithCache(1000, 100, 250); err != nil {
+		t.Fatalf("AddWithCache: %v", err)
+	}
+	if got := tr.CachedTokensToday(); got != 250 {
+		t.Errorf("CachedTokensToday() = %d, want 250", got)
+	}
+	if got := tr.CacheHitRateToday(); got != 25 {
+		t.Errorf("CacheHitRateToday() = %v, want 25", got)
+	}
+
+	// A second request accumulates rather than replacing.
+	if err := tr.AddWithCache(1000, 100, 750); err != nil {
+		t.Fatalf("AddWithCache: %v", err)
+	}
+	if got := tr.CachedTokensToday(); got != 1000 {
+		t.Errorf("CachedTokensToday() = %d, want 1000", got)
+	}
+	if got := tr.CacheHitRateToday(); got != 50 {
+		t.Errorf("CacheHitRateToday() = %v, want 50", got)
+	}
+}
+
+func TestTracker_BodyTokens(t *testing.T) {
+	tr := NewWithPath(0, "")
+
+	// Nothing recorded yet.
+	if got := tr.BodyTokens(); got != 0 {
+		t.Errorf("fresh tracker BodyTokens() = %d, want 0", got)
+	}
+
+	// The first prompt establishes the cached prefix baseline; the body is
+	// whatever accumulates past it.
+	tr.SetLastPromptTokens(10_000)
+	prefix := tr.CachePrefixTokens()
+	if got, want := tr.BodyTokens(), 10_000-prefix; got != want {
+		t.Errorf("BodyTokens() = %d, want %d (prompt 10000 - prefix %d)", got, want, prefix)
+	}
+}
+
+func TestTracker_BodyTokensNeverNegative(t *testing.T) {
+	// A prompt smaller than the established prefix (the window was rebuilt
+	// under us) must report an empty body, not a negative one.
+	tr := NewWithPath(0, "")
+	tr.SetLastPromptTokens(50_000)
+	tr.SetLastPromptTokens(10)
+
+	if got := tr.BodyTokens(); got < 0 {
+		t.Errorf("BodyTokens() = %d, want >= 0", got)
+	}
+}
+
+func TestTracker_ResetContextWindow(t *testing.T) {
+	tr := NewWithPath(0, "")
+	tr.SetContextWindowSize(200_000)
+	tr.SetLastPromptTokens(50_000)
+
+	tr.ResetContextWindow()
+
+	if got := tr.LastPromptTokens(); got != 0 {
+		t.Errorf("LastPromptTokens() = %d after reset, want 0", got)
+	}
+	if got := tr.CachePrefixTokens(); got != 0 {
+		t.Errorf("CachePrefixTokens() = %d after reset, want 0", got)
+	}
+	if got := tr.LastCachedTokens(); got != 0 {
+		t.Errorf("LastCachedTokens() = %d after reset, want 0", got)
+	}
+	if got := tr.BodyTokens(); got != 0 {
+		t.Errorf("BodyTokens() = %d after reset, want 0", got)
+	}
+	// The window size is a model property, not per-window state, so it
+	// survives the reset.
+	if got := tr.ContextWindowSize(); got != 200_000 {
+		t.Errorf("ContextWindowSize() = %d after reset, want it preserved at 200000", got)
+	}
+}
+
+func TestFormatCacheSuffix(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage Usage
+		want  string
+	}{
+		{
+			name:  "no prompt tokens yet says nothing",
+			usage: Usage{},
+			want:  "",
+		},
+		{
+			name:  "a single uncached request says nothing (too early to judge)",
+			usage: Usage{InputTokens: 1000, Requests: 1},
+			want:  "",
+		},
+		{
+			name:  "repeated requests with no hits is worth reporting",
+			usage: Usage{InputTokens: 1000, Requests: 2},
+			want:  " · cache: no hits",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatCacheSuffix(tc.usage); got != tc.want {
+				t.Errorf("formatCacheSuffix() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatCacheSuffix_ReportsHits(t *testing.T) {
+	got := formatCacheSuffix(Usage{InputTokens: 10_000, CachedInputTokens: 7_500, Requests: 3})
+
+	for _, want := range []string{"7.5k read", "75% of input", "2.5k fresh"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatCacheSuffix() = %q, want it to contain %q", got, want)
+		}
+	}
+}

--- a/internal/httplog/span_event_test.go
+++ b/internal/httplog/span_event_test.go
@@ -1,0 +1,244 @@
+package httplog
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// recordSpan runs fn with a live recording span in the context and returns the
+// finished span, so tests can assert on the events emitted onto it.
+func recordSpan(t *testing.T, fn func(ctx context.Context)) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutting down tracer provider: %v", err)
+		}
+	})
+
+	ctx, span := tp.Tracer("httplog-test").Start(context.Background(), "exchange")
+	fn(ctx)
+	span.End()
+
+	spans := exp.GetSpans().Snapshots()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	return spans[0]
+}
+
+// attrsOf flattens the first event's attributes into a lookup map.
+func attrsOf(t *testing.T, span sdktrace.ReadOnlySpan) (string, map[string]attribute.Value) {
+	t.Helper()
+
+	events := span.Events()
+	if len(events) != 1 {
+		t.Fatalf("got %d span events, want 1", len(events))
+	}
+	out := make(map[string]attribute.Value, len(events[0].Attributes))
+	for _, kv := range events[0].Attributes {
+		out[string(kv.Key)] = kv.Value
+	}
+	return events[0].Name, out
+}
+
+func TestEmitSpanEvent_NonRecordingSpanIsANoOp(t *testing.T) {
+	// The no-op tracer is what runs when OTel is not configured. Reaching this
+	// path must cost nothing and must not panic.
+	ctx := trace.ContextWithSpan(context.Background(), trace.SpanFromContext(context.Background()))
+	emitSpanEvent(ctx, Entry{Exchange: 1, Direction: DirectionRequest})
+}
+
+func TestEmitSpanEvent_RequestAttributes(t *testing.T) {
+	span := recordSpan(t, func(ctx context.Context) {
+		emitSpanEvent(ctx, Entry{
+			Exchange:  7,
+			Direction: DirectionRequest,
+			Method:    "POST",
+			URL:       "https://api.example.com/v1/messages",
+			Headers:   map[string][]string{"Content-Type": {"application/json"}},
+			Body:      `{"model":"test"}`,
+		})
+	})
+
+	name, attrs := attrsOf(t, span)
+	if name != "http.request" {
+		t.Errorf("event name = %q, want %q", name, "http.request")
+	}
+
+	want := map[string]string{
+		"http.exchange":                    "7",
+		"http.direction":                   "request",
+		"http.request.method":              "POST",
+		"url.full":                         "https://api.example.com/v1/messages",
+		"http.request.header.content-type": "application/json",
+		"http.request.header...body":       `{"model":"test"}`,
+	}
+	for k, v := range want {
+		got, ok := attrs[k]
+		if !ok {
+			t.Errorf("missing attribute %q", k)
+			continue
+		}
+		if got.String() != v {
+			t.Errorf("attribute %q = %q, want %q", k, got.String(), v)
+		}
+	}
+
+	// Response-only fields must not appear on a request entry.
+	for _, k := range []string{"http.response.status_code", "http.duration_ms", "error.message"} {
+		if _, ok := attrs[k]; ok {
+			t.Errorf("request entry carried response-only attribute %q", k)
+		}
+	}
+}
+
+func TestEmitSpanEvent_ResponseAttributesUseResponsePrefix(t *testing.T) {
+	span := recordSpan(t, func(ctx context.Context) {
+		emitSpanEvent(ctx, Entry{
+			Exchange:  8,
+			Direction: DirectionResponse,
+			Status:    429,
+			Duration:  1500 * time.Millisecond,
+			Err:       "rate limited",
+			Headers:   map[string][]string{"Retry-After": {"30"}},
+			Body:      "slow down",
+		})
+	})
+
+	name, attrs := attrsOf(t, span)
+	if name != "http.response" {
+		t.Errorf("event name = %q, want %q", name, "http.response")
+	}
+
+	want := map[string]string{
+		"http.response.status_code":        "429",
+		"http.duration_ms":                 "1500",
+		"error.message":                    "rate limited",
+		"http.response.header.retry-after": "30",
+		"http.response.header...body":      "slow down",
+	}
+	for k, v := range want {
+		got, ok := attrs[k]
+		if !ok {
+			t.Errorf("missing attribute %q", k)
+			continue
+		}
+		if got.String() != v {
+			t.Errorf("attribute %q = %q, want %q", k, got.String(), v)
+		}
+	}
+}
+
+func TestEmitSpanEvent_JoinsRepeatedHeaderValues(t *testing.T) {
+	span := recordSpan(t, func(ctx context.Context) {
+		emitSpanEvent(ctx, Entry{
+			Direction: DirectionRequest,
+			Headers:   map[string][]string{"Accept": {"text/event-stream", "application/json"}},
+		})
+	})
+
+	_, attrs := attrsOf(t, span)
+	got, ok := attrs["http.request.header.accept"]
+	if !ok {
+		t.Fatal("missing joined accept header")
+	}
+	if got.String() != "text/event-stream, application/json" {
+		t.Errorf("accept = %q, want the values joined", got.String())
+	}
+}
+
+func TestEmitSpanEvent_TruncatesOversizedBodyAndFlagsIt(t *testing.T) {
+	t.Cleanup(func() { SetOTelMaxBody(0) }) // restore the default
+	SetOTelMaxBody(16)
+
+	span := recordSpan(t, func(ctx context.Context) {
+		emitSpanEvent(ctx, Entry{
+			Direction: DirectionRequest,
+			Body:      strings.Repeat("x", 500),
+		})
+	})
+
+	_, attrs := attrsOf(t, span)
+	body, ok := attrs["http.request.header...body"]
+	if !ok {
+		t.Fatal("missing body attribute")
+	}
+	if len(body.String()) > 64 {
+		t.Errorf("body not truncated: %d bytes", len(body.String()))
+	}
+	flag, ok := attrs["http.body.truncated"]
+	if !ok || flag.String() != "true" {
+		t.Errorf("truncation flag = %v (present=%v), want true", flag.String(), ok)
+	}
+}
+
+func TestEmitSpanEvent_PropagatesPreTruncatedBodyFlag(t *testing.T) {
+	// The body was already cut by the capture layer, so emitSpanEvent's own
+	// truncate is a no-op — the flag must still be set.
+	span := recordSpan(t, func(ctx context.Context) {
+		emitSpanEvent(ctx, Entry{
+			Direction:     DirectionRequest,
+			Body:          "short",
+			BodyTruncated: true,
+		})
+	})
+
+	_, attrs := attrsOf(t, span)
+	flag, ok := attrs["http.body.truncated"]
+	if !ok || flag.String() != "true" {
+		t.Errorf("truncation flag = %v (present=%v), want true", flag.String(), ok)
+	}
+}
+
+func TestEmitSpanEvent_OmitsEmptyOptionalFields(t *testing.T) {
+	span := recordSpan(t, func(ctx context.Context) {
+		emitSpanEvent(ctx, Entry{Exchange: 1, Direction: DirectionRequest})
+	})
+
+	_, attrs := attrsOf(t, span)
+	for _, k := range []string{
+		"http.request.method", "url.full", "http.response.status_code",
+		"http.duration_ms", "error.message", "http.request.header...body",
+	} {
+		if _, ok := attrs[k]; ok {
+			t.Errorf("empty field emitted attribute %q", k)
+		}
+	}
+	// The two always-present fields are still there.
+	if _, ok := attrs["http.exchange"]; !ok {
+		t.Error("missing http.exchange")
+	}
+	if _, ok := attrs["http.direction"]; !ok {
+		t.Error("missing http.direction")
+	}
+}
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"short values reveal nothing", "abc", "***(3 bytes)"},
+		{"exactly at the keep length reveals nothing", "12345678", "***(8 bytes)"},
+		{"longer values keep an identifying prefix", "sk-ant-secret-value", "sk-ant-s***(19 bytes)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mask(tc.in); got != tc.want {
+				t.Errorf("mask(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/palace/drawer_service_search_test.go
+++ b/internal/palace/drawer_service_search_test.go
@@ -1,0 +1,225 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fixedEmbedder returns a canned vector per text, so similarity is fully
+// controlled by the test rather than by a model.
+type fixedEmbedder struct {
+	vecs map[string][]float32
+	err  error
+	// fallback is returned for any text not in vecs.
+	fallback []float32
+}
+
+func (f *fixedEmbedder) Embed(texts []string) ([][]float32, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([][]float32, 0, len(texts))
+	for _, txt := range texts {
+		if v, ok := f.vecs[txt]; ok {
+			out = append(out, v)
+			continue
+		}
+		out = append(out, f.fallback)
+	}
+	return out, nil
+}
+
+func (f *fixedEmbedder) Close() {}
+
+// emptyEmbedder returns no vectors at all, the degenerate case both Search and
+// CheckDuplicate have to survive.
+type emptyEmbedder struct{}
+
+func (emptyEmbedder) Embed([]string) ([][]float32, error) { return nil, nil }
+func (emptyEmbedder) Close()                              {}
+
+func newSearchService(t *testing.T, emb Embedder) *DrawerService {
+	t.Helper()
+	cfg := DefaultConfig()
+	return NewDrawerService(newTestStore(t), emb, cfg)
+}
+
+func addDrawer(t *testing.T, ds *DrawerService, wing, room, content string) *Drawer {
+	t.Helper()
+	d, err := ds.AddDrawer(context.Background(), DrawerInput{
+		Wing: wing, Room: room, Content: content, AddedBy: "test",
+	})
+	if err != nil {
+		t.Fatalf("AddDrawer(%q): %v", content, err)
+	}
+	return d
+}
+
+func TestDrawerService_SearchRejectsEmptyQuery(t *testing.T) {
+	ds := newSearchService(t, nil)
+
+	if _, err := ds.Search(context.Background(), SearchQuery{}); err == nil {
+		t.Fatal("Search with an empty query returned no error")
+	}
+}
+
+func TestDrawerService_SearchWithoutEmbedderUsesKeywordsOnly(t *testing.T) {
+	ds := newSearchService(t, nil)
+	addDrawer(t, ds, "pi-go", "internal", "the bash supervisor reaps process groups")
+	addDrawer(t, ds, "pi-go", "internal", "unrelated content about pancakes")
+
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "supervisor"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("keyword search returned nothing for a term that is present")
+	}
+	// Every keyword hit must carry a similarity score, since callers rank on it
+	// and a zero would sort a real match to the bottom.
+	for i, r := range got {
+		if r.Rank != 0 && r.Similarity <= 0 {
+			t.Errorf("result %d has rank %d but similarity %v, want a positive score", i, r.Rank, r.Similarity)
+		}
+	}
+}
+
+func TestDrawerService_SearchAppliesDefaultAndExplicitLimit(t *testing.T) {
+	ds := newSearchService(t, nil)
+	for range 9 {
+		addDrawer(t, ds, "pi-go", "internal", "supervisor supervisor supervisor")
+	}
+
+	// Limit <= 0 falls back to 5 rather than returning everything.
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "supervisor"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) > 5 {
+		t.Errorf("default limit returned %d results, want at most 5", len(got))
+	}
+
+	got, err = ds.Search(context.Background(), SearchQuery{Query: "supervisor", Limit: 2})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) > 2 {
+		t.Errorf("explicit limit returned %d results, want at most 2", len(got))
+	}
+}
+
+func TestDrawerService_SearchFallsBackToKeywordsWhenEmbeddingFails(t *testing.T) {
+	// An embedder outage must degrade to keyword search, not fail the query.
+	ds := newSearchService(t, &fixedEmbedder{err: errors.New("model down"), fallback: []float32{1, 0, 0}})
+	addDrawer(t, ds, "pi-go", "internal", "the bash supervisor reaps process groups")
+
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "supervisor"})
+	if err != nil {
+		t.Fatalf("Search must degrade rather than fail: %v", err)
+	}
+	if len(got) == 0 {
+		t.Error("fallback returned no keyword results")
+	}
+}
+
+func TestDrawerService_SearchSurvivesEmbedderReturningNoVectors(t *testing.T) {
+	ds := newSearchService(t, emptyEmbedder{})
+	addDrawer(t, ds, "pi-go", "internal", "the bash supervisor reaps process groups")
+
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "supervisor"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) == 0 {
+		t.Error("expected the keyword results to survive an empty embedding")
+	}
+}
+
+func TestDrawerService_CheckDuplicateWithoutEmbedderIsSkipped(t *testing.T) {
+	ds := newSearchService(t, nil)
+
+	got, err := ds.CheckDuplicate(context.Background(), "anything", DrawerFilter{})
+	if err != nil {
+		t.Fatalf("CheckDuplicate: %v", err)
+	}
+	if got != nil {
+		t.Errorf("CheckDuplicate without an embedder = %+v, want nil (skipped)", got)
+	}
+}
+
+func TestDrawerService_CheckDuplicateFindsIdenticalVector(t *testing.T) {
+	same := []float32{1, 0, 0}
+	emb := &fixedEmbedder{fallback: same}
+	ds := newSearchService(t, emb)
+
+	existing := addDrawer(t, ds, "pi-go", "internal", "original content")
+
+	// The candidate embeds to the same vector, so cosine similarity is 1.0 —
+	// comfortably over the 0.9 default threshold.
+	got, err := ds.CheckDuplicate(context.Background(), "original content", DrawerFilter{})
+	if err != nil {
+		t.Fatalf("CheckDuplicate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("an identical vector was not reported as a duplicate")
+	}
+	if got.ExistingID != existing.ID {
+		t.Errorf("ExistingID = %q, want %q", got.ExistingID, existing.ID)
+	}
+	if got.Similarity < ds.config.DeduplicationThreshold {
+		t.Errorf("Similarity = %v, want >= the %v threshold", got.Similarity, ds.config.DeduplicationThreshold)
+	}
+}
+
+func TestDrawerService_CheckDuplicateIgnoresDistantVector(t *testing.T) {
+	emb := &fixedEmbedder{
+		vecs: map[string][]float32{
+			"original content": {1, 0, 0},
+			"nothing alike":    {0, 1, 0}, // orthogonal => similarity 0
+		},
+	}
+	ds := newSearchService(t, emb)
+	addDrawer(t, ds, "pi-go", "internal", "original content")
+
+	got, err := ds.CheckDuplicate(context.Background(), "nothing alike", DrawerFilter{})
+	if err != nil {
+		t.Fatalf("CheckDuplicate: %v", err)
+	}
+	if got != nil {
+		t.Errorf("an orthogonal vector was reported as a duplicate: %+v", got)
+	}
+}
+
+func TestDrawerService_CheckDuplicatePropagatesEmbedError(t *testing.T) {
+	// Unlike Search, a dedup check that cannot embed must not silently report
+	// "no duplicate" — that would let the caller write a duplicate.
+	ds := newSearchService(t, &fixedEmbedder{err: errors.New("model down")})
+
+	_, err := ds.CheckDuplicate(context.Background(), "content", DrawerFilter{})
+	if err == nil {
+		t.Fatal("CheckDuplicate swallowed an embedding failure")
+	}
+}
+
+func TestDrawerService_CheckDuplicateSurvivesEmptyEmbedding(t *testing.T) {
+	ds := newSearchService(t, emptyEmbedder{})
+
+	got, err := ds.CheckDuplicate(context.Background(), "content", DrawerFilter{})
+	if err != nil {
+		t.Fatalf("CheckDuplicate: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %+v, want nil when the embedder returns no vector", got)
+	}
+}
+
+func TestDuplicateError_MessageNamesTheExistingDrawer(t *testing.T) {
+	err := &DuplicateError{Result: DuplicateResult{ExistingID: "drw_123", Similarity: 0.987}}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "drw_123") || !strings.Contains(msg, "0.987") {
+		t.Errorf("Error() = %q, want it to name the existing drawer and similarity", msg)
+	}
+}

--- a/internal/palace/embedder_selection_test.go
+++ b/internal/palace/embedder_selection_test.go
@@ -1,0 +1,145 @@
+package palace
+
+import (
+	"testing"
+)
+
+// stubEmbedder stands in for a local (non-Ollama) embedder, which is the only
+// property the selection helpers below actually branch on.
+type stubEmbedder struct {
+	closed bool
+}
+
+func (s *stubEmbedder) Embed(texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = []float32{0.1, 0.2, 0.3}
+	}
+	return out, nil
+}
+
+func (s *stubEmbedder) Close() { s.closed = true }
+
+func TestWithOllamaEmbedder(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseURL   string
+		model     string
+		wantURL   string
+		wantModel string
+	}{
+		{
+			name:      "explicit URL and model are used",
+			baseURL:   "http://ollama.internal:11434",
+			model:     "nomic-embed-text",
+			wantURL:   "http://ollama.internal:11434",
+			wantModel: "nomic-embed-text",
+		},
+		{
+			name:      "empty arguments keep the defaults",
+			baseURL:   "",
+			model:     "",
+			wantURL:   DefaultOllamaURL,
+			wantModel: DefaultOllamaEmbedModel,
+		},
+		{
+			name:      "an empty URL keeps the default but the model still applies",
+			baseURL:   "",
+			model:     "custom-model",
+			wantURL:   DefaultOllamaURL,
+			wantModel: "custom-model",
+		},
+		{
+			name:      "an empty model keeps the default but the URL still applies",
+			baseURL:   "http://elsewhere:1234",
+			model:     "",
+			wantURL:   "http://elsewhere:1234",
+			wantModel: DefaultOllamaEmbedModel,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := PalaceConfig{OllamaURL: DefaultOllamaURL, OllamaModel: DefaultOllamaEmbedModel}
+			WithOllamaEmbedder(tc.baseURL, tc.model)(&cfg)
+
+			if !cfg.UseOllama {
+				t.Error("WithOllamaEmbedder did not set UseOllama")
+			}
+			if cfg.OllamaURL != tc.wantURL {
+				t.Errorf("OllamaURL = %q, want %q", cfg.OllamaURL, tc.wantURL)
+			}
+			if cfg.OllamaModel != tc.wantModel {
+				t.Errorf("OllamaModel = %q, want %q", cfg.OllamaModel, tc.wantModel)
+			}
+		})
+	}
+}
+
+func TestBatchSizeFor(t *testing.T) {
+	// Ollama batches server-side and takes a much larger batch than the local
+	// pipeline, which is bounded by graph compilation.
+	if got := batchSizeFor(&ollamaEmbedder{model: "test"}); got != ollamaEmbedBatchSize {
+		t.Errorf("batchSizeFor(ollama) = %d, want %d", got, ollamaEmbedBatchSize)
+	}
+	if got := batchSizeFor(&stubEmbedder{}); got != embedBatchSize {
+		t.Errorf("batchSizeFor(local) = %d, want %d", got, embedBatchSize)
+	}
+}
+
+func TestEmbedderName(t *testing.T) {
+	if got, want := embedderName(&ollamaEmbedder{model: "nomic-embed-text"}), "ollama/nomic-embed-text"; got != want {
+		t.Errorf("embedderName(ollama) = %q, want %q", got, want)
+	}
+	if got := embedderName(&stubEmbedder{}); got != backendName {
+		t.Errorf("embedderName(local) = %q, want %q", got, backendName)
+	}
+}
+
+// TestEmbedderPool_OllamaIsSharedNotCloned is the guard for a correctness bug,
+// not a performance one: building extra *local* embedders alongside an Ollama
+// one mixes 768- and 384-dimension vectors into a single wing, where cosine
+// similarity silently returns 0 for every mismatched pair.
+func TestEmbedderPool_OllamaIsSharedNotCloned(t *testing.T) {
+	shared := &ollamaEmbedder{model: "test"}
+	p := &Palace{embedder: shared}
+
+	embs, cleanup := embedderPool(p, 8)
+	defer cleanup()
+
+	if len(embs) != 1 {
+		t.Fatalf("embedderPool returned %d embedders for Ollama, want 1 shared instance", len(embs))
+	}
+	if embs[0] != Embedder(shared) {
+		t.Error("embedderPool did not reuse the palace's own Ollama embedder")
+	}
+}
+
+func TestEmbedderPool_OllamaCleanupDoesNotCloseTheSharedEmbedder(t *testing.T) {
+	// Worker 0 always reuses the palace's embedder, whose lifetime the palace
+	// owns — closing it here would break the palace after a mine run.
+	shared := &ollamaEmbedder{model: "test"}
+	p := &Palace{embedder: shared}
+
+	_, cleanup := embedderPool(p, 4)
+	cleanup() // must be a no-op, and must not panic
+}
+
+func TestEmbedderPool_SingleWorkerReusesPalaceEmbedder(t *testing.T) {
+	local := &stubEmbedder{}
+	p := &Palace{embedder: local, config: PalaceConfig{ModelPath: t.TempDir()}}
+
+	embs, cleanup := embedderPool(p, 1)
+	defer cleanup()
+
+	if len(embs) != 1 {
+		t.Fatalf("embedderPool(workers=1) returned %d embedders, want 1", len(embs))
+	}
+	if embs[0] != Embedder(local) {
+		t.Error("the single-worker case must reuse the palace's embedder rather than allocating")
+	}
+
+	cleanup()
+	if local.closed {
+		t.Error("cleanup closed the palace's own embedder")
+	}
+}

--- a/internal/palace/miner_project_test.go
+++ b/internal/palace/miner_project_test.go
@@ -370,6 +370,12 @@ func gitInitRepo(t *testing.T, dir string) {
 		{"init"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "Test"},
+		// This repo sets commit.gpgsign globally and signs through 1Password's
+		// op-ssh-sign, which a temp repo inherits. Without turning it off the
+		// commit below blocks on the 1Password agent and fails after a 60s
+		// timeout — a failure that says nothing about the miner under test.
+		{"config", "commit.gpgsign", "false"},
+		{"config", "tag.gpgsign", "false"},
 		{"add", "-A"},
 		{"commit", "-m", "init", "--allow-empty"},
 	} {

--- a/internal/session/compaction_render_test.go
+++ b/internal/session/compaction_render_test.go
@@ -1,0 +1,533 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+
+	adkmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+// stubLLM is an adkmodel.LLM that replays a fixed script. LLMSummarizer only
+// ever makes one call, so a slice of responses plus an optional error is
+// enough to drive every branch.
+type stubLLM struct {
+	resps []*adkmodel.LLMResponse
+	err   error
+}
+
+func (m *stubLLM) Name() string { return "stub-model" }
+
+func (m *stubLLM) GenerateContent(_ context.Context, _ *adkmodel.LLMRequest, _ bool) iter.Seq2[*adkmodel.LLMResponse, error] {
+	return func(yield func(*adkmodel.LLMResponse, error) bool) {
+		if m.err != nil {
+			yield(nil, m.err)
+			return
+		}
+		for _, r := range m.resps {
+			if !yield(r, nil) {
+				return
+			}
+		}
+	}
+}
+
+func modelText(text string) *adkmodel.LLMResponse {
+	return &adkmodel.LLMResponse{Content: genai.NewContentFromText(text, genai.RoleModel)}
+}
+
+func textEvent(author, role, text string) *session.Event {
+	ev := &session.Event{Author: author}
+	ev.Content = genai.NewContentFromText(text, genai.Role(role))
+	return ev
+}
+
+func callEvent(author, name, id string, args map[string]any) *session.Event {
+	ev := &session.Event{Author: author}
+	ev.Content = &genai.Content{
+		Role:  string(genai.RoleModel),
+		Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: id, Name: name, Args: args}}},
+	}
+	return ev
+}
+
+func respEvent(name, id string, resp map[string]any) *session.Event {
+	ev := &session.Event{}
+	ev.Content = &genai.Content{
+		Role:  string(genai.RoleUser),
+		Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: id, Name: name, Response: resp}}},
+	}
+	return ev
+}
+
+// nilContentEvent is an event whose Content is nil — the shape every walker in
+// this package has to skip.
+func nilContentEvent(author string) *session.Event {
+	return &session.Event{Author: author}
+}
+
+// --- AutoCompactOutcome ----------------------------------------------------
+
+func TestAutoCompactOutcome_Reclaimed(t *testing.T) {
+	tests := []struct {
+		name   string
+		before int
+		after  int
+		want   int
+	}{
+		{"freed tokens", 10_000, 4_000, 6_000},
+		{"no change", 5_000, 5_000, 0},
+		{"grew (never negative)", 4_000, 9_000, 0},
+		{"zero value", 0, 0, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := AutoCompactOutcome{TokensBefore: tc.before, TokensAfter: tc.after}
+			if got := o.Reclaimed(); got != tc.want {
+				t.Errorf("Reclaimed() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAutoCompactOutcome_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome AutoCompactOutcome
+		want    []string
+	}{
+		{
+			name:    "shed names the result count and both token totals",
+			outcome: AutoCompactOutcome{Action: CompactionShed, ResultsShed: 3, TokensBefore: 120_000, TokensAfter: 90_500},
+			want:    []string{"Shed 3 superseded", "120.0k", "90.5k"},
+		},
+		{
+			name:    "summarize names the dropped event count",
+			outcome: AutoCompactOutcome{Action: CompactionSummarize, EventsDropped: 42, TokensBefore: 180_000, TokensAfter: 20_000},
+			want:    []string{"Summarized 42 event(s)", "180.0k", "20.0k"},
+		},
+		{
+			name:    "none says so plainly",
+			outcome: AutoCompactOutcome{Action: CompactionNone},
+			want:    []string{"No compaction needed."},
+		},
+		{
+			name:    "sub-1k counts render without the k suffix",
+			outcome: AutoCompactOutcome{Action: CompactionShed, ResultsShed: 1, TokensBefore: 999, TokensAfter: 12},
+			want:    []string{"999", "12"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.outcome.String()
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("String() = %q, want it to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatCount(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1.0k"},
+		{1500, "1.5k"},
+		{123_456, "123.5k"},
+	}
+	for _, tc := range tests {
+		if got := formatCount(tc.in); got != tc.want {
+			t.Errorf("formatCount(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCompactionAction_String(t *testing.T) {
+	tests := []struct {
+		action CompactionAction
+		want   string
+	}{
+		{CompactionNone, "none"},
+		{CompactionShed, "shed"},
+		{CompactionSummarize, "summarize"},
+		{CompactionAction(99), "none"},
+	}
+	for _, tc := range tests {
+		if got := tc.action.String(); got != tc.want {
+			t.Errorf("CompactionAction(%d).String() = %q, want %q", tc.action, got, tc.want)
+		}
+	}
+}
+
+// --- renderTranscript / truncateForPrompt ----------------------------------
+
+func TestRenderTranscript(t *testing.T) {
+	events := []*session.Event{
+		nil,                     // skipped
+		nilContentEvent("user"), // skipped
+		textEvent("user", string(genai.RoleUser), "fix it"), // author wins over role
+		callEvent("assistant", "read", "c1", map[string]any{"file_path": "a.go"}),
+		respEvent("read", "c1", map[string]any{"content": "package main"}),
+	}
+
+	got := renderTranscript(events)
+
+	for _, want := range []string{
+		"user: fix it",
+		"assistant called read(",
+		`"file_path":"a.go"`,
+		"read result:",
+		"package main",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("transcript missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTranscript_FallsBackToRoleWhenAuthorEmpty(t *testing.T) {
+	events := []*session.Event{textEvent("", string(genai.RoleModel), "hello")}
+	if got := renderTranscript(events); !strings.HasPrefix(got, "model: hello") {
+		t.Errorf("want role-prefixed line, got %q", got)
+	}
+}
+
+func TestRenderTranscript_TruncatesLargeToolResults(t *testing.T) {
+	huge := strings.Repeat("x", 5000)
+	events := []*session.Event{respEvent("bash", "c1", map[string]any{"stdout": huge})}
+
+	got := renderTranscript(events)
+
+	if len(got) > 3000 {
+		t.Errorf("transcript not truncated: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "more bytes)") {
+		t.Errorf("truncation not annotated: %q", got[max(0, len(got)-120):])
+	}
+}
+
+func TestRenderTranscript_Empty(t *testing.T) {
+	if got := renderTranscript(nil); got != "" {
+		t.Errorf("renderTranscript(nil) = %q, want empty", got)
+	}
+}
+
+func TestTruncateForPrompt(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"under limit is untouched", "short", 10, "short"},
+		{"exactly at limit is untouched", "12345", 5, "12345"},
+		{"over limit is annotated", "1234567890", 4, "1234... (6 more bytes)"},
+		{"empty", "", 5, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncateForPrompt(tc.in, tc.max); got != tc.want {
+				t.Errorf("truncateForPrompt(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- LLMSummarizer ---------------------------------------------------------
+
+func TestLLMSummarizer_UsesModelOutput(t *testing.T) {
+	llm := &stubLLM{resps: []*adkmodel.LLMResponse{modelText("did "), modelText("the thing")}}
+	events := []*session.Event{textEvent("user", string(genai.RoleUser), "do the thing")}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("LLMSummarizer: %v", err)
+	}
+	if got != "did the thing" {
+		t.Errorf("summary = %q, want %q", got, "did the thing")
+	}
+}
+
+func TestLLMSummarizer_NilModelFallsBackToSimple(t *testing.T) {
+	events := []*session.Event{textEvent("user", string(genai.RoleUser), "hi")}
+
+	got, err := LLMSummarizer(context.Background(), nil)(events)
+	if err != nil {
+		t.Fatalf("LLMSummarizer: %v", err)
+	}
+	want, _ := SimpleSummarizer(events)
+	if got != want {
+		t.Errorf("summary = %q, want the SimpleSummarizer output %q", got, want)
+	}
+}
+
+func TestLLMSummarizer_EmptyTranscriptFallsBackToSimple(t *testing.T) {
+	// Events with no renderable parts produce an empty transcript, which must
+	// not be sent to the model.
+	llm := &stubLLM{resps: []*adkmodel.LLMResponse{modelText("should not be used")}}
+	events := []*session.Event{nil, nilContentEvent("user")}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("LLMSummarizer: %v", err)
+	}
+	if strings.Contains(got, "should not be used") {
+		t.Errorf("model was called for an empty transcript: %q", got)
+	}
+}
+
+func TestLLMSummarizer_ModelErrorDegradesInsteadOfFailing(t *testing.T) {
+	// A failed summarization must still let the caller reclaim context.
+	llm := &stubLLM{err: errors.New("model exploded")}
+	events := []*session.Event{
+		textEvent("user", string(genai.RoleUser), "do it"),
+		callEvent("assistant", "edit", "c1", map[string]any{"file_path": "main.go"}),
+	}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("LLMSummarizer must not propagate model errors, got %v", err)
+	}
+	for _, want := range []string{"Compaction summary unavailable", "model exploded", "main.go"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("degraded summary missing %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestLLMSummarizer_EmptyModelOutputDegrades(t *testing.T) {
+	llm := &stubLLM{resps: []*adkmodel.LLMResponse{modelText("   "), {}, nil}}
+	events := []*session.Event{textEvent("user", string(genai.RoleUser), "do it")}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("LLMSummarizer: %v", err)
+	}
+	if !strings.Contains(got, "Compaction summary unavailable") {
+		t.Errorf("want degraded summary, got %q", got)
+	}
+	if strings.Contains(got, "Summarizer error") {
+		t.Errorf("no error occurred, so none should be reported: %q", got)
+	}
+}
+
+// --- responseMapKey / isPayloadField ---------------------------------------
+
+func TestIsPayloadField(t *testing.T) {
+	for _, k := range []string{"stdout", "content", "output", "diff", "result", "data"} {
+		if !isPayloadField(k) {
+			t.Errorf("isPayloadField(%q) = false, want true", k)
+		}
+	}
+	for _, k := range []string{"file_path", "path", "error", "exit_code", ""} {
+		if isPayloadField(k) {
+			t.Errorf("isPayloadField(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestResponseMapKey_PrefersNamedIdentifiers(t *testing.T) {
+	tests := []struct {
+		name string
+		resp map[string]any
+		want string
+	}{
+		{"file_path wins", map[string]any{"file_path": "a.go", "content": "x"}, "file_path=a.go"},
+		{"path", map[string]any{"path": "b.go"}, "path=b.go"},
+		{"filePath", map[string]any{"filePath": "c.go"}, "filePath=c.go"},
+		{"pattern", map[string]any{"pattern": "foo"}, "pattern=foo"},
+		{"command", map[string]any{"command": "ls"}, "command=ls"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := responseMapKey(tc.resp); got != tc.want {
+				t.Errorf("responseMapKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResponseMapKey_SkipsNonStringAndEmptyIdentifiers(t *testing.T) {
+	// A non-string or empty file_path must not be used as the key; the
+	// field-set fallback takes over.
+	got := responseMapKey(map[string]any{"file_path": 42, "exit_code": 0})
+	if strings.HasPrefix(got, "file_path=") {
+		t.Errorf("non-string identifier was used as key: %q", got)
+	}
+	if !strings.Contains(got, "exit_code=0") {
+		t.Errorf("want field-set fallback keyed on exit_code, got %q", got)
+	}
+}
+
+func TestResponseMapKey_FieldSetFallbackIgnoresPayload(t *testing.T) {
+	// Same non-payload fields, different payload => same key (a genuine repeat).
+	a := responseMapKey(map[string]any{"exit_code": 0, "stdout": "one"})
+	b := responseMapKey(map[string]any{"exit_code": 0, "stdout": "two"})
+	if a != b {
+		t.Errorf("payload changed the key: %q vs %q", a, b)
+	}
+
+	// Different non-payload fields => different keys.
+	c := responseMapKey(map[string]any{"exit_code": 1, "stdout": "one"})
+	if a == c {
+		t.Errorf("distinct non-payload values collapsed to one key: %q", a)
+	}
+}
+
+func TestResponseMapKey_PayloadOnlyFallsBackToContentHash(t *testing.T) {
+	a := responseMapKey(map[string]any{"stdout": "same"})
+	b := responseMapKey(map[string]any{"stdout": "same"})
+	c := responseMapKey(map[string]any{"stdout": "different"})
+
+	if !strings.HasPrefix(a, "hash=") {
+		t.Errorf("want a content hash for a payload-only response, got %q", a)
+	}
+	if a != b {
+		t.Error("identical payload-only responses must produce the same key")
+	}
+	if a == c {
+		t.Error("different payload-only responses must produce different keys")
+	}
+}
+
+func TestResponseMapKey_Empty(t *testing.T) {
+	if got := responseMapKey(map[string]any{}); !strings.HasPrefix(got, "hash=") {
+		t.Errorf("empty response should hash, got %q", got)
+	}
+}
+
+// --- clean-boundary adjustment ---------------------------------------------
+
+func TestAdvanceToCleanBoundary(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []*session.Event
+		split  int
+		want   int
+	}{
+		{
+			name:   "no function calls leaves the split alone",
+			events: []*session.Event{textEvent("user", "user", "a"), textEvent("model", "model", "b")},
+			split:  1,
+			want:   1,
+		},
+		{
+			name: "a call whose response is on the tail moves the split past it",
+			events: []*session.Event{
+				callEvent("model", "read", "c1", nil),
+				respEvent("read", "c1", map[string]any{"content": "x"}),
+				textEvent("model", "model", "done"),
+			},
+			split: 1,
+			want:  2,
+		},
+		{
+			name: "a response whose call is on the compacted side moves the split",
+			events: []*session.Event{
+				callEvent("model", "read", "c1", nil),
+				respEvent("read", "c1", map[string]any{"content": "x"}),
+			},
+			split: 1,
+			want:  2,
+		},
+		{
+			name: "an unmatched call does not move the split",
+			events: []*session.Event{
+				callEvent("model", "read", "c1", nil),
+				textEvent("model", "model", "gave up"),
+			},
+			split: 1,
+			want:  1,
+		},
+		{
+			name: "a call with no ID is ignored",
+			events: []*session.Event{
+				callEvent("model", "read", "", nil),
+				respEvent("read", "", map[string]any{"content": "x"}),
+			},
+			split: 1,
+			want:  1,
+		},
+		{
+			// The loop never runs, so the function clamps down to len(events)
+			// rather than handing back an out-of-range split.
+			name:   "split past the end is clamped to len(events)",
+			events: []*session.Event{textEvent("user", "user", "a")},
+			split:  5,
+			want:   1,
+		},
+		{
+			name: "nil events and nil content are skipped",
+			events: []*session.Event{
+				nil,
+				nilContentEvent("x"),
+				textEvent("user", "user", "a"),
+			},
+			split: 2,
+			want:  2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := advanceToCleanBoundary(tc.events, tc.split); got != tc.want {
+				t.Errorf("advanceToCleanBoundary(_, %d) = %d, want %d", tc.split, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAdvanceToCleanBoundary_RunsOutOfEvents(t *testing.T) {
+	// Every candidate split orphans a pair, so the boundary walks to the end.
+	events := []*session.Event{
+		callEvent("model", "read", "c1", nil),
+		callEvent("model", "read", "c2", nil),
+		respEvent("read", "c1", map[string]any{"content": "x"}),
+		respEvent("read", "c2", map[string]any{"content": "y"}),
+	}
+	if got := advanceToCleanBoundary(events, 1); got != len(events) {
+		t.Errorf("advanceToCleanBoundary = %d, want %d", got, len(events))
+	}
+}
+
+func TestCallOrphansResponseOnTail_OutOfRangeIndex(t *testing.T) {
+	events := []*session.Event{textEvent("user", "user", "a")}
+	if callOrphansResponseOnTail(events, -1, 0, len(events)) {
+		t.Error("negative index must report false")
+	}
+	if callOrphansResponseOnTail(events, 5, 0, len(events)) {
+		t.Error("index past the end must report false")
+	}
+}
+
+func TestResponseOrphansCallOnCompacted_EdgeCases(t *testing.T) {
+	events := []*session.Event{textEvent("user", "user", "a")}
+	if responseOrphansCallOnCompacted(events, len(events)) {
+		t.Error("split at the end must report false")
+	}
+	if responseOrphansCallOnCompacted([]*session.Event{nil}, 0) {
+		t.Error("nil event must report false")
+	}
+	if responseOrphansCallOnCompacted([]*session.Event{nilContentEvent("x")}, 0) {
+		t.Error("nil content must report false")
+	}
+	// A response with no ID cannot orphan anything.
+	noID := []*session.Event{
+		callEvent("model", "read", "c1", nil),
+		respEvent("read", "", map[string]any{"content": "x"}),
+	}
+	if responseOrphansCallOnCompacted(noID, 1) {
+		t.Error("response with an empty ID must report false")
+	}
+}

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -163,6 +163,23 @@ func (p *bashProc) running() bool {
 	}
 }
 
+// exitStatus returns the reaped exit code and whether the command has actually
+// been reaped yet.
+//
+// exitCode is written by the reaping goroutine in start, which closes done
+// immediately afterwards. Receiving from done is therefore what establishes
+// happens-before for the read; reading the field without checking races with
+// that write, and yields a zero value that reads as a clean "exit 0" for a
+// command that has not exited at all.
+func (p *bashProc) exitStatus() (code int, reaped bool) {
+	select {
+	case <-p.done:
+		return p.exitCode, true
+	default:
+		return 0, false
+	}
+}
+
 // runRequest is one call into the supervisor.
 type runRequest struct {
 	dir         string
@@ -564,15 +581,26 @@ func (s *BashSupervisor) killHandle(handle string) (BashStatus, error) {
 	p.outCur, p.errCur = outNext, errNext
 	p.curMu.Unlock()
 
+	exitCode, reaped := p.exitStatus()
 	st := BashStatus{
 		Handle:   handle,
 		Command:  p.command,
 		Running:  false,
-		ExitCode: p.exitCode,
+		ExitCode: exitCode,
 		Stdout:   redactSecrets(truncateOutput(outStr)),
 		Stderr:   redactSecrets(truncateOutput(stripRuntimeNoise(errStr))),
 		Elapsed:  roundDur(time.Since(p.started)).String(),
 		Note:     "Killed, along with every process it spawned.",
+	}
+	// The wait delay and the exec package's own WaitDelay are the same
+	// duration, so losing that race is expected rather than exotic: a
+	// descendant still holding a pipe keeps Wait blocked for exactly as long
+	// as we are willing to wait for it. Say so instead of reporting the zero
+	// value as a clean exit.
+	if !reaped {
+		st.ExitCode = -1
+		st.Note = "Killed, along with every process it spawned. It had not been reaped " +
+			roundDur(procs.DefaultWaitDelay).String() + " after the signal, so no exit status is available."
 	}
 	s.forget(handle)
 	return st, nil

--- a/internal/tools/bash_supervisor_exit_test.go
+++ b/internal/tools/bash_supervisor_exit_test.go
@@ -1,0 +1,207 @@
+package tools
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/procs"
+)
+
+// unreapedProc is a bashProc that has been registered but whose reaping
+// goroutine has not run — done is open and exitCode still holds its zero value.
+// This is the state killHandle lands in whenever a descendant keeps the
+// command's pipes open for as long as the wait delay.
+func unreapedProc(t *testing.T, sup *BashSupervisor) *bashProc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	p := &bashProc{
+		sup:     sup,
+		id:      sup.nextID(),
+		command: "sleep forever",
+		cmd:     exec.CommandContext(ctx, "true"),
+		cancel:  cancel,
+		stdout:  newStream(streamCap),
+		stderr:  newStream(streamCap),
+		started: time.Now(),
+		done:    make(chan struct{}),
+	}
+	sup.mu.Lock()
+	sup.procs[p.id] = p
+	sup.mu.Unlock()
+	return p
+}
+
+func TestBashProc_ExitStatusReportsWhetherReaped(t *testing.T) {
+	sup := fastSupervisor(t)
+	p := unreapedProc(t, sup)
+
+	if code, reaped := p.exitStatus(); reaped {
+		t.Errorf("exitStatus() = (%d, true) before reaping, want reaped=false", code)
+	}
+
+	p.exitCode = 42
+	close(p.done)
+
+	code, reaped := p.exitStatus()
+	if !reaped {
+		t.Fatal("exitStatus() reports not reaped after done was closed")
+	}
+	if code != 42 {
+		t.Errorf("exitStatus() code = %d, want 42", code)
+	}
+}
+
+// TestSupervisor_KillUnreapedDoesNotReportCleanExit is the regression guard for
+// the bug this fixes: killHandle used to read exitCode unconditionally, so a
+// command that had not been reaped within the wait delay was reported as
+// "exit 0" — a clean success for a command that was still alive.
+func TestSupervisor_KillUnreapedDoesNotReportCleanExit(t *testing.T) {
+	sup := fastSupervisor(t)
+	p := unreapedProc(t, sup)
+
+	// Keep the wait short; the point is the unreaped branch, not the delay.
+	done := make(chan BashStatus, 1)
+	go func() {
+		st, err := sup.killHandle(p.id)
+		if err != nil {
+			t.Errorf("killHandle: %v", err)
+		}
+		done <- st
+	}()
+
+	select {
+	case st := <-done:
+		if st.ExitCode == 0 {
+			t.Error("an unreaped command was reported as exit 0")
+		}
+		if st.ExitCode != -1 {
+			t.Errorf("ExitCode = %d, want -1 for an unreaped command", st.ExitCode)
+		}
+		if !strings.Contains(st.Note, "no exit status is available") {
+			t.Errorf("Note = %q, want it to say no exit status is available", st.Note)
+		}
+	case <-time.After(3 * procs.DefaultWaitDelay):
+		t.Fatal("killHandle did not return")
+	}
+}
+
+func TestSupervisor_KillReapedReportsRealExitCode(t *testing.T) {
+	sup := fastSupervisor(t)
+	out := run(t, sup, "sleep 30", 120*time.Millisecond)
+	if !out.Running {
+		t.Fatalf("command was not backgrounded: %+v", out)
+	}
+
+	st, err := sup.killHandle(out.Handle)
+	if err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
+	if st.Running {
+		t.Error("killed command still reports Running")
+	}
+	// A killed process reports a signal-derived status, never a clean 0.
+	if st.ExitCode == 0 {
+		t.Error("killed command reported exit 0")
+	}
+	if !strings.Contains(st.Note, "Killed") {
+		t.Errorf("Note = %q, want it to mention the kill", st.Note)
+	}
+}
+
+// TestSupervisor_ConcurrentKillAndReadAreRaceFree exercises the two readers of
+// a proc's exit state against a live reaping goroutine. It exists to be run
+// under -race.
+func TestSupervisor_ConcurrentKillAndReadAreRaceFree(t *testing.T) {
+	sup := fastSupervisor(t)
+	out := run(t, sup, "sleep 30", 100*time.Millisecond)
+	if !out.Running {
+		t.Fatalf("command was not backgrounded: %+v", out)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = sup.readOutput(out.Handle, 20*time.Millisecond)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = sup.killHandle(out.Handle)
+	}()
+	wg.Wait()
+}
+
+func TestSupervisor_HandlesListsBackgroundCommandsSorted(t *testing.T) {
+	sup := fastSupervisor(t)
+	if got := sup.Handles(); len(got) != 0 {
+		t.Errorf("fresh supervisor Handles() = %v, want empty", got)
+	}
+
+	first := run(t, sup, "sleep 30", 80*time.Millisecond)
+	second := run(t, sup, "sleep 30", 80*time.Millisecond)
+
+	got := sup.Handles()
+	if len(got) != 2 {
+		t.Fatalf("Handles() = %v, want 2 entries", got)
+	}
+	if got[0] > got[1] {
+		t.Errorf("Handles() = %v, want them sorted", got)
+	}
+	for _, h := range []string{first.Handle, second.Handle} {
+		if !contains(got, h) {
+			t.Errorf("Handles() = %v, missing %q", got, h)
+		}
+	}
+}
+
+func TestSupervisor_KillUnknownHandleNamesTheLiveOnes(t *testing.T) {
+	sup := fastSupervisor(t)
+	live := run(t, sup, "sleep 30", 80*time.Millisecond)
+
+	_, err := sup.killHandle("bg_nope")
+	if err == nil {
+		t.Fatal("killHandle on an unknown handle returned no error")
+	}
+	if !strings.Contains(err.Error(), live.Handle) {
+		t.Errorf("error %q does not name the live handle %q", err, live.Handle)
+	}
+}
+
+func TestOldestLocked_PrefersFinishedOverLive(t *testing.T) {
+	now := time.Now()
+	live := &bashProc{id: "live", started: now.Add(-time.Hour), done: make(chan struct{})}
+
+	finishedCh := make(chan struct{})
+	close(finishedCh)
+	finished := &bashProc{id: "finished", started: now, done: finishedCh}
+
+	// The live one started an hour earlier, but evicting a finished command
+	// costs nothing and evicting a live one destroys work.
+	got := oldestLocked(map[string]*bashProc{"live": live, "finished": finished})
+	if got == nil || got.id != "finished" {
+		t.Fatalf("oldestLocked picked %v, want the finished command", got)
+	}
+}
+
+func TestOldestLocked_FallsBackToOldestLive(t *testing.T) {
+	now := time.Now()
+	older := &bashProc{id: "older", started: now.Add(-time.Hour), done: make(chan struct{})}
+	newer := &bashProc{id: "newer", started: now, done: make(chan struct{})}
+
+	got := oldestLocked(map[string]*bashProc{"newer": newer, "older": older})
+	if got == nil || got.id != "older" {
+		t.Fatalf("oldestLocked picked %v, want the oldest live command", got)
+	}
+}
+
+func TestOldestLocked_Empty(t *testing.T) {
+	if got := oldestLocked(map[string]*bashProc{}); got != nil {
+		t.Errorf("oldestLocked(empty) = %v, want nil", got)
+	}
+}

--- a/internal/tools/bash_supervisor_leak_test.go
+++ b/internal/tools/bash_supervisor_leak_test.go
@@ -1,0 +1,207 @@
+package tools
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// settleGoroutines waits for the goroutine count to stop falling, so a test
+// does not mistake "the reaper has not been scheduled yet" for a leak. It
+// returns the settled count.
+func settleGoroutines(t *testing.T) int {
+	t.Helper()
+
+	last := runtime.NumGoroutine()
+	stable := 0
+	for range 200 {
+		time.Sleep(10 * time.Millisecond)
+		n := runtime.NumGoroutine()
+		if n == last {
+			stable++
+			if stable >= 5 {
+				return n
+			}
+			continue
+		}
+		stable = 0
+		last = n
+	}
+	return last
+}
+
+// TestSupervisor_ForegroundRunsLeakNoGoroutines guards the reaping goroutine
+// that start() spawns for every command. It is per-command and unbounded, so a
+// path that fails to let it finish leaks one goroutine per shell call — which
+// in a long session is thousands.
+func TestSupervisor_ForegroundRunsLeakNoGoroutines(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	// Warm up so one-time initialization is not counted as growth.
+	run(t, sup, "echo warmup", 5*time.Second)
+	baseline := settleGoroutines(t)
+
+	for range 25 {
+		out := run(t, sup, "echo hello", 5*time.Second)
+		if out.Running {
+			t.Fatalf("a fast command was backgrounded: %+v", out)
+		}
+	}
+
+	after := settleGoroutines(t)
+	if after > baseline+2 {
+		t.Errorf("goroutines grew from %d to %d over 25 foreground commands", baseline, after)
+	}
+}
+
+// TestSupervisor_BackgroundAndKillLeakNoGoroutines covers the handoff path,
+// which spawns a second (reap) goroutine per command on top of the reaper.
+func TestSupervisor_BackgroundAndKillLeakNoGoroutines(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	out := run(t, sup, "sleep 30", 80*time.Millisecond)
+	if _, err := sup.killHandle(out.Handle); err != nil {
+		t.Fatalf("killHandle: %v", err)
+	}
+	baseline := settleGoroutines(t)
+
+	for range 10 {
+		out := run(t, sup, "sleep 30", 80*time.Millisecond)
+		if !out.Running {
+			t.Fatalf("a silent long command was not backgrounded: %+v", out)
+		}
+		if _, err := sup.killHandle(out.Handle); err != nil {
+			t.Fatalf("killHandle: %v", err)
+		}
+	}
+
+	after := settleGoroutines(t)
+	if after > baseline+2 {
+		t.Errorf("goroutines grew from %d to %d over 10 background+kill cycles", baseline, after)
+	}
+}
+
+// TestSupervisor_CanceledForegroundRunsLeakNoGoroutines covers the ctx.Done
+// branch of supervise, which kills the group and waits for the reaper.
+func TestSupervisor_CanceledForegroundRunsLeakNoGoroutines(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	cancelOnce := func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(30 * time.Millisecond)
+			cancel()
+		}()
+		defer cancel()
+		_, err := sup.Run(ctx, runRequest{dir: t.TempDir(), command: "sleep 30", timeout: 10 * time.Second})
+		if err == nil {
+			t.Error("a canceled run returned no error")
+		}
+	}
+
+	cancelOnce()
+	baseline := settleGoroutines(t)
+
+	for range 10 {
+		cancelOnce()
+	}
+
+	after := settleGoroutines(t)
+	if after > baseline+2 {
+		t.Errorf("goroutines grew from %d to %d over 10 canceled commands", baseline, after)
+	}
+}
+
+// TestSupervisor_KillAllReleasesEverything checks the session-teardown path
+// leaves nothing behind: no tracked handles, no lingering goroutines.
+func TestSupervisor_KillAllReleasesEverything(t *testing.T) {
+	sup := NewBashSupervisor()
+	sup.idleTimeout = 80 * time.Millisecond
+	sup.heartbeat = 20 * time.Millisecond
+
+	baseline := settleGoroutines(t)
+
+	for range 5 {
+		if out := run(t, sup, "sleep 30", 80*time.Millisecond); !out.Running {
+			t.Fatal("command was not backgrounded")
+		}
+	}
+	if got := len(sup.Handles()); got != 5 {
+		t.Fatalf("Handles() has %d entries, want 5", got)
+	}
+
+	sup.KillAll()
+
+	if got := sup.Handles(); len(got) != 0 {
+		t.Errorf("Handles() = %v after KillAll, want empty", got)
+	}
+	after := settleGoroutines(t)
+	if after > baseline+2 {
+		t.Errorf("goroutines grew from %d to %d across KillAll", baseline, after)
+	}
+}
+
+// TestSupervisor_StreamBufferStaysBounded checks the retained-tail invariant
+// that keeps a noisy command from growing the heap without bound.
+func TestSupervisor_StreamBufferStaysBounded(t *testing.T) {
+	s := newStream(64)
+
+	for range 100 {
+		if _, err := s.Write([]byte("0123456789")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	if got := len(s.String()); got > 64 {
+		t.Errorf("retained %d bytes, want at most 64", got)
+	}
+	if got := s.Len(); got != 1000 {
+		t.Errorf("Len() = %d, want 1000 (total ever written, not retained)", got)
+	}
+
+	// A reader asking from offset 0 must be told what it missed rather than
+	// silently handed a later chunk as if it followed on.
+	data, next, dropped := s.since(0)
+	if dropped != 1000-int64(len(data)) {
+		t.Errorf("dropped = %d, want %d", dropped, 1000-int64(len(data)))
+	}
+	if next != 1000 {
+		t.Errorf("next offset = %d, want 1000", next)
+	}
+}
+
+func TestStream_ZeroLimitFallsBackToDefault(t *testing.T) {
+	s := newStream(0)
+	if s.limit != streamCap {
+		t.Errorf("limit = %d, want the default %d", s.limit, streamCap)
+	}
+}
+
+func TestStream_EmptyWriteIsANoOp(t *testing.T) {
+	s := newStream(64)
+	n, err := s.Write(nil)
+	if n != 0 || err != nil {
+		t.Errorf("Write(nil) = (%d, %v), want (0, nil)", n, err)
+	}
+	if s.Len() != 0 {
+		t.Errorf("Len() = %d after an empty write, want 0", s.Len())
+	}
+}
+
+func TestStream_SinceAtOrPastEnd(t *testing.T) {
+	s := newStream(64)
+	if _, err := s.Write([]byte("abc")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	data, next, dropped := s.since(3)
+	if data != "" || next != 3 || dropped != 0 {
+		t.Errorf("since(end) = (%q, %d, %d), want (\"\", 3, 0)", data, next, dropped)
+	}
+
+	data, next, dropped = s.since(99)
+	if data != "" || next != 3 || dropped != 0 {
+		t.Errorf("since(past end) = (%q, %d, %d), want (\"\", 3, 0)", data, next, dropped)
+	}
+}

--- a/internal/tools/dedup_callback_test.go
+++ b/internal/tools/dedup_callback_test.go
@@ -1,0 +1,190 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDeduper_FormatStats(t *testing.T) {
+	d := NewResultDeduper()
+
+	if got, want := d.FormatStats(), "No duplicate tool results elided this session."; got != want {
+		t.Errorf("FormatStats() on a fresh deduper = %q, want %q", got, want)
+	}
+
+	args := map[string]any{"file_path": "/a/b.go"}
+	body := bigContent("package main\n")
+	d.apply("read", args, map[string]any{"content": body})
+	d.apply("read", args, map[string]any{"content": body})
+
+	got := d.FormatStats()
+	for _, want := range []string{"Elided 1 duplicate tool result(s)", "bytes", "tokens"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("FormatStats() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestDeduper_NilReceiverIsInert(t *testing.T) {
+	// The deduper is optional wiring, so every exported method has to tolerate
+	// a nil receiver rather than making each caller check.
+	var d *ResultDeduper
+
+	calls, bytes := d.Stats()
+	if calls != 0 || bytes != 0 {
+		t.Errorf("nil Stats() = (%d, %d), want (0, 0)", calls, bytes)
+	}
+	d.Reset() // must not panic
+}
+
+func TestBuildDedupCallback_ElidesRepeatThroughTheCallback(t *testing.T) {
+	d := NewResultDeduper()
+	cb := BuildDedupCallback(d)
+	tl := &fakeCompactTool{name: "read"}
+	args := map[string]any{"file_path": "/a/b.go"}
+	body := bigContent("package main\n")
+
+	first := map[string]any{"content": body}
+	got, err := cb(nil, tl, args, first, nil)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if got["content"] != body {
+		t.Error("first call must pass through unchanged")
+	}
+
+	second := map[string]any{"content": body}
+	got, err = cb(nil, tl, args, second, nil)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	elided, _ := got["content"].(string)
+	if elided == body {
+		t.Error("repeat call was not elided")
+	}
+	if !strings.Contains(elided, "identical to the result of the earlier read call") {
+		t.Errorf("pointer text missing: %q", elided)
+	}
+}
+
+func TestBuildDedupCallback_PassesThroughWhenNotApplicable(t *testing.T) {
+	body := bigContent("package main\n")
+	args := map[string]any{"file_path": "/a/b.go"}
+
+	tests := []struct {
+		name    string
+		deduper *ResultDeduper
+		result  map[string]any
+		err     error
+	}{
+		{"nil deduper", nil, map[string]any{"content": body}, nil},
+		{"tool errored", NewResultDeduper(), map[string]any{"content": body}, errors.New("boom")},
+		{"nil result", NewResultDeduper(), nil, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := BuildDedupCallback(tc.deduper)
+			tl := &fakeCompactTool{name: "read"}
+
+			// Two identical calls; neither may be elided.
+			for i := range 2 {
+				got, err := cb(nil, tl, args, tc.result, tc.err)
+				if err != nil {
+					t.Fatalf("callback returned error: %v", err)
+				}
+				if tc.result == nil {
+					if got != nil {
+						t.Errorf("call %d: got %v, want nil passed through", i, got)
+					}
+					continue
+				}
+				if got["content"] != body {
+					t.Errorf("call %d: content was modified: %v", i, got["content"])
+				}
+			}
+		})
+	}
+}
+
+func TestDeduper_ResetAlsoResetsCallNumbering(t *testing.T) {
+	d := NewResultDeduper()
+	args := map[string]any{"file_path": "/a/b.go"}
+	body := bigContent("package main\n")
+
+	d.apply("read", args, map[string]any{"content": body})
+	d.Reset()
+
+	// After a reset the earlier result is no longer in the conversation, so the
+	// next identical call must pass through in full rather than pointing back.
+	after := map[string]any{"content": body}
+	d.apply("read", args, after)
+	if after["content"] != body {
+		t.Error("a repeat after Reset must pass through in full, not point at a dropped result")
+	}
+
+	// And the call counter restarts, so the next pointer says #1.
+	repeat := map[string]any{"content": body}
+	d.apply("read", args, repeat)
+	got, _ := repeat["content"].(string)
+	if !strings.Contains(got, "call #1") {
+		t.Errorf("call numbering did not restart after Reset: %q", got)
+	}
+}
+
+func TestCanonicalArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"empty", map[string]any{}, ""},
+		{"nil", nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalArgs(tc.args); got != tc.want {
+				t.Errorf("canonicalArgs(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalArgs_StableAcrossKeyOrderAndNesting(t *testing.T) {
+	a := canonicalArgs(map[string]any{"b": 2, "a": 1, "nested": map[string]any{"x": 1, "y": 2}})
+	b := canonicalArgs(map[string]any{"nested": map[string]any{"y": 2, "x": 1}, "a": 1, "b": 2})
+	if a != b {
+		t.Errorf("canonicalArgs is not order-stable:\n%q\n%q", a, b)
+	}
+
+	different := canonicalArgs(map[string]any{"a": 1, "b": 3})
+	if a == different {
+		t.Error("different values produced the same canonical form")
+	}
+}
+
+func TestCanonicalArgs_FallsBackForUnmarshalableValues(t *testing.T) {
+	// A channel cannot be JSON-encoded; the key must still appear rather than
+	// being silently dropped, which would collapse two distinct calls.
+	got := canonicalArgs(map[string]any{"ch": make(chan int), "file_path": "/a.go"})
+	if !strings.Contains(got, "ch=") {
+		t.Errorf("unmarshalable key was dropped: %q", got)
+	}
+	if !strings.Contains(got, "file_path=") {
+		t.Errorf("neighboring key was lost: %q", got)
+	}
+}
+
+func TestPrimaryOutputField_SkipsEmptyAndNonStringValues(t *testing.T) {
+	// A non-string or empty value in a higher-precedence field must not stop
+	// the search at that field.
+	field, content := primaryOutputField(map[string]any{"stdout": 42, "content": "", "output": "real"})
+	if field != "output" || content != "real" {
+		t.Errorf("primaryOutputField = (%q, %q), want (\"output\", \"real\")", field, content)
+	}
+
+	field, content = primaryOutputField(map[string]any{"unrelated": "x"})
+	if field != "" || content != "" {
+		t.Errorf("primaryOutputField with no payload = (%q, %q), want empty", field, content)
+	}
+}

--- a/internal/tools/git_overview_test.go
+++ b/internal/tools/git_overview_test.go
@@ -32,6 +32,14 @@ func initGitRepo(t *testing.T) string {
 	run("init")
 	run("config", "user.email", "test@test.com")
 	run("config", "user.name", "Test")
+	// This repo sets commit.gpgsign and tag.gpgsign globally, and signing goes
+	// through 1Password's op-ssh-sign. A temp repo inherits that, so every
+	// commit below would block on the 1Password agent and fail with
+	// "failed to fill whole buffer" after a 60s timeout — a test failure that
+	// says nothing about the code under test. Signing a throwaway fixture repo
+	// has no value, so turn it off explicitly.
+	run("config", "commit.gpgsign", "false")
+	run("config", "tag.gpgsign", "false")
 
 	return dir
 }

--- a/internal/tools/subagent_spawn_fail_test.go
+++ b/internal/tools/subagent_spawn_fail_test.go
@@ -1,0 +1,195 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// noRoleOrchestrator returns an orchestrator whose agents pass the existence
+// check but cannot be spawned: with no roles configured, ResolveRole fails, so
+// Spawn returns an error before any process starts.
+//
+// This is the branch that turns an infrastructure failure into a reportable
+// result. It matters because the handlers must never propagate a spawn error
+// to the model as a tool error — the model cannot act on that. They report a
+// failed AgentResult instead, which the model can read and route around.
+func noRoleOrchestrator(t *testing.T, names ...string) *subagent.Orchestrator {
+	t.Helper()
+
+	agents := make([]subagent.AgentConfig, 0, len(names))
+	for _, n := range names {
+		agents = append(agents, subagent.AgentConfig{Name: n, Description: "test agent", Role: "default"})
+	}
+
+	cfg := config.Defaults()
+	cfg.Roles = nil // ResolveRole -> ErrNoDefaultRole
+
+	orch := subagent.NewOrchestrator(&cfg, "", agents)
+	t.Cleanup(orch.Shutdown)
+	return orch
+}
+
+func TestSubagentSingleMode_SpawnFailureIsReportedNotReturned(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore")
+
+	out, err := subagentHandler(nil, orch, SubagentInput{Agent: "explore", Task: "look around"}, nil)
+	if err != nil {
+		t.Fatalf("a spawn failure must be reported in the result, not returned as an error: %v", err)
+	}
+
+	if out.Mode != "single" {
+		t.Errorf("mode = %q, want %q", out.Mode, "single")
+	}
+	if len(out.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(out.Results))
+	}
+	r := out.Results[0]
+	if r.Status != "failed" {
+		t.Errorf("status = %q, want %q", r.Status, "failed")
+	}
+	if r.Error == "" {
+		t.Error("a failed spawn produced no error message for the model to read")
+	}
+	if r.Agent != "explore" {
+		t.Errorf("agent = %q, want %q", r.Agent, "explore")
+	}
+	if r.Duration == "" {
+		t.Error("result carries no duration")
+	}
+	if !strings.Contains(out.Summary, "explore") {
+		t.Errorf("summary %q does not name the agent", out.Summary)
+	}
+}
+
+func TestSubagentParallelMode_SpawnFailureIsReportedPerTask(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore", "review")
+
+	out, err := subagentHandler(nil, orch, SubagentInput{Tasks: []TaskItem{
+		{Agent: "explore", Task: "a"},
+		{Agent: "review", Task: "b"},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out.Mode != "parallel" {
+		t.Errorf("mode = %q, want %q", out.Mode, "parallel")
+	}
+	if len(out.Results) != 2 {
+		t.Fatalf("got %d results, want one per task", len(out.Results))
+	}
+	// Order must follow the input, so the model can match results to the tasks
+	// it asked for.
+	for i, want := range []string{"explore", "review"} {
+		if out.Results[i].Agent != want {
+			t.Errorf("result %d is for %q, want %q", i, out.Results[i].Agent, want)
+		}
+		if out.Results[i].Status != "failed" {
+			t.Errorf("result %d status = %q, want %q", i, out.Results[i].Status, "failed")
+		}
+		if out.Results[i].Error == "" {
+			t.Errorf("result %d carries no error message", i)
+		}
+	}
+}
+
+func TestSubagentParallelMode_RejectsTooManyTasks(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore")
+
+	tasks := make([]TaskItem, maxParallelTasks+1)
+	for i := range tasks {
+		tasks[i] = TaskItem{Agent: "explore", Task: "x"}
+	}
+
+	out, err := subagentHandler(nil, orch, SubagentInput{Tasks: tasks}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Results) != 1 {
+		t.Fatalf("got %d results, want a single rejection", len(out.Results))
+	}
+	if out.Results[0].Status != "failed" {
+		t.Errorf("status = %q, want %q", out.Results[0].Status, "failed")
+	}
+	if !strings.Contains(out.Summary, "too many parallel tasks") {
+		t.Errorf("summary = %q, want it to explain the cap", out.Summary)
+	}
+}
+
+func TestSubagentChainMode_SpawnFailureStopsTheChain(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore", "review")
+
+	out, err := subagentHandler(nil, orch, SubagentInput{Chain: []ChainItem{
+		{Agent: "explore", Task: "first"},
+		{Agent: "review", Task: "second"},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out.Mode != "chain" {
+		t.Errorf("mode = %q, want %q", out.Mode, "chain")
+	}
+	if len(out.Results) == 0 {
+		t.Fatal("chain produced no results at all")
+	}
+	// A chain passes each result forward, so a failed step has nothing to hand
+	// on and the chain must stop rather than run the next step on nothing.
+	first := out.Results[0]
+	if first.Status != "failed" {
+		t.Errorf("first step status = %q, want %q", first.Status, "failed")
+	}
+	if first.Error == "" {
+		t.Error("first step carries no error message")
+	}
+	if len(out.Results) > 1 {
+		t.Errorf("chain continued past a failed step: %d results", len(out.Results))
+	}
+}
+
+func TestSubagentChainMode_UnknownAgentIsRejectedUpfront(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore")
+
+	out, err := subagentHandler(nil, orch, SubagentInput{Chain: []ChainItem{
+		{Agent: "nonexistent", Task: "first"},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(out.Results))
+	}
+	if out.Results[0].Status != "failed" {
+		t.Errorf("status = %q, want %q", out.Results[0].Status, "failed")
+	}
+	if !strings.Contains(out.Summary, "nonexistent") {
+		t.Errorf("summary = %q, want it to name the unknown agent", out.Summary)
+	}
+}
+
+// TestSubagentEventsAreEmittedForFailedSpawn checks the TUI still sees the
+// pipeline, so a failed subagent does not simply vanish from the sidebar.
+func TestSubagentEventsAreEmittedForFailedSpawn(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore")
+
+	var kinds []string
+	onEvent := func(ev SubagentEvent) {
+		kinds = append(kinds, ev.Kind)
+	}
+
+	if _, err := subagentHandler(nil, orch, SubagentInput{Agent: "explore", Task: "x"}, onEvent); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A spawn that never started emits nothing, which is correct — there is no
+	// agent ID to attach events to. The contract being pinned is that the
+	// handler does not panic on a non-nil callback in this path.
+	for _, k := range kinds {
+		if k == "" {
+			t.Error("emitted an event with an empty kind")
+		}
+	}
+}

--- a/internal/tui/agent_msg_markers_test.go
+++ b/internal/tui/agent_msg_markers_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+func TestWaitForSystemNotice_NilChannelReturnsNoCmd(t *testing.T) {
+	if cmd := waitForSystemNotice(nil); cmd != nil {
+		t.Error("waitForSystemNotice(nil) returned a command")
+	}
+}
+
+func TestWaitForSystemNotice_DeliversNotice(t *testing.T) {
+	ch := make(chan string, 1)
+	ch <- "compaction ran"
+
+	msg := waitForSystemNotice(ch)()
+
+	got, ok := msg.(systemNoticeMsg)
+	if !ok {
+		t.Fatalf("got %T, want systemNoticeMsg", msg)
+	}
+	if got.text != "compaction ran" {
+		t.Errorf("text = %q, want %q", got.text, "compaction ran")
+	}
+}
+
+func TestWaitForSystemNotice_ClosedChannelYieldsNil(t *testing.T) {
+	ch := make(chan string)
+	close(ch)
+
+	// A closed notice channel must not re-arm with a bogus message; nil ends
+	// the wait loop.
+	if msg := waitForSystemNotice(ch)(); msg != nil {
+		t.Errorf("closed channel yielded %#v, want nil", msg)
+	}
+}
+
+func TestWaitForSystemNotice_IsATeaCmd(t *testing.T) {
+	ch := make(chan string, 1)
+	ch <- "x"
+	cmd := waitForSystemNotice(ch)
+	if cmd == nil {
+		t.Fatal("waitForSystemNotice did not return a tea.Cmd")
+	}
+}
+
+func TestBashEventKind(t *testing.T) {
+	tests := []struct {
+		kind string
+		want string
+	}{
+		{"output", bashEventPrefix + "output"},
+		{"stderr", bashEventPrefix + "stderr"},
+		{"exit", bashEventPrefix + "exit"},
+		{"", bashEventPrefix},
+	}
+	for _, tc := range tests {
+		if got := BashEventKind(tc.kind); got != tc.want {
+			t.Errorf("BashEventKind(%q) = %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestBashEventKind_IsDistinguishableFromSubagentEvents(t *testing.T) {
+	// The whole point of the namespace is that a bash event sharing the
+	// subagent channel is never mistaken for subagent activity.
+	if strings.HasPrefix("tool_call", bashEventPrefix) {
+		t.Fatal("a subagent kind collides with the bash prefix")
+	}
+	if !strings.HasPrefix(BashEventKind("output"), bashEventPrefix) {
+		t.Error("BashEventKind did not apply the prefix")
+	}
+	if got := strings.TrimPrefix(BashEventKind("output"), bashEventPrefix); got != "output" {
+		t.Errorf("round trip gave %q, want %q", got, "output")
+	}
+}
+
+// --- sidebar agent section ------------------------------------------------
+
+func agentStatus(id, status string, started time.Time) subagent.AgentStatus {
+	return subagent.AgentStatus{AgentID: id, Status: status, StartedAt: started}
+}
+
+func TestSortAgentsForDisplay(t *testing.T) {
+	base := time.Unix(1000, 0)
+	agents := []subagent.AgentStatus{
+		agentStatus("z-killed", "killed", base),
+		agentStatus("b-done", "done", base),
+		agentStatus("a-running-late", "running", base.Add(time.Minute)),
+		agentStatus("c-failed", "failed", base),
+		agentStatus("a-running-early", "running", base),
+	}
+
+	sortAgentsForDisplay(agents)
+
+	want := []string{"a-running-early", "a-running-late", "b-done", "c-failed", "z-killed"}
+	for i, id := range want {
+		if agents[i].AgentID != id {
+			t.Errorf("position %d = %q, want %q (order: %v)", i, agents[i].AgentID, id, ids(agents))
+		}
+	}
+}
+
+func TestSortAgentsForDisplay_TiesBreakOnID(t *testing.T) {
+	base := time.Unix(1000, 0)
+	agents := []subagent.AgentStatus{
+		agentStatus("bbb", "running", base),
+		agentStatus("aaa", "running", base),
+	}
+
+	sortAgentsForDisplay(agents)
+
+	if agents[0].AgentID != "aaa" {
+		t.Errorf("order = %v, want it broken on ID", ids(agents))
+	}
+}
+
+func ids(agents []subagent.AgentStatus) []string {
+	out := make([]string, len(agents))
+	for i, a := range agents {
+		out[i] = a.AgentID
+	}
+	return out
+}
+
+func TestAgentHeadingStyle_ReflectsWorstStatus(t *testing.T) {
+	st := testSidebarStyles()
+	base := time.Unix(1000, 0)
+
+	tests := []struct {
+		name   string
+		agents []subagent.AgentStatus
+		want   string
+	}{
+		{
+			name:   "all finished is green",
+			agents: []subagent.AgentStatus{agentStatus("a", "done", base)},
+			want:   st.green.Bold(true).Render("x"),
+		},
+		{
+			name:   "any running outranks finished",
+			agents: []subagent.AgentStatus{agentStatus("a", "done", base), agentStatus("b", "running", base)},
+			want:   st.peach.Bold(true).Render("x"),
+		},
+		{
+			name: "any failure outranks running",
+			agents: []subagent.AgentStatus{
+				agentStatus("a", "running", base),
+				agentStatus("b", "failed", base),
+			},
+			want: st.red.Bold(true).Render("x"),
+		},
+		{
+			name:   "no agents is green",
+			agents: nil,
+			want:   st.green.Bold(true).Render("x"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := agentHeadingStyle(tc.agents, st).Render("x"); got != tc.want {
+				t.Errorf("agentHeadingStyle rendered %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSidebarAgentLines_NoOrchestratorRendersNothing(t *testing.T) {
+	got := sidebarAgentLines(SidebarRenderInput{}, 20, testSidebarStyles())
+	if got != nil {
+		t.Errorf("sidebarAgentLines with no orchestrator = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
Quality round over the 2026-08-08 work. Three real defects and a coverage
uplift.

killHandle read p.exitCode without waiting on p.done. The write happens in
the reaping goroutine that closes done, so receiving from done is what
establishes happens-before — the unguarded read is a data race. It is not
exotic: killHandle waits procs.DefaultWaitDelay (5s) and exec's own WaitDelay
is also 5s, so a descendant holding a pipe makes both fire together. The read
also returned the zero value for a command that had not exited, reporting a
still-running command as a clean "exit 0". exitStatus() now gates the read on
done and reports -1 with an explanatory note when the command was not reaped.

Git fixture tests inherited this repo's global commit.gpgsign and tried to
sign through 1Password, which is unreachable from a test. Ten integration
tests failed after exactly 60s each — 121s of hangs that said nothing about
the code — and two palace unit tests did the same. internal/cli's runGit
discards errors, so there the failure was silent: the fixture repo ended up
with no commits and the tests asserted against a weaker world than intended.
Signing is now off in all four fixture helpers. `make test-integration` goes
from 10 failures to green.

Coverage 87.3% -> 88.6% unit, 89.2% including integration tests (the 90%
target was not reached; the remaining ~320 statements are interactive TUI
update loops, terminal/network CLI entry points, and streaming provider
paths). New tests cover session compaction rendering and the LLM summarizer,
guardrail cache metrics, httplog OTel span events, the tools deduper,
bash-supervisor exit and stream semantics, subagent spawn-failure reporting,
palace embedder selection and drawer search/dedup, and cli progress
rendering.

Also adds goroutine-leak regression tests for the supervisor. A live pprof
run over `pi serve` showed goroutines flat and post-GC live heap flat
(4.43MB / ~33.7k objects across 80s) — the raw heap creep is inter-GC churn,
not a leak.

Full suite passes under -race with zero races; golangci-lint reports 0 issues.

Signed-off-by: dimetron <dimetron@me.com>
