### PR TITLE
fix(tui): render backgrounded commands as running, not as exit -1

### DIFF
--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -43,6 +43,17 @@ type BashOutput struct {
 	Running bool `json:"running,omitempty"`
 	// Handle identifies a still-running command for bash_output and bash_kill.
 	Handle string `json:"handle,omitempty"`
+	// Elapsed is how long the command has been running in total.
+	Elapsed string `json:"elapsed,omitempty"`
+	// Idle is how long it has been since the command last produced output.
+	Idle string `json:"idle,omitempty"`
+	// Timeout and IdleTimeout are the limits this command actually ran under,
+	// after defaults and clamping. They are reported rather than left implicit
+	// because a handoff is otherwise unexplainable from the result alone: the
+	// caller sees "moved to the background" with no way to tell whether the
+	// limit it hit was the 90s default or a 1s value it passed itself.
+	Timeout     string `json:"timeout,omitempty"`
+	IdleTimeout string `json:"idle_timeout,omitempty"`
 	// Note explains a non-obvious outcome in terms the model can act on.
 	Note string `json:"note,omitempty"`
 }
@@ -62,7 +73,12 @@ type BashStatus struct {
 	Elapsed string `json:"elapsed,omitempty"`
 	// Idle is how long it has been since the command last produced output.
 	Idle string `json:"idle,omitempty"`
-	Note string `json:"note,omitempty"`
+	// Timeout and IdleTimeout are the limits the command was started under, so
+	// a poll can say why it was handed off without the caller having to
+	// remember what it asked for several turns ago.
+	Timeout     string `json:"timeout,omitempty"`
+	IdleTimeout string `json:"idle_timeout,omitempty"`
+	Note        string `json:"note,omitempty"`
 }
 
 // BashOutputInput asks for output accumulated by a backgrounded command.

