### PR TITLE
feat(agent): abort turns that reason at length without ever acting

### DIFF
--- a/internal/agent/stuck.go
+++ b/internal/agent/stuck.go
@@ -11,10 +11,11 @@ import (
 )
 
 // StuckDetector recognizes an agent turn that has stopped making progress:
-// identical tool calls, a tool failing over and over, or the model's own output
-// collapsing into repetition. It lives here rather than in the TUI so every
-// front end -- interactive, print, json, rpc and ACP -- shares one guard. A
-// front end that skips it runs unprotected.
+// identical tool calls, a tool failing over and over, the model's own output
+// collapsing into repetition, or the model reasoning at length without ever
+// acting. It lives here rather than in the TUI so every front end --
+// interactive, print, json, rpc and ACP -- shares one guard. A front end that
+// skips it runs unprotected.
 //
 // The zero value is ready to use. Not safe for concurrent use; one value tracks
 // one run.
@@ -68,6 +69,40 @@ const (
 	// outputCheckEvery is how much new output accumulates between scans.
 	// Scanning per token would put a linear search in the streaming path.
 	outputCheckEvery = 512
+
+	// MaxThinkingEventStreak is how many consecutive model events may carry
+	// thinking or reply text without a single tool call before the turn is
+	// called degenerate. It is only half the test: MinThinkingStreakBytes
+	// must be met as well (see ObserveThinking).
+	//
+	// The number comes from measured runs. The longest tool-free reasoning
+	// burst seen in a *healthy* run was 45 events / 13 KB (minimax-m3, in a
+	// session that went on to make 37 tool calls); claude-sonnet's longest was
+	// 7. Degenerate runs measured 21, 34, 38, 57, 68, 78, 87, 89, 122 and 164
+	// events, spanning 10 KB to 148 KB. The two populations overlap at the low
+	// end, so no threshold separates them cleanly and the choice is which
+	// error to make. A false abort kills legitimate deep reasoning outright,
+	// while a missed loop is still covered by the other three arms — so this
+	// arm is deliberately biased towards missing.
+	//
+	// 50 sits above every healthy run observed and catches 7 of the 10
+	// degenerate ones, including the 57-event / 23 KB case that motivated this
+	// arm and tripped nothing else (its output was semantically repetitive but
+	// never byte-exact, so ObserveOutput saw reps=0). The three shortest
+	// degenerate runs are below the healthy ceiling and are conceded.
+	MaxThinkingEventStreak = 50
+
+	// MinThinkingStreakBytes is how much tool-free text must accompany that
+	// streak. Event *count* alone is not a safe signal: providers chunk the
+	// stream differently, and measured events range from 1 byte to ~2.9 KB, so
+	// a token-level stream reaches 50 events in a sentence. Requiring volume
+	// as well makes the arm depend on how much the model actually said rather
+	// than on how its provider happens to packetize.
+	//
+	// 16 KiB clears the 13 KB of the largest healthy burst with room to spare,
+	// so a legitimate reasoning burst has to beat the observed ceiling on
+	// *both* axes at once to trip — a far stronger bar than either alone.
+	MinThinkingStreakBytes = 16384
 )
 
 // StuckDetector tracks recent tool calls and detects repetition loops.
@@ -81,6 +116,8 @@ type StuckDetector struct {
 	errStreak   int      // consecutive errors for that tool
 	outBuf      string   // rolling tail of the model's own output
 	outSince    int      // bytes of output since the last repetition scan
+	thinkEvents int      // consecutive model events with text and no tool call
+	thinkBytes  int      // text bytes accumulated over that streak
 }
 
 // volatileToolArgs address a slice of a target rather than the target itself.
@@ -222,6 +259,41 @@ func (s *StuckDetector) ObserveOutput(text string) (stuck bool, detail string) {
 	return true, fmt.Sprintf("model repeated a %d-character phrase %d times", period, MaxOutputRepeats)
 }
 
