### PR TITLE
feat(sop,run): budget spec length against the read tool window

### DIFF
--- a/internal/sop/pdd_default.go
+++ b/internal/sop/pdd_default.go
@@ -84,6 +84,14 @@ You can reference rough-idea.md for the original idea.
   that needs more than ~10 files or ~400 lines of change is too big: split it.
   Oversized slices are the single largest cause of failed runs — the worker's context
   grows past the model limit and the provider drops the stream mid-slice.
+- **Keep plan.md under 2000 lines.** That is the read tool's window: a file longer
+  than it comes back one page at a time, so a worker sent to read its slice may act
+  on a partial plan or spend turns paging. design.md has the same ceiling.
+- **A plan that will not fit is telling you the spec is too big.** Do not solve it by
+  shrinking the prose or splitting plan.md into fragments — split the *feature* into
+  sequential specs, each with its own requirements/design/plan/PROMPT.md, and note
+  the running order in each one's Constraints. A plan too long to read in one call
+  is also too long to execute in one Coordinator.
 
 ### Phase 7: PROMPT.md Generation
 - Write PROMPT.md — the compressed execution briefing

--- a/internal/sop/sop_test.go
+++ b/internal/sop/sop_test.go
@@ -187,3 +187,19 @@ func TestDefaultPDDSOP_ForbidsWorktreeAgents(t *testing.T) {
 		t.Error("default PDD SOP should name the research subagent to delegate to")
 	}
 }
+
+// A plan longer than the read tool's window is served to workers a page at a
+// time, so the SOP must budget for it at planning time and say what to do
+// instead of letting the plan grow.
+func TestDefaultPDDSOP_BudgetsPlanLength(t *testing.T) {
+	for _, want := range []string{
+		"Keep plan.md under 2000 lines",
+		"read tool's window",
+		"design.md has the same ceiling",
+		"split the *feature* into",
+	} {
+		if !contains(DefaultPDDSOP, want) {
+			t.Errorf("default PDD SOP missing %q", want)
+		}
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -300,6 +300,17 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 	// Parse plan.md checklist for sidebar display.
 	checklist := parsePlanChecklist(m.cfg.WorkDir, specName)
 
+	// Warn before spawning: a spec file past the read window is served to
+	// workers one page at a time, so a worker sent to read its slice can act
+	// on a partial plan. The SOP tells /plan to avoid this; this catches the
+	// plans that arrive oversized anyway.
+	if oversized := oversizedSpecFiles(m.cfg.WorkDir, specName); len(oversized) > 0 {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: formatOversizedSpecWarning(oversized),
+		})
+	}
+
 	// Format gate info for display.
 	gateInfo := "none"
 	if len(gates) > 0 {
@@ -1450,6 +1461,67 @@ func parseGates(promptMD string) []Gate {
 	}
 
 	return gates
+}
+
+// readWindowLines mirrors the read tool's default line window
+// (defaultReadLimit in internal/tools/read.go). A spec file longer than this
+// is returned a page at a time, so a worker reading it may see only part.
+const readWindowLines = 2000
+
+// windowedSpecFiles are the spec documents a worker reads for slice detail.
+// PROMPT.md is excluded: /run loads it with os.ReadFile and embeds it whole in
+// the coordinator prompt, so the read window never applies to it.
+var windowedSpecFiles = []string{"plan.md", "design.md"}
+
+// oversizedSpecFile names a spec document that exceeds the read window.
+type oversizedSpecFile struct {
+	Name  string
+	Lines int
+}
+
+// oversizedSpecFiles returns the spec documents that exceed the read window,
+// in the order listed by windowedSpecFiles. Missing or unreadable files are
+// skipped — a spec without a design.md is normal, not an error.
+func oversizedSpecFiles(workDir, specName string) []oversizedSpecFile {
+	var out []oversizedSpecFile
+	for _, name := range windowedSpecFiles {
+		content, err := os.ReadFile(filepath.Join(workDir, "specs", specName, name))
+		if err != nil {
+			continue
+		}
+		if n := countLines(content); n > readWindowLines {
+			out = append(out, oversizedSpecFile{Name: name, Lines: n})
+		}
+	}
+	return out
+}
+
+// countLines counts the lines in a file, not counting a trailing newline as a
+// line of its own — the same off-by-one the read tool was corrected for.
+func countLines(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	n := bytes.Count(content, []byte("\n"))
+	if !bytes.HasSuffix(content, []byte("\n")) {
+		n++
+	}
+	return n
+}
+
+// formatOversizedSpecWarning explains what the length costs and what to do,
+// rather than only reporting the number.
+func formatOversizedSpecWarning(files []oversizedSpecFile) string {
+	var b strings.Builder
+	b.WriteString("**Spec exceeds the read window** — workers will page through it:\n\n")
+	for _, f := range files {
+		fmt.Fprintf(&b, "- `%s`: %d lines (window is %d)\n", f.Name, f.Lines, readWindowLines)
+	}
+	b.WriteString("\nA worker sent to read its slice may act on a partial view. ")
+	b.WriteString("Prefer splitting the feature into sequential specs over shrinking the prose — ")
+	b.WriteString("a plan too long to read in one call is also too long for one Coordinator.\n")
+	b.WriteString("Running anyway.\n")
+	return b.String()
 }
 
 // readPromptMD reads the PROMPT.md file from a spec directory.

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -1987,3 +1987,103 @@ func TestRunWorktreePath_NilOrchestrator(t *testing.T) {
 		t.Errorf("runWorktreePath = %q, want empty with no orchestrator", got)
 	}
 }
