### PR TITLE
fix(tui): bind a tool result to its own call, not the nearest one

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -370,10 +370,16 @@ type agentMsg interface{ agentMsg() }
 type agentTextMsg struct{ text string }
 type agentThinkingMsg struct{ text string }
 type agentToolCallMsg struct {
+	// id is the provider's function-call ID, the only thing that pairs a
+	// result with its own call when a turn issues several calls to the same
+	// tool at once. Empty when a provider omits it, or for the synthetic
+	// grounding pair.
+	id   string
 	name string
 	args map[string]any
 }
 type agentToolResultMsg struct {
+	id      string // matches the agentToolCallMsg.id this answers
 	name    string
 	content string
 }
@@ -752,7 +758,7 @@ func (m *model) emitEventParts(
 			// fires after `maxRepeatToolCalls` observations, so the abort
 			// semantics are unchanged — only the message ordering moves.
 			log.ToolCall(ev.Author, fc.Name, fc.Args)
-			ch <- agentToolCallMsg{name: fc.Name, args: fc.Args}
+			ch <- agentToolCallMsg{id: fc.ID, name: fc.Name, args: fc.Args}
 
 			if err := stuckErr(detector.observe(fc.Name, fc.Args)); err != nil {
 				return err
@@ -762,7 +768,7 @@ func (m *model) emitEventParts(
 		if fr := part.FunctionResponse; fr != nil {
 			respJSON, _ := json.Marshal(fr.Response)
 			log.ToolResult(ev.Author, fr.Name, string(respJSON))
-			ch <- agentToolResultMsg{name: fr.Name, content: string(respJSON)}
+			ch <- agentToolResultMsg{id: fr.ID, name: fr.Name, content: string(respJSON)}
 
 			// A changed result on a repeated call is progress, not a loop
 			// (a poll returning fresh output) — let it reset the
@@ -870,7 +876,7 @@ func (m *model) handleAgentToolCall(msg agentToolCallMsg) (tea.Model, tea.Cmd) {
 	})
 	toolIn := toolCallSummary(msg.name, msg.args)
 	newMsg := message{
-		role: "tool", tool: msg.name, toolIn: toolIn,
+		role: "tool", tool: msg.name, toolIn: toolIn, toolID: msg.id,
 	}
 	if msg.name == "agent" || msg.name == "subagent" {
 		// A single subagent tool call in parallel/chain mode spawns N children.
@@ -1011,14 +1017,61 @@ func (m *model) handleAgentToolResult(msg agentToolResultMsg) (tea.Model, tea.Cm
 	if msg.name != groundingToolName {
 		content = toolResultSummary(msg.content)
 	}
-	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
-		if m.chatModel.Messages[i].role == "tool" && m.chatModel.Messages[i].tool == msg.name && m.chatModel.Messages[i].content == "" {
-			m.chatModel.Messages[i].content = content
-			break
-		}
+	if i := matchToolResultCard(m.chatModel.Messages, msg.id, msg.name); i >= 0 {
+		m.chatModel.Messages[i].content = content
 	}
 	m.refreshDiffStats()
 	return m, waitForAgent(m.agentCh)
+}
+
+// matchToolResultCard finds the chat card an arriving tool result belongs to,
+// or -1 when none is waiting for it.
+//
+// The call ID is what makes this correct. A model turn routinely emits several
+// FunctionCall parts for the same tool in one response — two `read`s, three
+// `bash`es, six `edit`s are all ordinary — and ADK runs them concurrently and
+// answers with one merged event carrying every response. Picking "the newest
+// same-named card with no content yet" therefore handed the first result to the
+// last card and the last result to the first, so the user read each call's
+// output under the other call's arguments.
+//
+// Name matching survives as a fallback for cards that carry no ID: the
+// synthetic grounding pair, restored transcripts written before IDs were kept,
+// and any provider that leaves FunctionCall.ID empty. Unidentified cards are
+// preferred there so an ID-less result cannot steal a card that belongs to an
+// identified call, but an identified card is still accepted as a last resort
+// rather than leaving the result unrendered.
+func matchToolResultCard(messages []message, id, name string) int {
+	if id != "" {
+		claimed := false
+		for i := len(messages) - 1; i >= 0; i-- {
+			if messages[i].role != "tool" || messages[i].toolID != id {
+				continue
+			}
+			if messages[i].content == "" {
+				return i
+			}
+			// The card for this call already has its result: a duplicate
+			// re-send, which must not spill onto a different call's card.
+			claimed = true
+		}
+		if claimed {
+			return -1
+		}
+	}
+	fallback := -1
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].role != "tool" || messages[i].tool != name || messages[i].content != "" {
+			continue
+		}
+		if messages[i].toolID == "" {
+			return i
+		}
+		if fallback == -1 {
+			fallback = i
+		}
+	}
+	return fallback
 }
 
 // bashEventPrefix namespaces live shell-command events on the same channel the

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -107,6 +107,13 @@ type message struct {
 	preRendered bool
 	tool        string // tool name (for role=="tool")
 	toolIn      string // tool input args (for role=="tool")
+	// toolID is the provider's function-call ID, carried so an arriving result
+	// binds to the card for its own call. A turn routinely issues several calls
+	// to the same tool at once (two `read`s, six `edit`s), and matching by name
+	// alone hands each result to whichever same-named card is still empty —
+	// which is the wrong one. Empty for synthetic cards (grounding) and for any
+	// provider that does not populate FunctionCall.ID; see matchToolResultCard.
+	toolID string
 	// Subagent event stream (for tool=="agent" or tool=="subagent").
 	agentID       string    // subagent ID for matching events
 	agentType     string    // subagent type (e.g. "task", "explore")

--- a/internal/tui/session_restore.go
+++ b/internal/tui/session_restore.go
@@ -36,11 +36,12 @@ func restoreTranscript(events []*session.Event) []message {
 					role:   "tool",
 					tool:   fc.Name,
 					toolIn: toolCallSummary(fc.Name, fc.Args),
+					toolID: fc.ID,
 				})
 			case part.FunctionResponse != nil:
 				fr := part.FunctionResponse
 				respJSON, _ := json.Marshal(fr.Response)
-				attachToolResult(msgs, fr.Name, toolResultSummary(string(respJSON)))
+				attachToolResult(msgs, fr.ID, fr.Name, toolResultSummary(string(respJSON)))
 			case part.Text != "":
 				msgs = appendText(msgs, ev.Content.Role, part.Text)
 			}
@@ -64,16 +65,14 @@ func appendText(msgs []message, role, text string) []message {
 	return append(msgs, message{role: "assistant", content: text})
 }
 
-// attachToolResult fills in the output of the most recent still-unanswered call
-// to the named tool, mirroring handleAgentToolResult. Results arrive in their
-// own events, and parallel calls mean the matching call is not always the last
-// message.
-func attachToolResult(msgs []message, name, content string) {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].role == "tool" && msgs[i].tool == name && msgs[i].content == "" {
-			msgs[i].content = content
-			return
-		}
+// attachToolResult fills in the output of the call this response answers,
+// mirroring handleAgentToolResult — a replayed transcript must pair calls with
+// results the same way the live one did, or a resumed session shows parallel
+// same-tool calls holding each other's output. See matchToolResultCard for why
+// the call ID and not the tool name is what pairs them.
+func attachToolResult(msgs []message, id, name, content string) {
+	if i := matchToolResultCard(msgs, id, name); i >= 0 {
+		msgs[i].content = content
 	}
 }
 

--- a/internal/tui/session_restore_test.go
+++ b/internal/tui/session_restore_test.go
@@ -73,8 +73,10 @@ func TestRestoreTranscript_ToolCallPairsWithResult(t *testing.T) {
 	}
 }
 
