### PR TITLE
test: cover the subagent spawn-timeout override and run backup branches

### DIFF
--- a/internal/subagent/orchestrator_timeout_test.go
+++ b/internal/subagent/orchestrator_timeout_test.go
@@ -1,0 +1,334 @@
+package subagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sharedacp "github.com/dimetron/pi-go/internal/acp"
+)
+
+// captureSpawnOpts installs an ACP session constructor that records the
+// SpawnOpts it is handed and then immediately completes the session. It
+// returns a getter for the captured opts, which is safe to call once the
+// event stream has drained.
+func captureSpawnOpts(t *testing.T) func() SpawnOpts {
+	t.Helper()
+
+	var (
+		mu     sync.Mutex
+		opts   SpawnOpts
+		called bool
+	)
+
+	prev := startACPSessionFn
+	startACPSessionFn = func(_ context.Context, agentName, _ string, o SpawnOpts) (acpSession, error) {
+		mu.Lock()
+		opts, called = o, true
+		mu.Unlock()
+
+		s := newFakeACPSession()
+		go s.finish(sharedacp.RunResult{
+			Status:    sharedacp.StatusSuccess,
+			Result:    agentName + " ok",
+			SessionID: agentName + "-sess",
+		})
+		return s, nil
+	}
+	t.Cleanup(func() { startACPSessionFn = prev })
+
+	return func() SpawnOpts {
+		mu.Lock()
+		defer mu.Unlock()
+		if !called {
+			t.Fatal("ACP session was never started, so no SpawnOpts were captured")
+		}
+		return opts
+	}
+}
+
+// TestSpawn_ResolvesTimeout pins the precedence rule the spawn path applies:
+// an explicit per-spawn timeout wins over the one declared by the agent
+// definition, and anything else falls back to the agent's own value. This is
+// what lets a caller such as `/run` give a task agent an hour without editing
+// the bundled agent's frontmatter.
+func TestSpawn_ResolvesTimeout(t *testing.T) {
+	const hourMS = int(time.Hour / time.Millisecond)
+
+	tests := []struct {
+		name         string
+		agentTimeout int
+		inputTimeout int
+		want         int
+	}{
+		{"explicit timeout overrides the agent definition", 5_000, hourMS, hourMS},
+		{"unset timeout falls back to the agent definition", 5_000, 0, 5_000},
+		{"negative timeout is ignored", 5_000, -1, 5_000},
+		{"explicit timeout applies when the agent declares none", 0, 60_000, 60_000},
+		{"neither set leaves the spawner on its defaults", 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOpts := captureSpawnOpts(t)
+
+			orch := NewOrchestrator(testConfig(), "", nil)
+			t.Cleanup(orch.Shutdown)
+
+			events, _, err := orch.Spawn(context.Background(), SpawnInput{
+				Agent:   AgentConfig{Name: "claude", Role: "smol", Timeout: tt.agentTimeout},
+				Prompt:  "go",
+				Timeout: tt.inputTimeout,
+			})
+			if err != nil {
+				t.Fatalf("Spawn: %v", err)
+			}
+			for range events { //nolint:revive // drain the stream so the agent finishes
+			}
+
+			if got := gotOpts().Timeout; got != tt.want {
+				t.Errorf("SpawnOpts.Timeout = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSpawn_InputTimeoutIsEnforced is the behavioral half of the rule above:
+// the overriding value is not merely passed along, it is the deadline the
+// subagent actually dies on. The agent definition asks for 30s; the spawn asks
+// for 300ms; the agent must be stopped on the shorter one.
+func TestSpawn_InputTimeoutIsEnforced(t *testing.T) {
+	// Inactivity must not be what fires — the fake agent talks constantly, so
+	// only the absolute cap can stop it.
+	t.Setenv("PI_SUBAGENT_INACTIVITY_MS", "20000")
+
+	orch := NewOrchestrator(testConfig(), "", nil)
+	t.Cleanup(orch.Shutdown)
+	orch.spawner = NewSpawner(mockPiScript(t, `
+while true; do
+  printf '{"type":"text_delta","delta":"x"}\n'
+  sleep 0.05
+done
+`))
+
+	start := time.Now()
+	events, agentID, err := orch.Spawn(context.Background(), SpawnInput{
+		Agent:   AgentConfig{Name: "worker", Role: "smol", Timeout: 30_000},
+		Prompt:  "go",
+		Timeout: 300,
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	for range events { //nolint:revive // drain until the agent is killed
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Errorf("agent ran for %v — the 30s agent timeout fired, not the 300ms override", elapsed)
+	}
+
+	// The orchestrator must report the kill as a timeout rather than as a
+	// generic signal death: the spawner SIGKILLs the group, so without the
+	// explicit ErrSubagentTimeout check this would surface as "killed".
+	st, ok := orch.Get(agentID)
+	if !ok {
+		t.Fatalf("agent %s not tracked after completion", agentID)
+	}
+	if st.Status != "timeout" {
+		t.Errorf("status = %q, want %q", st.Status, "timeout")
+	}
+}
+
+// TestSpawnWithInput_CarriesTimeout covers the legacy AgentInput path, which
+// has to forward the timeout through ToSpawnInput or the override is silently
+// dropped for every caller still on the old API — including `/run`.
+func TestSpawnWithInput_CarriesTimeout(t *testing.T) {
+	in := AgentInput{
+		Type:    "claude",
+		Prompt:  "go",
+		Timeout: 90_000,
+	}
+
+	spawnIn, err := in.ToSpawnInput()
+	if err != nil {
+		t.Fatalf("ToSpawnInput: %v", err)
+	}
+	if spawnIn.Timeout != in.Timeout {
+		t.Fatalf("SpawnInput.Timeout = %d, want %d", spawnIn.Timeout, in.Timeout)
+	}
+
+	gotOpts := captureSpawnOpts(t)
+	orch := NewOrchestrator(testConfig(), "", nil)
+	t.Cleanup(orch.Shutdown)
+
+	events, _, err := orch.SpawnWithInput(context.Background(), in)
+	if err != nil {
+		t.Fatalf("SpawnWithInput: %v", err)
+	}
+	for range events { //nolint:revive // drain the stream so the agent finishes
+	}
+
+	if got := gotOpts().Timeout; got != in.Timeout {
+		t.Errorf("SpawnOpts.Timeout = %d, want %d", got, in.Timeout)
+	}
+}
+
+// TestSpawn_ShutdownDuringSetup covers the race the Spawn path guards against:
+// the orchestrator is shut down after the process has been launched but before
+// its state is registered. The half-started process must be canceled and its
+// pool slot returned, not leaked.
+func TestSpawn_ShutdownDuringSetup(t *testing.T) {
+	orch := NewOrchestrator(testConfig(), "", nil)
+	before := orch.pool.Available()
+
+	prev := startACPSessionFn
+	startACPSessionFn = func(_ context.Context, agentName, _ string, _ SpawnOpts) (acpSession, error) {
+		// Shut down while Spawn is still wiring the process up.
+		orch.Shutdown()
+
+		s := newFakeACPSession()
+		go s.finish(sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: agentName + " ok"})
+		return s, nil
+	}
+	t.Cleanup(func() { startACPSessionFn = prev })
+
+	_, _, err := orch.Spawn(context.Background(), SpawnInput{
+		Agent:  AgentConfig{Name: "claude", Role: "smol"},
+		Prompt: "go",
+	})
+	if err == nil {
+		t.Fatal("Spawn succeeded against a shut-down orchestrator")
+	}
+	if !strings.Contains(err.Error(), "shut down") {
+		t.Errorf("error %q does not say the orchestrator is shut down", err)
+	}
+	if got := orch.pool.Available(); got != before {
+		t.Errorf("pool slots available = %d, want %d — a slot was leaked", got, before)
+	}
+}
+
+// TestSpawn_LaunchFailureCleansUpWorktree checks the other unwind path: the
+// process never starts, so the worktree created for it and the pool slot held
+// for it both have to go back.
+func TestSpawn_LaunchFailureCleansUpWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	orch := NewOrchestrator(testConfig(), repo, nil)
+	t.Cleanup(orch.Shutdown)
+	before := orch.pool.Available()
+
+	prev := startACPSessionFn
+	startACPSessionFn = func(_ context.Context, _, _ string, _ SpawnOpts) (acpSession, error) {
+		return nil, fmt.Errorf("adapter binary not found")
+	}
+	t.Cleanup(func() { startACPSessionFn = prev })
+
+	useWorktree := true
+	_, _, err := orch.Spawn(context.Background(), SpawnInput{
+		Agent:    AgentConfig{Name: "claude", Role: "smol"},
+		Prompt:   "go",
+		Worktree: &useWorktree,
+	})
+	if err == nil {
+		t.Fatal("Spawn succeeded despite the adapter failing to launch")
+	}
+	if !strings.Contains(err.Error(), "adapter binary not found") {
+		t.Errorf("error %q loses the underlying launch failure", err)
+	}
+	if got := orch.pool.Available(); got != before {
+		t.Errorf("pool slots available = %d, want %d — a slot was leaked", got, before)
+	}
+	if len(orch.List()) != 0 {
+		t.Errorf("failed spawn left %d agents tracked, want 0", len(orch.List()))
+	}
+}
+
+// TestEvictCompletedAgents_DropsOldestFirst covers the bookkeeping that keeps
+// a long session's agent map from growing without bound: once finished agents
+// exceed the cap, the oldest are dropped and running ones are never touched.
+func TestEvictCompletedAgents_DropsOldestFirst(t *testing.T) {
+	orch := NewOrchestrator(testConfig(), "", nil)
+
+	const extra = 5
+	base := time.Now().Add(-time.Hour)
+
+	// Finished agents, oldest first: finished-0 is the oldest.
+	for i := range maxCompletedAgents + extra {
+		id := fmt.Sprintf("finished-%02d", i)
+		orch.agents[id] = &agentState{
+			ID:         id,
+			Type:       "worker",
+			Status:     "completed",
+			StartedAt:  base,
+			FinishedAt: base.Add(time.Duration(i) * time.Second),
+		}
+	}
+	// Plus one still running, which must survive regardless of age.
+	orch.agents["running-0"] = &agentState{
+		ID:        "running-0",
+		Type:      "worker",
+		Status:    "running",
+		StartedAt: base,
+	}
+
+	orch.mu.Lock()
+	orch.evictCompletedAgentsLocked()
+	orch.mu.Unlock()
+
+	if _, ok := orch.agents["running-0"]; !ok {
+		t.Error("a running agent was evicted")
+	}
+	if got := len(orch.agents); got != maxCompletedAgents+1 {
+		t.Errorf("tracked agents = %d, want %d", got, maxCompletedAgents+1)
+	}
+	for i := range extra {
+		id := fmt.Sprintf("finished-%02d", i)
+		if _, ok := orch.agents[id]; ok {
+			t.Errorf("%s is the %d-oldest finished agent and should have been evicted", id, i+1)
+		}
+	}
+	newest := fmt.Sprintf("finished-%02d", maxCompletedAgents+extra-1)
+	if _, ok := orch.agents[newest]; !ok {
+		t.Errorf("%s is the newest finished agent and should have been kept", newest)
+	}
+}
+
+// TestEvictCompletedAgents_UnderCapKeepsEverything guards the early return:
+// eviction must be a no-op until the cap is actually exceeded.
+func TestEvictCompletedAgents_UnderCapKeepsEverything(t *testing.T) {
+	orch := NewOrchestrator(testConfig(), "", nil)
+
+	for i := range maxCompletedAgents {
+		id := fmt.Sprintf("finished-%02d", i)
+		orch.agents[id] = &agentState{ID: id, Type: "worker", Status: "completed", FinishedAt: time.Now()}
+	}
+
+	orch.mu.Lock()
+	orch.evictCompletedAgentsLocked()
+	orch.mu.Unlock()
+
+	if got := len(orch.agents); got != maxCompletedAgents {
+		t.Errorf("tracked agents = %d, want %d — evicted below the cap", got, maxCompletedAgents)
+	}
+}
+
+// TestSpawn_RejectedAfterShutdown is the plain case: once shut down, the
+// orchestrator refuses new work outright.
+func TestSpawn_RejectedAfterShutdown(t *testing.T) {
+	orch := NewOrchestrator(testConfig(), "", nil)
+	orch.Shutdown()
+
+	_, _, err := orch.Spawn(context.Background(), SpawnInput{
+		Agent:  AgentConfig{Name: "worker", Role: "smol"},
+		Prompt: "go",
+	})
+	if err == nil {
+		t.Fatal("Spawn succeeded after Shutdown")
+	}
+	if !strings.Contains(err.Error(), "shut down") {
+		t.Errorf("error %q does not say the orchestrator is shut down", err)
+	}
+}

--- a/internal/tui/run_backup_test.go
+++ b/internal/tui/run_backup_test.go
@@ -1,0 +1,243 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// initRunTestRepo builds a throwaway git repo with one commit, which is the
+// minimum a WorktreeManager needs to create worktrees and branches.
+func initRunTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "config", "tag.gpgsign", "false"},
+		{"git", "commit", "--allow-empty", "-m", "initial commit"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+	return dir
+}
+
+func TestRunBackupBranchName(t *testing.T) {
+	tests := []struct {
+		name     string
+		specName string
+		suffix   string
+		want     string
+	}{
+		{"plain spec", "my-spec", "", "run/my-spec"},
+		{"nested spec flattens to dashes", "area/my-spec", "", "run/area-my-spec"},
+		{"suffix becomes a branch segment", "my-spec", "part-1", "run/my-spec/part-1"},
+		{"surrounding slashes are trimmed", "/my-spec/", "", "run/my-spec"},
+		{"nested spec with suffix", "area/my-spec", "part-2", "run/area-my-spec/part-2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runBackupBranchName(tt.specName, tt.suffix); got != tt.want {
+				t.Errorf("runBackupBranchName(%q, %q) = %q, want %q", tt.specName, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunBackupBranchName_DistinctPerAgent guards the property the parallel run
+// depends on: two agents working the same spec must not be handed the same
+// backup branch, or the second `git branch -f` silently overwrites the first.
+func TestRunBackupBranchName_DistinctPerAgent(t *testing.T) {
+	first := runBackupBranchName("my-spec", "part-1")
+	second := runBackupBranchName("my-spec", "part-2")
+	if first == second {
+		t.Errorf("both parallel agents got backup branch %q", first)
+	}
+}
+
+func TestCreateRunBackupBranch_NoOrchestrator(t *testing.T) {
+	m := &model{chatModel: ChatModel{Messages: make([]message, 0)}}
+
+	err := m.createRunBackupBranch("task-1", "run/my-spec")
+	if err == nil {
+		t.Fatal("expected an error with no orchestrator")
+	}
+	if !strings.Contains(err.Error(), "no worktree manager") {
+		t.Errorf("error %q does not name the missing worktree manager", err)
+	}
+}
+
+func TestCreateRunBackupBranch_NoWorktreeManager(t *testing.T) {
+	// An orchestrator built without a repo root has no worktree manager.
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	t.Cleanup(orch.Shutdown)
+
+	m := &model{cfg: Config{Orchestrator: orch}}
+
+	err := m.createRunBackupBranch("task-1", "run/my-spec")
+	if err == nil {
+		t.Fatal("expected an error with no worktree manager")
+	}
+	if !strings.Contains(err.Error(), "no worktree manager") {
+		t.Errorf("error %q does not name the missing worktree manager", err)
+	}
+}
+
+func TestCreateRunBackupBranch_CreatesBranch(t *testing.T) {
+	repo := initRunTestRepo(t)
+	orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)
+	t.Cleanup(orch.Shutdown)
+
+	const agentID = "task-backup-1"
+	if _, err := orch.Worktree().Create(agentID); err != nil {
+		t.Fatalf("creating worktree: %v", err)
+	}
+
+	m := &model{cfg: Config{Orchestrator: orch}}
+
+	branch := runBackupBranchName("my-spec", "")
+	if err := m.createRunBackupBranch(agentID, branch); err != nil {
+		t.Fatalf("createRunBackupBranch: %v", err)
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--verify", branch)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("backup branch %q was not created: %v: %s", branch, err, out)
+	}
+}
+
+func TestCreateRunBackupBranch_UnknownAgent(t *testing.T) {
+	repo := initRunTestRepo(t)
+	orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)
+	t.Cleanup(orch.Shutdown)
+
+	m := &model{cfg: Config{Orchestrator: orch}}
+
+	err := m.createRunBackupBranch("never-spawned", "run/my-spec")
+	if err == nil {
+		t.Fatal("expected an error for an agent with no worktree")
+	}
+	if !strings.Contains(err.Error(), "never-spawned") {
+		t.Errorf("error %q does not name the unknown agent", err)
+	}
+}
+
+// writeRunSpec lays out specs/<name>/{PROMPT.md,plan.md} under workDir.
+func writeRunSpec(t *testing.T, workDir, specName, prompt, plan string) {
+	t.Helper()
+	dir := filepath.Join(workDir, "specs", specName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "PROMPT.md"), []byte(prompt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if plan != "" {
+		if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte(plan), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// runTestModel returns a model wired to an orchestrator that cannot resolve a
+// model for the task role, so every spawn fails fast instead of launching a
+// real subagent.
+func runTestModel(t *testing.T, workDir string) *model {
+	t.Helper()
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	t.Cleanup(orch.Shutdown)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return &model{
+		ctx:       ctx,
+		cancel:    cancel,
+		cfg:       Config{WorkDir: workDir, Orchestrator: orch},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+	}
+}
+
+func lastMessage(t *testing.T, m *model) string {
+	t.Helper()
+	if len(m.chatModel.Messages) == 0 {
+		t.Fatal("no messages were appended")
+	}
+	return m.chatModel.Messages[len(m.chatModel.Messages)-1].content
+}
+
+// TestHandleRunCommand_SpawnFailure checks the single-agent path reports a
+// failed spawn rather than leaving the model in a half-started run state.
+func TestHandleRunCommand_SpawnFailure(t *testing.T) {
+	workDir := t.TempDir()
+	writeRunSpec(t, workDir, "my-spec", "# My Spec\n\n## Gates\n\n- **build**: `go build ./...`\n", "")
+
+	m := runTestModel(t, workDir)
+	m.handleRunCommand([]string{"my-spec"})
+
+	if got := lastMessage(t, m); !strings.Contains(got, "Failed to spawn task agent") {
+		t.Errorf("message %q does not report the spawn failure", got)
+	}
+	if m.run != nil {
+		t.Error("a run state was recorded despite the spawn failing")
+	}
+	if m.running {
+		t.Error("model was left in the running state despite the spawn failing")
+	}
+}
+
+// TestHandleRunCommand_ParallelSpawnFailure drives the --parallel branch, which
+// splits the plan checklist across two agents. The first spawn fails, so the
+// error must name agent 1 and no run state may be recorded.
+func TestHandleRunCommand_ParallelSpawnFailure(t *testing.T) {
+	workDir := t.TempDir()
+	plan := `# Plan
+
+- [ ] Step 1: first slice
+- [ ] Step 2: second slice
+- [ ] Step 3: third slice
+- [ ] Step 4: fourth slice
+`
+	writeRunSpec(t, workDir, "my-spec", "# My Spec\n", plan)
+
+	m := runTestModel(t, workDir)
+	m.handleRunCommand([]string{"my-spec", "--parallel"})
+
+	got := lastMessage(t, m)
+	if !strings.Contains(got, "Failed to spawn agent 1") {
+		t.Errorf("message %q does not report which parallel agent failed", got)
+	}
+	if m.run != nil {
+		t.Error("a run state was recorded despite the spawn failing")
+	}
+}
+
+// TestHandleRunCommand_ParallelFallsBackToSingleAgent guards the guard: with
+// fewer than two checklist steps there is nothing to split, so --parallel must
+// take the single-agent path instead of spawning two agents over one slice.
+func TestHandleRunCommand_ParallelFallsBackToSingleAgent(t *testing.T) {
+	workDir := t.TempDir()
+	writeRunSpec(t, workDir, "my-spec", "# My Spec\n", "# Plan\n\n- [ ] Step 1: the only slice\n")
+
+	m := runTestModel(t, workDir)
+	m.handleRunCommand([]string{"my-spec", "--parallel"})
+
+	if got := lastMessage(t, m); !strings.Contains(got, "Failed to spawn task agent") {
+		t.Errorf("message %q suggests the parallel path ran with a single slice", got)
+	}
+}


### PR DESCRIPTION
`f3f6803` (#122) added a per-spawn timeout override so `/run` can give a task agent an hour without editing the bundled agent's frontmatter — but none of the new lines were exercised. Codecov on `f5c1b30` showed the override branch, the legacy `AgentInput` passthrough, and both `run.go` backup-branch helpers uncovered.

Tests only — no production code changes.

## internal/subagent/orchestrator_timeout_test.go

- Table test pinning the precedence rule (explicit > agent definition; zero and negative ignored), asserted against the `SpawnOpts` the ACP session seam receives.
- Behavioral test that the override is the deadline the agent actually dies on — the agent definition asks for 30s, the spawn asks for 300ms — and that the orchestrator reports `timeout` rather than `killed`. The spawner SIGKILLs the group, so without the explicit `ErrSubagentTimeout` check this is indistinguishable from an OOM.
- `SpawnWithInput`/`ToSpawnInput` carry the timeout through the legacy path.
- Both `Spawn` unwind paths — shutdown mid-setup, and launch failure with a worktree — each checked for a leaked pool slot.
- `evictCompletedAgentsLocked`: oldest-first eviction, running agents kept, no-op below the cap.

## internal/tui/run_backup_test.go

- `runBackupBranchName` and `createRunBackupBranch`, both previously at 0%.
- `handleRunCommand` and its `--parallel` branch on spawn failure.

## Verification

Reverting the override in `orchestrator.go` fails all three timeout tests (the behavioral one by running the full 30s). Race detector clean on both packages; `golangci-lint` clean.

| Package | Before | After |
|---|---|---|
| `internal/subagent` | 86.2% | 88.1% |
| `internal/tui` | 89.2% | 89.4% |
| `Spawn` | 84.8% | 93.7% |
| `evictCompletedAgentsLocked` | 37.5% | 100% |
| `runBackupBranchName` / `createRunBackupBranch` | 0% | 100% |

## Known gap

`handleRunParallel` stays at 25%. Only its first `SpawnWithInput` is reachable — going further needs a real spawn, and `tui.Config` holds a concrete `*subagent.Orchestrator` whose spawner field is unexported, so there is no seam to inject a fake pi binary from package `tui`. Adding one is a production change and is left out deliberately.

https://claude.ai/code/session_016Dpc3f71hxXNJ4j4yxu8A2