### PR TITLE
fix(tui): stop the agent loop reading cfg while Update writes it

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -499,8 +499,37 @@ func (m *model) startAgentLoop(prompt string) tea.Cmd {
 	m.agentCh = ch
 	agentCtx, agentCancel := context.WithCancel(m.ctx)
 	m.agentCancel = agentCancel
-	go m.runAgentLoop(agentCtx, prompt, ch)
+	go m.runAgentLoop(agentCtx, prompt, ch, m.agentRun())
 	return waitForAgent(m.agentCh)
+}
+
+// agentRunConfig is the slice of cfg the agent loop needs, read once on the
+// Update goroutine and handed over by value.
+//
+// The loop used to reach through m.cfg for these while it ran. Update writes
+// m.cfg from a dozen places — /model swaps LLM, ModelName, ProviderName and
+// ActiveRole, /plan replaces SessionID, skill creation rewrites Skills, and
+// init assigns Agent and Logger outright — so the loop's read and Update's
+// write are two goroutines touching the same words. Nothing structural
+// separated them; the only reason it held was that handleModelCommand happens
+// to return early while m.running.
+//
+// Commit 35c3b25 fixed the sibling case, the agent channel, the same way: pass
+// what the goroutine needs rather than let it reach for the live struct.
+// Grouping the fields into a sub-struct would not have helped — the race is
+// about who may read m, not about how m is laid out.
+type agentRunConfig struct {
+	agent     *agent.Agent
+	sessionID string
+	logger    *logger.Logger
+}
+
+func (m *model) agentRun() agentRunConfig {
+	return agentRunConfig{
+		agent:     m.cfg.Agent,
+		sessionID: m.cfg.SessionID,
+		logger:    m.cfg.Logger,
+	}
 }
 
 type queuedPrompt struct {
@@ -613,7 +642,7 @@ func (m *model) setSessionTitle(text string) string {
 // close). Reading the shared field here would race with that write and, worse,
 // could close the next turn's channel. Capturing the channel by value makes
 // every send target the channel this turn actually owns.
-func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMsg) {
+func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMsg, run agentRunConfig) {
 	defer close(ch)
 	defer func() {
 		if r := recover(); r != nil {
@@ -621,18 +650,18 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 			// The session log, not stderr: the TUI holds the alternate
 			// screen, so a stack trace printed here would be painted over
 			// the UI. The panic still reaches the user as the turn's error.
-			m.cfg.Logger.Errorf("agent loop panicked: %v\n%s", r, stack)
+			run.logger.Errorf("agent loop panicked: %v\n%s", r, stack)
 			ch <- agentDoneMsg{err: fmt.Errorf("agent panic: %v", r)}
 		}
 	}()
 
 	// Guard against missing agent config (unit tests)
-	if m.cfg.Agent == nil {
+	if run.agent == nil {
 		ch <- agentDoneMsg{err: fmt.Errorf("agent not configured")}
 		return
 	}
 
-	log := m.cfg.Logger
+	log := run.logger
 	detector := &stuckDetector{}
 
 	// Providers like ollama/minimax emit per-token partial events AND a final
@@ -671,7 +700,7 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 	// the provider, where a single request can be re-sent without replaying the
 	// tool calls that already ran.
 	for ev, err := range agent.WithRetry(agent.DefaultRetryConfig(), func() iter.Seq2[*session.Event, error] {
-		return m.cfg.Agent.RunStreaming(ctx, m.cfg.SessionID, prompt)
+		return run.agent.RunStreaming(ctx, run.sessionID, prompt)
 	}) {
 		if err != nil {
 			fail(err)

--- a/internal/tui/agent_loop_e2e_test.go
+++ b/internal/tui/agent_loop_e2e_test.go
@@ -86,7 +86,7 @@ func TestRunAgentLoop_AbortsStuckBashLoop(t *testing.T) {
 		}
 	}()
 
-	go m.runAgentLoop(ctx, "run the analysis script", m.agentCh)
+	go m.runAgentLoop(ctx, "run the analysis script", m.agentCh, m.agentRun())
 
 	select {
 	case <-done:

--- a/internal/tui/agent_loop_error_e2e_test.go
+++ b/internal/tui/agent_loop_error_e2e_test.go
@@ -64,7 +64,7 @@ func TestRunAgentLoop_SurfacesProviderAPIError(t *testing.T) {
 		}
 	}()
 
-	go m.runAgentLoop(ctx, "hello", m.agentCh)
+	go m.runAgentLoop(ctx, "hello", m.agentCh, m.agentRun())
 
 	select {
 	case <-done:

--- a/internal/tui/agent_loop_run_e2e_test.go
+++ b/internal/tui/agent_loop_run_e2e_test.go
@@ -112,7 +112,7 @@ func driveRunLoop(t *testing.T, a *agent.Agent, sid, prompt string) runResult {
 		}
 	}()
 
-	go m.runAgentLoop(context.Background(), prompt, m.agentCh)
+	go m.runAgentLoop(context.Background(), prompt, m.agentCh, m.agentRun())
 
 	select {
 	case <-done:
@@ -136,7 +136,7 @@ func TestRunAgentLoop_AgentNotConfigured(t *testing.T) {
 			}
 		}
 	}()
-	go m.runAgentLoop(context.Background(), "hi", m.agentCh)
+	go m.runAgentLoop(context.Background(), "hi", m.agentCh, m.agentRun())
 	<-done
 
 	if doneErr == nil || !strings.Contains(doneErr.Error(), "not configured") {

--- a/internal/tui/agent_loop_runaway_test.go
+++ b/internal/tui/agent_loop_runaway_test.go
@@ -153,7 +153,7 @@ func TestRunAgentLoop_AbortsRunawayOutput(t *testing.T) {
 		}
 	}()
 
-	go m.runAgentLoop(ctx, "why is the hook message visible", m.agentCh)
+	go m.runAgentLoop(ctx, "why is the hook message visible", m.agentCh, m.agentRun())
 
 	select {
 	case <-done:
@@ -219,7 +219,7 @@ func TestRunAgentLoop_WarnsOnTruncatedTurn(t *testing.T) {
 		}
 	}()
 
-	go m.runAgentLoop(ctx, "write something long", m.agentCh)
+	go m.runAgentLoop(ctx, "write something long", m.agentCh, m.agentRun())
 
 	select {
 	case <-done:

--- a/internal/tui/agent_loop_runaway_units_test.go
+++ b/internal/tui/agent_loop_runaway_units_test.go
@@ -155,7 +155,7 @@ func TestRunAgentLoop_AbortsRunawayReplyText(t *testing.T) {
 		}
 	}()
 
-	go m.runAgentLoop(ctx, "explain the hook", m.agentCh)
+	go m.runAgentLoop(ctx, "explain the hook", m.agentCh, m.agentRun())
 
 	select {
 	case <-done:


### PR DESCRIPTION
runAgentLoop runs on its own goroutine and reached through m.cfg for the
agent, the session ID and the logger while it ran. Update writes m.cfg from
a dozen places on its own goroutine — /model swaps LLM, ModelName,
ProviderName and ActiveRole, /plan replaces SessionID, skill creation
rewrites Skills, init assigns Agent and Logger outright. Two goroutines,
same words, no synchronization.

Nothing structural kept them apart. It held only because handleModelCommand
happens to return early while m.running, which is a property of one command
rather than a rule the code enforces.

The three values are now read once on the Update goroutine, before the loop
starts, and handed over by value. Commit 35c3b25 fixed the sibling case, the
agent channel, exactly this way. Grouping the fields into a sub-struct would
not have helped: the race is about who may read m, not how m is laid out.

Verified with go test -race over the whole package.

Signed-off-by: dimetron <dimetron@me.com>
