### PR TITLE
docs(specs): memory-fixes — repair the dead observation pipeline

### DIFF
--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -18,6 +18,7 @@ specs/
 │   ├── TUI/             # Terminal UI
 │   └── WEB/             # Web server
 ├── issues/               # Issue tracking/fixes
+├── memory-fixes/         # Memory subsystem repair
 ├── research/             # Architecture improvements
 ├── sessio-errors/        # Session error analysis
 └── tools/                # Tool specifications
@@ -126,6 +127,12 @@ specs/
 | 007-write-tool-data-loss/ | readme | `write`/`edit` truncate before writing and never fsync — data loss on quit |
 | 008-adk-utils-go-review/  | research | adk-utils-go feature comparison & scored recommendations                  |
 | 009-tui-review-followups/ | readme | Deferred follow-ups from the TUI review and the PR #134 review           |
+
+### memory-fixes/
+
+| Spec           | Phases       | Description                                                                     |
+|----------------|--------------|---------------------------------------------------------------------------------|
+| memory-fixes/  | idea..prompt | Repair the memory subsystem: dead after-tool callback chain, worker lifecycle, palace paths, TUI wiring |
 
 ### research/
 

--- a/specs/memory-fixes/PROMPT.md
+++ b/specs/memory-fixes/PROMPT.md
@@ -1,0 +1,79 @@
+# Agent Prompt — Memory subsystem repair
+
+You are implementing `specs/memory-fixes/plan.md` in the pi-go repository.
+
+## Read first, in order
+
+1. `specs/memory-fixes/rough-idea.md` — what is broken and why it matters
+2. `specs/memory-fixes/research/findings.md` — the evidence; every claim is
+   measured, do not re-derive it
+3. `specs/memory-fixes/requirements.md` — acceptance criteria R1–R9
+4. `specs/memory-fixes/design.md` — the chosen approach and the rejected ones
+5. `specs/memory-fixes/plan.md` — the slices you are executing
+
+Also read `CLAUDE.md` (worktrees, signed commits, the two environment traps) and
+load the `code-guidelines-go` skill before writing Go.
+
+## The one thing to understand before touching code
+
+ADK ends the after-tool callback chain at the first callback returning a non-nil
+result. pi-go hands ADK six callbacks that all return the result map, so only
+the first runs. The memory recorder is last. That is why
+`~/.pi-go/memory/claude-mem.db` holds 6228 sessions and zero observations.
+
+Fixing the order alone does not work — it was tried, and the LSP callback simply
+becomes the new short-circuit. Compose the callbacks into one, as `design.md`
+§ 1 specifies.
+
+## How to work
+
+- One worktree for the whole task:
+  `git worktree add -b fix/memory-subsystem .worktrees/fix-memory-subsystem HEAD`
+- One commit per slice, `-s -S`, sandbox disabled for the commit. Never
+  `--no-verify`.
+- After each slice: `make test`, `make vet`, `make lint`. Run `internal/cli`
+  tests **outside the sandbox** — `httptest.NewServer` cannot bind inside it,
+  and that panic is not a real failure.
+- Do not proceed past Slice 2 until the manual verification in Slice 1 shows a
+  non-zero observation count.
+
+## Manual verification that matters
+
+After Slice 1:
+
+```bash
+make build
+./bin/pi --mode print "read go.mod and tell me the module name"
+sqlite3 ~/.pi-go/memory/claude-mem.db "select id,type,title,tool_name from observations order by id desc limit 5"
+```
+
+Expect at least one row. Zero rows means the chain is still short-circuiting —
+stop and find out where before continuing.
+
+After Slice 4:
+
+```bash
+pi memory init . && pi memory status     # note the resolved DB path
+```
+
+The path printed must be the one an agent session in the same directory opens.
+
+## Scope discipline
+
+Implement the slices as written. If you find further defects, record them in
+`summary.md` rather than fixing them inline — this branch is already touching
+four subsystems that have been dead long enough that re-enabling them is itself
+a behaviour change worth isolating.
+
+Do not attempt upstream MemPalace parity. `research/comparison.md` lists what is
+missing and it is deliberately out of scope.
+
+## Definition of done
+
+- R1–R9 in `requirements.md` all satisfied.
+- `TestObservationReachesPalace` and `TestShortSessionRecordsObservation` fail on
+  `69b4d03` and pass on the branch.
+- A real session records observations; `pi memory recent` shows them.
+- `summary.md` written: what landed, the recall@5 baseline, whether re-enabling
+  the compactor and LSP hooks visibly changed agent behaviour, and any defect
+  you found and deliberately left alone.

