### PR TITLE
feat(provider): send Ollama repetition-control sampling options

### DIFF
--- a/.pi-go/skills/pi-loop-forensics/SKILL.md
+++ b/.pi-go/skills/pi-loop-forensics/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: pi-loop-forensics
+description: Diagnose pi-go agent loops and degenerate turns — "agent loop aborted", runaway thinking with no tool calls, repeated phrases. Discriminates genuine model repetition collapse from a race, a tool-parse failure, or a too-low guard, and A/B replays a seed session across providers.
+---
+
+# Loop Forensics
+
+Use when a run dies with `agent loop aborted: ...`, or a model burns a long turn
+thinking without ever calling a tool. This skill decides **why** before anything
+is changed: the abort message names a symptom, not a cause.
+
+Sibling skill `pi-check-session-logs` covers *tool call errors*. This one covers
+*repetition and runaway turns*. They do not overlap.
+
+## Where the evidence lives
+
+| What | Path |
+|---|---|
+| Session logs (JSONL, one per run) | `~/.pi-go/log/<yyyy-mm-dd>/session-HH-MM-SS.log` |
+| Session state (resumable) | `~/.pi-go/sessions/<id>/` — `events.jsonl`, `meta.json`, `trajectory.atif.json` |
+| Detector source | `internal/tui/agent_loop.go` |
+
+Log rows are `{"time","type","content",...}` with `type` in `session_start`,
+`thinking`, `llm_text`, `tool_call`, `tool_result`, `user`, `error`. The model
+name is on the `session_start` row — always record it, findings are per-model.
+
+## How the guard actually works
+
+`stuckDetector` (`internal/tui/agent_loop.go:119`) has three independent arms:
+
+- `observe` — identical consecutive tool calls, trips at `maxRepeatToolCalls`=10.
+  Pagination args are stripped first (`volatileToolArgs`), so paging one file
+  collapses to one fingerprint.
+- `observeError` — same tool failing `maxToolErrorStreak`=10 times running.
+- `observeOutput` (`:246`) — the model's own text/thinking. Needs a period ≥
+  `minOutputPeriod`=16 bytes, ≥ `minPeriodVariety`=8 distinct bytes, and
+  `maxOutputRepeats`=12 **byte-exact** back-to-back copies inside an 8 KB tail.
+
+The third arm is the only one that sees a turn making no tool calls at all.
+`outBuf` is never reset across a run, and the thinking branch (`:690`) skips
+`dedup.SkipText`, unlike the text branch (`:697`).
+
+**Timeline caveat — check this before judging any old log.** Sessions predating
+these commits cannot be compared against current behavior:
+
+| Commit | Landed | Effect |
+|---|---|---|
+| `e069b34` | 2026-08-08 06:56:44 +0200 | added `observeOutput` (the phrase-repetition arm) |
+| `5a4cb8b` | 2026-08-08 18:52:42 +0200 | stopped aborting productive polling (`bash_output`) |
+
+## Steps
+
+1. **Sweep the corpus** for scale and per-model distribution:
+
+   ```bash
+   python3 .pi-go/skills/pi-loop-forensics/scan_logs.py
+   ```
+
+   Reports per model: session count, aborts, longest tool-free thinking run
+   (max/p95), worst periodic repetition. Also lists aborted sessions and the
+   top offenders. Loops are almost always concentrated in one model.
+
+2. **Score individual logs**:
+
+   ```bash
+   python3 .pi-go/skills/pi-loop-forensics/score_run.py ~/.pi-go/log/*/session-*.log
+   ```
+
+   Three metrics per log: `think_run` (longest tool-free thinking run),
+   `reps/period` (longest byte-exact periodic tail), `intent/calls`
+   ("let me write/run/test" phrases vs actual tool calls). A high intent:calls
+   ratio is the signature of announce-but-never-act.
+
+   `reps>=12` is the reliable discriminator. The `think_run>=20` arm is
+   heuristic and does produce false positives on models that legitimately think
+   in long bursts — confirm with `reps` before calling it a loop.
+
+3. **Discriminate the cause.** Run all three tests; do not stop at the first
+   plausible one.
+
+   - **Race / double-emission?** Hash every `thinking` payload in the session
+     and count exact duplicates, and check timestamps. Genuine model output has
+     **zero duplicate payloads**, varied lengths, and monotonic timestamps
+     spaced by stream latency. Duplicated payloads or identical timestamps
+     would mean pi-go re-emitted chunks — a real bug in the stream path.
+   - **Tool-parse failure?** Grep thinking *and* text for tool-call syntax that
+     leaked in as prose: `<tool_call`, `<function`, `tool_calls`,
+     `"name":...,"arguments"`, ` ```json `, `<think>`, `<｜tool`. If the model
+     emitted a call the provider layer failed to parse, the raw syntax shows up
+     in a text channel and the model never receives a result — which looks
+     exactly like a loop. Zero matches rules this out.
+   - **Guard too low?** Compare the tripping value against the corpus. Healthy
+     sessions peak around 1 periodic repeat; the threshold is 12 byte-exact
+     copies. If healthy runs sit far below the threshold, the guard is not the
+     problem.
+
+   If all three are ruled out, it is inference-level repetition collapse, and
+   the fix is a provider/sampling question, not a pi-go parsing question.
+
+4. **A/B replay across providers.** Find a seed session whose **last persisted
+   event is the tool result immediately before the spiral** — the degenerate
+   thinking usually never gets committed to `events.jsonl`, so resuming
+   restores the exact pre-failure state and the next turn is the one that broke.
+
+   ```bash
+   # From an isolated worktree — a resumed agent can write files.
+   PI=/path/to/pi TRIALS=3 OUT=/tmp/ab-replay \
+     bash .pi-go/skills/pi-loop-forensics/ab_replay.sh
+   ```
+
+   Arms are `ollama-cloud`, `ollama-local`, `opencode` (override with
+   `ARMS="ollama-cloud opencode"`). Each arm runs a **preflight** one-shot first
+   and is skipped with its error if credentials are dead, so a bad key costs one
+   call instead of every trial. Override the seed with `SEED=<session-id>`.
+
+   Per trial the script copies the seed to a throwaway session ID (the original
+   is never mutated), rewrites `meta.json` (`id`/`model`/`provider`/`workDir`),
+   resumes with `--trace-http --mode print`, scores the log, and deletes the copy.
+
+   - Nothing pins temperature or seed, so reproduction is **probabilistic** —
+     run several trials per arm and compare rates, not single outcomes.
+   - `--trace-http` writes full request/response bodies to the session log.
+     Credentials are masked (`internal/provider/provider.go:440`); **prompts and
+     source context are not**.
+   - Run from a git worktree, never the primary checkout: a resumed agent can
+     write files.
+
+## Guidelines
+
+- Always name the model and check it against the commit timeline before
+  concluding anything about an old log.
+- An abort message describes the symptom the guard caught, not the cause. A
+  correct abort on genuine degeneration and a false positive on healthy polling
+  look identical in the log.
+- Ollama requests set only `num_predict` (`internal/provider/ollama.go:104-110`)
+  — no `repeat_penalty`, `repeat_last_n`, `temperature`. A looping Ollama model
+  currently has no tunable knob, which makes provider A/B the informative test.
+- When reporting, separate *the guard behaved correctly* from *the model
+  degenerated*. Both can be true at once, and they imply different fixes.
+
+## Probing providers: `pi ping` is not trustworthy
+
+Verified 2026-08-09. `pi ping` resolves URLs and credentials differently from the
+real agent path, so a ping failure is **not** evidence a provider is down.
+Confirm with a one-shot real run instead:
+
+```bash
+./pi --model <model> --mode print "reply with exactly: OK"
+```
+
+Observed ping-only failures, all of which the real path handled fine:
+
+| Symptom | Cause |
+|---|---|
+| `DNS resolution failed: lookup : no such host` (empty host) on `opencode/*` | ping never applies `opencodeDefaultBaseURL` (`internal/provider/opencode.go:62`) |
+| `<model>:cloud` dials `localhost:11434` despite `OLLAMA_API_KEY` being set | ping does not pass the key, so the cloud-URL switch (`internal/provider/ollama.go:38`) never fires |
+| `dial tcp [::1]:11434: connection refused` while the daemon is up | ping's dialer picks the IPv6 literal; the Ollama daemon binds IPv4. Pass `--url http://127.0.0.1:11434` |
+
+Keys live in `~/.pi-go/.env` **and** `<repo>/.pi-go/.env`; pi-go merges both
+(`internal/config/config.go:387-389`). Neither is in a shell profile, so an
+agent's own shell will not have them exported — but pi-go reads the files
+itself, so that only matters for scripts that gate on env vars.
+
+## Examples
+
+- `/pi-loop-forensics` — sweep all logs, report per-model loop distribution
+- "why did my run abort with 'repeated a 89-character phrase'" — steps 2 and 3
+- "does this loop happen on the other provider too" — step 4

--- a/.pi-go/skills/pi-loop-forensics/ab_replay.sh
+++ b/.pi-go/skills/pi-loop-forensics/ab_replay.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# A/B replay of a degenerate-turn seed session across provider paths, traces on.
+#
+# The seed session must end at the tool result immediately BEFORE the spiral —
+# the degenerate thinking is usually never committed to events.jsonl, so
+# resuming restores the exact pre-failure state and the next turn is the one
+# that broke.
+#
+# Each trial copies the seed to a throwaway session ID (the original is never
+# mutated), rewrites meta.json (id/model/provider/workDir), resumes with
+# --trace-http, then scores the resulting log.
+#
+# Keys come from ~/.pi-go/.env and <repo>/.pi-go/.env, which pi-go merges itself.
+set -uo pipefail
+
+SEED=${SEED:-260809-1229-ecff9-4280b}
+SESS=~/.pi-go/sessions
+TRIALS=${TRIALS:-3}
+PROMPT=${PROMPT:-continue}
+PI=${PI:-pi}
+OUT=${OUT:-/tmp/ab-replay}
+WORKDIR=${WORKDIR:-$PWD}
+ARMS=${ARMS:-"ollama-cloud ollama-local opencode"}
+mkdir -p "$OUT"
+
+[[ -d "$SESS/$SEED" ]] || { echo "seed session missing: $SESS/$SEED"; exit 1; }
+
+model_for() { case "$1" in
+  ollama-cloud) echo "deepseek-v4-flash:0731:cloud";;
+  ollama-local) echo "ollama/deepseek-v4-flash:0731-cloud";;
+  opencode)     echo "opencode/deepseek-v4-flash";;
+  *) echo "";; esac; }
+provider_for() { case "$1" in opencode) echo opencode;; *) echo ollama;; esac; }
+
+for arm in $ARMS; do
+  model=$(model_for "$arm"); [[ -n "$model" ]] || { echo "unknown arm: $arm"; continue; }
+  # Preflight: a dead credential would waste every trial in the arm.
+  if ! timeout 120 "$PI" --model "$model" --mode print "reply with exactly: OK" >/dev/null 2>"$OUT/$arm.preflight"; then
+    echo "=== arm $arm : SKIPPED - preflight failed"
+    sed -n 's/.*error: /    /p' "$OUT/$arm.preflight" | head -2
+    continue
+  fi
+  echo "=== arm $arm : $model ==="
+  for i in $(seq 1 "$TRIALS"); do
+    id="replay-${arm}-${i}-$$"
+    cp -R "$SESS/$SEED" "$SESS/$id"
+    python3 - "$SESS/$id/meta.json" "$id" "$model" "$(provider_for "$arm")" "$WORKDIR" <<'PY'
+import json,sys
+p,i,m,pr,wd=sys.argv[1:6]
+d=json.load(open(p)); d.update(id=i,model=m,provider=pr,workDir=wd)
+json.dump(d,open(p,"w"),indent=2)
+PY
+    timeout 900 "$PI" --session "$id" --model "$model" --trace-http \
+        --mode print "$PROMPT" >"$OUT/${arm}-${i}.stdout" 2>&1
+    rc=$?
+    # Find the log by its session field, NOT by mtime: other pi sessions may run
+    # concurrently and would otherwise be picked up as this trial's log.
+    found=$(grep -l "\"session\":\"$id\"" ~/.pi-go/log/*/*.log 2>/dev/null | head -1)
+    if [[ -n "$found" ]]; then
+      cp "$found" "$OUT/${arm}-${i}.log"
+      printf "  trial %s rc=%-3s " "$i" "$rc"
+      python3 "$(dirname "$0")/score_run.py" "$OUT/${arm}-${i}.log"
+    else
+      echo "  trial $i rc=$rc (no log for session $id - see ${arm}-${i}.stdout)"
+    fi
+    rm -rf "$SESS/$id"
+  done
+done
+echo; echo "logs + traces in $OUT"

