### PR TITLE
fix(provider): route Ollama by the model's tag, not by whether a key is set

### DIFF
--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -24,22 +24,49 @@ type ollamaModel struct {
 	thinkingLevel string // "none", "low", "medium", "high"
 }
 
+// Ollama's two default endpoints. Which one a model belongs to is decided by
+// its tag, never by whether a key happens to be exported.
+const (
+	ollamaLocalURL = "http://localhost:11434"
+	ollamaCloudURL = "https://api.ollama.com"
+)
+
+// resolveOllamaEndpoint picks the server a model should be sent to.
+//
+// Routing follows the model's cloud tag, which is the rule the CLI help and
+// every other routing check in the tree already state. It used to follow the
+// presence of an API key instead, and that made OLLAMA_API_KEY a global switch:
+// exporting it once for a :cloud model silently sent every *local* model to
+// api.ollama.com too, where a privately pulled name like muse-glimmer:30b-mlx
+// does not exist. The key is a credential, not a destination.
+//
+// An explicit baseURL (OLLAMA_HOST) always wins — that is how someone points at
+// another machine, a container, or an authenticated proxy.
+//
+// Who receives the key is deliberately not decided here. It still goes to
+// whatever endpoint is chosen whenever one is set, unchanged, because an
+// authenticated daemon may be reached over loopback as easily as over the
+// network and this function cannot tell the two apart.
+func resolveOllamaEndpoint(modelName, baseURL string) string {
+	if endpoint := normalizeBaseURL(baseURL); endpoint != "" {
+		return endpoint
+	}
+	if isOllamaCloudModel(modelName) {
+		return ollamaCloudURL
+	}
+	return ollamaLocalURL
+}
+
 // NewOllama creates an Ollama model.LLM using the native Ollama Go client.
