### PR TITLE
feat(auth): add opencode console device login

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,6 +2,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -76,6 +77,7 @@ type Provider struct {
 	CodexDeviceAuth   bool   // use OpenAI's non-RFC-8628 device auth (see codex_device.go)
 	DeviceVerifyURL   string // page the user opens to enter the code
 	DeviceRedirectURI string // redirect_uri asserted in the device code exchange
+	DeviceJSONBody    bool   // POST device endpoints as JSON (opencode console) instead of form-encoded
 	TLSPreflight      bool   // run TLS preflight before OAuth (OpenAI Codex)
 	CodexOAuth        bool   // use Codex OAuth callback + token-exchange semantics
 	ManualCode        bool   // user pastes a code or callback URL (no local listener)
@@ -100,11 +102,25 @@ type TokenResponse struct {
 
 // DeviceCodeResponse holds the device authorization response.
 type DeviceCodeResponse struct {
-	DeviceCode      string `json:"device_code"`
-	UserCode        string `json:"user_code"`
-	VerificationURI string `json:"verification_uri"`
-	ExpiresIn       int    `json:"expires_in"`
-	Interval        int    `json:"interval"`
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"` // one-click URL that already embeds the code (optional)
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// VerificationURL returns the most specific verification URL for the device
+// flow: the one-click verification_uri_complete when present (it already
+// contains the user code), otherwise the plain verification_uri.
+func (d *DeviceCodeResponse) VerificationURL() string {
+	if d != nil && d.VerificationURIComplete != "" {
+		return d.VerificationURIComplete
+	}
+	if d != nil {
+		return d.VerificationURI
+	}
+	return ""
 }
 
 // Result is the outcome of an SSO login flow.
@@ -148,6 +164,24 @@ func Providers() []Provider {
 			DeviceURL:         "https://auth.openai.com/api/accounts/deviceauth",
 			DeviceVerifyURL:   "https://auth.openai.com/codex/device",
 			DeviceRedirectURI: "https://auth.openai.com/deviceauth/callback",
+		},
+		{
+			// OpenCode Console (console.opencode.ai) device flow — the same
+			// RFC 8628 flow the opencode CLI runs for `opencode console
+			// login` / `/connect`. The access token returned by the device
+			// grant is the bearer credential pi-go sends to
+			// opencode.ai/zen/go/v1, so it is saved as OPENCODE_API_KEY.
+			// The console endpoints speak JSON, not form-encoded.
+			Name:           "opencode",
+			EnvVar:         "OPENCODE_API_KEY",
+			ClientID:       "opencode-cli",
+			UseDeviceFlow:  true,
+			DeviceJSONBody: true,
+			DeviceURL:      "https://console.opencode.ai/auth/device/code",
+			TokenURL:       "https://console.opencode.ai/auth/device/token",
+			TokenToKey: func(tok *TokenResponse) string {
+				return tok.AccessToken
+			},
 		},
 	}
 }
@@ -457,15 +491,36 @@ func DeviceFlow(ctx context.Context, prov Provider) (*DeviceCodeResponse, error)
 		return nil, fmt.Errorf("provider %s does not support device code flow", prov.Name)
 	}
 