--- a/specs/memory-fixes/design.md
+++ b/specs/memory-fixes/design.md
@@ -1,0 +1,214 @@
+# Design
+
+## 1. Callback composition (R1)
+
+### Problem
+
+ADK's contract is "first non-nil result wins and ends the chain". pi-go treats
+the slice as a broadcast list. Both readings are defensible; only one is the
+library's. See `research/findings.md` § F1.
+
+### Decision
+
+Keep pi-go's semantics, and stop handing ADK a slice. Compose pi-go's callbacks
+into **one** ADK callback that owns the chaining rules.
+
+New file `internal/extension/chain.go`:
+
+```go
+// ChainAfterTool folds callbacks into a single ADK AfterToolCallback with
+// pi-go semantics: every callback runs, in order; a nil return means "no
+// change"; a non-nil return replaces the result passed to the next callback;
+// an error aborts the chain.
+//
+// ADK's own contract is different — it stops at the first non-nil result
+// (adk/v2 internal/llminternal/base_flow.go, invokeAfterToolCallbacks). Handing
+// ADK a slice therefore silently disables every callback but the first. Always
+// register exactly one composed callback.
+func ChainAfterTool(cbs ...llmagent.AfterToolCallback) llmagent.AfterToolCallback
+
+// ChainBeforeTool is the same fold for before-tool callbacks, where ADK's
+// short-circuit ("a non-nil result skips the tool") is the intended behaviour
+// and is preserved.
+func ChainBeforeTool(cbs ...llmagent.BeforeToolCallback) llmagent.BeforeToolCallback
+```
+
+`ChainAfterTool` semantics, precisely:
+
+| Callback returns | Chain does |
+|---|---|
+| `nil, nil` | keep current result, continue |
+| `m, nil` | current result becomes `m`, continue |
+| `_, err` | abort, return `nil, err` |
+
+Final return is the current result and the original tool error — matching ADK's
+`return fResult, fErr` tail.
+
+Both call sites become:
+
+```go
+AfterToolCallbacks: []llmagent.AfterToolCallback{
+    extension.ChainAfterTool(afterCBs...),
+},
+```
+
+Ordering matters and is now explicit: observers (tracing, memory) before
+transformers (compactor, dedup), so observers see the untransformed result.
+
+### Why not "make observers return nil"
+
+It would work today and break the first time someone appends a transformer
+after an observer. The bug is that a slice does not mean what the code assumes;
+fix that, not the symptom. Making tracing return `nil, nil` is still correct and
+lands as part of the ordering pass — it is just not the fix.
+
+## 2. Worker lifecycle and compression cost (R2, R3, R4)
+
+### Concurrency
+
+`internal/memory/worker.go` grows a configurable worker count.
+
+```go
+type WorkerConfig struct {
+    BufSize      int           // default 100
+    Concurrency  int           // default 4
+    DrainTimeout time.Duration // default 60s
+    ItemTimeout  time.Duration // default 45s
+}
+```
+
+`Start` launches `Concurrency` goroutines over the same channel. `processOne`
+wraps its compression in `context.WithTimeout(ctx, ItemTimeout)` so one stuck
+item cannot hold a slot for ten minutes.
+
+Ordering across observations is not guaranteed today either (single queue, async
+callback) and nothing depends on it — `created_at_epoch` orders reads.
+
+### Drop accounting
+
+`Enqueue`'s `default:` branch increments an atomic `dropped` counter alongside
+the existing warning. `Shutdown` logs the total. Silent loss becomes visible
+loss.
+
+### Shutdown ordering
+
+The current closer drains for 5 s then closes the store, so a compression in
+flight writes into a closed handle. New order:
+
+1. `close(obsChan)`
+2. wait for drain up to `DrainTimeout` (default 60 s > one compression)
+3. log `dropped` and any undrained count
+4. `store.Close()`
+
+Same change in both closers (`cli.go` `setupMemory`, `interactive.go`
+`initResources.close`).
+
+### In-process compression
+
+`SubagentCompressor` spawns a `pi --mode json` child per observation: ~5.6 s and
+one process. The `Compressor` interface already isolates this.
+
+Add `internal/memory/compress_llm.go` — `LLMCompressor`, which calls the
+resolved `smol` model directly through the provider layer, no subprocess, no
+worktree, no pool slot. Same prompt, same JSON contract, same
+`parseCompressedResponse`.
+
+Selection: `cfg.Memory.Compressor` = `"llm"` (default) | `"subagent"` | `"none"`.
+`"none"` stores the fallback observation without any model call — cheap, useful
+for CI and for users who want capture without inference.
+
+`ResolveRole` falling back to `default` stays, but the wiring logs once per
+session when `smol` is unconfigured, so a frontier-model fallback is visible
+rather than a surprise on the bill.
+
+This also removes the `memory → subagent` layering violation recorded as
+`TODO.md` item 36.
+
+## 3. Path resolution (R5)
+
+New `internal/palace/paths.go`, the single source of truth:
+
+```go
+// ResolveDBPath returns the palace database path for workDir.
+// Precedence: explicit → config → project → home.
+func ResolveDBPath(explicit string, cfg *config.PalaceConfig, workDir string) string
+
+// ResolveModelPath returns the embedding-model directory.
+// Precedence: config → $HOME/.pi-go/models/<DefaultModelDir>.
+func ResolveModelPath(cfg *config.PalaceConfig) string
+
+// DefaultModelDir is the on-disk name written by `pi memory model download`.
+const DefaultModelDir = "sentence-transformers_all-MiniLM-L6-v2"
+```
+
+"Project" means `<git root of workDir>/.pi-go/palace.db`, falling back to
+`workDir` when not in a repo — so `pi memory search` run from a subdirectory
+finds the palace `pi memory mine .` created at the root. That is a behaviour
+change for the `pi memory *` commands and is intentional; today they are
+cwd-relative and miss.
+
+Every current computation of these paths is replaced by a call:
+`memory.go:13`, `memory_init.go:48`, `memory_mine.go:283`, `memory_status.go:32`,
+`memory_search.go:43`, `memory_wakeup.go:38`, `memory_model.go:59,105,109`,
+`tui/memory.go:27`, `cli.go` `palaceConfigFromCLI`.
+
+`KnightsAnalytics_all-MiniLM-L6-v2` disappears — it names a directory that has
+never existed on disk.
+
+### Migration
+
+Users with an existing `$HOME/.pi-go/palace.db` and no project palace keep
+working: home is the last precedence step. `pi memory status` gains a line
+naming the resolved path and which precedence rule chose it, so "where is my
+palace" is answerable without reading code.
+
+## 4. Palace in the interactive path (R6, R7)
+
+`setupPalace` moves from `cli.go` to a shared helper both entry points call.
+Because the TUI builds resources after the UI starts, palace setup joins
+`initMemoryAfterUI`: open palace, register tools, wire the bridge, push the
+wake-up context.
+
+Wake-up context arrives after the instruction is built, so it goes in as an
+`InstructionParts` field rather than string concatenation — that keeps the
+context-gauge breakdown honest, which is the stated reason `instructionParts`
+exists.
+
+### Wing scoping
+
+`palace.WingForProject(project string) string` becomes the one derivation,
+extracted from `bridge.go:deriveWing`. Both the bridge and wake-up call it:
+
+```go
+wakeUp, err := p.WakeUp(ctx, palace.WingForProject(cwd))
+```
+
+Empty wing keeps meaning "all wings" at the store layer — that is right for
+`pi memory wake-up --wing ""`. Only the session call site becomes specific.
+
+## 5. Retrieval safety and measurement (R8, R9)
+
+Smallest useful versions; ANN indexing is deliberately deferred.
+
+- `palace.SanitizeQuery` — strips FTS5 operators and control characters beyond
+  today's quote-stripping.
+- Retrieved drawer bodies are fenced when injected, so drawer content cannot
+  read as instructions.
+- `internal/palace/testdata/bench/` — a small committed corpus with labelled
+  query → expected-drawer pairs. `TestRetrievalRecall` computes recall@5 and
+  fails below a floor. Runs with the deterministic hash embedder, no network.
+- `TestObservationReachesPalace` — the end-to-end assertion: fake tool call →
+  chained callbacks → worker → observation row → bridge → drawer → found by
+  search. This is the test whose absence let F1 hide for four months.
+
+Brute-force cosine stays. `GetAllEmbeddings` + `RankBySimilarity` is fine at
+current corpus sizes; the benchmark from R9 is what will tell us when it is not.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Enabling the compactor and LSP hooks for the first time changes model-visible output | Land Slice 1 alone and observe; compactor config already exists and is testable in isolation |
+| In-process compression adds latency to the agent's own provider path | Runs on worker goroutines, never the turn path; concurrency capped |
+| Compression cost per tool call is now real, where before it was zero | `Compressor: "none"` opt-out, plus the once-per-session log when `smol` is unconfigured |
+| Project-relative palace path changes where `pi memory *` looks | `pi memory status` prints the resolved path and rule; home remains the final fallback |

