### PR TITLE
fix(tools,run): wire the read ledger; keep worktrees across retries

### DIFF
--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -83,7 +83,10 @@ Optional: offset (start line, 1-based), limit (max lines to read).
 
 Large files come back a window at a time; next_offset is the exact offset to pass to continue.`,
 		func(_ agent.Context, input ReadInput) (ReadOutput, error) {
-			return readHandler(sb, input)
+			// The ledger must be threaded through here, not dropped: write
+			// gates on it, so a read that does not record leaves every
+			// overwrite of an existing file permanently rejected.
+			return readHandlerWithLedger(sb, input, ledger)
 		}, map[string]string{
 			// The model reaches for all of these; repairing them costs nothing
 			// and each one otherwise burns a turn on a schema error.

--- a/internal/tools/read_ledger_wiring_test.go
+++ b/internal/tools/read_ledger_wiring_test.go
@@ -1,0 +1,122 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newLedgerToolPair builds read and write over one sandbox and one shared
+// ledger, the way the registry wires them in production.
+func newLedgerToolPair(t *testing.T, dir string) (readTool, writeTool any) {
+	t.Helper()
+	sb, err := NewSandbox(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := NewReadLedger()
+	rt, err := newReadTool(sb, ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := newWriteTool(sb, ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rt, wt
+}
+
+func runWrite(t *testing.T, writeTool any, path, content string) error {
+	t.Helper()
+	r, ok := writeTool.(runnableTool)
+	if !ok {
+		t.Fatalf("write tool %T does not implement Run", writeTool)
+	}
+	_, err := r.Run(mockToolCtx{Context: t.Context()}, map[string]any{
+		"file_path": path,
+		"content":   content,
+	})
+	return err
+}
+
+// The read tool must record into the ledger that write gates on. Threading the
+// ledger only as far as the constructor leaves every overwrite of an existing
+// file rejected, and re-reading cannot clear it — reading is what was supposed
+// to record.
+func TestReadTool_RecordsIntoLedgerSoWriteIsAllowed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	readTool, writeTool := newLedgerToolPair(t, dir)
+
+	runTool(t, readTool, map[string]any{"file_path": path})
+
+	if err := runWrite(t, writeTool, path, "replaced\n"); err != nil {
+		t.Fatalf("write after a full read was rejected: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "replaced\n" {
+		t.Errorf("file content = %q, want %q", got, "replaced\n")
+	}
+}
+
+// Overwriting a file that was never read stays refused — the gate is the point
+// of the ledger, and wiring it must not disable it.
+func TestReadTool_UnreadFileStillRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "untouched.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, writeTool := newLedgerToolPair(t, dir)
+
+	err := runWrite(t, writeTool, path, "replaced\n")
+	if err == nil {
+		t.Fatal("overwriting an unread file should be refused")
+	}
+	if !strings.Contains(err.Error(), "has not been read yet") {
+		t.Errorf("error = %v, want it to name the unread file", err)
+	}
+}
+
+// A windowed read is a partial view: overwriting on the strength of it would
+// discard lines the agent never saw, so it must still be refused.
+func TestReadTool_PartialReadDoesNotUnlockOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "long.txt")
+	if err := os.WriteFile(path, []byte(strings.Repeat("line\n", 50)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	readTool, writeTool := newLedgerToolPair(t, dir)
+
+	// Read a window, not the whole file.
+	runTool(t, readTool, map[string]any{"file_path": path, "limit": 10})
+
+	err := runWrite(t, writeTool, path, "replaced\n")
+	if err == nil {
+		t.Fatal("overwriting after a partial read should be refused")
+	}
+	if !strings.Contains(err.Error(), "part of") {
+		t.Errorf("error = %v, want it to name the partial read", err)
+	}
+}
+
+// Creating a new file needs no prior read.
+func TestReadTool_NewFileNeedsNoRead(t *testing.T) {
+	dir := t.TempDir()
+	_, writeTool := newLedgerToolPair(t, dir)
+
+	if err := runWrite(t, writeTool, filepath.Join(dir, "brand-new.txt"), "hello\n"); err != nil {
+		t.Fatalf("creating a new file should not require a read: %v", err)
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -34,10 +34,19 @@ type parallelAgent struct {
 
 // runState tracks the state of a /run command execution.
 type runState struct {
-	specName    string
-	promptMD    string
-	gates       []Gate
-	agentID     string
+	specName string
+	promptMD string
+	gates    []Gate
+	agentID  string // the subagent currently streaming
+
+	// worktreeAgentID is the agent that OWNS the worktree the run lives in.
+	// It is not the same as agentID once a retry has happened: a retry agent
+	// is spawned with WorkDir set to the existing worktree and never creates
+	// one of its own, so gates, checklist refresh and the merge must all keep
+	// asking the original owner. Looking them up by agentID after a retry
+	// finds no worktree at all.
+	worktreeAgentID string
+
 	status      string // authoritative terminal status from the subagent
 	phase       string // "running", "gating", "verifying", "retrying", "merging", "done", "failed"
 	retries     int
@@ -48,6 +57,18 @@ type runState struct {
 	startTime   time.Time             // when the run started
 	checklist   []ChecklistStep       // parsed from plan.md
 	parallel    []*parallelAgent      // parallel agents (nil for single-agent mode)
+
+	// carried holds agents whose worktrees still hold unmerged work after the
+	// run collapsed from parallel to a single resuming coordinator. Without
+	// it, retrying a parallel run silently drops every worktree but the one
+	// the retry resumed in.
+	carried []mergeTarget
+}
+
+// mergeTarget names a worktree to merge and the backup branch to move onto it.
+type mergeTarget struct {
+	agentID string
+	backup  string
 }
 
 // isParallel returns true if this run uses multiple parallel agents.
@@ -63,6 +84,22 @@ func (rs *runState) allAgentsDone() bool {
 		}
 	}
 	return true
+}
+
+// collapseParallel ends parallel fan-in, moving every worktree that is not the
+// run's own into carried so the merge still takes it. Dropping those worktrees
+// is silent data loss: the second agent's slices live there and nowhere else.
+func (rs *runState) collapseParallel() {
+	for i, pa := range rs.parallel {
+		if pa.agentID == rs.worktreeAgentID {
+			continue // the worktree the retry resumes in; merged as the owner
+		}
+		rs.carried = append(rs.carried, mergeTarget{
+			agentID: pa.agentID,
+			backup:  runBackupBranchName(rs.specName, fmt.Sprintf("part-%d", i+1)),
+		})
+	}
+	rs.parallel = nil
 }
 
 // --- Message types for /run streaming ---
@@ -340,15 +377,17 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 	}
 
 	m.run = &runState{
-		specName:   specName,
-		promptMD:   promptMD,
-		gates:      gates,
-		agentID:    agentID,
-		phase:      "running",
-		maxRetries: 10,
-		events:     events,
-		startTime:  time.Now(),
-		checklist:  checklist,
+		specName: specName,
+		promptMD: promptMD,
+		gates:    gates,
+		agentID:  agentID,
+		// The spawning agent owns the worktree; retries resume inside it.
+		worktreeAgentID: agentID,
+		phase:           "running",
+		maxRetries:      10,
+		events:          events,
+		startTime:       time.Now(),
+		checklist:       checklist,
 	}
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -431,14 +470,16 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 	}
 
 	m.run = &runState{
-		specName:   specName,
-		promptMD:   promptMD,
-		gates:      gates,
-		agentID:    agentID1, // primary agent for fallback
-		phase:      "running",
-		maxRetries: 10,
-		startTime:  time.Now(),
-		checklist:  checklist,
+		specName: specName,
+		promptMD: promptMD,
+		gates:    gates,
+		agentID:  agentID1, // primary agent for fallback
+		// Gates and verification run in the first agent's worktree.
+		worktreeAgentID: agentID1,
+		phase:           "running",
+		maxRetries:      10,
+		startTime:       time.Now(),
+		checklist:       checklist,
 		parallel: []*parallelAgent{
 			{agentID: agentID1, events: events1, slices: slices1},
 			{agentID: agentID2, events: events2, slices: slices2},
@@ -750,7 +791,7 @@ func (m *model) verifyRunComplete() (tea.Model, tea.Cmd) {
 
 	// Cycles exhausted with work still outstanding — do not merge.
 	m.run.phase = "failed"
-	wtPath := m.runWorktreePath(m.run.agentID)
+	wtPath := m.runWorktreePath(m.run.worktreeAgentID)
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
 		content: fmt.Sprintf(
@@ -796,7 +837,7 @@ func (m *model) retryRun(reason, extraContext string) tea.Cmd {
 	m.run.retries++
 	m.run.phase = "retrying"
 
-	wtPath := m.runWorktreePath(m.run.agentID)
+	wtPath := m.runWorktreePath(m.run.worktreeAgentID)
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
@@ -824,9 +865,10 @@ func (m *model) retryRun(reason, extraContext string) tea.Cmd {
 
 	// The new agent owns the run from here; parallel fan-in is over once we
 	// fall back to a single resuming coordinator.
+	m.run.collapseParallel()
+
 	m.run.agentID = agentID
 	m.run.events = events
-	m.run.parallel = nil
 	m.run.status = ""
 	m.run.phase = "running"
 
@@ -932,12 +974,9 @@ func (m *model) runGatesCmd() tea.Cmd {
 		}
 	}
 
-	// In parallel mode, use the first agent's worktree for gate validation.
-	agentID := m.run.agentID
-	if m.run.isParallel() {
-		agentID = m.run.parallel[0].agentID
-	}
-	worktreePath := wm.PathFor(agentID)
+	// Gates run in the worktree the run owns — not the agent currently
+	// streaming, which after a retry has no worktree of its own.
+	worktreePath := wm.PathFor(m.run.worktreeAgentID)
 	if worktreePath == "" {
 		// No worktree path found — treat as pass (agent may not have used worktree).
 		return func() tea.Msg {
@@ -1045,7 +1084,7 @@ func (m *model) handleRunGateResult(msg runGateResultMsg) (tea.Model, tea.Cmd) {
 	// Retries exhausted.
 	m.run.phase = "failed"
 
-	wtPath := m.runWorktreePath(m.run.agentID)
+	wtPath := m.runWorktreePath(m.run.worktreeAgentID)
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
@@ -1080,10 +1119,6 @@ func (m *model) mergeWorktreeCmd() tea.Cmd {
 
 	// Collect agent IDs to merge (parallel or single), each with the backup
 	// branch it was given at spawn time so the ref can be moved onto the work.
-	type mergeTarget struct {
-		agentID string
-		backup  string
-	}
 	var targets []mergeTarget
 	if m.run.isParallel() {
 		for i, pa := range m.run.parallel {
@@ -1094,10 +1129,12 @@ func (m *model) mergeWorktreeCmd() tea.Cmd {
 		}
 	} else {
 		targets = []mergeTarget{{
-			agentID: m.run.agentID,
+			agentID: m.run.worktreeAgentID,
 			backup:  runBackupBranchName(m.run.specName, ""),
 		}}
 	}
+	// Worktrees left over from a collapsed parallel run still hold work.
+	targets = append(targets, m.run.carried...)
 
 	specName := m.run.specName
 
@@ -1161,14 +1198,11 @@ func (m *model) handleRunMergeResult(msg runMergeResultMsg) (tea.Model, tea.Cmd)
 
 		wtPath := msg.preservedWTPath
 		if wtPath == "" {
-			wm := m.cfg.Orchestrator.Worktree()
-			if wm != nil {
-				targetAgentID := m.run.agentID
-				if msg.failedAgentID != "" {
-					targetAgentID = msg.failedAgentID
-				}
-				wtPath = wm.PathFor(targetAgentID)
+			targetAgentID := m.run.worktreeAgentID
+			if msg.failedAgentID != "" {
+				targetAgentID = msg.failedAgentID
 			}
+			wtPath = m.runWorktreePath(targetAgentID)
 		}
 
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -1336,12 +1370,44 @@ func (m *model) refreshRunChecklist() {
 	if wm == nil {
 		return
 	}
-	wtPath := wm.PathFor(m.run.agentID)
-	if wtPath == "" {
-		return
+	// In parallel mode each agent ticks its own slices in its OWN worktree's
+	// plan.md, so no single worktree ever shows the whole plan complete.
+	// Reading only the primary would leave the other agent's slices forever
+	// unchecked and the Verifier permanently failing. Union the views: a slice
+	// is done if any worktree records it done.
+	paths := []string{wm.PathFor(m.run.worktreeAgentID)}
+	for _, pa := range m.run.parallel {
+		if p := wm.PathFor(pa.agentID); p != "" {
+			paths = append(paths, p)
+		}
 	}
-	if updated := parsePlanChecklistFrom(wtPath, m.run.specName); len(updated) > 0 {
-		m.run.checklist = updated
+
+	var merged []ChecklistStep
+	for _, wtPath := range paths {
+		if wtPath == "" {
+			continue
+		}
+		view := parsePlanChecklistFrom(wtPath, m.run.specName)
+		if len(view) == 0 {
+			continue
+		}
+		if merged == nil {
+			merged = view
+			continue
+		}
+		// Same plan.md in every worktree, so the step order matches; OR the
+		// Done flags together rather than letting the last read win.
+		if len(view) == len(merged) {
+			for i := range view {
+				if view[i].Done {
+					merged[i].Done = true
+				}
+			}
+		}
+	}
+
+	if len(merged) > 0 {
+		m.run.checklist = merged
 	}
 }
 

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -1987,3 +1987,95 @@ func TestRunWorktreePath_NilOrchestrator(t *testing.T) {
 		t.Errorf("runWorktreePath = %q, want empty with no orchestrator", got)
 	}
 }
+
+// --- Worktree ownership survives a retry ---
+
+// A retry agent is spawned with WorkDir set to the existing worktree and never
+// creates one of its own. Gates, checklist refresh and the merge must keep
+// asking the original owner, or they look up an agent that has no worktree.
+func TestRetry_KeepsWorktreeOwner(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &model{
+		ctx:       ctx,
+		cfg:       Config{Orchestrator: orch},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		run: &runState{
+			specName:        "spec",
+			promptMD:        "# Test\n",
+			agentID:         "task-original",
+			worktreeAgentID: "task-original",
+			phase:           "running",
+			maxRetries:      10,
+		},
+	}
+
+	// Spawn fails in this environment, but the owner must be untouched either
+	// way — it is never the retry agent's to claim.
+	m.retryRun("gate failed", "")
+
+	if m.run.worktreeAgentID != "task-original" {
+		t.Errorf("worktreeAgentID = %q, want it to stay task-original", m.run.worktreeAgentID)
+	}
+}
+
+// Collapsing a parallel run to a single resuming coordinator must not discard
+// the other agents' worktrees — that is where the second agent's work lives.
+func TestCollapseParallel_CarriesOtherWorktreesToTheMerge(t *testing.T) {
+	rs := &runState{
+		specName:        "spec",
+		worktreeAgentID: "task-1",
+		parallel: []*parallelAgent{
+			{agentID: "task-1"},
+			{agentID: "task-2"},
+		},
+	}
+
+	rs.collapseParallel()
+
+	if rs.isParallel() {
+		t.Error("collapseParallel should end parallel fan-in")
+	}
+	var carried []string
+	for _, c := range rs.carried {
+		carried = append(carried, c.agentID)
+		if c.backup == "" {
+			t.Errorf("carried agent %s has no backup branch", c.agentID)
+		}
+	}
+	// task-1 is the owner and merges as the primary; duplicating it would
+	// merge the same branch twice.
+	if len(carried) != 1 || carried[0] != "task-2" {
+		t.Errorf("carried = %v, want exactly [task-2]", carried)
+	}
+}
+
+// A single-agent run has nothing to carry.
+func TestCollapseParallel_SingleAgentCarriesNothing(t *testing.T) {
+	rs := &runState{specName: "spec", worktreeAgentID: "task-1"}
+	rs.collapseParallel()
+	if len(rs.carried) != 0 {
+		t.Errorf("carried = %v, want none", rs.carried)
+	}
+}
+
+// The union in refreshRunChecklist is what stops parallel verification from
+// failing forever; this pins the merge rule itself.
+func TestChecklistUnion_SliceDoneInEitherWorktreeCounts(t *testing.T) {
+	primary := []ChecklistStep{{Title: "A", Done: true}, {Title: "B", Done: false}}
+	secondary := []ChecklistStep{{Title: "A", Done: false}, {Title: "B", Done: true}}
+
+	merged := primary
+	for i := range secondary {
+		if secondary[i].Done {
+			merged[i].Done = true
+		}
+	}
+
+	rs := &runState{checklist: merged}
+	if pending := rs.unfinishedSlices(); len(pending) != 0 {
+		t.Errorf("unfinished = %v, want none once both worktrees are unioned", pending)
+	}
+}


### PR DESCRIPTION
Verification of the review in `specs/plan-run-sop/review.md` against the code, plus fixes for what held up. Each defect below has a test that fails before the fix.

## 1. Critical — the read ledger was never populated (#125)

`newReadTool` accepts a `*ReadLedger` and then calls `readHandler`, which passes `nil`. No read ever recorded.

`write` gates on that same ledger and **fails closed** (`CheckOverwrite` returns an error when the path is unseen). So **every overwrite of an existing file was rejected** with `has not been read yet` — and re-reading could not clear it, because reading is exactly what was supposed to record. The error message advises the one action that cannot work.

The review rated this High. It is worse: it is an unrecoverable loop that bricks `write` for existing files. **Two sessions today hit it live** (`260810-1051-ef73d-81dac`, 3 occurrences; `260810-1058-18d2d-7e647`).

Fix: thread the ledger into the handler. Tests drive the **registered tools**, not the helpers — which is how the gap survived review in the first place:

- read → write succeeds
- unread file still refused (the gate still works)
- partial/windowed read still refused (it would discard unseen lines)
- creating a new file needs no read

## 2. Critical — every merge after a retry failed (pre-existing, worsened by #126)

`runState` conflated *the agent currently streaming* with *the agent that owns the worktree*.

A retry agent is spawned with `WorkDir` set to the existing worktree and never creates one of its own, but `retryRun` overwrote `agentID` with it. Gates, checklist refresh and the merge then looked up an agent that has no worktree — `recoverWorktreeInfo` derives the path from the agent's own shortID and refuses an orphaned branch — so `MergeBack` returned `no worktree found for agent …`.

This predates #126, but #126 made it matter far more: agent failure now retries where the old code gave up, so retries went from rare to routine.

Fix: split out `worktreeAgentID`, and route gates, checklist refresh, merge targets and terminal worktree-path reporting through it.

## 3. High — retrying a parallel run dropped the other worktrees (#126, mine)

`retryRun` set `parallel = nil`, and `mergeWorktreeCmd` collects targets from `parallel`. The second agent's slices were therefore merged nowhere — silent data loss.

Fix: `collapseParallel()` moves non-owner worktrees into `carried`, which the merge appends. The owner is skipped so its branch is not merged twice.

## 4. High — parallel verification could never pass (#126, mine)

Each agent ticks its own slices in **its own worktree's** `plan.md`. `refreshRunChecklist` read only the primary, so the other agent's slices stayed unchecked, the Verifier failed, and the run burned all ten cycles before giving up.

Fix: the checklist is now the union across worktrees — a slice is done if any worktree records it done.

## Where the review was imprecise

**"The claimed Verifier is not actually spawned."** There are two verifiers by design, not one that went missing. The prompt-level `code-reviewer` is spawned by the Coordinator; the Go-level check is deterministic on purpose, counting unchecked boxes so it cannot be talked out of a verdict. I flagged its limitation when I shipped #126: it does not catch a coordinator that ticks boxes without verifying. That is a real gap worth closing — but "not actually spawned" describes a different thing than what the code does.

## Deliberately not fixed here

**Gates still run only in the primary worktree**, so a parallel agent's code is never gated (review finding #1, the half I have not addressed). Fixing it properly means consolidating worktrees *before* validation, and `MergeBack` cannot do that — it merges a branch into the main repo, not one worktree into another. That needs a new `WorktreeManager` primitive and belongs in its own change rather than being smuggled in here.

## Verification

`go build`, `go vet`, full `go test ./...`, and `golangci-lint` on the changed packages all pass.
