### PR TITLE
feat(subagent): report effective concurrency, not the per-call cap

### DIFF
--- a/internal/sop/pdd_default.go
+++ b/internal/sop/pdd_default.go
@@ -120,7 +120,9 @@ Coordinator → Worker → Verifier. The agent that receives this PROMPT.md is t
 
 - **Workers**: one ` + "`" + `worker` + "`" + ` subagent per slice (` + "`" + `quick-task` + "`" + ` for a single-file
   mechanical change). Slices marked parallel-safe may be batched in one parallel
-  ` + "`" + `subagent` + "`" + ` call; all others run one at a time, in order.
+  ` + "`" + `subagent` + "`" + ` call, but only up to the concurrency the ` + "`" + `subagent` + "`" + ` tool reports for
+  the running process — beyond that the tasks queue inside one call instead of
+  overlapping. All other slices run one at a time, in order.
 - **Verifier**: after the last slice, a ` + "`" + `code-reviewer` + "`" + ` subagent checks the Done
   Criteria below against the actual diff and returns VERDICT: PASS or VERDICT: FAIL.
 - **Loop**: on FAIL the Coordinator dispatches fix workers and re-verifies, up to
@@ -170,7 +172,9 @@ Follow the conventions in specs/AGENTS.md for spec directory structure and namin
 - Aim for plans with <50 distinct instructions per phase — large instruction counts degrade LLM compliance
 - **Delegate to subagents for anything small and self-contained** — a file lookup,
   an API-shape check, a convention question. Spawn ` + "`" + `explore` + "`" + ` (research) or
-  ` + "`" + `quick-task` + "`" + ` (small edits); batch independent ones into a single parallel call.
+  ` + "`" + `quick-task` + "`" + ` (small edits); batch independent ones into a single parallel call,
+  sized to the concurrency the ` + "`" + `subagent` + "`" + ` tool reports rather than to the number
+  of questions you have.
   Read files directly only when you need the exact text in your own context.
 - **Never delegate to a [worktree] agent from /plan or /run** (` + "`" + `task` + "`" + `, ` + "`" + `designer` + "`" + `).
   Their edits land in a nested worktree that is never merged, so the work is lost.

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -710,6 +710,18 @@ func (o *Orchestrator) Cancel(agentID string) error {
 	return nil
 }
 
+// Concurrency reports how many subagents this process may run at once. It is
+// the pool size, which is what actually gates a spawn — not maxParallelTasks,
+// which only caps how many tasks one call may name. A batch larger than this
+// does not run in parallel; it queues, and the call takes proportionally
+// longer.
+func (o *Orchestrator) Concurrency() int {
+	if o == nil || o.pool == nil {
+		return 0
+	}
+	return o.pool.Size()
+}
+
 // Worktree returns the WorktreeManager (may be nil if worktrees are disabled).
 func (o *Orchestrator) Worktree() *WorktreeManager {
 	return o.worktree

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -142,7 +142,21 @@ Worktree agents:
 		fmt.Fprintf(&b, "- %s%s: %s\n", ac.Name, marker, ac.Description)
 	}
 
-	fmt.Fprintf(&b, "\nMaximum %d concurrent subagents. Each agent runs as a separate process.", maxParallelTasks)
+	// Report the pool size, not just the per-call cap. They are different
+	// numbers and the model needs the smaller one: maxParallelTasks limits how
+	// many tasks a single call may name, while the pool is what actually gates
+	// a spawn. Naming more tasks than the pool allows does not run them in
+	// parallel — they queue, and the one tool call takes proportionally longer,
+	// which is how a "parallel" batch turns into a timeout.
+	concurrency := orch.Concurrency()
+	fmt.Fprintf(&b, "\nAt most %d task(s) per call. This process runs %d subagent(s) at a time",
+		maxParallelTasks, concurrency)
+	if concurrency <= 1 {
+		b.WriteString(" — parallel mode gives no speed-up here, so prefer one task per call")
+	} else {
+		fmt.Fprintf(&b, ", so batches larger than %d queue rather than overlap", concurrency)
+	}
+	b.WriteString(". Each agent runs as a separate process.")
 	return b.String()
 }
 

