### PR TITLE
feat(provider): add opt-in xAI server-side tools

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -454,6 +454,9 @@ type LLMOptions struct {
 	// and completions are not: the log holds the entire conversation in
 	// cleartext, which is the point and also the reason it is off by default.
 	TraceHTTP bool
+	// EnableXAITools opts into xAI server-side tools (web search, X search,
+	// and code interpreter) for xAI Responses API requests.
+	EnableXAITools bool
 }
 
 // NewLLM creates a model.LLM for the given provider info, API key, optional base URL, thinking level, and options.

--- a/internal/provider/xai.go
+++ b/internal/provider/xai.go
@@ -10,33 +10,37 @@ import (
 	"github.com/google/uuid"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
 	"google.golang.org/adk/v2/model"
 )
 
 const xaiDefaultBaseURL = "https://api.x.ai/v1"
 
-// xaiConversationHeader is xAI's cache-affinity hint for the Chat Completions
-// endpoint. xAI routes every request carrying the same value to the same
-// server, which is what makes a prompt cache hit likely; without it a
-// multi-turn session lands on a cache-cold server and pays full input price on
-// the whole prefix every turn. (The Responses API spells the same thing
-// `prompt_cache_key`.)
+// xaiConversationHeader is xAI's cache-affinity hint. xAI routes every request
+// carrying the same value to the same server, which is what makes a prompt
+// cache hit likely; without it a multi-turn session lands on a cache-cold
+// server and pays full input price on the whole prefix every turn. The
+// Responses API also accepts prompt_cache_key; we keep the header because it
+// is what the Chat Completions docs named and gateways already know.
 const xaiConversationHeader = "x-grok-conv-id"
 
 // xaiModel implements model.LLM for the xAI (Grok) API.
 //
-// xAI exposes an OpenAI-compatible chat completions endpoint, so this reuses
-// the OpenAI SDK and the shared oai* request/response helpers against
-// api.x.ai. Two things are xAI's own: the conversation header above, and
-// reasoning_effort, which Grok reasoning models accept with an extra "xhigh"
-// tier above OpenAI's.
+// xAI's recommended surface is the OpenAI-compatible Responses API
+// (/v1/responses). Chat Completions still works for function calling, but
+// server-side tools (web_search, x_search, code_interpreter) only run on
+// Responses — that is the loop the Python SDK's server_side_tools.py example
+// drives. This type embeds openaiModel so it can reuse the Responses stream
+// and non-stream runners; the xAI-specific pieces are the conversation
+// header, the extra reasoning_effort tier, and the built-in tools.
 type xaiModel struct {
-	modelName string
-	client    openai.Client
+	openaiModel
 	// reasoningEffort is the resolved thinking level, empty when the level is
 	// unset or unrecognized so the field is left off the wire entirely.
 	reasoningEffort shared.ReasoningEffort
+	enableXAITools  bool
 }
 
 // NewXAI creates an xAI model.LLM.
@@ -73,52 +77,98 @@ func NewXAI(_ context.Context, modelName, apiKey, baseURL, thinkingLevel string,
 	}
 	client := openai.NewClient(opts...)
 	return &xaiModel{
-		modelName:       modelName,
-		client:          client,
+		openaiModel: openaiModel{
+			modelName: modelName,
+			client:    client,
+		},
+		enableXAITools:  xaiToolsEnabled(llmOpts != nil && llmOpts.EnableXAITools),
 		reasoningEffort: xaiReasoningEffort(thinkingLevel),
 	}, nil
 }
 
