### PR TITLE
feat(run): preserve execution worktree backup branch

### DIFF
--- a/internal/subagent/worktree.go
+++ b/internal/subagent/worktree.go
@@ -222,6 +222,28 @@ func (m *WorktreeManager) Create(agentID string, requestedName ...string) (strin
 	return wtPath, nil
 }
 
+// CreateBackupBranch creates a permanent branch pointing at the worktree branch.
+// The backup survives Cleanup, which removes the temporary worktree branch.
+func (m *WorktreeManager) CreateBackupBranch(agentID, backupBranch string) error {
+	m.mu.Lock()
+	info, exists := m.active[agentID]
+	m.mu.Unlock()
+	if !exists {
+		var err error
+		info, err = m.recoverWorktreeInfo(agentID)
+		if err != nil {
+			return fmt.Errorf("no worktree found for agent %s", agentID)
+		}
+	}
+	if strings.TrimSpace(backupBranch) == "" {
+		return fmt.Errorf("backup branch is required")
+	}
+	if _, err := m.git("branch", "-f", backupBranch, info.Branch); err != nil {
+		return fmt.Errorf("create backup branch %q: %w", backupBranch, err)
+	}
+	return nil
+}
+
 // Cleanup removes the worktree and branch for the given agent ID.
 // After CleanupAll has started (closed=true), late Cleanup calls are
 // no-ops — CleanupAll owns all remaining entries at that point.

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -159,6 +159,23 @@ func runWorktreeName(specName string, suffix string) string {
 	return name
 }
 
+func runBackupBranchName(specName, suffix string) string {
+	name := strings.Trim(specName, "/")
+	name = strings.ReplaceAll(name, string(filepath.Separator), "-")
+	name = strings.ReplaceAll(name, "/", "-")
+	if suffix != "" {
+		name += "/" + suffix
+	}
+	return "run/" + name
+}
+
+func (m *model) createRunBackupBranch(agentID, branch string) error {
+	if m.cfg.Orchestrator == nil || m.cfg.Orchestrator.Worktree() == nil {
+		return fmt.Errorf("no worktree manager")
+	}
+	return m.cfg.Orchestrator.Worktree().CreateBackupBranch(agentID, branch)
+}
+
 func formatAvailableRunSpecsTable(specs []string) string {
 	var b strings.Builder
 	b.WriteString("**Available features:**\n\n")
@@ -264,6 +281,11 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if err := m.createRunBackupBranch(agentID, runBackupBranchName(specName, "")); err != nil {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: fmt.Sprintf("Failed to create run backup branch: %v", err)})
+		return m, nil
+	}
+
 	m.run = &runState{
 		specName:   specName,
 		promptMD:   promptMD,
@@ -331,6 +353,15 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 			role:    "assistant",
 			content: fmt.Sprintf("Failed to spawn agent 2 (agent 1 `%s` is running): %v", agentID1, err),
 		})
+		return m, nil
+	}
+
+	if err := m.createRunBackupBranch(agentID1, runBackupBranchName(specName, "part-1")); err != nil {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: fmt.Sprintf("Failed to create run backup branch for agent 1: %v", err)})
+		return m, nil
+	}
+	if err := m.createRunBackupBranch(agentID2, runBackupBranchName(specName, "part-2")); err != nil {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: fmt.Sprintf("Failed to create run backup branch for agent 2: %v", err)})
 		return m, nil
 	}
 


### PR DESCRIPTION
## Summary
- create a permanent run/<task-name> backup branch when /run starts
- preserve parallel execution snapshots as run/<task-name>/part-1 and part-2
- keep temporary execution worktree cleanup behavior unchanged

## Verification
- go test ./internal/tui ./internal/subagent