-	data := url.Values{
-		"client_id": {prov.ClientID},
-		"scope":     {strings.Join(prov.Scopes, " ")},
+	var resp *http.Response
+	var err error
+	if prov.DeviceJSONBody {
+		payload := map[string]string{"client_id": prov.ClientID}
+		if scope := strings.Join(prov.Scopes, " "); scope != "" {
+			payload["scope"] = scope
+		}
+		for k, v := range prov.ExtraParams {
+			payload[k] = v
+		}
+		body, merr := json.Marshal(payload)
+		if merr != nil {
+			return nil, fmt.Errorf("device code request: %w", merr)
+		}
+		req, rerr := http.NewRequestWithContext(ctx, http.MethodPost, prov.DeviceURL, bytes.NewReader(body))
+		if rerr != nil {
+			return nil, fmt.Errorf("device code request: %w", rerr)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err = http.DefaultClient.Do(req)
+	} else {
+		data := url.Values{
+			"client_id": {prov.ClientID},
+			"scope":     {strings.Join(prov.Scopes, " ")},
+		}
+		for k, v := range prov.ExtraParams {
+			data.Set(k, v)
+		}
+		resp, err = http.PostForm(prov.DeviceURL, data)
 	}
-	for k, v := range prov.ExtraParams {
-		data.Set(k, v)
-	}
-
-	resp, err := http.PostForm(prov.DeviceURL, data)
 	if err != nil {
 		return nil, fmt.Errorf("device code request: %w", err)
 	}
@@ -483,28 +538,59 @@ func DeviceFlow(ctx context.Context, prov Provider) (*DeviceCodeResponse, error)
 	if dcr.Interval == 0 {
 		dcr.Interval = 5
 	}
+	// opencode's console returns verification_uri_complete as a path relative
+	// to the console origin; resolve it against the device endpoint so callers
+	// can open the one-click URL directly.
+	if dcr.VerificationURIComplete != "" &&
+		!strings.HasPrefix(dcr.VerificationURIComplete, "http://") &&
+		!strings.HasPrefix(dcr.VerificationURIComplete, "https://") {
+		if u, perr := url.Parse(prov.DeviceURL); perr == nil && u.Scheme != "" && u.Host != "" {
+			dcr.VerificationURIComplete = u.Scheme + "://" + u.Host + dcr.VerificationURIComplete
+		}
+	}
 	return &dcr, nil
 }
 
 // PollDeviceToken polls for the device code token until authorized or expired.
-func PollDeviceToken(ctx context.Context, prov Provider, deviceCode string, interval int) (*Result, error) {
+// Polling is bounded by the response's expires_in (RFC 8628 §3.2) — when the
+// deadline passes before the user approves, the code has expired. A zero
+// expires_in means poll until the context is done.
+func PollDeviceToken(ctx context.Context, prov Provider, device *DeviceCodeResponse) (*Result, error) {
+	if device == nil {
+		return nil, fmt.Errorf("nil device code response")
+	}
+	interval := device.Interval
+	if interval < 1 {
+		interval = 5
+	}
 	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	defer ticker.Stop()
+
+	var deadline time.Time
+	if device.ExpiresIn > 0 {
+		deadline = time.Now().Add(time.Duration(device.ExpiresIn) * time.Second)
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return &Result{Provider: prov.Name, Err: ctx.Err()}, nil
 		case <-ticker.C:
-			tok, err := requestDeviceToken(ctx, prov, deviceCode)
+			if !deadline.IsZero() && time.Now().After(deadline) {
+				return &Result{Provider: prov.Name, Err: fmt.Errorf("device authorization timed out: device code expired")}, nil
+			}
+			tok, err := requestDeviceToken(ctx, prov, device.DeviceCode)
 			if err != nil {
 				// Check for "authorization_pending" — keep polling.
 				if strings.Contains(err.Error(), "authorization_pending") {
 					continue
 				}
-				// "slow_down" — increase interval.
+				// "slow_down" — increase the interval (RFC 8628 §3.5) and keep
+				// polling; the bump is cumulative across repeated slow_down
+				// responses.
 				if strings.Contains(err.Error(), "slow_down") {
-					ticker.Reset(time.Duration(interval+5) * time.Second)
+					interval += 5
+					ticker.Reset(time.Duration(interval) * time.Second)
 					continue
 				}
 				return &Result{Provider: prov.Name, Err: err}, nil
@@ -641,17 +727,34 @@ func exchangeCode(ctx context.Context, prov Provider, code, redirectURI, verifie
 }
 
 func requestDeviceToken(ctx context.Context, prov Provider, deviceCode string) (*TokenResponse, error) {
-	data := url.Values{
-		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
-		"device_code": {deviceCode},
-		"client_id":   {prov.ClientID},
+	var payload []byte
+	if prov.DeviceJSONBody {
+		var err error
+		payload, err = json.Marshal(map[string]string{
+			"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+			"device_code": deviceCode,
+			"client_id":   prov.ClientID,
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		payload = []byte(url.Values{
+			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+			"device_code": {deviceCode},
+			"client_id":   {prov.ClientID},
+		}.Encode())
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, prov.TokenURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, prov.TokenURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if prov.DeviceJSONBody {
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -661,14 +764,14 @@ func requestDeviceToken(ctx context.Context, prov Provider, deviceCode string) (
 
 	body, _ := io.ReadAll(resp.Body)
 
-	// Check for pending/slow_down errors (returned as 400 with error JSON).
-	if resp.StatusCode == http.StatusBadRequest {
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-			return nil, fmt.Errorf("%s", errResp.Error)
-		}
+	// Device endpoints report pending/slow_down/denied as {"error": "..."}.
+	// opencode's console may return this with a 4xx status or with 200, so
+	// check the body for an error field before the status handling.
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		return nil, fmt.Errorf("%s", errResp.Error)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -445,7 +445,7 @@ func TestPollDeviceToken_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := PollDeviceToken(ctx, prov, "device-test-code", 1)
+	result, err := PollDeviceToken(ctx, prov, &DeviceCodeResponse{DeviceCode: "device-test-code", Interval: 1})
 	if err != nil {
 		t.Fatalf("PollDeviceToken error: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestPollDeviceToken_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	result, err := PollDeviceToken(ctx, prov, "device-code", 1)
+	result, err := PollDeviceToken(ctx, prov, &DeviceCodeResponse{DeviceCode: "device-code", Interval: 1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -487,7 +487,7 @@ func TestPollDeviceToken_Timeout(t *testing.T) {
 }
 
 func TestFindProvider(t *testing.T) {
-	for _, name := range []string{"codex", "Codex", "CODEX"} {
+	for _, name := range []string{"codex", "Codex", "CODEX", "opencode", "OpenCode"} {
 		p, ok := FindProvider(name)
 		if !ok {
 			t.Errorf("expected to find provider %q", name)
@@ -495,6 +495,24 @@ func TestFindProvider(t *testing.T) {
 		if p.Name == "" {
 			t.Errorf("provider %q has empty name", name)
 		}
+	}
+
+	// opencode uses the JSON device flow against the console endpoints.
+	op, ok := FindProvider("opencode")
+	if !ok {
+		t.Fatal("expected opencode provider")
+	}
+	if !op.UseDeviceFlow || !op.DeviceJSONBody {
+		t.Errorf("opencode should use the JSON device flow, got UseDeviceFlow=%v DeviceJSONBody=%v", op.UseDeviceFlow, op.DeviceJSONBody)
+	}
+	if op.DeviceURL == "" || op.TokenURL == "" {
+		t.Errorf("opencode device endpoints not set: device=%q token=%q", op.DeviceURL, op.TokenURL)
+	}
+	if op.TokenToKey == nil {
+		t.Error("opencode TokenToKey must be set")
+	}
+	if got := op.TokenToKey(&TokenResponse{AccessToken: "jwt-token"}); got != "jwt-token" {
+		t.Errorf("opencode TokenToKey should pass access_token through, got %q", got)
 	}
 
 	for _, name := range []string{"anthropic", "openai", "gemini", "unknown"} {
@@ -651,9 +669,10 @@ func TestRunTLSPreflight_NetworkError(t *testing.T) {
 }
 
 func TestProviders_TokenToKey(t *testing.T) {
-	// The codex and anthropic OAuth providers pass access_token through
-	// unchanged (pi-mono parity); other providers prefer api_key when present
-	// and fall back to access_token.
+	// The codex, anthropic and opencode OAuth providers pass access_token
+	// through unchanged (the opencode console token endpoint only ever returns
+	// access_token, never an api_key field); other providers prefer api_key
+	// when present and fall back to access_token.
 	for _, p := range Providers() {
 		t.Run(p.Name+"_accesstoken", func(t *testing.T) {
 			tok := &TokenResponse{AccessToken: "access-token"}
@@ -661,7 +680,7 @@ func TestProviders_TokenToKey(t *testing.T) {
 				t.Errorf("expected 'access-token', got %q", got)
 			}
 		})
-		if p.Name == "codex" || p.Name == "anthropic" {
+		if p.Name == "codex" || p.Name == "anthropic" || p.Name == "opencode" {
 			continue
 		}
 		t.Run(p.Name+"_apikey", func(t *testing.T) {
@@ -955,7 +974,7 @@ func TestPollDeviceToken_SlowDown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	result, err := PollDeviceToken(ctx, prov, "code", 1)
+	result, err := PollDeviceToken(ctx, prov, &DeviceCodeResponse{DeviceCode: "code", Interval: 1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1106,7 +1125,7 @@ func TestPollDeviceToken_ContextDone(t *testing.T) {
 		cancel()
 	}()
 
-	result, err := PollDeviceToken(ctx, prov, "code", 60) // 60s interval, context cancels much sooner
+	result, err := PollDeviceToken(ctx, prov, &DeviceCodeResponse{DeviceCode: "code", Interval: 60}) // 60s interval, context cancels much sooner
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1137,7 +1156,7 @@ func TestPollDeviceToken_FatalError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := PollDeviceToken(ctx, prov, "code", 1)
+	result, err := PollDeviceToken(ctx, prov, &DeviceCodeResponse{DeviceCode: "code", Interval: 1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1476,5 +1495,144 @@ func TestLooksLikeAuthorizationRequest(t *testing.T) {
 	}
 	if looksLikeAuthorizationRequest(`{"code":"abc","state":"s"}`) {
 		t.Error("callback/code JSON should not be treated as authorization request")
+	}
+}
+
+func TestDeviceFlow_JSONBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json content type, got %q", ct)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		if body["client_id"] != "opencode-cli" {
+			t.Errorf("expected client_id opencode-cli, got %q", body["client_id"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DeviceCodeResponse{
+			DeviceCode:              "dc-1",
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://console.opencode.ai/device",
+			VerificationURIComplete: "/device?code=ABCD-EFGH",
+			ExpiresIn:               600,
+			Interval:                5,
+		})
+	}))
+	defer srv.Close()
+
+	prov := Provider{
+		Name:           "opencode",
+		DeviceURL:      srv.URL + "/auth/device/code",
+		ClientID:       "opencode-cli",
+		UseDeviceFlow:  true,
+		DeviceJSONBody: true,
+	}
+
+	dcr, err := DeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("DeviceFlow error: %v", err)
+	}
+	if dcr.DeviceCode != "dc-1" || dcr.UserCode != "ABCD-EFGH" {
+		t.Errorf("unexpected device response: %+v", dcr)
+	}
+	// Relative verification_uri_complete is resolved against the device origin.
+	if got := dcr.VerificationURL(); got != srv.URL+"/device?code=ABCD-EFGH" {
+		t.Errorf("expected resolved one-click URL, got %q", got)
+	}
+}
+
+func TestDeviceFlow_JSONBodyAbsoluteCompleteURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DeviceCodeResponse{
+			DeviceCode:              "dc-1",
+			UserCode:                "ABCD-EFGH",
+			VerificationURIComplete: "https://example.com/device?code=ABCD-EFGH",
+		})
+	}))
+	defer srv.Close()
+
+	prov := Provider{DeviceURL: srv.URL, ClientID: "c", DeviceJSONBody: true}
+	dcr, err := DeviceFlow(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("DeviceFlow error: %v", err)
+	}
+	if got := dcr.VerificationURL(); got != "https://example.com/device?code=ABCD-EFGH" {
+		t.Errorf("absolute URL must pass through untouched, got %q", got)
+	}
+}
+
+func TestRequestDeviceToken_JSONBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json content type, got %q", ct)
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["grant_type"] != "urn:ietf:params:oauth:grant-type:device_code" {
+			t.Errorf("wrong grant_type: %q", body["grant_type"])
+		}
+		if body["device_code"] != "dc-1" || body["client_id"] != "opencode-cli" {
+			t.Errorf("unexpected body: %v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "console-access-token"})
+	}))
+	defer srv.Close()
+
+	prov := Provider{TokenURL: srv.URL, ClientID: "opencode-cli", DeviceJSONBody: true}
+	tok, err := requestDeviceToken(context.Background(), prov, "dc-1")
+	if err != nil {
+		t.Fatalf("requestDeviceToken error: %v", err)
+	}
+	if tok.AccessToken != "console-access-token" {
+		t.Errorf("expected console-access-token, got %q", tok.AccessToken)
+	}
+}
+
+func TestRequestDeviceToken_JSONErrorBodyWithOKStatus(t *testing.T) {
+	// opencode's console can report pending/errors with a 200 status and an
+	// {"error": ...} body; that must surface as an error, not a bogus token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+	}))
+	defer srv.Close()
+
+	prov := Provider{TokenURL: srv.URL, ClientID: "opencode-cli", DeviceJSONBody: true}
+	_, err := requestDeviceToken(context.Background(), prov, "dc-1")
+	if err == nil {
+		t.Fatal("expected error for 200 response with error body")
+	}
+	if !strings.Contains(err.Error(), "authorization_pending") {
+		t.Errorf("expected authorization_pending, got: %v", err)
+	}
+}
+
+func TestPollDeviceToken_ExpiresIn(t *testing.T) {
+	// Server never authorizes; the device code expires after 1s. With a 1s
+	// interval, the second tick is definitely past the deadline, so the poll
+	// must return the expiry error rather than hanging until the ctx timeout.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+	}))
+	defer srv.Close()
+
+	prov := Provider{Name: "test", TokenURL: srv.URL, ClientID: "test",
+		TokenToKey: func(tok *TokenResponse) string { return tok.AccessToken },
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := PollDeviceToken(ctx, prov, &DeviceCodeResponse{DeviceCode: "dc", Interval: 1, ExpiresIn: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "expired") {
+		t.Fatalf("expected device-code-expired error, got: %v", result.Err)
 	}
 }

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -19,14 +19,16 @@ var flagLoginModel string
 func newLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login [provider]",
-		Short: "Authenticate with Codex",
-		Long: `Authenticate with Codex and save the credentials.
+		Short: "Authenticate with a provider",
+		Long: `Authenticate with a provider and save the credentials.
 
 Supported providers:
-  codex        ChatGPT (chatgpt.com) — browser OAuth PKCE
+  codex        ChatGPT (chatgpt.com) — device auth
+  opencode     OpenCode Console (console.opencode.ai) — device auth
 
 Examples:
   pi login codex                        # Authenticate with Codex
+  pi login opencode                     # Authenticate with OpenCode Console
   pi login                              # Interactive provider selection`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runLogin,
@@ -55,7 +57,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// Find the provider.
 	prov, ok := auth.FindProvider(providerName)
 	if !ok {
-		return fmt.Errorf("unknown provider %q — supported: codex", providerName)
+		return fmt.Errorf("unknown provider %q — supported: codex, opencode", providerName)
 	}
 
 	fmt.Printf("Logging in to %s...\n\n", prov.Name)
@@ -126,11 +128,11 @@ func runDeviceFlow(ctx context.Context, prov auth.Provider) (*auth.Result, error
 		return nil, fmt.Errorf("device flow: %w", err)
 	}
 
-	fmt.Printf("Visit: %s\n", sess.VerificationURI)
+	fmt.Printf("Visit: %s\n", sess.VerificationURL())
 	fmt.Printf("Code:  %s\n\n", sess.UserCode)
 	fmt.Println("Waiting for authorization...")
 
-	result, err := auth.PollDeviceToken(ctx, prov, sess.DeviceCode, sess.Interval)
+	result, err := auth.PollDeviceToken(ctx, prov, sess)
 	if err != nil {
 		return nil, fmt.Errorf("polling device token: %w", err)
 	}

--- a/internal/tui/login.go
+++ b/internal/tui/login.go
@@ -27,7 +27,7 @@ type loginSSOResultMsg struct {
 
 // handleLoginCommand initiates the /login flow.
 // Usage: /login [provider]
-// Providers: codex, openai, anthropic, gemini
+// Providers: codex, opencode
 // Auto-selects the best auth flow (device code, PKCE, or manual key entry).
 func (m *model) handleLoginCommand(args []string) (tea.Model, tea.Cmd) {
 	var provName string
@@ -48,7 +48,7 @@ func (m *model) handleLoginCommand(args []string) (tea.Model, tea.Cmd) {
 		m.logLogin("unknown provider requested: %q", provName)
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role:    "assistant",
-			content: fmt.Sprintf("Unknown provider: `%s`. Available: codex, openai, anthropic, gemini", provName),
+			content: fmt.Sprintf("Unknown provider: `%s`. Available: codex, opencode", provName),
 		})
 		return m, nil
 	}
@@ -312,7 +312,7 @@ func (m *model) loginStartDeviceFlow(prov auth.Provider) (tea.Model, tea.Cmd) {
 	}
 
 	// Open browser to verification URI.
-	_ = openBrowser(dcr.VerificationURI)
+	_ = openBrowser(dcr.VerificationURL())
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
@@ -322,21 +322,19 @@ func (m *model) loginStartDeviceFlow(prov auth.Provider) (tea.Model, tea.Cmd) {
 				"2. Enter code: **`%s`**\n"+
 				"3. Approve access in your browser\n\n"+
 				"Waiting for authorization... Press **Esc** to cancel.",
-			prov.Name, dcr.VerificationURI, dcr.UserCode),
+			prov.Name, dcr.VerificationURL(), dcr.UserCode),
 	})
 
 	// Poll for token in background.
-	deviceCode := dcr.DeviceCode
-	interval := dcr.Interval
 	log := m.cfg.Logger
 	if log != nil {
-		log.Info(fmt.Sprintf("login: device flow prompt provider=%s verification_uri=%s interval=%ds", prov.Name, dcr.VerificationURI, interval))
+		log.Info(fmt.Sprintf("login: device flow prompt provider=%s verification_uri=%s interval=%ds", prov.Name, dcr.VerificationURL(), dcr.Interval))
 	}
 	return m, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
-		result, err := auth.PollDeviceToken(ctx, prov, deviceCode, interval)
+		result, err := auth.PollDeviceToken(ctx, prov, dcr)
 		if err != nil {
 			if log != nil {
 				log.Errorf("login: device flow poll aborted provider=%s err=%v", prov.Name, err)


### PR DESCRIPTION
Wire the existing RFC 8628 device-code engine to the OpenCode Console, so
`pi login opencode` and `/login opencode` run the same JSON device flow
as opencode's `/connect` / `opencode console login`:

- register an opencode provider (console.opencode.ai, client_id opencode-cli)
  whose access token is saved as OPENCODE_API_KEY
- add DeviceJSONBody to POST device endpoints as JSON instead of form-encoded
- parse and resolve verification_uri_complete (relative to the console origin)
  into a one-click verification URL
- bound PollDeviceToken by the response's expires_in so an unapproved code
  expires instead of polling forever; make slow_down interval bumps cumulative

CLI and TUI device flows now print/open the one-click URL and pass the full
device response to PollDeviceToken.

Signed-off-by: dimetron <dimetron@me.com>
