### PR TITLE
feat(subagent): raise run/task agent timeout to 30 minutes

### DIFF
--- a/internal/subagent/bundled/task.md
+++ b/internal/subagent/bundled/task.md
@@ -3,6 +3,7 @@ name: task
 description: Complete coding tasks end-to-end in isolated worktree
 role: default
 worktree: true
+timeout: 1800000
 tools: read, write, edit, bash, grep, find, tree, ls, git-overview
 ---
 You are a task execution agent working in an isolated worktree. Complete the assigned coding task end-to-end.


### PR DESCRIPTION
The /run flow spawns the bundled task agent, which had no frontmatter
timeout and so fell back to DefaultAbsoluteTimeout (10m). A long spec run
crossed that cap and the subagent was killed mid-answer, skipping gates
and merge. Set timeout: 1800000 (30 min, milliseconds) on the task agent
so long productive runs survive the absolute backstop.

Signed-off-by: dimetron <dimetron@me.com>