--- a/internal/tools/subagent_description_test.go
+++ b/internal/tools/subagent_description_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// The subagent tool description must report the pool size, not only the
+// per-call cap. They are different numbers: maxParallelTasks limits how many
+// tasks one call may name, while the pool gates spawning. A model told only
+// "max 8" will batch eight tasks into a process that runs one at a time, and
+// the batch serializes inside a single tool call instead of overlapping.
+func TestSubagentDescription_ReportsEffectiveConcurrency(t *testing.T) {
+	t.Setenv(subagent.ConcurrencyEnvVar, "4")
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	t.Cleanup(orch.Shutdown)
+
+	desc := buildSubagentDescription(orch)
+
+	if !strings.Contains(desc, "runs 4 subagent(s) at a time") {
+		t.Errorf("description does not state the effective concurrency:\n%s", desc)
+	}
+	if !strings.Contains(desc, "queue rather than overlap") {
+		t.Error("description does not warn that oversized batches queue")
+	}
+}
+
+// At a concurrency of 1 the advice has to change outright — batching buys
+// nothing and only lengthens the call.
+func TestSubagentDescription_WarnsWhenParallelIsPointless(t *testing.T) {
+	t.Setenv(subagent.ConcurrencyEnvVar, "1")
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	t.Cleanup(orch.Shutdown)
+
+	desc := buildSubagentDescription(orch)
+
+	if !strings.Contains(desc, "no speed-up") {
+		t.Errorf("description does not tell the model parallel mode is pointless here:\n%s", desc)
+	}
+	if strings.Contains(desc, "queue rather than overlap") {
+		t.Error("description gives the batching advice that only applies above 1")
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -157,7 +157,12 @@ Spawn ONE worker per slice with the ` + "`" + `subagent` + "`" + ` tool:
 - ` + "`" + `{agent: "worker", task: "<self-contained brief>"}` + "`" + ` — the default.
 - ` + "`" + `{agent: "quick-task", task: "..."}` + "`" + ` — a single-file mechanical change.
 - ` + "`" + `{tasks: [{agent: "worker", task: "..."}, ...]}` + "`" + ` — several slices at once, ONLY
-  when the plan marks them parallel-safe and they touch disjoint files (max 8).
+  when the plan marks them parallel-safe, they touch disjoint files, AND the
+  ` + "`" + `subagent` + "`" + ` tool description says this process runs more than one subagent at a
+  time. Batching past that number does not overlap anything: the extra tasks
+  queue inside the same tool call and it takes proportionally longer, which is
+  how a "parallel" batch turns into a timeout. When in doubt, dispatch one
+  slice per call — sequential slices are the normal case.
 
 **Never spawn ` + "`" + `task` + "`" + ` or ` + "`" + `designer` + "`" + `.** They are [worktree] agents: their edits go to
 a nested worktree that is never merged back, so the slice silently produces

--- a/specs/run-coo-worker/plan.md
+++ b/specs/run-coo-worker/plan.md
@@ -8,6 +8,7 @@ Vertical slices. Each compiles and passes tests on its own.
 - [x] Step 2: Halve the budget for spawned children
 - [x] Step 3: Lower the default pool size to 3
 - [x] Step 4: Truncate session titles on a rune boundary
+- [x] Step 5: Report effective concurrency and align the SOP guidance
 
 ### Slice 1: Read the concurrency budget from the environment
 
@@ -48,6 +49,22 @@ Replace `title[:MaxSessionTitle]` with a rune-safe cut.
 
 Verify: `go test ./internal/session/`
 Parallel-safe: yes
+
+### Slice 5: Report effective concurrency and align the SOP guidance
+
+Files: `internal/subagent/orchestrator.go`, `internal/tools/subagent.go`,
+`internal/tui/run.go`, `internal/sop/pdd_default.go`
+
+Add `Orchestrator.Concurrency()`. The subagent tool description reports the
+pool size alongside the per-call cap and says what happens past the smaller
+one. The coordinator contract and the SOP tell the agent to size batches to the
+reported concurrency.
+
+Must ship with Slices 1-3: lowering concurrency while still advising 8-way
+batches trades a rate-limit failure for a timeout.
+
+Verify: `go test ./internal/tools/ ./internal/tui/ ./internal/sop/`
+Parallel-safe: no (depends on Slice 1)
 
 ## Gates
 

--- a/specs/run-coo-worker/recomendations.md
+++ b/specs/run-coo-worker/recomendations.md
@@ -148,11 +148,47 @@ to the user's terminal.
 Truncate on a rune boundary. One function, reusing the approach already proven
 in `internal/tools/truncate.go`.
 
+## Finding 4 — the SOP promises parallelism the runtime will not deliver
+
+Found by reviewing the SOP against the runtime *after* the Finding 1 fix, which
+is the only order in which it is visible.
+
+`coordinatorContract` (`internal/tui/run.go`) told the coordinator it may batch
+"several slices at once … (max 8)". The SOP repeated the advice for both slice
+execution and Phase 3 research. Both numbers came from `maxParallelTasks = 8`
+(`internal/tools/subagent.go:25`), and the subagent tool description advertised
+the same figure.
+
+But `maxParallelTasks` caps **how many tasks one call may name**. What actually
+gates a spawn is the pool. With the budget from Finding 1 a coordinator sits at
+depth 1 and gets a pool of 1, so an eight-task batch does not overlap at all:
+the tasks queue inside a single tool call and that call takes roughly eight
+times as long. A batch that was supposed to save time becomes the most likely
+thing to hit the agent timeout.
+
+This is worth stating as its own finding because it is a hazard *created by*
+fixing Finding 1. Lowering concurrency without correcting the guidance would
+have traded a rate-limit failure for a timeout failure.
+
+### Recommendation
+
+Report the effective concurrency, not the per-call cap, and make the advice
+follow it:
+
+- `Orchestrator.Concurrency()` exposes the pool size.
+- The subagent tool description states both numbers and what happens past the
+  smaller one; at a concurrency of 1 it says plainly that parallel mode buys
+  nothing.
+- The coordinator contract and the SOP tell the agent to size batches to the
+  reported concurrency, and that one slice per call is the normal case.
+
 ## Priority
 
 1. **Finding 1** — this is what stops runs completing.
-2. **Finding 3** — small, self-contained, and already corrupting stored data.
-3. **Finding 2** — additive and valuable, but nothing is blocked on it today.
+2. **Finding 4** — must ship with Finding 1, not after it. On its own, Finding
+   1 converts a rate-limit failure into a timeout failure.
+3. **Finding 3** — small, self-contained, and already corrupting stored data.
+4. **Finding 2** — additive and valuable, but nothing is blocked on it today.
 
 ## What this does not address
 


### PR DESCRIPTION
Reviewing the PDD SOP against the runtime *after* the budget change — the only order in which this is visible — turns up a hazard the budget change creates.

The coordinator contract told the agent it may batch "several slices at once … (max 8)", the SOP repeated it for slice execution and for Phase 3 research, and the subagent tool description advertised the same 8. All three took the number from maxParallelTasks, which caps how many tasks one *call* may name. What actually gates a spawn is the pool.

With the budget from the previous commit a coordinator sits at depth 1 and gets a pool of 1, so an eight-task batch does not overlap at all: the tasks queue inside a single tool call and it takes roughly eight times as long. The batch that was supposed to save time becomes the most likely thing to hit the agent timeout. Shipping the lower budget without this would have traded a rate-limit failure for a timeout failure.

Orchestrator.Concurrency exposes the pool size. The tool description now states both numbers and what happens past the smaller one, and at a concurrency of 1 says plainly that parallel mode buys nothing so one task per call is better. The coordinator contract and the SOP tell the agent to size batches to the reported concurrency, and that one slice per call is the normal case.

Recorded as Finding 4 in specs/run-coo-worker/recomendations.md, and ranked second in the priority list — it has to ship with the budget change, not after it.

Fixes a stray edit in the same pass: the Concurrency accessor had been inserted between Worktree's doc comment and its signature, leaving Worktree undocumented.