### PR TITLE
feat(bash): rename bash_output to bash_wait, and stop the poll storm in the TUI

### DIFF
--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -13,7 +13,19 @@ import (
 )
 
 const (
-	defaultBashTimeout = 120 * time.Second
+	// defaultBashTimeout caps how long a command holds the foreground before it
+	// is handed to the supervisor. It is a budget for the *turn*, not for the
+	// command: nothing is killed at the threshold, the command keeps running,
+	// and the caller gets a handle to watch it with.
+	//
+	// Thirty seconds is chosen so the common case stays whole — the vast
+	// majority of commands in this repo (git, go vet, a package test run, a
+	// warm build) finish well inside it — while anything genuinely long stops
+	// blocking a turn for two minutes before it says so. A caller that knows
+	// its command is long should raise `timeout` rather than discover this
+	// limit; the idle check then does the real work, firing well before the
+	// raised hard limit.
+	defaultBashTimeout = 30 * time.Second
 	maxBashTimeout     = 10 * time.Minute
 )
 
@@ -21,8 +33,10 @@ const (
 type BashInput struct {
 	// The shell command to execute.
 	Command string `json:"command"`
-	// Optional timeout in milliseconds. Default: 120000 (2 minutes). Max: 600000 (10 minutes).
-	// On expiry the command is moved to the background, not killed.
+	// Optional timeout in milliseconds. Default: 30000 (30 seconds). Max: 600000 (10 minutes).
+	// On expiry the command is moved to the background, not killed. Raise it for
+	// work you already know is long (a full test suite, an image build) so it
+	// finishes in the foreground instead of costing a round trip.
 	Timeout int `json:"timeout,omitempty"`
 	// Optional idle timeout in milliseconds. A command that produces no output
 	// at all for this long is moved to the background. Default: 90000.
@@ -41,7 +55,7 @@ type BashOutput struct {
 	// Running is true when the command outlived its timeout and is still
 	// executing in the background.
 	Running bool `json:"running,omitempty"`
-	// Handle identifies a still-running command for bash_output and bash_kill.
+	// Handle identifies a still-running command for bash_wait and bash_kill.
 	Handle string `json:"handle,omitempty"`
 	// Elapsed is how long the command has been running in total.
 	Elapsed string `json:"elapsed,omitempty"`
@@ -81,8 +95,8 @@ type BashStatus struct {
 	Note        string `json:"note,omitempty"`
 }
 
-// BashOutputInput asks for output accumulated by a backgrounded command.
-type BashOutputInput struct {
+// BashWaitInput asks for output accumulated by a backgrounded command.
+type BashWaitInput struct {
 	// Handle returned by a previous bash call.
 	Handle string `json:"handle"`
 	// WaitMs blocks up to this long for new output or for the command to exit,
@@ -97,11 +111,11 @@ type BashKillInput struct {
 	Handle string `json:"handle"`
 }
 
-const maxBashOutputWait = 60 * time.Second
+const maxBashWait = 60 * time.Second
 
 const bashDescription = `Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, running tests, building code, git operations, etc.
 
-A command that runs past its timeout, or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Use bash_output to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.`
+A command that runs past its timeout (30s by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.`
 
 func newBashTool(sb *Sandbox, sup *BashSupervisor) (tool.Tool, error) {
 	return newTool("bash", bashDescription, func(ctx agent.Context, input BashInput) (BashOutput, error) {
@@ -169,13 +183,13 @@ func clampDuration(ms int, fallback, maxDur time.Duration) time.Duration {
 // the model when something can actually background a command — a caller that
 // builds its own supervisor and never streams need not carry the extra schema.
 func BashControlTools(sup *BashSupervisor) ([]tool.Tool, error) {
-	outputTool, err := newTool("bash_output",
-		"Read output produced by a backgrounded shell command since the last read. Blocks up to 60 seconds for new output or command exit; use wait_ms to choose a shorter wait. Returns running=false and the exit code once it finishes, after which the handle is spent.",
-		func(_ agent.Context, input BashOutputInput) (BashStatus, error) {
+	waitTool, err := newTool("bash_wait",
+		"Wait on a backgrounded shell command and return whatever it produced since the last wait. Blocks up to 60 seconds for new output or for the command to exit; use wait_ms for a shorter wait. Returns running=false and the exit code once it finishes, after which the handle is spent. Wait once with a generous wait_ms rather than calling this in a loop — each call is a round trip, and an empty result means nothing new since the last one, not that the command is stuck.",
+		func(_ agent.Context, input BashWaitInput) (BashStatus, error) {
 			if input.Handle == "" {
 				return BashStatus{}, fmt.Errorf("handle is required (running: %v)", sup.Handles())
 			}
-			return sup.readOutput(input.Handle, clampDuration(input.WaitMs, maxBashOutputWait, maxBashOutputWait))
+			return sup.readOutput(input.Handle, clampDuration(input.WaitMs, maxBashWait, maxBashWait))
 		})
 	if err != nil {
 		return nil, err
@@ -193,5 +207,5 @@ func BashControlTools(sup *BashSupervisor) ([]tool.Tool, error) {
 		return nil, err
 	}
 
-	return []tool.Tool{outputTool, killTool}, nil
+	return []tool.Tool{waitTool, killTool}, nil
 }

--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -30,7 +30,7 @@ func TestBashControlTools_Registered(t *testing.T) {
 	for _, tool := range ts {
 		names[tool.Name()] = true
 	}
-	for _, want := range []string{"bash_output", "bash_kill"} {
+	for _, want := range []string{"bash_wait", "bash_kill"} {
 		if !names[want] {
 			t.Errorf("missing tool %q; got %v", want, names)
 		}
@@ -79,13 +79,13 @@ func TestBashControlTools_DefaultWaitsForOutput(t *testing.T) {
 	}
 
 	// An omitted wait_ms must use the same blocking-by-default behavior exposed
-	// by bash_output, rather than immediately returning an empty poll result.
-	res, err := runNamedTool(t, ts, "bash_output", map[string]any{"handle": out.Handle})
+	// by bash_wait, rather than immediately returning an empty poll result.
+	res, err := runNamedTool(t, ts, "bash_wait", map[string]any{"handle": out.Handle})
 	if err != nil {
-		t.Fatalf("bash_output: %v", err)
+		t.Fatalf("bash_wait: %v", err)
 	}
 	if !strings.Contains(fmtAny(res["stdout"]), "default-wait") {
-		t.Fatalf("bash_output default wait did not deliver the line: %v", res)
+		t.Fatalf("bash_wait default wait did not deliver the line: %v", res)
 	}
 	if running, _ := res["running"].(bool); !running {
 		t.Errorf("command should still be running, got %v", res)
@@ -113,15 +113,15 @@ func TestBashControlTools_RoundTrip(t *testing.T) {
 	}
 
 	// wait_ms means one call, not a polling loop — the whole reason it exists.
-	res, err := runNamedTool(t, ts, "bash_output", map[string]any{
+	res, err := runNamedTool(t, ts, "bash_wait", map[string]any{
 		"handle":  out.Handle,
 		"wait_ms": 3000,
 	})
 	if err != nil {
-		t.Fatalf("bash_output: %v", err)
+		t.Fatalf("bash_wait: %v", err)
 	}
 	if !strings.Contains(fmtAny(res["stdout"]), "hello") {
-		t.Fatalf("bash_output did not deliver the line: %v", res)
+		t.Fatalf("bash_wait did not deliver the line: %v", res)
 	}
 	if running, _ := res["running"].(bool); !running {
 		t.Errorf("command should still be running, got %v", res)
@@ -139,7 +139,7 @@ func TestBashControlTools_RoundTrip(t *testing.T) {
 	}
 
 	// A spent handle must not resolve again.
-	if _, err := runNamedTool(t, ts, "bash_output", map[string]any{"handle": out.Handle}); err == nil {
+	if _, err := runNamedTool(t, ts, "bash_wait", map[string]any{"handle": out.Handle}); err == nil {
 		t.Error("expected an error reading a killed handle")
 	}
 }
@@ -200,7 +200,7 @@ func TestBashControlTools_RejectMissingHandle(t *testing.T) {
 		t.Fatalf("BashControlTools: %v", err)
 	}
 
-	for _, name := range []string{"bash_output", "bash_kill"} {
+	for _, name := range []string{"bash_wait", "bash_kill"} {
 		if _, err := runNamedTool(t, ts, name, map[string]any{}); err == nil {
 			t.Errorf("%s accepted a call with no handle", name)
 		}
@@ -461,5 +461,23 @@ func TestSupervisorDefaults(t *testing.T) {
 	}
 	if got := s.capacity(); got != maxBackgroundProcs {
 		t.Errorf("capacity() = %d, want %d", got, maxBackgroundProcs)
+	}
+}
+
+// The foreground budget is a turn budget, not a command budget: a command that
+// crosses it is handed off with a handle, never killed. Thirty seconds is short
+// enough that the pin matters — a silent bump back to two minutes would put the
+// old round-trip cost back without failing anything else.
+func TestBashDefaultTimeout_IsTheForegroundBudget(t *testing.T) {
+	if defaultBashTimeout != 30*time.Second {
+		t.Errorf("defaultBashTimeout = %s, want 30s", defaultBashTimeout)
+	}
+	// The idle check only earns its keep while it can fire before the hard
+	// limit, which under defaults it cannot — it exists for callers that raise
+	// the timeout for known-long work.
+	if defaultIdleTimeout <= defaultBashTimeout {
+		t.Errorf("defaultIdleTimeout %s must stay above the foreground budget %s;"+
+			" below it the hard limit fires first and the idle check is dead code",
+			defaultIdleTimeout, defaultBashTimeout)
 	}
 }

--- a/internal/tools/bash_stream_test.go
+++ b/internal/tools/bash_stream_test.go
@@ -66,7 +66,7 @@ func TestStream_LenCountsEverythingEverWritten(t *testing.T) {
 	}
 }
 
-// TestStream_WaitWakesOnWrite covers the blocking read used by bash_output, and
+// TestStream_WaitWakesOnWrite covers the blocking read used by bash_wait, and
 // specifically the check-then-wait ordering: a waiter that took the channel
 // before a write must still be woken by it.
 func TestStream_WaitWakesOnWrite(t *testing.T) {

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -379,7 +379,7 @@ func (s *BashSupervisor) background(p *bashProc, reason string) BashOutput {
 
 	note := fmt.Sprintf(
 		"Command %s and was moved to the background; it is still running. "+
-			"Read more with bash_output(handle=%q) or stop it with bash_kill(handle=%q). "+
+			"Read more with bash_wait(handle=%q) or stop it with bash_kill(handle=%q). "+
 			"Output above is everything produced so far.",
 		reason, p.id, p.id)
 	if strings.TrimSpace(stdout) == "" && strings.TrimSpace(stderr) == "" {

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -25,7 +25,7 @@ const (
 	// maxRepeatToolCalls is the number of identical consecutive tool calls
 	// before the loop is considered stuck and aborted. A repeated call whose
 	// result changes resets the count (see observeResult): polling tools like
-	// bash_output repeat identical args by design, and only identical results
+	// bash_wait repeat identical args by design, and only identical results
 	// make the repetition meaningless.
 	maxRepeatToolCalls = 10
 
@@ -200,7 +200,7 @@ func (s *stuckDetector) observe(name string, args map[string]any) (stuck bool, d
 }
 
 // observeResult records a tool call's response. Polling tools repeat identical
-// calls by design — bash_output on a running command sends the same handle
+// calls by design — bash_wait on a running command sends the same handle
 // every time and gets fresh output back — so a response that differs from the
 // streak's previous response is progress, and resets the identical-call
 // streak. A response identical to the last one keeps the streak counting:
@@ -211,11 +211,11 @@ func (s *stuckDetector) observeResult(name string, response map[string]any) {
 	if name != s.lastName {
 		return
 	}
-	// bash_output includes elapsed/idle fields that change on every poll even
+	// bash_wait includes elapsed/idle fields that change on every poll even
 	// when the command produced no new output. Those fields are progress for the
 	// UI, not progress from the command, so exclude them from loop detection.
 	stable := response
-	if name == "bash_output" {
+	if isBashPoll(name) {
 		stable = make(map[string]any, len(response))
 		for key, value := range response {
 			if key != "elapsed" && key != "idle" {
@@ -916,11 +916,26 @@ func (m *model) handleAgentToolCall(msg agentToolCallMsg) (tea.Model, tea.Cmd) {
 		detail:  string(argsJSON),
 	})
 	toolIn := toolCallSummary(msg.name, msg.args)
-	if msg.name == "bash_output" || msg.name == "bash_kill" {
+	handle, _ := msg.args["handle"].(string)
+	if isBashControl(msg.name) {
 		toolIn = m.bashControlToolIn(msg.name, msg.args, toolIn)
+	}
+	if isBashPoll(msg.name) {
+		if i := findPollCard(m.chatModel.Messages, handle); i >= 0 {
+			card := &m.chatModel.Messages[i]
+			card.toolID = msg.id
+			card.pollCount++
+			card.pendingRefresh = true
+			return m, waitForAgent(m.agentCh)
+		}
 	}
 	newMsg := message{
 		role: "tool", tool: msg.name, toolIn: toolIn, toolID: msg.id,
+		// The handle identifies the command this card polls, so the next poll of
+		// the same handle can find and refresh this card instead of adding one.
+		// Only bash cards use agentID for live-event routing (handleBashEvent
+		// filters on tool=="bash"), so reusing the field here cannot cross wires.
+		agentID: handle, pollCount: 1,
 	}
 	if msg.name == "agent" || msg.name == "subagent" {
 		// A single subagent tool call in parallel/chain mode spawns N children.
@@ -1063,19 +1078,52 @@ func (m *model) handleAgentToolResult(msg agentToolResultMsg) (tea.Model, tea.Cm
 	}
 	if i := matchToolResultCard(m.chatModel.Messages, msg.id, msg.name); i >= 0 {
 		m.chatModel.Messages[i].content = content
+		m.chatModel.Messages[i].pendingRefresh = false
 		// Bind the card to its background handle when the bash result carries
 		// one. The bash:start event that normally stamps agentID travels on a
 		// separate channel and can arrive before the card exists, dropping the
 		// binding; the result is the reliable place to recover it so a later
-		// bash_output/bash_kill card can still find the command.
+		// bash_wait/bash_kill card can still find the command.
 		if msg.name == "bash" {
 			if handle := bashHandleFromResult(msg.content); handle != "" {
 				m.chatModel.Messages[i].agentID = handle
 			}
 		}
+		// A poll names its command in its own result, so a card that had to
+		// settle for a bare handle at call time can say what it is polling as
+		// soon as the answer lands. bashControlToolIn can only find the command
+		// when the bash card that started it is still in this transcript; after a
+		// /resume, a compaction, or a lost bash:start binding it is not, and the
+		// header read "bash_wait(bg_4)" for the rest of the command's life.
+		if isBashControl(msg.name) {
+			if header := bashControlHeaderFromResult(msg.content); header != "" {
+				m.chatModel.Messages[i].toolIn = header
+			}
+		}
 	}
 	m.refreshDiffStats()
 	return m, waitForAgent(m.agentCh)
+}
+
+// bashControlHeaderFromResult builds the "handle: command" header for a
+// bash_wait/bash_kill card out of the poll's own result, which carries both
+// (BashStatus.Command). Returns "" when either is missing, so the header the
+// card already has survives.
+//
+// The command is collapsed to one line: a header is one line by construction,
+// and a backgrounded heredoc or a multi-line pipeline would otherwise write its
+// newlines straight into the card and knock the rail out of its column.
+func bashControlHeaderFromResult(content string) string {
+	var data map[string]any
+	if json.Unmarshal([]byte(content), &data) != nil {
+		return ""
+	}
+	handle, _ := data["handle"].(string)
+	command, _ := data["command"].(string)
+	if handle == "" || command == "" {
+		return ""
+	}
+	return handle + ": " + collapseToSingleLine(command)
 }
 
 // bashHandleFromResult extracts the background handle from a raw bash tool
@@ -1087,6 +1135,28 @@ func bashHandleFromResult(content string) string {
 	}
 	h, _ := data["handle"].(string)
 	return h
+}
+
+// findPollCard returns the index of the card a repeated bash_wait poll should
+// refresh in place, or -1 when the poll deserves a card of its own.
+//
+// The rule is deliberately narrow: only the newest card in the transcript
+// qualifies, and only when it polls the same handle. Folding into an older card
+// would move fresh output above whatever the model did in between — a card that
+// jumps up the scrollback is worse than a duplicate one — and folding across
+// handles would merge two commands' windows. Anything the model says or does
+// between two polls therefore starts a new card, which is right: that text is
+// what makes the second poll a separate beat rather than a repeat.
+func findPollCard(messages []message, handle string) int {
+	if handle == "" || len(messages) == 0 {
+		return -1
+	}
+	i := len(messages) - 1
+	last := messages[i]
+	if last.role != "tool" || !isBashPoll(last.tool) || last.agentID != handle {
+		return -1
+	}
+	return i
 }
 
 // matchToolResultCard finds the chat card an arriving tool result belongs to,
@@ -1113,7 +1183,12 @@ func matchToolResultCard(messages []message, id, name string) int {
 			if messages[i].role != "tool" || messages[i].toolID != id {
 				continue
 			}
-			if messages[i].content == "" {
+			// pendingRefresh: a repeated poll folded into this card and its
+			// result is the one arriving now. The card still shows the previous
+			// poll's window — that is the point, it keeps the card from blanking
+			// while the poll runs — so the non-empty content must not read as
+			// "already answered" here.
+			if messages[i].content == "" || messages[i].pendingRefresh {
 				return i
 			}
 			// The card for this call already has its result: a duplicate
@@ -1149,13 +1224,13 @@ const bashEventPrefix = "bash:"
 // grow this without bound behind a window that shows five lines.
 const maxLiveBashEvents = 64
 
-// bashControlToolIn builds the header text for a bash_output/bash_kill card.
+// bashControlToolIn builds the header text for a bash_wait/bash_kill card.
 //
 // A poll's args carry only a handle, which on its own says nothing about what
 // is being polled. The original command lives on the bash card the supervisor
 // bound to this handle (handleBashEvent stamps it into agentID), so the header
-// folds that command in: "bash_output(bg_1): sleep 10 && echo done" reads far
-// better than a bare "bash_output". Falls back to the handle alone when no card
+// folds that command in: "bash_wait(bg_1): sleep 10 && echo done" reads far
+// better than a bare "bash_wait". Falls back to the handle alone when no card
 // is bound — the supervisor may have forgotten the command, or the transcript
 // was restored without one.
 func (m *model) bashControlToolIn(name string, args map[string]any, fallback string) string {

--- a/internal/tui/agent_loop_stuck_test.go
+++ b/internal/tui/agent_loop_stuck_test.go
@@ -108,7 +108,7 @@ func TestStuckDetector_Observe_StreakThreshold(t *testing.T) {
 }
 
 // TestStuckDetector_ObserveResult_PollingNotStuck reproduces session
-// 260808-1813: bash_output polled a running background command with identical
+// 260808-1813: bash_wait polled a running background command with identical
 // args, but every response carried fresh progress (elapsed, streamed output).
 // Changing results must reset the identical-call streak so productive polling
 // outlives maxRepeatToolCalls.
@@ -116,11 +116,11 @@ func TestStuckDetector_ObserveResult_PollingNotStuck(t *testing.T) {
 	s := &stuckDetector{}
 	args := map[string]any{"handle": "bg_16", "wait_ms": 1000}
 	for i := 0; i < maxRepeatToolCalls*3; i++ {
-		stuck, detail := s.observe("bash_output", args)
+		stuck, detail := s.observe("bash_wait", args)
 		if stuck {
 			t.Fatalf("poll %d flagged stuck: %s", i, detail)
 		}
-		s.observeResult("bash_output", map[string]any{
+		s.observeResult("bash_wait", map[string]any{
 			"handle":  "bg_16",
 			"elapsed": i,
 			"stdout":  fmt.Sprintf("line %d\n", i), // command progress: every response differs
@@ -133,11 +133,11 @@ func TestStuckDetector_ObserveResult_ChangingTimingDoesNotReset(t *testing.T) {
 	s := &stuckDetector{}
 	args := map[string]any{"handle": "bg_16"}
 	for i := 0; i < maxRepeatToolCalls; i++ {
-		stuck, _ := s.observe("bash_output", args)
+		stuck, _ := s.observe("bash_wait", args)
 		if i == maxRepeatToolCalls-1 && !stuck {
 			t.Fatalf("timing-only polls should trip after %d repeats", maxRepeatToolCalls)
 		}
-		s.observeResult("bash_output", map[string]any{
+		s.observeResult("bash_wait", map[string]any{
 			"handle":  "bg_16",
 			"elapsed": i,
 			"idle":    i + 1,
@@ -154,9 +154,9 @@ func TestStuckDetector_ObserveResult_IdenticalResultsStillStuck(t *testing.T) {
 	resp := map[string]any{"running": false, "stdout": "done"}
 	tripped := false
 	for i := 0; i < maxRepeatToolCalls; i++ {
-		stuck, _ := s.observe("bash_output", args)
+		stuck, _ := s.observe("bash_wait", args)
 		tripped = tripped || stuck
-		s.observeResult("bash_output", resp)
+		s.observeResult("bash_wait", resp)
 	}
 	if !tripped {
 		t.Errorf("identical calls with identical results should still trip after %d repeats", maxRepeatToolCalls)

--- a/internal/tui/bash_poll_fold_test.go
+++ b/internal/tui/bash_poll_fold_test.go
@@ -1,0 +1,368 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// pollResult builds the JSON a bash_wait poll of a still-running command
+// returns, so a test drives the same content the supervisor sends.
+func pollResult(handle, stdout, elapsed, idle string) string {
+	return fmt.Sprintf(
+		`{"handle":%q,"command":"cd wiki && make daily-all","running":true,"stdout":%q,`+
+			`"elapsed":%q,"idle":%q,"timeout":"3.6s","idle_timeout":"1s"}`,
+		handle, stdout, elapsed, idle,
+	)
+}
+
+// poll drives one full call/result round trip for a bash_wait poll.
+func poll(m *model, id, handle, stdout, elapsed, idle string) {
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: id, name: "bash_wait", args: map[string]any{"handle": handle},
+	})
+	m.handleAgentToolResult(agentToolResultMsg{
+		id: id, name: "bash_wait", content: pollResult(handle, stdout, elapsed, idle),
+	})
+}
+
+// A command that goes quiet is polled every few seconds, and every poll used to
+// append its own card — the transcript filled with a dozen near-identical
+// "◉ bash_wait(bg_4: make daily-all)" blocks whose only difference was the
+// elapsed counter, pushing everything the user cared about off the screen.
+// Repeat polls of the same handle refresh one card in place instead.
+func TestBashPoll_RepeatedPollsRefreshOneCard(t *testing.T) {
+	m := newHandlerModel()
+
+	poll(m, "call_1", "bg_4", "", "27.1s", "7.7s")
+	poll(m, "call_2", "bg_4", "", "29.5s", "10.2s")
+	poll(m, "call_3", "bg_4", "compiling", "32.1s", "0.1s")
+
+	if got := len(m.chatModel.Messages); got != 1 {
+		t.Fatalf("3 polls of one handle produced %d cards, want 1", got)
+	}
+	card := m.chatModel.Messages[0]
+	if card.pollCount != 3 {
+		t.Errorf("pollCount = %d, want 3", card.pollCount)
+	}
+	if card.toolID != "call_3" {
+		t.Errorf("card toolID = %q, want the newest call call_3", card.toolID)
+	}
+	if !strings.Contains(card.content, "compiling") || !strings.Contains(card.content, "32.1s elapsed") {
+		t.Errorf("card does not show the newest poll: %q", card.content)
+	}
+	if card.pendingRefresh {
+		t.Error("pendingRefresh still set after the result arrived")
+	}
+}
+
+// The window from the previous poll has to stay on screen while the next poll
+// runs. Blanking the card for the seconds a poll takes would make a live
+// command look like a card that lost its output.
+func TestBashPoll_KeepsPreviousWindowWhileRefreshing(t *testing.T) {
+	m := newHandlerModel()
+	poll(m, "call_1", "bg_4", "building", "5s", "1s")
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_2", name: "bash_wait", args: map[string]any{"handle": "bg_4"},
+	})
+
+	card := m.chatModel.Messages[0]
+	if !strings.Contains(card.content, "building") {
+		t.Errorf("previous window lost while the next poll is in flight: %q", card.content)
+	}
+	if !card.pendingRefresh {
+		t.Error("refreshing card not marked pendingRefresh")
+	}
+	if !card.toolPending() {
+		t.Error("refreshing card must count as pending so its bullet keeps blinking")
+	}
+}
+
+// Folding only ever touches the newest card. A poll that follows something the
+// model said is a separate beat in the transcript, and pulling its output up
+// into an older card would reorder the scrollback under the reader.
+func TestBashPoll_TextBetweenPollsStartsANewCard(t *testing.T) {
+	m := newHandlerModel()
+	poll(m, "call_1", "bg_4", "", "5s", "5s")
+
+	m.handleAgentText(agentTextMsg{text: "still waiting on the build"})
+	poll(m, "call_2", "bg_4", "", "10s", "10s")
+
+	if got := len(m.chatModel.Messages); got != 3 {
+		t.Fatalf("got %d messages, want poll + text + poll", got)
+	}
+	if m.chatModel.Messages[2].tool != "bash_wait" || m.chatModel.Messages[2].pollCount != 1 {
+		t.Errorf("poll after text did not get its own fresh card: %+v", m.chatModel.Messages[2])
+	}
+}
+
+// Two backgrounded commands polled in the same turn must keep separate cards:
+// merging them would show one command's output under the other's header.
+func TestBashPoll_DifferentHandlesKeepSeparateCards(t *testing.T) {
+	m := newHandlerModel()
+
+	poll(m, "call_1", "bg_1", "build line", "5s", "1s")
+	poll(m, "call_2", "bg_2", "test line", "5s", "1s")
+	poll(m, "call_3", "bg_1", "build line 2", "9s", "1s")
+
+	if got := len(m.chatModel.Messages); got != 3 {
+		t.Fatalf("got %d cards, want one per poll (no handle may fold into another)", got)
+	}
+	if !strings.Contains(m.chatModel.Messages[1].content, "test line") {
+		t.Errorf("bg_2 card content = %q", m.chatModel.Messages[1].content)
+	}
+	if !strings.Contains(m.chatModel.Messages[2].content, "build line 2") {
+		t.Errorf("second bg_1 poll card content = %q", m.chatModel.Messages[2].content)
+	}
+}
+
+// The parallel case, with both calls issued before either result lands: the
+// results must still reach their own cards. A folded card carries a fresh
+// toolID, so this is the guard that folding did not break ID matching.
+func TestBashPoll_ParallelPollsNotTransposed(t *testing.T) {
+	m := newHandlerModel()
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_1", name: "bash_wait", args: map[string]any{"handle": "bg_1"},
+	})
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_2", name: "bash_wait", args: map[string]any{"handle": "bg_2"},
+	})
+	m.handleAgentToolResult(agentToolResultMsg{
+		id: "call_2", name: "bash_wait", content: pollResult("bg_2", "test line", "5s", "1s"),
+	})
+	m.handleAgentToolResult(agentToolResultMsg{
+		id: "call_1", name: "bash_wait", content: pollResult("bg_1", "build line", "5s", "1s"),
+	})
+
+	if !strings.Contains(m.chatModel.Messages[0].content, "build line") {
+		t.Errorf("bg_1 card got %q, want the build output", m.chatModel.Messages[0].content)
+	}
+	if !strings.Contains(m.chatModel.Messages[1].content, "test line") {
+		t.Errorf("bg_2 card got %q, want the test output", m.chatModel.Messages[1].content)
+	}
+}
+
+// bash_kill ends a command, so it is never a repeat of anything and always
+// deserves its own card — the poll before it and the kill are different events.
+func TestBashPoll_KillIsNotFoldedIntoAPoll(t *testing.T) {
+	m := newHandlerModel()
+	poll(m, "call_1", "bg_4", "", "5s", "5s")
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_2", name: "bash_kill", args: map[string]any{"handle": "bg_4"},
+	})
+
+	if got := len(m.chatModel.Messages); got != 2 {
+		t.Fatalf("got %d cards, want the poll and the kill to stay separate", got)
+	}
+	if m.chatModel.Messages[1].tool != "bash_kill" {
+		t.Errorf("second card = %q, want bash_kill", m.chatModel.Messages[1].tool)
+	}
+}
+
+// Folding is bash_wait-only. Repeated subagent calls each spawn a real child
+// with its own event stream, so every call keeps its own card — collapsing them
+// would hide one agent's work behind another's.
+func TestBashPoll_SubagentCardsAreNeverFolded(t *testing.T) {
+	m := newHandlerModel()
+
+	for i, id := range []string{"call_1", "call_2"} {
+		m.handleAgentToolCall(agentToolCallMsg{
+			id: id, name: "agent",
+			args: map[string]any{"type": "explore", "prompt": fmt.Sprintf("search %d", i)},
+		})
+	}
+
+	if got := len(m.chatModel.Messages); got != 2 {
+		t.Fatalf("got %d subagent cards, want one per call", got)
+	}
+}
+
+// A parallel subagent call fans out into one card per child; each card must
+// stay independent so the two agents' streams never share a window.
+func TestSubagentCards_ParallelFanOutKeepsOneCardPerChild(t *testing.T) {
+	m := newHandlerModel()
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_1", name: "agent",
+		args: map[string]any{"tasks": []any{
+			map[string]any{"agent": "claude", "task": "review the diff"},
+			map[string]any{"agent": "explore", "task": "map the package"},
+		}},
+	})
+
+	if got := len(m.chatModel.Messages); got != 2 {
+		t.Fatalf("parallel call produced %d cards, want one per child", got)
+	}
+	if got := m.chatModel.Messages[0].agentType; got != "claude" {
+		t.Errorf("first card agentType = %q, want claude", got)
+	}
+	if got := m.chatModel.Messages[1].agentType; got != "explore" {
+		t.Errorf("second card agentType = %q, want explore", got)
+	}
+}
+
+// A `bash` card names its command; a poll of that command should too. It used
+// to manage that only by finding the bash card that started the handle, so a
+// poll in a restored session — or after the bash:start binding was lost — read
+// "bash_wait(bg_4)" and never said what was running. The poll result carries
+// the command (BashStatus.Command), which is the source that always exists.
+func TestBashPoll_HeaderNamesCommandFromTheResult(t *testing.T) {
+	m := newHandlerModel() // no bash card in the transcript to cross-reference
+
+	poll(m, "call_1", "bg_4", "", "27.1s", "7.7s")
+
+	if got, want := m.chatModel.Messages[0].toolIn, "bg_4: cd wiki && make daily-all"; got != want {
+		t.Errorf("poll card header = %q, want %q", got, want)
+	}
+}
+
+// bash_kill recovers the command the same way, so the card that reports a
+// command's death says which command died.
+func TestBashKill_HeaderNamesCommandFromTheResult(t *testing.T) {
+	m := newHandlerModel()
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_1", name: "bash_kill", args: map[string]any{"handle": "bg_4"},
+	})
+	m.handleAgentToolResult(agentToolResultMsg{
+		id: "call_1", name: "bash_kill",
+		content: `{"handle":"bg_4","command":"make daily-all","running":false,"exit_code":-1,"stdout":""}`,
+	})
+
+	if got, want := m.chatModel.Messages[0].toolIn, "bg_4: make daily-all"; got != want {
+		t.Errorf("kill card header = %q, want %q", got, want)
+	}
+}
+
+// A header is one line by construction. A backgrounded heredoc or multi-line
+// pipeline must be collapsed, or its newlines write straight into the card and
+// knock the rail out of its column.
+func TestBashPoll_HeaderCollapsesMultiLineCommand(t *testing.T) {
+	m := newHandlerModel()
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_1", name: "bash_wait", args: map[string]any{"handle": "bg_1"},
+	})
+	m.handleAgentToolResult(agentToolResultMsg{
+		id: "call_1", name: "bash_wait",
+		content: `{"handle":"bg_1","command":"cat <<EOF\n  line one\n  line two\nEOF","running":true,"stdout":""}`,
+	})
+
+	got := m.chatModel.Messages[0].toolIn
+	if strings.ContainsAny(got, "\n\t") {
+		t.Errorf("header carries raw newlines: %q", got)
+	}
+	if want := "bg_1: cat <<EOF line one line two EOF"; got != want {
+		t.Errorf("header = %q, want %q", got, want)
+	}
+}
+
+// A result that names no command must leave the header the call built — an
+// older supervisor, or a transcript replayed from a session written before
+// BashStatus carried the command, should not blank the handle out.
+func TestBashPoll_HeaderKeptWhenResultNamesNoCommand(t *testing.T) {
+	m := newHandlerModel()
+	m.chatModel.Messages = []message{
+		{role: "tool", tool: "bash", toolIn: "sleep 10", agentID: "bg_1"},
+	}
+
+	m.handleAgentToolCall(agentToolCallMsg{
+		id: "call_1", name: "bash_wait", args: map[string]any{"handle": "bg_1"},
+	})
+	m.handleAgentToolResult(agentToolResultMsg{
+		id: "call_1", name: "bash_wait", content: `{"handle":"bg_1","running":true,"stdout":""}`,
+	})
+
+	if got, want := m.chatModel.Messages[1].toolIn, "bg_1: sleep 10"; got != want {
+		t.Errorf("header = %q, want the one built at call time %q", got, want)
+	}
+}
+
+// The tally is the only trace the folded-away polls leave. Without it a card
+// showing "32.1s elapsed" looks like a single slow poll rather than the tenth
+// check on a command the agent has been watching for half a minute.
+func TestRenderRegularTool_ShowsPollTally(t *testing.T) {
+	td := &ToolDisplayModel{Width: 100, BlinkOn: true}
+	card := message{
+		role: "tool", tool: "bash_wait", toolIn: "bg_4: make daily-all",
+		content: "⏳ 32.1s elapsed", pollCount: 7,
+	}
+
+	got := lipgloss.NewStyle().Render(td.RenderToolMessage(card))
+
+	if !strings.Contains(got, "×7") {
+		t.Errorf("expected the ×7 poll tally in %q", got)
+	}
+	td.CompactTools = true
+	if got := td.RenderToolMessage(card); !strings.Contains(got, "×7") {
+		t.Errorf("expected the ×7 poll tally in the compact card %q", got)
+	}
+}
+
+// A card called once must not carry a tally — "×1" on every tool card would be
+// noise on the common case.
+func TestRenderRegularTool_NoTallyForASingleCall(t *testing.T) {
+	td := &ToolDisplayModel{Width: 100, BlinkOn: true}
+	card := message{role: "tool", tool: "bash", toolIn: "make build", content: "ok", pollCount: 1}
+
+	if got := td.RenderToolMessage(card); strings.Contains(got, "×") {
+		t.Errorf("single-call card carries a tally: %q", got)
+	}
+}
+
+// The render cache keys on the message's fields, so a fold that changes only
+// the counter or the pending flag must still produce a different key —
+// otherwise the refreshed card would redraw from the previous poll's cache.
+func TestRenderKey_ChangesWhenAPollFoldsIn(t *testing.T) {
+	base := message{role: "tool", tool: "bash_wait", toolIn: "bg_4: make daily-all", content: "⏳ 5s"}
+	key := func(m message) uint64 { return m.renderKey(100, false, false, false, 0, false) }
+
+	folded := base
+	folded.pollCount = 2
+	if key(base) == key(folded) {
+		t.Error("a bumped poll count did not change the render key")
+	}
+
+	refreshing := base
+	refreshing.pendingRefresh = true
+	if key(base) == key(refreshing) {
+		t.Error("pendingRefresh did not change the render key")
+	}
+}
+
+// A session restored from before the rename replays the old tool name in its
+// events. The display still has to recognize it as a poll — header, window
+// formatter and fold all key off the name — or an old transcript degrades into
+// bare unknown-tool cards with no command and no window. Same reason the
+// display answers to both "grep" and "ripgrep".
+func TestBashPoll_LegacyNameIsStillRecognized(t *testing.T) {
+	m := newHandlerModel()
+
+	for _, id := range []string{"call_1", "call_2"} {
+		m.handleAgentToolCall(agentToolCallMsg{
+			id: id, name: "bash_output", args: map[string]any{"handle": "bg_4"},
+		})
+		m.handleAgentToolResult(agentToolResultMsg{
+			id: id, name: "bash_output", content: pollResult("bg_4", "", "5s", "5s"),
+		})
+	}
+
+	if got := len(m.chatModel.Messages); got != 1 {
+		t.Fatalf("legacy-named polls produced %d cards, want them folded into 1", got)
+	}
+	card := m.chatModel.Messages[0]
+	if card.pollCount != 2 {
+		t.Errorf("pollCount = %d, want 2", card.pollCount)
+	}
+	if want := "bg_4: cd wiki && make daily-all"; card.toolIn != want {
+		t.Errorf("legacy card header = %q, want %q", card.toolIn, want)
+	}
+	if got := toolCallSummary("bash_output", map[string]any{"handle": "bg_1"}); got != "bg_1" {
+		t.Errorf("legacy toolCallSummary = %q, want bg_1", got)
+	}
+}

--- a/internal/tui/bash_stream_test.go
+++ b/internal/tui/bash_stream_test.go
@@ -78,12 +78,12 @@ func TestHandleBashEvent_CapsRetainedEvents(t *testing.T) {
 }
 
 // TestToolCallSummary_BashControl shows the handle in the card header of a
-// bash_output/bash_kill poll. Without a case for these tools the header fell
-// through to the empty summary and rendered as a bare "◉ bash_output" with no
+// bash_wait/bash_kill poll. Without a case for these tools the header fell
+// through to the empty summary and rendered as a bare "◉ bash_wait" with no
 // clue which command was being polled.
 func TestToolCallSummary_BashControl(t *testing.T) {
-	if got := toolCallSummary("bash_output", map[string]any{"handle": "bg_1"}); got != "bg_1" {
-		t.Errorf("bash_output summary = %q, want bg_1", got)
+	if got := toolCallSummary("bash_wait", map[string]any{"handle": "bg_1"}); got != "bg_1" {
+		t.Errorf("bash_wait summary = %q, want bg_1", got)
 	}
 	if got := toolCallSummary("bash_kill", map[string]any{"handle": "bg_2"}); got != "bg_2" {
 		t.Errorf("bash_kill summary = %q, want bg_2", got)
@@ -93,8 +93,8 @@ func TestToolCallSummary_BashControl(t *testing.T) {
 // TestHandleAgentToolCall_BashControlHeaderFoldsCommand verifies that a poll of
 // a backgrounded command names the command in its card header. The bash card
 // bound to the handle carries the command (handleBashEvent stamps agentID), and
-// the poll card should read "bash_output(bg_1: sleep 10 ...)" rather than a
-// bare "◉ bash_output".
+// the poll card should read "bash_wait(bg_1: sleep 10 ...)" rather than a
+// bare "◉ bash_wait".
 func TestHandleAgentToolCall_BashControlHeaderFoldsCommand(t *testing.T) {
 	m := newHandlerModel()
 	m.chatModel.Messages = []message{
@@ -102,12 +102,12 @@ func TestHandleAgentToolCall_BashControlHeaderFoldsCommand(t *testing.T) {
 	}
 
 	m.handleAgentToolCall(agentToolCallMsg{
-		id: "call_poll", name: "bash_output", args: map[string]any{"handle": "bg_1"},
+		id: "call_poll", name: "bash_wait", args: map[string]any{"handle": "bg_1"},
 	})
 
 	last := m.chatModel.Messages[len(m.chatModel.Messages)-1]
 	if want := `bg_1: sleep 10 && echo "done"`; last.toolIn != want {
-		t.Errorf("bash_output card toolIn = %q, want %q", last.toolIn, want)
+		t.Errorf("bash_wait card toolIn = %q, want %q", last.toolIn, want)
 	}
 }
 
@@ -131,7 +131,7 @@ func TestHandleAgentToolCall_BashControlHeaderFallsBackToHandle(t *testing.T) {
 // for a lost bash:start binding: when the start event arrives before the card
 // exists (separate buffered channel), the card never gets its agentID stamped.
 // The bash result carries the handle, so it is the reliable place to bind —
-// a later bash_output/bash_kill card then still finds the command.
+// a later bash_wait/bash_kill card then still finds the command.
 func TestHandleAgentToolResult_BindsBashHandleFromResult(t *testing.T) {
 	m := newHandlerModel()
 	m.chatModel.Messages = []message{

--- a/internal/tui/bash_window_test.go
+++ b/internal/tui/bash_window_test.go
@@ -76,7 +76,10 @@ func TestFormatToolResult_PollOfRunningCommandIsReadable(t *testing.T) {
 
 	got := formatToolResult(data)
 
-	if strings.Contains(got, `&`) || strings.HasPrefix(got, "{") {
+	// The tell for the raw-JSON fallback is Go's `\u0026` escaping of &, not a
+	// bare ampersand: the window now prints the command, and shell commands are
+	// full of legitimate &&.
+	if strings.Contains(got, `\u0026`) || strings.HasPrefix(got, "{") {
 		t.Errorf("poll rendered as raw JSON: %q", got)
 	}
 	if !strings.Contains(got, "no new output") {
@@ -84,6 +87,42 @@ func TestFormatToolResult_PollOfRunningCommandIsReadable(t *testing.T) {
 	}
 	if !strings.Contains(got, "1m30s elapsed") {
 		t.Errorf("expected elapsed time in %q", got)
+	}
+	// The command being watched belongs in the box, not only in the card header,
+	// which truncates to the terminal's arg width.
+	if !strings.Contains(got, "$ make lint && make vet") {
+		t.Errorf("expected the watched command in the window, got %q", got)
+	}
+}
+
+// The bash tool's own handoff result carries no command field — only a poll's
+// BashStatus does — and that card needs none, since its header is the command.
+// A "$ " line with nothing after it would be worse than no line.
+func TestFormatBashWindow_NoCommandLineWhenResultNamesNoCommand(t *testing.T) {
+	got := formatToolResult(map[string]any{
+		"handle": "bg_1", "running": true, "stdout": "compiling\n",
+		"elapsed": "5s", "idle": "1s",
+	})
+
+	if strings.Contains(got, "$ ") {
+		t.Errorf("empty command line rendered: %q", got)
+	}
+	if !strings.Contains(got, "compiling") {
+		t.Errorf("expected the output in %q", got)
+	}
+}
+
+// A backgrounded heredoc or multi-line pipeline must be collapsed before it
+// reaches the box: raw newlines there break out of the "  │ " gutter and knock
+// the rail out of its column.
+func TestFormatBashWindow_CollapsesMultiLineCommand(t *testing.T) {
+	got := formatToolResult(map[string]any{
+		"handle": "bg_1", "command": "cat <<EOF\n  one\n  two\nEOF",
+		"running": true, "stdout": "", "elapsed": "5s",
+	})
+
+	if !strings.Contains(got, "$ cat <<EOF one two EOF") {
+		t.Errorf("multi-line command not collapsed: %q", got)
 	}
 }
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -114,6 +114,19 @@ type message struct {
 	// which is the wrong one. Empty for synthetic cards (grounding) and for any
 	// provider that does not populate FunctionCall.ID; see matchToolResultCard.
 	toolID string
+	// pollCount counts how many calls have folded into this card. A polling
+	// tool (bash_wait on a running command) repeats the same call every few
+	// seconds by design; each repeat used to append a fresh card, so a command
+	// polled fifty times scrolled fifty near-identical blocks past the user.
+	// Repeats now refresh the card in place and bump this counter, which the
+	// header shows as "×N". Zero for a card that was called once.
+	pollCount int
+	// pendingRefresh marks a card whose result has been superseded by a newer
+	// call that folded into it: the previous output is still on screen, but a
+	// fresh result is in flight. It is what lets the card keep showing the last
+	// poll's window instead of blanking for the seconds a poll takes, and
+	// matchToolResultCard treats it like an empty card when binding the result.
+	pendingRefresh bool
 	// Subagent event stream (for tool=="agent" or tool=="subagent").
 	agentID       string    // subagent ID for matching events
 	agentType     string    // subagent type (e.g. "task", "explore")
@@ -189,11 +202,12 @@ func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlac
 	h = fnvInt(h, width)
 	h = fnvInt(h, m.pipelineStep)
 	h = fnvInt(h, m.pipelineTotal)
+	h = fnvInt(h, m.pollCount)
 	h = fnvInt(h, int(themeKey))
 	// The pending-tool bullet blinks on a wall-clock phase; a cached render
 	// must not freeze at one phase, so the phase is part of the key. Finished
 	// cards render the bullet solid and must not re-render on the phase.
-	if blinkOn && m.role == "tool" && m.content == "" {
+	if blinkOn && m.toolPending() {
 		h = fnvByte(h, 1)
 	}
 
@@ -216,7 +230,17 @@ func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlac
 	if m.preRendered {
 		flags |= 1 << 5
 	}
+	if m.pendingRefresh {
+		flags |= 1 << 6
+	}
 	return fnvByte(h, flags)
+}
+
+// toolPending reports whether a tool card is still waiting on a result, and so
+// should draw the blinking bullet rather than the solid one. A card refreshed
+// by a repeat call is pending even though it still shows the previous result.
+func (m *message) toolPending() bool {
+	return m.role == "tool" && (m.content == "" || m.pendingRefresh)
 }
 
 // agentEv is a single event from a subagent's event stream.

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -157,11 +157,22 @@ func (t *ToolDisplayModel) renderSkillTool(msg message, dim lipgloss.Style, p Pa
 	return b.String()
 }
 
+// pollTally renders the "×N" suffix for a card that several repeated calls
+// folded into, or "" for a card called once. It tells the reader that the one
+// window on screen is the latest of N polls rather than the only one — the
+// count is the only trace those earlier polls now leave.
+func pollTally(msg message, dim lipgloss.Style) string {
+	if msg.pollCount < 2 {
+		return ""
+	}
+	return dim.Render(fmt.Sprintf(" ×%d", msg.pollCount))
+}
+
 // renderCompactTool renders a one-line tally for a tool message.
 func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style, p Palette) string {
 	toolStyle := lipgloss.NewStyle().Foreground(p.Tool).Bold(true)
 	checkStyle := lipgloss.NewStyle().Foreground(p.Tool)
-	toolBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Tool).Bold(true), msg.content == "")
+	toolBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Tool).Bold(true), msg.toolPending())
 
 	var b strings.Builder
 	b.WriteString(toolBullet)
@@ -176,6 +187,7 @@ func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style, p 
 		b.WriteString(dim.Render(args))
 		b.WriteString(dim.Render(")"))
 	}
+	b.WriteString(pollTally(msg, dim))
 
 	if msg.content != "" {
 		summary := toolResultSummary(msg.content)
@@ -463,7 +475,7 @@ func softWrap(s string, width int) []string {
 func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p Palette) string {
 	toolStyle := lipgloss.NewStyle().Foreground(p.Tool).Bold(true)
 	argStyle := lipgloss.NewStyle().Foreground(p.Dim)
-	toolBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Tool).Bold(true), msg.content == "")
+	toolBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Tool).Bold(true), msg.toolPending())
 
 	var b strings.Builder
 	b.WriteString(toolBullet)
@@ -474,6 +486,7 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p 
 		b.WriteString(argStyle.Render(args))
 		b.WriteString(dim.Render(")"))
 	}
+	b.WriteString(pollTally(msg, dim))
 	b.WriteString("\n")
 	if msg.content == "" && len(msg.agentEvents) > 0 {
 		// Still running: show the live tail instead of an empty card. Once the
@@ -502,7 +515,7 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p 
 		switch {
 		case msg.tool == "read" && msg.toolIn != "":
 			styled = highlightReadOutput(lines, msg.toolIn, p)
-		case msg.tool == "bash" || msg.tool == "bash_output" || msg.tool == "bash_kill":
+		case msg.tool == "bash" || isBashControl(msg.tool):
 			// Bash output is plain text most of the time but frequently contains
 			// runnable snippets (`cat file`, `curl ...`, `go test` output). Run it
 			// through chroma's content-sniffing lexer so it gets at least some
@@ -563,7 +576,7 @@ func toolCallSummary(name string, args map[string]any) string {
 		if cmd, ok := args["command"].(string); ok {
 			return cmd
 		}
-	case "bash_output", "bash_kill":
+	case "bash_wait", "bash_output", "bash_kill":
 		if h, ok := args["handle"].(string); ok {
 			return h
 		}
@@ -729,7 +742,7 @@ func formatToolResult(data map[string]any) string {
 		return diag
 	}
 	// A backgrounded command, either at the moment of handoff (the bash tool) or
-	// on any later poll of it (bash_output, bash_kill). Both carry a handle, and
+	// on any later poll of it (bash_wait, bash_kill). Both carry a handle, and
 	// both have to be taken before the exit-code branch below.
 	//
 	// While such a command is still running it has no exit status: the bash tool
@@ -779,6 +792,16 @@ func formatBashWindow(handle string, data map[string]any) string {
 	timing := bashTiming(data)
 
 	var lines []string
+	// What is being watched, inside the box rather than only in the header.
+	// The header truncates to the terminal's arg width and leads with the
+	// handle, so on a narrow terminal a long pipeline reads as
+	// "bash_wait(bg_4: cd wiki && make dai...)" — the box has the full
+	// command, soft-wrapped, and stays legible when several handles are live.
+	// The bash tool's own handoff result carries no command field (only a poll's
+	// BashStatus does), and needs none: that card's header is the command.
+	if cmd := collapseToSingleLine(commandOf(data)); cmd != "" {
+		lines = append(lines, "$ "+cmd)
+	}
 	switch {
 	case running:
 		lines = append(lines, "⏳"+timing)
@@ -802,6 +825,32 @@ func formatBashWindow(handle string, data map[string]any) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// commandOf returns the command a bash result describes, or "" when the result
+// does not name one. Only a poll's BashStatus carries it; the bash tool's own
+// BashOutput does not.
+func commandOf(data map[string]any) string {
+	cmd, _ := data["command"].(string)
+	return cmd
+}
+
+// isBashPoll reports whether name is the tool the model uses to read a
+// backgrounded command.
+//
+// "bash_output" is the pre-rename name. It is still accepted because a restored
+// session written before the rename replays the old name, and without this the
+// card would lose its header, its formatter and its poll fold and render as a
+// bare unknown tool. Same reason the display answers to both "grep" and
+// "ripgrep".
+func isBashPoll(name string) bool {
+	return name == "bash_wait" || name == "bash_output"
+}
+
+// isBashControl reports whether name is one of the handle-taking tools that act
+// on an already-backgrounded command.
+func isBashControl(name string) bool {
+	return isBashPoll(name) || name == "bash_kill"
 }
 
 func commaTiming(timing string) string {

--- a/specs/issues/bash_wait_removal.md
+++ b/specs/issues/bash_wait_removal.md
@@ -1,0 +1,373 @@
+# Issue: Can `bash_wait` be removed and folded into `bash`?
+
+**Status:** evaluated — removal rejected; three of the changes below are landed.
+**Raised by:** polling storms in the TUI (see Evidence).
+**Related branch:** `fix/bash-wait-card-reuse`.
+
+### Decisions taken
+
+| Decision | Where |
+|---|---|
+| **Keep the tool.** Removal rejected — see Options | this doc |
+| **Renamed `bash_output` → `bash_wait`.** The old name described the payload and read as a cheap getter, which is what invited the poll loop; the new one names the act and matches the shell's `wait`. `bash_watch` was considered and dropped: `watch(1)` *re-executes* its argument, the one connotation this tool cannot carry | `bash.go:186`; display accepts the old name for restored sessions (`isBashPoll`, `tool_display.go`) |
+| **Foreground budget 120s → 30s.** It is a budget for the *turn*, not the command; nothing is killed at the threshold | `defaultBashTimeout`, `bash.go:28` |
+| **The watched command is now inside the card**, not only in its truncating header | `formatBashWindow`, `tool_display.go` |
+| Repeat polls fold into one card with a `×N` tally | `findPollCard`, `agent_loop.go` |
+
+Still open: the `background` flag (Recommended change), and D1–D4.
+
+## Summary
+
+The proposal was to collapse `bash_wait` into `bash`, on the reading that the
+only difference between them is synchronous vs asynchronous execution — so a
+`background: true` flag on `bash` should cover it.
+
+That reading does not survive contact with the code. `bash` is not the
+synchronous tool: it is synchronous *until it isn't*, because a command that
+crosses either timeout is handed to the supervisor mid-call
+(`internal/tools/bash_supervisor.go:307,315`). The axis separating the two tools
+is not sync/async but **who owns the process**:
+
+| Tool | Verb | Args | State it owns |
+|---|---|---|---|
+| `bash` | **start** a process | `command`, `timeout`, `idle_timeout` | none afterwards — it hands off |
+| `bash_wait` | **attach** to a running one | `handle`, `wait_ms` | the handle's incremental read cursor, blocking wait |
+| `bash_kill` | **stop** one | `handle` | process-group termination, plus a brief wait for reaping |
+
+A flag changes how a command *starts*. Collecting its output happens in a later
+turn by definition, so it is a second tool call no matter what it is named. The
+flag and the read tool are orthogonal halves, not two spellings of one thing.
+
+**But the question surfaced a real defect**: `BashInput` has no `background`
+flag (`internal/tools/bash.go:20-30`), so the only supervisor-managed detach the
+API exposes is a timeout or idle-timeout handoff. (A command can of course
+background itself with `&` or `nohup`, but that process gets no handle of its
+own — no cursor, no cap, and nothing for `bash_wait` or `bash_kill` to attach
+to.)
+
+That is the cause of the *premature handoffs* — commands detached at 1s that
+should have run to completion in the foreground. It is not, on its own, the
+cause of the *polling rate*: how often a detached command gets polled is a
+separate policy question, and it is made worse by a rendering defect found while
+reviewing this spec (D3 below) that leaves a backgrounded command with no
+visible progress, so polling becomes the only way to see anything.
+
+## Evidence
+
+From a live session — session evidence, not reproducible from the repo alone:
+
+```
+◉ bash_output(bg_4: cd wiki && make daily-all)
+  │ ⏳ 42.1s elapsed, 22.7s without output
+  │ (no new output)
+  │ idle_timeout 1s, timeout 3.6s
+```
+
+`idle_timeout 1s, timeout 3.6s` are not limits anyone chose for a wiki build.
+They are a hand-rolled `background: true` — the model set absurd limits to force
+an immediate handoff, then polled the handle ~20 times.
+
+The supervisor already anticipates this shape and warns about it
+(`limitsHint`, `internal/tools/bash_supervisor.go:417`):
+
+> An idle_timeout under 15s backgrounds ordinary builds and test runs the
+> moment they go quiet — pass a larger idle_timeout (or omit it for the 1m30s
+> default) rather than polling the handle.
+
+(`shortIdleTimeout = 15s`, `defaultIdleTimeout = 90s`,
+`bash_supervisor.go:32,41`.)
+
+The hint names the workaround as the problem, but the tool offers nothing to use
+instead. That is the gap.
+
+## What `bash_wait` owns that a flag cannot
+
+Removing the tool means re-homing all of this, and every item lands on the model
+if it lands anywhere:
+
+1. **The handle's read cursor.** `p.stdout.since(p.outCur)`
+   (`bash_supervisor.go:593`) returns only what was produced since the last
+   read. Without it, every read re-sends the entire buffer into context. Note
+   the cursor pair lives on the process, not on a caller
+   (`outCur`/`errCur`, `bash_supervisor.go:153-157`): it supports one logical
+   polling reader per handle, and concurrent readers would race through the
+   same position under `curMu`.
+2. **Blocking wait.** `awaitChange` parks on `p.stdout.wait()`
+   (`bash_supervisor.go:634,639`) for up to 60s (`maxBashWait`, `bash.go:114`).
+   This is what makes the operation a *wait* rather than a *poll*, and it is the
+   single most valuable thing the tool does — the property the rename now says
+   out loud.
+3. **Exit status and reaping.** `exit_code` is meaningful only once
+   `running=false`; the handle is spent and forgotten after the final read
+   (`forget`, `bash_supervisor.go:541`).
+4. **Output budgeting and secret redaction.** `budgetStreams`
+   (`bash_supervisor.go:434`) truncates and runs `redactSecrets` on the tool
+   path — not on anything the command writes elsewhere.
+5. **Handle lifecycle.** A cap on concurrent background commands
+   (`maxBackgroundProcs = 8`, `bash_supervisor.go:51`) and a 30-minute lifetime
+   ceiling (`backgroundMaxLifetime`, `bash_supervisor.go:56`). The cap does not
+   reject a new command — `register` evicts and terminates a victim to make
+   room (`bash_supervisor.go:458-470`), preferring an already-finished entry but
+   falling back to the oldest live one (`oldestLocked`, `:502-521`). Backgrounding
+   a ninth command can therefore kill the first.
+6. **Consumers keyed on the tool name.** The stuck detector strips
+   `elapsed`/`idle` before fingerprinting `bash_wait` results
+   (`internal/tui/agent_loop.go:214-225`); the TUI keys its call-time header
+   builder (`agent_loop.go:1236`), its result-side header recovery
+   (`agent_loop.go:1098`, helper at `:1116`) and its poll-card fold
+   (`agent_loop.go:923`, `findPollCard` at `:1150`) off the name. (`formatBashWindow`,
+   `internal/tui/tool_display.go:787`, is *not* one of these — it is selected by
+   the presence of a `handle` field in the result, so it would survive a rename.)
+
+Note what is **not** on this list: live output. The supervisor fans output to an
+`OutputSink` while the command runs (`bash_supervisor.go:59-67`, `sinkWriter` at
+`:692-724`), which is how the TUI streams a running command without polling.
+That path is deliberately best-effort and is not a substitute for the model's
+read: the sink drops events rather than block a pipe (`:59-67`), and
+`sinkWriter` emits only completed non-blank lines, holding a trailing partial
+until it sees a newline or the chunk passes 8192 bytes (`:711-724`). Those bytes
+stay in the retained stream and still come back through `bash_wait`.
+`bash_wait` is the *model's* reliable read path; the sink is the *display's*
+lossy one.
+
+## Options evaluated
+
+### A. Union tool — `bash(command | handle, ...)`
+
+One tool, mutually exclusive argument groups. **Rejected.**
+
+The wrong branch is destructive, not merely wrong: a poll that arrives carrying
+`command` instead of `handle` does not return stale output — it **runs the
+command a second time**. `make deploy` twice, `terraform apply` twice. The
+current split makes *that* failure unreachable: `bash_wait` has no code path
+that can start anything, so a mis-shaped poll errors instead of executing.
+(Nothing stops a model from deliberately calling `bash` again — the guarantee is
+about the poll, not about the model's judgment.)
+
+It also saves less than it looks: `bash_kill` still needs a handle-shaped tool,
+so three tools become two, at the cost of the one failure mode that must never
+happen.
+
+### A2. Single tool with an explicit operation discriminator
+
+The objection to A is specific to an *implicit* union — the branch is inferred
+from which field happens to be set. A tagged schema removes that inference:
+
+```json
+{"op": "start", "command": "make all", "background": true}
+{"op": "read",  "handle": "bg_1", "wait_ms": 60000}
+{"op": "kill",  "handle": "bg_1"}
+```
+
+Dispatch validates before touching a process: `start` requires `command` and
+forbids `handle`, `read`/`kill` require `handle` and forbid `command`, anything
+ambiguous is rejected. Internally it still calls `Run`, `readOutput`,
+`killHandle`, so every capability above survives.
+
+**Viable, but not adopted.** It is honestly the strongest one-tool design and
+the spec should not pretend otherwise. What it trades:
+
+- The destructive branch moves from *unreachable* to *guarded*. Today
+  `bash_wait` has no code path that can start a process; under A2 it does,
+  behind a validation check. That is a real downgrade for the one failure mode
+  that must never occur, in exchange for a schema saving.
+- It saves no calls. Reading still happens in a later turn; only the name on the
+  wire changes.
+- Three narrow schemas become one wide one with conditionally-required fields —
+  the shape models describe worst and get wrong most.
+- Every name-keyed consumer in §"What `bash_wait` owns" item 6 has to switch
+  to dispatching on an argument instead, including the stuck detector.
+
+Worth revisiting if tool-schema context cost ever becomes the binding
+constraint; it is not today.
+
+### B. Log-file redirect + existing read tools
+
+`bash("make all > /tmp/run.log 2>&1", background: true)`, then `read` / `grep`
+the log. **Rejected.**
+
+Genuinely fewer tools, all pre-existing — but it loses items 1-4 above. No
+blocking wait, so the model busy-polls a file (worse than today); no convenient
+exit status; no redaction or truncation on the output path; and the model must
+track byte offsets itself, which it will not, so every read re-sends the whole
+log. It also adds temp-file lifecycle to something the supervisor currently
+handles.
+
+Two things this variant does *not* necessarily lose, and the spec should not
+claim it does: if the command is still started through the supervisor, the
+handle and therefore `bash_kill` remain (`bash.go:184-196`,
+`bash_supervisor.go:645-689`); and the supervisor still reaps the process — what
+the model loses is the status *read channel*, not the reaping.
+
+### C. Add `background` to `bash`, keep all three tools — **recommended**
+
+Removes zero tools. Removes the *fake timeouts*, and with them the accidental
+backgrounding of every build that pauses for a moment.
+
+### D. Do nothing
+
+Leaves the model forging detachment out of 1-second idle timeouts, and leaves
+`limitsHint` warning about a workaround the API forces. **Rejected.**
+
+### E. Completion injection — the host pushes, the model never polls
+
+Attack the *reason* for polling instead of the tool. When a backgrounded command
+exits, the host appends its final output and exit status to the model's history
+as an event, unprompted. The model stops asking "is it done yet" because it is
+told.
+
+**Viable, and the most interesting of the alternatives — but much larger.**
+Nothing today can carry it: `OutputSink` is explicitly lossy and must not block
+(`bash_supervisor.go:59-67`), and the TUI's consumer only mutates card state
+(`internal/tui/agent_loop.go:1250-1278`). It needs a durable session-level event
+channel plus rules for appending a message after the function response that
+already closed the call — which is a session/protocol change, not a tool change.
+
+It also does not remove `bash_wait`: a model that wants output *before* the
+command exits still has to ask. It removes the *end-of-life* poll, which is the
+most common one. Worth its own spec if polling volume remains a problem after
+the `background` flag lands.
+
+### F. Remove background handoff entirely
+
+Delete the third state: on timeout, kill the command and return what it printed,
+as the foreground cancellation path already does
+(`bash_supervisor.go:297-304`). No handles, so no `bash_wait` and no
+`bash_kill` — the whole family goes.
+
+**Rejected, but honestly the cleanest design on paper.** It trades away every
+long-running workload: no dev server, no watcher, no 20-minute build, no
+`make daily-all`. The supervisor exists precisely because killing those at the
+two-minute mark was worse than handing them off. Recording it here so the
+trade-off is explicit rather than assumed.
+
+## Defects found while reviewing this spec
+
+Checking the spec's claims against the code turned up four real problems that
+are not about the spec at all. They are listed here because three of them
+directly shape how much a `background` flag helps, and they should be fixed
+before intentional detachment makes backgrounded commands more common.
+
+### D1. A poll can block 60s with unread output already buffered
+
+`readOutput` calls `awaitChange` **before** reading the cursor
+(`bash_supervisor.go:582-596`). `awaitChange` selects on the stream's notify
+channel (`:634-643`), and `stream.Write` wakes waiters by closing the *current*
+notify channel and installing a fresh one (`bash_stream.go:42-59`). So output
+written between two polls has already closed the channel the previous poll held;
+the new poll gets the fresh, unclosed one and waits for the *next* write.
+
+A command that prints a burst and then goes quiet therefore makes the next poll
+block the full 60s while its output sits in the buffer, unread. The fix is
+ordering: read `since(cursor)` first, and only wait when it comes back empty.
+
+### D2. Waits ignore turn cancellation
+
+The `bash_wait` handler discards its context — `func(_ agent.Context, input
+BashOutputInput)` (`bash.go:174-179`) — and `readOutput` takes no context at
+all. An aborted turn still has up to 60 seconds of unstoppable wait in it.
+
+### D3. A backgrounded command stops showing progress
+
+The TUI renders the live event window only while the card has no result:
+`if msg.content == "" && len(msg.agentEvents) > 0`
+(`internal/tui/tool_display.go:491-496`). The handoff *is* a result, so the
+moment a command goes to the background its card fills with the handoff summary
+and the live window disappears — while `handleBashEvent` keeps faithfully
+appending events to it (`agent_loop.go:1266-1275`) that nothing draws.
+
+This is the rendering half of the polling problem: after handoff there is no
+visible progress, so polling is the only way to see whether anything is
+happening. Fix it and the pressure to poll drops on its own.
+
+### D4. `background` publishes the handle before initializing cursors
+
+`background` calls `register` (making the handle lookupable) and only then
+computes and stores `outCur`/`errCur` (`bash_supervisor.go:370-378`). A read
+landing in that window would start from 0 and re-deliver everything, and the
+late assignment would rewind the cursor under it.
+
+Latent rather than live: the model cannot know the handle until the call
+returns, so nothing can currently race it. Worth reordering anyway — an
+in-process consumer of the supervisor API has no such protection.
+
+## Recommended change
+
+1. **`BashInput.Background bool`** (`internal/tools/bash.go:20`):
+
+   ```go
+   // Background starts the command detached: bash returns a handle
+   // immediately instead of waiting for output or for a timeout to hand it
+   // off. Use for servers, watchers, and long builds — not as a way to avoid
+   // waiting for a command that will finish in seconds.
+   Background bool `json:"background,omitempty"`
+   ```
+
+2. **Handler path** — `background: true` should go through a supervisor entry
+   point of its own (`StartBackground`, say) rather than having the tool handler
+   reach for `sup.background(p, reason)` (`bash_supervisor.go:370`), which today
+   is an internal step of `supervise` and assumes a foreground attempt already
+   ran. The detached path arms no idle timer. The 30-minute lifetime ceiling and
+   the 8-process cap still apply; detaching is not a licence to leak processes.
+
+3. **Add a third handoff reason.** `background` already takes one and reports
+   it: `"still running after 2m"` for the hard timeout (`:306-307`) and
+   `"no output for 1s"` for the idle one (`:313-315`). Neither can express
+   intent, so a detached start needs its own — `"started detached"` — and the
+   card should render that differently from "backgrounded after going quiet".
+
+4. **`bashDescription`** (`bash.go:102`) should point at the flag: *start
+   long-running work with `background: true`; do not shrink the timeouts to
+   force a handoff.* Keep `limitsHint` as the backstop for callers that do it
+   anyway.
+
+5. **TUI** — poll cards fold in place instead of appending one block per poll
+   (done on `fix/bash-output-card-reuse`); the header names the command from
+   the poll's own `BashStatus.Command` so it survives compaction and `/resume`.
+
+### Acceptance criteria
+
+- [ ] `bash(command, background: true)` returns `running=true` + a handle
+      without waiting for either timeout to expire.
+- [ ] The result distinguishes an intentional detach from a timeout handoff, in
+      the `note` and on the TUI card.
+- [ ] A detached command still counts against `maxBackgroundProcs` and is still
+      reaped at `backgroundMaxLifetime`. Decide explicitly whether an
+      intentional detach may evict and kill an older live command the way
+      `register` does today (`bash_supervisor.go:458-470`) — silently killing a
+      running build to make room for a detached one is a worse surprise when the
+      caller asked for the detach than when a timeout forced it.
+- [ ] `bash_wait` / `bash_kill` are unchanged and remain the only *model-facing*
+      way to read from or stop a handle; the `OutputSink` live stream to the TUI
+      is unaffected.
+- [ ] Tests: detach is immediate (no dependence on wall-clock timeouts), caps
+      still enforced, note text distinguishable, existing timeout-handoff
+      behaviour unaffected.
+
+## Non-goals
+
+- Merging `bash_wait` into `bash` in any form (Options A, A2 and B above).
+- Removing `bash_kill`.
+- Merging the poll card into the originating `bash` card in the TUI. Feasible —
+  binding by handle already exists — but the merged card sits where the command
+  *started*, which after fifty polls is far up the scrollback, so live status
+  would update off-screen. Tracked separately; the likely answer is one card per
+  command in the transcript plus a live line for each running command in the
+  status bar. That last part is not free: `status.go:200-212` renders active
+  tools by *name* only (`tool: bash (1.2s)`) and knows nothing about handles or
+  commands, so it is an insertion point, not existing plumbing.
+
+## Open questions
+
+- Should `background: true` suppress `idle_timeout` entirely, or keep a very
+  long one as a leak guard? Proposal: suppress it; `backgroundMaxLifetime`
+  already bounds the process.
+- Should a detached command still stream live events to its card
+  (`bash:output` via `AgentEventCh`)? It should — but note that event *delivery*
+  already works while *rendering* does not (D3): the events arrive at the card
+  and are dropped on the floor by the renderer. This is a renderer change, not
+  new plumbing.
+- Does the `background` flag warrant a different default `wait_ms` on the first
+  poll of an intentionally detached command? The flag says "I do not expect this
+  soon", which is an argument for a longer wait, not the 60s cap — but see D1
+  first, since today a long wait can be spent ignoring output already in hand.


### PR DESCRIPTION
### Why

One backgrounded command produced twenty near-identical cards in the transcript, each differing only in an elapsed counter:

```
◉ bash_output(bg_4: cd wiki && make daily-all)
  │ ⏳ 27.1s elapsed, 7.7s without output
  │ (no new output)
◉ bash_output(bg_4: cd wiki && make daily-all)
  │ ⏳ 29.5s elapsed, 10.2s without output
  │ (no new output)
  … ×18 more
```

Fixing the rendering surfaced why the model was polling that hard in the first place.

### What changed

**`bash_output` → `bash_wait`.** The old name describes the payload and reads as a cheap getter, which is what invites calling it in a loop. The new one names the act, and matches the shell's `wait`. `bash_watch` was considered and dropped: `watch(1)` *re-executes* its argument, the one connotation this tool cannot carry.

The display still answers to the old name (`isBashPoll`), so a session restored from before the rename renders as a poll card rather than a bare unknown tool — the same accommodation already made for `grep`/`ripgrep`.

**`defaultBashTimeout` 120s → 30s.** It is a budget for the *turn*, not for the command: nothing is killed at the threshold, the caller gets a handle. `defaultIdleTimeout` deliberately stays at 90s — it can no longer fire under defaults, but it is what protects a caller who raises `timeout` for a known-long build, and a test now pins that ordering.

**One card per watched command.** Repeat polls of the same handle refresh a single card and carry a `×N` tally. Only the newest card folds, and only for the same handle, so output never jumps up the scrollback and two commands' windows never merge. A refreshing card keeps the previous window on screen while the next poll is in flight, rather than blanking for the seconds a poll takes.

**The command is visible in the box**, recovered from the poll's own `BashStatus.Command` rather than by cross-referencing the originating `bash` card — so it survives compaction and `/resume` instead of degrading to a bare `bash_wait(bg_4)`:

```
◉ bash_wait(bg_4: cd wiki && make daily-all) ×7
  │ $ cd wiki && make daily-all
  │ ⏳ 42.1s elapsed, 22.7s without output
  │ (no new output)
  │ idle_timeout 1s, timeout 3.6s
```

### `specs/issues/bash_wait_removal.md`

Evaluates removing the tool outright — the original question was whether `bash` plus a `background` flag could replace it. **Rejected**, with the alternatives written up (implicit union, tagged `op` discriminator, log-file redirect, completion injection, removing background handoff entirely).

Reviewing that spec against the code turned up four defects, documented but **not fixed here**:

- **D1** a poll can block the full 60s with unread output already buffered — the wait runs before the cursor read, and only the *next* write can wake it
- **D2** waits ignore turn cancellation (`func(_ agent.Context, …)`)
- **D3** a backgrounded command stops rendering progress: the live window is gated on the card having no result, and the handoff *is* a result — so events keep arriving and nothing draws them. This is the rendering half of the polling problem
- **D4** `background` publishes the handle before initializing its cursors (latent — unreachable through the model-facing API)

Still open: the `background` flag itself, so a dev server can be started detached instead of by tripping a timeout.

### Testing

`make test-all` — exit 0, 123 package results. `make lint` — 0 issues.

New: `internal/tui/bash_poll_fold_test.go` (15 cases — fold behaviour, header recovery, legacy-name acceptance, parallel polls not transposed, subagent cards never folded, tally rendering, render-key invalidation), plus window cases in `bash_window_test.go` and a default-timeout pin in `bash_control_test.go`.

One pre-existing assertion needed sharpening rather than renaming: `TestFormatToolResult_PollOfRunningCommandIsReadable` used "no `&` in the output" as a raw-JSON canary, and its fixture command is `make lint && make vet`. It now checks for Go's `&` escaping, which is the actual tell.