-func (m *xaiModel) Name() string { return m.modelName }
-
 func (m *xaiModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		messages, systemInstruction := oaiContentsToMessages(req.Contents, req.Config)
+		if req == nil {
+			_ = yield(nil, fmt.Errorf("xAI responses: nil LLM request"))
+			return
+		}
+		input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
+		if err != nil {
+			_ = yield(nil, fmt.Errorf("xAI responses input: %w", err))
+			return
+		}
 
 		modelName := req.Model
 		if modelName == "" {
 			modelName = m.modelName
 		}
 
-		params := openai.ChatCompletionNewParams{
-			Model:    modelName,
-			Messages: messages,
+		params := responses.ResponseNewParams{
+			Model: modelName,
+			Input: input,
+			// Match the OpenAI Responses default: do not persist the turn
+			// server-side. Multi-turn continues via the full conversation
+			// replayed in params.Input.
+			Store: param.NewOpt(false),
 		}
-		if systemInstruction != "" {
-			params.Messages = append([]openai.ChatCompletionMessageParamUnion{
-				openai.SystemMessage(systemInstruction),
-			}, params.Messages...)
+		if instructions != "" {
+			params.Instructions = param.NewOpt(instructions)
 		}
 
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = oaiGenaiToolsToOpenAI(req.Config.Tools)
-			params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
-				OfAuto: openai.String("auto"),
+		tools := xaiRequestTools(req, m.enableXAITools)
+		if len(tools) > 0 {
+			params.Tools = tools
+		}
+		if !xaiToolsDisabled() && m.enableXAITools {
+			params.Include = []responses.ResponseIncludable{
+				responses.ResponseIncludableWebSearchCallResults,
+				responses.ResponseIncludableWebSearchCallActionSources,
+				responses.ResponseIncludableCodeInterpreterCallOutputs,
 			}
 		}
 
 		if m.reasoningEffort != "" && xaiModelReasons(modelName) {
-			params.ReasoningEffort = m.reasoningEffort
+			params.Reasoning = shared.ReasoningParam{Effort: m.reasoningEffort}
+		}
+
+		send := func(y func(*model.LLMResponse, error) bool) {
+			var sendErr error
+			if stream {
+				_, sendErr = m.runResponsesStreaming(ctx, params, y)
+			} else {
+				_, sendErr = m.runResponsesNonStreaming(ctx, params, y)
+			}
+			if sendErr == nil {
+				return
+			}
+			if stream {
+				_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: sendErr.Error()}, nil)
+				return
+			}
+			_ = y(nil, fmt.Errorf("xAI Responses API failed: %w", sendErr))
 		}
 
 		if stream {
-			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
-				oaiRunStreaming(ctx, &m.client, params, y)
-			})
+			retryStream(ctx, streamRetryConfig(), yield, send)
 		} else {
-			oaiRunNonStreaming(ctx, &m.client, params, yield)
+			send(yield)
 		}
 	}
+}
+
+// xaiRequestTools is the function declarations from the ADK request plus
+// xAI's built-in server-side tools. The built-ins run inside the request
+// (the model searches / executes and keeps going); client-side functions
+// still come back as FunctionCalls for pi's own loop to execute.
+func xaiRequestTools(req *model.LLMRequest, enabled bool) []responses.ToolUnionParam {
+	var tools []responses.ToolUnionParam
+	if req != nil && req.Config != nil && len(req.Config.Tools) > 0 {
+		tools = oaiGenaiToolsToResponses(req.Config.Tools)
+	}
+	if enabled && !xaiToolsDisabled() {
+		tools = append(tools, xaiServerSideTools()...)
+	}
+	return tools
 }
 
 // xaiReasoningEffort maps pi's thinking level onto xAI's reasoning_effort.

