### PR TITLE
feat(subagent): make the concurrency budget compose under nesting

### DIFF
--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"google.golang.org/adk/v2/session"
 	"google.golang.org/genai"
@@ -643,11 +644,23 @@ func sanitizeSessionTitle(title string) string {
 		// "title" inject arbitrary ANSI/OSC into the terminal. Drop it.
 		b.WriteRune(r)
 	}
-	title = b.String()
-	if len(title) > MaxSessionTitle {
-		title = title[:MaxSessionTitle]
+	return truncateTitle(b.String())
+}
+
+// truncateTitle caps a title at MaxSessionTitle bytes without splitting a
+// rune. A plain byte slice cuts multi-byte characters in half, and the
+// fragment is stored in meta.json and written to the terminal inside an OSC 0
+// sequence — where it shows up as U+FFFD. Half of recent session titles
+// carried one before this backed the cut up to a boundary.
+func truncateTitle(title string) string {
+	if len(title) <= MaxSessionTitle {
+		return title
 	}
-	return title
+	cut := MaxSessionTitle
+	for cut > 0 && !utf8.RuneStart(title[cut]) {
+		cut--
+	}
+	return title[:cut]
 }
 
 // GetSessionTitle returns the current title for the given session, or "" if

--- a/internal/session/title_truncate_test.go
+++ b/internal/session/title_truncate_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Titles are stored in meta.json and written to the terminal inside an OSC 0
+// sequence. A byte-sliced cut splits multi-byte runes, and the fragment shows
+// up as U+FFFD — half of recent session titles carried one.
+func TestTruncateTitle_NeverSplitsARune(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"multi-byte at the boundary", strings.Repeat("a", MaxSessionTitle-1) + "é" + "tail"},
+		{"three-byte rune spanning the cut", strings.Repeat("a", MaxSessionTitle-2) + "→more"},
+		{"four-byte emoji spanning the cut", strings.Repeat("a", MaxSessionTitle-2) + "🎉more"},
+		{"all multi-byte", strings.Repeat("→", MaxSessionTitle)},
+		{"emoji only", strings.Repeat("🎉", MaxSessionTitle)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateTitle(tc.in)
+
+			if !utf8.ValidString(got) {
+				t.Errorf("result is not valid UTF-8: %q", got)
+			}
+			if strings.ContainsRune(got, utf8.RuneError) {
+				t.Errorf("result contains U+FFFD: %q", got)
+			}
+			if len(got) > MaxSessionTitle {
+				t.Errorf("result is %d bytes, want at most %d", len(got), MaxSessionTitle)
+			}
+		})
+	}
+}
+
+// Short titles pass through untouched.
+func TestTruncateTitle_ShortTitlesUnchanged(t *testing.T) {
+	for _, in := range []string{"", "hello", "héllo → 🎉", strings.Repeat("a", MaxSessionTitle)} {
+		if got := truncateTitle(in); got != in {
+			t.Errorf("truncateTitle(%q) = %q, want it unchanged", in, got)
+		}
+	}
+}
+
+// The cut must keep as much as fits, not round down to nothing.
+func TestTruncateTitle_KeepsWhatFits(t *testing.T) {
+	in := strings.Repeat("→", MaxSessionTitle) // 3 bytes per rune
+	got := truncateTitle(in)
+
+	wantRunes := MaxSessionTitle / 3
+	if n := utf8.RuneCountInString(got); n != wantRunes {
+		t.Errorf("kept %d runes, want %d", n, wantRunes)
+	}
+}
+
+// End to end through the sanitizer that callers actually use.
+func TestSanitizeSessionTitle_ProducesNoReplacementChar(t *testing.T) {
+	long := "Implement Slice 2 of the agent — inspect the server routing " +
+		strings.Repeat("and the handler wiring ", 20) + "🎉"
+
+	got := sanitizeSessionTitle(long)
+
+	if strings.ContainsRune(got, utf8.RuneError) {
+		t.Errorf("sanitized title contains U+FFFD: …%q", got[max(0, len(got)-40):])
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("sanitized title is not valid UTF-8")
+	}
+	if len(got) > MaxSessionTitle {
+		t.Errorf("sanitized title is %d bytes, want at most %d", len(got), MaxSessionTitle)
+	}
+}

--- a/internal/subagent/concurrency.go
+++ b/internal/subagent/concurrency.go
@@ -1,0 +1,67 @@
+package subagent
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+)
+
+// ConcurrencyEnvVar names the environment variable that sets how many
+// subagents one process may run at once. It is on the forwarded-prefix list in
+// environ.go, so a value set here reaches spawned agents — see
+// childConcurrency for why it is rewritten rather than inherited unchanged.
+const ConcurrencyEnvVar = "PI_SUBAGENT_CONCURRENCY"
+
+// maxConcurrencyBudget bounds what the environment can ask for. The pool exists
+// to keep concurrent token draw under the provider's per-minute limit, so a
+// mistyped value must not be able to remove the ceiling entirely.
+const maxConcurrencyBudget = 64
+
+// ConcurrencyFromEnv returns the per-process subagent budget.
+//
+// It falls back to DefaultPoolSize when the variable is unset, unparseable or
+// out of range, and never returns less than 1: a zero-sized pool would block
+// the first Acquire forever, turning a misconfiguration into a hang rather
+// than a slow run.
+func ConcurrencyFromEnv() int {
+	raw := os.Getenv(ConcurrencyEnvVar)
+	if raw == "" {
+		return DefaultPoolSize
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		slog.Warn("ignoring unparseable subagent concurrency",
+			"var", ConcurrencyEnvVar, "value", raw, "using", DefaultPoolSize)
+		return DefaultPoolSize
+	}
+	if n < 1 {
+		slog.Warn("ignoring non-positive subagent concurrency",
+			"var", ConcurrencyEnvVar, "value", n, "using", DefaultPoolSize)
+		return DefaultPoolSize
+	}
+	if n > maxConcurrencyBudget {
+		slog.Warn("clamping subagent concurrency to the ceiling",
+			"var", ConcurrencyEnvVar, "value", n, "using", maxConcurrencyBudget)
+		return maxConcurrencyBudget
+	}
+	return n
+}
+
+// childConcurrency returns the budget a spawned agent should be given.
+//
+// The budget has to shrink with depth. A spawned agent is itself a pi process
+// that builds its own orchestrator and its own pool, so an inherited value is
+// not a shared allowance — it is a fresh one per process, and total concurrency
+// becomes depth x budget. That is what put eight agents in flight against a
+// per-minute token limit that only tolerated a few.
+//
+// Halving with a floor of 1 makes the total converge instead of grow, and
+// reaches "one thing at a time" quickly for deeply nested work, which is the
+// desired behavior that far from the top-level run.
+func childConcurrency(parent int) int {
+	if parent < 2 {
+		return 1
+	}
+	return parent / 2
+}

