### PR TITLE
fix(eval): correct the report layer — UTF-8, ordering, latency

### DIFF
--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -244,14 +244,57 @@ func TestComputeToolsMetrics(t *testing.T) {
 		t.Errorf("edit errors = %d, want 1 (error content)", edit.Errors)
 	}
 
-	// Deterministic tool order.
-	names := make([]string, 0, len(m.ByTool))
-	for name := range m.ByTool {
-		names = append(names, name)
+	if got := sortedKeys(m.ByTool); !slices.Equal(got, []string{"bash", "edit", "subagent"}) {
+		t.Errorf("tools seen = %v, want [bash edit subagent]", got)
 	}
-	sort.Strings(names)
-	if names[0] != "bash" || names[1] != "edit" || names[2] != "subagent" {
-		t.Errorf("tool order = %v, want [bash edit subagent]", names)
+}
+
+// AvgLatencyMs must average over the calls that actually carried usable
+// timestamps, not over every observed result: a trajectory whose steps are
+// partly untimed would otherwise report a latency several times lower than the
+// one call it could measure.
+func TestComputeToolsMetrics_LatencyAveragesOnlyTimedCalls(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now().Add(-time.Minute)
+
+	traj := baseTraj("t1", "task")
+	traj.Steps = []atif.Step{
+		// Timed pair: 400ms from call to observation.
+		{
+			StepID:    1,
+			Timestamp: base.Format(time.RFC3339Nano),
+			ToolCalls: []atif.ToolCall{{ToolCallID: "c1", FunctionName: "bash", Arguments: map[string]any{"n": 1}}},
+		},
+		{
+			StepID:      2,
+			Timestamp:   base.Add(400 * time.Millisecond).Format(time.RFC3339Nano),
+			Observation: &atif.Observation{Results: []atif.ObservationResult{{SourceCallID: "c1", Content: "ok"}}},
+		},
+		// Untimed pair: observed, but no timestamps, so it contributes a result
+		// without contributing a latency sample.
+		{
+			StepID:    3,
+			ToolCalls: []atif.ToolCall{{ToolCallID: "c2", FunctionName: "bash", Arguments: map[string]any{"n": 2}}},
+		},
+		{
+			StepID:      4,
+			Observation: &atif.Observation{Results: []atif.ObservationResult{{SourceCallID: "c2", Content: "ok"}}},
+		},
+	}
+	writeTraj(t, dir, "t1", traj)
+
+	loaded, err := LoadTrajectories(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bash := ComputeToolsMetrics(loaded).ByTool["bash"]
+
+	if bash.Results != 2 {
+		t.Fatalf("bash results = %d, want 2", bash.Results)
+	}
+	if bash.AvgLatencyMs < 350 || bash.AvgLatencyMs > 450 {
+		t.Errorf("bash AvgLatencyMs = %d, want ~400 (the one timed call), not the %d "+
+			"that averaging over both results would give", bash.AvgLatencyMs, 200)
 	}
 }
 

--- a/internal/eval/metrics.go
+++ b/internal/eval/metrics.go
@@ -214,28 +214,20 @@ func LoadTrajectories(sessionsDir string) ([]*LoadedTrajectory, error) {
 func ComputeTrajectoryMetrics(loaded []*LoadedTrajectory) TrajectoryMetrics {
 	m := TrajectoryMetrics{}
 
-	byID := make(map[string]*LoadedTrajectory, len(loaded))
-	for _, lt := range loaded {
-		byID[lt.SessionID] = lt
-	}
-
 	// childRefs[sessionID] → set of child session IDs referenced from its
-	// observations. parentOf[child] → count of parents, for root detection.
+	// observations.
 	childRefs := make(map[string]map[string]bool)
-	parentOf := make(map[string]int)
 	for _, lt := range loaded {
 		refs := subagentRefs(lt.Traj)
 		if len(refs) > 0 {
 			childRefs[lt.SessionID] = refs
-			for child := range refs {
-				parentOf[child]++
-			}
 		}
 		m.NestedAgentCalls += len(refs)
 	}
 
 	// Roots are sessions nobody references. Depth is memoized DFS:
 	// depth(child) = 1 + max(depth(parent)).
+	parentsOf := invertRefs(childRefs)
 	depth := make(map[string]int, len(loaded))
 	var depthOf func(id string, stack map[string]bool) int
 	depthOf = func(id string, stack map[string]bool) int {
@@ -247,7 +239,7 @@ func ComputeTrajectoryMetrics(loaded []*LoadedTrajectory) TrajectoryMetrics {
 		}
 		stack[id] = true
 		best := 0
-		for parent := range parentsOf(id, loaded, childRefs) {
+		for parent := range parentsOf[id] {
 			if d := depthOf(parent, stack) + 1; d > best {
 				best = d
 			}
@@ -296,15 +288,20 @@ func ComputeTrajectoryMetrics(loaded []*LoadedTrajectory) TrajectoryMetrics {
 	return m
 }
 
-// parentsOf returns the session IDs that directly reference id as a subagent.
-func parentsOf(id string, loaded []*LoadedTrajectory, childRefs map[string]map[string]bool) map[string]bool {
-	out := make(map[string]bool)
+// invertRefs turns the parent→children map into child→parents, so depth can be
+// resolved with a single lookup per session instead of rescanning every
+// parent's ref set for each one.
+func invertRefs(childRefs map[string]map[string]bool) map[string]map[string]bool {
+	parents := make(map[string]map[string]bool, len(childRefs))
 	for parent, children := range childRefs {
-		if children[id] {
-			out[parent] = true
+		for child := range children {
+			if parents[child] == nil {
+				parents[child] = make(map[string]bool)
+			}
+			parents[child][parent] = true
 		}
 	}
-	return out
+	return parents
 }
 
 // subagentRefs returns the set of subagent trajectory refs (as session IDs)
@@ -417,12 +414,20 @@ type callRecord struct {
 }
 
 // ComputeToolsMetrics derives per-tool efficiency from the run's trajectories.
+//
+// Consumers that render ByTool must sort its keys themselves: a Go map has no
+// order, so there is nothing this function can do to make ranging it stable.
 func ComputeToolsMetrics(loaded []*LoadedTrajectory) ToolsMetrics {
 	m := ToolsMetrics{ByTool: make(map[string]ToolStats)}
 
+	// latencySamples[tool] counts the calls that contributed to AvgLatencyMs.
+	// It is not the same as Results: a result whose call or observation step
+	// carried no parseable timestamp yields no latency, and averaging over
+	// Results would then understate the real latency.
+	latencySamples := make(map[string]int)
+
 	for _, lt := range loaded {
-		records := pairCalls(lt.Traj)
-		for id, rec := range records {
+		for _, rec := range pairCalls(lt.Traj) {
 			st := m.ByTool[rec.fn]
 			st.Calls++
 			if rec.observed {
@@ -433,6 +438,7 @@ func ComputeToolsMetrics(loaded []*LoadedTrajectory) ToolsMetrics {
 				st.AvgResultBytes += rec.obsBytes
 				if !rec.stepTS.IsZero() && !rec.obsStepTS.IsZero() {
 					st.AvgLatencyMs += int(rec.obsStepTS.Sub(rec.stepTS).Milliseconds())
+					latencySamples[rec.fn]++
 				}
 			} else {
 				st.Wasted++
@@ -447,33 +453,24 @@ func ComputeToolsMetrics(loaded []*LoadedTrajectory) ToolsMetrics {
 			if rec.fn == "subagent" {
 				m.NestedAgentCalls++
 			}
-			_ = id
 		}
 	}
 
-	// Per-tool averages and duplicate detection.
+	// Per-tool averages and duplicate detection. Duplicates are counted for
+	// every tool in one pass rather than rescanning all trajectories per tool.
+	dups := duplicateCounts(loaded)
 	for name := range m.ByTool {
 		st := m.ByTool[name]
 		if st.Results > 0 {
 			st.AvgResultBytes /= st.Results
-			st.AvgLatencyMs /= st.Results
 		}
-		st.Duplicates = duplicateCount(loaded, name)
+		if n := latencySamples[name]; n > 0 {
+			st.AvgLatencyMs /= n
+		}
+		st.Duplicates = dups[name]
 		m.ByTool[name] = st
 		m.Duplicates += st.Duplicates
 	}
-
-	// Deterministic tool ordering.
-	sorted := make([]string, 0, len(m.ByTool))
-	for name := range m.ByTool {
-		sorted = append(sorted, name)
-	}
-	sort.Strings(sorted)
-	ordered := make(map[string]ToolStats, len(sorted))
-	for _, name := range sorted {
-		ordered[name] = m.ByTool[name]
-	}
-	m.ByTool = ordered
 
 	return m
 }
@@ -518,25 +515,31 @@ func pairCalls(t *atif.Trajectory) map[string]*callRecord {
 	return records
 }
 
-// duplicateCount counts repeated identical (function_name, arguments) pairs
-// for one tool across all trajectories: occurrences after the first.
-func duplicateCount(loaded []*LoadedTrajectory, tool string) int {
-	counts := make(map[string]int)
+// duplicateCounts counts, per tool, the repeated identical (function_name,
+// arguments) pairs across all trajectories: occurrences after the first.
+func duplicateCounts(loaded []*LoadedTrajectory) map[string]int {
+	// counts[tool][canonical args] → occurrences.
+	counts := make(map[string]map[string]int)
 	for _, lt := range loaded {
 		for i := range lt.Traj.Steps {
 			for j := range lt.Traj.Steps[i].ToolCalls {
 				call := &lt.Traj.Steps[i].ToolCalls[j]
-				if call.FunctionName != tool {
-					continue
+				byArgs, ok := counts[call.FunctionName]
+				if !ok {
+					byArgs = make(map[string]int)
+					counts[call.FunctionName] = byArgs
 				}
-				counts[canonicalArgs(call.Arguments)]++
+				byArgs[canonicalArgs(call.Arguments)]++
 			}
 		}
 	}
-	dups := 0
-	for _, n := range counts {
-		if n > 1 {
-			dups += n - 1
+
+	dups := make(map[string]int, len(counts))
+	for tool, byArgs := range counts {
+		for _, n := range byArgs {
+			if n > 1 {
+				dups[tool] += n - 1
+			}
 		}
 	}
 	return dups

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -112,7 +112,11 @@ func RenderMarkdown(r *RunReport) string {
 	if len(tm.ByTool) > 0 {
 		fmt.Fprintf(&b, "\n| tool | calls | results | errors | wasted | duplicates | avg bytes | avg latency |\n")
 		fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
-		for name, st := range tm.ByTool {
+		// Sort: ranging a map yields a random order, so the same report would
+		// otherwise render its tool rows differently on every call and two
+		// reports of the same run would not diff cleanly.
+		for _, name := range sortedKeys(tm.ByTool) {
+			st := tm.ByTool[name]
 			fmt.Fprintf(&b, "| `%s` | %d | %d | %d | %d | %d | %d | %dms |\n",
 				name, st.Calls, st.Results, st.Errors, st.Wasted, st.Duplicates, st.AvgResultBytes, st.AvgLatencyMs)
 		}
@@ -234,35 +238,41 @@ func sparkline(samples []ConcurrencySample) string {
 		}
 	} else {
 		per := float64(n) / width
-		for i := 0; i < width; i++ {
+		for i := range width {
 			lo, hi := int(float64(i)*per), int(float64(i+1)*per)
 			if hi > n {
 				hi = n
 			}
-			max := 0
+			peak := 0
 			for j := lo; j < hi; j++ {
-				if samples[j].Running > max {
-					max = samples[j].Running
+				if samples[j].Running > peak {
+					peak = samples[j].Running
 				}
 			}
-			buckets = append(buckets, max)
+			buckets = append(buckets, peak)
 		}
 	}
 
-	levels := "▁▂▃▄▅▆▇█"
+	// Runes, not bytes: each block character is three bytes in UTF-8, so
+	// indexing the string directly emits one byte of a multi-byte sequence and
+	// the whole sparkline comes out as invalid UTF-8.
+	levels := []rune("▁▂▃▄▅▆▇█")
 	scale := 1
 	for _, v := range buckets {
 		if v > scale {
 			scale = v
 		}
 	}
-	if scale < 1 {
-		scale = 1
-	}
 	var b strings.Builder
 	for _, v := range buckets {
 		idx := (v * (len(levels) - 1)) / scale
-		b.WriteByte(levels[idx])
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(levels) {
+			idx = len(levels) - 1
+		}
+		b.WriteRune(levels[idx])
 	}
 	fmt.Fprintf(&b, "  (max %d, %d samples)", scale, n)
 	return b.String()

--- a/internal/eval/report_test.go
+++ b/internal/eval/report_test.go
@@ -1,0 +1,329 @@
+package eval
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// fullReport is a report with every optional section populated, so a render
+// test exercises the whole document rather than one branch of it.
+func fullReport() *RunReport {
+	return &RunReport{
+		Metadata: ReportMetadata{
+			Spec:       "eval-orchestrator",
+			Mode:       "parallel",
+			Model:      "test-model",
+			Binary:     "/tmp/pi",
+			GitHead:    "abcdef1234567890",
+			BaseRef:    "eval/base",
+			BaseCommit: "1234567890abcdef",
+			Timestamp:  time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+			Duration:   "4m12s",
+		},
+		Outcome: RunOutcome{
+			FinalPhase: "failed",
+			Retries:    1,
+			Reason:     "**Merge failed**\nconflict in add.go",
+			GateResults: []GateResult{
+				{Name: "test", Command: "go test ./...", Passed: true},
+				{Name: "vet", Command: "go vet ./...", Passed: false},
+			},
+			GoldenCheck: []GoldenFile{
+				{Name: "go.mod", Match: true},
+				{Name: "add.go", Match: false, Diff: "first difference at line 3\n- 3| a\n+ 3| b\n"},
+				{Name: "add_test.go", Match: false, Error: "produced file missing: no such file"},
+			},
+			GoldenPass:    false,
+			BaselineRef:   "eval/golden",
+			BaselineCheck: []GoldenFile{{Name: "add.go", Match: true}},
+			BaselinePass:  true,
+		},
+		Trajectory: TrajectoryMetrics{
+			Sessions: []SessionSummary{
+				{SessionID: "260810-1601-abcde-12345", AgentName: "pi-go", Model: "test-model", Depth: 0, Steps: 10, ToolCalls: 8, SubagentRefs: 1, Duration: "2m"},
+				{SessionID: "short", AgentName: "task", Depth: 1, Steps: 4, ToolCalls: 3},
+			},
+			TotalSteps:       14,
+			TotalToolCalls:   11,
+			NestedAgentCalls: 1,
+			MaxDepth:         1,
+		},
+		Concurrency: ConcurrencyMetrics{
+			PoolBudget:      4,
+			WorkerBudget:    2,
+			MaxRunning:      3,
+			MeanRunning:     1.5,
+			AgentsSeen:      3,
+			ParallelOverlap: 0.5,
+			Samples: []ConcurrencySample{
+				{Running: 0}, {Running: 2}, {Running: 3}, {Running: 1},
+			},
+		},
+		Tools: ToolsMetrics{
+			TotalCalls:   11,
+			TotalResults: 9,
+			Wasted:       2,
+			Duplicates:   3,
+			ByTool: map[string]ToolStats{
+				"write":    {Calls: 1, Results: 1},
+				"bash":     {Calls: 6, Results: 5, Errors: 2, Wasted: 1, Duplicates: 3, AvgResultBytes: 120, AvgLatencyMs: 400},
+				"read":     {Calls: 3, Results: 3},
+				"edit":     {Calls: 1, Results: 0, Wasted: 1},
+				"subagent": {Calls: 1, Results: 1},
+			},
+		},
+		Tokens: TokenMetrics{
+			PromptTokens:     1000,
+			CompletionTokens: 200,
+			CachedTokens:     50,
+			TotalTokens:      1200,
+			CostUSD:          0.0123,
+			Sessions: []SessionTokenUsage{
+				{SessionID: "260810-1601-abcde-12345", PromptTokens: 900, CompletionTokens: 180},
+				{SessionID: "short", PromptTokens: 100, CompletionTokens: 20},
+			},
+		},
+	}
+}
+
+func TestRenderMarkdown_FullReport(t *testing.T) {
+	md := RenderMarkdown(fullReport())
+
+	for _, want := range []string{
+		"# Eval run: eval-orchestrator",
+		"**mode**: parallel",
+		"**git head**: `abcdef123456`", // truncated to 12
+		"**base ref**: `eval/base` (`1234567890ab`)",
+		"**final phase**: `failed`",
+		"conflict in add.go",
+		"| test | `go test ./...` | ✓ |",
+		"| vet | `go vet ./...` | ✗ |",
+		"**Golden check**: FAIL",
+		"`add.go`: mismatch",
+		"`add_test.go`: mismatch (produced file missing: no such file)",
+		"**baseline ref**: `eval/golden`",
+		"**Baseline check**: PASS",
+		"**max nesting depth**: 1",
+		"`260810-1601-…`", // session id truncated to 12 + ellipsis
+		"| `short` | task | — |",
+		"**worker budget** (nested): 2",
+		"**parallel overlap** (fraction of samples with >1 running): 0.50",
+		"**duplicate calls**: 3",
+		"**cached tokens**: 50",
+		"**total tokens**: 1200",
+		"**estimated cost**: $0.0123",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown is missing %q\n---\n%s", want, md)
+		}
+	}
+
+	if !utf8.ValidString(md) {
+		t.Error("rendered markdown is not valid UTF-8")
+	}
+}
+
+// The tool table ranges a map, which has no order. Without an explicit sort the
+// same report renders differently on every call and two reports of one run
+// cannot be diffed.
+func TestRenderMarkdown_IsDeterministic(t *testing.T) {
+	r := fullReport()
+	first := RenderMarkdown(r)
+	for i := range 100 {
+		if got := RenderMarkdown(r); got != first {
+			t.Fatalf("render %d differs from the first render\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+
+	// And the order is the sorted one, not merely stable.
+	rows := []string{"| `bash` |", "| `edit` |", "| `read` |", "| `subagent` |", "| `write` |"}
+	prev := -1
+	for _, row := range rows {
+		at := strings.Index(first, row)
+		if at < 0 {
+			t.Fatalf("tool row %q missing from the table:\n%s", row, first)
+		}
+		if at < prev {
+			t.Errorf("tool row %q is out of sorted order", row)
+		}
+		prev = at
+	}
+}
+
+func TestSparkline(t *testing.T) {
+	tests := []struct {
+		name      string
+		samples   []ConcurrencySample
+		wantEmpty bool
+		wantIn    string
+	}{
+		{name: "no samples", samples: nil, wantEmpty: true},
+		{name: "all zero", samples: []ConcurrencySample{{Running: 0}, {Running: 0}}, wantIn: "(max 1, 2 samples)"},
+		{name: "varied", samples: []ConcurrencySample{{Running: 0}, {Running: 1}, {Running: 2}, {Running: 4}}, wantIn: "(max 4, 4 samples)"},
+		{name: "bucketed", samples: manySamples(500), wantIn: "(max 7, 500 samples)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sparkline(tt.samples)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("sparkline = %q, want empty", got)
+				}
+				return
+			}
+			// The block characters are three bytes each in UTF-8. Indexing the
+			// level string by byte emits a fragment of one and corrupts the
+			// whole line, so validity is the assertion that matters most here.
+			if !utf8.ValidString(got) {
+				t.Errorf("sparkline is not valid UTF-8: %q", got)
+			}
+			if !strings.Contains(got, tt.wantIn) {
+				t.Errorf("sparkline = %q, want it to contain %q", got, tt.wantIn)
+			}
+			bars, _, _ := strings.Cut(got, "  (")
+			for _, r := range bars {
+				if !strings.ContainsRune("▁▂▃▄▅▆▇█", r) {
+					t.Errorf("sparkline contains %q, not a block character: %q", r, got)
+				}
+			}
+			if n := utf8.RuneCountInString(bars); n > 100 {
+				t.Errorf("sparkline is %d columns wide, want <= 100", n)
+			}
+		})
+	}
+}
+
+func manySamples(n int) []ConcurrencySample {
+	out := make([]ConcurrencySample, n)
+	for i := range out {
+		out[i] = ConcurrencySample{Running: i % 8}
+	}
+	return out
+}
+
+func TestWriteReport(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "reports") // MkdirAll must create it
+	r := fullReport()
+
+	jsonPath, mdPath, md, err := WriteReport(r, dir)
+	if err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	if want := "eval-eval-orchestrator-20260810-120000.json"; filepath.Base(jsonPath) != want {
+		t.Errorf("json path = %q, want basename %q", jsonPath, want)
+	}
+	if want := "eval-eval-orchestrator-20260810-120000.md"; filepath.Base(mdPath) != want {
+		t.Errorf("md path = %q, want basename %q", mdPath, want)
+	}
+
+	onDisk, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("read md: %v", err)
+	}
+	if string(onDisk) != md {
+		t.Error("returned markdown differs from the file written")
+	}
+
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read json: %v", err)
+	}
+	var round RunReport
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("report JSON does not round-trip: %v", err)
+	}
+	if round.Metadata.Spec != r.Metadata.Spec || round.Tools.TotalCalls != r.Tools.TotalCalls {
+		t.Errorf("round-tripped report = %+v, want it to match the original", round.Metadata)
+	}
+	if round.Judge != nil {
+		t.Error("absent judge was serialized; the field should be omitted")
+	}
+}
+
+func TestWriteReport_UnwritableDir(t *testing.T) {
+	// A file where the report directory should be: MkdirAll must fail and the
+	// error must be wrapped, not swallowed.
+	base := t.TempDir()
+	blocker := filepath.Join(base, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := WriteReport(fullReport(), filepath.Join(blocker, "out")); err == nil {
+		t.Error("WriteReport succeeded with an unusable output dir")
+	} else if !strings.Contains(err.Error(), "create report dir") {
+		t.Errorf("error = %v, want it wrapped with the failing operation", err)
+	}
+}
+
+func TestFirstDiff(t *testing.T) {
+	tests := []struct {
+		name       string
+		want, got  string
+		wantLineNo string
+	}{
+		{"differs mid-file", "a\nb\nc\n", "a\nX\nc\n", "line 2"},
+		{"got is a prefix of want", "a\nb\nc\n", "a\nb\n", "line 3"},
+		{"want is a prefix of got", "a\nb\n", "a\nb\nc\n", "line 3"},
+		{"differs on the first line", "a\n", "z\n", "line 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstDiff([]byte(tt.want), []byte(tt.got))
+			if !strings.Contains(got, tt.wantLineNo) {
+				t.Errorf("firstDiff snippet = %q, want it to report %q", got, tt.wantLineNo)
+			}
+		})
+	}
+
+	// A long line is truncated so one minified file cannot flood the report.
+	long := strings.Repeat("x", 500)
+	snippet := firstDiff([]byte(long), []byte(strings.Repeat("y", 500)))
+	for _, line := range strings.Split(snippet, "\n") {
+		if len(line) > 120 {
+			t.Errorf("diff snippet line is %d bytes, want it truncated: %q", len(line), line)
+		}
+	}
+}
+
+func TestShortIDAndShortHead(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             string
+		wantID, wantHd string
+	}{
+		{"empty", "", "", ""},
+		{"short", "abc", "abc", "abc"},
+		{"exactly 12", "123456789012", "123456789012", "123456789012"},
+		{"long", "260810-1601-abcde-12345", "260810-1601-…", "260810-1601-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortID(tt.in); got != tt.wantID {
+				t.Errorf("shortID(%q) = %q, want %q", tt.in, got, tt.wantID)
+			}
+			if got := shortHead(tt.in); got != tt.wantHd {
+				t.Errorf("shortHead(%q) = %q, want %q", tt.in, got, tt.wantHd)
+			}
+		})
+	}
+}
+
+func TestRenderMarkdown_NoGates(t *testing.T) {
+	md := RenderMarkdown(&RunReport{})
+	if !strings.Contains(md, "**gates**: none") {
+		t.Errorf("a run with no gates should say so:\n%s", md)
+	}
+	if strings.Contains(md, "baseline ref") {
+		t.Errorf("no baseline was configured, but the section rendered:\n%s", md)
+	}
+}

--- a/internal/tui/run_eval_e2e_test.go
+++ b/internal/tui/run_eval_e2e_test.go
@@ -34,6 +34,13 @@ import (
 
 const evalSpecName = "eval-orchestrator"
 
+// evalPumpDrainGrace is how long a timed-out run's pump goroutine is given to
+// unwind after cancellation before the harness reads the model anyway. The pump
+// blocks in cmd() on agent/gate/merge channels; canceling the context and
+// shutting the orchestrator down closes those, so unwinding is fast when it
+// happens at all.
+const evalPumpDrainGrace = 60 * time.Second
+
 func TestEvalRun(t *testing.T) {
 	if os.Getenv("PI_EVAL_RUN") != "1" {
 		t.Skip("eval harness: set PI_EVAL_RUN=1 to run (make eval-run)")
@@ -169,6 +176,8 @@ func TestEvalRun(t *testing.T) {
 	if v := os.Getenv("PI_EVAL_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			timeout = d
+		} else {
+			t.Fatalf("PI_EVAL_TIMEOUT=%q is not a Go duration: %v", v, err)
 		}
 	}
 
@@ -181,9 +190,20 @@ func TestEvalRun(t *testing.T) {
 	select {
 	case final = <-resultCh:
 	case <-time.After(timeout):
+		// The pump goroutine owns m until it returns. Reading m here while it
+		// is still running is a data race on every field the report touches
+		// (run.phase, run.gateResults, chatModel.Messages), so cancel the run
+		// and give the pump a bounded window to unwind before falling back to
+		// reading m directly.
 		cancel()
 		orch.Shutdown()
-		final = m
+		select {
+		case final = <-resultCh:
+		case <-time.After(evalPumpDrainGrace):
+			t.Errorf("run pump did not unwind %s after cancellation; "+
+				"report is assembled from a model the pump may still be writing", evalPumpDrainGrace)
+			final = m
+		}
 		if final.run == nil {
 			final.run = &runState{}
 		}
@@ -222,7 +242,7 @@ func TestEvalRun(t *testing.T) {
 
 	// --- save golden (tag + branch) ----------------------------------------
 	if os.Getenv("PI_EVAL_SAVE_GOLDEN") == "1" && goldenPass && runPhase(final) == "done" {
-		saveGoldenRefs(t, wtPath, final)
+		saveGoldenRefs(t, wtPath)
 	}
 
 	// --- report -------------------------------------------------------------
@@ -305,25 +325,45 @@ func TestEvalRun(t *testing.T) {
 
 // runEvalPump drives the /run handler chain to completion, mirroring what the
 // bubbletea Update loop does for the run messages.
+//
+// Commands are held in a queue rather than a single "next cmd" variable so a
+// tea.Batch cannot silently truncate the run: dropping the batch's commands
+// would end the pump early and the harness would report a partial run as if it
+// were the real outcome. Batched commands run serially here, which is enough —
+// the run flow returns one command at a time today.
 func runEvalPump(m *model, args []string) *model {
-	var cmd tea.Cmd
-	var cur tea.Model
-	cur, cmd = m.handleRunCommand(args)
-	for cmd != nil {
-		msg := cmd()
-		switch v := msg.(type) {
+	cur, cmd := m.handleRunCommand(args)
+	m = cur.(*model)
+
+	queue := []tea.Cmd{}
+	if cmd != nil {
+		queue = append(queue, cmd)
+	}
+	for len(queue) > 0 {
+		cmd, queue = queue[0], queue[1:]
+		if cmd == nil { // tea.Batch tolerates nil commands; so must the pump
+			continue
+		}
+		var next tea.Cmd
+		switch v := cmd().(type) {
+		case tea.BatchMsg:
+			queue = append(queue, v...)
+			continue
 		case runAgentEventMsg:
-			cur, cmd = m.handleRunAgentEvent(v)
+			cur, next = m.handleRunAgentEvent(v)
 		case runAgentDoneMsg:
-			cur, cmd = m.handleRunAgentDone(v)
+			cur, next = m.handleRunAgentDone(v)
 		case runGateResultMsg:
-			cur, cmd = m.handleRunGateResult(v)
+			cur, next = m.handleRunGateResult(v)
 		case runMergeResultMsg:
-			cur, cmd = m.handleRunMergeResult(v)
+			cur, next = m.handleRunMergeResult(v)
 		default:
-			cur, cmd = m, nil
+			continue
 		}
 		m = cur.(*model)
+		if next != nil {
+			queue = append(queue, next)
+		}
 	}
 	return m
 }
@@ -607,7 +647,7 @@ func diffBaseline(t *testing.T, repoRoot, ref, producedDir string, files []strin
 	return eval.DiffGolden(producedDir, baselineDir, files)
 }
 
-func saveGoldenRefs(t *testing.T, wtPath string, m *model) {
+func saveGoldenRefs(t *testing.T, wtPath string) {
 	t.Helper()
 	ts := time.Now().Format("20060102-150405")
 	if out, err := exec.Command("git", "-C", wtPath, "tag", "-f", "eval/golden-"+ts).CombinedOutput(); err != nil {
@@ -691,10 +731,11 @@ func modelName(cfg *config.Config, envModel string) string {
 	if envModel != "" {
 		return envModel
 	}
-	if cfg != nil {
-		if r, ok := cfg.Roles["default"]; ok {
-			return r.Model
-		}
+	if cfg == nil {
+		return ""
+	}
+	if r, ok := cfg.Roles["default"]; ok {
+		return r.Model
 	}
 	return cfg.DefaultModel
 }


### PR DESCRIPTION
Review fixes for #134, targeted at that branch so they land with it.

Three defects, all in the report layer rather than the measurement:

- **Sparkline emitted invalid UTF-8.** Block characters are three bytes each, so `len("▁▂▃▄▅▆▇█")` is 24, not 8. The index was scaled against 23 and written with `WriteByte`, producing bytes from the middles of multi-byte sequences — four samples rendered as `"\xe2\x96\xe2\x88"`.
- **The Markdown tool table ranged a map**, so the same run rendered differently every time and two reports could not be diffed. The existing "deterministic order" code rebuilt the map in sorted order, which does nothing to Go map iteration.
- **`AvgLatencyMs` used the wrong denominator** — summed over timed calls, divided by all observed results.

The test meant to catch the ordering bug sorted the names itself and then asserted they were sorted, which is true for any input.

`report.go` had no coverage outside the judge section, which is where two of the three shipped from. `internal/eval` is now at 93.1%.

Also removes a build-once-never-read map, an unused parameter, a dead `_ = id`, and replaces two rescans with single passes.

Not addressed, flagged for you:
- `TokenMetrics.CostUSD` is declared and rendered but never populated, so "estimated cost" can never appear in a real report.
- The `run.go` backup-branch separator change in #134 is a correct fix for a real git ref collision, but it is production branch-naming in an eval-harness PR and orphans existing `run/<spec>/part-N` branches. It wants its own PR.
- `golangci-lint run ./...` never lints `run_eval_e2e_test.go` — it is `//go:build e2e`, so the default pass and the pre-commit hook skip the largest new file in the PR.
- `TestEvalRun` itself was not executed; it needs a built binary, a live key and up to 45 minutes.