### PR TITLE
Enable xAI server-side search tools

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -480,6 +480,9 @@ func NewLLM(ctx context.Context, info Info, apiKey, baseURL, thinkingLevel strin
 	case "mistral":
 		return NewMistral(ctx, info.Model, apiKey, baseURL, opts)
 	case "xai":
+		// xAI server-side tools, including x_search, are enabled for the
+		// xAI provider by default. PI_NO_XAI_TOOLS remains the kill switch.
+		opts.EnableXAITools = true
 		return NewXAI(ctx, info.Model, apiKey, baseURL, thinkingLevel, opts)
 	case "opencode":
 		return NewOpenCode(ctx, info.Model, apiKey, baseURL, thinkingLevel, opts)


### PR DESCRIPTION
## Summary
- enable xAI server-side tools automatically when the xai provider is active
- includes x_search, web_search, and code_interpreter
- preserve PI_NO_XAI_TOOLS as the kill switch

## Verification
- make lint
- make build
- go test ./internal/provider
- make vet started the full unit suite; the long-running suite was stopped after the targeted checks passed