--- a/specs/memory-fixes/plan.md
+++ b/specs/memory-fixes/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan — Memory subsystem repair
+
+> Vertical slices. Each ends in a passing build and a green package test.
+> No slice depends on a later one being merged.
+>
+> Repo gate per slice: `make test`, `make vet`, `make lint`.
+> `internal/cli` tests bind local listeners — run them **outside the sandbox**
+> (`CLAUDE.md` § "Two environment traps").
+>
+> Slices 1–2 are the outage. Land and verify them before starting 3.
+
+---
+
+## Slice 1 — Callback chaining (R1)
+
+The whole outage. Ship it alone.
+
+- [ ] **Create `internal/extension/chain.go`** with `ChainAfterTool` and
+  `ChainBeforeTool` per `design.md` § 1. Document ADK's differing contract in
+  the doc comment, with the `base_flow.go` reference — the next person needs to
+  know why a bare slice is wrong.
+- [ ] **`internal/cli/cli.go`** — replace `AfterToolCallbacks: afterCBs` with a
+  single `extension.ChainAfterTool(afterCBs...)`. Same for `BeforeToolCallbacks`.
+- [ ] **`internal/cli/interactive.go`** — identical change.
+- [ ] **Reorder the chain** so observers precede transformers:
+  `hooks → tracing → memory recorder → LSP → compactor → dedup`.
+  The memory recorder moves ahead of the compactor so observations record the
+  untruncated output.
+- [ ] **`internal/extension/hooks.go`** — the OTel after-tool callback returns
+  `nil, nil` on both paths. It observes; it must not claim to transform.
+- [ ] **Tests** (`internal/extension/chain_test.go`):
+  - `TestChainAfterTool_AllRun` — three callbacks, all observed.
+  - `TestChainAfterTool_NilIsNoChange` — nil return preserves the prior result.
+  - `TestChainAfterTool_ResultThreads` — cb1's map is what cb2 receives.
+  - `TestChainAfterTool_ErrorAborts` — cb2 errors, cb3 never runs, error propagates.
+  - `TestChainAfterTool_Empty` — returns the original result and error.
+  - `TestChainBeforeTool_ShortCircuits` — first non-nil skips the tool (ADK
+    semantics preserved for the before chain).
+- [ ] **Regression test** (`internal/cli/callback_chain_test.go`): build the real
+  chain, fire one tool result through it, assert the memory recorder enqueued
+  **and** the compactor truncated. This is the test that pins the bug shut.
+- [ ] **Verify manually.** Build, run
+  `pi --mode print "read go.mod"`, then
+  `sqlite3 ~/.pi-go/memory/claude-mem.db "select count(*) from observations"`.
+  Expect ≥ 1. Today it is 0.
+
+---
+
+## Slice 2 — Worker lifecycle (R2, R3)
+
+- [ ] **`internal/memory/worker.go`** — add `WorkerConfig{BufSize, Concurrency,
+  DrainTimeout, ItemTimeout}` with the defaults from `design.md` § 2. Keep
+  `NewWorker(store, compressor, bufSize)` as a thin wrapper so existing callers
+  and tests compile.
+- [ ] `Start` launches `Concurrency` goroutines over `obsChan`; `w.done` closes
+  once all have exited (`sync.WaitGroup`, not the current single `close`).
+- [ ] `processOne` wraps compression in `context.WithTimeout(ctx, ItemTimeout)`.
+- [ ] `Enqueue` increments an atomic `dropped` counter on the `default:` branch.
+- [ ] `Shutdown` logs `dropped` and the undrained count when the deadline expires.
+- [ ] **Fix shutdown ordering** in `cli.go` `setupMemory` and `interactive.go`
+  `initResources.close`: drain to completion (or `DrainTimeout`) **before**
+  `store.Close()`. Raise the budget from 5 s to `DrainTimeout`.
+- [ ] **`internal/subagent/bundled/memory-compressor.md`** — `timeout: 600000` →
+  `45000`.
+- [ ] **Tests** (`internal/memory/worker_test.go`):
+  - `TestWorker_ConcurrentDrain` — N slow mock compressions finish in roughly
+    `N/Concurrency × d`, not `N × d`.
+  - `TestWorker_ItemTimeout` — a compressor that never returns yields a fallback
+    observation and frees its slot.
+  - `TestWorker_DroppedCounter` — buffer 1, blocked worker, second enqueue
+    increments `dropped`.
+  - `TestWorker_ShutdownDrainsBeforeClose` — no insert lands on a closed store.
+- [ ] **Verify:** `go test ./internal/memory/... ./internal/cli/...` (outside sandbox).
+
+---
+
+## Slice 3 — In-process compression (R4)
+
+- [ ] **`internal/memory/compress_llm.go`** — `LLMCompressor` implementing
+  `Compressor` against the provider layer, reusing `buildCompressionPrompt`,
+  `parseCompressedResponse` and `SummarizeSession`'s prompt.
+- [ ] **`internal/config`** — add `Memory.Compressor` (`"llm"` default,
+  `"subagent"`, `"none"`) and `Memory.Concurrency`, `Memory.DrainTimeout`,
+  `Memory.ItemTimeout`.
+- [ ] **Wiring** picks the compressor from config. `NoopCompressor` for `"none"`
+  returns the fallback observation directly.
+- [ ] **Log once per session** when `smol` is unresolved and `ResolveRole` fell
+  back to `default`, naming the model that will actually be billed.
+- [ ] **Move `SubagentCompressor` out of `internal/memory`** into the wiring
+  layer so `memory` no longer imports `subagent`. Closes `TODO.md` item 36.
+  `memory` keeps only the `Compressor` interface.
+- [ ] **Tests:**
+  - `TestLLMCompressor_ParsesResponse` — fake provider, fenced JSON, fields map.
+  - `TestLLMCompressor_MalformedFallsBack` — bad JSON surfaces an error so the
+    worker's fallback path runs.
+  - `TestNoopCompressor` — produces the fallback observation, calls no model.
+  - `TestCompressorSelection` — each config value builds the right type.
+- [ ] **Verify:** memory package no longer imports `internal/subagent`
+  (`go list -deps` assertion in the test).
+
+---
+
+## Slice 4 — Path unification (R5)
+
+- [ ] **Create `internal/palace/paths.go`** — `ResolveDBPath`, `ResolveModelPath`,
+  `DefaultModelDir` per `design.md` § 3.
+- [ ] **Replace every ad-hoc computation** with a call: `memory.go:13`,
+  `memory_init.go:48`, `memory_mine.go:283`, `memory_status.go:32`,
+  `memory_search.go:43`, `memory_wakeup.go:38`, `memory_model.go:59,105,109`,
+  `tui/memory.go:27`, `cli.go` `palaceConfigFromCLI`.
+- [ ] **Delete the `KnightsAnalytics_all-MiniLM-L6-v2` literal.** No such
+  directory has ever existed.
+- [ ] **`pi memory status`** prints the resolved DB path, the resolved model
+  path, and which precedence rule selected each.
+- [ ] **Tests** (`internal/palace/paths_test.go`): table-driven over the
+  precedence ladder — explicit beats config beats project beats home; project
+  resolution walks up to the git root; no-repo falls back to `workDir`.
+- [ ] **Verify:** `pi memory init . && pi memory status` and a session in the
+  same directory report the same file.
+
+---
+
+## Slice 5 — Palace in the TUI, scoped wake-up (R6, R7)
+
+- [ ] **Extract `setupPalace`** from `cli.go` into a helper both entry points use.
+- [ ] **Call it from `initMemoryAfterUI`** (`interactive.go`): open the palace,
+  append `palace.PalaceTools`, wire `OnAfterStore(bridge.ConvertAndStore)`,
+  deliver the wake-up context.
+- [ ] **Wake-up context as an `InstructionParts` field**, not string
+  concatenation, so the context gauge attributes it correctly.
+- [ ] **Extract `palace.WingForProject`** from `bridge.go:deriveWing`; the bridge
+  and both wake-up call sites use it. Session wake-up passes the project wing;
+  `pi memory wake-up` keeps its `--wing` flag with `""` meaning all wings.
+- [ ] **Close the palace** in `initResources.close`, after the memory worker
+  drains — the bridge writes drawers from worker goroutines.
+- [ ] **Tests:**
+  - `TestWingForProject` — path → wing, including `/`, `.`, and empty.
+  - `TestWakeUpScopedToWing` — two wings present, only the requested one renders.
+  - `TestInteractivePalaceWiring` — TUI setup registers palace tools when a
+    palace exists and stays silent when it does not.
+- [ ] **Verify:** start the TUI in a project with a mined palace; palace tools
+  are listed and the sidebar drawer count matches `pi memory status`.
+
+---
+
+## Slice 6 — End-to-end regression test (R9, part 1)
+
+The test that should have existed from the start. Written after 1–5 so it
+asserts the repaired behaviour.
+
+- [ ] **`internal/cli/memory_e2e_test.go`** — `TestObservationReachesPalace`:
+  temp home, temp palace, fake tool result through the real composed chain →
+  worker (noop compressor, deterministic) → `observations` row → bridge →
+  `drawers` row → retrievable via `mem-search`. No network, no API key.
+- [ ] **`TestShortSessionRecordsObservation`** — enqueue then immediately run the
+  real shutdown closer; assert the row exists and no closed-DB error is logged.
+- [ ] **Verify:** both fail against `69b4d03` and pass on the branch.
+
+---
+
+## Slice 7 — Query sanitisation and fencing (R8)
+
+- [ ] **`palace.SanitizeQuery`** — strip FTS5 operators, control characters and
+  instruction-shaped prefixes; replaces the bare quote-stripping in
+  `sanitizeFTS5Query`.
+- [ ] **Fence retrieved drawer bodies** in wake-up, recall and `mem-search`
+  output so drawer content cannot read as instructions.
+- [ ] **Tests:** operator injection (`"a" OR "b"`, `NEAR/3`, `*`) is neutralised;
+  a drawer containing `## System:` renders fenced.
+
+---
+
+## Slice 8 — Retrieval benchmark (R9, part 2)
+
+- [ ] **`internal/palace/testdata/bench/`** — small committed corpus plus
+  labelled query → expected-drawer pairs.
+- [ ] **`TestRetrievalRecall`** — recall@5 against the fixtures with the
+  deterministic hash embedder; assert a floor and print the number.
+- [ ] **`make test-memory-bench`** target.
+- [ ] **Record the baseline** in `summary.md` so the next change has something to
+  regress against.
+
+---
+
+## Post-merge
+
+- [ ] Rebuild and install the local `pi` binary.
+- [ ] Run a real session; confirm observations accumulate and
+  `pi memory recent` shows them.
+- [ ] Note in `summary.md` whether re-enabling the compactor and LSP hooks
+  changed model-visible behaviour — they have been dead the whole time, so this
+  is the first honest measurement of them.