--- a/internal/tools/bash_limits_test.go
+++ b/internal/tools/bash_limits_test.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A handoff has to explain itself. Without the limits the result says only that
+// the command went quiet — not that the threshold it crossed was one the caller
+// picked, which is the difference between waiting and fixing the call.
+func TestSupervisor_HandoffReportsItsLimits(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	out := run(t, sup, "sleep 30", 10*time.Second)
+
+	if !out.Running {
+		t.Fatalf("expected a backgrounded command, got %+v", out)
+	}
+	if want := (150 * time.Millisecond).String(); out.IdleTimeout != want {
+		t.Errorf("IdleTimeout = %q, want %q", out.IdleTimeout, want)
+	}
+	if want := (10 * time.Second).String(); out.Timeout != want {
+		t.Errorf("Timeout = %q, want %q", out.Timeout, want)
+	}
+	if out.Elapsed == "" {
+		t.Error("Elapsed should be set on a handoff")
+	}
+	if !strings.Contains(out.Note, "idle_timeout") {
+		t.Errorf("Note should name the limits, got %q", out.Note)
+	}
+}
+
+// The limits survive the handoff: a poll several turns later can still say what
+// the command was started under, without the caller having to remember.
+func TestSupervisor_PollReportsTheSameLimits(t *testing.T) {
+	sup := fastSupervisor(t)
+
+	out := run(t, sup, "sleep 30", 10*time.Second)
+	if out.Handle == "" {
+		t.Fatal("expected a handle")
+	}
+	st, err := sup.readOutput(out.Handle, 0)
+	if err != nil {
+		t.Fatalf("readOutput: %v", err)
+	}
+
+	if st.IdleTimeout != out.IdleTimeout {
+		t.Errorf("poll IdleTimeout = %q, want %q", st.IdleTimeout, out.IdleTimeout)
+	}
+	if st.Timeout != out.Timeout {
+		t.Errorf("poll Timeout = %q, want %q", st.Timeout, out.Timeout)
+	}
+}
+
+func TestLimitsHint(t *testing.T) {
+	tests := []struct {
+		name          string
+		timeout, idle time.Duration
+		want          []string
+		notWant       []string
+	}{
+		{
+			// The case that produced fifty-five polls of one handle: a
+			// one-second idle limit backgrounds every build in this repo.
+			name:    "a hair-trigger idle limit is called out",
+			timeout: 2 * time.Minute,
+			idle:    time.Second,
+			want:    []string{"idle_timeout 1s", "timeout 2m0s", "rather than polling the handle"},
+		},
+		{
+			name:    "an ordinary idle limit is stated, not argued with",
+			timeout: 5 * time.Minute,
+			idle:    90 * time.Second,
+			want:    []string{"idle_timeout 1m30s", "timeout 5m0s"},
+			notWant: []string{"rather than polling the handle"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := limitsHint(tt.timeout, tt.idle)
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("limitsHint() = %q, want it to contain %q", got, w)
+				}
+			}
+			for _, w := range tt.notWant {
+				if strings.Contains(got, w) {
+					t.Errorf("limitsHint() = %q, should not contain %q", got, w)
+				}
+			}
+		})
+	}
+}

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -31,6 +31,15 @@ const (
 	// enough to trip on every build is merely annoying.
 	defaultIdleTimeout = 90 * time.Second
 
+	// shortIdleTimeout is the threshold below which a caller-supplied
+	// idle_timeout is treated as self-defeating and called out in the result.
+	//
+	// Nothing is overridden — a caller that genuinely wants a hair trigger
+	// keeps it. But the heartbeat only samples every 5s, so any value below
+	// that cannot fire sooner than 5s anyway, and values in that range
+	// background every build in this repo on its first quiet moment.
+	shortIdleTimeout = 15 * time.Second
+
 	// heartbeatInterval is how often a running command reports that it is still
 	// alive. It drives the "45s, no output" line in the UI, which is the whole
 	// point of streaming — a stall you can see is not a hang.
@@ -129,6 +138,12 @@ type bashProc struct {
 
 	started time.Time
 	lastOut atomic.Int64 // UnixNano of the most recent byte of output
+
+	// The resolved limits this command runs under, kept so a handoff or a later
+	// poll can report them. They are set once before the process starts and
+	// never written again, so no synchronization is needed.
+	timeout     time.Duration
+	idleTimeout time.Duration
 
 	done     chan struct{} // closed once the process has been reaped
 	exitCode int
@@ -230,15 +245,17 @@ func (s *BashSupervisor) start(ctx context.Context, req runRequest) (*bashProc, 
 	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
 	p := &bashProc{
-		sup:     s,
-		id:      s.nextID(),
-		command: req.command,
-		dir:     req.dir,
-		cancel:  cancel,
-		stdout:  newStream(streamCap),
-		stderr:  newStream(streamCap),
-		started: time.Now(),
-		done:    make(chan struct{}),
+		sup:         s,
+		id:          s.nextID(),
+		command:     req.command,
+		dir:         req.dir,
+		cancel:      cancel,
+		stdout:      newStream(streamCap),
+		stderr:      newStream(streamCap),
+		started:     time.Now(),
+		timeout:     req.timeout,
+		idleTimeout: req.idleTimeout,
+		done:        make(chan struct{}),
 	}
 
 	cmd := exec.CommandContext(runCtx, "bash", "-c", req.command)
@@ -368,6 +385,7 @@ func (s *BashSupervisor) background(p *bashProc, reason string) BashOutput {
 	if strings.TrimSpace(stdout) == "" && strings.TrimSpace(stderr) == "" {
 		note += " It has produced no output at all — if that is unexpected, the command is probably too broad (a filesystem-wide scan, or a prompt waiting for input) and should be killed and narrowed."
 	}
+	note += " " + limitsHint(p.timeout, p.idleTimeout)
 
 	outStr, errStr := budgetStreams(stdout, stderr)
 	if d := droppedNote(p.stdout.droppedBytes() + p.stderr.droppedBytes()); d != "" {
@@ -375,13 +393,37 @@ func (s *BashSupervisor) background(p *bashProc, reason string) BashOutput {
 	}
 
 	return BashOutput{
-		Stdout:   outStr,
-		Stderr:   errStr,
-		ExitCode: -1,
-		Running:  true,
-		Handle:   p.id,
-		Note:     note,
+		Stdout:      outStr,
+		Stderr:      errStr,
+		ExitCode:    -1,
+		Running:     true,
+		Handle:      p.id,
+		Elapsed:     roundDur(time.Since(p.started)).String(),
+		Idle:        roundDur(p.idleFor()).String(),
+		Timeout:     p.timeout.String(),
+		IdleTimeout: p.idleTimeout.String(),
+		Note:        note,
 	}
+}
+
+// limitsHint states the limits a command ran under and what to do about them.
+//
+// It exists because the handoff is otherwise a dead end for the caller: the
+// note says the command went quiet, but not that the threshold it crossed was
+// one the caller chose. A one-second idle_timeout backgrounds every build,
+// lint, and test run in this repo on its first quiet moment, and the only
+// visible consequence is a handle the model then polls dozens of times. Naming
+// the limit turns that into a one-line fix.
+func limitsHint(timeout, idle time.Duration) string {
+	hint := fmt.Sprintf("Limits for this command: timeout %s, idle_timeout %s.",
+		roundDur(timeout), roundDur(idle))
+	if idle < shortIdleTimeout {
+		hint += fmt.Sprintf(" An idle_timeout under %s backgrounds ordinary builds and"+
+			" test runs the moment they go quiet — pass a larger idle_timeout"+
+			" (or omit it for the %s default) rather than polling the handle.",
+			roundDur(shortIdleTimeout), roundDur(defaultIdleTimeout))
+	}
+	return hint
 }
 
 // budgetStreams applies the standard cleanup to both streams.
@@ -555,12 +597,14 @@ func (s *BashSupervisor) readOutput(handle string, wait time.Duration) (BashStat
 
 	budgetedOut, budgetedErr := budgetStreams(outStr, errStr)
 	st := BashStatus{
-		Handle:  handle,
-		Command: p.command,
-		Running: p.running(),
-		Stdout:  budgetedOut,
-		Stderr:  budgetedErr,
-		Elapsed: roundDur(time.Since(p.started)).String(),
+		Handle:      handle,
+		Command:     p.command,
+		Running:     p.running(),
+		Stdout:      budgetedOut,
+		Stderr:      budgetedErr,
+		Elapsed:     roundDur(time.Since(p.started)).String(),
+		Timeout:     p.timeout.String(),
+		IdleTimeout: p.idleTimeout.String(),
 	}
 	// Here the drop is measured against this reader's own cursor, not the whole
 	// stream: it counts output this caller had not yet collected when the buffer

--- a/internal/tui/bash_window_test.go
+++ b/internal/tui/bash_window_test.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A backgrounded command has no exit status, and the -1 the bash tool reports
+// in its place is a placeholder, not a failure. Rendering it through the
+// exit-code path printed "exit -1: golangci-lint run ./..." for a lint run that
+// was alive and would go on to pass — the card accused the command of crashing
+// and named make's echoed recipe line as the evidence.
+func TestFormatToolResult_BackgroundedCommandIsNotAFailure(t *testing.T) {
+	data := map[string]any{
+		"exit_code":    float64(-1),
+		"running":      true,
+		"handle":       "bg_16",
+		"stdout":       "golangci-lint run ./...\n",
+		"elapsed":      "5s",
+		"idle":         "5s",
+		"timeout":      "2m0s",
+		"idle_timeout": "1s",
+		"note":         "Command no output for 5s and was moved to the background",
+	}
+
+	got := formatToolResult(data)
+
+	if strings.Contains(got, "exit -1") {
+		t.Errorf("a running command must not be reported as an exit status, got %q", got)
+	}
+	for _, want := range []string{"running", "bg_16", "5s elapsed", "golangci-lint run ./..."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %q", want, got)
+		}
+	}
+}
+
+// The limits belong on the card because they are the actionable half of the
+// story: "backgrounded" says the command went quiet, "idle_timeout 1s" says the
+// threshold it crossed was one the caller chose.
+func TestFormatToolResult_RunningCommandShowsItsLimits(t *testing.T) {
+	data := map[string]any{
+		"running":      true,
+		"handle":       "bg_16",
+		"stdout":       "",
+		"timeout":      "2m0s",
+		"idle_timeout": "1s",
+	}
+
+	got := formatToolResult(data)
+
+	if !strings.Contains(got, "idle_timeout 1s") {
+		t.Errorf("expected the idle limit in %q", got)
+	}
+	if !strings.Contains(got, "timeout 2m0s") {
+		t.Errorf("expected the hard limit in %q", got)
+	}
+}
+
+// A poll of a live command carries no exit_code at all — BashStatus omits it
+// while running — so it used to miss the bash branch entirely and land in the
+// raw-JSON fallback, which printed &-escaped argument soup and truncated it
+// mid-token. Fifty-five of those in a row said nothing about the command.
+func TestFormatToolResult_PollOfRunningCommandIsReadable(t *testing.T) {
+	data := map[string]any{
+		"handle":       "bg_16",
+		"command":      "make lint && make vet",
+		"running":      true,
+		"stdout":       "",
+		"stderr":       "",
+		"elapsed":      "1m30s",
+		"idle":         "1m25s",
+		"timeout":      "2m0s",
+		"idle_timeout": "1s",
+	}
+
+	got := formatToolResult(data)
+
+	if strings.Contains(got, `&`) || strings.HasPrefix(got, "{") {
+		t.Errorf("poll rendered as raw JSON: %q", got)
+	}
+	if !strings.Contains(got, "no new output") {
+		t.Errorf("a silent poll must say so, got %q", got)
+	}
+	if !strings.Contains(got, "1m30s elapsed") {
+		t.Errorf("expected elapsed time in %q", got)
+	}
+}
+
+func TestFormatToolResult_FinishedBackgroundCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		want string
+	}{
+		{
+			name: "clean exit",
+			data: map[string]any{
+				"handle": "bg_3", "running": false,
+				"stdout": "0 issues.", "elapsed": "12s",
+			},
+			want: "exit 0 (bg_3), 12s elapsed",
+		},
+		{
+			name: "failure",
+			data: map[string]any{
+				"handle": "bg_3", "running": false,
+				"exit_code": float64(2), "stdout": "boom",
+			},
+			want: "exit 2 (bg_3)",
+		},
+		{
+			// -1 on a stopped command means killed, or killed and not reaped
+			// before the wait delay expired. There is no status to report, and
+			// "exit -1" invites a hunt for a code that never existed.
+			name: "killed without a status",
+			data: map[string]any{
+				"handle": "bg_3", "running": false,
+				"exit_code": float64(-1), "stdout": "",
+			},
+			want: "killed, no exit status (bg_3)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatToolResult(tt.data)
+			if !strings.HasPrefix(got, tt.want) {
+				t.Errorf("formatToolResult() = %q, want prefix %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A finished command reports its status, not the limits it never hit.
+func TestFormatToolResult_FinishedCommandOmitsLimits(t *testing.T) {
+	data := map[string]any{
+		"handle": "bg_3", "running": false,
+		"stdout": "done", "timeout": "2m0s", "idle_timeout": "90s",
+	}
+
+	if got := formatToolResult(data); strings.Contains(got, "limits:") {
+		t.Errorf("finished command should not carry a limits hint, got %q", got)
+	}
+}
+
+// The foreground path is untouched: no handle, no window.
+func TestFormatToolResult_ForegroundBashUnchanged(t *testing.T) {
+	data := map[string]any{"exit_code": float64(1), "stdout": "build failed"}
+
+	got := formatToolResult(data)
+
+	if got != "exit 1: build failed" {
+		t.Errorf("formatToolResult() = %q, want %q", got, "exit 1: build failed")
+	}
+}
+
+func TestBashOutputPreview(t *testing.T) {
+	tests := []struct {
+		name           string
+		stdout, stderr string
+		want           string
+	}{
+		{name: "empty", want: ""},
+		{name: "falls back to stderr", stderr: "boom", want: "boom"},
+		{name: "prefers stdout", stdout: "out", stderr: "err", want: "out"},
+		{name: "short output is whole", stdout: "a\nb\nc\n", want: "a\nb\nc"},
+		{name: "long output is head and tail", stdout: "1\n2\n3\n4\n5\n6", want: "1\n2\n5\n6"},
+		{
+			name:   "long lines are clipped",
+			stdout: strings.Repeat("x", 100),
+			want:   strings.Repeat("x", 77) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bashOutputPreview(tt.stdout, tt.stderr); got != tt.want {
+				t.Errorf("bashOutputPreview() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -678,38 +678,27 @@ func formatToolResult(data map[string]any) string {
 	if diag, ok := data["lsp_diagnostics"].(string); ok && diag != "" {
 		return diag
 	}
+	// A backgrounded command, either at the moment of handoff (the bash tool) or
+	// on any later poll of it (bash_output, bash_kill). Both carry a handle, and
+	// both have to be taken before the exit-code branch below.
+	//
+	// While such a command is still running it has no exit status: the bash tool
+	// reports the -1 placeholder, which the exit-code branch renders as
+	// "exit -1: <first line of output>" — a live lint run reading as a crashed
+	// one. A poll is worse: BashStatus omits exit_code entirely while running, so
+	// it missed the branch altogether and fell through to the raw-JSON fallback,
+	// printing &-escaped argument soup instead of the command's output.
+	if handle, ok := data["handle"].(string); ok && handle != "" {
+		return formatBashWindow(handle, data)
+	}
 	// bash tool: show exit code + first 2 and last 2 output lines (preserve newlines for better visibility)
 	if code, ok := data["exit_code"].(float64); ok {
 		stdout, _ := data["stdout"].(string)
 		stderr, _ := data["stderr"].(string)
-
-		// For bash streaming display, show first 2 and last 2 lines of stdout (or stderr if stdout is empty).
-		var preview string
-		output := stdout
-		if output == "" {
-			output = stderr
+		result := bashOutputPreview(stdout, stderr)
+		if result == "" {
+			result = "(No output)"
 		}
-		if output != "" {
-			lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-			if len(lines) > 4 {
-				preview = strings.Join([]string{lines[0], lines[1], lines[len(lines)-2], lines[len(lines)-1]}, "\n")
-			} else {
-				preview = strings.Join(lines, "\n")
-			}
-		} else {
-			preview = "(No output)"
-		}
-
-		// Truncate each line to 80 chars for display
-		var truncated []string
-		for _, line := range strings.Split(preview, "\n") {
-			if len(line) > 80 {
-				line = line[:77] + "..."
-			}
-			truncated = append(truncated, line)
-		}
-		result := strings.Join(truncated, "\n")
-
 		if int(code) != 0 {
 			return fmt.Sprintf("exit %d: %s", int(code), result)
 		}
@@ -722,6 +711,103 @@ func formatToolResult(data map[string]any) string {
 		return s[:117] + "..."
 	}
 	return s
+}
+
+// formatBashWindow renders the card for a backgrounded command: what state it
+// is in, what it has printed, and — while it is still running — the limits it
+// was started under.
+//
+// The state line is the point of the card and is never omitted. A poll that
+// returns no new output is otherwise a blank card, indistinguishable from a
+// finished one, which is how fifty-five consecutive polls of the same handle
+// scrolled past without saying anything at all.
+func formatBashWindow(handle string, data map[string]any) string {
+	running, _ := data["running"].(bool)
+	stdout, _ := data["stdout"].(string)
+	stderr, _ := data["stderr"].(string)
+	code, hasCode := data["exit_code"].(float64)
+	timing := bashTiming(data)
+
+	var lines []string
+	switch {
+	case running:
+		lines = append(lines, fmt.Sprintf("running (%s)%s", handle, timing))
+	case hasCode && int(code) == -1:
+		// Killed, or killed and not reaped before the wait delay expired. Either
+		// way there is no status to report, and printing "exit -1" invites the
+		// reader to look for a exit code that never existed.
+		lines = append(lines, fmt.Sprintf("killed, no exit status (%s)%s", handle, timing))
+	default:
+		lines = append(lines, fmt.Sprintf("exit %d (%s)%s", int(code), handle, timing))
+	}
+
+	if preview := bashOutputPreview(stdout, stderr); preview != "" {
+		lines = append(lines, preview)
+	} else if running {
+		lines = append(lines, "(no new output)")
+	}
+	if running {
+		if hint := bashLimitsHint(data); hint != "" {
+			lines = append(lines, hint)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// bashTiming renders however much of the elapsed/idle pair the result carries.
+func bashTiming(data map[string]any) string {
+	elapsed, _ := data["elapsed"].(string)
+	idle, _ := data["idle"].(string)
+	switch {
+	case elapsed != "" && idle != "":
+		return fmt.Sprintf(", %s elapsed, %s idle", elapsed, idle)
+	case elapsed != "":
+		return ", " + elapsed + " elapsed"
+	case idle != "":
+		return ", " + idle + " idle"
+	}
+	return ""
+}
+
+// bashLimitsHint names the limits a running command was started under.
+//
+// Without it the card says a command went to the background but not that the
+// threshold it crossed was one the caller picked — which is the difference
+// between "this build is slow" and "idle_timeout was set to one second".
+func bashLimitsHint(data map[string]any) string {
+	timeout, _ := data["timeout"].(string)
+	idle, _ := data["idle_timeout"].(string)
+	switch {
+	case timeout != "" && idle != "":
+		return fmt.Sprintf("limits: idle_timeout %s, timeout %s", idle, timeout)
+	case timeout != "":
+		return "limits: timeout " + timeout
+	case idle != "":
+		return "limits: idle_timeout " + idle
+	}
+	return ""
+}
+
+// bashOutputPreview condenses command output to its first and last two lines,
+// each clipped to 80 columns. Returns "" when there was no output at all, which
+// callers report in their own words.
+func bashOutputPreview(stdout, stderr string) string {
+	output := stdout
+	if output == "" {
+		output = stderr
+	}
+	if output == "" {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) > 4 {
+		lines = []string{lines[0], lines[1], lines[len(lines)-2], lines[len(lines)-1]}
+	}
+	clipped := make([]string, len(lines))
+	for i, line := range lines {
+		clipped[i] = truncateRunes(line, 80)
+	}
+	return strings.Join(clipped, "\n")
 }
 
 // highlightReadOutput applies syntax highlighting to read tool output lines.


### PR DESCRIPTION
A command handed off to the background has no exit status. The bash tool
reports -1 as a placeholder, and the TUI rendered any non-zero code as a
failure — so a lint run that was alive and would go on to pass appeared as
"exit -1: golangci-lint run ./...", with make's echoed recipe line offered
as the evidence.

A later poll of the same handle was worse. BashStatus omits exit_code while
the command runs, so the poll missed the bash branch entirely and fell
through to the raw-JSON fallback, printing &-escaped argument soup clipped
at 117 characters. Fifty-five consecutive polls of one handle said nothing
about the command at all.

Both now render a window: state, output, and — while running — the limits
the command was started under. The limits are the actionable half. A
handoff otherwise says the command went quiet without saying that the
threshold it crossed was one the caller chose; an idle_timeout of one
second backgrounds every build in this repo on its first quiet moment, and
naming it turns a polling loop into a one-line fix.

The supervisor now keeps each command's resolved limits and reports them on
handoff and on every poll, and calls out an idle_timeout below 15s in the
note. Nothing is overridden — a caller that wants a hair trigger keeps it.

Claude-Session: https://claude.ai/code/session_01GVZZ1EeTv9FoZ1enFBMzGo
Signed-off-by: dimetron <dimetron@me.com>
