### PR TITLE
fix(provider): retry a stream that dies before it produces anything

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1317,14 +1317,17 @@ func TestRebuildWithModelNilLLM(t *testing.T) {
 func TestDefaultRetryConfig(t *testing.T) {
 	cfg := DefaultRetryConfig()
 
-	if cfg.MaxRetries != 3 {
-		t.Errorf("MaxRetries = %d, want 3", cfg.MaxRetries)
+	if cfg.MaxRetries != 5 {
+		t.Errorf("MaxRetries = %d, want 5", cfg.MaxRetries)
 	}
 	if cfg.InitialDelay != 1*time.Second {
 		t.Errorf("InitialDelay = %v, want 1s", cfg.InitialDelay)
 	}
-	if cfg.MaxDelay != 30*time.Second {
-		t.Errorf("MaxDelay = %v, want 30s", cfg.MaxDelay)
+	// A minute, because the limits that produce a retryable 429 are per-minute
+	// windows: the old 30s cap could only ever retry inside the same exhausted
+	// window it was waiting out.
+	if cfg.MaxDelay != 60*time.Second {
+		t.Errorf("MaxDelay = %v, want 60s", cfg.MaxDelay)
 	}
 }
 

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -1,98 +1,44 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"iter"
-	"math"
-	"strings"
 	"time"
 
 	"google.golang.org/adk/v2/session"
+
+	"github.com/dimetron/pi-go/internal/retry"
 )
 
 // RetryConfig controls retry behavior for transient LLM errors.
-type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default 3).
-	MaxRetries int
-
-	// InitialDelay is the base delay before the first retry (default 1s).
-	InitialDelay time.Duration
-
-	// MaxDelay caps the exponential backoff delay (default 30s).
-	MaxDelay time.Duration
-}
+type RetryConfig = retry.Config
 
 // DefaultRetryConfig returns sensible defaults for retry behavior.
 func DefaultRetryConfig() RetryConfig {
-	return RetryConfig{
-		MaxRetries:   3,
-		InitialDelay: 1 * time.Second,
-		MaxDelay:     30 * time.Second,
-	}
+	return retry.DefaultConfig()
 }
 
 // isTransient returns true if the error is likely transient and worth retrying.
-// This covers rate limits (429), server errors (5xx), timeouts, and connection resets.
+// Classification lives in internal/retry so that internal/provider, which
+// cannot import this package, applies exactly the same rules.
 func isTransient(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-
-	transientPatterns := []string{
-		"429",
-		"rate limit",
-		"rate_limit",
-		"too many requests",
-		"500",
-		"502",
-		"503",
-		"504",
-		"internal server error",
-		"bad gateway",
-		"service unavailable",
-		"gateway timeout",
-		"connection reset",
-		"connection refused",
-		"timeout",
-		"deadline exceeded",
-		"temporary failure",
-		"overloaded",
-	}
-
-	lower := strings.ToLower(msg)
-	for _, pattern := range transientPatterns {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-
-	var timeoutErr interface{ Timeout() bool }
-	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
-		return true
-	}
-
-	var tempErr interface{ Temporary() bool }
-	if errors.As(err, &tempErr) && tempErr.Temporary() {
-		return true
-	}
-
-	return false
+	return retry.IsTransient(err)
 }
 
-// retryDelay calculates the delay for attempt n using exponential backoff.
+// retryDelay calculates the delay before retry attempt n (0-based).
 func retryDelay(cfg RetryConfig, attempt int) time.Duration {
-	delay := float64(cfg.InitialDelay) * math.Pow(2, float64(attempt))
-	if delay > float64(cfg.MaxDelay) {
-		delay = float64(cfg.MaxDelay)
-	}
-	return time.Duration(delay)
+	return retry.Delay(cfg, attempt, nil)
 }
 
 // WithRetry wraps an agent run function with retry logic for transient errors.
 // If the iterator yields a transient error, it sleeps and retries the entire run.
 // Non-transient errors are yielded immediately without retry.
+//
+// This is the coarse net. It can only replay a run that produced nothing, so it
+// does not help once a turn is underway — by the time a mid-turn request fails,
+// tool calls have already been yielded and re-running them is not safe. The
+// finer net is in internal/provider, which retries the single failed HTTP
+// request without disturbing the turn around it.
 func WithRetry(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error]) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
 		for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
@@ -123,8 +69,7 @@ func WithRetry(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error]) i
 			}
 
 			if attempt < cfg.MaxRetries {
-				delay := retryDelay(cfg, attempt)
-				time.Sleep(delay)
+				time.Sleep(retry.Delay(cfg, attempt, transientErr))
 				continue
 			}
 

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -131,7 +131,9 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequ
 			thinkingCfgBeta := antThinkingConfigBeta(m.thinkingLevel)
 			params := m.buildBetaParams(modelName, messages, systemPrompt, maxTokens, thinkingCfgBeta, req.Config)
 			if stream {
-				antRunStreamingBeta(ctx, &m.betaClient, params, yield)
+				retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+					antRunStreamingBeta(ctx, &m.betaClient, params, y)
+				})
 			} else {
 				antRunNonStreamingBeta(ctx, &m.betaClient, params, yield)
 			}
@@ -165,7 +167,9 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequ
 		}
 
 		if stream {
-			antRunStreaming(ctx, &m.client, params, yield)
+			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+				antRunStreaming(ctx, &m.client, params, y)
+			})
 		} else {
 			antRunNonStreaming(ctx, &m.client, params, yield)
 		}

