### PR TITLE
chore(hooks): version pre-commit hook excluding worktrees

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+# Format code with gofmt and goimports.
+# Exclude worktree directories (.worktrees/, .pi-go/) — they are separate
+# checkouts on their own branches and must not be reformatted by this hook.
+echo "Formatting code..."
+find . -name '*.go' \
+  -not -path './.git/*' \
+  -not -path './.worktrees/*' \
+  -not -path './.pi-go/*' \
+  -exec gofmt -l -s -w {} +
+find . -name '*.go' \
+  -not -path './.git/*' \
+  -not -path './.worktrees/*' \
+  -not -path './.pi-go/*' \
+  -exec goimports -l -w {} +
+
+# Stage any formatting changes
+git add -u
+
+# Run linters
+echo "Running golangci-lint..."
+golangci-lint run ./...


### PR DESCRIPTION
Move the pre-commit hook into .githooks/ so it is tracked, and exclude
.worktrees/ and .pi-go/ from gofmt/goimports. The formatter previously
recursed into every worktree checkout and reformatted files on other
branches; golangci-lint already skips dot-directories via the Go package
loader.

Signed-off-by: dimetron <dimetron@me.com>