+// ObserveThinking records one model event that carried textBytes of thinking or
+// reply text and made no tool call, and reports whether the turn has spent too
+// long reasoning without ever acting.
+//
+// ObserveOutput above already watches for a turn that makes no tool calls, but
+// only catches *byte-exact* repetition. A model can loop semantically instead —
+// restating the same intent in fresh words on every pass, never calling a tool,
+// never making progress. Repetition penalties make that shape more likely, not
+// less, because they suppress the very signature ObserveOutput keys on. This
+// arm ignores what the text says and watches only for the absence of action.
+//
+// Both MaxThinkingEventStreak and MinThinkingStreakBytes must be exceeded; see
+// their comments for why one alone is not a safe signal.
+func (s *StuckDetector) ObserveThinking(textBytes int) (stuck bool, detail string) {
+	if textBytes <= 0 {
+		return false, ""
+	}
+	s.thinkEvents++
+	s.thinkBytes += textBytes
+	if s.thinkEvents < MaxThinkingEventStreak || s.thinkBytes < MinThinkingStreakBytes {
+		return false, ""
+	}
+	return true, fmt.Sprintf("model produced %d thinking events (%d bytes) with no tool call",
+		s.thinkEvents, s.thinkBytes)
+}
+
+// ResetThinking clears the tool-free streak. A tool call is progress by
+// definition, and so is its response; a turn that alternates reasoning with
+// action never accumulates a streak no matter how long it runs. Text authored
+// by anyone but the model resets it too, because that begins a fresh turn.
+func (s *StuckDetector) ResetThinking() {
+	s.thinkEvents = 0
+	s.thinkBytes = 0
+}
+
 // repeatPeriod returns the distance between the tail of buf and the previous
 // occurrence of that same tail — the length of the phrase the model may be
 // cycling on — or 0 when the tail does not recur.