--- a/internal/provider/mistral.go
+++ b/internal/provider/mistral.go
@@ -80,7 +80,9 @@ func (m *mistralModel) GenerateContent(ctx context.Context, req *model.LLMReques
 		}
 
 		if stream {
-			oaiRunStreaming(ctx, &m.client, params, yield)
+			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+				oaiRunStreaming(ctx, &m.client, params, y)
+			})
 		} else {
 			oaiRunNonStreaming(ctx, &m.client, params, yield)
 		}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -139,7 +139,9 @@ func (m *ollamaModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 		}
 
 		if stream {
-			ollamaRunStreaming(ctx, m.client, chatReq, yield)
+			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+				ollamaRunStreaming(ctx, m.client, chatReq, y)
+			})
 		} else {
 			chatReq.Stream = new(false)
 			ollamaRunNonStreaming(ctx, m.client, chatReq, yield)

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -39,7 +39,9 @@ func (m *openaiModel) generateChat(ctx context.Context, req *model.LLMRequest, m
 		}
 
 		if stream {
-			oaiRunStreaming(ctx, &m.client, params, yield)
+			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+				oaiRunStreaming(ctx, &m.client, params, y)
+			})
 		} else {
 			oaiRunNonStreaming(ctx, &m.client, params, yield)
 		}

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -97,38 +97,48 @@ func (m *openaiModel) generateResponses(ctx context.Context, req *model.LLMReque
 			}
 		}
 