--- a/.pi-go/skills/pi-loop-forensics/scan_logs.py
+++ b/.pi-go/skills/pi-loop-forensics/scan_logs.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Scan all pi-go session logs for loop / degenerate-turn signatures."""
+import json, os, glob, re
+from collections import Counter, defaultdict
+
+ROOT = os.path.expanduser("~/.pi-go/log")
+files = sorted(glob.glob(os.path.join(ROOT, "*", "*.log")))
+
+def load(p):
+    rows = []
+    with open(p, errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                pass
+    return rows
+
+def repeat_period(buf, probe=48):
+    if len(buf) < probe * 2:
+        return 0
+    p = buf[-probe:]
+    prev = buf.rfind(p, 0, len(buf) - probe)
+    if prev < 0:
+        return 0
+    return len(buf) - probe - prev
+
+def max_periodic_repeats(buf, period):
+    """How many back-to-back copies of the tail period exist."""
+    if period <= 0:
+        return 0
+    n = 1
+    while (n + 1) * period <= len(buf):
+        a = buf[len(buf) - (n + 1) * period: len(buf) - n * period]
+        b = buf[len(buf) - n * period:]
+        if a != b[:period]:
+            break
+        n += 1
+    return n
+
+sessions = []
+for p in files:
+    rows = load(p)
+    if not rows:
+        continue
+    start = next((r for r in rows if r.get("type") == "session_start"), {})
+    model = start.get("model", "?")
+    types = Counter(r.get("type") for r in rows)
+    aborted = [r for r in rows if r.get("type") == "error"
+               and "loop aborted" in str(r.get("content", ""))]
+
+    # longest run of consecutive thinking events with no tool_call between
+    run = 0
+    best_run = 0
+    best_bytes = 0
+    cur_bytes = 0
+    runs = []
+    for r in rows:
+        t = r.get("type")
+        if t == "thinking":
+            run += 1
+            cur_bytes += len(str(r.get("content", "")))
+        elif t in ("tool_call", "user", "llm_text"):
+            if run:
+                runs.append((run, cur_bytes))
+            run = 0
+            cur_bytes = 0
+    if run:
+        runs.append((run, cur_bytes))
+    if runs:
+        best_run, best_bytes = max(runs, key=lambda x: x[1])
+
+    # near-miss repetition: scan concatenated thinking for periodic tails
+    think = "".join(str(r.get("content", "")) for r in rows if r.get("type") == "thinking")
+    near = 0
+    near_period = 0
+    # sample the stream in windows to find the worst periodicity
+    step = 2000
+    for i in range(step, len(think) + step, step):
+        w = think[max(0, i - 8192): i]
+        per = repeat_period(w)
+        if per >= 16:
+            reps = max_periodic_repeats(w, per)
+            if reps > near:
+                near, near_period = reps, per
+
+    # identical consecutive tool calls
+    sig = None
+    streak = 0
+    max_streak = 0
+    max_streak_name = ""
+    for r in rows:
+        if r.get("type") != "tool_call":
+            continue
+        s = json.dumps(r.get("content"), sort_keys=True) if not isinstance(r.get("content"), str) else r.get("content")
+        s = f"{r.get('tool','')}|{s}"
+        if s == sig:
+            streak += 1
+        else:
+            sig, streak = s, 1
+        if streak > max_streak:
+            max_streak, max_streak_name = streak, r.get("tool", "?")
+
+    sessions.append(dict(
+        path=p, model=model, rows=len(rows), types=types,
+        aborted=[str(a.get("content")) for a in aborted],
+        max_think_run=best_run, max_think_bytes=best_bytes,
+        near_repeats=near, near_period=near_period,
+        max_tool_streak=max_streak, max_tool_name=max_streak_name,
+    ))
+
+print(f"scanned {len(sessions)} sessions across {len(set(os.path.dirname(s['path']) for s in sessions))} days\n")
+
+by_model = defaultdict(lambda: dict(n=0, aborts=0, think_runs=[], near=[]))
+for s in sessions:
+    m = by_model[s["model"]]
+    m["n"] += 1
+    m["aborts"] += len(s["aborted"])
+    m["think_runs"].append(s["max_think_run"])
+    m["near"].append(s["near_repeats"])
+
+print("=== per model ===")
+for model, m in sorted(by_model.items(), key=lambda x: -x[1]["n"]):
+    tr = sorted(m["think_runs"])
+    p95 = tr[int(len(tr) * .95)] if tr else 0
+    print(f"{model:38s} sessions={m['n']:4d} aborts={m['aborts']:3d} "
+          f"max_think_run(max/p95)={max(tr or [0]):4d}/{p95:4d} "
+          f"max_near_repeats={max(m['near'] or [0]):3d}")
+
+print("\n=== sessions that aborted ===")
+for s in sessions:
+    if s["aborted"]:
+        print(f"{os.path.basename(os.path.dirname(s['path']))}/{os.path.basename(s['path']):24s} "
+              f"{s['model']:34s} {s['aborted']}")
+
+print("\n=== top 20 by longest tool-free thinking run ===")
+for s in sorted(sessions, key=lambda x: -x["max_think_run"])[:20]:
+    print(f"{s['max_think_run']:4d} events {s['max_think_bytes']:7d}B  near_reps={s['near_repeats']:3d}(p={s['near_period']:4d}) "
+          f"toolstreak={s['max_tool_streak']:2d}  {s['model']:34s} "
+          f"{os.path.basename(os.path.dirname(s['path']))}/{os.path.basename(s['path'])}")
+
+print("\n=== top 15 by near-miss repetition (never aborted) ===")
+for s in sorted([x for x in sessions if not x["aborted"]], key=lambda x: -x["near_repeats"])[:15]:
+    print(f"reps={s['near_repeats']:3d} period={s['near_period']:5d}  think_run={s['max_think_run']:4d}  "
+          f"{s['model']:34s} {os.path.basename(os.path.dirname(s['path']))}/{os.path.basename(s['path'])}")

--- a/.pi-go/skills/pi-loop-forensics/score_run.py
+++ b/.pi-go/skills/pi-loop-forensics/score_run.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Score one pi-go session log for degenerate-turn signatures.
+
+Reports the three metrics that distinguish the failure modes seen in the corpus:
+  think_run   longest run of consecutive thinking events with no tool call
+  reps/period longest byte-exact periodic tail (the shape the guard aborts on)
+  intent/calls "let me write/run/test" phrases vs actual tool calls
+"""
+import json, sys, os, re
+
+def load(p):
+    out = []
+    for l in open(p, errors="replace"):
+        l = l.strip()
+        if l.startswith("{"):
+            try: out.append(json.loads(l))
+            except Exception: pass
+    return out
+
+def repeat_period(buf, probe=48):
+    if len(buf) < probe * 2: return 0
+    p = buf[-probe:]
+    prev = buf.rfind(p, 0, len(buf) - probe)
+    return 0 if prev < 0 else len(buf) - probe - prev
+
+def periodic_reps(buf, period):
+    if period <= 0: return 0
+    n = 1
+    while (n + 1) * period <= len(buf):
+        if buf[len(buf)-(n+1)*period: len(buf)-n*period] != buf[len(buf)-n*period:][:period]:
+            break
+        n += 1
+    return n
+
+def score(p):
+    rows = load(p)
+    start = next((r for r in rows if r.get("type") == "session_start"), {})
+    run = b = best = bb = 0
+    for r in rows:
+        if r.get("type") == "thinking":
+            run += 1; b += len(str(r.get("content", "")))
+        elif r.get("type") in ("tool_call", "user", "llm_text"):
+            if b > bb: best, bb = run, b
+            run = b = 0
+    if b > bb: best, bb = run, b
+
+    think = "".join(str(r.get("content","")) for r in rows if r.get("type")=="thinking")
+    reps = per = 0
+    for i in range(2000, len(think) + 2000, 2000):
+        w = think[max(0, i-8192):i]
+        pp = repeat_period(w)
+        if pp >= 16:
+            rr = periodic_reps(w, pp)
+            if rr > reps: reps, per = rr, pp
+
+    intents = len(re.findall(r"(?i)let me (write|run|create|test|do)", think))
+    calls = sum(1 for r in rows if r.get("type") == "tool_call")
+    aborted = any("loop aborted" in str(r.get("content","")) for r in rows if r.get("type")=="error")
+
+    verdict = "LOOP" if (aborted or reps >= 12 or best >= 20) else ("suspect" if best >= 8 else "ok")
+    print(f"{verdict:8s} think_run={best:4d} ({bb:7d}B) reps={reps:3d}/p={per:5d} "
+          f"intent={intents:3d} calls={calls:3d} aborted={aborted} model={start.get('model','?')}")
+    return verdict
+
+if __name__ == "__main__":
+    for p in sys.argv[1:]:
+        score(p)