--- a/specs/memory-fixes/requirements.md
+++ b/specs/memory-fixes/requirements.md
@@ -1,0 +1,132 @@
+# Requirements
+
+## Scope
+
+Repair the existing memory subsystem so it records what it was designed to
+record. No new memory features, no data-model changes, no parity work against
+upstream MemPalace beyond the two items called out in R8 and R9.
+
+## Acceptance criteria
+
+### R1 — Every after-tool callback runs
+
+**Given** a session with the default callback set (hooks, OTel tracing, LSP,
+compactor, dedup, memory recorder)
+**When** any tool call completes successfully
+**Then** all six callbacks execute, in registration order, and the tool result
+the model sees is the one produced by the last transforming callback.
+
+- A callback returning `nil` must be treated as "no change", not "stop".
+- A callback returning a map must feed that map to the next callback.
+- A callback returning an error must abort the chain and propagate — unchanged
+  from today.
+- Regression test asserts all of: an observation is enqueued, the compactor
+  truncated the output, and the deduper saw the call — for one tool call.
+
+**Rationale:** this is the whole outage. See `research/findings.md` § F1.
+
+### R2 — Observations survive a short session
+
+**Given** a `--mode print` run that makes one tool call and exits immediately
+**When** the process shuts down
+**Then** the observation is stored, and no `sql: database is closed` error is
+logged.
+
+- The store must not close until the worker has drained or the drain deadline
+  expires.
+- The drain deadline must be configurable and default to a value larger than one
+  compression (≥ 30 s).
+- Dropped work must be counted and logged at shutdown: "N observations dropped".
+
+### R3 — Compression does not serialise the pipeline
+
+**Given** a session producing tool calls faster than compression completes
+**When** the queue is under load
+**Then** compressions proceed concurrently and enqueue never silently discards.
+
+- Configurable worker concurrency, default > 1.
+- Per-compression timeout ≤ 60 s, not the current 600 s.
+- A dropped enqueue increments a counter surfaced in the shutdown log.
+
+### R4 — Compression is affordable
+
+**Given** the default configuration
+**When** an observation is compressed
+**Then** it does not spawn a `pi` child process per tool call.
+
+- Compression runs in-process against the resolved `smol` role.
+- `smol` resolves to an actual small model; if no `smol` role is configured, the
+  fallback must be logged once per session, not silently billed at frontier
+  prices.
+- The existing `Compressor` interface is the seam — `SubagentCompressor` remains
+  available and selectable.
+
+### R5 — One palace path
+
+**Given** any pi-go entry point — `pi memory *`, the TUI sidebar, or an agent
+session
+**When** it resolves the palace database
+**Then** all of them resolve to the same file for the same working directory.
+
+- Single exported resolver; no entry point computes the path itself.
+- Precedence: `--db` flag → `cfg.Palace.DBPath` → project `<root>/.pi-go/palace.db`
+  → `$HOME/.pi-go/palace.db`.
+- Same rule for the embedding-model directory; `pi memory model download`,
+  `pi memory model status` and the session embedder must agree.
+
+### R6 — Palace works in the TUI
+
+**Given** an interactive session in a project with a palace
+**When** the session starts
+**Then** palace tools are registered, wake-up context is injected, and the
+observation bridge is wired — exactly as in the headless path.
+
+- Absent palace remains a silent no-op, not an error.
+- The sidebar reads the same database the session opened.
+
+### R7 — Wake-up is scoped to the project
+
+**Given** a palace containing drawers from several projects
+**When** a session in project X wakes up
+**Then** only wing X's drawers appear in the L1 essential story.
+
+- The wing derivation used by wake-up and by `ObservationBridge` must be one
+  shared function.
+
+### R8 — Search input is sanitised
+
+**Given** a drawer whose content contains instruction-shaped text
+**When** it is retrieved and injected into the prompt
+**Then** it is delimited as untrusted data.
+
+- Query text is neutralised before it reaches FTS5 beyond quote-stripping.
+- Retrieved drawer bodies are fenced in the injected context.
+
+### R9 — Retrieval is measured
+
+**Given** a committed fixture corpus
+**When** `make test-memory-bench` runs
+**Then** it prints recall@5 and asserts a floor, so a regression fails CI.
+
+- Fixture corpus committed, small, no network, no API key.
+- A test asserts the end-to-end path: tool call → observation → drawer →
+  retrievable by `mem-search`. This is the test that would have caught the
+  outage on day one.
+
+## Constraints
+
+- No change to the `drawers`, `observations`, `sessions`, `triples` or
+  `entities` schemas. Additive migrations only if unavoidable.
+- Memory and palace stay best-effort: any failure degrades to "no memory" with a
+  warning and never blocks a turn.
+- Existing public surfaces stay: `memory.Store`, `memory.Compressor`,
+  `palace.PalaceStore`, `palace.PalaceTools`, all `pi memory` subcommands.
+- Gate for every slice: `make test`, `make vet`, `make lint`.
+- `internal/cli` tests bind local listeners and must be run outside the sandbox
+  (`CLAUDE.md` § "Two environment traps").
+
+## Out of scope
+
+AAAK dialect, entity detection/disambiguation, repair/export/onboarding
+commands, the MCP surface, pluggable vector backends, per-message sweeping,
+verbatim (non-compressed) storage. Catalogued in `research/comparison.md`.