-		runOnce := func(p responses.ResponseNewParams) (bool, error) {
-			if stream {
-				return m.runResponsesStreaming(ctx, p, yield)
+		// send performs the request once, including the previous_response_id
+		// recovery below. It takes its own yield so retryStream can re-run it.
+		send := func(y func(*model.LLMResponse, error) bool) {
+			runOnce := func(p responses.ResponseNewParams) (bool, error) {
+				if stream {
+					return m.runResponsesStreaming(ctx, p, y)
+				}
+				return m.runResponsesNonStreaming(ctx, p, y)
 			}
-			return m.runResponsesNonStreaming(ctx, p, yield)
+
+			emitted, err := runOnce(params)
+
+			// A stored previous_response_id can stop resolving upstream at any
+			// point: a proxy or load balancer routing the next turn to a different
+			// deployment, `store=false` (zero-data-retention accounts), expiry, or
+			// a model switch. The full conversation is already in params.Input —
+			// previous_response_id is only an optimisation here — so retrying
+			// without it is lossless. Only retry when nothing was streamed yet,
+			// otherwise the caller would see the turn's text twice.
+			if err != nil && sentPreviousResponseID && !emitted && isPreviousResponseNotFound(err) {
+				m.clearPreviousResponseID()
+				params.PreviousResponseID = param.Opt[string]{}
+				// The retry is the last attempt, so its emitted flag is moot.
+				_, err = runOnce(params)
+			}
+
+			if err != nil {
+				// Clear the stale pointer so the next turn starts fresh rather
+				// than replaying the same rejected id.
+				m.clearPreviousResponseID()
+				if stream {
+					_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+					return
+				}
+				_ = y(nil, fmt.Errorf("OpenAI Responses API failed: %w", err))
+			}
 		}
 
-		emitted, err := runOnce(params)
-
-		// A stored previous_response_id can stop resolving upstream at any
-		// point: a proxy or load balancer routing the next turn to a different
-		// deployment, `store=false` (zero-data-retention accounts), expiry, or
-		// a model switch. The full conversation is already in params.Input —
-		// previous_response_id is only an optimisation here — so retrying
-		// without it is lossless. Only retry when nothing was streamed yet,
-		// otherwise the caller would see the turn's text twice.
-		if err != nil && sentPreviousResponseID && !emitted && isPreviousResponseNotFound(err) {
-			m.clearPreviousResponseID()
-			params.PreviousResponseID = param.Opt[string]{}
-			// The retry is the last attempt, so its emitted flag is moot.
-			_, err = runOnce(params)
-		}
-
-		if err != nil {
-			// Clear the stale pointer so the next turn starts fresh rather
-			// than replaying the same rejected id.
-			m.clearPreviousResponseID()
-			if stream {
-				_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
-				return
-			}
-			_ = yield(nil, fmt.Errorf("OpenAI Responses API failed: %w", err))
+		if stream {
+			retryStream(ctx, streamRetryConfig(), yield, send)
+		} else {
+			send(yield)
 		}
 	}
 }

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/adk/v2/model"
+
+	"github.com/dimetron/pi-go/internal/retry"
+)
+
+// streamAttempt runs one streaming request, forwarding responses to yield.
+type streamAttempt func(yield func(*model.LLMResponse, error) bool)
+
+// streamRetry is the budget for re-sending a request that died before it
+// produced anything. It is deliberately smaller than the agent-level budget:
+// this retries a single HTTP request, so it runs inside whatever timeout the
+// caller already set for the turn.
+//
+// It is a package variable so the provider tests, which drive real error
+// responses through httptest servers, can shrink the pauses instead of paying
+// the full backoff in wall clock. See TestMain.
+var streamRetry = defaultStreamRetry()
+
+func defaultStreamRetry() retry.Config {
+	cfg := retry.DefaultConfig()
+	cfg.MaxRetries = 3
+	return cfg
+}
+
+// streamRetryConfig returns the current stream-retry budget.
+func streamRetryConfig() retry.Config { return streamRetry }
+
+// retryStream re-sends a streaming request that failed transiently *before*
+// emitting anything.
+//
+// The "before emitting anything" condition is what makes this safe, and it is
+// why the retry lives here rather than around the agent run. A provider reports
+// a stream failure as a content-less LLMResponse carrying ErrorCode — see
+// oaiRunStreaming — with a nil Go error, so nothing upstream can tell a failed
+// request from a finished one. Catching it at the source means a rate-limited
+// request is re-sent on its own, with the turn's tool calls and partial text
+// left untouched; once any of those have been forwarded, the attempt is
+// committed and the error passes straight through.
+func retryStream(ctx context.Context, cfg retry.Config, yield func(*model.LLMResponse, error) bool, attemptFn streamAttempt) {
+	for attempt := 0; ; attempt++ {
+		var (
+			emitted  bool
+			failResp *model.LLMResponse
+			failErr  error
+			halted   bool
+		)
+
+		attemptFn(func(resp *model.LLMResponse, err error) bool {
+			if failure := streamFailure(resp, err); failure != nil && !emitted {
+				failResp, failErr = resp, err
+				return false
+			}
+			emitted = true
+			if !yield(resp, err) {
+				halted = true
+				return false
+			}
+			return true
+		})
+
+		if halted {
+			return
+		}
+		cause := streamFailure(failResp, failErr)
+		if cause == nil {
+			return
+		}
+
+		if attempt >= cfg.MaxRetries || !retry.IsTransient(cause) || ctx.Err() != nil {
+			_ = yield(failResp, failErr)
+			return
+		}
+
+		if !sleepCtx(ctx, retry.Delay(cfg, attempt, cause)) {
+			// Canceled while waiting. Report it as a cancellation rather than
+			// as the rate limit, so the turn ends the way Esc ends it.
+			_ = yield(canceledResponse(), nil)
+			return
+		}
+	}
+}
+
+// streamFailure reduces a yielded (response, error) pair to the failure it
+// describes, or nil if it describes progress.
+func streamFailure(resp *model.LLMResponse, err error) error {
+	if err != nil {
+		return err
+	}
+	if resp == nil || resp.ErrorCode == "" {
+		return nil
+	}
+	if resp.ErrorMessage == "" {
+		return errors.New(resp.ErrorCode)
+	}
+	// Keep the code alongside the message: named codes such as
+	// DAILY_LIMIT_EXCEEDED carry the only signal that a failure is terminal.
+	return errors.New(resp.ErrorCode + ": " + resp.ErrorMessage)
+}
+
+// sleepCtx waits for d, reporting false if ctx was canceled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -1,0 +1,260 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/retry"
+)
+
+// TestMain shrinks the stream-retry budget for the whole package. Several
+// existing tests drive genuine 5xx responses through httptest servers, and
+// those are transient by design, so every one of them now re-sends. Left at
+// production settings they sit through the backoff *and* through the vendor
+// SDK's own internal retry on each attempt, which added ~30s to the suite.
+//
+// The retry behavior itself is covered by the tests below, which pass their
+// own explicit configs to retryStream, so nothing is lost by trimming here.
+func TestMain(m *testing.M) {
+	streamRetry = retry.Config{
+		MaxRetries:   1,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     2 * time.Millisecond,
+	}
+	os.Exit(m.Run())
+}
+
+// fastRetry keeps the sleeps out of the test's wall clock while leaving the
+// attempt budget intact.
+func fastRetry(maxRetries int) retry.Config {
+	return retry.Config{
+		MaxRetries:   maxRetries,
+		InitialDelay: time.Millisecond,
+		MaxDelay:     2 * time.Millisecond,
+	}
+}
+
+func textResponse(s string) *model.LLMResponse {
+	return &model.LLMResponse{
+		Partial: true,
+		Content: &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: s}}},
+	}
+}
+
+func streamError(msg string) *model.LLMResponse {
+	return &model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: msg}
+}
+
+// collectStream drains a retryStream run into the responses it forwarded.
+func collectStream(ctx context.Context, t *testing.T, cfg retry.Config, attempt streamAttempt) []*model.LLMResponse {
+	t.Helper()
+	var got []*model.LLMResponse
+	retryStream(ctx, cfg, func(resp *model.LLMResponse, err error) bool {
+		if err != nil {
+			got = append(got, &model.LLMResponse{ErrorCode: "GO_ERROR", ErrorMessage: err.Error()})
+			return true
+		}
+		got = append(got, resp)
+		return true
+	}, attempt)
+	return got
+}
+
+// The regression this whole change exists for: a rate limit that arrives before
+// any content must be re-sent, not surfaced.
+func TestRetryStreamRetriesRateLimitBeforeContent(t *testing.T) {
+	const rateLimit = `received error while streaming: {"code":"rate_limit_exceeded",` +
+		`"message":"Rate limit reached on tokens per min (TPM). Please try again in 1ms."}`
+
+	calls := 0
+	got := collectStream(context.Background(), t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		if calls < 3 {
+			y(streamError(rateLimit), nil)
+			return
+		}
+		y(textResponse("recovered"), nil)
+	})
+
+	if calls != 3 {
+		t.Errorf("attempts = %d, want 3", calls)
+	}
+	if len(got) != 1 {
+		t.Fatalf("forwarded %d responses, want 1", len(got))
+	}
+	if got[0].ErrorCode != "" {
+		t.Errorf("forwarded an error to the caller: %+v", got[0])
+	}
+}
+
+// Quota exhaustion also arrives as a 429. Retrying it only delays a failure the
+// user has to fix, so it must pass through on the first attempt.
+func TestRetryStreamDoesNotRetryQuotaExhaustion(t *testing.T) {
+	const quota = "429 Too Many Requests: you (dimetron) have reached your weekly " +
+		"usage limit, upgrade for higher limits: https://ollama.com/upgrade"
+
+	calls := 0
+	got := collectStream(context.Background(), t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		y(streamError(quota), nil)
+	})
+
+	if calls != 1 {
+		t.Errorf("attempts = %d, want 1 (quota is terminal)", calls)
+	}
+	if len(got) != 1 || got[0].ErrorMessage != quota {
+		t.Errorf("want the original error forwarded once, got %+v", got)
+	}
+}
+
+// Once text has reached the caller the attempt is committed: replaying it would
+// duplicate the turn's output.
+func TestRetryStreamDoesNotRetryAfterContent(t *testing.T) {
+	calls := 0
+	got := collectStream(context.Background(), t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		y(textResponse("partial"), nil)
+		y(streamError("503 service unavailable"), nil)
+	})
+
+	if calls != 1 {
+		t.Errorf("attempts = %d, want 1 (content already emitted)", calls)
+	}
+	if len(got) != 2 {
+		t.Fatalf("forwarded %d responses, want 2", len(got))
+	}
+	if got[1].ErrorCode != "STREAM_ERROR" {
+		t.Errorf("want the stream error forwarded, got %+v", got[1])
+	}
+}
+
+func TestRetryStreamExhaustsBudget(t *testing.T) {
+	calls := 0
+	got := collectStream(context.Background(), t, fastRetry(2), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		y(streamError("503 service unavailable"), nil)
+	})
+
+	if calls != 3 {
+		t.Errorf("attempts = %d, want 3 (initial + 2 retries)", calls)
+	}
+	if len(got) != 1 || got[0].ErrorMessage != "503 service unavailable" {
+		t.Errorf("want the last error forwarded, got %+v", got)
+	}
+}
+
+// A Go error on the error channel is the non-streaming shape, and must be
+// retried on the same terms.
+func TestRetryStreamRetriesGoError(t *testing.T) {
+	calls := 0
+	got := collectStream(context.Background(), t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		if calls < 2 {
+			y(nil, errors.New("connection reset by peer"))
+			return
+		}
+		y(textResponse("ok"), nil)
+	})
+
+	if calls != 2 {
+		t.Errorf("attempts = %d, want 2", calls)
+	}
+	if len(got) != 1 || got[0].ErrorCode != "" {
+		t.Errorf("want one clean response, got %+v", got)
+	}
+}
+
+func TestRetryStreamSuccessIsNotRetried(t *testing.T) {
+	calls := 0
+	got := collectStream(context.Background(), t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		y(textResponse("a"), nil)
+		y(textResponse("b"), nil)
+	})
+
+	if calls != 1 {
+		t.Errorf("attempts = %d, want 1", calls)
+	}
+	if len(got) != 2 {
+		t.Errorf("forwarded %d responses, want 2", len(got))
+	}
+}
+
+// Canceling mid-wait must end the turn the way Esc ends it, not by reporting
+// the rate limit the user never needs to see.
+func TestRetryStreamCancelDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := retry.Config{MaxRetries: 3, InitialDelay: time.Hour, MaxDelay: time.Hour}
+
+	started := make(chan struct{})
+	done := make(chan []*model.LLMResponse, 1)
+	go func() {
+		done <- collectStream(ctx, t, cfg, func(y func(*model.LLMResponse, error) bool) {
+			close(started)
+			y(streamError("503 service unavailable"), nil)
+		})
+	}()
+
+	// The first attempt has to land before the cancel, or there is no backoff
+	// to interrupt. cfg retries only once here, so started is closed once.
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first attempt never ran")
+	}
+	cancel()
+
+	select {
+	case got := <-done:
+		if len(got) != 1 {
+			t.Fatalf("forwarded %d responses, want 1", len(got))
+		}
+		if got[0].ErrorCode != "" {
+			t.Errorf("want a cancellation, got error %+v", got[0])
+		}
+		if !got[0].TurnComplete {
+			t.Error("want the canceled response to complete the turn")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("retryStream did not return after cancel")
+	}
+}
+
+// A caller that stops consuming (Esc, or a downstream break) must stop the
+// retry loop too rather than re-sending the request.
+func TestRetryStreamStopsWhenCallerHalts(t *testing.T) {
+	calls := 0
+	retryStream(context.Background(), fastRetry(3), func(*model.LLMResponse, error) bool {
+		return false
+	}, func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		y(textResponse("a"), nil)
+		y(streamError("503 service unavailable"), nil)
+	})
+
+	if calls != 1 {
+		t.Errorf("attempts = %d, want 1", calls)
+	}
+}
+
+func TestStreamFailure(t *testing.T) {
+	if got := streamFailure(textResponse("hi"), nil); got != nil {
+		t.Errorf("content response should not be a failure, got %v", got)
+	}
+	if got := streamFailure(nil, nil); got != nil {
+		t.Errorf("nil pair should not be a failure, got %v", got)
+	}
+	if got := streamFailure(&model.LLMResponse{ErrorCode: "API_ERROR"}, nil); got == nil || got.Error() != "API_ERROR" {
+		t.Errorf("bare code should surface as the message, got %v", got)
+	}
+	got := streamFailure(&model.LLMResponse{ErrorCode: "DAILY_LIMIT_EXCEEDED", ErrorMessage: "over budget"}, nil)
+	if got == nil || got.Error() != "DAILY_LIMIT_EXCEEDED: over budget" {
+		t.Errorf("want code and message, got %v", got)
+	}
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,241 @@
+// Package retry classifies provider failures as retryable or terminal and
+// paces the re-attempts.
+//
+// It exists because "is this worth retrying?" has to be answered identically in
+// two places that cannot import each other: internal/provider, which retries a
+// single failed HTTP request, and internal/agent, which retries a whole run.
+//
+// The classification is deliberately message-based. Providers hand pi-go their
+// failures as opaque strings — an SSE stream error is a JSON body, not a typed
+// error — so pattern matching on the text is the only signal available at both
+// layers.
+package retry
+
+import (
+	"errors"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config controls how many times a failed attempt is repeated and how long the
+// pauses between attempts grow.
+type Config struct {
+	// MaxRetries is the number of retries after the initial attempt.
+	MaxRetries int
+
+	// InitialDelay is the pause before the first retry.
+	InitialDelay time.Duration
+
+	// MaxDelay caps the exponential backoff, and also caps any delay the
+	// server itself asked for.
+	MaxDelay time.Duration
+}
+
+// DefaultConfig returns the shared defaults.
+//
+// MaxDelay is a minute because the limits that produce a retryable 429 are
+// per-minute windows: a shorter cap would guarantee the retry lands inside the
+// same exhausted window it is waiting out.
+func DefaultConfig() Config {
+	return Config{
+		MaxRetries:   5,
+		InitialDelay: 1 * time.Second,
+		MaxDelay:     60 * time.Second,
+	}
+}
+
+// terminalPatterns are failures no amount of waiting will clear: the request,
+// the credentials, or the account is wrong.
+//
+// These are matched *before* transientPatterns, because the most common failure
+// in pi-go's own session history is a 429 that is not a rate limit at all —
+// "you have reached your weekly usage limit" and "You exceeded your current
+// quota" both arrive as 429 Too Many Requests. Classifying those by status code
+// alone spends the full retry budget sleeping before reporting a failure the
+// user has to fix by upgrading a plan.
+var terminalPatterns = []string{
+	// Quota and plan exhaustion, mostly wearing a 429.
+	"usage limit",
+	"upgrade for higher limits",
+	"insufficient_quota",
+	"exceeded your current quota",
+	"check your plan and billing",
+	"quota exceeded",
+
+	// Authentication and authorization.
+	"unauthorized",
+	"forbidden",
+	"invalid_api_key",
+	"invalid api key",
+	"incorrect api key",
+	"token_expired",
+	"insufficient permissions",
+	"autherror",
+
+	// Malformed or unroutable requests.
+	"bad request",
+	"invalid_request_error",
+	"not found",
+
+	// The sandbox denying the dial. Retrying re-denies it.
+	"operation not permitted",
+}
+
+// transientPatterns are failures that a later identical request may survive.
+var transientPatterns = []string{
+	// Rate limiting proper — reached only if no terminal pattern matched.
+	"429",
+	"rate limit",
+	"rate_limit",
+	"too many requests",
+
+	// Upstream faults.
+	"500",
+	"502",
+	"503",
+	"504",
+	"internal server error",
+	"server_error",
+	"bad gateway",
+	"service unavailable",
+	"gateway timeout",
+	"overloaded",
+	"temporary failure",
+
+	// Connection-level faults.
+	"connection reset",
+	"connection refused",
+	"timeout",
+	"timed out",
+	"deadline exceeded",
+
+	// A stream that died mid-flight. An HTTP/2 reset arrives as
+	// "stream error: stream ID 9; INTERNAL_ERROR; received from peer", and a
+	// truncated SSE body as "unexpected EOF" or "unexpected end of JSON
+	// input" — none of which match any of the patterns above.
+	"stream error:",
+	"internal_error",
+	"unexpected eof",
+	"unexpected end of json input",
+}
+
+// IsTerminal reports whether err describes a failure that will recur
+// identically however long the caller waits.
+func IsTerminal(err error) bool {
+	if err == nil {
+		return false
+	}
+	return containsAny(strings.ToLower(err.Error()), terminalPatterns)
+}
+
+// IsTransient reports whether err is worth retrying.
+func IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+
+	// Terminal wins on a tie: a quota 429 matches both lists.
+	if containsAny(msg, terminalPatterns) {
+		return false
+	}
+	if containsAny(msg, transientPatterns) {
+		return true
+	}
+
+	var timeoutErr interface{ Timeout() bool }
+	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
+		return true
+	}
+
+	var tempErr interface{ Temporary() bool }
+	if errors.As(err, &tempErr) && tempErr.Temporary() {
+		return true
+	}
+
+	return false
+}
+
+func containsAny(msg string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// durationHintRe matches a Go-parseable duration after a retry hint, covering
+// the "9.422s" and "6m0.339s" forms OpenAI uses.
+var durationHintRe = regexp.MustCompile(
+	`(?i)(?:try again in|retry[- ]after:?)\s+((?:[0-9]+h)?(?:[0-9]+m)?[0-9]+(?:\.[0-9]+)?(?:ms|s|m|h))`)
+
+// numberHintRe matches a bare number followed by an optional spelled-out unit,
+// covering "retry after 30 seconds" and a raw Retry-After value.
+var numberHintRe = regexp.MustCompile(
+	`(?i)(?:try again in|retry[- ]after:?)\s+([0-9]+(?:\.[0-9]+)?)\s*(milliseconds?|ms|seconds?|secs?|minutes?|mins?)?`)
+
+// ServerDelay extracts the wait the provider asked for, if it named one.
+//
+// A rate-limit body usually carries the exact figure ("Please try again in
+// 9.422s"), and honoring it is the difference between one well-timed retry and
+// a backoff schedule that keeps landing inside the same exhausted window.
+func ServerDelay(err error) (time.Duration, bool) {
+	if err == nil {
+		return 0, false
+	}
+	msg := err.Error()
+
+	if m := durationHintRe.FindStringSubmatch(msg); m != nil {
+		if d, parseErr := time.ParseDuration(m[1]); parseErr == nil && d > 0 {
+			return d, true
+		}
+	}
+
+	m := numberHintRe.FindStringSubmatch(msg)
+	if m == nil {
+		return 0, false
+	}
+	n, parseErr := strconv.ParseFloat(m[1], 64)
+	if parseErr != nil || n <= 0 {
+		return 0, false
+	}
+	// A bare number means seconds: that is what the Retry-After header carries.
+	unit := time.Second
+	switch strings.ToLower(m[2]) {
+	case "ms", "millisecond", "milliseconds":
+		unit = time.Millisecond
+	case "m", "min", "mins", "minute", "minutes":
+		unit = time.Minute
+	}
+	return time.Duration(n * float64(unit)), true
+}
+
+// Delay returns how long to wait before the given retry attempt (0-based).
+//
+// A server-supplied hint wins over the computed backoff, since the server knows
+// when its window reopens and we do not. Both are clamped to cfg.MaxDelay so a
+// provider cannot park a turn indefinitely.
+func Delay(cfg Config, attempt int, err error) time.Duration {
+	maxDelay := cfg.MaxDelay
+	if maxDelay <= 0 {
+		maxDelay = DefaultConfig().MaxDelay
+	}
+
+	if hinted, ok := ServerDelay(err); ok {
+		return min(hinted, maxDelay)
+	}
+
+	initial := cfg.InitialDelay
+	if initial <= 0 {
+		initial = DefaultConfig().InitialDelay
+	}
+	backoff := float64(initial) * math.Pow(2, float64(attempt))
+	if backoff > float64(maxDelay) {
+		return maxDelay
+	}
+	return time.Duration(backoff)
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,191 @@
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// providerErr wraps a verbatim provider message. Provider text is prose — it
+// starts with a capital and ends with a full stop — which is exactly what the
+// error-strings linter rejects at an errors.New call site, so it is built here
+// instead of inline.
+func providerErr(msg string) error { return errors.New(msg) }
+
+// The messages below are verbatim from ~/.pi-go/sessions/*/events.jsonl, so the
+// classifier is tested against the failures pi-go actually records rather than
+// invented ones.
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrecognized", errors.New("something broke"), false},
+
+		// Retryable: rate limiting with a reopening window.
+		{"tpm rate limit", errors.New(`received error while streaming: {"type":"tokens","code":"rate_limit_exceeded","message":"Rate limit reached for gpt-5.6-luna on tokens per min (TPM): Limit 200000, Used 105953, Requested 125455. Please try again in 9.422s."}`), true},
+		{"bare 429", errors.New("429 Too Many Requests"), true},
+		{"rate limit prose", errors.New("rate limit exceeded"), true},
+		{"rate_limit code", errors.New("rate_limit_error"), true},
+
+		// Retryable: upstream faults.
+		{"500", errors.New("500 Internal Server Error"), true},
+		{"502", errors.New("502 Bad Gateway"), true},
+		{"503", errors.New("503 Service Unavailable"), true},
+		{"504", errors.New("504 Gateway Timeout"), true},
+		{"ref'd 500", errors.New("Internal Server Error (ref: ed5c545e-ddee-4abf-a1f4-90ab10fdbcc2)"), true},
+		{"overloaded model", errors.New("503 Service Unavailable: model 'minimax-m3' is temporarily overloaded, please retry shortly or try a different model"), true},
+		{"sse server_error", errors.New(`received error while streaming: {"type":"server_error","code":"server_error","message":"An error occurred while processing your request. You can retry your request"}`), true},
+
+		// Retryable: connection and stream faults.
+		{"connection reset", errors.New("connection reset by peer"), true},
+		{"connection refused", errors.New("connection refused"), true},
+		{"deadline", errors.New("context deadline exceeded"), true},
+		{"wrapped timeout", fmt.Errorf("wrapped: %w", errors.New("timeout")), true},
+		{"timed out", errors.New("read tcp 192.168.1.103:57601->104.18.32.47:443: read: operation timed out"), true},
+		{"http2 reset", errors.New("stream error: stream ID 9; INTERNAL_ERROR; received from peer"), true},
+		{"truncated sse", errors.New("unexpected EOF"), true},
+		{"truncated json", errors.New("unexpected end of JSON input"), true},
+
+		// Terminal: a 429 that is quota exhaustion, not rate limiting. These
+		// are the majority of 429s in the session corpus, and retrying them
+		// only delays a failure the user has to fix by upgrading.
+		{"ollama weekly quota", errors.New("429 Too Many Requests: you (dimetron) have reached your weekly usage limit, upgrade for higher limits: https://ollama.com/upgrade"), false},
+		{"ollama session quota", errors.New("429 Too Many Requests: you (dimetron) have reached your session usage limit, upgrade for higher limits: https://ollama.com/upgrade"), false},
+		{"openai quota", errors.New(`POST "https://api.openai.com/v1/chat/completions": 429 Too Many Requests {"message": "You exceeded your current quota, please check your plan and billing details."}`), false},
+
+		// Terminal: auth and malformed requests.
+		{"401", errors.New("401 Unauthorized"), false},
+		{"expired token", errors.New(`POST "https://chatgpt.com/backend-api/codex/responses": 401 Unauthorized {"message": "Provided authentication token is expired.","code": "token_expired"}`), false},
+		{"invalid key", errors.New("invalid api key"), false},
+		{"missing scopes", errors.New("401 Unauthorized {\"message\": \"You have insufficient permissions for this operation. Missing scopes: api.responses.write\"}"), false},
+		{"400", errors.New(`POST "https://api.openai.com/v1/responses": 400 Bad Request {"message": "Invalid 'input[2].call_id': empty string."}`), false},
+		{"missing model", errors.New("404 Not Found: model 'deepseek-v4-flash:0731' not found"), false},
+		{"sandbox dial", errors.New(`Post "https://api.openai.com/v1/chat/completions": dial tcp 172.66.0.243:443: connect: operation not permitted`), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransient(tt.err); got != tt.want {
+				t.Errorf("IsTransient(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+type timeoutError struct{ msg string }
+
+func (e *timeoutError) Error() string { return e.msg }
+func (e *timeoutError) Timeout() bool { return true }
+
+type temporaryError struct{ msg string }
+
+func (e *temporaryError) Error() string   { return e.msg }
+func (e *temporaryError) Temporary() bool { return true }
+
+func TestIsTransientInterfaces(t *testing.T) {
+	if !IsTransient(&timeoutError{msg: "unique xyz123"}) {
+		t.Error("Timeout() error should be transient")
+	}
+	if !IsTransient(&temporaryError{msg: "unique xyz123"}) {
+		t.Error("Temporary() error should be transient")
+	}
+	if IsTransient(errors.New("unique non-matching error xyz123")) {
+		t.Error("unmatched error should not be transient")
+	}
+}
+
+// A Temporary() error whose message says the quota is gone must stay terminal:
+// the interface is a transport-level hint and knows nothing about billing.
+func TestIsTransientTerminalBeatsInterface(t *testing.T) {
+	err := &temporaryError{msg: "429: you have reached your weekly usage limit"}
+	if IsTransient(err) {
+		t.Error("quota exhaustion should be terminal despite Temporary()")
+	}
+	if !IsTerminal(err) {
+		t.Error("IsTerminal should report quota exhaustion")
+	}
+}
+
+func TestServerDelay(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want time.Duration
+		ok   bool
+	}{
+		{"fractional seconds", "Please try again in 9.422s. Visit ...", 9422 * time.Millisecond, true},
+		{"minutes and seconds", "Please try again in 6m0.339s.", 6*time.Minute + 339*time.Millisecond, true},
+		{"milliseconds", "Please try again in 500ms.", 500 * time.Millisecond, true},
+		{"whole seconds", "Please try again in 20s.", 20 * time.Second, true},
+		{"spelled out", "retry after 30 seconds", 30 * time.Second, true},
+		{"spelled minutes", "Retry after 2 minutes", 2 * time.Minute, true},
+		{"bare number is seconds", "Retry-After: 30", 30 * time.Second, true},
+		{"no hint", "429 Too Many Requests", 0, false},
+		{"empty", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ServerDelay(errors.New(tt.msg))
+			if ok != tt.ok {
+				t.Fatalf("ServerDelay(%q) ok = %v, want %v", tt.msg, ok, tt.ok)
+			}
+			if ok && got != tt.want {
+				t.Errorf("ServerDelay(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerDelayNil(t *testing.T) {
+	if _, ok := ServerDelay(nil); ok {
+		t.Error("ServerDelay(nil) should not report a delay")
+	}
+}
+
+func TestDelayBackoff(t *testing.T) {
+	cfg := Config{MaxRetries: 5, InitialDelay: 100 * time.Millisecond, MaxDelay: time.Second}
+	err := errors.New("503 service unavailable")
+
+	for attempt, want := range map[int]time.Duration{
+		0: 100 * time.Millisecond,
+		1: 200 * time.Millisecond,
+		2: 400 * time.Millisecond,
+		3: 800 * time.Millisecond,
+		4: time.Second, // capped
+	} {
+		if got := Delay(cfg, attempt, err); got != want {
+			t.Errorf("Delay(attempt %d) = %v, want %v", attempt, got, want)
+		}
+	}
+}
+
+// The whole point of parsing the hint: the server's figure must beat a backoff
+// that would otherwise retry inside the same exhausted window.
+func TestDelayPrefersServerHint(t *testing.T) {
+	cfg := Config{MaxRetries: 5, InitialDelay: time.Second, MaxDelay: time.Minute}
+	err := providerErr("Rate limit reached. Please try again in 9.422s.")
+
+	if got := Delay(cfg, 0, err); got != 9422*time.Millisecond {
+		t.Errorf("Delay = %v, want the server's 9.422s", got)
+	}
+}
+
+func TestDelayClampsServerHint(t *testing.T) {
+	cfg := Config{MaxRetries: 5, InitialDelay: time.Second, MaxDelay: 10 * time.Second}
+	err := providerErr("Please try again in 6m0.339s.")
+
+	if got := Delay(cfg, 0, err); got != 10*time.Second {
+		t.Errorf("Delay = %v, want the 10s cap", got)
+	}
+}
+
+func TestDelayZeroConfigUsesDefaults(t *testing.T) {
+	if got := Delay(Config{}, 0, errors.New("503")); got != DefaultConfig().InitialDelay {
+		t.Errorf("Delay with zero config = %v, want %v", got, DefaultConfig().InitialDelay)
+	}
+}

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -632,7 +633,14 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string) {
 		m.agentCh <- agentDoneMsg{err: err}
 	}
 
-	for ev, err := range m.cfg.Agent.RunStreaming(ctx, m.cfg.SessionID, prompt) {
+	// Same retry wrapper the print and RPC front-ends use, so a run that dies
+	// before producing anything is replayed here too instead of ending the turn
+	// with an error on screen. Mid-turn failures are handled a layer down, in
+	// the provider, where a single request can be re-sent without replaying the
+	// tool calls that already ran.
+	for ev, err := range agent.WithRetry(agent.DefaultRetryConfig(), func() iter.Seq2[*session.Event, error] {
+		return m.cfg.Agent.RunStreaming(ctx, m.cfg.SessionID, prompt)
+	}) {
 		if err != nil {
 			fail(err)
 			return


### PR DESCRIPTION
A rate-limited turn ended with `Agent stopped` and nothing else. The failure never reached the one piece of code meant to catch it.

## Why the retry never fired

Providers report a streaming failure as a content-less `LLMResponse` carrying `ErrorCode`, yielded with a **nil Go error** (`internal/provider/openai_completions.go:283`). `agent.WithRetry` only inspects the error channel, so it never saw the failure — in the CLI, the RPC server and the ACP runtime alike. The TUI had no retry wrapper at all: `agent_loop.go` turned the event straight into a `fail()`.

Retrying the whole run cannot fix this anyway. By the time a mid-turn request is rate limited, tool calls have already been yielded, and `WithRetry`'s `hadEvents` guard correctly refuses to replay them. The right granularity is the single HTTP request, so the retry now lives in the provider.

## What changed

- **`internal/retry`** (new) — classification, `Retry-After` parsing and backoff, shared by the two layers that cannot import each other.
- **`internal/provider/retry.go`** (new) — `retryStream` re-sends an attempt that failed transiently *before* emitting anything, wired into all five streaming paths (OpenAI completions + responses, Anthropic standard + beta, Ollama, Mistral). Once a partial or tool call has been forwarded the attempt is committed and the error passes through untouched.
- **TUI** wired to `agent.WithRetry` for parity with the other front-ends.

## Classification rebuilt from real failures

The rules are derived from what pi-go actually records in `~/.pi-go/sessions/*/events.jsonl`, and that corpus contradicts the old ones in both directions:

| Failure | Occurrences | Was | Now |
|---|---|---|---|
| `429 … reached your session/weekly usage limit` (Ollama) | 94 | retried ×3 | terminal |
| `429 … You exceeded your current quota` (OpenAI) | 9 | retried ×3 | terminal |
| `stream error: … INTERNAL_ERROR` (HTTP/2 reset) | 8 | permanent | retried |
| `unexpected EOF` / `unexpected end of JSON input` | 7 | permanent | retried |
| SSE `{"type":"server_error"}` | 4 | permanent | retried |
| `read: operation timed out` | 1 | permanent | retried |

Most 429s in practice are quota exhaustion, not rate limiting. The old `429 -> transient` rule spent the whole retry budget sleeping before reporting a failure only a plan upgrade can clear, so terminal patterns are now matched first.

## Backoff honours the server

OpenAI's body says `Please try again in 9.422s`. The old schedule slept 1s, 2s, 4s and gave up after 7s — inside the same 60s window it was waiting out. `ServerDelay` parses the hint (`9.422s`, `6m0.339s`, `retry after 30 seconds`, a raw `Retry-After`) and it wins over the computed backoff, clamped to `MaxDelay`. `MaxDelay` rises from 30s to 60s for the same reason.

## Not the fix: compaction

Auto-compaction was considered and ruled out. It is measured against the context window (`internal/session/compaction.go:81`) and the failing request was well under it — this was a tokens-per-minute limit, a different resource. Compaction lowers how often the wall is hit; only retry recovers from it.

## Notes for review

- The vendored SDKs already retry 5xx internally, so `retryStream` stacks on top for HTTP-level faults. It is not redundant for the case that matters: an in-stream SSE error arrives *after* a 200 OK, so the SDK's retry never sees it. The stacking did add ~30s to the provider suite, so `TestMain` trims the budget for tests.
- The TUI cannot amplify the provider retry — an exhausted attempt surfaces as an event, which `WithRetry` ignores.

## Verification

`go test ./...` green (40 packages), `go test -race` green on the affected packages, `make lint` 0 issues.

https://claude.ai/code/session_01Qg9SfrpzntNUJemzgUD9xe