### PR TITLE
refactor(tui): share one proportional bar and one context estimate

### DIFF
--- a/internal/tui/bar.go
+++ b/internal/tui/bar.go
@@ -1,0 +1,38 @@
+package tui
+
+import "strings"
+
+// Proportional bars are drawn in four places — the status bar's context gauge,
+// two sections of /context, and the startup progress line — and until this file
+// existed each one clamped its own fill and repeated its own glyphs. They had
+// already drifted: three clamped the fill against the width, one clamped the
+// percentage as well, and the block characters were spelled out four times.
+//
+// The split into fill-then-draw is what the call sites actually need. The
+// status gauge colors the filled and empty runs differently, so it wants the
+// count and builds its own two styled segments; everything else renders into
+// markdown, where ANSI inside a code span would be printed literally, so it
+// wants the plain string.
+
+const (
+	barFilled = "█"
+	barEmpty  = "░"
+)
+
+// barFill returns how many of width cells represent fraction, clamped so a bar
+// can never draw past its own width — the guard every call site used to carry.
+func barFill(fraction float64, width int) int {
+	if fraction <= 0 || width <= 0 {
+		return 0
+	}
+	return min(int(fraction*float64(width)), width)
+}
+
+// barGlyphs draws an unstyled proportional bar, filled cells first.
+func barGlyphs(filled, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	filled = min(max(filled, 0), width)
+	return strings.Repeat(barFilled, filled) + strings.Repeat(barEmpty, width-filled)
+}