@@ -333,22 +405,41 @@ func StuckErr(stuck bool, detail string) error {
 //
 // This exists so each front end does not hand-roll the same four calls in a
 // different order and drift apart.
+//
+// The tool-free-thinking arm is scored per event rather than per part, so an
+// event carrying three text parts counts once; the parts are summed first and
+// the verdict taken after the loop, once it is known whether the same event
+// also acted.
+//
+// No stream dedup is applied here, so under SSE the aggregate re-send is
+// counted alongside the deltas and the byte total runs roughly double. That is
+// deliberate rather than overlooked: the session logs the thresholds were
+// calibrated from are written without dedup on the thinking path too, so
+// measurement and runtime inflate alike. The practical effect is that
+// MinThinkingStreakBytes behaves like ~8 KiB of genuine text, which offsets
+// some of the conservatism chosen above.
 func (s *StuckDetector) ObserveEvent(ev *session.Event) error {
 	if ev == nil || ev.Content == nil {
 		return nil
 	}
+	textBytes, acted := 0, false
 	for _, part := range ev.Content.Parts {
 		if part.Text != "" {
+			textBytes += len(part.Text)
 			if err := StuckErr(s.ObserveOutput(part.Text)); err != nil {
 				return err
 			}
 		}
 		if fc := part.FunctionCall; fc != nil {
+			acted = true
+			s.ResetThinking()
 			if err := StuckErr(s.Observe(fc.Name, fc.Args)); err != nil {
 				return err
 			}
 		}
 		if fr := part.FunctionResponse; fr != nil {
+			acted = true
+			s.ResetThinking()
 			// A changed result on a repeated call is progress, not a loop.
 			s.ObserveResult(fr.Name, fr.Response)
 			_, isErr := fr.Response["error"]
@@ -357,5 +448,14 @@ func (s *StuckDetector) ObserveEvent(ev *session.Event) error {
 			}
 		}
 	}
-	return nil
+	if acted || textBytes == 0 {
+		return nil
+	}
+	// Text the model did not author — a user turn — starts the count over
+	// rather than adding to it.
+	if !modelRoles[ev.Content.Role] {
+		s.ResetThinking()
+		return nil
+	}
+	return StuckErr(s.ObserveThinking(textBytes))
 }

--- a/internal/agent/stuck_test.go
+++ b/internal/agent/stuck_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -432,5 +433,175 @@ func TestObserveEvent_ProductivePollingSurvives(t *testing.T) {
 		if err := d.ObserveEvent(respEvent("bash_output", map[string]any{"out": i})); err != nil {
 			t.Fatalf("productive polling aborted on result at %d: %v", i, err)
 		}
+	}
+}
+
+// The tool-free-thinking arm: a turn that reasons at length and never acts.
+
+// thinkingChunk returns a distinct ~360-byte block of model reasoning. Distinct
+// matters: identical blocks would trip ObserveOutput's byte-exact arm first, and
+// the test would silently stop exercising the arm it names.
+func thinkingChunk(i int) string {
+	return fmt.Sprintf("Pass %d: restating the goal in fresh words, %s, and still calling nothing.\n",
+		i, strings.Repeat(fmt.Sprintf("clause-%d ", i), 30))
+}
+
+// bigThinkingEvent is one model event carrying that block.
+func bigThinkingEvent(i int) *session.Event {
+	return textEvent("thinking", thinkingChunk(i), true)
+}
+
+func TestObserveEvent_TripsOnToolFreeThinking(t *testing.T) {
+	var d StuckDetector
+	var err error
+	seen := 0
+	for i := range MaxThinkingEventStreak * 2 {
+		seen = i + 1
+		if err = d.ObserveEvent(bigThinkingEvent(i)); err != nil {
+			break
+		}
+	}
+	if err == nil {
+		t.Fatalf("%d tool-free thinking events must abort", seen)
+	}
+	if !strings.Contains(err.Error(), "no tool call") {
+		t.Fatalf("a different arm fired: %q", err)
+	}
+	if seen < MaxThinkingEventStreak {
+		t.Errorf("aborted after %d events, want at least %d", seen, MaxThinkingEventStreak)
+	}
+}
+
+func TestObserveEvent_ThinkingBelowThresholdSurvives(t *testing.T) {
+	var d StuckDetector
+	for i := range MaxThinkingEventStreak - 1 {
+		if err := d.ObserveEvent(bigThinkingEvent(i)); err != nil {
+			t.Fatalf("aborted at event %d, below the threshold of %d: %v", i+1, MaxThinkingEventStreak, err)
+		}
+	}
+}
+
+// Volume alone is not enough either: a long streak of tiny chunks is how a
+// token-level provider packetizes ordinary reasoning, not a stalled turn.
+func TestObserveEvent_TinyThinkingChunksSurvive(t *testing.T) {
+	var d StuckDetector
+	total := 0
+	for i := range MaxThinkingEventStreak * 20 {
+		chunk := fmt.Sprintf("ok%d ", i)
+		total += len(chunk)
+		if err := d.ObserveEvent(textEvent("thinking", chunk, true)); err != nil {
+			t.Fatalf("aborted at event %d on %d bytes: %v", i+1, total, err)
+		}
+	}
+	if total >= MinThinkingStreakBytes {
+		t.Fatalf("test fed %d bytes, at or above the %d-byte floor; it no longer proves anything",
+			total, MinThinkingStreakBytes)
+	}
+}
+
+// A turn that alternates reasoning with action never accumulates a streak, no
+// matter how long it runs.
+func TestObserveEvent_ToolCallResetsThinkingStreak(t *testing.T) {
+	var d StuckDetector
+	for i := range MaxThinkingEventStreak * 10 {
+		if err := d.ObserveEvent(bigThinkingEvent(i)); err != nil {
+			t.Fatalf("interleaved run aborted at thinking event %d: %v", i+1, err)
+		}
+		if i%(MaxThinkingEventStreak-1) != 0 {
+			continue
+		}
+		// Distinct args, so neither the identical-call nor the cycle arm fires.
+		if err := d.ObserveEvent(callEvent("read", map[string]any{"path": fmt.Sprintf("f%d.go", i)})); err != nil {
+			t.Fatalf("interleaved run aborted on the tool call at %d: %v", i+1, err)
+		}
+	}
+}
+
+func TestObserveEvent_ToolResponseResetsThinkingStreak(t *testing.T) {
+	var d StuckDetector
+	for range 3 {
+		for i := range MaxThinkingEventStreak - 1 {
+			if err := d.ObserveEvent(bigThinkingEvent(i)); err != nil {
+				t.Fatalf("aborted at thinking event %d: %v", i+1, err)
+			}
+		}
+		if err := d.ObserveEvent(respEvent("read", map[string]any{"content": "ok"})); err != nil {
+			t.Fatalf("aborted on the tool response: %v", err)
+		}
+	}
+}
+
+// Text from anyone but the model is a new turn, not a continuation of the streak.
+func TestObserveEvent_UserTextResetsThinkingStreak(t *testing.T) {
+	var d StuckDetector
+	for range 3 {
+		for i := range MaxThinkingEventStreak - 1 {
+			if err := d.ObserveEvent(bigThinkingEvent(i)); err != nil {
+				t.Fatalf("aborted at thinking event %d: %v", i+1, err)
+			}
+		}
+		if err := d.ObserveEvent(textEvent("user", "actually, do this instead", false)); err != nil {
+			t.Fatalf("aborted on the user turn: %v", err)
+		}
+	}
+}
+
+// An event that both reasons and acts is progress; it must not count as
+// tool-free even though it carries text.
+func TestObserveEvent_ThinkingWithCallInSameEventIsProgress(t *testing.T) {
+	var d StuckDetector
+	for i := range MaxThinkingEventStreak * 3 {
+		ev := bigThinkingEvent(i)
+		ev.Content.Parts = append(ev.Content.Parts, &genai.Part{
+			FunctionCall: &genai.FunctionCall{Name: "read", Args: map[string]any{"path": fmt.Sprintf("f%d.go", i)}},
+		})
+		if err := d.ObserveEvent(ev); err != nil {
+			t.Fatalf("an event that reasons and acts aborted at %d: %v", i+1, err)
+		}
+	}
+}
+
+func TestObserveThinking_RequiresBothGates(t *testing.T) {
+	// Count without volume.
+	var byCount StuckDetector
+	for range MaxThinkingEventStreak * 4 {
+		if stuck, detail := byCount.ObserveThinking(1); stuck {
+			t.Fatalf("one-byte events must not trip on count alone: %s", detail)
+		}
+	}
+	// Volume without count.
+	var byBytes StuckDetector
+	if stuck, detail := byBytes.ObserveThinking(MinThinkingStreakBytes * 4); stuck {
+		t.Fatalf("a single large block must not trip on volume alone: %s", detail)
+	}
+	// Both.
+	var both StuckDetector
+	var stuck bool
+	var detail string
+	for range MaxThinkingEventStreak {
+		stuck, detail = both.ObserveThinking(MinThinkingStreakBytes/MaxThinkingEventStreak + 1)
+	}
+	if !stuck {
+		t.Fatal("meeting both gates must trip")
+	}
+	if !strings.Contains(detail, "no tool call") {
+		t.Errorf("detail = %q, want it to name the missing tool call", detail)
+	}
+}
+
+func TestObserveThinking_ResetAndEmpty(t *testing.T) {
+	var d StuckDetector
+	for range MaxThinkingEventStreak - 1 {
+		d.ObserveThinking(MinThinkingStreakBytes)
+	}
+	d.ResetThinking()
+	if d.thinkEvents != 0 || d.thinkBytes != 0 {
+		t.Fatalf("ResetThinking left events=%d bytes=%d, want both 0", d.thinkEvents, d.thinkBytes)
+	}
+	if stuck, _ := d.ObserveThinking(0); stuck {
+		t.Error("an event with no text must not count")
+	}
+	if d.thinkEvents != 0 {
+		t.Errorf("an event with no text advanced the streak to %d", d.thinkEvents)
 	}
 }

