### PR TITLE
feat(tui): show skill activation confirmation card

### DIFF
--- a/internal/tui/create_skill.go
+++ b/internal/tui/create_skill.go
@@ -25,6 +25,15 @@ func (m *model) handleSkillCommand(skill extension.Skill, args []string) (tea.Mo
 	if m.cfg.Logger != nil {
 		m.cfg.Logger.Info(fmt.Sprintf("skill:%s instruction=%d bytes", skill.Name, len(body)))
 	}
+	// Show a visible confirmation that the skill was loaded and activated. The
+	// card renders as "⏺ Skill(disk-check) Successfully loaded skill" so a
+	// slash-activated skill is not invisible in the transcript.
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "tool",
+		tool:    "skill",
+		toolIn:  skill.Name,
+		content: "Successfully loaded skill",
+	})
 	// Send the user's args (without the body) as the user prompt.
 	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "user", content: display})
 	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: ""})

--- a/internal/tui/create_skill_test.go
+++ b/internal/tui/create_skill_test.go
@@ -225,6 +225,25 @@ func TestHandleSkillCommand_UserMessageIsClean(t *testing.T) {
 
 	_, _ = m.handleSkillCommand(skills[0], []string{"simplify", "this"})
 
+	// The skill-activation confirmation card must be present before the user
+	// message: "⏺ Skill(ponytail) Successfully loaded skill".
+	var skillCard *message
+	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
+		if m.chatModel.Messages[i].role == "tool" && m.chatModel.Messages[i].tool == "skill" {
+			skillCard = &m.chatModel.Messages[i]
+			break
+		}
+	}
+	if skillCard == nil {
+		t.Fatal("no skill-activation card appended by handleSkillCommand")
+	}
+	if skillCard.toolIn != "ponytail" {
+		t.Errorf("skill card toolIn = %q, want %q", skillCard.toolIn, "ponytail")
+	}
+	if skillCard.content != "Successfully loaded skill" {
+		t.Errorf("skill card content = %q, want %q", skillCard.content, "Successfully loaded skill")
+	}
+
 	// Find the user message (the last "user" role before any tool events).
 	var userMsg *message
 	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -125,10 +125,36 @@ func (t *ToolDisplayModel) RenderToolMessage(msg message) string {
 	if t.CompactTools {
 		return t.renderCompactTool(msg, dim, p)
 	}
+	if msg.tool == "skill" {
+		return t.renderSkillTool(msg, dim, p)
+	}
 	if msg.tool == "agent" || msg.tool == "subagent" {
 		return t.renderAgentTool(msg, dim, p)
 	}
 	return t.renderRegularTool(msg, dim, p)
+}
+
+// renderSkillTool renders a skill-activation confirmation on a single line:
+// "◉ skill(disk-check) Successfully loaded skill". The card is a notice, not a
+// tool with output, so it never opens a content gutter.
+func (t *ToolDisplayModel) renderSkillTool(msg message, dim lipgloss.Style, p Palette) string {
+	toolStyle := lipgloss.NewStyle().Foreground(p.Tool).Bold(true)
+	toolBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Tool).Bold(true), false)
+
+	var b strings.Builder
+	b.WriteString(toolBullet)
+	b.WriteString(toolStyle.Render(msg.tool))
+	if msg.toolIn != "" {
+		b.WriteString(dim.Render("("))
+		b.WriteString(dim.Render(msg.toolIn))
+		b.WriteString(dim.Render(")"))
+	}
+	if msg.content != "" {
+		b.WriteString(" ")
+		b.WriteString(dim.Render(msg.content))
+	}
+	b.WriteString("\n")
+	return b.String()
 }
 
 // renderCompactTool renders a one-line tally for a tool message.

--- a/internal/tui/tool_display_test.go
+++ b/internal/tui/tool_display_test.go
@@ -124,6 +124,51 @@ func TestRenderCompactTool_NoContent(t *testing.T) {
 	}
 }
 
+// TestRenderSkillTool verifies the skill-activation confirmation card renders
+// as a single line: "◉ skill(disk-check) Successfully loaded skill". It must
+// not open a content gutter like a regular tool card.
+func TestRenderSkillTool(t *testing.T) {
+	td := ToolDisplayModel{Width: 80}
+	msg := message{
+		role:    "tool",
+		tool:    "skill",
+		toolIn:  "disk-check",
+		content: "Successfully loaded skill",
+	}
+	result := td.RenderToolMessage(msg)
+	plain := stripANSI(result)
+	if !strings.Contains(plain, "skill(disk-check)") {
+		t.Errorf("expected skill name in parens, got %q", plain)
+	}
+	if !strings.Contains(plain, "Successfully loaded skill") {
+		t.Errorf("expected success message, got %q", plain)
+	}
+	// Single line, no content gutter.
+	lines := strings.Split(strings.TrimRight(result, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line, got %d: %q", len(lines), result)
+	}
+	if strings.Contains(result, "│") {
+		t.Errorf("skill card must not open a content gutter, got %q", result)
+	}
+}
+
+// TestRenderSkillTool_NoContent renders a skill card with no result text; the
+// header must still show the skill name.
+func TestRenderSkillTool_NoContent(t *testing.T) {
+	td := ToolDisplayModel{Width: 80}
+	msg := message{
+		role:   "tool",
+		tool:   "skill",
+		toolIn: "ponytail",
+	}
+	result := td.RenderToolMessage(msg)
+	plain := stripANSI(result)
+	if !strings.Contains(plain, "skill(ponytail)") {
+		t.Errorf("expected skill name in parens, got %q", plain)
+	}
+}
+
 func TestContentWidth_DefaultWhenZero(t *testing.T) {
 	td := ToolDisplayModel{Width: 0}
 	cw := td.contentWidth()


### PR DESCRIPTION
When a dynamic skill is activated via /<name>, append a tool-style card
rendered as "◉ skill(disk-check) Successfully loaded skill" so the
activation is visible in the transcript instead of being invisible.

Adds a dedicated single-line renderer for the skill tool card and tests
for both the message construction and the renderer.

Signed-off-by: dimetron <dimetron@me.com>
