### PR TITLE
feat(tools): gate palace and LSP, and cut the default LSP surface to two tools

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"log/slog"
 	"maps"
 	"net/http"
 	_ "net/http/pprof" // registers pprof HTTP handlers on /debug/pprof
@@ -63,6 +64,7 @@ var (
 	flagSlow      bool
 	flagPlan      bool
 	flagMemoryOff bool
+	flagLSP       string
 	flagSystem    string
 	flagPprof     string
 	flagPprofPort string
@@ -193,6 +195,7 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 	cmd.Flags().BoolVar(&flagInsecure, "insecure", false, "Skip TLS certificate verification for LLM API calls")
 	cmd.Flags().StringVar(&flagCACert, "ca-cert", "", "PEM bundle to trust for LLM API calls, in addition to the system roots")
 	cmd.Flags().BoolVar(&flagMemoryOff, "memory-off", false, "Disable the persistent memory system for this session")
+	cmd.Flags().StringVar(&flagLSP, "lsp", "min", "Language-server tools: off, min (symbols+diagnostics), or full (all seven)")
 	// Persistent, not local: `pi memory mine . --pprof true` and every other
 	// subcommand must accept these too. As local flags they were rejected with
 	// "unknown flag: --pprof" the moment a subcommand was used.
@@ -624,11 +627,18 @@ func runNonInteractive(
 		afterCBs = append(afterCBs, memoryObservationCallback(memWorker, cfg, cwd, &memSessionID))
 	}
 
-	lspTools, err := tools.LSPTools(lspMgr)
-	if err != nil {
-		return fmt.Errorf("creating LSP tools: %w", err)
+	// LSP tool declarations are billed on every request, and with no server
+	// installed every call they enable fails — so the model pays tokens for
+	// capability it cannot use. Gate on a server existing, then advertise only
+	// as much surface as the mode asks for. The after-tool callback stays wired
+	// either way; it is free when no server starts.
+	if lspMgr.AnyAvailable() {
+		lspTools, lspErr := tools.LSPToolsFor(lspMgr, resolveLSPMode())
+		if lspErr != nil {
+			return fmt.Errorf("creating LSP tools: %w", lspErr)
+		}
+		coreTools = append(coreTools, lspTools...)
 	}
-	coreTools = append(coreTools, lspTools...)
 
 	allToolsets := buildToolsets(cfg)
 
@@ -967,6 +977,32 @@ func setupMemory(ctx context.Context, cfg config.Config, orch *subagent.Orchestr
 	}
 }
 
+// resolveLSPMode turns the --lsp flag into a mode, warning once on a value it
+// does not recognize rather than silently picking one. A subagent inherits the
+// parent's choice through the same flag on its command line, which is how an
+// agent that needs the wide surface gets it without every session paying for it.
+func resolveLSPMode() tools.LSPMode {
+	mode, ok := tools.ParseLSPMode(flagLSP)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "pi-go: warning: unknown --lsp value %q; using %q\n", flagLSP, mode)
+	}
+	return mode
+}
+
+// palaceHasContent reports whether the palace holds at least one drawer.
+// A count error is treated as "no content": the tools would fail anyway, and
+// the caller's job is to decide whether advertising them is worth the tokens.
+func palaceHasContent(p *palace.Palace) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	status, err := p.Status(ctx)
+	if err != nil {
+		slog.Warn("palace: drawer count failed, not advertising palace tools", "error", err)
+		return false
+	}
+	return status.DrawerCount > 0
+}
+
 // setupPalace opens the memory palace when one already exists on disk, and
 // returns its tools plus the wake-up context to inject into the system prompt.
 // A missing palace is not an error — it simply contributes nothing.
@@ -992,6 +1028,21 @@ func setupPalace(cfg config.Config, memWorker *memory.Worker) ([]adktool.Tool, s
 		return nil, "", noop
 	}
 	closePalace := func() { _ = p.Close() }