--- a/specs/issues/009-agent-loop-no-progress/README.md
+++ b/specs/issues/009-agent-loop-no-progress/README.md
@@ -1,0 +1,173 @@
+# Issue 009: Agent Turns That Make No Progress — Repetition Collapse and Semantic Looping
+
+## Summary
+
+An agent turn can stop making progress while still producing output: the model reasons,
+restates, and never calls a tool. Nothing new enters the loop, so it circles. Left unbounded
+this burns tokens quadratically (every turn resends the whole conversation), and until
+recently it ran unguarded on four of pi-go's five front ends.
+
+Three distinct failure shapes exist, and they need different guards:
+
+| Shape | What it looks like | Caught by |
+|---|---|---|
+| **Identical tool calls** | Same call, same args, same result, repeatedly | `Observe` (10) |
+| **Tool error streak** | Same tool failing over and over | `ObserveError` (10) |
+| **Repetition collapse** | Output degenerates into a byte-exact repeating phrase | `ObserveOutput` (12) |
+| **Semantic looping** | Model paraphrases itself forever, calls nothing | **nothing, until 009** |
+
+The fourth is the dangerous one: it precedes the third, produces no byte-exact signature,
+and is made *more* likely by the usual mitigation for the third.
+
+## Incident
+
+**2026-08-09**, session `260809-1229-ecff9-4280b`, model `deepseek-v4-flash:0731:cloud`.
+
+A run aborted with:
+
+```
+agent loop aborted: model repeated a 89-character phrase 12 times
+```
+
+The unit was exactly 89 bytes, repeated 14 times, byte-exact:
+
+```
+".\n\nLet me do it.\n\nLet me write the test program.\n\nLet me do it.\n\nLet me write the program"
+```
+
+Before that collapse: **68 consecutive thinking events, ~45 KB, zero tool calls.** The model
+spent them relitigating one design decision, restating the same trade-off roughly twenty times
+without committing. The tell is the ratio — **130 "let me write/run/test" phrases against 43
+actual tool calls**. It kept announcing actions it never took.
+
+### Corpus scale
+
+A sweep of 496 sessions across 29 days and 25 models (`pi-loop-forensics` skill,
+`scan_logs.py`):
+
+- Longest tool-free thinking run, healthy models: claude-sonnet **7**, minimax-m3 **45**
+  (but with 37 tool calls that session — legitimate deep reasoning).
+- Degenerate runs, all `deepseek-v4-flash` on Ollama: **21, 34, 38, 57, 68, 78, 87, 89, 122,
+  164** events (10 KB–148 KB).
+- One turn emitted **148 KB of the same sentence over 87 seconds**
+  (`internal/provider/ollama.go`, `defaultOllamaNumPredict` doc comment).
+
+**The ranges overlap.** No threshold cleanly separates deep reasoning from a loop.
+
+## Root cause
+
+Three hypotheses were tested and eliminated before concluding it is model behaviour:
+
+- **Race / double-emission** — ruled out. 415 thinking payloads hashed: **zero exact
+  duplicates**, varied lengths, monotonic timestamps ~500 ms apart. Genuine streamed output,
+  not pi-go re-emitting chunks.
+- **Tool-parse failure** — ruled out. Zero occurrences of `<tool_call`, `<function`,
+  `tool_calls`, `"name":…,"arguments"`, ` ```json `, `<think>`, `<｜tool` in either the
+  thinking or text channel. Nothing was emitted-and-dropped; the model never called a tool.
+- **Threshold too low** — ruled out. Healthy sessions peak at ~1 periodic repeat against a
+  threshold of 12 byte-exact copies.
+
+It is inference-level repetition collapse. Reproduced on demand by resuming a seed session
+whose last persisted event is the tool result immediately before the spiral: **3/3 on
+ollama-local, 2/3 on ollama-cloud**.
+
+Thinking level is not the lever. Measured across `low`/`medium`/`high`/`max` on one prompt,
+within-level variance (703 → 25 436 chars) dwarfed any between-level difference.
+
+## Guardrails
+
+Four layers. No single one is sufficient, and two of them interact badly — that interaction
+is the most important thing on this page.
+
+### 1. Prevent — make the model less likely to collapse
+
+`internal/provider/ollama.go`, opt-in via env (see
+`specs/features/LLM/002-ollama-sampling-parameters`):
+
+| Env var | Option | Ollama default |
+|---|---|---|
+| `PI_OLLAMA_REPEAT_PENALTY` | `repeat_penalty` | 1.1 |
+| `PI_OLLAMA_REPEAT_LAST_N` | `repeat_last_n` | 64 |
+| `PI_OLLAMA_PRESENCE_PENALTY` | `presence_penalty` | 0.0 |
+| `PI_OLLAMA_FREQUENCY_PENALTY` | `frequency_penalty` | 0.0 |
+
+The default penalty window is 64 tokens; observed cycles run 25–55 tokens, so a full cycle can
+fall outside what the penalty can see. Widening `repeat_last_n` targets that directly.
+
+> **⚠ This layer degrades layer 3.** Measured: with `repeat_last_n=512, repeat_penalty=1.2`,
+> byte-exact repetition was **eliminated** (`reps` 67 and 42 → 0 in every trial) — but one
+> trial still spun **57 thinking events with no tool call**. Penalties work by pushing the
+> model off tokens it just used, which is exactly how verbatim repetition becomes paraphrase.
+> They convert a *detectable* loop into an *undetectable* one. **Never raise these without
+> the semantic-loop arm in place.**
+
+### 2. Bound — cap the blast radius
+
+- `defaultOllamaNumPredict = 16384` (`internal/provider/ollama.go:176`) caps **one turn's**
+  output. Override with `PI_OLLAMA_NUM_PREDICT`.
+- **Gap:** there is no session-level cap. A 68-turn loop can still burn 68 × 16 K. The only
+  `TokenBudget` in the tree (`internal/config/config.go:36`, `Memory.TokenBudget`) belongs to the memory subsystem,
+  not spend control.
+- Cost is dominated by **input**, not output: a measured day showed **16.8 M input vs 192 K
+  output** across 295 requests, because every turn resends the whole conversation. Output caps
+  barely touch the bill; a session cap must count input.
+
+### 3. Detect — abort a turn that has stopped progressing
+
+`StuckDetector` in `internal/agent/stuck.go`, one entry point `ObserveEvent`, called by every
+front end.
+
+> **The guard must live in the shared agent layer, not a front end.** It was instantiated only
+> in `internal/tui/agent_loop.go`, so `runPrint`, `json`, `rpc` and ACP had **no protection at
+> all** — replay trials with **71, 67 and 42 byte-exact repeats ran to completion without
+> aborting**, against a threshold of 12. Fixed by moving it; the lesson generalises to any
+> future guard.
+
+Arms and thresholds: `MaxRepeatToolCalls` 10, `MaxToolErrorStreak` 10, `MaxOutputRepeats` 12,
+and `MaxThinkingEventStreak` 50 **and** `MinThinkingStreakBytes` 16384 for the semantic arm.
+
+The semantic arm gates on both axes because neither is safe alone: providers chunk streams
+differently (measured events run 1 byte to ~2.9 KB), so a token-level stream reaches 50 events
+inside one sentence. Requiring volume too means a legitimate burst must beat the observed
+healthy ceiling on **both** axes to trip.
+
+Threshold guidance: because healthy (45) and degenerate (21+) ranges overlap, the semantic arm
+must be set **conservatively above legitimate deep reasoning**. A false abort on a model that
+was genuinely thinking is worse than a missed short loop, because the other three arms remain
+as backstops. At 50 events this **concedes 3 of the 10 measured degenerate runs** (those at 21,
+34 and 38 events, all below the healthy ceiling of 45) — an accepted trade, not an oversight.
+
+### 4. Diagnose — make failures visible after the fact
+
+- Every mode must write a session log. ACP wrote **none** until `feat/shared-stuck-guard`:
+  across 533 sessions, `session_start` carried only `interactive`, `print`, `json`, `rpc`. An
+  ACP loop was unguarded *and* undiagnosable.
+- `pi-loop-forensics` skill: `scan_logs.py` (corpus sweep), `score_run.py` (per-log scoring on
+  `think_run` / `reps` / intent-vs-calls), `ab_replay.sh` (provider A/B replay).
+- Seed-replay technique: a spiralling turn's thinking is usually never committed to
+  `events.jsonl`, so the session ends at the tool result *before* the spiral and resuming it
+  reproduces the failure.
+
+## Status
+
+| Item | State |
+|---|---|
+| Sampling knobs exposed | done — PR #112 |
+| Guard shared across all front ends | done — PR #113 |
+| ACP session logging | done — PR #113 |
+| Semantic-loop arm (thinking with no tool call) | done — PR #114 |
+| Session-level token cap (input-counting) | **open** |
+| Default penalty values | **deliberately not set** — blocked on the semantic arm |
+
+## Pitfalls for whoever picks this up
+
+- **`pi ping` is not a provider health check.** It resolves URLs and credentials differently
+  from the real agent path and produced three false "provider down" readings (empty-host DNS
+  on `opencode/*`; `:cloud` dialing `localhost:11434` despite a key being set; `[::1]` when the
+  daemon binds IPv4). Verify with `pi --mode print "reply with exactly: OK"`.
+- **Check the commit timeline before judging an old log.** `e069b34` (2026-08-08 06:56) added
+  the output-repetition arm; `5a4cb8b` (2026-08-08 18:52) stopped aborting productive polling.
+  Sessions before those cannot be compared against current behaviour, and "no abort" in a
+  pre-move log does not mean "no loop".
+- **Reproduction is probabilistic.** Nothing pins temperature or seed. Compare rates across
+  several trials, never single runs.


### PR DESCRIPTION
Stacked on #113 (which is stacked on #112).

## The gap

The output arm catches **byte-exact** repetition — the terminal collapse, not the failure that precedes it. A model can loop *semantically*: restating the same intent in fresh words, calling nothing, making no progress.

Measured: one turn ran **57 consecutive thinking events / 23 KB with zero tool calls and `reps=0`**. Nothing fired.

**Repetition penalties make this shape more likely, not less.** They work by pushing the model off tokens it just used — which is exactly how verbatim repetition becomes paraphrase. Tuning them (as #112 enables) suppresses the signature the output arm keys on while leaving the non-progress untouched. That is why #112 deliberately ships **no default penalty values**: this arm is the precondition.

## The arm

`ObserveThinking`, gated on **both**:

| Constant | Value |
|---|---|
| `MaxThinkingEventStreak` | 50 |
| `MinThinkingStreakBytes` | 16384 |

Neither is safe alone. Providers chunk streams differently — measured events run from **1 byte to ~2.9 KB** — so a token-level stream reaches 50 events inside a single sentence. Requiring volume too makes the arm depend on how much the model actually *said* rather than on how its provider packetizes, so a legitimate burst must beat the observed healthy ceiling on both axes at once.

A tool call or tool response resets the streak, as does text the model did not author. A turn alternating reasoning with action never accumulates one, however long it runs. Scoring is per **event**, not per part, with the verdict taken after the parts loop — so an event that both reasons and calls a tool counts as progress.

## Thresholds, and what they concede

| Population | Longest tool-free thinking run |
|---|---|
| Healthy — claude-sonnet | 7 events |
| Healthy — minimax-m3 | 45 events / 13 KB (session made 37 tool calls) |
| Degenerate | 21, 34, 38, 57, 68, 78, 87, 89, 122, 164 events (10 KB–148 KB) |

**The populations overlap**, so no threshold separates them cleanly and the only real choice is which error to make. 50 sits above every healthy run observed and **concedes the three shortest degenerate runs** (21, 34, 38 — all below the healthy ceiling). That is an accepted trade: a false abort kills legitimate deep reasoning outright, while a missed loop still has three other arms behind it.

The 57-event case that motivated this arm — the one that tripped nothing else — is caught.

## Known limitation, documented in the code

`ObserveEvent` applies no stream dedup, so under SSE the aggregate re-send is counted alongside the deltas and byte totals run roughly double. The effective byte gate is nearer ~8 KiB of genuine text than 16 KiB.

This is largely self-cancelling — the session logs the thresholds were calibrated from are also written without dedup on the thinking path, so measurement and runtime inflate alike — but it is not exact for reply text, where the TUI dedups before logging. Net effect: slightly more trigger-happy than the constants suggest, partially offsetting the deliberate conservatism. Written into the `ObserveEvent` doc comment rather than left to be rediscovered.

## Tests

9 new: trips at threshold; survives below it; **tiny chunks do not trip** (the byte gate doing its job); tool call resets; tool response resets; user text resets; thinking + call in one event is progress; both gates required; reset/empty handling.

## Verification

- Full unit suite: **0 failures**
- `golangci-lint run ./internal/...`: **0 issues**
- `gofmt -l internal/`: clean

## Also included

`specs/issues/009-agent-loop-no-progress` — the full investigation: the three eliminated hypotheses (race, tool-parse, low threshold, each with the evidence that ruled it out), the corpus data, and a **four-layer guardrail model** (prevent / bound / detect / diagnose) with the warning that layer 1 degrades layer 3.

Still open after this: no session-level token cap, and it must count **input** — a measured day showed 16.8 M input against 192 K output, so output caps barely touch the cost of a loop.
