### PR TITLE
fix(subagent): stop killing productive agents; say "timeout" when it is one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/coder/acp-go-sdk v0.13.5
 	github.com/creack/pty v1.1.24
 	github.com/go-logr/logr v1.4.4
+	github.com/google/go-cmp v0.7.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -36,6 +37,8 @@ require (
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	go.opentelemetry.io/proto/otlp v1.11.0
+	golang.org/x/sys v0.47.0
+	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
 	google.golang.org/adk/v2 v2.1.0
 	google.golang.org/genai v1.66.0
@@ -80,7 +83,6 @@ require (
 	github.com/gomlx/go-xla v0.4.1 // indirect
 	github.com/gomlx/gomlx v0.28.2 // indirect
 	github.com/gomlx/onnx-gomlx v0.5.2 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/safehtml v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.18 // indirect
@@ -129,8 +131,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/api v0.288.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -94,7 +94,7 @@ func runInteractive(
 	go func() {
 		defer close(initDone)
 		defer close(initCh)
-		deferredInit(initCtx, cfg, llm, info.Provider, tokenTracker, cwd, sandboxRoot, worktreeDir, initCh, &res)
+		deferredInit(initCtx, cfg, llm, info.Provider, info.BaseURL, tokenTracker, cwd, sandboxRoot, worktreeDir, initCh, &res)
 	}()
 
 	tuiErr := tui.Run(ctx, tui.Config{
@@ -134,6 +134,7 @@ func deferredInit(
 	cfg config.Config,
 	llm adkmodel.LLM,
 	providerName string,
+	baseURL string,
 	tokenTracker *guardrail.Tracker,
 	cwd, sandboxRoot, worktreeDir string,
 	ch chan<- tui.InitEvent,
@@ -435,6 +436,10 @@ func deferredInit(
 	if resumed {
 		_ = sessionSvc.SetSessionModel(sessionID, llm.Name()) // best-effort metadata
 	}
+	// Record the backend for every session, resumed or fresh. The model name on
+	// its own does not identify what actually served the request, which is the
+	// first thing anyone needs when reading a transcript back.
+	_ = sessionSvc.SetSessionProvider(sessionID, providerName, baseURL) // best-effort metadata
 
 	// Store session ID for resume hint on exit.
 	res.sessionID = sessionID
@@ -901,6 +906,11 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 			baseURL = "http://localhost:11434"
 		}
 	}
+
+	// Record the endpoint actually chosen, after every fallback above has had
+	// its say, so session metadata names the backend rather than leaving the
+	// model name to be interpreted.
+	info.BaseURL = baseURL
 
 	llmOpts := &provider.LLMOptions{
 		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),

--- a/internal/cli/interactive_deferred_test.go
+++ b/internal/cli/interactive_deferred_test.go
@@ -62,7 +62,7 @@ func TestDeferredInit_MemoryOffBasic(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", tracker, cwd, cwd, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, cwd, cwd, "", ch, &res)
 		close(ch)
 	}()
 
@@ -124,7 +124,7 @@ func TestDeferredInit_WithMCP(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
 		close(ch)
 	}()
 
@@ -162,7 +162,7 @@ func TestDeferredInit_WithMemoryEnabled(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
 		close(ch)
 	}()
 
@@ -386,7 +386,7 @@ func TestDeferredInit_WithSkillDir(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, config.Config{}, llm, "openai", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, config.Config{}, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
 		close(ch)
 	}()
 

--- a/internal/cli/run_modes_test.go
+++ b/internal/cli/run_modes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/guardrail"
+	"github.com/dimetron/pi-go/internal/provider"
 )
 
 func TestResolveMode_ExplicitFlag(t *testing.T) {
@@ -84,17 +85,14 @@ func TestRunInteractive_CancelContext(t *testing.T) {
 	}
 }
 
-// provInfo returns a provider.Info-like struct. We use a minimal shim
-// because importing provider.Info here just duplicates setup.
-func provInfo(provider, model string) provInfoT {
-	return provInfoT{Provider: provider, Model: model}
-}
-
-type provInfoT = struct {
-	Provider string
-	Model    string
-	Ollama   bool
-	Custom   bool
+// provInfo builds a provider.Info for tests.
+//
+// This used to be a structurally-identical shim, on the reasoning that
+// importing provider.Info "just duplicates setup". The shim silently became a
+// compile error the first time a field was added to the real struct, which is
+// the failure mode a mirror type always has. Use the real one.
+func provInfo(providerName, model string) provider.Info {
+	return provider.Info{Provider: providerName, Model: model}
 }
 
 func TestRunNonInteractive_JSONEmptyPromptEarlyExit(t *testing.T) {

--- a/internal/codex/process_unix.go
+++ b/internal/codex/process_unix.go
@@ -4,15 +4,18 @@ package codex
 
 import (
 	"os/exec"
-	"syscall"
+
+	"github.com/dimetron/pi-go/internal/procs"
 )
 
 // setPlatformAttrs configures Unix process group management so the
 // `codex app-server` subprocess and all its children (e.g. shell commands it
 // spawns) can be killed together.
+//
+// This delegates to internal/procs rather than hand-rolling
+// kill(-cmd.Process.Pid, SIGKILL), which assumed the group ID equals the
+// child's PID and never checked that the PID was still ours to signal. See
+// internal/procs/procs_unix.go for why signaling a stale PID is dangerous.
 func setPlatformAttrs(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
+	procs.Isolate(cmd)
 }

--- a/internal/procs/procs_unix.go
+++ b/internal/procs/procs_unix.go
@@ -34,7 +34,27 @@ func terminate(cmd *exec.Cmd, grace time.Duration) error {
 	if err := signalGroup(cmd, syscall.SIGTERM); err != nil {
 		return err
 	}
+	// The follow-up SIGKILL must not fire at a process that has already been
+	// reaped.
+	//
+	// On the normal path SIGTERM works in milliseconds and os/exec reaps the
+	// child immediately, returning its PID to the kernel's free pool. A timer
+	// firing two seconds later would then signal a PID that is no longer ours —
+	// and pi forks constantly, so that PID may since have been handed to one of
+	// its own non-isolated children, which sit in pi's own process group. The
+	// group branch below would resolve to pi's group and take down the session.
+	//
+	// Canceling the timer on reap is not possible from here: Wait belongs to
+	// os/exec and cannot be called twice. Probing with signal 0 is, because
+	// os.Process tracks its own reaped state and reports ErrProcessDone rather
+	// than touching the PID — the one check the raw Getpgid/Kill path skips.
 	time.AfterFunc(grace, func() {
+		if cmd.Process == nil {
+			return
+		}
+		if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+			return // already reaped, or gone; the PID is not ours to signal
+		}
 		_ = signalGroup(cmd, syscall.SIGKILL)
 	})
 	return nil
@@ -49,9 +69,18 @@ func kill(cmd *exec.Cmd) error {
 //
 // The negative-PID form of kill(2) addresses a group, and getting the sign
 // wrong here is unusually costly: pi runs as a normal user process, so
-// kill(-pid) against our own group would take down the session. The Setpgid
-// check is what rules that out — without it there is no guarantee the child
-// leads a group of its own, and -pid could name the group pi itself is in.
+// kill(-pid) against our own group would take down the session.
+//
+// Three things rule that out, and the first two are not sufficient on their own:
+//
+//   - Setpgid on SysProcAttr says a group was *requested*. It is a struct field,
+//     not proof the kernel applied it — a caller that sets it after Start gets
+//     the flag with no effect, and Getpgid then returns pi's own group.
+//   - pgid > 1 rejects the degenerate targets: kill(-0) is kill(0), which
+//     signals the caller's entire group, and 1 is init.
+//   - Comparing against Getpgrp is what actually closes it. If the resolved
+//     group is the one pi is in, there is no version of this call that is
+//     correct, so fall through to signaling the lone child instead.
 func signalGroup(cmd *exec.Cmd, sig syscall.Signal) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
@@ -66,7 +95,7 @@ func signalGroup(cmd *exec.Cmd, sig syscall.Signal) error {
 		// the same for a group leader, but a child that called setpgid itself
 		// has moved on, and signaling a stale group would miss it entirely.
 		pgid, err := syscall.Getpgid(pid)
-		if err == nil && pgid > 1 {
+		if err == nil && pgid > 1 && pgid != syscall.Getpgrp() {
 			if err := syscall.Kill(-pgid, sig); err == nil || errors.Is(err, syscall.ESRCH) {
 				return nil
 			}

--- a/internal/procs/selfkill_test.go
+++ b/internal/procs/selfkill_test.go
@@ -1,0 +1,125 @@
+//go:build !windows
+
+package procs
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSignalGroup_RefusesOwnProcessGroup is the guard that matters most here.
+//
+// signalGroup trusts SysProcAttr.Setpgid as evidence that the child leads its
+// own group, but that field is only a *request*: setting it after Start records
+// the flag with no kernel effect, and Getpgid then returns the test binary's own
+// group. Issuing kill(-pgid, SIGKILL) at that point would kill the caller.
+//
+// This test builds exactly that shape — a child in the caller's group, with the
+// Setpgid flag set after the fact — and asserts the caller survives. If the
+// pgid == Getpgrp() check is removed, this test kills the test binary outright.
+func TestSignalGroup_RefusesOwnProcessGroup(t *testing.T) {
+	// A child started WITHOUT Setpgid inherits our process group.
+	cmd := exec.Command("bash", "-c", "sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("getpgid: %v", err)
+	}
+	if pgid != syscall.Getpgrp() {
+		t.Skipf("child is not in our group (pgid=%d, ours=%d); nothing to test", pgid, syscall.Getpgrp())
+	}
+
+	// Now lie the way a post-Start Isolate would: claim a group that was never
+	// created. Without the self-group guard, signalGroup takes the group branch
+	// and SIGKILLs our own group.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := signalGroup(cmd, syscall.SIGTERM); err != nil {
+		t.Fatalf("signalGroup: %v", err)
+	}
+
+	// Reaching this line at all is the assertion: we were not killed.
+	if err := cmd.Process.Signal(syscall.Signal(0)); err != nil && !alive(cmd.Process.Pid) {
+		// The child took the SIGTERM directly, which is the correct fallback.
+		t.Logf("child received the signal directly, as intended")
+	}
+}
+
+// TestTerminate_DoesNotSignalAfterReap covers the delayed SIGKILL in terminate.
+//
+// terminate schedules a SIGKILL for `grace` later. On the normal path the child
+// dies immediately and os/exec reaps it, freeing the PID — so when the timer
+// fires it must not touch that PID, which the kernel may since have handed to
+// something else.
+func TestTerminate_DoesNotSignalAfterReap(t *testing.T) {
+	grace := 150 * time.Millisecond
+
+	cmd := exec.CommandContext(context.Background(), "bash", "-c", "true")
+	IsolateWithDelay(cmd, time.Second, grace)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Arm the escalation, then let the process exit and be reaped.
+	if err := terminate(cmd, grace); err != nil {
+		t.Fatalf("terminate: %v", err)
+	}
+	_ = cmd.Wait()
+
+	// Occupy the freed PID's role: a live process in OUR group. If the timer
+	// fires against a stale PID and takes the group branch, this test binary
+	// dies. Waiting past the grace period is the assertion.
+	time.Sleep(grace * 3)
+
+	// Still here.
+	if os.Getpid() <= 0 {
+		t.Fatal("unreachable")
+	}
+	_ = pid
+}
+
+// TestKill_AfterExitDoesNotSignalOurGroup makes the property that
+// TestKill_AfterExitIsHarmless states in its comment ("must not signal whatever
+// inherited its PID") actually testable: it runs Kill on a reaped command whose
+// recorded PID has been rewritten to name a live process in our own group.
+func TestKill_AfterExitDoesNotSignalOurGroup(t *testing.T) {
+	// A live sibling in our process group, standing in for a PID-reuse victim.
+	victim := exec.Command("bash", "-c", "sleep 30")
+	if err := victim.Start(); err != nil {
+		t.Fatalf("start victim: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = victim.Process.Kill()
+		_ = victim.Wait()
+	})
+
+	// A reaped, isolated command.
+	cmd := CommandContext(context.Background(), "bash", "-c", "true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// Point it at the victim's PID, which is the situation PID reuse creates.
+	cmd.Process = victim.Process
+
+	if err := Kill(cmd); err != nil {
+		t.Errorf("Kill: %v", err)
+	}
+
+	// We must still be alive, and so must the rest of our group.
+	if !alive(os.Getpid()) {
+		t.Fatal("Kill signaled our own process group")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -150,6 +150,11 @@ type Info struct {
 	Model    string
 	Ollama   bool // true when model is served by Ollama
 	Custom   bool // true when using an explicit custom OpenAI-compatible endpoint
+	// BaseURL is the endpoint finally selected for this model, recorded so a
+	// session transcript identifies the backend and not just the model name.
+	// The same name served by ollama, by a gateway, and by a vendor API behaves
+	// differently, and a transcript without it cannot be reproduced.
+	BaseURL string
 }
 
 // Known model prefixes mapped to providers.

--- a/internal/session/hostenv.go
+++ b/internal/session/hostenv.go
@@ -1,0 +1,45 @@
+package session
+
+import "runtime"
+
+// HostEnv is a snapshot of the machine at session start.
+//
+// It exists to answer one question after the fact: when a process died with
+// nothing but "signal: killed" to show for it, was the machine out of something?
+// A SIGKILL from an OOM killer, a timeout, and a manual kill are indistinguishable
+// at the point the error is read, and by the time anyone investigates the memory
+// pressure that caused it is long gone. Recording the numbers up front turns a
+// guess into a check.
+//
+// Every field is best-effort: a platform that will not report one leaves it zero
+// rather than failing session creation over diagnostics.
+type HostEnv struct {
+	// GOOS/GOARCH and CPU count, for reading the numbers below in proportion.
+	OS   string `json:"os,omitempty"`
+	Arch string `json:"arch,omitempty"`
+	CPUs int    `json:"cpus,omitempty"`
+
+	// TotalMemoryBytes is physical RAM; AvailableMemoryBytes is what was free
+	// at session start. The ratio is what matters — "68MB free of 32GB" is the
+	// shape of a machine about to start killing things.
+	TotalMemoryBytes     uint64 `json:"totalMemoryBytes,omitempty"`
+	AvailableMemoryBytes uint64 `json:"availableMemoryBytes,omitempty"`
+
+	// Disk figures are for the session directory's filesystem, which is where
+	// transcripts, the palace DB and any worktrees land.
+	DiskTotalBytes uint64 `json:"diskTotalBytes,omitempty"`
+	DiskFreeBytes  uint64 `json:"diskFreeBytes,omitempty"`
+}
+
+// captureHostEnv snapshots the machine. path selects the filesystem to report
+// on; pass the session directory.
+func captureHostEnv(path string) HostEnv {
+	env := HostEnv{
+		OS:   runtime.GOOS,
+		Arch: runtime.GOARCH,
+		CPUs: runtime.NumCPU(),
+	}
+	env.TotalMemoryBytes, env.AvailableMemoryBytes = memoryStats()
+	env.DiskTotalBytes, env.DiskFreeBytes = diskStats(path)
+	return env
+}

--- a/internal/session/hostenv_darwin.go
+++ b/internal/session/hostenv_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+
+package session
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// memoryStats reports total and available physical memory.
+//
+// "Available" on macOS is not a single number the kernel hands out. The honest
+// approximation is free + inactive + speculative pages: inactive pages are
+// clean and reclaimable on demand, and counting only genuinely free pages makes
+// a healthy machine look like it is seconds from death — a 32GB box in normal
+// use routinely reports well under 1GB truly free.
+func memoryStats() (total, available uint64) {
+	if n, err := unix.SysctlUint64("hw.memsize"); err == nil {
+		total = n
+	}
+
+	// vm_stat is the only reliable way to get the page breakdown without cgo.
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return total, 0
+	}
+
+	pageSize := uint64(4096)
+	var free, inactive, speculative uint64
+	for _, line := range strings.Split(string(out), "\n") {
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if strings.Contains(name, "page size of") {
+			// Header line: "Mach Virtual Memory Statistics: (page size of 16384 bytes)"
+			continue
+		}
+		digits := strings.Trim(strings.TrimSpace(value), ".")
+		n, convErr := strconv.ParseUint(digits, 10, 64)
+		if convErr != nil {
+			continue
+		}
+		switch strings.TrimSpace(name) {
+		case "Pages free":
+			free = n
+		case "Pages inactive":
+			inactive = n
+		case "Pages speculative":
+			speculative = n
+		}
+	}
+
+	// The header carries the real page size; parse it rather than assuming.
+	if i := strings.Index(string(out), "page size of "); i >= 0 {
+		rest := string(out)[i+len("page size of "):]
+		if fields := strings.Fields(rest); len(fields) > 0 {
+			if n, convErr := strconv.ParseUint(fields[0], 10, 64); convErr == nil && n > 0 {
+				pageSize = n
+			}
+		}
+	}
+
+	return total, (free + inactive + speculative) * pageSize
+}

--- a/internal/session/hostenv_disk_other.go
+++ b/internal/session/hostenv_disk_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package session
+
+// diskStats is unimplemented off Unix. Zero means "not reported" and is dropped
+// from meta.json by the omitempty tags.
+func diskStats(string) (total, free uint64) {
+	return 0, 0
+}

--- a/internal/session/hostenv_disk_unix.go
+++ b/internal/session/hostenv_disk_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package session
+
+import "syscall"
+
+// diskStats reports total and available bytes for the filesystem holding path.
+//
+// Bavail is used rather than Bfree: Bfree counts blocks reserved for root,
+// which an ordinary pi process cannot touch, so it overstates what is actually
+// writable.
+func diskStats(path string) (total, free uint64) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, 0
+	}
+	//nolint:gosec,unconvert // Bsize is int64 on some platforms and uint32 on others.
+	bsize := uint64(st.Bsize)
+	//nolint:gosec,unconvert // Blocks/Bavail likewise vary in width across Unixes.
+	return uint64(st.Blocks) * bsize, uint64(st.Bavail) * bsize
+}

--- a/internal/session/hostenv_linux.go
+++ b/internal/session/hostenv_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package session
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// memoryStats reports total and available physical memory from /proc/meminfo.
+//
+// MemAvailable is used rather than MemFree because it is the kernel's own
+// estimate of what a new allocation could actually get, accounting for
+// reclaimable page cache. MemFree alone understates it badly on any machine
+// that has been up for a while.
+func memoryStats() (total, available uint64) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		name, value, ok := strings.Cut(sc.Text(), ":")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(value)
+		if len(fields) == 0 {
+			continue
+		}
+		kb, convErr := strconv.ParseUint(fields[0], 10, 64)
+		if convErr != nil {
+			continue
+		}
+		switch name {
+		case "MemTotal":
+			total = kb * 1024
+		case "MemAvailable":
+			available = kb * 1024
+		}
+	}
+	return total, available
+}

--- a/internal/session/hostenv_other.go
+++ b/internal/session/hostenv_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !linux
+
+package session
+
+// memoryStats is unimplemented off Darwin and Linux. Zero means "not reported",
+// which the omitempty JSON tags drop from meta.json entirely — better than
+// recording a made-up number that a future reader would trust.
+func memoryStats() (total, available uint64) {
+	return 0, 0
+}

--- a/internal/session/hostenv_test.go
+++ b/internal/session/hostenv_test.go
@@ -1,0 +1,172 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+)
+
+func TestCaptureHostEnv_ReportsPlausibleNumbers(t *testing.T) {
+	env := captureHostEnv(t.TempDir())
+
+	if env.OS != runtime.GOOS {
+		t.Errorf("OS = %q, want %q", env.OS, runtime.GOOS)
+	}
+	if env.Arch != runtime.GOARCH {
+		t.Errorf("Arch = %q, want %q", env.Arch, runtime.GOARCH)
+	}
+	if env.CPUs <= 0 {
+		t.Errorf("CPUs = %d, want a positive count", env.CPUs)
+	}
+
+	// Disk is reported on every platform this is tested on.
+	if env.DiskTotalBytes == 0 {
+		t.Error("DiskTotalBytes = 0; the temp dir's filesystem should report a size")
+	}
+	if env.DiskFreeBytes > env.DiskTotalBytes {
+		t.Errorf("DiskFreeBytes %d exceeds DiskTotalBytes %d", env.DiskFreeBytes, env.DiskTotalBytes)
+	}
+
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		if env.TotalMemoryBytes == 0 {
+			t.Error("TotalMemoryBytes = 0 on a platform that reports it")
+		}
+		if env.AvailableMemoryBytes > env.TotalMemoryBytes {
+			t.Errorf("AvailableMemoryBytes %d exceeds TotalMemoryBytes %d",
+				env.AvailableMemoryBytes, env.TotalMemoryBytes)
+		}
+	}
+}
+
+func TestCaptureHostEnv_UnreadablePathStillReturnsRuntimeFacts(t *testing.T) {
+	// A bad path must degrade to zeroed disk figures, not fail — this runs on
+	// the session-creation path and must never be the reason a session cannot
+	// be created.
+	env := captureHostEnv("/definitely/does/not/exist/anywhere")
+
+	if env.CPUs <= 0 {
+		t.Errorf("CPUs = %d, want the runtime facts regardless", env.CPUs)
+	}
+	if env.DiskTotalBytes != 0 || env.DiskFreeBytes != 0 {
+		t.Errorf("disk figures should be zero for an unreadable path, got %d/%d",
+			env.DiskFreeBytes, env.DiskTotalBytes)
+	}
+}
+
+func TestCreate_PersistsHostEnvAndModel(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{
+		AppName: "pi-go", UserID: "local",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := resp.Session.ID()
+
+	raw, err := os.ReadFile(filepath.Join(svc.baseDir, id, "meta.json"))
+	if err != nil {
+		t.Fatalf("reading meta.json: %v", err)
+	}
+
+	var meta Meta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("parsing meta.json: %v", err)
+	}
+
+	if meta.Host == nil {
+		t.Fatal("meta.json carries no host snapshot")
+	}
+	if meta.Host.CPUs <= 0 {
+		t.Errorf("host.cpus = %d, want a positive count", meta.Host.CPUs)
+	}
+	if meta.Host.OS != runtime.GOOS {
+		t.Errorf("host.os = %q, want %q", meta.Host.OS, runtime.GOOS)
+	}
+	// The whole point is troubleshooting a kill after the fact, so the two
+	// resource numbers have to survive the round trip.
+	if meta.Host.DiskTotalBytes == 0 {
+		t.Error("host.diskTotalBytes did not survive serialization")
+	}
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		if meta.Host.TotalMemoryBytes == 0 {
+			t.Error("host.totalMemoryBytes did not survive serialization")
+		}
+	}
+}
+
+func TestSetSessionProvider_RecordsBackend(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{
+		AppName: "pi-go", UserID: "local",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := resp.Session.ID()
+
+	if err := svc.SetSessionModel(id, "qwen2.5:latest"); err != nil {
+		t.Fatalf("SetSessionModel: %v", err)
+	}
+	if err := svc.SetSessionProvider(id, "ollama", "http://localhost:11434"); err != nil {
+		t.Fatalf("SetSessionProvider: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(svc.baseDir, id, "meta.json"))
+	if err != nil {
+		t.Fatalf("reading meta.json: %v", err)
+	}
+	var meta Meta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("parsing meta.json: %v", err)
+	}
+
+	if meta.Model != "qwen2.5:latest" {
+		t.Errorf("model = %q, want %q", meta.Model, "qwen2.5:latest")
+	}
+	// The same model name means different things per backend, so the provider
+	// is what makes the record unambiguous.
+	if meta.Provider != "ollama" {
+		t.Errorf("provider = %q, want %q", meta.Provider, "ollama")
+	}
+	if meta.BaseURL != "http://localhost:11434" {
+		t.Errorf("baseURL = %q, want the endpoint", meta.BaseURL)
+	}
+}
+
+func TestSetSessionProvider_EmptyValuesStayOutOfMeta(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{
+		AppName: "pi-go", UserID: "local",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := resp.Session.ID()
+
+	if err := svc.SetSessionProvider(id, "", ""); err != nil {
+		t.Fatalf("SetSessionProvider: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(svc.baseDir, id, "meta.json"))
+	if err != nil {
+		t.Fatalf("reading meta.json: %v", err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatalf("parsing meta.json: %v", err)
+	}
+	for _, k := range []string{"provider", "baseURL"} {
+		if _, present := generic[k]; present {
+			t.Errorf("empty %q was written to meta.json; omitempty should drop it", k)
+		}
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -45,14 +45,29 @@ const MaxSessionTitle = 200
 
 // Meta holds session metadata persisted in meta.json.
 type Meta struct {
-	ID          string       `json:"id"`
-	AppName     string       `json:"appName"`
-	UserID      string       `json:"userID"`
-	WorkDir     string       `json:"workDir,omitempty"`
-	Model       string       `json:"model"`
-	Title       string       `json:"title,omitempty"`
-	CreatedAt   time.Time    `json:"createdAt"`
-	UpdatedAt   time.Time    `json:"updatedAt"`
+	ID      string `json:"id"`
+	AppName string `json:"appName"`
+	UserID  string `json:"userID"`
+	WorkDir string `json:"workDir,omitempty"`
+
+	// Model is the model name as configured. Provider is recorded alongside it
+	// because the same name means different things to different backends —
+	// "qwen2.5:latest" via ollama and via a hosted gateway are not the same
+	// model, and a transcript that records only the name cannot tell them apart
+	// after the fact.
+	Model    string `json:"model"`
+	Provider string `json:"provider,omitempty"`
+	BaseURL  string `json:"baseURL,omitempty"`
+
+	Title     string    `json:"title,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	// Host is a snapshot of the machine when the session began. It is here so a
+	// process that later dies with nothing but "signal: killed" can be checked
+	// against the resources it had, instead of guessed at.
+	Host *HostEnv `json:"host,omitempty"`
+
 	PlanContext *PlanContext `json:"planContext,omitempty"`
 }
 
@@ -132,6 +147,7 @@ func (s *FileService) Create(_ context.Context, req *session.CreateRequest) (*se
 
 	now := time.Now()
 	cwd, _ := os.Getwd()
+	host := captureHostEnv(sessionDir)
 	meta := Meta{
 		ID:        sessionID,
 		AppName:   req.AppName,
@@ -140,6 +156,7 @@ func (s *FileService) Create(_ context.Context, req *session.CreateRequest) (*se
 		Model:     UnknownModel,
 		CreatedAt: now,
 		UpdatedAt: now,
+		Host:      &host,
 	}
 
 	if err := writeMeta(sessionDir, &meta); err != nil {
@@ -538,6 +555,37 @@ func (s *FileService) SetSessionModel(sessionID, modelName string) error {
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
 	sess.meta.Model = modelName
+	return writeMeta(filepath.Join(s.baseDir, sessionID), &sess.meta)
+}
+
+// SetSessionProvider records which backend served the model, and the base URL
+// when one was configured.
+//
+// The model name alone is ambiguous: the same string routed to ollama, to a
+// hosted gateway, or to a vendor API is three different models with three
+// different failure modes. Recording the name without the backend leaves a
+// transcript that cannot be reproduced. Both fields are optional — an empty
+// value clears rather than writes a blank string, so meta.json stays quiet when
+// there is nothing to say.
+func (s *FileService) SetSessionProvider(sessionID, provider, baseURL string) error {
+	provider = strings.TrimSpace(provider)
+	baseURL = strings.TrimSpace(baseURL)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		loaded, err := s.loadSessionUnchecked(sessionID)
+		if err != nil {
+			return err
+		}
+		sess = loaded
+	}
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	sess.meta.Provider = provider
+	sess.meta.BaseURL = baseURL
 	return writeMeta(filepath.Join(s.baseDir, sessionID), &sess.meta)
 }
 

--- a/internal/subagent/agents.go
+++ b/internal/subagent/agents.go
@@ -4,11 +4,17 @@ import (
 	"bufio"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 )
+
+// minAgentTimeoutMs is the smallest frontmatter `timeout:` treated as a real
+// value. Below this the author almost certainly meant seconds; honoring it
+// would kill the agent before it could produce anything.
+const minAgentTimeoutMs = 1000
 
 // AgentScope defines the scope for agent discovery.
 type AgentScope string
@@ -109,7 +115,18 @@ func parseAgentContent(content, path string) (AgentConfig, error) {
 				cfg.Worktree = strings.ToLower(value) == "true"
 			case "timeout":
 				if ms, err := strconv.Atoi(value); err == nil && ms > 0 {
-					cfg.Timeout = ms
+					// The unit is milliseconds, which reads as seconds at a
+					// glance — a bundled agent shipped `timeout: 30` and was
+					// SIGKILLed 30ms in, every time, unable to emit a single
+					// token. Anything under a second cannot be deliberate, so
+					// treat it as the unit mistake it is rather than honoring a
+					// value that guarantees the agent never runs.
+					if ms < minAgentTimeoutMs {
+						slog.Warn("subagent: implausibly small timeout ignored; the unit is milliseconds",
+							"agent", cfg.Name, "timeout_ms", ms, "using", "default")
+					} else {
+						cfg.Timeout = ms
+					}
 				}
 			case "tools":
 				for _, t := range strings.Split(value, ",") {

--- a/internal/subagent/bundled/memory-compressor.md
+++ b/internal/subagent/bundled/memory-compressor.md
@@ -4,7 +4,7 @@ description: Compress tool observations into structured memory entries
 role: smol
 worktree: false
 tools: []
-timeout: 30
+timeout: 600000
 ---
 You are a memory compression agent. Your job is to compress raw tool usage data into a concise structured observation.
 

--- a/internal/subagent/bundled_timeout_test.go
+++ b/internal/subagent/bundled_timeout_test.go
@@ -1,0 +1,107 @@
+package subagent
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBundledAgentTimeoutsAreSane walks every shipped agent definition and
+// resolves the timeout it would actually run with.
+//
+// This exists because `memory-compressor` shipped `timeout: 30`. The unit is
+// milliseconds, so that agent was SIGKILLed 30ms after starting — every single
+// time, before it could emit a token — and nothing anywhere reported the cause.
+// The value reads perfectly reasonable if you assume seconds, which is exactly
+// why a person reviewing the file did not catch it.
+func TestBundledAgentTimeoutsAreSane(t *testing.T) {
+	res, err := DiscoverAgents(t.TempDir(), ScopeBundled)
+	if err != nil {
+		t.Fatalf("DiscoverAgents: %v", err)
+	}
+	if len(res.All) == 0 {
+		t.Fatal("no bundled agents were loaded")
+	}
+
+	for _, a := range res.All {
+		t.Run(a.Name, func(t *testing.T) {
+			cfg := ResolveTimeout(a.Timeout)
+
+			// A second is not enough for a model round trip, so any resolved
+			// absolute timeout below it means the agent can never succeed.
+			if cfg.Absolute < time.Second {
+				t.Errorf("agent %q resolves to a %v absolute timeout — it can never produce output "+
+					"(frontmatter `timeout:` is in MILLISECONDS; got %d)", a.Name, cfg.Absolute, a.Timeout)
+			}
+			if cfg.Inactivity <= 0 {
+				t.Errorf("agent %q resolves to a non-positive inactivity timeout %v", a.Name, cfg.Inactivity)
+			}
+		})
+	}
+}
+
+func TestMemoryCompressorHasAWorkableTimeout(t *testing.T) {
+	res, err := DiscoverAgents(t.TempDir(), ScopeBundled)
+	if err != nil {
+		t.Fatalf("DiscoverAgents: %v", err)
+	}
+
+	var found bool
+	for _, a := range res.All {
+		if a.Name != "memory-compressor" {
+			continue
+		}
+		found = true
+		cfg := ResolveTimeout(a.Timeout)
+		if cfg.Absolute < time.Minute {
+			t.Errorf("memory-compressor absolute timeout = %v, want at least a minute "+
+				"(the value is in milliseconds)", cfg.Absolute)
+		}
+	}
+	if !found {
+		t.Fatal("memory-compressor is not among the bundled agents")
+	}
+}
+
+// TestParseAgentRejectsSubSecondTimeout pins the guard that stops the
+// milliseconds-read-as-seconds mistake from silently recurring.
+func TestParseAgentRejectsSubSecondTimeout(t *testing.T) {
+	const def = `---
+name: too-eager
+description: test
+role: smol
+timeout: 30
+---
+body
+`
+	cfg, err := parseAgentContent(def, "test.md")
+	if err != nil {
+		t.Fatalf("parseAgentContent: %v", err)
+	}
+	if cfg.Timeout != 0 {
+		t.Errorf("Timeout = %d, want 0 (implausible value ignored so the default applies)", cfg.Timeout)
+	}
+	if got := ResolveTimeout(cfg.Timeout); got.Absolute != DefaultAbsoluteTimeout {
+		t.Errorf("resolved absolute = %v, want the default %v", got.Absolute, DefaultAbsoluteTimeout)
+	}
+}
+
+func TestParseAgentKeepsPlausibleTimeout(t *testing.T) {
+	const def = `---
+name: patient
+description: test
+role: smol
+timeout: 600000
+---
+body
+`
+	cfg, err := parseAgentContent(def, "test.md")
+	if err != nil {
+		t.Fatalf("parseAgentContent: %v", err)
+	}
+	if cfg.Timeout != 600000 {
+		t.Errorf("Timeout = %d, want 600000", cfg.Timeout)
+	}
+	if got := ResolveTimeout(cfg.Timeout); got.Absolute != 10*time.Minute {
+		t.Errorf("resolved absolute = %v, want 10m", got.Absolute)
+	}
+}

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -500,12 +500,18 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 
 		o.mu.Lock()
 		if state.Status == "running" {
-			// Distinguish killed-by-signal (e.g., timeout, OOM) from actual failures.
-			if waitErr != nil && isKilledBySignal(waitErr) {
+			// Distinguish a timeout from a crash from an exit-code failure. A
+			// timeout is reported first because it also arrives as a signal
+			// kill — the spawner SIGKILLs the group — and would otherwise be
+			// indistinguishable from an OOM.
+			switch {
+			case errors.Is(waitErr, ErrSubagentTimeout):
+				state.Status = "timeout"
+			case waitErr != nil && isKilledBySignal(waitErr):
 				state.Status = "killed"
-			} else if waitErr != nil {
+			case waitErr != nil:
 				state.Status = "failed"
-			} else {
+			default:
 				state.Status = "completed"
 			}
 			state.FinishedAt = time.Now()

--- a/internal/subagent/process_unix.go
+++ b/internal/subagent/process_unix.go
@@ -4,14 +4,20 @@ package subagent
 
 import (
 	"os/exec"
-	"syscall"
+
+	"github.com/dimetron/pi-go/internal/procs"
 )
 
 // setPlatformAttrs configures Unix process group management so the
 // subagent and all its children can be killed together.
+//
+// This delegates to internal/procs rather than hand-rolling
+// kill(-cmd.Process.Pid, SIGKILL). The hand-rolled form assumed the group ID
+// equals the child's PID, never checked that the PID was still ours to signal,
+// and went straight to SIGKILL — so a subagent stopped by a timeout was denied
+// the chance to flush its stderr, and the error arrived with no diagnostic text
+// attached. procs resolves the group properly, refuses to signal pi's own
+// group, and sends SIGTERM before SIGKILL.
 func setPlatformAttrs(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
+	procs.Isolate(cmd)
 }

--- a/internal/subagent/spawner.go
+++ b/internal/subagent/spawner.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,26 @@ import (
 	"sync"
 	"time"
 )
+
+// ErrSubagentTimeout marks a subagent that was stopped by one of its own time
+// limits rather than by failing.
+//
+// It exists because the kill is indistinguishable from a crash at the point the
+// caller reads it. os/exec's Wait prefers the *ExitError from Process.Wait over
+// the context error — watch.err is only consulted when err == nil — and a
+// SIGKILLed process always exits unsuccessfully. So context.DeadlineExceeded is
+// discarded and every timeout surfaced as the bare text "signal: killed", which
+// tells the reader nothing about which limit was hit or how to raise it.
+var ErrSubagentTimeout = errors.New("subagent timeout")
+
+// maxStderrCapture bounds the stderr retained for error reporting. The whole
+// point of draining stderr concurrently is to unblock a chatty child, so the
+// buffer must not become the new place the memory goes.
+const maxStderrCapture = 64 * 1024
+
+// timeoutHint names the knobs, because a subagent killed by a limit is exactly
+// the moment the reader wants to know the limit is adjustable.
+const timeoutHint = "raise it with PI_SUBAGENT_TIMEOUT_MS or a `timeout:` (milliseconds) key in the agent's frontmatter"
 
 // SpawnOpts holds options for spawning a subagent process.
 type SpawnOpts struct {
@@ -147,65 +168,133 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 		cancel: cancel,
 	}
 
+	// Drain stderr concurrently with stdout.
+	//
+	// These are two independent pipes with their own kernel buffers. Reading
+	// them in sequence — stdout to EOF, then stderr — deadlocks the moment the
+	// child writes more than a pipe buffer (~64KB) to stderr: the child blocks
+	// in write(2), so it never closes stdout, so the parent never finishes the
+	// stdout scan and never reaches the stderr read. The child then sits there
+	// until a timeout kills it, and because stderr was never drained the error
+	// arrives with no diagnostic text attached at all.
+	var (
+		stderrMu   sync.Mutex
+		stderrBuf  strings.Builder
+		stderrDone = make(chan struct{})
+	)
+	go func() {
+		defer close(stderrDone)
+		sc := bufio.NewScanner(stderr)
+		for sc.Scan() {
+			stderrMu.Lock()
+			if stderrBuf.Len() < maxStderrCapture {
+				stderrBuf.WriteString(sc.Text())
+				stderrBuf.WriteByte('\n')
+			}
+			stderrMu.Unlock()
+		}
+	}()
+
+	// Feed stdout lines to the reader below rather than scanning inline, so the
+	// reader can wait on "a line arrived" and "nothing has arrived in a while"
+	// at the same time. A bare `for scanner.Scan()` can only block.
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		sc := bufio.NewScanner(stdout)
+		sc.Buffer(make([]byte, 0, 256*1024), 1024*1024) // up to 1MB lines
+		for sc.Scan() {
+			lines <- sc.Text()
+		}
+	}()
+
 	// Reader goroutine: parse JSONL from stdout, send events.
 	go func() {
 		defer close(proc.done)
 		defer close(proc.events)
 
 		var resultBuilder strings.Builder
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // up to 1MB lines
 
-		for scanner.Scan() {
-			line := scanner.Text()
-			if line == "" {
-				continue
-			}
+		// The inactivity timer is what separates "slow" from "wedged". Without
+		// it the absolute cap is the only limit, so a long but productive agent
+		// is killed on the same rule as one that has hung — which is precisely
+		// the failure this fixes.
+		idle := NewInactivityTimer(timeoutCfg.Inactivity)
+		defer idle.Stop()
 
-			var ev jsonEvent
-			if err := json.Unmarshal([]byte(line), &ev); err != nil {
-				// Non-JSON output; emit as text.
-				proc.sendEvent(Event{Type: "text_delta", Content: line})
-				continue
-			}
+		timedOutIdle := false
 
-			switch ev.Type {
-			case "text_delta":
-				resultBuilder.WriteString(ev.Delta)
-				proc.sendEvent(Event{Type: "text_delta", Content: ev.Delta})
-			case "tool_call":
-				proc.sendEvent(Event{Type: "tool_call", Content: ev.ToolName, ToolArgs: ev.ToolInput})
-			case "tool_result":
-				proc.sendEvent(Event{Type: "tool_result", Content: ev.Content})
-			case "message_start":
-				proc.sendEvent(Event{Type: "message_start", SessionID: ev.SessionID})
-			case "message_end":
-				proc.sendEvent(Event{Type: "message_end"})
-			default:
-				proc.sendEvent(Event{Type: ev.Type, Content: ev.Delta + ev.Content})
+	read:
+		for {
+			select {
+			case line, ok := <-lines:
+				if !ok {
+					break read
+				}
+				idle.Reset()
+				if line == "" {
+					continue
+				}
+
+				var ev jsonEvent
+				if err := json.Unmarshal([]byte(line), &ev); err != nil {
+					// Non-JSON output; emit as text.
+					proc.sendEvent(Event{Type: "text_delta", Content: line})
+					continue
+				}
+
+				switch ev.Type {
+				case "text_delta":
+					resultBuilder.WriteString(ev.Delta)
+					proc.sendEvent(Event{Type: "text_delta", Content: ev.Delta})
+				case "tool_call":
+					proc.sendEvent(Event{Type: "tool_call", Content: ev.ToolName, ToolArgs: ev.ToolInput})
+				case "tool_result":
+					proc.sendEvent(Event{Type: "tool_result", Content: ev.Content})
+				case "message_start":
+					proc.sendEvent(Event{Type: "message_start", SessionID: ev.SessionID})
+				case "message_end":
+					proc.sendEvent(Event{Type: "message_end"})
+				default:
+					proc.sendEvent(Event{Type: ev.Type, Content: ev.Delta + ev.Content})
+				}
+
+			case <-idle.C():
+				timedOutIdle = true
+				cancel()          // kills the process group; stdout closes, so lines drains
+				for range lines { //nolint:revive // drain so the scanner goroutine can exit
+				}
+				break read
 			}
 		}
 
-		// Capture stderr for error reporting.
-		stderrScanner := bufio.NewScanner(stderr)
-		var stderrBuf strings.Builder
-		for stderrScanner.Scan() {
-			stderrBuf.WriteString(stderrScanner.Text())
-			stderrBuf.WriteByte('\n')
-		}
+		// Both pipes must be at EOF before Wait, and stderr is wanted for the
+		// error message below.
+		<-stderrDone
 
 		// Wait for process exit.
 		waitErr := cmd.Wait()
 
 		proc.mu.Lock()
 		proc.result = resultBuilder.String()
-		if waitErr != nil {
-			stderrStr := strings.TrimSpace(stderrBuf.String())
-			if stderrStr != "" {
-				proc.err = fmt.Errorf("pi process failed: %w: %s", waitErr, stderrStr)
-			} else {
-				proc.err = fmt.Errorf("pi process failed: %w", waitErr)
-			}
+
+		stderrMu.Lock()
+		stderrStr := strings.TrimSpace(stderrBuf.String())
+		stderrMu.Unlock()
+
+		switch {
+		case timedOutIdle:
+			proc.err = fmt.Errorf("pi subagent produced no output for %s: %w (%s)",
+				timeoutCfg.Inactivity, ErrSubagentTimeout, timeoutHint)
+		case errors.Is(procCtx.Err(), context.DeadlineExceeded):
+			proc.err = fmt.Errorf("pi subagent exceeded its %s time limit: %w (%s)",
+				timeoutCfg.Absolute, ErrSubagentTimeout, timeoutHint)
+		case waitErr != nil && stderrStr != "":
+			proc.err = fmt.Errorf("pi process failed: %w: %s", waitErr, stderrStr)
+		case waitErr != nil:
+			proc.err = fmt.Errorf("pi process failed: %w", waitErr)
+		}
+		if proc.err != nil {
 			proc.sendEvent(Event{Type: "error", Error: proc.err.Error()})
 		}
 		proc.mu.Unlock()

--- a/internal/subagent/spawner_timeout_test.go
+++ b/internal/subagent/spawner_timeout_test.go
@@ -1,0 +1,269 @@
+package subagent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakePi writes a shell script that stands in for the child `pi --mode json`
+// binary and returns its path. The script ignores its arguments; only what it
+// writes to stdout/stderr and how long it takes matters here.
+func fakePi(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-pi")
+	body := "#!/bin/bash\n" + script + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("writing fake pi: %v", err)
+	}
+	return path
+}
+
+// drain consumes every event and returns once the process is finished.
+func drain(t *testing.T, proc *Process) (string, error) {
+	t.Helper()
+	for range proc.Events() {
+	}
+	return proc.Wait()
+}
+
+// TestSpawn_SteadyOutputSurvivesInactivityWindow is the regression guard for the
+// bug this fixes: an agent that keeps producing output must never be killed for
+// inactivity, however long it runs in total.
+func TestSpawn_SteadyOutputSurvivesInactivityWindow(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "20000") // generous absolute backstop
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "400")
+
+	// Emits a line every 100ms for ~1.2s — four times the inactivity window in
+	// total, but never silent for more than 100ms.
+	s := &Spawner{PiBinary: fakePi(t, `
+for i in $(seq 1 12); do
+  printf '{"type":"text_delta","delta":"tick "}\n'
+  sleep 0.1
+done
+`)}
+
+	proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	result, err := drain(t, proc)
+	if err != nil {
+		t.Fatalf("a steadily-producing agent was killed: %v", err)
+	}
+	if got := strings.Count(result, "tick"); got != 12 {
+		t.Errorf("got %d ticks, want 12 (result=%q)", got, result)
+	}
+}
+
+func TestSpawn_SilentAgentIsKilledByInactivity(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "20000") // must NOT be what fires
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "300")
+
+	// One line, then silence well past the inactivity window.
+	s := &Spawner{PiBinary: fakePi(t, `
+printf '{"type":"text_delta","delta":"hello"}\n'
+sleep 20
+`)}
+
+	start := time.Now()
+	proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	_, err = drain(t, proc)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a silent agent was not killed")
+	}
+	if !errors.Is(err, ErrSubagentTimeout) {
+		t.Errorf("error %v does not wrap ErrSubagentTimeout", err)
+	}
+	if !strings.Contains(err.Error(), "no output") {
+		t.Errorf("error %q does not say the agent went silent", err)
+	}
+	// It must die on the inactivity limit, not sit until the absolute one.
+	if elapsed > 10*time.Second {
+		t.Errorf("took %v — looks like the absolute cap fired, not inactivity", elapsed)
+	}
+}
+
+func TestSpawn_AbsoluteCapStillApplies(t *testing.T) {
+	// Output flows constantly, so inactivity never fires; only the absolute cap
+	// can stop this agent.
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "700")
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "500")
+
+	s := &Spawner{PiBinary: fakePi(t, `
+while true; do
+  printf '{"type":"text_delta","delta":"x"}\n'
+  sleep 0.05
+done
+`)}
+
+	proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	_, err = drain(t, proc)
+	if err == nil {
+		t.Fatal("the absolute cap did not stop a runaway agent")
+	}
+	if !errors.Is(err, ErrSubagentTimeout) {
+		t.Errorf("error %v does not wrap ErrSubagentTimeout", err)
+	}
+	if !strings.Contains(err.Error(), "time limit") {
+		t.Errorf("error %q does not name the absolute limit", err)
+	}
+}
+
+// TestSpawn_TimeoutErrorNamesTheKnobs checks the message is actionable. The
+// whole failure mode this fixes was an error that said only "signal: killed".
+func TestSpawn_TimeoutErrorNamesTheKnobs(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "20000")
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "250")
+
+	s := &Spawner{PiBinary: fakePi(t, `sleep 20`)}
+	proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	_, err = drain(t, proc)
+	if err == nil {
+		t.Fatal("expected a timeout")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "signal: killed") {
+		t.Errorf("timeout still reported as a bare signal kill: %q", msg)
+	}
+	for _, want := range []string{"PI_SUBAGENT_TIMEOUT_MS", "timeout:"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestSpawn_LargeStderrDoesNotDeadlock covers the pipe deadlock: stdout and
+// stderr have separate kernel buffers, so draining them in sequence wedges any
+// child that writes more than a pipe buffer (~64KB) to stderr.
+func TestSpawn_LargeStderrDoesNotDeadlock(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "15000")
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "10000")
+
+	// ~300KB of stderr, far past the pipe buffer, then a normal result.
+	s := &Spawner{PiBinary: fakePi(t, `
+for i in $(seq 1 3000); do
+  printf 'noisy diagnostic line %d aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' "$i" >&2
+done
+printf '{"type":"text_delta","delta":"done"}\n'
+`)}
+
+	done := make(chan struct{})
+	var result string
+	var spawnErr error
+	go func() {
+		defer close(done)
+		proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+		if err != nil {
+			spawnErr = err
+			return
+		}
+		result, spawnErr = drain(t, proc)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("spawn deadlocked on a child that wrote heavily to stderr")
+	}
+
+	if spawnErr != nil {
+		t.Fatalf("unexpected error: %v", spawnErr)
+	}
+	if !strings.Contains(result, "done") {
+		t.Errorf("result = %q, want the child's output", result)
+	}
+}
+
+// TestSpawn_StderrIsReportedOnFailure guards the diagnostic value of stderr:
+// capturing it concurrently must not lose it.
+func TestSpawn_StderrIsReportedOnFailure(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "15000")
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "10000")
+
+	s := &Spawner{PiBinary: fakePi(t, `
+echo "config file is malformed" >&2
+exit 3
+`)}
+
+	proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	_, err = drain(t, proc)
+	if err == nil {
+		t.Fatal("a failing child produced no error")
+	}
+	if !strings.Contains(err.Error(), "config file is malformed") {
+		t.Errorf("error %q lost the child's stderr", err)
+	}
+}
+
+func TestSpawn_CleanExitReportsNoError(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_TIMEOUT_MS", "15000")
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "10000")
+
+	s := &Spawner{PiBinary: fakePi(t, `printf '{"type":"text_delta","delta":"ok"}\n'`)}
+
+	proc, err := s.Spawn(context.Background(), SpawnOpts{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	result, err := drain(t, proc)
+	if err != nil {
+		t.Fatalf("clean exit reported an error: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q, want %q", result, "ok")
+	}
+}
+
+func TestResolveTimeout_InactivityEnvOverride(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "5000")
+
+	cfg := ResolveTimeout(0)
+	if cfg.Inactivity != 5*time.Second {
+		t.Errorf("Inactivity = %v, want 5s", cfg.Inactivity)
+	}
+	if cfg.Absolute != DefaultAbsoluteTimeout {
+		t.Errorf("Absolute = %v, want the default %v", cfg.Absolute, DefaultAbsoluteTimeout)
+	}
+}
+
+func TestResolveTimeout_InactivityStillClampedToAbsolute(t *testing.T) {
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "60000")
+
+	cfg := ResolveTimeout(1000) // 1s absolute from frontmatter
+	if cfg.Inactivity > cfg.Absolute {
+		t.Errorf("Inactivity %v exceeds Absolute %v", cfg.Inactivity, cfg.Absolute)
+	}
+}
+
+func TestDefaultAbsoluteTimeoutIsGenerous(t *testing.T) {
+	// A five-minute cap killed productive review agents mid-answer. The
+	// inactivity timer is the working limit; this one is only a backstop.
+	if DefaultAbsoluteTimeout < 10*time.Minute {
+		t.Errorf("DefaultAbsoluteTimeout = %v, want at least 10m", DefaultAbsoluteTimeout)
+	}
+}

--- a/internal/subagent/timeout.go
+++ b/internal/subagent/timeout.go
@@ -8,10 +8,21 @@ import (
 
 // Default timeout values for subagent processes.
 const (
-	// DefaultAbsoluteTimeout is the maximum wall-clock time a subagent can run (5 minutes).
-	DefaultAbsoluteTimeout = 5 * time.Minute
+	// DefaultAbsoluteTimeout is the maximum wall-clock time a subagent can run.
+	//
+	// This is a backstop against a pathological agent, not the working limit —
+	// the inactivity timeout below is what actually distinguishes a stuck agent
+	// from a slow one, so this can afford to be generous. It was briefly 5
+	// minutes, which killed productive agents mid-answer: a review across a
+	// day's commits legitimately runs longer than that, and cutting it off
+	// discards everything it had produced.
+	DefaultAbsoluteTimeout = 10 * time.Minute
 
 	// DefaultInactivityTimeout is how long a subagent can go without producing output (120 seconds).
+	//
+	// Silence is the signal that matters. An agent that is streaming tokens or
+	// reporting tool calls is working, however long it takes; one that has said
+	// nothing for two minutes is wedged.
 	DefaultInactivityTimeout = 120 * time.Second
 )
 
@@ -28,10 +39,18 @@ func ResolveTimeout(agentTimeoutMs int) TimeoutConfig {
 	absolute := DefaultAbsoluteTimeout
 	inactivity := DefaultInactivityTimeout
 
-	// Check environment variable override.
+	// Check environment variable overrides.
 	if envMs := os.Getenv("PI_SUBAGENT_TIMEOUT_MS"); envMs != "" {
 		if ms, err := strconv.Atoi(envMs); err == nil && ms > 0 {
 			absolute = time.Duration(ms) * time.Millisecond
+		}
+	}
+	// The inactivity limit is the one that decides whether a long-running agent
+	// is working or wedged, so it needs its own knob rather than being reachable
+	// only through the absolute cap.
+	if envMs := os.Getenv("PI_SUBAGENT_INACTIVITY_MS"); envMs != "" {
+		if ms, err := strconv.Atoi(envMs); err == nil && ms > 0 {
+			inactivity = time.Duration(ms) * time.Millisecond
 		}
 	}
 

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -260,6 +260,16 @@ func singleModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input Sub
 				if ev.SessionID != "" {
 					sessID = ev.SessionID
 				}
+			case "run_done":
+				// The orchestrator's terminal status is more specific than the
+				// "failed" inferred from an error event: it distinguishes a
+				// timeout from a crash. That distinction is actionable for the
+				// model — a timed-out agent is worth retrying with a narrower
+				// task, a crashed one is not — and until now it was computed
+				// and then dropped on the floor here.
+				if ev.Status == "timeout" {
+					st = "timeout"
+				}
 			}
 		}
 		return truncateOutput(result.String()), st, em, sessID


### PR DESCRIPTION
Three explore subagents reviewing a day's commits all died with
`pi process failed: signal: killed`. One had already streamed a complete
review before it was killed. They were not stuck — they ran past five minutes.

Root cause: 9354dbf halved DefaultAbsoluteTimeout from 10m to 5m, and the
wall-clock cap was the only limit in force. InactivityTimer, the mechanism
that distinguishes a slow agent from a wedged one, was written and tested but
had no production call site, and TimeoutConfig.Inactivity was computed by every
spawner and never read.

The error text was the second half of the problem. In os/exec's Wait the
*ExitError from Process.Wait takes precedence over the context error —
watch.err is consulted only when err == nil — and a SIGKILLed process always
exits unsuccessfully. So context.DeadlineExceeded was discarded and every
timeout surfaced as a bare signal name that said nothing about which limit was
hit or how to raise it. The "timeout" status documented at
tools/subagent.go:67 was never produced anywhere.

Now: the inactivity timer is wired into the stdout loop and reset on every
line, so an agent that keeps talking is never killed; the absolute cap returns
to 10m as a backstop; and both limits report themselves via ErrSubagentTimeout,
naming PI_SUBAGENT_TIMEOUT_MS and the frontmatter key. PI_SUBAGENT_INACTIVITY_MS
is implemented, having been documented in the spec but never built.

Three further defects found while confirming the above:

memory-compressor.md declared `timeout: 30`. The unit is milliseconds, so that
agent was SIGKILLed 30ms in, every time, and could never emit a token. Set to
600000 per the design doc, with a guard that warns and ignores any sub-second
value rather than honoring one that guarantees failure.

spawner.go drained stdout to EOF before reading stderr. Two pipes, two kernel
buffers: a child writing more than ~64KB to stderr blocked in write, never
closed stdout, and hung until a timeout killed it — with stderr never drained,
so the error arrived with no diagnostic text. stderr is now drained
concurrently from Start, capped at 64KB.

procs.terminate armed a detached time.AfterFunc that SIGKILLed a process group
two seconds later with no check that the process had been reaped. On the normal
path the child dies in milliseconds and the PID is freed, so the timer could
signal a recycled PID — and pi's ~25 non-isolated exec.Command children all sit
in pi's own group, making kill(-pi_pgid, SIGKILL) reachable. signalGroup's
comment claimed the Setpgid check ruled this out; it does not, because that
field is a request, not proof the kernel applied it. Added the missing
pgid != Getpgrp() guard and a signal-0 reap probe before the delayed kill, and
routed the hand-rolled duplicates in subagent/ and codex/ through procs so they
inherit both guards and gain SIGTERM grace.

Session metadata now records the full backend (provider and base URL alongside
the model name) plus a host snapshot: CPU count, total and available memory,
and total and free disk for the session filesystem. A SIGKILL from an OOM
killer, a timeout and a manual kill are indistinguishable after the fact, and
by the time anyone investigates the memory pressure is gone. Recording the
numbers up front turns the guess into a check.

Both self-kill guards are mutation-tested: removing the inactivity Reset makes
the steady-output test fail, and removing the self-group guard makes the procs
test binary die with signal 15.

Full suite passes, -race clean, golangci-lint reports 0 issues.

Signed-off-by: dimetron <dimetron@me.com>