-// A result must fill in its own call, not the nearest one, or parallel calls to
-// the same tool would show each other's output.
+// Two calls with no IDs — the pre-ID persisted shape. All this can pin is that
+// each call gets some answer and the two answers are distinct; nothing in the
+// events says which result belongs to which call. Pairing them correctly needs
+// the call ID, which TestRestoreTranscript_ParallelSameToolNotTransposed covers.
 func TestRestoreTranscript_ResultFillsOldestOpenCall(t *testing.T) {
 	msgs := restoreTranscript([]*session.Event{
 		event("model", callPart("grep", nil)),

--- a/internal/tui/tool_result_match_test.go
+++ b/internal/tui/tool_result_match_test.go
@@ -1,0 +1,212 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// newResultMatchModel builds a model wired for driving handleAgentToolCall and
+// handleAgentToolResult back to back.
+func newResultMatchModel(t *testing.T) *model {
+	t.Helper()
+	m := newHandlerModel()
+	m.cfg.WorkDir = t.TempDir()
+	m.statusModel.ActiveTools = map[string]time.Time{}
+	return m
+}
+
+// TestToolResultMatching_ParallelSameToolNotTransposed pins the defect this
+// file exists for: a model turn that calls the same tool twice (two `read`
+// parts in one LLM response, which ADK runs concurrently and answers with one
+// merged event carrying both responses in call order) must not have its two
+// results swapped between the two cards.
+//
+// Before ID matching, the backscan for "newest tool card with this name and no
+// content yet" handed result #1 to card #2 and result #2 to card #1.
+func TestToolResultMatching_ParallelSameToolNotTransposed(t *testing.T) {
+	m := newResultMatchModel(t)
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_1", name: "read", args: map[string]any{"file_path": "a.go"},
+	})
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_2", name: "read", args: map[string]any{"file_path": "b.go"},
+	})
+
+	m.handleAgentToolResult(agentToolResultMsg{id: "call_1", name: "read", content: "contents of a"})
+	m.handleAgentToolResult(agentToolResultMsg{id: "call_2", name: "read", content: "contents of b"})
+
+	if got := len(m.chatModel.Messages); got != 2 {
+		t.Fatalf("expected 2 tool cards, got %d", got)
+	}
+	if got := m.chatModel.Messages[0].content; got != "contents of a" {
+		t.Errorf("card for call_1 (a.go) got result %q, want %q", got, "contents of a")
+	}
+	if got := m.chatModel.Messages[1].content; got != "contents of b" {
+		t.Errorf("card for call_2 (b.go) got result %q, want %q", got, "contents of b")
+	}
+}
+
+// TestToolResultMatching_OutOfOrderResults covers the same-name case when the
+// merged response event lists the slower call's result first. Nothing in ADK
+// guarantees response order tracks call order across every provider, so the
+// match must not depend on it.
+func TestToolResultMatching_OutOfOrderResults(t *testing.T) {
+	m := newResultMatchModel(t)
+
+	m.handleAgentToolCall(agentToolCallMsg{id: "call_1", name: "bash", args: map[string]any{"command": "make build"}})
+	m.handleAgentToolCall(agentToolCallMsg{id: "call_2", name: "bash", args: map[string]any{"command": "make lint"}})
+
+	m.handleAgentToolResult(agentToolResultMsg{id: "call_2", name: "bash", content: "lint clean"})
+	m.handleAgentToolResult(agentToolResultMsg{id: "call_1", name: "bash", content: "build ok"})
+
+	if got := m.chatModel.Messages[0].content; got != "build ok" {
+		t.Errorf("card for call_1 got %q, want %q", got, "build ok")
+	}
+	if got := m.chatModel.Messages[1].content; got != "lint clean" {
+		t.Errorf("card for call_2 got %q, want %q", got, "lint clean")
+	}
+}
+
+func TestMatchToolResultCard(t *testing.T) {
+	tests := []struct {
+		name string
+		msgs []message
+		id   string
+		tool string
+		want int
+	}{
+		{
+			name: "id match wins over newest empty same-name card",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "a"},
+				{role: "tool", tool: "read", toolID: "b"},
+			},
+			id: "a", tool: "read", want: 0,
+		},
+		{
+			name: "duplicate result for an already-filled card is dropped",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "a", content: "done"},
+				{role: "tool", tool: "read", toolID: "b"},
+			},
+			id: "a", tool: "read", want: -1,
+		},
+		{
+			name: "unknown id falls back to newest unidentified same-name card",
+			msgs: []message{
+				{role: "tool", tool: "read"},
+				{role: "tool", tool: "read", toolID: "b"},
+			},
+			id: "zz", tool: "read", want: 0,
+		},
+		{
+			name: "no id falls back to newest empty same-name card",
+			msgs: []message{
+				{role: "tool", tool: "grounding", content: "old"},
+				{role: "tool", tool: "grounding"},
+			},
+			tool: "grounding", want: 1,
+		},
+		{
+			name: "id-less result still binds an identified card as a last resort",
+			msgs: []message{{role: "tool", tool: "read", toolID: "a"}},
+			tool: "read", want: 0,
+		},
+		{
+			name: "name mismatch matches nothing",
+			msgs: []message{{role: "tool", tool: "read"}},
+			tool: "bash", want: -1,
+		},
+		{
+			name: "non-tool roles are never matched",
+			msgs: []message{{role: "assistant"}},
+			tool: "read", want: -1,
+		},
+		{
+			name: "all same-id cards filled and none share the name",
+			msgs: nil,
+			id:   "a", tool: "read", want: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchToolResultCard(tt.msgs, tt.id, tt.tool); got != tt.want {
+				t.Errorf("matchToolResultCard() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestToolResultMatching_SubagentSplitCards guards the one call -> N cards
+// path: splitSubagentCards stamps every card with the same call ID, and the
+// single result must land on the newest of them, exactly as name matching did.
+func TestToolResultMatching_SubagentSplitCards(t *testing.T) {
+	m := newResultMatchModel(t)
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id:   "call_1",
+		name: "agent",
+		args: map[string]any{"tasks": []any{
+			map[string]any{"agent": "pi", "task": "one"},
+			map[string]any{"agent": "claude", "task": "two"},
+		}},
+	})
+	if got := len(m.chatModel.Messages); got != 2 {
+		t.Fatalf("expected 2 subagent cards, got %d", got)
+	}
+	for i, msg := range m.chatModel.Messages {
+		if msg.toolID != "call_1" {
+			t.Errorf("card %d toolID = %q, want %q", i, msg.toolID, "call_1")
+		}
+	}
+
+	m.handleAgentToolResult(agentToolResultMsg{id: "call_1", name: "agent", content: "both done"})
+
+	if m.chatModel.Messages[1].content == "" {
+		t.Error("expected the newest subagent card to receive the result")
+	}
+}
+
+// parallelReadEvents mirrors what a real session records for two concurrent
+// `read` calls: one model event carrying both calls, then one merged user event
+// carrying both responses, every part tagged with the call ID that pairs them.
+// Taken from the shape in ~/.pi-go/sessions/*/events.jsonl.
+func parallelReadEvents() []*session.Event {
+	call := func(id, path string) *genai.Part {
+		return &genai.Part{FunctionCall: &genai.FunctionCall{
+			ID: id, Name: "read", Args: map[string]any{"file_path": path},
+		}}
+	}
+	result := func(id, out string) *genai.Part {
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{
+			ID: id, Name: "read", Response: map[string]any{"content": out},
+		}}
+	}
+	return []*session.Event{
+		event("model", call("call_1", "a.go"), call("call_2", "b.go")),
+		event("user", result("call_1", "alpha"), result("call_2", "beta")),
+	}
+}
+
+// TestRestoreTranscript_ParallelSameToolNotTransposed covers the persisted
+// path: replaying a session that used parallel same-name calls must rebuild the
+// transcript with each result under its own call.
+func TestRestoreTranscript_ParallelSameToolNotTransposed(t *testing.T) {
+	events := parallelReadEvents()
+
+	msgs := restoreTranscript(events)
+
+	if got := len(msgs); got != 2 {
+		t.Fatalf("expected 2 restored tool cards, got %d", got)
+	}
+	if got := msgs[0].content; got != "alpha" {
+		t.Errorf("restored card for a.go got %q, want %q", got, "alpha")
+	}
+	if got := msgs[1].content; got != "beta" {
+		t.Errorf("restored card for b.go got %q, want %q", got, "beta")
+	}
+}


