### PR TITLE
fix(run): coordinator/worker/verifier loop so /run finishes the plan

### DIFF
--- a/internal/sop/pdd_default.go
+++ b/internal/sop/pdd_default.go
@@ -29,6 +29,11 @@ You can reference rough-idea.md for the original idea.
 - When requirements are clear, summarize them and get explicit confirmation before moving on
 
 ### Phase 3: Objective Research
+- Delegate research to subagents rather than reading files into your own context.
+  Split the question into 2-5 independent angles and dispatch them in ONE parallel
+  ` + "`" + `subagent` + "`" + ` call: ` + "`" + `{tasks: [{agent: "explore", task: "..."}, ...]}` + "`" + `.
+  Each angle gets its own agent, and each returns findings — not file contents.
+  This keeps the planning session's context small enough to reach Phase 7.
 - Explore the codebase to understand relevant existing code
 - IMPORTANT: Focus only on facts — how the code works today, what patterns exist, what
   dependencies are involved. Do NOT propose solutions or implementation ideas during research.
@@ -70,14 +75,25 @@ You can reference rough-idea.md for the original idea.
   - What to implement (specific files and changes)
   - Verification checkpoint: what build/test command confirms this slice works
   - Dependencies on previous slices
+  - Parallel-safe: yes/no — "yes" only when the slice shares no files with any
+    other slice that has no ordering dependency on it
 - Every slice must compile and pass tests independently
 - Steps should build incrementally — never require more than one slice to be done before testing
+- **Size every slice to fit one worker subagent's context.** /run does not execute
+  the plan in a single agent — a Coordinator delegates one slice per worker. A slice
+  that needs more than ~10 files or ~400 lines of change is too big: split it.
+  Oversized slices are the single largest cause of failed runs — the worker's context
+  grows past the model limit and the provider drops the stream mid-slice.
 
 ### Phase 7: PROMPT.md Generation
 - Write PROMPT.md — the compressed execution briefing
 - Use the template below
 - IMPORTANT: Discover the project's build and test commands during research
   and embed them in the Gates section
+- IMPORTANT: Fill in the Execution Model and Done Criteria sections. /run reads
+  them to drive the Coordinator → Worker → Verifier loop. A PROMPT.md without
+  Done Criteria makes the Verifier fall back to checkbox counting alone, which
+  cannot tell "implemented" from "stubbed".
 
 ## PROMPT.md Template
 
@@ -95,8 +111,27 @@ You can reference rough-idea.md for the original idea.
 - Given <precondition>, when <action>, then <expected outcome>
 
 ## Implementation Slices
-1. **<Slice name>** — <what to implement>, verify: <build/test command>
-2. **<Slice name>** — <what to implement>, verify: <build/test command>
+1. **<Slice name>** — <what to implement>, files: ` + "`" + `<paths>` + "`" + `, verify: <build/test command>, parallel-safe: <yes|no>
+2. **<Slice name>** — <what to implement>, files: ` + "`" + `<paths>` + "`" + `, verify: <build/test command>, parallel-safe: <yes|no>
+
+## Execution Model
+Coordinator → Worker → Verifier. The agent that receives this PROMPT.md is the
+**Coordinator**; it delegates rather than implements.
+
+- **Workers**: one ` + "`" + `worker` + "`" + ` subagent per slice (` + "`" + `quick-task` + "`" + ` for a single-file
+  mechanical change). Slices marked parallel-safe may be batched in one parallel
+  ` + "`" + `subagent` + "`" + ` call; all others run one at a time, in order.
+- **Verifier**: after the last slice, a ` + "`" + `code-reviewer` + "`" + ` subagent checks the Done
+  Criteria below against the actual diff and returns VERDICT: PASS or VERDICT: FAIL.
+- **Loop**: on FAIL the Coordinator dispatches fix workers and re-verifies, up to
+  10 cycles total.
+
+## Done Criteria
+The Verifier checks these against the diff, not against the checklist. Each must
+be objectively checkable by reading code or running a command.
+- [ ] <observable outcome, e.g. "POST /api/x returns 202 and enqueues a job — see handler_test.go">
+- [ ] <observable outcome>
+- [ ] No slice is left as a stub, TODO, or panic("not implemented")
 
 ## Gates
 - **build**: ` + "`" + `<build command discovered during research>` + "`" + `
@@ -133,4 +168,11 @@ Follow the conventions in specs/AGENTS.md for spec directory structure and namin
 - Gates should use the project's actual build/test commands
 - Be thorough but efficient — ask only necessary questions
 - Aim for plans with <50 distinct instructions per phase — large instruction counts degrade LLM compliance