--- a/specs/memory-fixes/research/comparison.md
+++ b/specs/memory-fixes/research/comparison.md
@@ -1,0 +1,78 @@
+# Research — MemPalace (upstream) vs pi-go port
+
+Upstream: `tmp/memory/mempalace`, MemPalace v3.7.1, Python, ~45k LOC.
+Port: `internal/palace` (~14k LOC incl. tests) + `internal/memory`.
+
+The port is a genuine reimplementation, not a wrapper: same conceptual model
+(wings → rooms → drawers, temporal knowledge graph, L0–L3 wake-up stack), Go
+types, SQLite instead of ChromaDB.
+
+## Ported and working
+
+Verified by `go test ./internal/palace/... ./internal/memory/...` (2.8 s, passes
+outside the sandbox).
+
+| Capability | Upstream | pi-go |
+|---|---|---|
+| Wings / rooms / halls / drawers | `palace.py` | `palace.go`, `sqlite_store.go` |
+| Hybrid search (keyword + vector) | `searcher.py` | `drawer_service.go:122` — FTS5 ∪ cosine, merged |
+| Dedup | `dedup.py` | content-hash + cosine (`drawer_service.go:60-89`) |
+| Temporal knowledge graph | `knowledge_graph.py` | `kg.go` — add/query/invalidate/timeline with validity windows |
+| LLM entity/relation extraction | `llm_refine.py` | `tool_kg_extract.go` |
+| Room graph traversal, cross-wing tunnels | `palace_graph.py` | `graph.go` |
+| Agent diaries | MCP diary tools | `tool_diary.go` |
+| L0–L3 memory stack | `layers.py` | `layers.go` |
+| Project miner | `miner.py` | `miner_project.go` |
+| Conversation miner | `convo_miner.py` | `miner_convo.go` (JSONL + plaintext) |
+| Local embeddings | ONNX / sentence-transformers | `embedder_backend_ort.go`, `embedder_backend_go.go` |
+| Server embeddings | openai-compat endpoint | `embedder_ollama.go` (Ollama only) |
+| Embedding cache | — | `embedding_cache.go` |
+| Storage seam | `backends/base.py` | `store.go` — `PalaceStore` interface |
+| Schema migration | `migrate.py` | `schema_versions` table |
+| CLI | `mempalace <cmd>` | `pi memory model\|init\|status\|mine\|search\|kg\|wake-up\|recent\|clear` |
+
+## Not ported
+
+Catalogued for completeness. **None of these is scheduled in this spec** except
+where `plan.md` says otherwise (query sanitisation and the benchmark, in Slice 8).
+
+| Upstream | What it does | pi-go |
+|---|---|---|
+| `dialect.py` | AAAK compressed index layer — lets an LLM scan thousands of entries and pick a drawer without reading content | absent |
+| `entity_detector.py`, `entity_registry.py` | auto-detect and disambiguate people/projects; entity-first indexing | absent — `kg.go` auto-creates entities by name string only |
+| `query_sanitizer.py` | prompt-contamination mitigation on search input | absent |
+| `repair.py` | palace consistency check and repair | absent |
+| `exporter.py` | palace export | absent |
+| `onboarding.py` | interactive first-run model/config setup | `pi memory init` only creates the DB |
+| `sweeper.py` | one verbatim drawer per user/assistant message, idempotent | absent |
+| `spellcheck.py`, `normalize.py`, `encoding_repair.py` | transcript normalisation | partial, inside `miner_convo.go` |
+| `mcp_server.py` — 44 MCP tools | palace over MCP for any client | 11 ADK tools, no MCP or HTTP surface |
+| ChromaDB HNSW | ANN vector index | brute-force cosine over all embeddings |
+| `backends/` — chroma, sqlite_exact, milvus, qdrant, pgvector | pluggable vector stores | SQLite only (interface exists) |
+| `benchmarks/` — LongMemEval, LoCoMo, ConvoMem, MemBench | reproducible retrieval numbers | none |
+| `hooks/` — Stop + PreCompact auto-save | out-of-process capture | in-process `ObservationBridge` (different design, deliberately) |
+
+## Design divergences worth keeping
+
+Three places where pi-go deviates on purpose and should not be "corrected"
+toward upstream:
+
+1. **Storage.** SQLite + FTS5 for everything, including vectors as BLOBs. One
+   file, no daemon, no Python. Upstream needs ChromaDB and a ~300 MB model
+   download before the first query.
+2. **Capture.** Upstream captures through shell hooks that re-read transcripts
+   off disk. pi-go captures in-process from the ADK after-tool callback and
+   bridges observations into drawers. Lower latency, no transcript parsing, no
+   30-day expiry problem — once it is reachable (F1).
+3. **Compression.** Upstream stores verbatim and never summarises ("verbatim
+   always" is its stated non-negotiable). pi-go compresses each tool call into a
+   structured observation. That is a real semantic difference: pi-go's index is
+   lossy by design. It buys a much smaller context injection; it costs exact
+   recall. Worth stating explicitly rather than drifting into it.
+
+## Bottom line
+
+The gap between pi-go and upstream is not feature coverage. It is that pi-go's
+version has never run. Closing F1–F4 gets the port from "0 observations in 6228
+sessions" to "working memory system"; the missing-features table above only
+starts to matter after that.

--- a/specs/memory-fixes/research/findings.md
+++ b/specs/memory-fixes/research/findings.md
@@ -1,0 +1,199 @@
+# Research — Evidence for each defect
+
+Everything below was measured on 2026-08-13 against the live databases and by
+running the binary. Line references are against `69b4d03`.
+
+---
+
+## F1 — After-tool callback chain stops at the first callback
+
+### Upstream semantics
+
+`$(go env GOMODCACHE)/google.golang.org/adk/v2@v2.0.0/internal/llminternal/base_flow.go:1296`
+
+```go
+func (f *Flow) invokeAfterToolCallbacks(...) (map[string]any, error) {
+	for _, callback := range f.AfterToolCallbacks {
+		result, err := callback(toolCtx, tool, fArgs, fResult, fErr)
+		if err != nil {
+			return nil, err
+		}
+		// When a list of callbacks is provided, the callbacks will be called in the
+		// order they are listed while a callback returns nil.
+		if result != nil {
+			return result, nil
+		}
+	}
+	return fResult, fErr
+}
+```
+
+A non-nil return means "override the tool result and stop". It does not mean
+"here is the result, carry on".
+
+### What pi-go registers
+
+`internal/cli/cli.go:602-624` (headless) and `internal/cli/interactive.go:338-358`
+(TUI) build the same chain in the same order:
+
+| # | Callback | Returns | Source |
+|---|----------|---------|--------|
+| 1 | `extension.BuildAfterToolCallbacks(hooks)` | `result` | `internal/extension/hooks.go:256` |
+| 2 | `extension.BuildTracingCallbacks` (OTel) | `result` | `internal/extension/hooks.go:266` |
+| 3 | `lsp.BuildLSPAfterToolCallback` | `result` | `internal/lsp/hooks.go:36,81` |
+| 4 | `tools.BuildCompactorCallback` | `result` | `internal/tools/compactor.go:82,91` |
+| 5 | `tools.BuildDedupCallback` | `result` | `internal/tools/dedup.go:110,113` |
+| 6 | `memoryObservationCallback` / `memRecorder.afterTool` | `result` | `internal/cli/cli.go:1091` |
+
+No hooks are configured by default, so **#2 is the first to return non-nil and
+#3, #4, #5 and #6 never execute**. The OTel callback returns `result` on both
+its paths, including the `span == nil` early return, so the short-circuit is
+unconditional.
+
+Consequences, all four silent:
+
+- LSP diagnostics/format-on-write after-tool hooks: dead.
+- Tool-output compaction: dead — full untruncated outputs reach the model.
+- Result dedup: dead.
+- Memory observation recording: dead.
+
+### Proof by experiment
+
+Built two binaries from `aae880b` in a throwaway worktree.
+
+**A — tracing patched to return `nil, nil`.** Still zero observations: #3 (LSP)
+becomes the new short-circuit. Reordering one callback does not fix it.
+
+**B — memory callback prepended to the slice.**
+
+```
+before:  t=40s obs=0
+after:   t=5s  obs=1   →  1|discovery|Inspected memory package files|bash
+```
+
+The pipeline itself is sound. Only the position in the chain was wrong.
+
+---
+
+## F2 — Compression cannot finish inside the shutdown budget
+
+### Cost per observation
+
+Measured with a direct `orchestrator.Spawn` of the `memory-compressor` agent
+against the configured model:
+
+```
+spawn -> err=<nil> (2.2ms)
+[  4.64s] message_start
+[  6.05s] stream closed, 54 events
+worker drain (enqueue → stored): 5.6s
+```
+
+**5.6 s per observation**, because each one spawns a full `pi --mode json` child
+process.
+
+### The pipeline cannot absorb that
+
+- `internal/memory/worker.go:67-76` — one goroutine, strictly serial.
+- `internal/subagent/bundled/memory-compressor.md` — `timeout: 600000`, so a
+  single stuck compression blocks the queue for ten minutes.
+- `internal/memory/worker.go:55-64` — `Enqueue` drops silently when the 100-slot
+  buffer fills.
+- `internal/cli/interactive.go:57-61` and `internal/cli/cli.go:959-967` — a
+  **5 s** shutdown budget, less than one compression.
+
+### Observed failure at exit
+
+From experiment B's stderr, after the run finished:
+
+```
+WARN  memory: compression failed  error="pi process failed: signal: terminated"
+ERROR memory: failed to store observation  error="sql: database is closed"
+WARN  palace bridge: failed to store       error="sql: database is closed"
+```
+
+Two distinct problems in three lines: the compressor child is killed when the
+parent exits, and the store is closed before the worker has drained, so even a
+successful compression writes into a closed handle.
+
+### Role resolution
+
+`memory-compressor` declares `role: smol`. `~/.pi-go/config.json` defines only
+`default`, and `Config.ResolveRole` (`internal/config/config.go:191-196`) falls
+back to `default` — a frontier model. Every tool call in every session would
+bill a frontier-model subprocess call if the pipeline were running.
+
+---
+
+## F3 — Palace database and model paths disagree
+
+| Consumer | Path | Source |
+|---|---|---|
+| `pi memory init` | `<dir>/.pi-go/palace.db` | `memory_init.go:48` |
+| `pi memory mine` | `<dir>/.pi-go/palace.db` | `memory_mine.go:283` |
+| `pi memory status/search/wake-up` | `.pi-go/palace.db` (cwd-relative) | `memory_status.go:32`, `memory_search.go:43`, `memory_wakeup.go:38` |
+| TUI sidebar | `<workDir>/.pi-go/palace.db` | `tui/memory.go:27` |
+| **Agent session** | `$HOME/.pi-go/palace.db` | `cli.go:1719` |
+
+Anything mined into a project is invisible to the agent running in that project.
+
+`setupPalace` (`cli.go:991-995`) returns early when the file does not exist, so
+the mismatch degrades to "palace silently absent" rather than an error.
+
+Same class of bug for the embedding model:
+
+| Consumer | Directory |
+|---|---|
+| `pi memory model download` writes | `~/.pi-go/models/sentence-transformers_all-MiniLM-L6-v2` |
+| `pi memory model status` checks | `sentence-transformers_all-MiniLM-L6-v2` (`memory_model.go:109`) |
+| `defaultPalaceModelPath()` | `sentence-transformers_all-MiniLM-L6-v2` (`memory.go:13`) |
+| **`palaceConfigFromCLI`** | `KnightsAnalytics_all-MiniLM-L6-v2` (`cli.go:1724`) |
+
+On disk: `~/.pi-go/models/sentence-transformers_all-MiniLM-L6-v2` exists,
+`KnightsAnalytics_*` does not. The in-process embedder fallback can never load
+at session time. It is masked today because `DefaultConfig().UseOllama` is true
+(`palace/config.go:38`) and Ollama has `all-minilm` pulled — it surfaces the
+moment Ollama is not running.
+
+---
+
+## F4 — Palace is absent from the interactive path, and wake-up is unscoped
+
+`setupPalace` is called from exactly one place — `cli.go:588`, the headless
+`--mode print` path. `internal/cli/interactive.go` never calls it. In the TUI:
+no palace tools, no wake-up context, no observation bridge. The TUI's only
+palace contact is the sidebar status widget, which reads a different file (F3).
+
+Where the palace *is* wired, the wake-up call is unscoped:
+
+- `cli.go:1010` — `p.WakeUp(context.Background(), "")`.
+- `palace/layers.go:47-49` → `ListDrawers(DrawerFilter{Wing: ""})`.
+- `sqlite_store.go:199` — an empty wing adds no `WHERE` clause, so all wings match.
+
+Meanwhile the bridge files every drawer under `wing = strings.ToLower(filepath.Base(project))`
+(`palace/bridge.go:65-74`). Wake-up therefore mixes every project the user has
+ever worked on into one L1 essential story, ranked by importance alone.
+
+---
+
+## F5 — Retrieval does not scale and is not measured
+
+- `SQLitePalaceStore.GetAllEmbeddings` (`sqlite_store.go:253`) selects **every**
+  embedding matching the wing/room filter; `RankBySimilarity` scores them all in
+  process. No ANN index anywhere in `internal/palace`. Fine at 3 drawers, a full
+  scan per query at 100k. Upstream gets HNSW from ChromaDB.
+- No equivalent of upstream's `query_sanitizer.py`. Search input reaches FTS5
+  through `sanitizeFTS5Query` (quote-stripping only) and the retrieved drawer
+  text is injected into the prompt verbatim.
+- No retrieval benchmark. Upstream publishes reproducible LongMemEval / LoCoMo /
+  ConvoMem / MemBench numbers; pi-go has no measurement at all, which is why a
+  four-month outage went unnoticed.
+
+---
+
+## Environment note
+
+`go test ./internal/palace/...` panics under the sandbox in
+`TestOllamaEmbedSerializesAcrossGoroutines` — `httptest.NewServer` cannot bind.
+Outside the sandbox both packages pass (2.8 s). See `CLAUDE.md` § "Two
+environment traps"; do not read that panic as a real failure.

--- a/specs/memory-fixes/rough-idea.md
+++ b/specs/memory-fixes/rough-idea.md
@@ -1,0 +1,58 @@
+# Rough Idea — Repair the memory subsystem
+
+## Source
+
+A comparison of `tmp/memory/mempalace` (upstream MemPalace, Python, ~45k LOC)
+against pi-go's port (`internal/palace` + `internal/memory`, ~14k LOC including
+tests), performed 2026-08-13.
+
+The port turned out to be broadly faithful in *feature coverage* and completely
+dead in *production behaviour*. The port is not the problem. The wiring is.
+
+## The observation that started it
+
+```
+~/.pi-go/memory/claude-mem.db   6228 sessions,  0 observations,  0 summaries
+~/.pi-go/palace.db              3 drawers (all NULL embeddings), last write Aug 2
+```
+
+Sessions have been recorded for months. Not one observation has ever been
+stored. Every downstream feature — recent-context injection, `mem-search`,
+`mem-timeline`, session summaries, and the palace observation bridge — reads
+from tables that are empty and always have been.
+
+## Why it is empty
+
+ADK ends the after-tool callback chain at the first callback that returns a
+non-nil result. pi-go registers five to six after-tool callbacks and every one
+of them returns the tool's result map. Only the first ever runs.
+
+The memory recorder is registered last, so it never runs. Neither do the three
+callbacks in front of it — the LSP hooks, the output compactor, and the result
+deduper. One wiring bug silently disables four subsystems.
+
+## What this spec covers
+
+Five fixes, in dependency order:
+
+1. Compose pi-go's after-tool callbacks so all of them run.
+2. Stop compression from blocking the pipeline, and drain before closing the DB.
+3. Unify the palace database and embedding-model paths.
+4. Wire the palace into the interactive TUI path and scope wake-up per project.
+5. Make retrieval measurable and safe — ANN index, query sanitisation, benchmark.
+
+Fix 1 is the load-bearing one. Fixes 2–4 are the difference between "records
+something" and "records everything reliably". Fix 5 is what stops the next
+regression going unnoticed for four months.
+
+## Non-goals
+
+- Reaching feature parity with upstream MemPalace. The missing pieces (AAAK
+  dialect, entity disambiguation, repair/export/onboarding, MCP surface,
+  pluggable vector backends) are catalogued in `research/comparison.md` but are
+  not scheduled here.
+- Changing the palace data model. Wings/rooms/halls/drawers and the temporal
+  knowledge graph stay exactly as they are.
+- Replacing the observation → drawer bridge with upstream's hook-based
+  auto-save. The in-process bridge is a better fit for pi-go; it just needs to
+  be reachable.