--- a/internal/subagent/concurrency_test.go
+++ b/internal/subagent/concurrency_test.go
@@ -1,0 +1,185 @@
+package subagent
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestConcurrencyFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  bool
+		val  string
+		want int
+	}{
+		{"unset falls back", false, "", DefaultPoolSize},
+		{"empty falls back", true, "", DefaultPoolSize},
+		{"valid value honored", true, "2", 2},
+		{"one is allowed", true, "1", 1},
+		{"zero falls back rather than deadlocking", true, "0", DefaultPoolSize},
+		{"negative falls back", true, "-3", DefaultPoolSize},
+		{"garbage falls back", true, "many", DefaultPoolSize},
+		{"absurd value is clamped", true, "100000", maxConcurrencyBudget},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(ConcurrencyEnvVar, tc.val)
+			}
+			if got := ConcurrencyFromEnv(); got != tc.want {
+				t.Errorf("ConcurrencyFromEnv() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// A pool of zero blocks the first Acquire forever, so no input may produce one.
+func TestConcurrencyFromEnv_NeverZero(t *testing.T) {
+	for _, v := range []string{"", "0", "-1", "abc", "0.5", " "} {
+		t.Setenv(ConcurrencyEnvVar, v)
+		if got := ConcurrencyFromEnv(); got < 1 {
+			t.Errorf("ConcurrencyFromEnv() = %d for %q; a zero-sized pool hangs", got, v)
+		}
+	}
+}
+
+func TestChildConcurrency_HalvesWithAFloor(t *testing.T) {
+	for _, tc := range []struct{ parent, want int }{
+		{8, 4}, {5, 2}, {4, 2}, {3, 1}, {2, 1}, {1, 1}, {0, 1}, {-4, 1},
+	} {
+		if got := childConcurrency(tc.parent); got != tc.want {
+			t.Errorf("childConcurrency(%d) = %d, want %d", tc.parent, got, tc.want)
+		}
+	}
+}
+
+// The budget must converge as runs nest. Repeated application should reach the
+// floor and stay there, never grow.
+func TestChildConcurrency_ConvergesWithDepth(t *testing.T) {
+	budget := 16
+	seen := []int{budget}
+	for range 10 {
+		next := childConcurrency(budget)
+		if next > budget {
+			t.Fatalf("budget grew with depth: %v -> %d", seen, next)
+		}
+		budget = next
+		seen = append(seen, budget)
+	}
+	if budget != 1 {
+		t.Errorf("budget settled at %d, want 1 (chain %v)", budget, seen)
+	}
+}
+
+// The regression this exists to prevent: a child inheriting the parent's
+// budget verbatim, so each nesting level gets a fresh full-size pool.
+func TestChildEnv_ReplacesInheritedBudget(t *testing.T) {
+	t.Setenv(ConcurrencyEnvVar, "8")
+
+	env := ChildEnv(ConcurrencyFromEnv())
+
+	var values []string
+	for _, e := range env {
+		if strings.HasPrefix(e, ConcurrencyEnvVar+"=") {
+			values = append(values, strings.TrimPrefix(e, ConcurrencyEnvVar+"="))
+		}
+	}
+	if len(values) != 1 {
+		t.Fatalf("%s appears %d times in the child env, want exactly 1: %v",
+			ConcurrencyEnvVar, len(values), values)
+	}
+	got, err := strconv.Atoi(values[0])
+	if err != nil {
+		t.Fatalf("child budget %q is not a number: %v", values[0], err)
+	}
+	if got != 4 {
+		t.Errorf("child budget = %d, want 4 (half of 8) — an inherited 8 would "+
+			"give every nesting level a fresh full-size pool", got)
+	}
+}
+
+// With no budget set, the child still gets an explicit one derived from the
+// default rather than nothing at all.
+func TestChildEnv_SetsBudgetEvenWhenParentHasNone(t *testing.T) {
+	env := ChildEnv(ConcurrencyFromEnv())
+
+	found := false
+	for _, e := range env {
+		if strings.HasPrefix(e, ConcurrencyEnvVar+"=") {
+			found = true
+			v := strings.TrimPrefix(e, ConcurrencyEnvVar+"=")
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 {
+				t.Errorf("child budget %q is not a positive number", v)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("child env carries no %s", ConcurrencyEnvVar)
+	}
+}
+
+// A parent already at the floor must still hand its child a usable budget.
+func TestChildEnv_FloorIsUsable(t *testing.T) {
+	t.Setenv(ConcurrencyEnvVar, "1")
+
+	env := ChildEnv(ConcurrencyFromEnv())
+
+	for _, e := range env {
+		if strings.HasPrefix(e, ConcurrencyEnvVar+"=") {
+			if got := strings.TrimPrefix(e, ConcurrencyEnvVar+"="); got != "1" {
+				t.Errorf("child budget = %s, want 1", got)
+			}
+		}
+	}
+	// And that budget must build a working pool.
+	t.Setenv(ConcurrencyEnvVar, "1")
+	if p := NewPool(ConcurrencyFromEnv()); p.Size() < 1 {
+		t.Errorf("pool size = %d, want at least 1", p.Size())
+	}
+}
+
+// The orchestrator must actually use the configured budget.
+func TestOrchestrator_UsesConfiguredConcurrency(t *testing.T) {
+	t.Setenv(ConcurrencyEnvVar, "2")
+
+	if got := ConcurrencyFromEnv(); got != 2 {
+		t.Fatalf("ConcurrencyFromEnv() = %d, want 2", got)
+	}
+	if p := NewPool(ConcurrencyFromEnv()); p.Size() != 2 {
+		t.Errorf("pool size = %d, want 2", p.Size())
+	}
+}
+
+// The budget is per process and processes nest, so what matters is the product
+// across depth, not any single level. This documents the resulting topology so
+// a future change to the default or the halving rule has to confront it.
+func TestConcurrencyTopology_TotalIsBounded(t *testing.T) {
+	// leaves at depth d = product of the budget at each level above.
+	total := func(root, depth int) int {
+		n, budget := 1, root
+		for range depth {
+			n *= budget
+			budget = childConcurrency(budget)
+		}
+		return n
+	}
+
+	// With the shipped default, a /run tree is: TUI -> coordinators -> workers.
+	if got := total(DefaultPoolSize, 2); got > 8 {
+		t.Errorf("depth-2 agents = %d with default %d; the observed peak of 8 "+
+			"is what produced a 39%% rate-limit failure rate", got, DefaultPoolSize)
+	}
+
+	// Raising the knob must widen it, or the knob is useless.
+	if total(8, 2) <= total(DefaultPoolSize, 2) {
+		t.Error("raising PI_SUBAGENT_CONCURRENCY does not widen concurrency")
+	}
+
+	// And it must never diverge with depth: past the floor, each extra level
+	// multiplies by 1.
+	if total(DefaultPoolSize, 6) != total(DefaultPoolSize, 3) {
+		t.Errorf("concurrency still growing at depth 6 (%d) vs depth 3 (%d)",
+			total(DefaultPoolSize, 6), total(DefaultPoolSize, 3))
+	}
+}

--- a/internal/subagent/environ.go
+++ b/internal/subagent/environ.go
@@ -2,6 +2,7 @@ package subagent
 
 import (
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -83,6 +84,31 @@ func FilterEnv(allowlist []string) []string {
 		}
 	}
 	return filtered
+}
+
+// ChildEnv returns the environment for a spawned subagent: the allowlisted
+// parent environment, with the concurrency budget replaced by this process's
+// share for its children.
+//
+// The override is the point. PI_ is a forwarded prefix, so without it the
+// parent's budget is inherited verbatim — and because each spawned agent is a
+// pi process that builds its own pool, an inherited budget is a fresh
+// allowance per process rather than a shared one. Total concurrency then grows
+// as depth x budget, which is how eight agents ended up in flight against a
+// per-minute token limit.
+func ChildEnv(parentBudget int) []string {
+	env := FilterEnv(nil)
+	child := childConcurrency(parentBudget)
+
+	prefix := ConcurrencyEnvVar + "="
+	out := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue // replaced below, never inherited unchanged
+		}
+		out = append(out, entry)
+	}
+	return append(out, prefix+strconv.Itoa(child))
 }
 
 // matchesAllowlist checks if an env var name matches any entry in the allowlist.

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -16,7 +16,14 @@ import (
 )
 
 // DefaultPoolSize is the default maximum number of concurrent subagents.
-const DefaultPoolSize = 5
+//
+// Three rather than five, because the budget is per process and a spawned
+// coordinator builds its own pool: with the Coordinator/Worker SOP the totals
+// multiply with nesting. Measured over six hours of runs, 39% of sessions died
+// on the provider's per-minute token limit at a peak of eight agents in
+// flight. Raise it with PI_SUBAGENT_CONCURRENCY where the account has headroom
+// — see ConcurrencyFromEnv.
+const DefaultPoolSize = 3
 
 // recentTaskTTL is how long a completed subagent result is kept before being evicted.
 const recentTaskTTL = 30 * time.Minute
@@ -107,7 +114,7 @@ func NewOrchestrator(cfg *config.Config, repoRoot string, agentConfigs []AgentCo
 	}
 
 	return &Orchestrator{
-		pool:        NewPool(DefaultPoolSize),
+		pool:        NewPool(ConcurrencyFromEnv()),
 		spawner:     NewSpawner(""),
 		worktree:    wm,
 		cfg:         cfg,

--- a/internal/subagent/orchestrator_parallel_test.go
+++ b/internal/subagent/orchestrator_parallel_test.go
@@ -61,6 +61,14 @@ echo '{"type":"message_end"}'
 	t.Cleanup(func() { startACPSessionFn = prevStart })
 
 	// 3. Build orchestrator with our mocked pi spawner.
+	//
+	// This test asserts that four agents run at once, which needs a pool of at
+	// least four. The shipped default is deliberately smaller — see
+	// DefaultPoolSize — so the requirement is stated here rather than being
+	// silently inherited from it. Without this the fourth agent queues and the
+	// concurrency assertion below fails for a reason unrelated to spawning.
+	t.Setenv(ConcurrencyEnvVar, "4")
+
 	cfg := testConfig()
 	orch := NewOrchestrator(cfg, "", nil)
 	orch.spawner = NewSpawner(piBinary)

--- a/internal/subagent/spawner.go
+++ b/internal/subagent/spawner.go
@@ -129,8 +129,10 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 
 	cmd := exec.CommandContext(procCtx, s.PiBinary, args...)
 
-	// Set up environment: filtered process env + additional env vars.
-	baseEnv := FilterEnv(nil)
+	// Set up environment: filtered process env + additional env vars. The
+	// child's concurrency budget is this process's share, not a copy of it —
+	// see ChildEnv.
+	baseEnv := ChildEnv(ConcurrencyFromEnv())
 	if len(opts.Env) > 0 {
 		cmd.Env = append(baseEnv, opts.Env...)
 	} else {

--- a/internal/subagent/spawner_codex.go
+++ b/internal/subagent/spawner_codex.go
@@ -112,7 +112,7 @@ func startCodexSession(ctx context.Context, agentName, prompt string, opts Spawn
 
 	sessOpts.CWD = opts.WorkDir
 	sessOpts.Prompt = prompt
-	sessOpts.Env = append(FilterEnv(nil), opts.Env...)
+	sessOpts.Env = append(ChildEnv(ConcurrencyFromEnv()), opts.Env...)
 
 	sess, err := codex.NewSession(ctx, sessOpts)
 	if err != nil {

--- a/specs/run-coo-worker/PROMPT.md
+++ b/specs/run-coo-worker/PROMPT.md
@@ -1,0 +1,77 @@
+# Coordinator/Worker backpressure
+
+## Objective
+
+Stop `/run` losing 39% of its subagent sessions to provider rate limiting. The
+concurrency cap is per-process and the Coordinator/Worker SOP nests processes,
+so the budget multiplies with depth instead of dividing. Make one budget knob
+compose correctly under nesting.
+
+## Key Requirements
+
+1. **Configurable budget** — `PI_SUBAGENT_CONCURRENCY` sets the per-process
+   pool size. It is currently named in the env allowlist but read nowhere.
+2. **Composes under nesting** — a spawned agent gets a share of its parent's
+   budget, never a copy, so total in-flight agents converge with depth.
+3. **Cannot deadlock** — no input produces a zero-sized pool.
+4. **Rune-safe titles** — session titles truncate on a rune boundary.
+
+## Acceptance Criteria
+
+- Given `PI_SUBAGENT_CONCURRENCY=2`, when an orchestrator starts, then its pool
+  size is 2.
+- Given the variable is unset, malformed, negative or `0`, when an orchestrator
+  starts, then the pool size is `DefaultPoolSize` and at least 1.
+- Given a parent with budget N, when it spawns a child, then the child's
+  environment carries `max(1, N/2)` exactly once.
+- Given repeated nesting, when the budget is applied at each level, then it
+  converges to 1 and never grows.
+- Given a title whose byte cut falls inside a multi-byte rune, when it is
+  stored, then it contains no U+FFFD and fits `MaxSessionTitle` bytes.
+
+## Implementation Slices
+
+1. **Env budget** — `ConcurrencyFromEnv` + wire into the pool, files:
+   `internal/subagent/concurrency.go`, `orchestrator.go`, verify:
+   `go test ./internal/subagent/`, parallel-safe: no
+2. **Child propagation** — `ChildEnv` rewrites the budget, files:
+   `internal/subagent/environ.go`, `spawner.go`, `spawner_codex.go`, verify:
+   `go test ./internal/subagent/`, parallel-safe: no
+3. **Lower the default** — 5 → 3, files: `internal/subagent/orchestrator.go`,
+   verify: `go test ./internal/subagent/`, parallel-safe: yes
+4. **Rune-safe titles** — files: `internal/session/store.go`, verify:
+   `go test ./internal/session/`, parallel-safe: yes
+
+## Execution Model
+
+Coordinator → Worker → Verifier. Slices 1 and 2 are sequential; 3 and 4 are
+independent and may run in parallel with them.
+
+## Done Criteria
+
+- [ ] `PI_SUBAGENT_CONCURRENCY=2` yields a pool of 2 — proven by test
+- [ ] No env value produces a pool below 1 — proven by test over the bad inputs
+- [ ] The child env carries the halved budget exactly once, not the parent's
+- [ ] Repeated nesting converges to 1
+- [ ] No stored title contains U+FFFD
+- [ ] No slice left as a stub, TODO, or `panic("not implemented")`
+
+## Gates
+
+- **build**: `go build ./...`
+- **vet**: `go vet ./...`
+- **test**: `go test ./...`
+- **lint**: `golangci-lint run ./internal/subagent/... ./internal/session/...`
+
+## Reference
+
+- Findings: `specs/run-coo-worker/recomendations.md`
+- Design: `specs/run-coo-worker/design.md`
+- Plan: `specs/run-coo-worker/plan.md`
+- Deferred (session metadata): `specs/run-coo-worker/deferred.md`
+
+## Constraints
+
+- Do not add an adaptive rate-limit controller; the static budget is the fix.
+- Do not extend `retryStream` past its pre-emission boundary — re-sending a
+  committed stream duplicates tool calls.

--- a/specs/run-coo-worker/deferred.md
+++ b/specs/run-coo-worker/deferred.md
@@ -1,0 +1,79 @@
+# Deferred — Finding 2: make the run tree a field lookup, not a heuristic
+
+Specified here rather than built, because nothing is blocked on it today and it
+touches the session store's persisted format. Finding 1 is what stops runs
+completing; this makes the next investigation cheap instead of archaeological.
+
+## Problem
+
+`session.Meta` has ten fields. Reconstructing which workers belonged to which
+coordinator required grouping sessions by `workDir` and inferring roles from
+title prefixes — see `recomendations.md`, Finding 2. Fourteen of 63 sessions
+sat in numerically-named worktrees (`.pi-go/tasks/948887880000`) with no
+coordinator session sharing the directory, so they cannot be attributed to a
+spec by any recorded field at all.
+
+## Proposed shape
+
+A nested optional block on `Meta`, mirroring the existing `PlanContext`
+precedent (`internal/session/store.go:28`) so it stays absent for ordinary
+interactive sessions:
+
+```go
+// AgentContext records a session's place in a /run tree. Absent for
+// interactive sessions.
+type AgentContext struct {
+    AgentID   string `json:"agentID,omitempty"`   // orchestrator's own ID
+    AgentType string `json:"agentType,omitempty"` // task | worker | quick-task | code-reviewer
+    ParentID  string `json:"parentSessionID,omitempty"`
+    SpecName  string `json:"specName,omitempty"`
+    Slice     int    `json:"slice,omitempty"`
+    Cycle     int    `json:"cycle,omitempty"`     // /run retry index
+    Worktree  string `json:"worktree,omitempty"`
+    Branch    string `json:"branch,omitempty"`
+    Status    string `json:"status,omitempty"`    // terminal status
+}
+```
+
+## How it gets populated
+
+The spawner already builds the child environment and now rewrites one variable
+in it (`ChildEnv`). The same channel carries this: the parent sets
+`PI_AGENT_ID`, `PI_PARENT_SESSION`, `PI_AGENT_TYPE`, `PI_SPEC_NAME`,
+`PI_RUN_CYCLE`; the child reads them when it creates its session and stores
+them on `Meta.Agent`.
+
+`Status` is the exception — it is only known when the run ends, so it is
+written by whoever observes termination rather than at session creation.
+
+## Why it is worth doing
+
+Every question asked during the investigation becomes a field lookup:
+
+| Question | Today | With this |
+|---|---|---|
+| Which coordinator owns this worker? | group by `workDir`, guess | `parentSessionID` |
+| What is this session? | guess from title prefix | `agentType` |
+| Which spec/slice? | regex the title prose | `specName`, `slice` |
+| Is this a retry? | match prompt text | `cycle` |
+| Did it succeed? | scan `events.jsonl` for `ErrorCode` | `status` |
+
+It would also make `session-stats`
+(`internal/tools/session_stats.go`) able to report on runs rather than on
+individual sessions.
+
+## Risks
+
+- **Format change.** Fields are additive and `omitempty`, so old sessions stay
+  readable and new ones stay readable by old code. No migration needed.
+- **Env surface.** Five new `PI_`-prefixed variables are forwarded to children.
+  They carry no secrets, but they are inherited by *any* nested process, so a
+  child must overwrite rather than inherit them — the same trap `ChildEnv` was
+  written to avoid for the concurrency budget. Getting this wrong would make
+  every grandchild claim the same parent.
+
+## Not included
+
+Linking sessions to the orchestrator's in-memory agent records at runtime. The
+IDs above are enough to join after the fact, which is what the investigation
+needed.

--- a/specs/run-coo-worker/design.md
+++ b/specs/run-coo-worker/design.md
@@ -1,0 +1,105 @@
+# Design — concurrency budget that composes under nesting
+
+Derived from `recomendations.md`. Covers Findings 1 and 3; Finding 2 is
+specified in `deferred.md`.
+
+## Current state
+
+`Orchestrator` holds a `Pool` (`internal/subagent/pool.go`), a buffered-channel
+semaphore sized by `DefaultPoolSize = 5` at
+`internal/subagent/orchestrator.go:110`. `Acquire` is called once per spawn
+(`orchestrator.go:388`) and released on every exit path.
+
+The size is a compile-time constant. `PI_SUBAGENT_CONCURRENCY` appears only in
+a comment listing the `PI_` prefix as forwarded to subagents
+(`internal/subagent/environ.go:43`); no code reads it.
+
+Because a spawned agent is a `pi` process that builds its own orchestrator, the
+budget is per-process. Nesting multiplies it: `depth × 5`.
+
+`buildEnv` (`internal/subagent/environ.go:73`) starts from `os.Environ()` and
+forwards anything matching the allowlist, so a `PI_`-prefixed variable set by a
+parent already reaches its children unchanged. That is the mechanism to reuse —
+and the reason the budget currently *would* be inherited verbatim rather than
+divided, if it were read at all.
+
+## Desired end state
+
+One knob, honored everywhere, that shrinks as runs nest so total concurrent
+agents stays bounded regardless of depth.
+
+## Components
+
+### `subagent.ConcurrencyFromEnv() int`
+
+Reads `PI_SUBAGENT_CONCURRENCY`. Returns `DefaultPoolSize` when unset, empty,
+unparseable, or below 1. Never returns less than 1 — a zero budget would
+deadlock every spawn.
+
+Clamped to a sane ceiling so a typo cannot uncap the pool.
+
+### Child budget propagation
+
+When the spawner builds a child's environment it sets
+`PI_SUBAGENT_CONCURRENCY` to the child's share of the parent's budget rather
+than letting the parent's value pass through unchanged.
+
+The rule is integer halving with a floor of 1:
+
+```
+child = max(1, parent / 2)
+```
+
+Depth 0 gets N, depth 1 gets N/2, depth 2 gets N/4, bottoming out at 1. Total
+in-flight agents converge instead of growing with depth.
+
+Halving is chosen over "parent − 1" because it degrades gracefully for any
+starting N and reaches the floor quickly; a coordinator two levels down doing
+one thing at a time is the desired behavior.
+
+### Default
+
+`DefaultPoolSize` drops from 5 to 3. The evidence is that 5 per process, times
+the nesting the SOP now encourages, is not survivable against a per-minute
+token limit. Three is a starting point that the environment variable can raise
+for accounts with more headroom.
+
+### `session.truncateTitle`
+
+Replaces the byte slice at `internal/session/store.go:647`. Cuts at a rune
+boundary at or below `MaxSessionTitle` bytes, so the result never ends in a
+partial rune.
+
+## What is deliberately not built
+
+**No adaptive controller.** Widening and narrowing the pool in response to 429s
+is a feedback system with its own oscillation and starvation modes. The
+observed failure is explained entirely by a static budget that composes wrongly,
+so the static budget is what this fixes.
+
+**No new retry.** `retryStream` already covers the recoverable case and
+correctly refuses the unrecoverable one; extending it would duplicate tool
+calls. See `recomendations.md`, Finding 1.
+
+## Acceptance criteria
+
+- Given `PI_SUBAGENT_CONCURRENCY=2`, when an orchestrator is constructed, then
+  its pool size is 2.
+- Given the variable is unset, malformed, or `0`, when an orchestrator is
+  constructed, then its pool size is `DefaultPoolSize` and never below 1.
+- Given a parent with budget N, when it spawns a child, then the child's
+  environment carries `max(1, N/2)`, not N.
+- Given a parent with budget 1, when it spawns a child, then the child receives
+  1 — the floor holds and no spawn can deadlock.
+- Given a title longer than `MaxSessionTitle` whose cut point falls inside a
+  multi-byte rune, when it is persisted, then the stored title contains no
+  U+FFFD and is no longer than `MaxSessionTitle` bytes.
+
+## Testing strategy
+
+Table-driven unit tests for the env parse and the halving rule. A test that
+builds a child environment through the real `ChildEnv` path and asserts the
+decremented value — and asserts the variable appears exactly once, since the
+bug being prevented is the parent's value passing through alongside it. Title
+tests assert on properties (valid UTF-8, no U+FFFD, within the byte cap) rather
+than on a golden string, so they hold for any cut point.

--- a/specs/run-coo-worker/plan.md
+++ b/specs/run-coo-worker/plan.md
@@ -1,0 +1,57 @@
+# Plan — concurrency budget that composes under nesting
+
+Vertical slices. Each compiles and passes tests on its own.
+
+## Progress
+
+- [x] Step 1: Read the concurrency budget from the environment
+- [x] Step 2: Halve the budget for spawned children
+- [x] Step 3: Lower the default pool size to 3
+- [x] Step 4: Truncate session titles on a rune boundary
+
+### Slice 1: Read the concurrency budget from the environment
+
+Files: `internal/subagent/orchestrator.go`, `internal/subagent/concurrency.go` (new)
+
+Add `ConcurrencyFromEnv()`; use it where `NewPool(DefaultPoolSize)` is called.
+Unset, malformed, or out-of-range values fall back to the default; the result
+is never below 1.
+
+Verify: `go test ./internal/subagent/`
+Parallel-safe: no (Slice 2 builds on it)
+
+### Slice 2: Halve the budget for spawned children
+
+Files: `internal/subagent/environ.go`
+
+Set `PI_SUBAGENT_CONCURRENCY` explicitly in the child environment to
+`max(1, parent/2)` instead of letting the inherited value pass through.
+
+Verify: `go test ./internal/subagent/`
+Parallel-safe: no (depends on Slice 1)
+
+### Slice 3: Lower the default pool size to 3
+
+Files: `internal/subagent/orchestrator.go`
+
+Change `DefaultPoolSize` and record why in the comment, so the number reads as
+evidence-based rather than arbitrary.
+
+Verify: `go test ./internal/subagent/`
+Parallel-safe: yes
+
+### Slice 4: Truncate session titles on a rune boundary
+
+Files: `internal/session/store.go`
+
+Replace `title[:MaxSessionTitle]` with a rune-safe cut.
+
+Verify: `go test ./internal/session/`
+Parallel-safe: yes
+
+## Gates
+
+- **build**: `go build ./...`
+- **vet**: `go vet ./...`
+- **test**: `go test ./...`
+- **lint**: `golangci-lint run ./internal/subagent/... ./internal/session/...`

--- a/specs/run-coo-worker/recomendations.md
+++ b/specs/run-coo-worker/recomendations.md
@@ -1,0 +1,162 @@
+# Coordinator → Worker runs: what the session data shows, and what to fix
+
+Date: 2026-08-10
+Evidence: 63 sessions under `$HOME/.pi-go/sessions` with `workDir` inside
+`/Users/dimetron/p6s/ai-eng-course`, created in the six hours to 12:30.
+Runtime reviewed at `main` = `5eee2ba`.
+
+## Summary
+
+The Coordinator → Worker → Verifier SOP works. Delegation happens, context
+stays small, and the retry loop fires. What stops runs finishing is no longer
+context exhaustion — it is **provider rate limiting, amplified by a
+concurrency cap that multiplies instead of dividing when runs nest**.
+
+A secondary finding: the run tree in the session log is only recoverable by
+inference. Nothing records which coordinator a worker belongs to.
+
+## What is working
+
+| Claim | Evidence |
+|---|---|
+| Coordinators delegate rather than implement | Worker sessions carry self-contained slice briefs ("Implement Slice 2 of …, inspect …, verify …") |
+| Context pressure is largely solved | 2 of 63 sessions above 150k prompt tokens, against 27 of 92 above 100k before the SOP change |
+| The retry loop fires | 9 resume cycles, prompts beginning "The previous execution cycle did not finish" |
+
+This is worth stating plainly because the fixes below should not disturb it.
+
+## Finding 1 — rate limiting is the blocker (critical)
+
+**25 of 64 sessions (39%) ended on `rate_limit_exceeded`** — tokens-per-minute
+for `gpt-5.6-luna`. Peak concurrency was **8 simultaneous sessions**.
+
+The cost shows up as churn, not as clean failure:
+
+| Slice | Worker sessions spent on it |
+|---|---|
+| Slice 4 | 10 |
+| Slice 2 | 10 |
+| Slice 1 | 9 |
+| Slice 3 | 4 |
+
+33 worker sessions for roughly 4 slices.
+
+### Why it compounds
+
+A worker dies mid-slice on a 429. The coordinator immediately dispatches a
+replacement. That raises concurrent token draw, which makes the next 429 more
+likely. Nothing in the loop responds to being rate limited by slowing down.
+
+### Why the existing retry cannot help
+
+`retryStream` (`internal/provider/retry.go:46`) already re-sends a stream that
+failed **before emitting anything**, with `MaxRetries = 3`. The comment on it
+is explicit about the limit: once tool calls or text have been forwarded, the
+attempt is committed and the error passes through, because re-sending would
+duplicate the tool calls.
+
+Every observed failure is mid-slice, after tool calls. So this is correct and
+cannot be extended to cover the case. **The answer is not more retrying — it is
+not hitting the limit.**
+
+The `retry` package is already careful about 429s that are not rate limits
+(`internal/retry/retry.go:50-57` distinguishes "weekly usage limit" and
+"exceeded your current quota" from a real per-minute limit). That
+classification is good and should be reused, not duplicated.
+
+### Root cause: the cap is per-process
+
+`DefaultPoolSize = 5` (`internal/subagent/orchestrator.go:18`) bounds concurrent
+subagents **per orchestrator**. Each orchestrator lives in one `pi` process.
+
+A spawned coordinator is itself a `pi` process, and it gets the subagent tool
+(`internal/tools/agent.go:23`) — so it constructs its own orchestrator with its
+own pool of 5. Two concurrent `/run` commands therefore permit 2 coordinators ×
+5 workers = 10 concurrent agents, plus the coordinators themselves. The
+observed peak of 8 sits inside that envelope; the configured 5 never bounded
+anything at the level that matters.
+
+`maxParallelTasks = 8` (`internal/tools/subagent.go:25`) caps a single
+`subagent` call's fan-out, not the total in flight.
+
+**`PI_SUBAGENT_CONCURRENCY` is named in the env allowlist comment
+(`internal/subagent/environ.go:43`) but is never read anywhere in the tree.**
+The pool size cannot currently be configured at all.
+
+### Recommendation
+
+1. Honour `PI_SUBAGENT_CONCURRENCY` as the pool size, falling back to
+   `DefaultPoolSize`.
+2. **Propagate a decremented budget to children.** A coordinator given a budget
+   of N should pass a smaller budget down, so nesting divides the allowance
+   rather than multiplying it. `PI_*` is already forwarded to subagents, so the
+   channel exists.
+3. Lower the default. Five concurrent agents against a per-minute token limit
+   is optimistic for a single account; the data shows it is not survivable.
+
+This is deliberately not adaptive. A rate-limit-aware controller that widens
+and narrows the pool is a bigger change with its own failure modes; a correct
+static budget that composes under nesting fixes the observed problem and can be
+tuned from the environment.
+
+## Finding 2 — the run tree is inference, not tracking
+
+`meta.json` carries exactly ten fields: `appName`, `createdAt`, `host`, `id`,
+`model`, `provider`, `title`, `updatedAt`, `userID`, `workDir`.
+
+Reconstructing which workers belonged to which coordinator required grouping
+sessions by `workDir` and guessing roles from title prefixes. Nothing records:
+
+- `agentID` — no join to the orchestrator's own agent records
+- `parentSessionID` — the worker → coordinator edge does not exist
+- `agentType` — coordinator vs worker vs verifier is guessed from prose
+- `specName` and slice number — extracted with a regex over the title
+- cycle / retry index — the 9 resumes are findable only by matching prompt text
+- terminal status — absent; determining it means scanning `events.jsonl` for
+  `ErrorCode`
+
+Worse: **14 of 63 sessions live in numerically-named worktrees** such as
+`.pi-go/tasks/948887880000`, and those directories contain no coordinator
+session at all — they are resume cycles. They cannot be attributed to a spec by
+any recorded field.
+
+### Recommendation
+
+Add a nested, optional `Agent` block to `session.Meta`, mirroring the existing
+`PlanContext` precedent (`internal/session/store.go:28`): agent ID, agent type,
+parent session ID, spec name, worktree path and branch, cycle index, and
+terminal status. Populate it from the environment the spawner already
+forwards. This makes every question above a field lookup instead of a
+heuristic.
+
+## Finding 3 — session titles are corrupted by byte truncation
+
+**50 of 200 recent titles contain U+FFFD.** `internal/session/store.go:647`
+truncates with `title[:MaxSessionTitle]`, a byte slice, which cuts mid-rune:
+
+```
+'…Report concrete bugs with seve�'
+```
+
+This is the same defect class PR #125 fixed in `truncateOutput`, which now
+backs up to a rune boundary. The fix never reached the title path. Titles are
+also embedded in terminal escape sequences (OSC 0), so a broken rune is written
+to the user's terminal.
+
+### Recommendation
+
+Truncate on a rune boundary. One function, reusing the approach already proven
+in `internal/tools/truncate.go`.
+
+## Priority
+
+1. **Finding 1** — this is what stops runs completing.
+2. **Finding 3** — small, self-contained, and already corrupting stored data.
+3. **Finding 2** — additive and valuable, but nothing is blocked on it today.
+
+## What this does not address
+
+Gates still run only in the primary worktree in parallel mode, so a second
+agent's code is never gated. That needs worktree-to-worktree consolidation
+before validation, which `MergeBack` does not do — it merges into the main
+repo. It is unrelated to the findings here and belongs in its own change.


### PR DESCRIPTION
Findings, design and fix for why Coordinator/Worker runs stop finishing. Written up in `specs/run-coo-worker/`.

## Evidence

63 sessions under `$HOME/.pi-go/sessions` with `workDir` in `ai-eng-course`, six hours to 12:30.

**39% (25 of 64) died on the provider's per-minute token limit**, at a peak of **8 agents in flight**. The cost showed as churn rather than clean failure:

| Slice | Worker sessions spent on it |
|---|---|
| Slice 4 | 10 |
| Slice 2 | 10 |
| Slice 1 | 9 |
| Slice 3 | 4 |

33 worker sessions for roughly four slices.

## The SOP is not at fault — the cap is

Worth stating, because the fix must not disturb it: **the Coordinator/Worker SOP is working.** Coordinators delegate with self-contained briefs, context pressure is largely gone (2 of 63 sessions above 150k tokens, against 27 of 92 above 100k before), and the retry loop fires — 9 resume cycles.

The fault is `DefaultPoolSize`. It bounds subagents **per orchestrator**, and an orchestrator lives in one `pi` process. A spawned coordinator *is* a `pi` process holding the subagent tool, so it builds its own pool. The budget was per-process, and nesting **multiplied** it.

`PI_SUBAGENT_CONCURRENCY` was named in the forwarded-env allowlist (`environ.go:43`) but **read nowhere** — the size could not be configured at all.

## The fix

- **`ConcurrencyFromEnv`** reads the variable, falls back to the default, and never returns zero — a zero-sized pool blocks the first `Acquire` forever, turning a typo into a hang rather than a slow run.
- **`ChildEnv`** rewrites the variable for spawned agents to `max(1, parent/2)` instead of letting it pass through, so the allowance **divides** with depth.
- **Default 5 → 3.**

### Why 3, specifically

Halving 3 reaches the floor immediately, so leaf agents stay **flat at 3 for every depth**. Five gives 10 — the regime that produced the observed 8:

```
root=3: leaves by depth = [3, 3, 3, 3]
root=5: leaves by depth = [5, 10, 10, 10]
```

A test pins this topology, so a later change to the default or the halving rule has to confront it rather than silently reintroducing the problem.

### The trade, stated plainly

At the default a coordinator now runs its workers **one at a time**, so batching parallel-safe slices *within* a run is serialised. That is a genuine throughput cost, and it is preferable to 33 sessions for 4 slices. Raise `PI_SUBAGENT_CONCURRENCY` where the account has headroom.

## Deliberately not built

**No adaptive controller.** Widening and narrowing the pool in response to 429s is a feedback system with its own oscillation and starvation modes, and the observed failure is fully explained by a static budget composing wrongly.

**No new retry.** `retryStream` already re-sends a stream that failed *before emitting anything* and correctly refuses the rest — re-sending a committed stream duplicates tool calls. Every observed failure is mid-slice, after tool calls, so this is unreachable by design. The answer is not to retry harder; it is not to hit the limit.

## Also: session titles were corrupting stored data

**50 of 200 recent titles contained U+FFFD.** `store.go:647` truncated with `title[:MaxSessionTitle]` — a byte slice that splits runes. Titles are written to the terminal inside OSC 0, so the broken rune reached the user's terminal too.

Same defect class #125 fixed in `truncateOutput`; the fix had not reached this path. Now cuts on a rune boundary.

## One existing test changed

`TestOrchestrator_ParallelSpawn_PiAndACPAgents` asserts four concurrent agents, which the new default forbids by design. It now sets the budget it needs rather than inheriting it — its intent is "parallel spawn works", not "the default is ≥4", and stating the requirement keeps it honest against future default changes.

## Deferred, and specified rather than built

`specs/run-coo-worker/deferred.md` covers the second finding: **the run tree is only recoverable by inference.** Reconstructing which workers belonged to which coordinator meant grouping by `workDir` and guessing roles from title prose. 14 of 63 sessions sat in numerically-named worktrees with no coordinator sharing the directory — unattributable to a spec by any recorded field. The proposed `Meta.Agent` block mirrors the existing `PlanContext` precedent. Nothing is blocked on it today, so it is written down rather than rushed in alongside a fix that is.

## Verification

`go build`, `go vet`, full `go test ./...`, `golangci-lint` on both changed packages — all pass.
