### PR TITLE
feat(tui): recover from a stuck agent loop instead of ending the turn

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"runtime/debug"
@@ -70,6 +71,12 @@ const (
 	// outputCheckEvery is how much new output accumulates between scans.
 	// Scanning per token would put a linear search in the streaming path.
 	outputCheckEvery = 512
+
+	// maxStuckRecoveries is how many times a stuck turn is handed back to the
+	// model with the detector's reason before the run is ended for real.
+	// Deliberately small: repetition that survives being named is not going to
+	// be fixed by naming it a third time, and each attempt costs a whole turn.
+	maxStuckRecoveries = 2
 )
 
 // extractAgentType returns a label for the subagent tool call by inspecting
@@ -680,12 +687,6 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 	}
 
 	log := run.logger
-	detector := &stuckDetector{}
-
-	// Providers like ollama/minimax emit per-token partial events AND a final
-	// aggregate containing the whole turn; forwarding both duplicates the text
-	// on screen (observed as "I'll spawn...I'll spawn...").
-	var dedup agent.StreamDedup
 
 	// GroundingMetadata is repeated on every streamed chunk of the response it
 	// grounds, so the same search would otherwise print once per chunk. Key on
@@ -712,6 +713,56 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 		ch <- agentDoneMsg{err: err}
 	}
 