--- a/internal/tui/bar_test.go
+++ b/internal/tui/bar_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The clamps are the whole reason this helper exists: four call sites each
+// carried their own, and a bar that overflows its width pushes every column to
+// its right out of place — which in the status bar means the rail moves.
+func TestBarFill(t *testing.T) {
+	tests := []struct {
+		name     string
+		fraction float64
+		width    int
+		want     int
+	}{
+		{name: "empty", fraction: 0, width: 20, want: 0},
+		{name: "half", fraction: 0.5, width: 20, want: 10},
+		{name: "full", fraction: 1, width: 20, want: 20},
+		{name: "truncates rather than rounds", fraction: 0.99, width: 10, want: 9},
+		{name: "over one is clamped to width", fraction: 2.5, width: 20, want: 20},
+		{name: "negative is clamped to zero", fraction: -1, width: 20, want: 0},
+		{name: "zero width has no cells", fraction: 0.5, width: 0, want: 0},
+		{name: "negative width has no cells", fraction: 0.5, width: -3, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := barFill(tt.fraction, tt.width); got != tt.want {
+				t.Errorf("barFill(%v, %d) = %d, want %d", tt.fraction, tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBarGlyphs(t *testing.T) {
+	tests := []struct {
+		name          string
+		filled, width int
+		want          string
+	}{
+		{name: "empty", filled: 0, width: 4, want: "░░░░"},
+		{name: "partial", filled: 2, width: 4, want: "██░░"},
+		{name: "full", filled: 4, width: 4, want: "████"},
+		{name: "overfull is clamped", filled: 9, width: 4, want: "████"},
+		{name: "negative is clamped", filled: -2, width: 4, want: "░░░░"},
+		{name: "zero width", filled: 3, width: 0, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := barGlyphs(tt.filled, tt.width)
+			if got != tt.want {
+				t.Errorf("barGlyphs(%d, %d) = %q, want %q", tt.filled, tt.width, got, tt.want)
+			}
+			// A bar is a fixed-width field. Whatever it is asked for, it draws
+			// exactly width cells or the caller's layout shifts under it.
+			if want := max(tt.width, 0); len([]rune(got)) != want {
+				t.Errorf("barGlyphs(%d, %d) drew %d cells, want %d",
+					tt.filled, tt.width, len([]rune(got)), want)
+			}
+		})
+	}
+}
+
+// The status gauge builds its own two styled runs from barFill rather than
+// using barGlyphs, so this pins that the two still describe the same bar.
+func TestRenderContextBarWidthMatchesBarGlyphs(t *testing.T) {
+	for _, pct := range []float64{-10, 0, 33.3, 60, 80, 100, 250} {
+		bar := renderContextBar(pct, Palette{}.Transparent, paletteOrDark(Palette{}))
+		filled := strings.Count(bar, barFilled)
+		empty := strings.Count(bar, barEmpty)
+		if filled+empty != contextBarWidth {
+			t.Errorf("renderContextBar(%v) drew %d+%d cells, want %d",
+				pct, filled, empty, contextBarWidth)
+		}
+		if want := barFill(min(max(pct, 0), 100)/100, contextBarWidth); filled != want {
+			t.Errorf("renderContextBar(%v) filled %d cells, want %d", pct, filled, want)
+		}
+	}
+}
+
+// The existing TestEstimateContextTokenCount only asserts the estimate is
+// positive. Pin the actual arithmetic here, since the status bar and /context
+// now share it and a change to the ratio would move both at once.
+func TestEstimateContextTokenCountIsExact(t *testing.T) {
+	msgs := []message{
+		{role: "user", content: strings.Repeat("a", 40)},
+		{role: "tool", tool: strings.Repeat("b", 8), toolIn: strings.Repeat("c", 12)},
+	}
+
+	// 40 + 8 + 12 = 60 chars at ~4 chars per token.
+	if got := estimateContextTokenCount(msgs); got != 15 {
+		t.Errorf("estimateContextTokenCount() = %d, want 15", got)
+	}
+}
+
+// messageChars decides what counts toward the estimate. It is one function
+// because it used to be three, and a field added to message would then have
+// been counted by some of them and not others.
+func TestMessageCharsCountsEveryTextField(t *testing.T) {
+	msg := message{content: "abcd", tool: "ef", toolIn: "ghij"}
+	if got := messageChars(msg); got != 10 {
+		t.Errorf("messageChars() = %d, want 10", got)
+	}
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -563,10 +563,10 @@ func (m *model) formatContextUsage() string {
 		b.WriteString("\n\n")
 	}
 
-	// Count chars per role (rough token estimate: ~4 chars per token).
+	// Same estimate as the status bar's, split by role.
 	userChars, assistantChars, toolChars := 0, 0, 0
 	for _, msg := range m.chatModel.Messages {
-		size := len(msg.content) + len(msg.tool) + len(msg.toolIn)
+		size := messageChars(msg)
 		switch msg.role {
 		case "user":
 			userChars += size
@@ -576,11 +576,10 @@ func (m *model) formatContextUsage() string {
 			toolChars += size
 		}
 	}
-	totalChars := userChars + assistantChars + toolChars
-	totalTokens := int64(totalChars / 4)
-	userTokens := int64(userChars / 4)
-	assistantTokens := int64(assistantChars / 4)
-	toolTokens := int64(toolChars / 4)
+	totalTokens := estimateTokens(userChars + assistantChars + toolChars)
+	userTokens := estimateTokens(userChars)
+	assistantTokens := estimateTokens(assistantChars)
+	toolTokens := estimateTokens(toolChars)
 
 	// Header.
 	b.WriteString("**Context Usage**\n\n")
@@ -591,27 +590,17 @@ func (m *model) formatContextUsage() string {
 	var limitTokens int64
 	if tt := m.cfg.TokenTracker; tt != nil && tt.Limit() > 0 {
 		limitTokens = tt.Limit()
-		pct := float64(tt.TotalUsed()) / float64(limitTokens)
-		usedBlocks = int(pct * barLen)
-		if usedBlocks > barLen {
-			usedBlocks = barLen
-		}
-	} else {
-		// No limit — show context proportion only.
-		if totalTokens > 0 {
-			usedBlocks = 1
-			if totalTokens > 10000 {
-				usedBlocks = int(float64(totalTokens) / 100000 * barLen)
-				if usedBlocks < 1 {
-					usedBlocks = 1
-				}
-				if usedBlocks > barLen {
-					usedBlocks = barLen
-				}
-			}
+		usedBlocks = barFill(float64(tt.TotalUsed())/float64(limitTokens), barLen)
+	} else if totalTokens > 0 {
+		// No limit to measure against — show the context against a nominal 100k
+		// window instead, and never less than one block, so a short conversation
+		// still reads as "something is in here".
+		usedBlocks = 1
+		if totalTokens > 10000 {
+			usedBlocks = max(barFill(float64(totalTokens)/100000, barLen), 1)
 		}
 	}
-	bar := strings.Repeat("█", usedBlocks) + strings.Repeat("░", barLen-usedBlocks)
+	bar := barGlyphs(usedBlocks, barLen)
 
 	// Model line with bar.
 	modelLabel := m.cfg.ModelName
@@ -665,11 +654,7 @@ func (m *model) formatContextUsage() string {
 			}
 
 			const ctxBarLen = 20
-			ctxUsedBlocks := int(pct / 100 * ctxBarLen)
-			if ctxUsedBlocks > ctxBarLen {
-				ctxUsedBlocks = ctxBarLen
-			}
-			ctxBar := strings.Repeat("█", ctxUsedBlocks) + strings.Repeat("░", ctxBarLen-ctxUsedBlocks)
+			ctxBar := barGlyphs(barFill(pct/100, ctxBarLen), ctxBarLen)
 
 			fmt.Fprintf(&b, "`%s`  %s / %s (%.0f%%)\n",
 				ctxBar,

--- a/internal/tui/context_rule.go
+++ b/internal/tui/context_rule.go
@@ -319,13 +319,26 @@ func (m *model) hitContextClear(x, y int) bool {
 	return x >= lay.ClearStart && x < lay.ClearEnd
 }
 
-// estimateContextTokenCount approximates context size from message text at the
-// usual ~4 characters per token, for the window before the provider reports a
-// real count.
+// messageChars is what a message contributes to a context estimate. Kept in one
+// place because three call sites used to spell the field list out for
+// themselves, and a field added to message would have been counted by some of
+// them and not others.
+func messageChars(msg message) int {
+	return len(msg.content) + len(msg.tool) + len(msg.toolIn)
+}
+
+// estimateTokens converts a character count at the usual ~4 characters per
+// token. The ratio is a guess, which is exactly why it should be guessed once.
+func estimateTokens(chars int) int64 {
+	return int64(chars / 4)
+}
+
+// estimateContextTokenCount approximates context size from message text, for
+// the window before the provider reports a real count.
 func estimateContextTokenCount(msgs []message) int64 {
 	chars := 0
 	for _, msg := range msgs {
-		chars += len(msg.content) + len(msg.tool) + len(msg.toolIn)
+		chars += messageChars(msg)
 	}
-	return int64(chars / 4)
+	return estimateTokens(chars)
 }

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -57,17 +57,9 @@ const contextBarWidth = 10
 // renderContextBar returns a color-coded visual bar like "████░░░░░░ 42%".
 // Colors: green < 60%, orange 60-80%, red > 80%.
 func renderContextBar(pct float64, bg color.Color, p Palette) string {
-	if pct < 0 {
-		pct = 0
-	}
-	if pct > 100 {
-		pct = 100
-	}
+	pct = min(max(pct, 0), 100)
 
-	filled := int(pct / 100 * contextBarWidth)
-	if filled > contextBarWidth {
-		filled = contextBarWidth
-	}
+	filled := barFill(pct/100, contextBarWidth)
 	empty := contextBarWidth - filled
 
 	var fg color.Color
@@ -84,8 +76,8 @@ func renderContextBar(pct float64, bg color.Color, p Palette) string {
 	emptyStyle := lipgloss.NewStyle().Background(bg).Foreground(p.Surface)
 	pctStyle := lipgloss.NewStyle().Background(bg).Foreground(fg)
 
-	return filledStyle.Render(strings.Repeat("█", filled)) +
-		emptyStyle.Render(strings.Repeat("░", empty)) +
+	return filledStyle.Render(strings.Repeat(barFilled, filled)) +
+		emptyStyle.Render(strings.Repeat(barEmpty, empty)) +
 		pctStyle.Render(fmt.Sprintf(" %.0f%%", pct))
 }
 
@@ -157,12 +149,9 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 		pct := tt.PercentUsed()
 		parts = append(parts, renderContextBar(pct, noBg, p))
 	} else {
-		// Fallback: rough context size estimate (~4 chars per token).
-		ctxChars := 0
-		for _, msg := range in.Messages {
-			ctxChars += len(msg.content) + len(msg.tool) + len(msg.toolIn)
-		}
-		ctxTokens := ctxChars / 4
+		// Fallback: the same rough estimate /context shows, so the two cannot
+		// disagree about the same conversation.
+		ctxTokens := estimateContextTokenCount(in.Messages)
 		switch {
 		case ctxTokens >= 1000:
 			parts = append(parts, dim.Render(fmt.Sprintf("ctx: %.1fk", float64(ctxTokens)/1000)))

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1715,24 +1715,19 @@ func renderStartupProgress(loadingItems map[string]bool, loadingTotal int) strin
 		total = len(loadingItems)
 	}
 	if total < 1 {
-		return fmt.Sprintf(" [%s 0%%]", strings.Repeat("░", startupProgressBarWidth))
+		return fmt.Sprintf(" [%s 0%%]", barGlyphs(0, startupProgressBarWidth))
 	}
 
-	pct := done * 100 / total
-	if pct > 100 {
-		pct = 100
-	}
+	pct := min(done*100/total, 100)
 
+	// Any progress at all claims a block. Init finishes a long tail of small
+	// items, and a bar that reads empty for the first few of them looks stuck.
 	filled := done * startupProgressBarWidth / total
 	if done > 0 && filled == 0 {
 		filled = 1
 	}
-	if filled > startupProgressBarWidth {
-		filled = startupProgressBarWidth
-	}
 
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", startupProgressBarWidth-filled)
-	return fmt.Sprintf(" [%s %d%% %d/%d]", bar, pct, done, total)
+	return fmt.Sprintf(" [%s %d%% %d/%d]", barGlyphs(filled, startupProgressBarWidth), pct, done, total)
 }
 
 func renderStartupDetail(loadingItems map[string]bool) string {


### PR DESCRIPTION
Four places drew a proportional bar — the status bar's context gauge, two
sections of /context, and the startup progress line — and each clamped its
own fill and spelled out its own block characters. They had already drifted:
three clamped the fill against the width, one clamped the percentage too.

Three places estimated context size from message text at ~4 characters per
token, each listing the message fields that count for itself. A field added
to message would have been counted by some of them and not others, and the
status bar and /context would then have disagreed about the same
conversation while both looked authoritative.

barFill/barGlyphs split the bar into fill-then-draw because that is what the
call sites need: the status gauge colors filled and empty differently so it
wants the count, and everything else renders into markdown where ANSI in a
code span would print literally, so it wants the plain string.

No output changes. The arithmetic is equivalent at every call site,
including the /context fallback that shows a nominal 100k window when no
token limit is known.

Signed-off-by: dimetron <dimetron@me.com>