### PR DESCRIPTION
## What

Adds `specs/memory-fixes/`, a full PDD spec for repairing the memory subsystem. Documentation only — no code changes.

## Why

```
~/.pi-go/memory/claude-mem.db   6228 sessions,  0 observations,  0 summaries
~/.pi-go/palace.db              3 drawers (all NULL embeddings), last write Aug 2
```

Sessions have been recorded for months. Not one observation has ever been stored. `mem-search`, `mem-timeline`, recent-context injection, session summaries and the palace observation bridge all read tables that have always been empty.

## Root cause

ADK ends the after-tool callback chain at the first callback returning a non-nil result — `adk/v2@v2.0.0/internal/llminternal/base_flow.go:1296`:

```go
if result != nil {
    return result, nil   // chain ends here
}
```

pi-go registers six after-tool callbacks and every one returns the result map:

| # | Callback | Returns |
|---|---|---|
| 1 | hooks | `result` |
| 2 | OTel tracing | `result` |
| 3 | LSP | `result` |
| 4 | compactor | `result` |
| 5 | dedup | `result` |
| 6 | memory recorder | `result` |

No hooks are configured by default, so **#2 short-circuits and #3–#6 never execute**. One wiring bug silently disables four subsystems: LSP after-tool hooks, tool-output compaction, result dedup, and memory recording.