### PR DESCRIPTION
A model turn routinely emits several FunctionCall parts for the same tool in
one response — two reads, three bashes, six edits are all ordinary — and ADK
runs them concurrently and answers with one merged event carrying every
response. Both cards are therefore appended before either result arrives.
The chat attached each result by scanning backwards for the newest
same-named card with no content yet, which handed result #1 to card #2 and
result #2 to card #1. The user read each call's output under the other
call's arguments, with nothing to signal the swap.

The same backscan sat on the replay path in session_restore.go, so resuming
a session rebuilt its transcript transposed in the same way.

The provider's function-call ID is what pairs them, so carry it: onto
agentToolCallMsg and agentToolResultMsg from the event parts, onto the chat
card, into the restored transcript, and into matchToolResultCard, which both
paths now share.

Name matching survives as a fallback for cards with no ID — the synthetic
grounding pair, transcripts persisted before IDs were kept, and any provider
that leaves FunctionCall.ID empty. There it prefers an unidentified card so
an ID-less result cannot steal one belonging to an identified call, and a
result whose own card is already filled is dropped rather than spilled onto
a different call's card.

The subagent path is unchanged in effect: splitSubagentCards fans one call
into N cards that now share one ID, and the single result still binds to the
newest of them.

The comment on TestRestoreTranscript_ResultFillsOldestOpenCall claimed it
pinned this property; it could not, since its events carry no IDs, and it
passed for the whole life of the bug. It now says what it actually pins, and
the real constraint has its own test.

Signed-off-by: dimetron <dimetron@me.com>