--- a/internal/provider/xai_test.go
+++ b/internal/provider/xai_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3/shared"
@@ -149,6 +150,88 @@ func TestXAIModelReasons(t *testing.T) {
 	}
 	if xaiModelReasons("grok-4.20-0309-non-reasoning") {
 		t.Error("grok-4.20-0309-non-reasoning should not be sent reasoning_effort")
+	}
+}
+
+func TestXAIToolsDisabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"one", "1", true},
+		{"true", "true", true},
+		{"yes", "yes", true},
+		{"on", "on", true},
+		{"mixed case", "TrUe", true},
+		{"surrounded by whitespace", "  on\t", true},
+		{"zero", "0", false},
+		{"false", "false", false},
+		{"unrecognized", "maybe", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(xaiToolsDisableEnvVar, tt.value)
+			if got := xaiToolsDisabled(); got != tt.want {
+				t.Errorf("xaiToolsDisabled() with %s=%q = %v, want %v", xaiToolsDisableEnvVar, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestXAIToolsEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured bool
+		value      string
+		want       bool
+	}{
+		// The configured flag short-circuits before the environment is read,
+		// so an explicit --xai-tools cannot be undone by a stale export.
+		{"configured with empty env", true, "", true},
+		{"configured with falsey env", true, "false", true},
+		{"empty env", false, "", false},
+		{"one", false, "1", true},
+		{"true", false, "true", true},
+		{"yes", false, "yes", true},
+		{"on", false, "on", true},
+		{"mixed case", false, "YES", true},
+		{"surrounded by whitespace", false, " 1 ", true},
+		{"zero", false, "0", false},
+		{"false", false, "false", false},
+		{"unrecognized", false, "maybe", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(xaiToolsEnvVar, tt.value)
+			if got := xaiToolsEnabled(tt.configured); got != tt.want {
+				t.Errorf("xaiToolsEnabled(%v) with %s=%q = %v, want %v",
+					tt.configured, xaiToolsEnvVar, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// The built-in tool objects are assembled as raw JSON rather than marshaled,
+// so pin that the bytes still match what marshaling the equivalent map would
+// have produced — that equivalence is the whole justification for writing them
+// out by hand.
+func TestXAIBuiltInToolWireFormat(t *testing.T) {
+	for _, typ := range xaiServerSideToolTypes {
+		t.Run(typ, func(t *testing.T) {
+			want, err := json.Marshal(map[string]string{"type": typ})
+			if err != nil {
+				t.Fatalf("marshaling the reference form: %v", err)
+			}
+			got, err := json.Marshal(xaiBuiltInTool(typ))
+			if err != nil {
+				t.Fatalf("marshaling xaiBuiltInTool(%q): %v", typ, err)
+			}
+			if string(got) != string(want) {
+				t.Errorf("xaiBuiltInTool(%q) = %s, want %s", typ, got, want)
+			}
+		})
 	}
 }
 
@@ -384,6 +467,129 @@ func TestXAISendsSystemInstructionAndTools(t *testing.T) {
 			t.Errorf("tools = %v, want built-in %q", types, want)
 		}
 	}
+}
+
+// PI_NO_XAI_TOOLS is the kill switch: it has to beat an explicit opt-in, and
+// it has to strip both the built-in tools and the include list that only makes
+// sense alongside them, while leaving client-side functions untouched.
+func TestXAIToolsKillSwitchBeatsOptIn(t *testing.T) {
+	t.Setenv(xaiToolsDisableEnvVar, "1")
+
+	var header http.Header
+	var body map[string]any
+	srv := xaiCaptureServer(t, &header, &body)
+	defer srv.Close()
+
+	m, err := NewXAI(context.Background(), "grok-4.6", "test-key", srv.URL, "high", &LLMOptions{EnableXAITools: true})
+	if err != nil {
+		t.Fatalf("NewXAI() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}}},
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{Name: "read_file"}},
+			}},
+		},
+	}
+	for _, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+	}
+
+	if got := body["include"]; got != nil {
+		t.Errorf("include = %v, want it omitted when %s is set", got, xaiToolsDisableEnvVar)
+	}
+	types := xaiToolTypes(body)
+	if !containsString(types, "function") {
+		t.Errorf("tools = %v, want the client-side function to survive the kill switch", types)
+	}
+	for _, unwanted := range xaiServerSideToolTypes {
+		if containsString(types, unwanted) {
+			t.Errorf("tools = %v, want built-in %q suppressed by %s", types, unwanted, xaiToolsDisableEnvVar)
+		}
+	}
+}
+
+func TestXAIRejectsNilRequest(t *testing.T) {
+	m, err := NewXAI(context.Background(), "grok-4.6", "test-key", "http://127.0.0.1:1", "high", nil)
+	if err != nil {
+		t.Fatalf("NewXAI() error: %v", err)
+	}
+
+	for _, stream := range []bool{false, true} {
+		name := "non-streaming"
+		if stream {
+			name = "streaming"
+		}
+		t.Run(name, func(t *testing.T) {
+			var errs []error
+			for resp, err := range m.GenerateContent(context.Background(), nil, stream) {
+				if resp != nil {
+					t.Errorf("expected no response for a nil request, got %+v", resp)
+				}
+				errs = append(errs, err)
+			}
+			if len(errs) != 1 {
+				t.Fatalf("expected exactly one error, got %d: %v", len(errs), errs)
+			}
+			if got := errs[0]; got == nil || !strings.Contains(got.Error(), "nil LLM request") {
+				t.Errorf("error = %v, want it to name the nil request", got)
+			}
+		})
+	}
+}
+
+// A send failure surfaces differently by mode: streaming reports it as a
+// content-less response carrying STREAM_ERROR (which is what lets retryStream
+// see it), non-streaming as a wrapped Go error.
+func TestXAISendErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"invalid request"}}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	m, err := NewXAI(context.Background(), "grok-4.6", "test-key", srv.URL, "high", nil)
+	if err != nil {
+		t.Fatalf("NewXAI() error: %v", err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}}},
+	}
+
+	t.Run("non-streaming", func(t *testing.T) {
+		var errs []error
+		for _, err := range m.GenerateContent(context.Background(), req, false) {
+			errs = append(errs, err)
+		}
+		if len(errs) != 1 || errs[0] == nil {
+			t.Fatalf("expected exactly one error, got %v", errs)
+		}
+		if got := errs[0].Error(); !strings.Contains(got, "xAI Responses API failed") {
+			t.Errorf("error = %q, want it wrapped with the xAI Responses prefix", got)
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		var resps []*model.LLMResponse
+		for resp, err := range m.GenerateContent(context.Background(), req, true) {
+			if err != nil {
+				t.Fatalf("streaming yielded a Go error, want a STREAM_ERROR response: %v", err)
+			}
+			resps = append(resps, resp)
+		}
+		if len(resps) != 1 {
+			t.Fatalf("expected exactly one response, got %d", len(resps))
+		}
+		if got := resps[0].ErrorCode; got != "STREAM_ERROR" {
+			t.Errorf("ErrorCode = %q, want STREAM_ERROR", got)
+		}
+		if resps[0].ErrorMessage == "" {
+			t.Error("ErrorMessage is empty; the provider failure is invisible without it")
+		}
+	})
 }
 
 func TestXAIStreaming(t *testing.T) {

--- a/internal/provider/xai_test.go
+++ b/internal/provider/xai_test.go
@@ -152,7 +152,7 @@ func TestXAIModelReasons(t *testing.T) {
 	}
 }
 