## Verified, not inferred

Two binaries built from `aae880b` in a throwaway worktree:

- **Patching only the OTel callback to return `nil`** — still zero observations. The LSP callback becomes the new short-circuit. Reordering one callback does not fix it.
- **Prepending the memory callback** — `t=5s obs=1 → 1|discovery|Inspected memory package files|bash`.

The pipeline is sound. Only its position in the chain was wrong.

Other defects measured the same way and documented in `research/findings.md`:

- Compression costs **5.6 s** per observation (a `pi --mode json` child process each) against a **5 s** shutdown budget, drained by **one** goroutine, with the store closed before the drain — so `sql: database is closed` is the normal outcome.
- `memory-compressor` declares `role: smol`; with no `smol` role configured `ResolveRole` falls back to `default`, a frontier model, per tool call.
- The palace DB path splits three ways: `pi memory *` and the TUI sidebar use `<cwd>/.pi-go/palace.db`, the agent session uses `$HOME/.pi-go/palace.db`. Anything mined is invisible to the agent.
- `palaceConfigFromCLI` looks for `KnightsAnalytics_all-MiniLM-L6-v2`; the downloader writes `sentence-transformers_all-MiniLM-L6-v2`. That directory has never existed on disk.
- `setupPalace` is only called from the headless path — the TUI has no palace tools, no wake-up context, no bridge.
- Session wake-up calls `WakeUp(ctx, "")`, which means *all wings*, while the bridge files drawers per project wing.