+- **Delegate to subagents for anything small and self-contained** — a file lookup,
+  an API-shape check, a convention question. Spawn ` + "`" + `explore` + "`" + ` (research) or
+  ` + "`" + `quick-task` + "`" + ` (small edits); batch independent ones into a single parallel call.
+  Read files directly only when you need the exact text in your own context.
+- **Never delegate to a [worktree] agent from /plan or /run** (` + "`" + `task` + "`" + `, ` + "`" + `designer` + "`" + `).
+  Their edits land in a nested worktree that is never merged, so the work is lost.
+  Use ` + "`" + `worker` + "`" + ` or ` + "`" + `quick-task` + "`" + ` — they edit the current directory.
 `

--- a/internal/sop/sop_test.go
+++ b/internal/sop/sop_test.go
@@ -157,3 +157,33 @@ func searchString(s, substr string) bool {
 	}
 	return false
 }
+
+// The default SOP must teach the Coordinator → Worker → Verifier model, and
+// must generate a PROMPT.md that /run's verifier can act on. Without these
+// sections a plan produces a single monolithic agent whose context outgrows
+// the model before the last slice lands.
+func TestDefaultPDDSOP_CarriesCoordinatorWorkflow(t *testing.T) {
+	for _, want := range []string{
+		"## Execution Model",
+		"Coordinator → Worker → Verifier",
+		"## Done Criteria",
+		"code-reviewer",
+		"VERDICT: PASS",
+		"parallel-safe",
+	} {
+		if !contains(DefaultPDDSOP, want) {
+			t.Errorf("default PDD SOP missing %q", want)
+		}
+	}
+}
+
+// Delegating to a [worktree] agent from /plan or /run drops the edits into a
+// nested worktree that is never merged, so the SOP must rule it out.
+func TestDefaultPDDSOP_ForbidsWorktreeAgents(t *testing.T) {
+	if !contains(DefaultPDDSOP, "Never delegate to a [worktree] agent") {
+		t.Error("default PDD SOP should forbid delegating to [worktree] agents")
+	}
+	if !contains(DefaultPDDSOP, "explore") {
+		t.Error("default PDD SOP should name the research subagent to delegate to")
+	}
+}

--- a/internal/tui/plan_run_e2e_test.go
+++ b/internal/tui/plan_run_e2e_test.go
@@ -511,27 +511,33 @@ Build something.
 		t.Error("gate output should not include passed gates")
 	}
 
-	// Build retry prompt.
-	retryPrompt := buildRetryPrompt("my-feature", promptMD, gateOutput)
+	// Build the resume prompt for the next cycle.
+	retryPrompt := buildResumePrompt("my-feature", promptMD, "Gate failed", gateOutput)
 
-	// Verify retry prompt contains all expected sections.
-	if !strings.Contains(retryPrompt, "failed gate validation") {
-		t.Error("retry prompt should mention gate validation failure")
+	// Verify resume prompt contains all expected sections.
+	if !strings.Contains(retryPrompt, "Gate failed") {
+		t.Error("resume prompt should name the reason the cycle stopped")
 	}
-	if !strings.Contains(retryPrompt, "## Gate Failures") {
-		t.Error("retry prompt should contain gate failures section")
+	if !strings.Contains(retryPrompt, "## State") {
+		t.Error("resume prompt should contain the carried-over state section")
 	}
 	if !strings.Contains(retryPrompt, "FAIL: TestFoo") {
-		t.Error("retry prompt should contain specific failure output")
+		t.Error("resume prompt should contain specific failure output")
 	}
 	if !strings.Contains(retryPrompt, "## Original Task") {
-		t.Error("retry prompt should contain original task")
+		t.Error("resume prompt should contain original task")
 	}
 	if !strings.Contains(retryPrompt, "Build something.") {
-		t.Error("retry prompt should contain original objective")
+		t.Error("resume prompt should contain original objective")
 	}
-	if !strings.Contains(retryPrompt, "Fix the issues") {
-		t.Error("retry prompt should contain fix instructions")
+	if !strings.Contains(retryPrompt, "## Resume Instructions") {
+		t.Error("resume prompt should contain resume instructions")
+	}
+	if !strings.Contains(retryPrompt, "SAME worktree") {
+		t.Error("resume prompt should tell the agent the prior work is on disk")
+	}
+	if !strings.Contains(retryPrompt, "Your Role: Coordinator") {
+		t.Error("resume prompt should carry the coordinator contract")
 	}
 }
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -750,11 +750,7 @@ func (m *model) verifyRunComplete() (tea.Model, tea.Cmd) {
 
 	// Cycles exhausted with work still outstanding — do not merge.
 	m.run.phase = "failed"
-	wm := m.cfg.Orchestrator.Worktree()
-	wtPath := ""
-	if wm != nil {
-		wtPath = wm.PathFor(m.run.agentID)
-	}
+	wtPath := m.runWorktreePath(m.run.agentID)
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
 		content: fmt.Sprintf(
@@ -769,6 +765,20 @@ func (m *model) verifyRunComplete() (tea.Model, tea.Cmd) {
 		})
 	}
 	return m, nil
+}
+
+// runWorktreePath returns the worktree directory for an agent, or "" when
+// there is no orchestrator or worktree manager to ask. Callers reach it from
+// terminal-reporting paths that may run without either.
+func (m *model) runWorktreePath(agentID string) string {
+	if m.cfg.Orchestrator == nil {
+		return ""
+	}
+	wm := m.cfg.Orchestrator.Worktree()
+	if wm == nil {
+		return ""
+	}
+	return wm.PathFor(agentID)
 }
 
 // retryRun spawns the next cycle in the same worktree, carrying `context`
@@ -786,10 +796,7 @@ func (m *model) retryRun(reason, extraContext string) tea.Cmd {
 	m.run.retries++
 	m.run.phase = "retrying"
 
-	wtPath := ""
-	if wm := m.cfg.Orchestrator.Worktree(); wm != nil {
-		wtPath = wm.PathFor(m.run.agentID)
-	}
+	wtPath := m.runWorktreePath(m.run.agentID)
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
@@ -1038,11 +1045,7 @@ func (m *model) handleRunGateResult(msg runGateResultMsg) (tea.Model, tea.Cmd) {
 	// Retries exhausted.
 	m.run.phase = "failed"
 
-	wm := m.cfg.Orchestrator.Worktree()
-	wtPath := ""
-	if wm != nil {
-		wtPath = wm.PathFor(m.run.agentID)
-	}
+	wtPath := m.runWorktreePath(m.run.agentID)
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -39,7 +39,7 @@ type runState struct {
 	gates       []Gate
 	agentID     string
 	status      string // authoritative terminal status from the subagent
-	phase       string // "running", "gating", "merging", "done", "failed"
+	phase       string // "running", "gating", "verifying", "retrying", "merging", "done", "failed"
 	retries     int
 	maxRetries  int
 	events      <-chan subagent.Event // subagent event channel (single-agent mode)
@@ -101,13 +101,65 @@ type runMergeResultMsg struct {
 	preservedWTPath string
 }
 
+// coordinatorContract is the Coordinator → Worker → Verifier execution contract
+// injected into every /run prompt. It is the reason a run survives long plans:
+// the coordinator's own context stays small because each slice is implemented in
+// a fresh worker context that is discarded once the slice lands.
+const coordinatorContract = `
+## Your Role: Coordinator
+
+You are the **Coordinator**. You do NOT implement slices yourself — you delegate
+each one to a worker subagent, verify it, and record progress. Implementing
+slices inline is what makes runs die: the context grows with every file read and
+every diff until the provider drops the stream mid-slice.
+
+### Delegating a slice
+
+Spawn ONE worker per slice with the ` + "`" + `subagent` + "`" + ` tool:
+
+- ` + "`" + `{agent: "worker", task: "<self-contained brief>"}` + "`" + ` — the default.
+- ` + "`" + `{agent: "quick-task", task: "..."}` + "`" + ` — a single-file mechanical change.
+- ` + "`" + `{tasks: [{agent: "worker", task: "..."}, ...]}` + "`" + ` — several slices at once, ONLY
+  when the plan marks them parallel-safe and they touch disjoint files (max 8).
+
+**Never spawn ` + "`" + `task` + "`" + ` or ` + "`" + `designer` + "`" + `.** They are [worktree] agents: their edits go to
+a nested worktree that is never merged back, so the slice silently produces
+nothing. ` + "`" + `worker` + "`" + ` and ` + "`" + `quick-task` + "`" + ` edit the current directory, which is what you want.
+
+Each worker brief must stand alone — the worker cannot see this conversation.
+State the exact files, the change, the surrounding conventions, and the verify
+command. Do NOT paste the whole plan into a worker brief; give it only its slice.
+
+### After each slice
+
+1. Run that slice's verify command yourself.
+2. If it fails, send a fix brief to a new worker (up to 3 attempts per slice),
+   including the exact error output.
+3. Tick the checkbox in specs/%[1]s/plan.md: ` + "`" + `- [ ] Step N:` + "`" + ` → ` + "`" + `- [x] Step N:` + "`" + `.
+
+Tick a box only after its verify command has actually passed. A checked box that
+was never verified is worse than an unchecked one — it ends the run early.
+
+### After the last slice: Verify
+
+Spawn the Verifier and act on its verdict:
+
+` + "`" + `{agent: "code-reviewer", task: "Check the working-tree diff against these Done Criteria: <paste the Done Criteria from the briefing above, or the Acceptance Criteria if absent>. For each criterion answer MET or NOT MET with the file and line that proves it. Flag any stub, TODO, or panic(\"not implemented\") left in the changed files. End your reply with exactly one line: VERDICT: PASS or VERDICT: FAIL."}` + "`" + `
+
+- **VERDICT: FAIL** — dispatch fix workers for the NOT MET items, then verify again.
+  Repeat up to 10 cycles.
+- **VERDICT: PASS** — report the changed files and stop. Do not commit or merge;
+  /run handles gates and the merge.
+`
+
 // buildRunPrompt constructs the augmented prompt for the task subagent.
 // If the plan.md uses heading-only format (no checkboxes), it injects a
 // checklist so the agent can mark steps as completed.
 func buildRunPrompt(specName, promptMD string, checklist []ChecklistStep) string {
 	var b strings.Builder
 	b.WriteString(promptMD)
-	b.WriteString("\n\n## Execution Instructions\n")
+	fmt.Fprintf(&b, coordinatorContract, specName)
+	b.WriteString("\n## Execution Instructions\n")
 	b.WriteString("- Follow the plan in specs/")
 	b.WriteString(specName)
 	b.WriteString("/plan.md step by step\n")
@@ -420,13 +472,15 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 func buildParallelPrompt(specName, promptMD string, checklist []ChecklistStep, from, to int) string {
 	var b strings.Builder
 	b.WriteString(promptMD)
-	b.WriteString("\n\n## Execution Instructions (Parallel Mode)\n")
-	b.WriteString("You are ONE OF TWO agents working on this spec in parallel.\n")
-	b.WriteString("You are responsible for implementing ONLY these slices:\n\n")
+	fmt.Fprintf(&b, coordinatorContract, specName)
+	b.WriteString("\n## Execution Instructions (Parallel Mode)\n")
+	b.WriteString("You are ONE OF TWO coordinators working on this spec in parallel.\n")
+	b.WriteString("You are responsible for delegating ONLY these slices:\n\n")
 	for i := from; i < to; i++ {
 		fmt.Fprintf(&b, "- Slice %d: %s\n", i+1, checklist[i].Title)
 	}
-	b.WriteString("\nDo NOT implement slices assigned to the other agent.\n")
+	b.WriteString("\nDo NOT implement slices assigned to the other coordinator.\n")
+	b.WriteString("Verify only your own slices — the Verifier step covers your half.\n")
 	b.WriteString("- Follow the plan in specs/")
 	b.WriteString(specName)
 	b.WriteString("/plan.md for details on your assigned slices\n")
@@ -584,16 +638,24 @@ func (m *model) handleRunAgentDone(msg runAgentDoneMsg) (tea.Model, tea.Cmd) {
 	m.run.status = msg.status
 
 	// Verify that every subagent exited cleanly (status == "completed")
-	// before moving on to gate validation.
+	// before moving on to gate validation. A non-clean exit is usually a
+	// provider stream error (429/502/400) rather than a decision to stop —
+	// the work so far is intact in the worktree, so resume there rather than
+	// abandoning the whole run.
 	if bad := m.failedAgentIDs(); len(bad) > 0 {
+		m.refreshRunChecklist()
+		if cmd := m.retryRun("agent exited with non-zero status",
+			m.unfinishedSlicesContext()); cmd != nil {
+			return m, cmd
+		}
 		m.run.phase = "failed"
 		wtPaths := m.runWorktreePathsFor(bad)
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role: "assistant",
 			content: fmt.Sprintf(
-				"**Subagent exited with non-zero status** for spec `%s` — skipping gates and merge.\n"+
+				"**Subagent exited with non-zero status** for spec `%s` after %d retries — skipping gates and merge.\n"+
 					"Inspect the worktree(s) below and re-run `/run %s` once the issue is fixed.\n%s",
-				m.run.specName, m.run.specName, wtPaths),
+				m.run.specName, m.run.maxRetries, m.run.specName, wtPaths),
 		})
 		if report, rerr := m.writeRunSummary("agent_failed"); rerr == nil {
 			m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -609,19 +671,188 @@ func (m *model) handleRunAgentDone(msg runAgentDoneMsg) (tea.Model, tea.Cmd) {
 		content: "**All agents finished** — validating gates...",
 	})
 
-	// If no gates, skip directly to merge.
+	// If no gates, skip straight to completeness verification.
 	if len(m.run.gates) == 0 {
-		m.run.phase = "merging"
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role:    "assistant",
-			content: "No gates defined — proceeding to merge.",
+			content: "No gates defined — verifying plan completeness.",
 		})
-		return m, m.mergeWorktreeCmd()
+		return m.verifyRunComplete()
 	}
 
 	// Run gate validation.
 	m.run.phase = "gating"
 	return m, m.runGatesCmd()
+}
+
+// unfinishedSlices returns the checklist steps that are still unchecked,
+// as 1-based "Step N: Title" strings.
+func (rs *runState) unfinishedSlices() []string {
+	var out []string
+	for i, step := range rs.checklist {
+		if !step.Done {
+			out = append(out, fmt.Sprintf("Step %d: %s", i+1, step.Title))
+		}
+	}
+	return out
+}
+
+// unfinishedSlicesContext renders the unchecked slices as a prompt fragment
+// for the next cycle. Empty when the checklist is absent or fully ticked.
+func (m *model) unfinishedSlicesContext() string {
+	if m.run == nil {
+		return ""
+	}
+	pending := m.run.unfinishedSlices()
+	if len(pending) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "The previous cycle stopped with %d of %d slices unfinished:\n\n",
+		len(pending), len(m.run.checklist))
+	for _, p := range pending {
+		fmt.Fprintf(&b, "- %s\n", p)
+	}
+	b.WriteString("\nWork already on disk is intact — inspect the worktree before redoing anything.\n")
+	b.WriteString("Resume from the first unfinished slice.\n")
+	return b.String()
+}
+
+// verifyRunComplete is the Verifier stage: gates only prove the tree builds,
+// not that the plan was carried out. A green build over a half-implemented
+// plan is the failure this catches — it re-reads plan.md from the worktree and
+// refuses to merge while slices remain unchecked, looping instead.
+func (m *model) verifyRunComplete() (tea.Model, tea.Cmd) {
+	m.run.phase = "verifying"
+	m.refreshRunChecklist()
+
+	pending := m.run.unfinishedSlices()
+	if len(pending) == 0 {
+		done := len(m.run.checklist)
+		msg := "**Verifier: PASS** — no plan checklist to verify."
+		if done > 0 {
+			msg = fmt.Sprintf("**Verifier: PASS** — all %d slices complete.", done)
+		}
+		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: msg})
+		m.run.phase = "merging"
+		return m, m.mergeWorktreeCmd()
+	}
+
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role: "assistant",
+		content: fmt.Sprintf("**Verifier: FAIL** — %d of %d slices still unchecked in plan.md.",
+			len(pending), len(m.run.checklist)),
+	})
+
+	if cmd := m.retryRun("plan incomplete", m.unfinishedSlicesContext()); cmd != nil {
+		return m, cmd
+	}
+
+	// Cycles exhausted with work still outstanding — do not merge.
+	m.run.phase = "failed"
+	wm := m.cfg.Orchestrator.Worktree()
+	wtPath := ""
+	if wm != nil {
+		wtPath = wm.PathFor(m.run.agentID)
+	}
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role: "assistant",
+		content: fmt.Sprintf(
+			"**Verification failed** for spec `%s` after %d retries — %d slices never completed.\n"+
+				"Not merging. Worktree preserved at: `%s`",
+			m.run.specName, m.run.maxRetries, len(pending), wtPath),
+	})
+	if report, err := m.writeRunSummary("verify_failed"); err == nil {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: fmt.Sprintf("Summary report: `%s`", report),
+		})
+	}
+	return m, nil
+}
+
+// retryRun spawns the next cycle in the same worktree, carrying `context`
+// (unfinished slices, gate output) into the new coordinator's prompt.
+// It returns nil when the retry budget is spent, leaving the caller to
+// decide how to report the terminal failure.
+func (m *model) retryRun(reason, extraContext string) tea.Cmd {
+	if m.run == nil || m.run.retries >= m.run.maxRetries {
+		return nil
+	}
+	if m.cfg.Orchestrator == nil {
+		return nil
+	}
+
+	m.run.retries++
+	m.run.phase = "retrying"
+
+	wtPath := ""
+	if wm := m.cfg.Orchestrator.Worktree(); wm != nil {
+		wtPath = wm.PathFor(m.run.agentID)
+	}
+
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role: "assistant",
+		content: fmt.Sprintf("**%s** — cycle %d/%d (retry %d) in worktree `%s`...",
+			reason, m.run.retries+1, m.run.maxRetries, m.run.retries, wtPath),
+	})
+
+	prompt := buildResumePrompt(m.run.specName, m.run.promptMD, reason, extraContext)
+
+	events, agentID, err := m.cfg.Orchestrator.SpawnWithInput(m.ctx, subagent.AgentInput{
+		Type:        "task",
+		Prompt:      prompt,
+		WorkDir:     wtPath,
+		SkipCleanup: true,
+		Timeout:     int((60 * time.Minute) / time.Millisecond),
+	})
+	if err != nil {
+		m.run.phase = "failed"
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: fmt.Sprintf("Failed to spawn retry agent: %v", err),
+		})
+		return nil
+	}
+
+	// The new agent owns the run from here; parallel fan-in is over once we
+	// fall back to a single resuming coordinator.
+	m.run.agentID = agentID
+	m.run.events = events
+	m.run.parallel = nil
+	m.run.status = ""
+	m.run.phase = "running"
+
+	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: ""})
+	m.chatModel.Streaming = ""
+	m.chatModel.Thinking = ""
+	m.running = true
+	m.chatModel.Scroll = 0
+
+	return waitForRunAgent(events, agentID)
+}
+
+// buildResumePrompt constructs the prompt for a cycle that resumes an
+// interrupted or incomplete run in an existing worktree.
+func buildResumePrompt(specName, promptMD, reason, extraContext string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "The previous execution cycle did not finish: %s.\n\n", reason)
+	if extraContext != "" {
+		b.WriteString("## State\n")
+		b.WriteString(extraContext)
+		b.WriteString("\n")
+	}
+	b.WriteString("## Original Task\n")
+	b.WriteString(promptMD)
+	fmt.Fprintf(&b, coordinatorContract, specName)
+	b.WriteString("\n## Resume Instructions\n")
+	b.WriteString("- You are continuing in the SAME worktree as the previous cycle — its work is already on disk\n")
+	b.WriteString("- Read specs/")
+	b.WriteString(specName)
+	b.WriteString("/plan.md first to see which slices are already ticked\n")
+	b.WriteString("- Re-verify one completed slice before trusting the checklist; if a ticked slice does not actually work, untick it\n")
+	b.WriteString("- Delegate the remaining slices to workers as described above\n")
+	return b.String()
 }
 
 // failedAgentIDs returns the IDs of subagents (single or parallel) that
@@ -789,65 +1020,19 @@ func (m *model) handleRunGateResult(msg runGateResultMsg) (tea.Model, tea.Cmd) {
 	})
 
 	if msg.passed {
-		// All gates passed — proceed to merge.
-		m.run.phase = "merging"
+		// Gates prove the tree builds; the Verifier proves the plan was done.
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role:    "assistant",
-			content: "All gates passed — merging worktree branch...",
+			content: "All gates passed — verifying plan completeness...",
 		})
-		return m, m.mergeWorktreeCmd()
+		return m.verifyRunComplete()
 	}
 
 	// Gates failed — attempt retry or give up.
 	m.run.gateOutput = formatGateFailures(msg.results)
 
-	if m.run.retries < m.run.maxRetries {
-		// Retry: re-spawn agent in the same worktree with failure context.
-		m.run.retries++
-		m.run.phase = "retrying"
-
-		wm := m.cfg.Orchestrator.Worktree()
-		wtPath := ""
-		if wm != nil {
-			wtPath = wm.PathFor(m.run.agentID)
-		}
-
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role: "assistant",
-			content: fmt.Sprintf("**Gate failed** — cycle %d/%d (retry %d) in worktree `%s`...",
-				m.run.retries+1, m.run.maxRetries, m.run.retries, wtPath),
-		})
-
-		retryPrompt := buildRetryPrompt(m.run.specName, m.run.promptMD, m.run.gateOutput)
-
-		// Spawn a new agent in the same worktree directory.
-		events, agentID, err := m.cfg.Orchestrator.SpawnWithInput(m.ctx, subagent.AgentInput{
-			Type:        "task",
-			Prompt:      retryPrompt,
-			WorkDir:     wtPath,
-			SkipCleanup: true,
-		})
-		if err != nil {
-			m.run.phase = "failed"
-			m.chatModel.Messages = append(m.chatModel.Messages, message{
-				role:    "assistant",
-				content: fmt.Sprintf("Failed to spawn retry agent: %v", err),
-			})
-			return m, nil
-		}
-
-		m.run.agentID = agentID
-		m.run.phase = "running"
-		m.run.events = events
-
-		// Add empty assistant message for streaming.
-		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: ""})
-		m.chatModel.Streaming = ""
-		m.chatModel.Thinking = ""
-		m.running = true
-		m.chatModel.Scroll = 0
-
-		return m, waitForRunAgent(events, agentID)
+	if cmd := m.retryRun("Gate failed", m.run.gateOutput); cmd != nil {
+		return m, cmd
 	}
 
 	// Retries exhausted.
@@ -1017,6 +1202,9 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 	fmt.Fprintf(&b, "| Agent | `%s` |\n", rs.agentID)
 	fmt.Fprintf(&b, "| Outcome | **%s** |\n", outcome)
 	fmt.Fprintf(&b, "| Retries | %d / %d |\n", rs.retries, rs.maxRetries)
+	if n := len(rs.checklist); n > 0 {
+		fmt.Fprintf(&b, "| Slices | %d / %d complete |\n", n-len(rs.unfinishedSlices()), n)
+	}
 	if !rs.startTime.IsZero() {
 		fmt.Fprintf(&b, "| Started | %s |\n", rs.startTime.Format(time.RFC3339))
 		fmt.Fprintf(&b, "| Duration | %s |\n", time.Since(rs.startTime).Truncate(time.Second))
@@ -1058,13 +1246,24 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 		}
 	}
 
+	// Unfinished slices, when the run stopped short of the plan.
+	if pending := rs.unfinishedSlices(); len(pending) > 0 {
+		b.WriteString("## Unfinished Slices\n\n")
+		for _, p := range pending {
+			fmt.Fprintf(&b, "- %s\n", p)
+		}
+		b.WriteString("\n")
+	}
+
 	// Outcome details.
 	b.WriteString("## Result\n\n")
 	switch outcome {
 	case "completed":
-		b.WriteString("All gates passed and changes were merged successfully.\n")
+		b.WriteString("All gates passed, the plan checklist was complete, and changes were merged successfully.\n")
 	case "gate_failed":
 		fmt.Fprintf(&b, "Gate validation failed after %d retries. Worktree preserved for manual inspection.\n", rs.retries)
+	case "verify_failed":
+		fmt.Fprintf(&b, "Gates passed but the plan was still incomplete after %d retries — the run stopped short of the checklist. Nothing was merged; the worktree is preserved so the finished slices are not lost.\n", rs.retries)
 	case "merge_failed":
 		b.WriteString("Gates passed but merge into the main branch failed. Worktree preserved for manual resolution.\n")
 	case "agent_failed":
@@ -1073,23 +1272,6 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 		fmt.Fprintf(&b, "Run ended with status: %s\n", outcome)
 	}
 
-	return b.String()
-}
-
-// buildRetryPrompt constructs the prompt for a retry agent after gate failure.
-func buildRetryPrompt(specName, promptMD, gateOutput string) string {
-	var b strings.Builder
-	b.WriteString("The previous implementation attempt failed gate validation.\n\n")
-	b.WriteString("## Gate Failures\n")
-	b.WriteString(gateOutput)
-	b.WriteString("\n## Original Task\n")
-	b.WriteString(promptMD)
-	b.WriteString("\n\n## Instructions\n")
-	b.WriteString("Fix the issues identified by the gate failures. The failing commands were run in the worktree.\n")
-	b.WriteString("Continue working in the current directory. Run the failing commands yourself to verify fixes.\n")
-	b.WriteString("Update specs/")
-	b.WriteString(specName)
-	b.WriteString("/plan.md checklist as you complete steps.\n")
 	return b.String()
 }
 

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -902,29 +902,41 @@ func TestFormatGateFailures(t *testing.T) {
 
 // --- Step 7 tests: Retry Logic on Gate Failure ---
 
-func TestBuildRetryPrompt_IncludesGateOutput(t *testing.T) {
+func TestBuildResumePrompt_IncludesGateOutput(t *testing.T) {
 	promptMD := "# My Feature\n\n## Objective\n\nBuild something.\n"
 	gateOutput := "Gate `test` (`go test ./...`) FAILED:\nFAIL pkg/foo\n\n"
 
-	result := buildRetryPrompt("my-feature", promptMD, gateOutput)
+	result := buildResumePrompt("my-feature", promptMD, "Gate failed", gateOutput)
 
-	if !strings.Contains(result, "failed gate validation") {
-		t.Error("retry prompt should mention gate validation failure")
+	if !strings.Contains(result, "Gate failed") {
+		t.Error("resume prompt should name the reason the cycle stopped")
 	}
-	if !strings.Contains(result, "## Gate Failures") {
-		t.Error("retry prompt should contain gate failures section")
+	if !strings.Contains(result, "## State") {
+		t.Error("resume prompt should contain the carried-over state section")
 	}
 	if !strings.Contains(result, "FAIL pkg/foo") {
-		t.Error("retry prompt should include gate failure output")
+		t.Error("resume prompt should include gate failure output")
 	}
 	if !strings.Contains(result, promptMD) {
-		t.Error("retry prompt should include original PROMPT.md")
+		t.Error("resume prompt should include original PROMPT.md")
 	}
 	if !strings.Contains(result, "specs/my-feature/plan.md") {
-		t.Error("retry prompt should reference the spec's plan.md")
+		t.Error("resume prompt should reference the spec's plan.md")
 	}
-	if !strings.Contains(result, "Fix the issues") {
-		t.Error("retry prompt should include fix instructions")
+	if !strings.Contains(result, "## Resume Instructions") {
+		t.Error("resume prompt should include resume instructions")
+	}
+}
+
+// A resume prompt with no carried state must not emit an empty State section.
+func TestBuildResumePrompt_NoStateSection(t *testing.T) {
+	result := buildResumePrompt("my-feature", "# My Feature\n", "agent exited with non-zero status", "")
+
+	if strings.Contains(result, "## State") {
+		t.Error("resume prompt should omit the State section when there is no carried state")
+	}
+	if !strings.Contains(result, "agent exited with non-zero status") {
+		t.Error("resume prompt should still name the reason")
 	}
 }
 
@@ -1435,8 +1447,11 @@ func TestBuildParallelPrompt(t *testing.T) {
 	if strings.Contains(prompt, "Slice 3") {
 		t.Error("should NOT include slice 3 (assigned to other agent)")
 	}
-	if !strings.Contains(prompt, "ONE OF TWO agents") {
+	if !strings.Contains(prompt, "ONE OF TWO coordinators") {
 		t.Error("should explain parallel assignment")
+	}
+	if !strings.Contains(prompt, "Your Role: Coordinator") {
+		t.Error("parallel prompt should carry the coordinator contract")
 	}
 }
 
@@ -1693,5 +1708,253 @@ func TestHandleRunAgentDone_UsesTerminalStatusAfterOrchestratorEviction(t *testi
 
 	if m.run.phase != "merging" {
 		t.Fatalf("phase = %q, want merging", m.run.phase)
+	}
+}
+
+// --- Verifier tests: gates passing must not merge an incomplete plan ---
+
+// A green build over a half-implemented plan is the failure the Verifier
+// exists to catch: gates pass, but slices remain unchecked, so the run must
+// loop instead of merging.
+func TestVerifier_IncompletePlanDoesNotMerge(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &model{
+		ctx:       ctx,
+		cfg:       Config{Orchestrator: orch},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		run: &runState{
+			specName:   "half-done",
+			promptMD:   "# Test\n",
+			agentID:    "task-1",
+			phase:      "gating",
+			retries:    0,
+			maxRetries: 3,
+			checklist: []ChecklistStep{
+				{Title: "Core", Done: true},
+				{Title: "HTTP", Done: false},
+			},
+		},
+	}
+
+	m.handleRunGateResult(runGateResultMsg{
+		results: []GateResult{{Name: "build", Command: "go build ./...", Passed: true}},
+		passed:  true,
+	})
+
+	if m.run.phase == "merging" || m.run.phase == "done" {
+		t.Fatalf("phase = %q — must not merge while slices are unchecked", m.run.phase)
+	}
+	if m.run.retries != 1 {
+		t.Errorf("retries = %d, want 1 (verifier should trigger a cycle)", m.run.retries)
+	}
+
+	var sawVerdict bool
+	for _, msg := range m.chatModel.Messages {
+		if strings.Contains(msg.content, "Verifier: FAIL") {
+			sawVerdict = true
+		}
+	}
+	if !sawVerdict {
+		t.Error("expected a 'Verifier: FAIL' message")
+	}
+}
+
+// With every slice ticked, the Verifier passes and the run proceeds to merge.
+func TestVerifier_CompletePlanProceedsToMerge(t *testing.T) {
+	m := &model{
+		cfg:       Config{Orchestrator: subagent.NewOrchestrator(&config.Config{}, "", nil)},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		run: &runState{
+			specName:   "all-done",
+			agentID:    "task-1",
+			phase:      "gating",
+			maxRetries: 3,
+			checklist: []ChecklistStep{
+				{Title: "Core", Done: true},
+				{Title: "HTTP", Done: true},
+			},
+		},
+	}
+
+	m.handleRunGateResult(runGateResultMsg{
+		results: []GateResult{{Name: "build", Command: "go build ./...", Passed: true}},
+		passed:  true,
+	})
+
+	if m.run.phase != "merging" {
+		t.Fatalf("phase = %q, want merging", m.run.phase)
+	}
+	if m.run.retries != 0 {
+		t.Errorf("retries = %d, want 0 — a complete plan should not retry", m.run.retries)
+	}
+}
+
+// A spec with no plan.md checklist has nothing to verify; the run must still
+// merge rather than stalling forever.
+func TestVerifier_NoChecklistProceedsToMerge(t *testing.T) {
+	m := &model{
+		cfg:       Config{Orchestrator: subagent.NewOrchestrator(&config.Config{}, "", nil)},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		run: &runState{
+			specName:   "no-plan",
+			agentID:    "task-1",
+			phase:      "gating",
+			maxRetries: 3,
+		},
+	}
+
+	m.handleRunGateResult(runGateResultMsg{passed: true})
+
+	if m.run.phase != "merging" {
+		t.Fatalf("phase = %q, want merging", m.run.phase)
+	}
+}
+
+// Once the retry budget is spent, an incomplete plan ends the run as
+// verify_failed — it must never fall through to a merge.
+func TestVerifier_ExhaustedRetriesFailsWithoutMerging(t *testing.T) {
+	m := &model{
+		cfg:       Config{Orchestrator: subagent.NewOrchestrator(&config.Config{}, "", nil)},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		run: &runState{
+			specName:   "stuck",
+			agentID:    "task-1",
+			phase:      "gating",
+			retries:    3,
+			maxRetries: 3,
+			checklist:  []ChecklistStep{{Title: "HTTP", Done: false}},
+		},
+	}
+
+	m.handleRunGateResult(runGateResultMsg{passed: true})
+
+	if m.run.phase != "failed" {
+		t.Fatalf("phase = %q, want failed", m.run.phase)
+	}
+	var sawNotMerging bool
+	for _, msg := range m.chatModel.Messages {
+		if strings.Contains(msg.content, "Not merging") {
+			sawNotMerging = true
+		}
+	}
+	if !sawNotMerging {
+		t.Error("expected the failure message to state that nothing was merged")
+	}
+}
+
+// --- Agent-failure retry: a dropped provider stream must not end the run ---
+
+// A subagent that exits non-clean (429/502 mid-stream) used to end the whole
+// run. It must now consume a retry cycle instead.
+func TestAgentFailure_TriggersRetryInsteadOfGivingUp(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &model{
+		ctx:       ctx,
+		cfg:       Config{Orchestrator: orch},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		run: &runState{
+			specName:   "dropped-stream",
+			promptMD:   "# Test\n",
+			agentID:    "task-1",
+			phase:      "running",
+			retries:    0,
+			maxRetries: 10,
+			checklist:  []ChecklistStep{{Title: "Core", Done: false}},
+		},
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-1", status: "failed"})
+
+	if m.run.retries != 1 {
+		t.Errorf("retries = %d, want 1 — an agent failure should start a new cycle", m.run.retries)
+	}
+	if m.run.phase == "gating" || m.run.phase == "merging" {
+		t.Errorf("phase = %q — a failed agent must not reach gates or merge", m.run.phase)
+	}
+}
+
+// With the retry budget spent, an agent failure reports agent_failed and stops.
+func TestAgentFailure_ExhaustedRetriesReportsFailure(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	m := &model{
+		cfg:       Config{Orchestrator: orch},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		run: &runState{
+			specName:   "dropped-stream",
+			agentID:    "task-1",
+			phase:      "running",
+			retries:    10,
+			maxRetries: 10,
+		},
+	}
+
+	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-1", status: "failed"})
+
+	if m.run.phase != "failed" {
+		t.Fatalf("phase = %q, want failed", m.run.phase)
+	}
+}
+
+// --- Unfinished-slice context carried into the next cycle ---
+
+func TestUnfinishedSlicesContext(t *testing.T) {
+	m := &model{
+		run: &runState{
+			checklist: []ChecklistStep{
+				{Title: "Core", Done: true},
+				{Title: "HTTP handler", Done: false},
+				{Title: "Docs", Done: false},
+			},
+		},
+	}
+
+	got := m.unfinishedSlicesContext()
+
+	if !strings.Contains(got, "2 of 3 slices unfinished") {
+		t.Errorf("context should count unfinished slices, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Step 2: HTTP handler") {
+		t.Error("context should list unfinished slices with their 1-based index")
+	}
+	if strings.Contains(got, "Step 1: Core") {
+		t.Error("context should not list completed slices")
+	}
+}
+
+func TestUnfinishedSlicesContext_AllDone(t *testing.T) {
+	m := &model{run: &runState{checklist: []ChecklistStep{{Title: "Core", Done: true}}}}
+	if got := m.unfinishedSlicesContext(); got != "" {
+		t.Errorf("context should be empty when all slices are done, got %q", got)
+	}
+}
+
+// --- Coordinator contract present in the /run prompt ---
+
+func TestBuildRunPrompt_CarriesCoordinatorContract(t *testing.T) {
+	prompt := buildRunPrompt("my-feature", "# My Feature\n", nil)
+
+	for _, want := range []string{
+		"Your Role: Coordinator",
+		`{agent: "worker"`,
+		"code-reviewer",
+		"VERDICT: PASS",
+		"specs/my-feature/plan.md",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("run prompt missing %q", want)
+		}
+	}
+
+	// Worktree agents would silently discard their edits into a nested worktree.
+	if !strings.Contains(prompt, "Never spawn `task` or `designer`") {
+		t.Error("run prompt should forbid delegating to [worktree] agents")
 	}
 }

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -1958,3 +1958,32 @@ func TestBuildRunPrompt_CarriesCoordinatorContract(t *testing.T) {
 		t.Error("run prompt should forbid delegating to [worktree] agents")
 	}
 }
+
+// Terminal verifier reporting runs on paths that may have no orchestrator at
+// all; looking up the worktree there must not panic.
+func TestVerifier_ExhaustedRetriesWithoutOrchestrator(t *testing.T) {
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		run: &runState{
+			specName:   "stuck",
+			agentID:    "task-1",
+			phase:      "gating",
+			retries:    3,
+			maxRetries: 3,
+			checklist:  []ChecklistStep{{Title: "HTTP", Done: false}},
+		},
+	}
+
+	m.verifyRunComplete()
+
+	if m.run.phase != "failed" {
+		t.Fatalf("phase = %q, want failed", m.run.phase)
+	}
+}
+
+func TestRunWorktreePath_NilOrchestrator(t *testing.T) {
+	m := &model{}
+	if got := m.runWorktreePath("task-1"); got != "" {
+		t.Errorf("runWorktreePath = %q, want empty with no orchestrator", got)
+	}
+}


### PR DESCRIPTION
## Why

No `/run` session in the last 24h completed its loop. Reviewing all 92 sessions under `~/.pi-go/sessions` from that window turned up **three distinct causes**, not one:

| Cause | Evidence |
|---|---|
| **Context blowup** — one agent carried every slice, so its context grew with each file read and diff | 27 of 92 sessions exceeded 100k prompt tokens, peaking at **256k**, 219k, 213k. The provider then dropped the stream mid-slice. |
| **A dropped stream ended the run** | 14 sessions ended on `STREAM_ERROR` — 429 ollama session limit, 400 opencode, 502 — each abandoning intact work in the worktree. |
| **Gates mistaken for done** | `go build` passes over a half-implemented plan, so a run could merge with slices never started. |

The second cause is why the loop was never 10x: `handleRunAgentDone` treated any non-clean subagent exit as terminal and skipped gates and merge outright. The existing retry only ever covered *gate* failure — a 429 exited before the loop, and a green build exited it as "success".

## What changed

**`/plan` SOP** (`internal/sop/pdd_default.go`)
- Generated PROMPT.md now carries `## Execution Model` and `## Done Criteria` sections that `/run`'s Verifier acts on.
- Slices are sized to fit one worker's context and marked parallel-safe.
- Phase 3 research is delegated to parallel `explore` agents, so the planning session itself stops blowing up before it reaches Phase 7.

**`/run` prompt** (`internal/tui/run.go`)
- The top agent is now a **Coordinator**: it delegates each slice to a fresh `worker`/`quick-task` subagent rather than implementing inline, so its own context stays flat — each slice's context is discarded once the slice lands.
- After the last slice it spawns a `code-reviewer` **Verifier** that must answer `VERDICT: PASS` or `VERDICT: FAIL`.
- Both the SOP and the contract forbid delegating to `task`/`designer`. Those are `[worktree]` agents, so from inside a run worktree their edits land in a *nested* worktree and are silently lost — a live footgun.

**`/run` control loop** (`internal/tui/run.go`)
- New `verifying` phase between gates and merge: re-reads `plan.md` and refuses to merge while slices remain unchecked.
- Shared `retryRun` helper so **agent failure, gate failure and verifier failure** all resume in the same worktree, up to the existing 10 cycles. The resume prompt carries the unfinished slices forward.
- `SUMMARY.md` gains a slice-completion count and an Unfinished Slices section; new `verify_failed` outcome.

## On ADK workflow agents

ADK v2.1.0 does ship `sequentialagent`/`parallelagent`/`loopagent`, and pi-go currently uses none of them. They compose **in-process** `agent.Agent` values, whereas `/run` drives **subprocess** agents through the orchestrator — whose `chain` and `parallel` modes already provide the same sequencing. Swapping them in would be an architectural rewrite that touches none of the three causes above, so the loop lives in the TUI control loop instead. Worth revisiting separately if we want in-process composition.

## Tests

- Verifier: incomplete plan (no merge), complete plan (merge), no checklist (merge), exhausted cycles (fail without merging).
- Agent-failure retry: a non-clean exit consumes a cycle instead of ending the run; exhausted budget reports `agent_failed`.
- Resume-prompt contents, unfinished-slice context, coordinator contract present in run and parallel prompts.
- SOP sections and the `[worktree]`-agent prohibition.
- A nil-orchestrator panic I introduced on the new terminal-reporting path, caught in self-review and fixed in the second commit.

`go build`, `go vet`, full `go test ./...`, and `golangci-lint` all pass. Note the `internal/tui` pty and `httptest` failures are the documented sandbox traps and clear when run outside the sandbox.
