### PR TITLE
test(tui): stop a failed nil check from taking the test binary down

### DIFF
--- a/internal/tui/plan_run_e2e_test.go
+++ b/internal/tui/plan_run_e2e_test.go
@@ -415,7 +415,7 @@ func TestE2E_PlanDuplicateSpecName(t *testing.T) {
 	// Second creation should fail.
 	_, err = createSpecSkeleton(tmpDir, taskName, idea)
 	if err == nil {
-		t.Error("expected error for duplicate spec name")
+		t.Fatal("expected error for duplicate spec name")
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("error should mention 'already exists', got: %v", err)

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -120,7 +120,7 @@ func TestCreateSpecSkeleton_AlreadyExists(t *testing.T) {
 
 	_, err := createSpecSkeleton(tmpDir, "existing-feature", "Some idea")
 	if err == nil {
-		t.Error("expected error when spec directory already exists")
+		t.Fatal("expected error when spec directory already exists")
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("error should mention 'already exists', got: %v", err)
@@ -248,7 +248,7 @@ func TestPlanInstruction_ExistingSpecReturnsError(t *testing.T) {
 	// createSpecSkeleton should fail with "already exists".
 	_, err := createSpecSkeleton(tmpDir, "existing-feature", "Some idea")
 	if err == nil {
-		t.Error("expected error when spec directory already exists")
+		t.Fatal("expected error when spec directory already exists")
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("error should mention 'already exists', got: %v", err)

--- a/internal/tui/tui_mouse_branch_test.go
+++ b/internal/tui/tui_mouse_branch_test.go
@@ -379,7 +379,7 @@ func TestNewBranchPopup_WithBranches(t *testing.T) {
 	m.newBranchPopup()
 
 	if m.branchPopup == nil {
-		t.Error("branchPopup should be created")
+		t.Fatal("branchPopup should be created")
 	}
 	if len(m.branchPopup.branches) == 0 {
 		t.Error("branches should not be empty for a git repo")


### PR DESCRIPTION
Four assertions reported a nil value with t.Error and then dereferenced it
on the next line. t.Error does not stop the function, so the deref panics —
and a panic in a test kills the whole binary, so every test after it is
never run and never reported. A failure in one of these would have hidden an
arbitrary amount of the suite behind it, at exactly the moment the suite was
most worth reading.

t.Fatal stops at the assertion that actually failed and lets the rest run.

None of the four fires today: newBranchPopup finds branches because the repo
is a git repo, and the three duplicate-spec cases do return their error.
They are landmines rather than bugs, which is why they have sat there.

Signed-off-by: dimetron <dimetron@me.com>