+
+// --- Spec length budget: warn when a spec outgrows the read window ---
+
+func writeSpecFile(t *testing.T, workDir, specName, file string, lines int) {
+	t.Helper()
+	dir := filepath.Join(workDir, "specs", specName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat("a line of plan prose\n", lines)
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOversizedSpecFiles_UnderWindowIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	writeSpecFile(t, dir, "small", "plan.md", readWindowLines)
+
+	if got := oversizedSpecFiles(dir, "small"); len(got) != 0 {
+		t.Errorf("a plan exactly at the window should not warn, got %+v", got)
+	}
+}
+
+func TestOversizedSpecFiles_OverWindowIsReported(t *testing.T) {
+	dir := t.TempDir()
+	writeSpecFile(t, dir, "big", "plan.md", readWindowLines+1)
+
+	got := oversizedSpecFiles(dir, "big")
+	if len(got) != 1 {
+		t.Fatalf("got %d oversized files, want 1", len(got))
+	}
+	if got[0].Name != "plan.md" {
+		t.Errorf("Name = %q, want plan.md", got[0].Name)
+	}
+	if got[0].Lines != readWindowLines+1 {
+		t.Errorf("Lines = %d, want %d", got[0].Lines, readWindowLines+1)
+	}
+}
+
+// design.md is read by workers too, so it carries the same ceiling.
+func TestOversizedSpecFiles_ChecksDesignToo(t *testing.T) {
+	dir := t.TempDir()
+	writeSpecFile(t, dir, "big", "plan.md", 10)
+	writeSpecFile(t, dir, "big", "design.md", readWindowLines+50)
+
+	got := oversizedSpecFiles(dir, "big")
+	if len(got) != 1 || got[0].Name != "design.md" {
+		t.Fatalf("got %+v, want only design.md", got)
+	}
+}
+
+// PROMPT.md is embedded whole via os.ReadFile, so the window never applies.
+func TestOversizedSpecFiles_IgnoresPromptMD(t *testing.T) {
+	dir := t.TempDir()
+	writeSpecFile(t, dir, "big", "PROMPT.md", readWindowLines*2)
+
+	if got := oversizedSpecFiles(dir, "big"); len(got) != 0 {
+		t.Errorf("PROMPT.md is never windowed, got %+v", got)
+	}
+}
+
+// A spec with no design.md is normal, not an error.
+func TestOversizedSpecFiles_MissingFilesAreSkipped(t *testing.T) {
+	dir := t.TempDir()
+	if got := oversizedSpecFiles(dir, "nonexistent"); len(got) != 0 {
+		t.Errorf("missing spec should yield no warnings, got %+v", got)
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"empty", "", 0},
+		{"one line no newline", "a", 1},
+		{"one line trailing newline", "a\n", 1},
+		{"two lines trailing newline", "a\nb\n", 2},
+		{"two lines no trailing newline", "a\nb", 2},
+		{"blank line counts", "a\n\nb\n", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countLines([]byte(tc.in)); got != tc.want {
+				t.Errorf("countLines(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatOversizedSpecWarning(t *testing.T) {
+	out := formatOversizedSpecWarning([]oversizedSpecFile{{Name: "plan.md", Lines: 2500}})
+
+	for _, want := range []string{"plan.md", "2500", "2000", "sequential specs", "Running anyway"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning missing %q, got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #126, and the companion rule to the slice-sizing guidance it added.

## Why

#126 capped how much work one worker takes on ("size every slice to fit one worker subagent's context"). Nothing capped **the document that worker reads**.

That gap matters specifically because of #125. Before it, `.go`/`.py`/`.ts` skipped the line window and everything else got 2000 lines. #125 removed the source-file carve-out — reasonably, since it meant the largest files in a repo were the ones with no ceiling — so **every** file now answers to the 2000-line window, markdown included.

So a `plan.md` past 2000 lines comes back a page at a time. A worker sent to read its slice can act on a partial plan, or spend turns paging to avoid it.

## Planning time — the SOP budgets the plan

`internal/sop/pdd_default.go` gains two rules next to the existing slice-sizing one:

- Keep `plan.md` under 2000 lines; `design.md` has the same ceiling.
- **A plan that will not fit is telling you the spec is too big.** Not to be solved by shrinking prose or fragmenting `plan.md` into slice files — split the *feature* into sequential specs, each with its own requirements/design/plan/PROMPT.md and a running order in Constraints.

The reasoning behind the second rule is the point of the change: a plan too long to read in one call is also too long to execute in one Coordinator. Fragmenting the file would hide the signal instead of acting on it.

## Execution time — `/run` warns before spawning

`/run` measures `plan.md` and `design.md` before spawning and reports any that exceed the window, with the line count and the remedy, **then runs anyway**. This catches plans that arrive oversized regardless of the SOP — hand-written, or produced by an older `/plan`.

`PROMPT.md` is deliberately exempt: `/run` loads it with `os.ReadFile` and embeds it whole in the coordinator prompt, so the read window never applies to it. A test pins that exemption so nobody "fixes" it later.

## It stays silent until earned

No spec in the repo trips this today — largest `design.md` is 945 lines, largest `plan.md` 572, against a ceiling of 2000. The warning costs nothing until a spec actually outgrows the window. Verified across every `plan.md`/`design.md` in `specs/`.

## Notes

- `readWindowLines` duplicates the value of `defaultReadLimit` in `internal/tools`. That constant is unexported, so the comment names it as the source of truth rather than the two drifting silently. Worth exporting if this coupling grows a third user.
- `countLines` does not count a trailing newline as a line of its own, matching the off-by-one correction #125 made to `TotalLines`. Table-driven test covers the boundary cases.

## Verification

`go build`, `go vet`, full `go test ./...`, and `golangci-lint run` on the changed packages all pass. New tests cover the window boundary (exactly at the ceiling is silent, one over reports), `design.md` inclusion, `PROMPT.md` exemption, missing files, line counting, and the warning text.