-// baseURL defaults to http://localhost:11434 if empty, or https://api.ollama.com
-// if an apiKey is provided (ollama.com cloud).
+// The server is chosen by resolveOllamaEndpoint: an explicit baseURL if given,
+// otherwise api.ollama.com for a :cloud/-cloud tagged model and localhost for
+// everything else.
 // thinkingLevel controls extended thinking: "none", "low", "medium", "high".
 func NewOllama(_ context.Context, modelName, apiKey, baseURL, thinkingLevel string, opts *LLMOptions) (model.LLM, error) {
 	if modelName == "" {
 		return nil, fmt.Errorf("model name is required")
 	}
-	baseURL = normalizeBaseURL(baseURL)
-	if baseURL == "" {
-		if apiKey != "" {
-			baseURL = "https://api.ollama.com"
-		} else {
-			baseURL = "http://localhost:11434"
-		}
-	}
+	baseURL = resolveOllamaEndpoint(modelName, baseURL)
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Ollama URL %q: %w", baseURL, err)
@@ -48,7 +75,7 @@ func NewOllama(_ context.Context, modelName, apiKey, baseURL, thinkingLevel stri
 	if err != nil {
 		return nil, err
 	}
-	// Inject Bearer token for ollama.com cloud API when an API key is provided.
+	// Inject Bearer token for the ollama.com cloud API when an API key is provided.
 	if apiKey != "" {
 		baseTransport := httpClient.Transport
 		if baseTransport == nil {

--- a/internal/provider/ollama_endpoint_test.go
+++ b/internal/provider/ollama_endpoint_test.go
@@ -1,0 +1,124 @@
+package provider
+
+import "testing"
+
+// The case this file exists for: a locally pulled model, an OLLAMA_API_KEY
+// exported for some cloud model, and a request that used to be posted to
+// api.ollama.com — where a private name like muse-glimmer:30b-mlx does not
+// exist, so the run failed with a model-not-found from a server the user never
+// meant to talk to.
+func TestResolveOllamaEndpoint(t *testing.T) {
+	const key = "sk-ollama-test"
+
+	tests := []struct {
+		name         string
+		model        string
+		apiKey       string // recorded to document the scenario; routing must not consult it
+		baseURL      string
+		wantEndpoint string
+	}{
+		{
+			name:         "local model with a key exported stays local",
+			model:        "muse-glimmer:30b-mlx",
+			apiKey:       key,
+			wantEndpoint: ollamaLocalURL,
+		},
+		{
+			name:         "local model without a key",
+			model:        "muse-glimmer:30b-mlx",
+			wantEndpoint: ollamaLocalURL,
+		},
+		{
+			name:         "cloud tag routes to the cloud",
+			model:        "minimax-m3:cloud",
+			apiKey:       key,
+			wantEndpoint: ollamaCloudURL,
+		},
+		{
+			// The form most of the cloud catalog actually uses.
+			name:         "sized cloud tag routes to the cloud",
+			model:        "deepseek-v4-flash:0731-cloud",
+			apiKey:       key,
+			wantEndpoint: ollamaCloudURL,
+		},
+		{
+			name:         "explicit host wins over the cloud tag",
+			model:        "minimax-m3:cloud",
+			apiKey:       key,
+			baseURL:      "http://gpu-box.lan:11434",
+			wantEndpoint: "http://gpu-box.lan:11434",
+		},
+		{
+			name:         "explicit remote host is honored",
+			model:        "muse-glimmer:30b-mlx",
+			apiKey:       key,
+			baseURL:      "https://ollama.internal.example.com",
+			wantEndpoint: "https://ollama.internal.example.com",
+		},
+		{
+			name:         "explicit localhost is honored",
+			model:        "muse-glimmer:30b-mlx",
+			apiKey:       key,
+			baseURL:      "http://localhost:11434",
+			wantEndpoint: "http://localhost:11434",
+		},
+		{
+			name:         "explicit loopback IP is honored",
+			model:        "muse-glimmer:30b-mlx",
+			apiKey:       key,
+			baseURL:      "http://127.0.0.1:11434",
+			wantEndpoint: "http://127.0.0.1:11434",
+		},
+		{
+			name:         "IPv6 loopback is honored",
+			model:        "muse-glimmer:30b-mlx",
+			apiKey:       key,
+			baseURL:      "http://[::1]:11434",
+			wantEndpoint: "http://[::1]:11434",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if endpoint := resolveOllamaEndpoint(tt.model, tt.baseURL); endpoint != tt.wantEndpoint {
+				t.Errorf("resolveOllamaEndpoint(%q, %q) = %q, want %q",
+					tt.model, tt.baseURL, endpoint, tt.wantEndpoint)
+			}
+		})
+	}
+}
+
+func TestIsOllamaCloudModel(t *testing.T) {
+	cloud := []string{"minimax-m3:cloud", "deepseek-v4-flash:0731-cloud", "gpt-oss:120b-cloud"}
+	local := []string{
+		"muse-glimmer:30b-mlx",
+		"llama3.3:70b",
+		"qwen3:latest",
+		// "cloud" has to be the tag, not merely present in the name.
+		"cloudy-llm:7b",
+		"nimbus-cloud-13b:q4",
+	}
+
+	for _, m := range cloud {
+		if !isOllamaCloudModel(m) {
+			t.Errorf("isOllamaCloudModel(%q) = false, want true", m)
+		}
+	}
+	for _, m := range local {
+		if isOllamaCloudModel(m) {
+			t.Errorf("isOllamaCloudModel(%q) = true, want false", m)
+		}
+	}
+}
+
+// NewOllama is the real entry point, so pin that it honors the routing rather
+// than only testing the helper underneath it.
+func TestNewOllamaAcceptsLocalTaggedModel(t *testing.T) {
+	llm, err := NewOllama(t.Context(), "muse-glimmer:30b-mlx", "sk-ollama-test", "", "none", nil)
+	if err != nil {
+		t.Fatalf("NewOllama: %v", err)
+	}
+	if got := llm.Name(); got != "muse-glimmer:30b-mlx" {
+		t.Errorf("Name() = %q, want the model name unchanged", got)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -172,6 +172,18 @@ var modelPrefixes = map[string]string{
 // ollama/ prefix, or the :cloud tag for Ollama cloud models.
 var OllamaModelPrefixes = []string{}
 
+// isOllamaCloudModel reports whether a model name is tagged for ollama.com's
+// hosted service. Ollama publishes both forms — a bare ":cloud" and the
+// ":<size>-cloud" that most of the catalog uses — so a check for one alone
+// silently misses the other.
+//
+// This is the single fact that decides local versus cloud, and it is the
+// model's name that decides it. Nothing about the caller's environment enters
+// into it.
+func isOllamaCloudModel(modelName string) bool {
+	return strings.HasSuffix(modelName, ":cloud") || strings.HasSuffix(modelName, "-cloud")
+}
+
 // KnownModels lists recognized model names per provider.
 // The check is prefix-based: a model is valid if it starts with any entry.
 // Ollama models are not validated here (they are dynamic).
@@ -334,7 +346,7 @@ func Resolve(modelName string) (Info, error) {
 
 	// Detect :cloud or -cloud suffix → native Ollama provider.
 	// Keep the full model name — :cloud and -cloud are valid Ollama model tags.
-	if strings.HasSuffix(modelName, ":cloud") || strings.HasSuffix(modelName, "-cloud") {
+	if isOllamaCloudModel(modelName) {
 		return Info{Provider: "ollama", Model: modelName, Ollama: true}, nil
 	}
 


### PR DESCRIPTION
NewOllama chose its endpoint from the presence of an API key: any key at all
meant https://api.ollama.com, no key meant localhost. That turned
OLLAMA_API_KEY into a global destination switch. Exporting it once for a
:cloud model silently sent every local model to the cloud as well, where a
privately pulled name — muse-glimmer:30b-mlx, say — does not exist, so the
run failed with a model-not-found from a server the user never meant to
address. There was no way to use a cloud model and a local one from the same
shell.

The cloud tag is what decides, which is the rule the CLI help and both other
routing checks already state. An explicit OLLAMA_HOST still wins over both.

The suffix test is now one function instead of the fourth open-coded copy of
`HasSuffix(":cloud") || HasSuffix("-cloud")`; a check for one form alone
misses the ":<size>-cloud" that most of the cloud catalog uses, which has
already happened once in this file's history.

Credential handling is deliberately unchanged. An earlier draft also withheld
the key from loopback, which read as tidier and broke TestBearerTransport:
an authenticated daemon can sit behind localhost as easily as behind a
hostname, and nothing here can tell those apart. Who gets the key is a
separate question from where the request goes.

Signed-off-by: dimetron <dimetron@me.com>