+	// A stuck turn is recoverable: the model gets told what the detector saw and
+	// continues in the same session, so the work already done is not thrown
+	// away. The budget is small on purpose — repetition that survives being
+	// named is not going to be fixed by naming it again, and every attempt
+	// costs a full turn.
+	for attempt := 0; ; attempt++ {
+		err := m.streamTurn(ctx, ch, prompt, run, groundedSeen, &truncated, log)
+
+		var stuck *stuckError
+		if !errors.As(err, &stuck) {
+			if err != nil {
+				fail(err)
+			}
+			return
+		}
+
+		if attempt >= maxStuckRecoveries {
+			fail(fmt.Errorf("%w (gave up after %d recovery attempt(s))", err, attempt))
+			return
+		}
+
+		log.Info(fmt.Sprintf("agent loop stuck (%s); telling the model and resuming", stuck.Detail()))
+		ch <- agentWarningMsg{
+			text: fmt.Sprintf("Loop detected (%s) — telling the model and resuming (attempt %d of %d).",
+				stuck.Detail(), attempt+1, maxStuckRecoveries),
+		}
+		prompt = recoverStuckPrompt(stuck.Detail())
+	}
+}
+
+// streamTurn runs one streaming turn and forwards its events. It returns a
+// *stuckError when the detectors call the turn dead, any other error when the
+// run failed outright, and nil on a clean finish.
+//
+// The stuck detector and the stream deduper are per-turn state and are rebuilt
+// here on every attempt: carrying the previous attempt's output window across a
+// recovery would re-trip the guard on text the model has already been told to
+// stop producing.
+func (m *model) streamTurn(
+	ctx context.Context,
+	ch chan agentMsg,
+	prompt string,
+	run agentRunConfig,
+	groundedSeen map[string]bool,
+	truncated *bool,
+	log *logger.Logger,
+) error {
+	detector := &stuckDetector{}
+	var dedup agent.StreamDedup
+
 	// Same retry wrapper the print and RPC front-ends use, so a run that dies
 	// before producing anything is replayed here too instead of ending the turn
 	// with an error on screen. Mid-turn failures are handled a layer down, in
@@ -721,8 +772,7 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 		return run.agent.RunStreaming(ctx, run.sessionID, prompt)
 	}) {
 		if err != nil {
-			fail(err)
-			return
+			return err
 		}
 		if ev == nil {
 			continue
@@ -738,15 +788,14 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 		// A provider failure is a content-less event, so it has to be caught
 		// before the guard below drops it. See agent.EventError.
 		if evErr := agent.EventError(ev); evErr != nil {
-			fail(evErr)
-			return
+			return evErr
 		}
 
 		// A turn cut short at the output cap is otherwise indistinguishable
 		// from a complete one: the finish reason was mapped by every provider
 		// and then read by nobody, so a truncated reply just looked short.
-		if ev.FinishReason == genai.FinishReasonMaxTokens && !truncated {
-			truncated = true
+		if ev.FinishReason == genai.FinishReasonMaxTokens && !*truncated {
+			*truncated = true
 			ch <- agentWarningMsg{
 				text: "Response truncated: the model hit its output-token limit.",
 			}
@@ -757,10 +806,10 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 		}
 		dedup.BeginEvent(ev)
 		if abortErr := m.emitEventParts(ch, ev, &dedup, detector, log); abortErr != nil {
-			fail(abortErr)
-			return
+			return abortErr
 		}
 	}
+	return nil
 }
 
 // emitEventParts forwards one event's parts to the TUI channel. It returns a
@@ -828,13 +877,45 @@ func (m *model) emitEventParts(
 	return nil
 }
 
+// stuckError is a loop abort the run can recover from. It is distinguished
+// from a fatal error so runAgentLoop can hand the detail back to the model and
+// let it try again, rather than ending the turn on the model's first bad
+// stretch. See recoverStuckPrompt.
+type stuckError struct{ detail string }
+
+func (e *stuckError) Error() string { return "agent loop aborted: " + e.detail }
+
+// Detail returns the human-readable reason the loop was called dead.
+func (e *stuckError) Detail() string { return e.detail }
+
 // stuckErr adapts a stuckDetector verdict into an error, so both detector call
 // sites read as a single guard instead of a repeated five-line block.
 func stuckErr(stuck bool, detail string) error {
 	if !stuck {
 		return nil
 	}
-	return fmt.Errorf("agent loop aborted: %s", detail)
+	return &stuckError{detail: detail}
+}
+
+// recoverStuckPrompt is what the model is told after it gets stuck. It names
+// the specific failure the detector saw, because "try again" on its own tends
+// to produce the same output a second time — the model has no way to know what
+// tripped the guard unless it is told.
+func recoverStuckPrompt(detail string) string {
+	return fmt.Sprintf(
+		`Your previous turn was stopped automatically: %s.
+
+That is a loop, not progress, and repeating it will stop the turn again. Do not
+continue where you left off and do not restate what you already said.
+
+Change approach:
+- If you were repeating text, say the point once and move on.
+- If you were repeating a tool call, the call is not going to start working —
+  use a different tool, different arguments, or reason from what you already have.
+- If you are genuinely blocked, say so plainly and stop, rather than filling
+  the turn.
+
+Continue the original task from here.`, detail)
 }
 
 // handleAgentThinking processes an agentThinkingMsg.

--- a/internal/tui/agent_loop_e2e_test.go
+++ b/internal/tui/agent_loop_e2e_test.go
@@ -97,7 +97,12 @@ func TestRunAgentLoop_AbortsStuckBashLoop(t *testing.T) {
 	if doneErr == nil || !strings.Contains(doneErr.Error(), "aborted") {
 		t.Fatalf("expected loop-aborted error, got: %v", doneErr)
 	}
-	if toolCalls != maxRepeatErrorCalls {
-		t.Fatalf("aborted after %d identical failing tool calls, want %d", toolCalls, maxRepeatErrorCalls)
+	// The guard fires every attempt, and a stuck turn is handed back to the
+	// model maxStuckRecoveries times before the run ends — so the bound is
+	// per-attempt, not per-run. Anything above this means a guard stopped firing.
+	wantCalls := maxRepeatErrorCalls * (1 + maxStuckRecoveries)
+	if toolCalls != wantCalls {
+		t.Fatalf("aborted after %d identical failing tool calls, want %d (%d per attempt x %d attempts)",
+			toolCalls, wantCalls, maxRepeatErrorCalls, 1+maxStuckRecoveries)
 	}
 }

--- a/internal/tui/agent_loop_recovery_e2e_test.go
+++ b/internal/tui/agent_loop_recovery_e2e_test.go
@@ -1,0 +1,134 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	llmmodel "google.golang.org/adk/v2/model"
+
+	"github.com/dimetron/pi-go/internal/agent"
+)
+
+// driveRunLoopWithWarnings is driveRunLoop plus the warning stream, which is
+// how a recovery announces itself to the user.
+func driveRunLoopWithWarnings(t *testing.T, a *agent.Agent, sid, prompt string) (runResult, []string) {
+	t.Helper()
+	m := &model{cfg: Config{Agent: a, SessionID: sid}, ctx: context.Background()}
+	m.agentCh = make(chan agentMsg, 4096)
+
+	var res runResult
+	var warnings []string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for msg := range m.agentCh {
+			switch v := msg.(type) {
+			case agentTextMsg:
+				res.texts = append(res.texts, v.text)
+			case agentToolCallMsg:
+				res.toolCalls = append(res.toolCalls, v)
+			case agentWarningMsg:
+				warnings = append(warnings, v.text)
+			case agentDoneMsg:
+				res.doneErr = v.err
+				res.doneCount++
+			}
+		}
+	}()
+
+	go m.runAgentLoop(context.Background(), prompt, m.agentCh, m.agentRun())
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runAgentLoop did not terminate within 30s")
+	}
+	return res, warnings
+}
+
+// TestRunAgentLoop_RecoversFromRepeatedOutput is the behavior the user asked
+// for: the run is not ended on the model's first degenerate stretch. The
+// detector's reason is handed back and the turn continues in the same session.
+func TestRunAgentLoop_RecoversFromRepeatedOutput(t *testing.T) {
+	var mu sync.Mutex
+	turn := 0
+
+	phrase := "I will now carefully re-examine the situation and consider the available options once more. "
+	llm := &fnLLM{name: "babbler", gen: func(_ int) (*llmmodel.LLMResponse, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		turn++
+		if turn == 1 {
+			// Enough copies to trip maxOutputRepeats on the first turn.
+			return textResp(strings.Repeat(phrase, maxOutputRepeats+4)), nil
+		}
+		return textResp("Understood - stopping the repetition. The answer is 42."), nil
+	}}
+
+	a, sid := newRunTestAgent(t, llm)
+	res, warnings := driveRunLoopWithWarnings(t, a, sid, "explain something")
+
+	if res.doneErr != nil {
+		t.Fatalf("run ended with an error instead of recovering: %v", res.doneErr)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("recovery happened silently; the user must be told the loop was detected")
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "Loop detected") {
+		t.Fatalf("warning does not mention the loop:\n%s", strings.Join(warnings, "\n"))
+	}
+	joined := strings.Join(res.texts, "")
+	if !strings.Contains(joined, "42") {
+		t.Fatalf("recovered turn's answer never reached the user; got:\n%s", truncateForTest(joined))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if turn < 2 {
+		t.Fatalf("model was asked %d time(s), want >= 2 (the retry never happened)", turn)
+	}
+}
+
+// TestRunAgentLoop_GivesUpAfterRecoveryBudget is the other half: recovery is
+// bounded, so a model that repeats no matter what still ends the run rather
+// than retrying forever.
+func TestRunAgentLoop_GivesUpAfterRecoveryBudget(t *testing.T) {
+	var mu sync.Mutex
+	turns := 0
+
+	phrase := "Let me reconsider this from the beginning one more time before proceeding further. "
+	llm := &fnLLM{name: "hopeless", gen: func(_ int) (*llmmodel.LLMResponse, error) {
+		mu.Lock()
+		turns++
+		mu.Unlock()
+		return textResp(strings.Repeat(phrase, maxOutputRepeats+4)), nil
+	}}
+
+	a, sid := newRunTestAgent(t, llm)
+	res, _ := driveRunLoopWithWarnings(t, a, sid, "explain something")
+
+	if res.doneErr == nil {
+		t.Fatal("expected the run to end after the recovery budget, got no error")
+	}
+	if !strings.Contains(res.doneErr.Error(), "aborted") {
+		t.Fatalf("error lost the 'aborted' wording: %v", res.doneErr)
+	}
+	if !strings.Contains(res.doneErr.Error(), "gave up after") {
+		t.Fatalf("error does not say recovery was attempted: %v", res.doneErr)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if want := 1 + maxStuckRecoveries; turns != want {
+		t.Fatalf("model was asked %d times, want exactly %d (1 attempt + %d recoveries)",
+			turns, want, maxStuckRecoveries)
+	}
+}
+
+func truncateForTest(s string) string {
+	if len(s) > 300 {
+		return s[:300] + "..."
+	}
+	return s
+}

--- a/internal/tui/agent_loop_recovery_test.go
+++ b/internal/tui/agent_loop_recovery_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStuckErrIsRecoverable(t *testing.T) {
+	err := stuckErr(true, "model repeated a 106-character phrase 12 times")
+
+	var stuck *stuckError
+	if !errors.As(err, &stuck) {
+		t.Fatalf("stuckErr returned %T, want *stuckError so the run loop can recover", err)
+	}
+	if stuck.Detail() != "model repeated a 106-character phrase 12 times" {
+		t.Fatalf("Detail() = %q, want the detector's reason verbatim", stuck.Detail())
+	}
+	// The rendered message is what the user sees; keep the existing wording so
+	// log greps and the e2e assertions on "aborted" keep working.
+	if !strings.Contains(err.Error(), "agent loop aborted: ") {
+		t.Fatalf("Error() = %q, want it to keep the 'agent loop aborted' prefix", err.Error())
+	}
+}
+
+func TestStuckErrNilWhenNotStuck(t *testing.T) {
+	if err := stuckErr(false, "ignored"); err != nil {
+		t.Fatalf("stuckErr(false) = %v, want nil", err)
+	}
+}
+
+// TestRecoverStuckPromptNamesTheFailure pins the property that makes recovery
+// work at all: the model is told what specifically tripped the guard. A generic
+// "try again" tends to reproduce the same output, because nothing in the
+// conversation tells the model what went wrong.
+func TestRecoverStuckPromptNamesTheFailure(t *testing.T) {
+	detail := "identical tool call \"read\" repeated 10 times"
+	got := recoverStuckPrompt(detail)
+
+	if !strings.Contains(got, detail) {
+		t.Fatalf("recovery prompt does not contain the detector's reason %q:\n%s", detail, got)
+	}
+	for _, want := range []string{
+		"stopped automatically",
+		"Do not",
+		"Change approach",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("recovery prompt missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestMaxStuckRecoveriesIsBounded guards the cost side of this feature. An
+// unbounded retry turns a runaway loop into a runaway bill, which is the exact
+// thing the stuck detector exists to prevent.
+func TestMaxStuckRecoveriesIsBounded(t *testing.T) {
+	if maxStuckRecoveries < 1 {
+		t.Fatalf("maxStuckRecoveries = %d, want >= 1 or the feature does nothing", maxStuckRecoveries)
+	}
+	if maxStuckRecoveries > 3 {
+		t.Fatalf("maxStuckRecoveries = %d: each attempt costs a full turn, keep the budget small", maxStuckRecoveries)
+	}
+}

--- a/internal/tui/agent_loop_run_e2e_test.go
+++ b/internal/tui/agent_loop_run_e2e_test.go
@@ -194,8 +194,10 @@ func TestRunAgentLoop_AbortsIdenticalSuccessfulCallLoop(t *testing.T) {
 	if res.doneErr == nil || !strings.Contains(res.doneErr.Error(), "aborted") {
 		t.Fatalf("expected loop-aborted error, got %v", res.doneErr)
 	}
-	if len(res.toolCalls) > maxRepeatToolCalls {
-		t.Fatalf("detector allowed %d identical calls (want <= %d)", len(res.toolCalls), maxRepeatToolCalls)
+	// Bounded per attempt: the turn is retried maxStuckRecoveries times with
+	// the reason fed back to the model before the run is ended.
+	if want := maxRepeatToolCalls * (1 + maxStuckRecoveries); len(res.toolCalls) > want {
+		t.Fatalf("detector allowed %d identical calls (want <= %d)", len(res.toolCalls), want)
 	}
 }
 
@@ -211,8 +213,8 @@ func TestRunAgentLoop_AbortsSameToolVaryingArgs(t *testing.T) {
 	if res.doneErr == nil || !strings.Contains(res.doneErr.Error(), "aborted") {
 		t.Fatalf("expected loop-aborted error, got %v", res.doneErr)
 	}
-	if len(res.toolCalls) > maxToolErrorStreak {
-		t.Fatalf("same-tool guard allowed %d failing calls (want <= %d)", len(res.toolCalls), maxToolErrorStreak)
+	if want := maxToolErrorStreak * (1 + maxStuckRecoveries); len(res.toolCalls) > want {
+		t.Fatalf("same-tool guard allowed %d failing calls (want <= %d)", len(res.toolCalls), want)
 	}
 }
 


### PR DESCRIPTION
## Problem

A run that trips the stuck detector dies outright:

```
✖ Error: agent loop aborted: model repeated a 106-character phrase 12 times
```

Everything the turn had already done is discarded. The detector is *right* that the model is looping — but ending the run is a heavier response than the situation needs, and the user is left to retype the request.

## What happens now

The turn is handed back to the model with the detector's reason and continues **in the same session**, so prior work is kept:

```
Your previous turn was stopped automatically: model repeated a 106-character
phrase 12 times.

That is a loop, not progress, and repeating it will stop the turn again. Do not
continue where you left off and do not restate what you already said.

Change approach:
- If you were repeating text, say the point once and move on.
- If you were repeating a tool call, the call is not going to start working —
  use a different tool, different arguments, or reason from what you already have.
- If you are genuinely blocked, say so plainly and stop, rather than filling the turn.

Continue the original task from here.
```

The user sees `Loop detected (…) — telling the model and resuming (attempt 1 of 2).` Recovery is never silent.

**Naming the specific failure is the load-bearing part.** A bare "try again" tends to reproduce the same output, because nothing in the conversation tells the model what tripped the guard. `TestRecoverStuckPromptNamesTheFailure` pins that the detector's reason reaches the prompt verbatim.

## Structure

- `stuckError` is a distinct type, so `runAgentLoop` can tell recoverable repetition from a run that actually failed, via `errors.As`.
- The streaming body moves into `streamTurn`, which returns an error instead of calling `fail()` — the outer loop decides whether to retry.
- The detector and stream deduper are rebuilt **per attempt**. Carrying the previous attempt's output window across a recovery would instantly re-trip the guard on text the model was just told to stop producing.

## Bounded on purpose

`maxStuckRecoveries = 2`, applying to all three guards (repeated output, identical tool calls, same-tool error streaks). After that the run ends for real with `gave up after 2 recovery attempt(s)`.

Repetition that survives being named is not going to be fixed by naming it a third time, and each attempt costs a full turn. An unbounded retry would invert the cost protection the detector exists to provide — `TestMaxStuckRecoveriesIsBounded` fails if anyone raises the budget above 3.

## Consequence worth reviewing

**A pathological model now burns up to 3× the tool calls before the run ends.** That is the price of the feature and the main thing to weigh — `maxStuckRecoveries = 1` is a one-word change if 3× is too loose.

Three existing e2e tests asserted "aborts after ≤ 10 identical calls". The real bound is per-attempt, so they now assert `maxRepeatToolCalls * (1 + maxStuckRecoveries)` with the arithmetic visible rather than a hardcoded 30. The guarantee changed; the tests say so explicitly instead of quietly accepting a larger number.

## Tests

New: `agent_loop_recovery_test.go` (unit — error type, prompt content, budget bounds) and `agent_loop_recovery_e2e_test.go` (two end-to-end cases).

- `TestRunAgentLoop_RecoversFromRepeatedOutput` — a model that babbles once then answers: run completes, warning is emitted, the recovered answer reaches the user.
- `TestRunAgentLoop_GivesUpAfterRecoveryBudget` — a model that always babbles: run ends after exactly `1 + maxStuckRecoveries` attempts.

`make test`, `make lint` (0 issues), `make vet` clean.