--- a/README.md
+++ b/README.md
@@ -291,6 +291,39 @@ Precedence is `--url` flag, then environment variable, then `baseURLs` config. T
 `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `MISTRAL_BASE_URL`, `OPENCODE_BASE_URL`, and `OLLAMA_HOST`. A per-shell or
 CI override still takes effect. An empty env var does not mask a configured value.
 
+### Ollama generation tuning
+
+Ollama's per-request options are left at the server's own defaults, except for an
+output cap. Each knob below is opt-in: unset means the option is not sent at all,
+so Ollama's default stays in force. An unparseable value is ignored rather than
+fatal — a typo in an env var should not take down an otherwise healthy session.
+
+| Env var | Ollama option | Ollama default | Purpose |
+|---|---|---|---|
+| `PI_OLLAMA_NUM_PREDICT` | `num_predict` | unlimited | Max tokens generated per turn. Pi defaults this to `16384`; `0` or less removes the cap. |
+| `PI_OLLAMA_REPEAT_PENALTY` | `repeat_penalty` | `1.1` | How strongly repeated tokens are penalised. `1.0` disables. |
+| `PI_OLLAMA_REPEAT_LAST_N` | `repeat_last_n` | `64` | How many recent tokens the penalty looks back over. `0` disables, `-1` uses the full context. |
+| `PI_OLLAMA_PRESENCE_PENALTY` | `presence_penalty` | `0.0` | Flat penalty for tokens already used. |
+| `PI_OLLAMA_FREQUENCY_PENALTY` | `frequency_penalty` | `0.0` | Penalty scaled by how often a token was used. |
+
+These matter for models prone to repetition collapse, where a turn stops making
+progress and restates the same phrase until it hits a limit. `num_predict` only
+bounds how far such a turn runs; it does not stop it degenerating. The penalty
+window is the knob that targets the cause, and the default window is narrow:
+Ollama penalises repeats across the last 64 tokens only, while observed
+degenerate turns cycle on phrases of roughly 25–55 tokens, so a full cycle can
+fall outside the window the penalty can see.
+
+```bash
+# Widen the repetition window and penalise repeats harder.
+export PI_OLLAMA_REPEAT_LAST_N=512
+export PI_OLLAMA_REPEAT_PENALTY=1.2
+```
+
+Both apply to local Ollama and Ollama Cloud — they share one request path. Raising
+these trades diversity for repetition control, and a value that helps one model can
+degrade another, so tune per model rather than setting them globally.
+
 ### Custom OpenAI-compatible provider
 
 For OpenAI-compatible APIs with model names that Pi cannot infer from a prefix, explicitly set the role provider to

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -107,6 +107,15 @@ func (m *ollamaModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 			chatReq.Options["num_predict"] = n
 		}
 
+		if sampling := ollamaSamplingOptions(); len(sampling) > 0 {
+			if chatReq.Options == nil {
+				chatReq.Options = map[string]any{}
+			}
+			for k, v := range sampling {
+				chatReq.Options[k] = v
+			}
+		}
+
 		// No num_ctx for cloud models. api.ollama.com already serves each model
 		// at its native window, and sending a fixed value caps it instead of
 		// raising it: deepseek-v4-flash:0731-cloud has 1M, so the 256K that
@@ -179,6 +188,69 @@ func ollamaNumPredict() int {
 		return defaultOllamaNumPredict
 	}
 	return n
+}
+
+// ollamaSamplingOptions returns Ollama's repetition-control knobs, omitting any
+// the operator has not set so the server's own defaults stay in force. Nothing
+// is sent by default: these change generation quality for every model, and the
+// value that helps one can degrade another.
+//
+// They exist because num_predict only bounds how far a degenerate turn runs, it
+// does not stop the turn degenerating. Ollama applies repeat_penalty (default
+// 1.1) across the last repeat_last_n (default 64) tokens only. Measured
+// degenerate turns on deepseek-v4-flash cycle on phrases of 89-194 bytes,
+// roughly 25-55 tokens, so a 64-token window may not span a full cycle and the
+// penalty never sees the repetition it is meant to suppress. Widening
+// PI_OLLAMA_REPEAT_LAST_N is the knob that addresses that directly.
+//
+//	PI_OLLAMA_REPEAT_PENALTY     float, Ollama default 1.1 (1.0 disables)
+//	PI_OLLAMA_REPEAT_LAST_N      int, Ollama default 64 (0 disables, -1 = num_ctx)
+//	PI_OLLAMA_PRESENCE_PENALTY   float, Ollama default 0.0
+//	PI_OLLAMA_FREQUENCY_PENALTY  float, Ollama default 0.0
+//
+// An unparseable value is ignored rather than fatal: a typo in an env var
+// should not take down a session that would otherwise run.
+func ollamaSamplingOptions() map[string]any {
+	opts := make(map[string]any, 4)
+	if v, ok := ollamaEnvFloat("PI_OLLAMA_REPEAT_PENALTY"); ok {
+		opts["repeat_penalty"] = v
+	}
+	if v, ok := ollamaEnvInt("PI_OLLAMA_REPEAT_LAST_N"); ok {
+		opts["repeat_last_n"] = v
+	}
+	if v, ok := ollamaEnvFloat("PI_OLLAMA_PRESENCE_PENALTY"); ok {
+		opts["presence_penalty"] = v
+	}
+	if v, ok := ollamaEnvFloat("PI_OLLAMA_FREQUENCY_PENALTY"); ok {
+		opts["frequency_penalty"] = v
+	}
+	return opts
+}
+
+// ollamaEnvFloat reads a float env var, reporting whether it was set and valid.
+func ollamaEnvFloat(name string) (float64, bool) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// ollamaEnvInt reads an int env var, reporting whether it was set and valid.
+func ollamaEnvInt(name string) (int, bool) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
 }
 
 func ollamaFinishReasonToGenai(reason string) genai.FinishReason {

--- a/internal/provider/ollama_sampling_test.go
+++ b/internal/provider/ollama_sampling_test.go
@@ -1,0 +1,157 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// clearSamplingEnv pins every sampling var to empty, so the test is
+// deterministic on a machine where the operator has set them for real.
+func clearSamplingEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"PI_OLLAMA_REPEAT_PENALTY",
+		"PI_OLLAMA_REPEAT_LAST_N",
+		"PI_OLLAMA_PRESENCE_PENALTY",
+		"PI_OLLAMA_FREQUENCY_PENALTY",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestOllamaSamplingOptions_UnsetSendsNothing(t *testing.T) {
+	clearSamplingEnv(t)
+	if got := ollamaSamplingOptions(); len(got) != 0 {
+		t.Errorf("unset must send nothing so Ollama's defaults stay in force, got %v", got)
+	}
+}
+
+func TestOllamaSamplingOptions_SetValues(t *testing.T) {
+	clearSamplingEnv(t)
+	t.Setenv("PI_OLLAMA_REPEAT_PENALTY", "1.25")
+	t.Setenv("PI_OLLAMA_REPEAT_LAST_N", "512")
+	t.Setenv("PI_OLLAMA_PRESENCE_PENALTY", "0.5")
+	t.Setenv("PI_OLLAMA_FREQUENCY_PENALTY", "-0.25")
+
+	got := ollamaSamplingOptions()
+	want := map[string]any{
+		"repeat_penalty":    1.25,
+		"repeat_last_n":     512,
+		"presence_penalty":  0.5,
+		"frequency_penalty": -0.25,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d options, want %d: %v", len(got), len(want), got)
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("%s = %v (%T), want %v (%T)", k, got[k], got[k], w, w)
+		}
+	}
+}
+
+// A typo in an env var must not take down a session that would otherwise run.
+func TestOllamaSamplingOptions_GarbageIgnored(t *testing.T) {
+	clearSamplingEnv(t)
+	t.Setenv("PI_OLLAMA_REPEAT_PENALTY", "not-a-number")
+	t.Setenv("PI_OLLAMA_REPEAT_LAST_N", "1.5") // not an int
+	t.Setenv("PI_OLLAMA_PRESENCE_PENALTY", "0.3")
+
+	got := ollamaSamplingOptions()
+	if _, ok := got["repeat_penalty"]; ok {
+		t.Error("unparseable float must be dropped, not sent")
+	}
+	if _, ok := got["repeat_last_n"]; ok {
+		t.Error("unparseable int must be dropped, not sent")
+	}
+	if got["presence_penalty"] != 0.3 {
+		t.Errorf("a valid sibling must still be sent, got %v", got["presence_penalty"])
+	}
+}
+
+// repeat_last_n = 0 disables the penalty window and -1 means num_ctx; both are
+// meaningful to Ollama, so neither may be swallowed as "unset".
+func TestOllamaSamplingOptions_ZeroAndNegativeAreMeaningful(t *testing.T) {
+	clearSamplingEnv(t)
+	t.Setenv("PI_OLLAMA_REPEAT_LAST_N", "0")
+	if got := ollamaSamplingOptions()["repeat_last_n"]; got != 0 {
+		t.Errorf("repeat_last_n=0 must be sent, got %v", got)
+	}
+	t.Setenv("PI_OLLAMA_REPEAT_LAST_N", "-1")
+	if got := ollamaSamplingOptions()["repeat_last_n"]; got != -1 {
+		t.Errorf("repeat_last_n=-1 must be sent, got %v", got)
+	}
+}
+
+func TestOllamaChatRequest_CarriesSamplingOptions(t *testing.T) {
+	clearSamplingEnv(t)
+	t.Setenv("PI_OLLAMA_REPEAT_PENALTY", "1.3")
+	t.Setenv("PI_OLLAMA_REPEAT_LAST_N", "256")
+
+	var gotOptions map[string]any
+	srv := newMockOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotOptions, _ = body["options"].(map[string]any)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		writeNDJSON(w, []any{
+			ollamaChatLine("test", "assistant", "hi", "", "stop", true, 1, 1, nil),
+		})
+	})
+
+	llm := newOllamaModelFromServer(t, srv, "test", "none")
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+	}
+	for range llm.GenerateContent(context.Background(), req, true) { //nolint:revive // drain
+	}
+
+	if gotOptions == nil {
+		t.Fatal("request carried no options")
+	}
+	if got, ok := gotOptions["repeat_penalty"].(float64); !ok || got != 1.3 {
+		t.Errorf("repeat_penalty = %v, want 1.3", gotOptions["repeat_penalty"])
+	}
+	if got, ok := gotOptions["repeat_last_n"].(float64); !ok || int(got) != 256 {
+		t.Errorf("repeat_last_n = %v, want 256", gotOptions["repeat_last_n"])
+	}
+	// The existing output cap must survive the merge.
+	if got, ok := gotOptions["num_predict"].(float64); !ok || int(got) != defaultOllamaNumPredict {
+		t.Errorf("num_predict = %v, want %d", gotOptions["num_predict"], defaultOllamaNumPredict)
+	}
+}
+
+// With nothing configured the request must look exactly as it did before this
+// feature existed: the cap, and no sampling keys at all.
+func TestOllamaChatRequest_NoSamplingKeysWhenUnset(t *testing.T) {
+	clearSamplingEnv(t)
+
+	var gotOptions map[string]any
+	srv := newMockOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotOptions, _ = body["options"].(map[string]any)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		writeNDJSON(w, []any{
+			ollamaChatLine("test", "assistant", "hi", "", "stop", true, 1, 1, nil),
+		})
+	})
+
+	llm := newOllamaModelFromServer(t, srv, "test", "none")
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}}},
+	}
+	for range llm.GenerateContent(context.Background(), req, true) { //nolint:revive // drain
+	}
+
+	for _, k := range []string{"repeat_penalty", "repeat_last_n", "presence_penalty", "frequency_penalty"} {
+		if _, ok := gotOptions[k]; ok {
+			t.Errorf("%s must not be sent when unset", k)
+		}
+	}
+}

--- a/specs/features/LLM/002-ollama-sampling-parameters/ollama-sampling-parameters.md
+++ b/specs/features/LLM/002-ollama-sampling-parameters/ollama-sampling-parameters.md
@@ -1,0 +1,219 @@
+# Ollama Sampling Parameters
+
+> Source: Ollama API docs — `options` object in the generate/chat request.
+> Captured: 2026-08-06
+
+Ollama exposes four parameters that control how the underlying llama.cpp engine
+penalizes token repetition: `repeat_penalty`, `repeat_last_n`, `presence_penalty`,
+and `frequency_penalty`.
+
+---
+
+## repeat_penalty
+
+- **What it does:** Applies a multiplicative penalty to tokens that have already
+  appeared in the recent context, making the model less likely to repeat them.
+- **How it works:** For each token already seen in the last `repeat_last_n`
+  tokens, its logit is divided by `repeat_penalty`. A value of `1.1` reduces the
+  score of repeated tokens by ~10%.
+- **Typical range:** `1.0` (off) to `2.0`. Default is `1.1`.
+- **Use case:** The main knob for suppressing loops, stutters, and verbatim
+  repetition.
+
+## repeat_last_n
+
+- **What it does:** Sets the window of recent tokens that `repeat_penalty` looks at.
+- **How it works:** Only tokens within the last `repeat_last_n` tokens are
+  considered "recent" and get penalized. Tokens older than that are ignored.
+- **Typical range:** `64`–`512`. Default is `64`.
+- **Sentinels:** `0` **disables** the penalty entirely; `-1` means "use the whole
+  context" (`num_ctx`).
+- **Use case:** Balance between stopping short-range repetition (small window)
+  and long-range repetition (large window).
+
+> **Correction (2026-08-09).** An earlier revision of this note stated that `0`
+> penalises against the whole context. That is inverted. Verified against
+> `github.com/ollama/ollama@v0.32.5`:
+> `x/mlxrunner/sample/sample.go:225` — *"RepeatLastN == 0 disables the penalty
+> ring per the repeat_last_n API contract (0 = disabled), overriding any penalty
+> coefficients"* — and `:236` resolves the `-1` sentinel against `num_ctx`.
+> Setting `0` to "be safe" therefore turns repetition control **off**, including
+> `presence_penalty` and `frequency_penalty`, which share the same history ring.
+
+## presence_penalty
+
+- **What it does:** Adds a fixed penalty to any token that has appeared at all in
+  the context, regardless of how many times.
+- **How it works:** A constant is subtracted from the logit of any token present
+  in the context. It is a flat "you've been used, so you're less likely to be used
+  again" penalty.
+- **Typical range:** `-2.0` to `2.0`. Default is `0` (off).
+- **Use case:** Encourages the model to talk about new topics. Because it is a
+  flat penalty, it does not punish *frequency* — just presence.
+
+## frequency_penalty
+
+- **What it does:** Penalizes tokens in proportion to how many times they've appeared.
+- **How it works:** The penalty scales with the token's count in the context — the
+  more often a token appears, the more its logit is reduced.
+- **Typical range:** `-2.0` to `2.0`. Default is `0` (off).
+- **Use case:** Discourages the model from overusing common words or phrases,
+  pushing toward more varied vocabulary.
+
+---
+
+## How they relate
+
+| Parameter | Penalty type | Scales with count? | Window-limited? |
+|---|---|---|---|
+| `repeat_penalty` | multiplicative | no (flat per occurrence) | yes (`repeat_last_n`) |
+| `repeat_last_n` | window control | — | — |
+| `presence_penalty` | additive, flat | no | no |
+| `frequency_penalty` | additive, scaled | yes | no |
+
+**Key distinction:** `repeat_penalty` is the llama.cpp-native mechanism
+(multiplicative, windowed). `presence_penalty` and `frequency_penalty` are the
+OpenAI-style additive penalties that Ollama also exposes — `presence` is a flat
+"seen it" penalty, `frequency` scales with how often a token appears.
+
+---
+
+## Practical guidance
+
+- To stop loops/stutters: raise `repeat_penalty` (e.g. `1.1` → `1.3`).
+- To force more diverse vocabulary: raise `frequency_penalty` (e.g. `0.5`–`1.0`).
+- To push toward new topics: raise `presence_penalty`.
+- If you raise `repeat_penalty` but still see long-range repetition, increase
+  `repeat_last_n`.
+
+---
+
+## API usage
+
+In Ollama's API these are passed in the `options` object of a request:
+
+```json
+{
+  "model": "llama3",
+  "prompt": "...",
+  "options": {
+    "repeat_penalty": 1.2,
+    "repeat_last_n": 128,
+    "presence_penalty": 0.5,
+    "frequency_penalty": 0.5
+  }
+}
+```
+
+---
+
+## Implementation in pi-go
+
+**Status:** implemented 2026-08-09 on `feat/ollama-sampling-options`.
+**Code:** `internal/provider/ollama.go` (`ollamaSamplingOptions`, `ollamaEnvFloat`,
+`ollamaEnvInt`). **Tests:** `internal/provider/ollama_sampling_test.go`.
+**User docs:** README → *Ollama generation tuning*.
+
+Before this change pi-go sent exactly one Ollama option, `num_predict`. All four
+repetition controls ran at server defaults with no way to tune them.
+
+| Env var | Ollama option | Ollama default |
+|---|---|---|
+| `PI_OLLAMA_NUM_PREDICT` | `num_predict` | unlimited (pi-go defaults to `16384`) |
+| `PI_OLLAMA_REPEAT_PENALTY` | `repeat_penalty` | `1.1` |
+| `PI_OLLAMA_REPEAT_LAST_N` | `repeat_last_n` | `64` |
+| `PI_OLLAMA_PRESENCE_PENALTY` | `presence_penalty` | `0.0` |
+| `PI_OLLAMA_FREQUENCY_PENALTY` | `frequency_penalty` | `0.0` |
+
+### Design decisions
+
+- **Opt-in, no new defaults.** An unset var is omitted from the request entirely
+  rather than sent as a zero value, so Ollama's own defaults stay in force and
+  behaviour is unchanged for anyone who sets nothing. Picking new defaults would
+  change generation quality for every Ollama model, and a value that helps one
+  model can degrade another.
+- **`0` and `-1` are forwarded, not swallowed.** Both are meaningful to Ollama
+  (see the correction above), so "set to 0" must not be indistinguishable from
+  "unset".
+- **Invalid values are ignored, not fatal.** A typo in an env var should not take
+  down a session that would otherwise run. A valid sibling still applies.
+- **One request path.** Local Ollama and Ollama Cloud share it, so these apply to
+  both. The only local/cloud divergence is `num_ctx`, deliberately not sent for
+  cloud models.
+
+### Why this was needed
+
+From a corpus sweep of 496 pi-go session logs (29 days, 25 models), degenerate
+"repetition collapse" turns — where a turn stops making progress and restates
+one phrase — were concentrated almost entirely in `deepseek-v4-flash` served by
+Ollama. Other models peaked at a longest tool-free thinking run of 0–45 events;
+DeepSeek reached 164 events / 148 KB.
+
+Measured properties of those turns:
+
+- Repeating units of **89–194 bytes**, roughly **25–55 tokens**.
+- Repeated **12–71 times back to back**, byte-exact.
+- Up to **80 KB of thinking with zero tool calls** in a single turn.
+
+The default `repeat_last_n` of 64 tokens may not span a full cycle at that
+length, so the penalty can fail to see the repetition it exists to suppress.
+That is the specific reason `repeat_last_n` is the knob of interest here, and
+why `num_predict` alone was insufficient: it bounds how far a degenerate turn
+runs, it does not stop the turn degenerating.
+
+Thinking level is *not* a viable lever for this model. Measured on one prompt at
+`low`/`medium`/`high`/`max`, within-level variance (703 → 25 436 chars) dwarfed
+any between-level difference, so the level does not reliably control reasoning
+length for `deepseek-v4-flash`.
+
+### Validation
+
+Method: resume a seed session whose last persisted event is the tool result
+immediately before a known spiral, then score the resulting log (see the
+`pi-loop-forensics` skill and its `ab_replay.sh`).
+
+Wire format confirmed on a live request:
+`"options":{"num_predict":16384,"repeat_last_n":512,"repeat_penalty":1.2}`.
+
+| Configuration | Trials | Looped | Byte-exact `reps` observed |
+|---|---|---|---|
+| Baseline, ollama-local | 3 | **3/3** | 0, 67, 42 |
+| Baseline, ollama-cloud | 3 | **2/3** | 1, 71, 1 |
+| `repeat_last_n=512`, `repeat_penalty=1.2` | 3 | **1/3** | 0, 0, 0 |
+
+Per-trial detail for the tuned run (`think_run` = longest tool-free thinking run):
+
+| Trial | Verdict | `think_run` | `reps` |
+|---|---|---|---|
+| 1 | ok | 3 (1.4 KB) | 0 |
+| 2 | LOOP | 57 (23 KB) | 0 |
+| 3 | suspect | 8 (4.0 KB) | 0 |
+
+**Interpretation — the penalties do what they are designed to do, and no more.**
+Byte-exact repetition was eliminated: `reps` fell to 0 in every tuned trial,
+against 67 and 42 in the baseline. But trial 2 still spun for 57 consecutive
+thinking events and 23 KB without calling a tool. The model stopped repeating
+*verbatim* and carried on repeating *semantically* — paraphrasing itself instead
+of copying itself.
+
+Two consequences follow:
+
+1. `repeat_penalty` / `repeat_last_n` are a genuine mitigation for the collapse
+   shape that `observeOutput` detects, and appear to reduce the overall loop rate
+   (3/3 → 1/3). On n=3 with unpinned sampling that rate difference is suggestive,
+   not established; the `reps` → 0 effect is the solid part.
+2. They make the failure **harder to detect**. The guard keys on byte-exact
+   periodicity, so suppressing verbatim repeats can convert a detectable loop
+   into an undetectable one. Any default change here should land together with a
+   detector that catches semantic looping — a cap on consecutive thinking events
+   with no tool call — or it will trade a visible failure for a silent one.
+
+No default is proposed on this evidence.
+
+### Follow-up, not addressed here
+
+The runaway guard (`stuckDetector`) is instantiated only in
+`internal/tui/agent_loop.go`. `runPrint` and the json/socket/rpc and ACP paths
+have no repetition protection at all — trials with 71, 67 and 42 byte-exact
+repeats ran to completion without aborting. Sampling parameters reduce the odds
+of a loop; they are not a substitute for that guard.


### PR DESCRIPTION
## What

pi-go sent exactly one Ollama option, `num_predict`. The four repetition controls Ollama exposes ran at server defaults with no way to tune them, so a model in repetition collapse had no knob at all.

| Env var | Ollama option | Ollama default |
|---|---|---|
| `PI_OLLAMA_REPEAT_PENALTY` | `repeat_penalty` | `1.1` |
| `PI_OLLAMA_REPEAT_LAST_N` | `repeat_last_n` | `64` |
| `PI_OLLAMA_PRESENCE_PENALTY` | `presence_penalty` | `0.0` |
| `PI_OLLAMA_FREQUENCY_PENALTY` | `frequency_penalty` | `0.0` |

## Design decisions

- **Opt-in, no new defaults.** An unset var is omitted from the request entirely rather than sent as a zero value, so Ollama's defaults stay in force and behaviour is byte-identical for anyone who sets nothing. Picking defaults would change generation quality for every Ollama model, and a value that helps one can degrade another.
- **`0` and `-1` are forwarded, not swallowed.** Both are meaningful to `repeat_last_n` — `0` disables the penalty ring, `-1` means `num_ctx` — so "set to 0" must not be indistinguishable from "unset".
- **Invalid values are ignored, not fatal.** A typo in an env var should not take down a session that would otherwise run; a valid sibling still applies.
- **One request path.** Local Ollama and Ollama Cloud share it, so these apply to both.

## Why

`num_predict` bounds how far a degenerate turn runs; it does not stop the turn degenerating. Ollama penalises repeats across the last 64 tokens by default, while measured degenerate turns on `deepseek-v4-flash` cycle on phrases of 89–194 bytes (~25–55 tokens) — so a full cycle can fall outside the window the penalty can see.

Found via a sweep of 496 session logs (29 days, 25 models). Degenerate turns were concentrated almost entirely in `deepseek-v4-flash` on Ollama: other models peaked at a longest tool-free thinking run of 0–45 events, DeepSeek reached 164 events / 148 KB.

## Validation

Method: resume a seed session whose last persisted event is the tool result immediately before a known spiral, then score the resulting log. Wire format confirmed live: `"options":{"num_predict":16384,"repeat_last_n":512,"repeat_penalty":1.2}`.

| Configuration | Trials | Looped | byte-exact `reps` |
|---|---|---|---|
| Baseline, ollama-local | 3 | **3/3** | 0, 67, 42 |
| Baseline, ollama-cloud | 3 | **2/3** | 1, 71, 1 |
| `repeat_last_n=512`, `repeat_penalty=1.2` | 3 | **1/3** | **0, 0, 0** |

**The penalties do what they are designed to do, and no more.** Byte-exact repetition was eliminated. But the surviving failure still spun 57 consecutive thinking events / 23 KB with no tool call — the model stopped repeating *verbatim* and kept repeating *semantically*.

Two consequences, both stated in the spec:

1. The 3/3 → 1/3 rate drop is suggestive but **not established** at n=3 with unpinned sampling. The `reps` → 0 effect is the solid part.
2. These settings can make the failure **harder to detect**. `observeOutput` keys on byte-exact periodicity, so suppressing verbatim repeats can convert a detectable loop into a silent one.

**No default is proposed on this evidence.** A default should land together with a semantic-loop detector, or it trades a visible failure for an invisible one.

## Tests

6 new in `internal/provider/ollama_sampling_test.go`:

- unset sends nothing (Ollama defaults preserved)
- values marshal with correct types
- garbage dropped while a valid sibling survives
- `0` and `-1` preserved as meaningful
- wire test: merge does not clobber `num_predict`
- regression: no sampling keys present when unset

Full unit suite green, `go vet` clean, `golangci-lint run internal/provider/...` → 0 issues.

> Note: `TestNewPromptHandler_NoAPIKey` (`internal/acp/server`) fails when `ANTHROPIC_API_KEY` is set in the environment — it expects the no-key path but makes a real API call. Confirmed **pre-existing on clean `main`** and passing with the key unset. Unrelated to this change.

## Also included

- **`.pi-go/skills/pi-loop-forensics/`** — the skill used to produce these measurements: `scan_logs.py` (corpus sweep), `score_run.py` (per-log scoring), `ab_replay.sh` (provider A/B replay with preflight). Documents the detector's mechanics, a commit-timeline caveat for judging old logs, a three-way procedure for discriminating a race vs a tool-parse failure vs a too-low guard, and the fact that `pi ping` resolves URLs and credentials differently from the real agent path (it gave three false "provider down" readings).
- **Spec correction** — `specs/features/LLM/002-ollama-sampling-parameters` had the `repeat_last_n` sentinels inverted, claiming `0` scans the whole context. Verified against `ollama@v0.32.5` (`x/mlxrunner/sample/sample.go:225`): `0` **disables** the penalty entirely, overriding the coefficients, and `-1` means `num_ctx`.

## Follow-up, not in this PR

The runaway guard (`stuckDetector`) is instantiated only in `internal/tui/agent_loop.go`. `runPrint` and the json/socket/rpc and ACP paths have **no repetition protection at all** — replay trials with 71, 67 and 42 byte-exact repeats ran to completion without aborting. There is also no session-level token cap; the only `TokenBudget` in the tree belongs to the memory subsystem.