## Contents

| File | Purpose |
|---|---|
| `rough-idea.md` | The finding and the shape of the fix |
| `requirements.md` | R1–R9 acceptance criteria, constraints, out-of-scope |
| `research/findings.md` | Evidence per defect, with line references and measurements |
| `research/comparison.md` | MemPalace upstream vs the port — ported, missing, and deliberate divergences |
| `design.md` | `ChainAfterTool` composition, worker lifecycle, path resolver, TUI wiring, risks |
| `plan.md` | 8 vertical slices, each with tests and a verification command |
| `PROMPT.md` | Execution prompt for the implementing agent |

Also adds a `memory-fixes/` row to the `specs/AGENTS.md` index.

## Two decisions worth reviewing

1. **Compose the callbacks rather than reorder them.** Reordering was tried and fails. The spec introduces `extension.ChainAfterTool`, which folds pi-go's callbacks into one ADK callback with pi-go's semantics: nil means "no change", non-nil threads into the next callback, error aborts.

2. **Move compression in-process.** A subprocess LLM call per tool call at frontier-model prices should not be un-broken and left running. `Memory.Compressor` becomes `"llm"` (default) | `"subagent"` | `"none"`. This also closes the `memory → subagent` layering violation tracked as `TODO.md` item 36.

## Note

Enabling the compactor and the LSP after-tool hooks for the first time is itself a behaviour change — they have been dead the entire time. `plan.md` lands the chaining fix as its own slice so that change can be observed in isolation.

## Out of scope

Upstream MemPalace parity — AAAK dialect, entity disambiguation, repair/export/onboarding, the MCP surface, pluggable vector backends. Catalogued in `research/comparison.md`, not scheduled.