-// xaiCaptureServer answers one chat completion and hands the caller the
+// xaiCaptureServer answers one Responses call and hands the caller the
 // request headers and decoded body that produced it.
 func xaiCaptureServer(t *testing.T, header *http.Header, body *map[string]any) *httptest.Server {
 	t.Helper()
@@ -163,17 +163,53 @@ func xaiCaptureServer(t *testing.T, header *http.Header, body *map[string]any) *
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":     "chat-123",
-			"object": "chat.completion",
+			"id":     "resp_x",
+			"object": "response",
+			"status": "completed",
 			"model":  "grok-4.6",
-			"choices": []map[string]any{{
-				"index":         0,
-				"message":       map[string]any{"role": "assistant", "content": "Hello from Grok!"},
-				"finish_reason": "stop",
+			"output": []map[string]any{{
+				"type":   "message",
+				"id":     "msg_x",
+				"role":   "assistant",
+				"status": "completed",
+				"content": []map[string]any{{
+					"type":        "output_text",
+					"text":        "Hello from Grok!",
+					"annotations": []any{},
+				}},
 			}},
-			"usage": map[string]any{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+			"usage": map[string]any{"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
 		})
 	}))
+}
+
+func xaiReasoningFromBody(body map[string]any) any {
+	reasoning, _ := body["reasoning"].(map[string]any)
+	if reasoning == nil {
+		return nil
+	}
+	return reasoning["effort"]
+}
+
+func xaiToolTypes(body map[string]any) []string {
+	raw, _ := body["tools"].([]any)
+	var types []string
+	for _, item := range raw {
+		tool, _ := item.(map[string]any)
+		if typ, _ := tool["type"].(string); typ != "" {
+			types = append(types, typ)
+		}
+	}
+	return types
+}
+
+func containsString(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 func xaiDrain(t *testing.T, m model.LLM, modelName string) []*model.LLMResponse {
@@ -218,8 +254,8 @@ func TestXAINonStreamingSendsReasoningAndConvID(t *testing.T) {
 		t.Error("expected TurnComplete = true")
 	}
 
-	if got := body["reasoning_effort"]; got != "medium" {
-		t.Errorf("reasoning_effort = %v, want medium", got)
+	if got := xaiReasoningFromBody(body); got != "medium" {
+		t.Errorf("reasoning.effort = %v, want medium", got)
 	}
 	if got := header.Get(xaiConversationHeader); got == "" {
 		t.Errorf("%s header not sent; cache affinity depends on it", xaiConversationHeader)
@@ -259,8 +295,8 @@ func TestXAIOmitsReasoningForNonReasoningModel(t *testing.T) {
 	}
 
 	xaiDrain(t, m, "")
-	if _, ok := body["reasoning_effort"]; ok {
-		t.Errorf("reasoning_effort sent to a non-reasoning model: %v", body["reasoning_effort"])
+	if got := xaiReasoningFromBody(body); got != nil {
+		t.Errorf("reasoning.effort sent to a non-reasoning model: %v", got)
 	}
 }
 
@@ -278,8 +314,8 @@ func TestXAIPerRequestModelOverrideGatesReasoning(t *testing.T) {
 	}
 
 	xaiDrain(t, m, "grok-4.20-0309-non-reasoning")
-	if _, ok := body["reasoning_effort"]; ok {
-		t.Errorf("reasoning_effort sent for request model override: %v", body["reasoning_effort"])
+	if got := xaiReasoningFromBody(body); got != nil {
+		t.Errorf("reasoning.effort sent for request model override: %v", got)
 	}
 	if got := body["model"]; got != "grok-4.20-0309-non-reasoning" {
 		t.Errorf("model = %v, want the per-request override", got)
@@ -310,7 +346,7 @@ func TestXAISendsSystemInstructionAndTools(t *testing.T) {
 	srv := xaiCaptureServer(t, &header, &body)
 	defer srv.Close()
 
-	m, err := NewXAI(context.Background(), "grok-4.6", "test-key", srv.URL, "high", nil)
+	m, err := NewXAI(context.Background(), "grok-4.6", "test-key", srv.URL, "high", &LLMOptions{EnableXAITools: true})
 	if err != nil {
 		t.Fatalf("NewXAI() error: %v", err)
 	}
@@ -333,37 +369,48 @@ func TestXAISendsSystemInstructionAndTools(t *testing.T) {
 		}
 	}
 
-	messages, _ := body["messages"].([]any)
-	if len(messages) == 0 {
-		t.Fatal("expected messages on the wire")
+	if got := body["include"]; got == nil {
+		t.Error("include is missing for enabled xAI server-side tools")
 	}
-	first, _ := messages[0].(map[string]any)
-	if first["role"] != "system" || first["content"] != "You are terse." {
-		t.Errorf("first message = %v, want the system instruction prepended", first)
+	if got := body["instructions"]; got != "You are terse." {
+		t.Errorf("instructions = %v, want the system instruction", got)
 	}
-
-	tools, _ := body["tools"].([]any)
-	if len(tools) != 1 {
-		t.Fatalf("tools = %v, want one declaration", body["tools"])
+	types := xaiToolTypes(body)
+	if !containsString(types, "function") {
+		t.Errorf("tools = %v, want a function declaration", types)
 	}
-	if body["tool_choice"] != "auto" {
-		t.Errorf("tool_choice = %v, want auto", body["tool_choice"])
+	for _, want := range xaiServerSideToolTypes {
+		if !containsString(types, want) {
+			t.Errorf("tools = %v, want built-in %q", types, want)
+		}
 	}
 }
 
 func TestXAIStreaming(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		chunks := []string{
-			`{"id":"c1","object":"chat.completion.chunk","model":"grok-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
-			`{"id":"c1","object":"chat.completion.chunk","model":"grok-4.6","choices":[{"index":0,"delta":{"content":" from Grok"},"finish_reason":null}]}`,
-			`{"id":"c1","object":"chat.completion.chunk","model":"grok-4.6","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":3,"total_tokens":11}}`,
+		flusher := w.(http.Flusher)
+		writeEvent := func(payload map[string]any) {
+			b, _ := json.Marshal(payload)
+			_, _ = w.Write([]byte("event: " + payload["type"].(string) + "\n"))
+			_, _ = w.Write([]byte("data: " + string(b) + "\n\n"))
+			flusher.Flush()
 		}
-		for _, c := range chunks {
-			_, _ = w.Write([]byte("data: " + c + "\n\n"))
-			w.(http.Flusher).Flush()
-		}
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		writeEvent(map[string]any{
+			"type": "response.output_text.delta", "sequence_number": 1,
+			"item_id": "msg_1", "output_index": 0, "content_index": 0, "delta": "Hello",
+		})
+		writeEvent(map[string]any{
+			"type": "response.output_text.delta", "sequence_number": 2,
+			"item_id": "msg_1", "output_index": 0, "content_index": 0, "delta": " from Grok",
+		})
+		writeEvent(map[string]any{
+			"type": "response.completed", "sequence_number": 3,
+			"response": map[string]any{
+				"id": "resp_1", "object": "response", "status": "completed",
+				"usage": map[string]any{"input_tokens": 8, "output_tokens": 3, "total_tokens": 11},
+			},
+		})
 	}))
 	defer srv.Close()
 

--- a/internal/provider/xai_tools.go
+++ b/internal/provider/xai_tools.go
@@ -46,13 +46,14 @@ func xaiServerSideTools() []responses.ToolUnionParam {
 	return out
 }
 
+// xaiBuiltInTool builds `{"type":"<typ>"}`, which is the whole of a built-in
+// tool object on xAI's wire. The JSON is written out directly rather than
+// marshaled from a map: typ only ever comes from xaiServerSideToolTypes, so
+// the shape is fixed, there is nothing in it that needs escaping, and the
+// alternative is an error path that can never be taken and never be tested.
+// TestXAIBuiltInToolWireFormat pins the bytes against the marshaled form.
 func xaiBuiltInTool(typ string) responses.ToolUnionParam {
-	raw, err := json.Marshal(map[string]string{"type": typ})
-	if err != nil {
-		// typ is a package-level constant; marshal of a string map cannot fail.
-		panic("xai built-in tool: " + err.Error())
-	}
-	return param.Override[responses.ToolUnionParam](json.RawMessage(raw))
+	return param.Override[responses.ToolUnionParam](json.RawMessage(`{"type":"` + typ + `"}`))
 }
 
 // xaiToolsEnabled reports whether the caller explicitly enabled xAI server-side tools.

--- a/internal/provider/xai_tools.go
+++ b/internal/provider/xai_tools.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+// xaiToolsEnvVar enables xAI's built-in server-side tools process-wide.
+// Same truthy tokens as PI_NO_GROUNDING: "1", "true", "yes", "on".
+const (
+	xaiToolsEnvVar        = "PI_XAI_TOOLS"
+	xaiToolsDisableEnvVar = "PI_NO_XAI_TOOLS"
+)
+
+// xaiServerSideToolTypes is the built-in set from xAI's server_side_tools.py
+// example: web search, X (Twitter) search, and the sandboxed code interpreter.
+// Collections search and remote MCP are omitted — they need user-supplied IDs
+// or a server URL, so they cannot be turned on safely by default.
+var xaiServerSideToolTypes = []string{"web_search", "x_search", "code_interpreter"}
+
+// xaiToolsDisabled reports whether PI_NO_XAI_TOOLS is set to a recognized
+// truthy value.
+func xaiToolsDisabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(xaiToolsDisableEnvVar)))
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// xaiServerSideTools returns the built-in tool objects xAI's Responses API
+// executes on the server. The OpenAI SDK has first-class types for web_search
+// and code_interpreter, but x_search is xAI-only, and xAI's code_interpreter
+// is just `{"type":"code_interpreter"}` (no OpenAI container). Override keeps
+// all three on the same raw-JSON path so the wire matches the docs exactly.
+func xaiServerSideTools() []responses.ToolUnionParam {
+	out := make([]responses.ToolUnionParam, 0, len(xaiServerSideToolTypes))
+	for _, typ := range xaiServerSideToolTypes {
+		out = append(out, xaiBuiltInTool(typ))
+	}
+	return out
+}
+
+func xaiBuiltInTool(typ string) responses.ToolUnionParam {
+	raw, err := json.Marshal(map[string]string{"type": typ})
+	if err != nil {
+		// typ is a package-level constant; marshal of a string map cannot fail.
+		panic("xai built-in tool: " + err.Error())
+	}
+	return param.Override[responses.ToolUnionParam](json.RawMessage(raw))
+}
+
+// xaiToolsEnabled reports whether the caller explicitly enabled xAI server-side tools.
+func xaiToolsEnabled(configured bool) bool {
+	if configured {
+		return true
+	}
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(xaiToolsEnvVar)))
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- route xAI requests through the Responses API
- add opt-in web search, X search, and code interpreter server-side tools
- preserve tool output includes and update provider tests
- add nil request validation

## Verification
- `go test ./internal/provider ./internal/agent ./cmd/pi -count=1`
- `make lint`
- `make vet`
- `make build`

Full `go test ./...` was started but stopped after timing out in the environment; targeted provider, agent, and CLI tests passed.