### PR TITLE
test(bash): pin that a wait ends on child exit, not on its budget

### DIFF
--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"google.golang.org/adk/v2/tool"
+
+	"github.com/dimetron/pi-go/internal/procs"
 )
 
 // TestBashControlTools_Registered checks the two control tools exist under the
@@ -479,5 +481,90 @@ func TestBashDefaultTimeout_IsTheForegroundBudget(t *testing.T) {
 		t.Errorf("defaultIdleTimeout %s must stay above the foreground budget %s;"+
 			" below it the hard limit fires first and the idle check is dead code",
 			defaultIdleTimeout, defaultBashTimeout)
+	}
+}
+
+// A wait must end when the child exits, not when its budget runs out. The
+// distinction is invisible until a command produces no output at all — a run
+// with `> file 2>&1` sends everything to the file, so the streams the wait
+// parks on never fire and only process exit can wake it. If that path were
+// broken, every such command would sit for the full 60s after finishing and
+// look hung when it was done.
+func TestBashWait_EndsWhenTheChildExits(t *testing.T) {
+	sup := testSupervisor(t)
+	sup.heartbeat = 20 * time.Millisecond
+
+	out, err := sup.Run(t.Context(), runRequest{
+		dir:     t.TempDir(),
+		command: `sleep 2 > out.log 2>&1`,
+		timeout: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !out.Running {
+		t.Fatalf("expected a handoff, got %+v", out)
+	}
+
+	start := time.Now()
+	st, err := sup.readOutput(out.Handle, 30*time.Second)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("readOutput: %v", err)
+	}
+	if st.Running {
+		t.Errorf("still reported running after %s; exit was not detected", elapsed)
+	}
+	if st.ExitCode != 0 {
+		t.Errorf("exit_code = %d, want 0", st.ExitCode)
+	}
+	// Generous, because it only has to separate "woken by exit" (~2s) from
+	// "waited out the budget" (30s).
+	if elapsed > 10*time.Second {
+		t.Errorf("wait took %s; it burned its budget instead of ending on exit", elapsed)
+	}
+}
+
+// A command that leaves a grandchild behind — `some-daemon &` — does not get a
+// clean exit status, and this pins how long that costs and what it reports.
+//
+// cmd.Wait() cannot return until every writer of the inherited pipe is gone,
+// and the backgrounded grandchild holds it. Wait therefore blocks past the
+// shell's own exit until procs.DefaultWaitDelay fires and the group is killed,
+// so a shell that exited 0 is reported as exit -1 a few seconds later. That is
+// a fidelity loss, not a hang: the wait still ends, and the card renders
+// "killed, no exit status" rather than inventing a code.
+func TestBashWait_LingeringGrandchildCostsTheExitStatus(t *testing.T) {
+	sup := testSupervisor(t)
+	sup.heartbeat = 20 * time.Millisecond
+
+	out, err := sup.Run(t.Context(), runRequest{
+		dir:     t.TempDir(),
+		command: `sleep 30 & echo started > out.log 2>&1; exit 0`,
+		timeout: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !out.Running {
+		t.Skip("command completed in the foreground; nothing to observe")
+	}
+
+	start := time.Now()
+	st, err := sup.readOutput(out.Handle, 30*time.Second)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("readOutput: %v", err)
+	}
+	if st.Running {
+		t.Errorf("still running after %s; the group was never reaped", elapsed)
+	}
+	if st.ExitCode != -1 {
+		t.Logf("exit_code = %d (was -1 when this was written; Wait no longer"+
+			" blocks on the inherited pipe, which is an improvement)", st.ExitCode)
+	}
+	if elapsed > 15*time.Second {
+		t.Errorf("wait took %s; expected it to end when the wait delay (%s) fires",
+			elapsed, procs.DefaultWaitDelay)
 	}
 }

--- a/specs/issues/bash_wait_removal.md
+++ b/specs/issues/bash_wait_removal.md
@@ -291,6 +291,24 @@ Latent rather than live: the model cannot know the handle until the call
 returns, so nothing can currently race it. Worth reordering anyway — an
 in-process consumer of the supervisor API has no such protection.
 
+### D5. A lingering grandchild costs the exit status, and five seconds
+
+`cmd.Wait()` cannot return until every writer of the inherited stdout pipe is
+gone. A command that backgrounds anything — `some-daemon &`, and by extension
+most "start it and move on" shell idioms — leaves a grandchild holding that
+pipe after the shell itself has exited 0.
+
+Wait therefore blocks past the shell's exit until `procs.DefaultWaitDelay`
+(5s, `internal/procs/procs.go:34`) fires and the group is killed, and the
+result reports `exit_code: -1` for a command that succeeded. Measured, not
+inferred: `TestBashWait_LingeringGrandchildCostsTheExitStatus` sees the wait
+return after ~4.7s with -1.
+
+Not a hang — the wait ends and the card honestly renders "killed, no exit
+status" rather than inventing a code — but the status is wrong and the delay is
+paid on every such command. A fix would give the shell its own pipe rather than
+sharing one with whatever it spawns.
+
 ## Recommended change
 
 1. **`BashInput.Background bool`** (`internal/tools/bash.go:20`):


### PR DESCRIPTION
Follow-up to #153 — this commit was pushed to that branch after it had already merged, so it never reached `main`.

### Why

A report that `bash_wait` looked stuck: a card showed `2m6s elapsed, 2m6s without output` for `go test … > /tmp/test-full.log 2>&1`, with the suspicion that the tests had failed and the wait was hanging on an already-dead child.

They hadn't. The run was genuinely mid-flight — its log held 19 of ~45 package lines and stopped at `internal/audit`, and the trailing `echo "EXIT=$?"` (which writes to the pipe, not the redirected file) never fired. The `FAIL` lines that prompted the suspicion were `[setup failed]` from `tmp/adk/adk-samples/…`, which `go test ./...` reports and then continues past.

But the question deserved a test rather than an argument, and the second test found something.

### What this adds

**`TestBashWait_EndsWhenTheChildExits`** — a wait must end when the child exits, not when its budget runs out. The distinction is invisible unless the command is silent: `> file 2>&1` sends everything to the file, so the streams `awaitChange` parks on never fire and only process exit can wake it. Measured: the wait returns 1.7s into a 30s budget when the child exits at 2s. Were this path to regress, every fully-redirected command would sit for the full 60s after finishing and read as hung.

**`TestBashWait_LingeringGrandchildCostsTheExitStatus`** — a characterization test for a real fidelity loss (**D5** in the spec). `cmd.Wait()` cannot return until every writer of the inherited stdout pipe is gone, so a command that backgrounds anything (`some-daemon &`) keeps that pipe open after the shell itself exits 0. Wait blocks until `procs.DefaultWaitDelay` (5s) fires and the group is killed, and the result reports **`exit_code: -1` for a command that succeeded** — measured at ~4.7s.

Not a hang: the wait ends and the card honestly renders "killed, no exit status" rather than inventing a code. But the status is wrong and the delay is paid on every such command. A fix would give the shell its own pipe instead of sharing one with whatever it spawns; that is left for its own change, and D5 in `specs/issues/bash_wait_removal.md` records it.

### Testing

Both tests pass on `main` (7.4s for the package). `make lint` — 0 issues.