+
+	// Eleven palace tool declarations cost ~1.6k tokens on every request. An
+	// empty palace has nothing for them to find, so searching it is a wasted
+	// call and the tokens buy nothing — the same trade the LSP gate makes. An
+	// existing file is not evidence of content: `pi memory init` creates one
+	// with zero drawers. Gate on drawers, not on the file.
+	//
+	// The palace is still opened when empty: the bridge below fills it, and the
+	// tools appear on the next session once it has content.
+	if !palaceHasContent(p) {
+		if memWorker != nil {
+			memWorker.OnAfterStore(palace.NewObservationBridge(p).ConvertAndStore)
+		}
+		return nil, "", closePalace
+	}
 
 	// A tool-building failure still leaves a usable palace for the bridge and
 	// the wake-up context below, so it only costs the tools.

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -229,7 +229,13 @@ func deferredInit(
 		defer wg.Done()
 		send("lsp", false)
 		mgr := lsp.NewManager(nil)
-		lt, _ := tools.LSPTools(mgr)
+		// Only advertise the LSP tools when a server can actually answer them —
+		// see the matching note in cli.go. The manager itself is always kept:
+		// the after-tool callback and diagnostics plumbing cost nothing idle.
+		var lt []adktool.Tool
+		if mgr.AnyAvailable() {
+			lt, _ = tools.LSPToolsFor(mgr, resolveLSPMode())
+		}
 		ps.mu.Lock()
 		ps.lspMgr = mgr
 		ps.lspTools = lt

--- a/internal/cli/palace_gate_test.go
+++ b/internal/cli/palace_gate_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/palace"
+)
+
+// newTestPalace opens a palace backed by a temp database, with no embedder, so
+// the gate is exercised against real storage rather than a stub.
+func newTestPalace(t *testing.T) *palace.Palace {
+	t.Helper()
+	p, err := palace.New(
+		palace.WithDBPath(filepath.Join(t.TempDir(), "palace.db")),
+		palace.WithLocalEmbedder(),
+	)
+	if err != nil {
+		t.Fatalf("palace.New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// TestPalaceHasContentEmpty is the case that motivated the gate: `pi memory
+// init` leaves a valid database with zero drawers, and eleven tool
+// declarations against it buy nothing.
+func TestPalaceHasContentEmpty(t *testing.T) {
+	if palaceHasContent(newTestPalace(t)) {
+		t.Fatal("palaceHasContent() = true for a palace with no drawers, want false")
+	}
+}
+
+func TestPalaceHasContentWithDrawer(t *testing.T) {
+	p := newTestPalace(t)
+	if _, err := p.AddDrawer(context.Background(), palace.DrawerInput{
+		Wing:    "pi-go",
+		Room:    "cli",
+		Content: "the palace gate reads drawer count, not file existence",
+	}); err != nil {
+		t.Fatalf("AddDrawer: %v", err)
+	}
+	if !palaceHasContent(p) {
+		t.Fatal("palaceHasContent() = false after adding a drawer, want true")
+	}
+}
+
+// TestPalaceHasContentClosed pins the failure direction: when the count cannot
+// be read the gate must stay shut, so a broken palace costs no context.
+func TestPalaceHasContentClosed(t *testing.T) {
+	p := newTestPalace(t)
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if palaceHasContent(p) {
+		t.Fatal("palaceHasContent() = true on a closed palace, want false")
+	}
+}

--- a/internal/lsp/availability_test.go
+++ b/internal/lsp/availability_test.go
@@ -1,0 +1,77 @@
+package lsp
+
+import (
+	"slices"
+	"testing"
+)
+
+// newManagerWithAvailable builds a Manager with a hand-set availability map,
+// so the gate can be tested without depending on what is installed on the host.
+func newManagerWithAvailable(available map[string]bool) *Manager {
+	return &Manager{
+		languages:   map[string]*LanguageConfig{},
+		servers:     map[string]*Server{},
+		diagnostics: map[string][]Diagnostic{},
+		available:   available,
+	}
+}
+
+func TestAnyAvailable(t *testing.T) {
+	tests := []struct {
+		name      string
+		available map[string]bool
+		want      bool
+	}{
+		{"nil map", nil, false},
+		{"empty map", map[string]bool{}, false},
+		{"all false", map[string]bool{"go": false, "rust": false}, false},
+		{"one true", map[string]bool{"go": true, "rust": false}, true},
+		{"all true", map[string]bool{"go": true, "rust": true}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newManagerWithAvailable(tt.available).AnyAvailable(); got != tt.want {
+				t.Fatalf("AnyAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAvailableLanguages(t *testing.T) {
+	tests := []struct {
+		name      string
+		available map[string]bool
+		want      []string
+	}{
+		{"nil map", nil, []string{}},
+		{"skips false entries", map[string]bool{"go": true, "rust": false}, []string{"go"}},
+		{"sorted", map[string]bool{"rust": true, "go": true, "python": true}, []string{"go", "python", "rust"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newManagerWithAvailable(tt.available).AvailableLanguages()
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("AvailableLanguages() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAvailableLanguagesAgreesWithAnyAvailable pins the two accessors together:
+// the gate reads AnyAvailable, diagnostics read the list, and they must never
+// disagree about whether anything is installed.
+func TestAvailableLanguagesAgreesWithAnyAvailable(t *testing.T) {
+	for _, available := range []map[string]bool{
+		nil,
+		{},
+		{"go": false},
+		{"go": true},
+		{"go": true, "rust": false},
+	} {
+		m := newManagerWithAvailable(available)
+		if got, want := m.AnyAvailable(), len(m.AvailableLanguages()) > 0; got != want {
+			t.Fatalf("available=%v: AnyAvailable()=%v but AvailableLanguages()=%v",
+				available, got, m.AvailableLanguages())
+		}
+	}
+}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sync"
 )
 
@@ -353,6 +354,31 @@ func (m *Manager) Languages() map[string]*LanguageConfig {
 // Available returns whether a language server binary was found.
 func (m *Manager) Available(lang string) bool {
 	return m.available[lang]
+}
+
+// AvailableLanguages returns the languages whose server binary was found, sorted.
+// Callers use it to decide whether registering the LSP tools is worth the
+// context they cost: seven tool declarations are ~1.4k tokens on every request,
+// and in a checkout with no server installed every call they enable fails.
+func (m *Manager) AvailableLanguages() []string {
+	langs := make([]string, 0, len(m.available))
+	for name, ok := range m.available {
+		if ok {
+			langs = append(langs, name)
+		}
+	}
+	slices.Sort(langs)
+	return langs
+}
+
+// AnyAvailable reports whether at least one language server is installed.
+func (m *Manager) AnyAvailable() bool {
+	for _, ok := range m.available {
+		if ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Shutdown gracefully shuts down all running servers.

--- a/internal/subagent/agents.go
+++ b/internal/subagent/agents.go
@@ -34,7 +34,12 @@ type AgentConfig struct {
 	Timeout     int      // Absolute timeout in milliseconds (0 = use default)
 	Instruction string   // System prompt (markdown body)
 	Tools       []string // Allowed tool names (empty = all tools)
-	Source      string   // "bundled", "user", or "project"
+	// LSP selects this agent's language-server surface: "off", "min" or
+	// "full". Empty means inherit the child process default (min). Set it in
+	// frontmatter on agents that navigate code, so the wide LSP surface is
+	// bought per-agent instead of by every session.
+	LSP    string
+	Source string // "bundled", "user", or "project"
 }
 
 // AgentDiscoveryResult contains all discovered agents.
@@ -128,6 +133,8 @@ func parseAgentContent(content, path string) (AgentConfig, error) {
 						cfg.Timeout = ms
 					}
 				}
+			case "lsp":
+				cfg.LSP = strings.ToLower(strings.TrimSpace(value))
 			case "tools":
 				for _, t := range strings.Split(value, ",") {
 					t = strings.TrimSpace(t)

--- a/internal/subagent/lsp_frontmatter_test.go
+++ b/internal/subagent/lsp_frontmatter_test.go
@@ -1,0 +1,93 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeAgent drops a SKILL-style agent definition into dir and returns its path.
+func writeAgent(t *testing.T, dir, name, frontmatter string) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".md")
+	body := "---\nname: " + name + "\ndescription: test agent\n" + frontmatter + "---\nYou are a test agent.\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write agent: %v", err)
+	}
+	return path
+}
+
+func TestAgentConfigLSPFrontmatter(t *testing.T) {
+	tests := []struct {
+		name        string
+		frontmatter string
+		want        string
+	}{
+		{"absent", "", ""},
+		{"full", "lsp: full\n", "full"},
+		{"off", "lsp: off\n", "off"},
+		{"min", "lsp: min\n", "min"},
+		{"lowercased", "lsp: FULL\n", "full"},
+		{"trimmed", "lsp:    full   \n", "full"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeAgent(t, dir, "navigator", tt.frontmatter)
+
+			cfg, err := ParseAgentFile(path)
+			if err != nil {
+				t.Fatalf("ParseAgentFile: %v", err)
+			}
+			if cfg.LSP != tt.want {
+				t.Fatalf("LSP = %q, want %q", cfg.LSP, tt.want)
+			}
+		})
+	}
+}
+
+// TestSpawnOptsLSPReachesArgs pins the seam that makes "LSP in subagents only"
+// work: the child's surface is chosen by the parent, on the child's command
+// line. Without this the child falls back to its own default and the parent
+// cannot hand it the wide set.
+func TestSpawnOptsLSPReachesArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		lsp      string
+		wantFlag bool
+		wantVal  string
+	}{
+		{"empty leaves flag off", "", false, ""},
+		{"full is passed through", "full", true, "full"},
+		{"off is passed through", "off", true, "off"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := spawnArgs(SpawnOpts{Prompt: "do the thing", LSP: tt.lsp})
+
+			idx := -1
+			for i, a := range args {
+				if a == "--lsp" {
+					idx = i
+					break
+				}
+			}
+			if !tt.wantFlag {
+				if idx != -1 {
+					t.Fatalf("args contain --lsp for empty LSP: %v", args)
+				}
+				return
+			}
+			if idx == -1 {
+				t.Fatalf("args missing --lsp: %v", args)
+			}
+			if idx+1 >= len(args) || args[idx+1] != tt.wantVal {
+				t.Fatalf("--lsp value = %v, want %q (args: %v)", args[idx+1:], tt.wantVal, args)
+			}
+			// The prompt must stay last — it is positional.
+			if args[len(args)-1] != "do the thing" {
+				t.Fatalf("prompt is not the final arg: %v", args)
+			}
+		})
+	}
+}

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -454,6 +454,7 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 		BaseURL:     o.BaseURL,
 		Insecure:    o.Insecure,
 		Headers:     o.Headers,
+		LSP:         agent.LSP,
 	}
 
 	// ACP-bundled agents (claude/gemini/cursor/copilot) launch their own CLI

--- a/internal/subagent/spawner.go
+++ b/internal/subagent/spawner.go
@@ -45,6 +45,11 @@ type SpawnOpts struct {
 	BaseURL     string   // LLM API base URL (passed as --url flag)
 	Insecure    bool     // Skip TLS verification (passed as --insecure flag)
 	Headers     []string // Extra HTTP headers (passed as --header flags)
+	// LSP selects the child's language-server tool surface (passed as --lsp).
+	// Empty leaves the flag off, so the child uses its own default. This is the
+	// seam that lets a navigation-heavy agent run with the full LSP set while
+	// the parent session pays for none of it.
+	LSP string
 }
 
 // Spawner creates and manages subagent pi processes.
@@ -98,17 +103,10 @@ func (p *Process) Cancel() {
 	p.cancel()
 }
 
-// Spawn starts a pi subprocess in JSON mode and returns a Process handle for streaming events.
-func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
-	if opts.Prompt == "" {
-		return nil, fmt.Errorf("prompt is required")
-	}
-
-	// Resolve timeout configuration (applies defaults if not set).
-	timeoutCfg := ResolveTimeout(opts.Timeout)
-	procCtx, cancel := context.WithTimeout(ctx, timeoutCfg.Absolute)
-
-	// Build command arguments.
+// spawnArgs builds the child pi command line. Split out from Spawn so the flag
+// wiring can be tested without starting a process — the --lsp value in
+// particular decides how much context the child spends on tool declarations.
+func spawnArgs(opts SpawnOpts) []string {
 	args := []string{"--mode", "json"}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
@@ -125,7 +123,24 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 	if opts.Instruction != "" {
 		args = append(args, "--system", opts.Instruction)
 	}
-	args = append(args, opts.Prompt)
+	if opts.LSP != "" {
+		args = append(args, "--lsp", opts.LSP)
+	}
+	// The prompt is positional and must stay last.
+	return append(args, opts.Prompt)
+}
+
+// Spawn starts a pi subprocess in JSON mode and returns a Process handle for streaming events.
+func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
+	if opts.Prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	// Resolve timeout configuration (applies defaults if not set).
+	timeoutCfg := ResolveTimeout(opts.Timeout)
+	procCtx, cancel := context.WithTimeout(ctx, timeoutCfg.Absolute)
+
+	args := spawnArgs(opts)
 
 	cmd := exec.CommandContext(procCtx, s.PiBinary, args...)
 

--- a/internal/tools/lsp.go
+++ b/internal/tools/lsp.go
@@ -208,16 +208,72 @@ Line and column are 0-based.`,
 		}, lspFileAliases)
 }
 
-// LSPTools returns the LSP ADK tools.
+// LSPMode selects how much of the LSP surface is advertised to the model.
+type LSPMode string
+
+const (
+	// LSPOff registers nothing.
+	LSPOff LSPMode = "off"
+	// LSPMin registers symbols + diagnostics only. This is the default.
+	LSPMin LSPMode = "min"
+	// LSPFull registers all seven tools.
+	LSPFull LSPMode = "full"
+)
+
+// ParseLSPMode maps a flag value to a mode. It accepts the three mode names
+// plus the truthy/falsey spellings a user is likely to reach for, so
+// `--lsp true` and `--lsp full` mean the same thing. An unrecognized value
+// returns LSPMin and false, letting the caller report it rather than guess.
+func ParseLSPMode(v string) (LSPMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "min", "minimal", "default":
+		return LSPMin, true
+	case "full", "all", "1", "true", "yes", "on":
+		return LSPFull, true
+	case "off", "none", "0", "false", "no":
+		return LSPOff, true
+	default:
+		return LSPMin, false
+	}
+}
+
+// minimalLSPBuilders is the pair that carries the traffic. Measured over this
+// repo's session history, lsp-symbols and lsp-diagnostics are 592 of 657 LSP
+// calls — 90% — while the other five cost 989 tokens on every request for the
+// remaining 65. The model reaches for ripgrep instead of lsp-references
+// (8171 calls vs 3), so the wide surface is not paying for itself.
+//
+// Use LSPFull to get the rest back; see ParseLSPMode.
+var minimalLSPBuilders = []func(*lsp.Manager) (tool.Tool, error){
+	newLSPSymbolsTool,
+	newLSPDiagnosticsTool,
+}
+
+var fullLSPBuilders = []func(*lsp.Manager) (tool.Tool, error){
+	newLSPDiagnosticsTool,
+	newLSPDefinitionTool,
+	newLSPReferencesTool,
+	newLSPHoverTool,
+	newLSPSymbolsTool,
+	newLSPWorkspaceSymbolTool,
+	newLSPCodeActionTool,
+}
+
+// LSPTools returns the default (minimal) LSP tool set.
 func LSPTools(mgr *lsp.Manager) ([]tool.Tool, error) {
-	builders := []func(*lsp.Manager) (tool.Tool, error){
-		newLSPDiagnosticsTool,
-		newLSPDefinitionTool,
-		newLSPReferencesTool,
-		newLSPHoverTool,
-		newLSPSymbolsTool,
-		newLSPWorkspaceSymbolTool,
-		newLSPCodeActionTool,
+	return LSPToolsFor(mgr, LSPMin)
+}
+
+// LSPToolsFor returns the LSP ADK tools for the given mode.
+func LSPToolsFor(mgr *lsp.Manager, mode LSPMode) ([]tool.Tool, error) {
+	var builders []func(*lsp.Manager) (tool.Tool, error)
+	switch mode {
+	case LSPOff:
+		return nil, nil
+	case LSPFull:
+		builders = fullLSPBuilders
+	default:
+		builders = minimalLSPBuilders
 	}
 
 	result := make([]tool.Tool, 0, len(builders))

--- a/internal/tools/lsp_mode_test.go
+++ b/internal/tools/lsp_mode_test.go
@@ -1,0 +1,119 @@
+package tools
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/lsp"
+)
+
+func TestParseLSPMode(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   LSPMode
+		wantOK bool
+	}{
+		{"", LSPMin, true},
+		{"min", LSPMin, true},
+		{"minimal", LSPMin, true},
+		{"default", LSPMin, true},
+		{"full", LSPFull, true},
+		{"all", LSPFull, true},
+		{"true", LSPFull, true},
+		{"1", LSPFull, true},
+		{"  FULL  ", LSPFull, true},
+		{"off", LSPOff, true},
+		{"false", LSPOff, true},
+		{"0", LSPOff, true},
+		{"none", LSPOff, true},
+		{"banana", LSPMin, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, ok := ParseLSPMode(tt.in)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("ParseLSPMode(%q) = (%q, %v), want (%q, %v)", tt.in, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func toolNames(ts []interface{ Name() string }) []string {
+	out := make([]string, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, t.Name())
+	}
+	return out
+}
+
+func TestLSPToolsForMode(t *testing.T) {
+	mgr := lsp.NewManager(nil)
+
+	tests := []struct {
+		mode LSPMode
+		want []string
+	}{
+		{LSPOff, nil},
+		{LSPMin, []string{"lsp-symbols", "lsp-diagnostics"}},
+		{LSPFull, []string{
+			"lsp-diagnostics", "lsp-definition", "lsp-references", "lsp-hover",
+			"lsp-symbols", "lsp-workspace-symbol", "lsp-code-action",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			ts, err := LSPToolsFor(mgr, tt.mode)
+			if err != nil {
+				t.Fatalf("LSPToolsFor(%q): %v", tt.mode, err)
+			}
+			named := make([]interface{ Name() string }, len(ts))
+			for i, x := range ts {
+				named[i] = x
+			}
+			got := toolNames(named)
+			if len(tt.want) == 0 {
+				if len(got) != 0 {
+					t.Fatalf("mode %q returned %v, want none", tt.mode, got)
+				}
+				return
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("mode %q = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLSPToolsDefaultsToMinimal pins the default: the exported LSPTools is what
+// every session pays for, so it must be the two-tool set, not all seven.
+func TestLSPToolsDefaultsToMinimal(t *testing.T) {
+	ts, err := LSPTools(lsp.NewManager(nil))
+	if err != nil {
+		t.Fatalf("LSPTools: %v", err)
+	}
+	if len(ts) != 2 {
+		named := make([]interface{ Name() string }, len(ts))
+		for i, x := range ts {
+			named[i] = x
+		}
+		t.Fatalf("LSPTools returned %d tools (%v), want the 2 minimal ones", len(ts), toolNames(named))
+	}
+}
+
+// TestMinimalIsSubsetOfFull keeps the two lists honest: whatever min advertises
+// must still exist in full, so raising the mode never removes a tool.
+func TestMinimalIsSubsetOfFull(t *testing.T) {
+	mgr := lsp.NewManager(nil)
+	minTools, _ := LSPToolsFor(mgr, LSPMin)
+	fullTools, _ := LSPToolsFor(mgr, LSPFull)
+
+	fullNames := make([]string, 0, len(fullTools))
+	for _, x := range fullTools {
+		fullNames = append(fullNames, x.Name())
+	}
+	for _, x := range minTools {
+		if !slices.Contains(fullNames, x.Name()) {
+			t.Fatalf("minimal tool %q is missing from the full set %v", x.Name(), fullNames)
+		}
+	}
+}

--- a/internal/tools/lsp_test.go
+++ b/internal/tools/lsp_test.go
@@ -7,13 +7,16 @@ import (
 	"github.com/dimetron/pi-go/internal/lsp"
 )
 
+// TestLSPTools_Count covers the full set, which LSPTools no longer returns by
+// default: the default is now the two-tool minimal set (see
+// TestLSPToolsDefaultsToMinimal), and the seven are reached via LSPFull.
 func TestLSPTools_Count(t *testing.T) {
 	mgr := lsp.NewManager(nil)
 	defer mgr.Shutdown()
 
-	tools, err := LSPTools(mgr)
+	tools, err := LSPToolsFor(mgr, LSPFull)
 	if err != nil {
-		t.Fatalf("LSPTools: %v", err)
+		t.Fatalf("LSPToolsFor(full): %v", err)
 	}
 	if len(tools) != 7 {
 		t.Fatalf("expected 7 LSP tools, got %d", len(tools))


### PR DESCRIPTION
## Why

Tool declarations are billed on **every request**. Measured on this repo by serializing each tool's `Declaration()` — the same accounting `buildContextBreakdown` uses for the TUI gauge — the default set costs **7429 tokens**:

| Group | Tools | ~Tokens | Share |
|---|---:|---:|---:|
| core | 13 | 2612 | 35.2% |
| palace | 11 | 1646 | 22.2% |
| lsp | 7 | 1427 | 19.2% |
| agent | 1 | 880 | 11.9% |
| bash-control | 2 | 462 | 6.2% |
| memory | 3 | 400 | 5.4% |

Two of the largest groups bought nothing in the common case.

**LSP** registered all seven tools unconditionally — including in a checkout with no language server installed, where every call they enable fails. 1427 tokens for capability the model cannot use.

**Palace** registered eleven tools whenever `palace.db` existed. `pi memory init` creates that file with **zero drawers**, so an empty palace advertised 1646 tokens of search over nothing. On this machine the palace holds 3 drawers and was last written weeks ago.

## What changed

### Gates

`lsp.Manager` grows `AnyAvailable()` and `AvailableLanguages()`; both call sites register the tools only when a server binary exists. The manager is always kept — the after-tool callback and diagnostics plumbing cost nothing idle.

The palace gate reads **drawer count, not file existence**, and fails closed when the count errors. The palace is still opened when empty so the observation bridge keeps filling it; the tools appear next session once there is content.

### Default LSP surface: two tools

Usage across this repo's entire session history:

| Tool | Calls | Tokens | Errors |
|---|---:|---:|---|
| `lsp-symbols` | 310 | 198 | 4/155 |
| `lsp-diagnostics` | 282 | 240 | 4/141 |
| `lsp-workspace-symbol` | 28 | 223 | 0 |
| `lsp-hover` | 23 | 140 | 1/11 |
| `lsp-definition` | 9 | 188 | 0 |
| `lsp-references` | 3 | 192 | 0 |
| `lsp-code-action` | 2 | 244 | 0 |

Two tools are **592 of 657 calls — 90%**. The other five cost 989 tokens per request for the remaining 65. Error rates are near zero, so the skew is preference rather than failure: `lsp-references` was called **3 times** against **8171 ripgrep calls**.

### `--lsp off|min|full`

| Value | Tools | Tokens |
|---|---|---:|
| `off` / `false` / `0` / `none` | none | 0 |
| `min` (default) / `""` | symbols, diagnostics | 438 |
| `full` / `true` / `all` / `1` | all seven | 1427 |

An unrecognized value warns and falls back to `min` rather than guessing silently.

### Subagent seam

The same value reaches a child through `SpawnOpts.LSP` (passed as `--lsp`) and an `lsp:` frontmatter key on an agent definition. So `pi --lsp off` plus `lsp: full` on a code-navigation agent gives the wide surface only while that agent runs.

`spawnArgs` is split out of `Spawner.Spawn` so the flag wiring is testable without starting a process.

## Savings

- No server installed + empty palace: **3073 of 7429 tokens (41%)**
- Server installed: **989 tokens** from the LSP surface alone

## Tests

New: `internal/lsp/availability_test.go`, `internal/cli/palace_gate_test.go`, `internal/tools/lsp_mode_test.go`, `internal/subagent/lsp_frontmatter_test.go`.

`TestLSPTools_Count` was updated rather than deleted — it now covers `LSPFull`, and `TestLSPToolsDefaultsToMinimal` pins the new default. `TestMinimalIsSubsetOfFull` keeps the two lists honest so raising the mode can never remove a tool.

`make test`, `make lint` (0 issues) and `make vet` are clean.

## Decisions worth reviewing

**Default is `min`, not `off`.** Every session still gets the two-tool set. Flipping to `off` — making LSP subagent-only — is a one-word change once that model is settled.

**No bundled agent declares `lsp: full` yet.** Which agents deserve it is a content call; `explore` and `architect` look like candidates.

**A dispatcher was prototyped and dropped.** A single `lsp` tool with an `op` parameter measured 574 tokens against 1427 — a real 60% saving with no capability loss — but `min` reaches 438 and matches observed behaviour, so the simpler change won. The prototype is not in this branch.

## Unrelated finding

`AgentConfig.Tools` is parsed from frontmatter at `agents.go:135` and **read nowhere** — `tools:` is decorative, and `memory-compressor`'s `tools: []` gets the full tool set anyway. That is why `lsp:` is a separate field rather than reusing `tools:`. It also means subagents currently pay for every tool group. Left alone here; worth its own look.