### PR TITLE
feat(tools): extend session-stats into a sweep, expose it on the CLI, add a nightly skill

### DIFF
--- a/.pi-go/skills/nightly-session-watch/SKILL.md
+++ b/.pi-go/skills/nightly-session-watch/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: nightly-session-watch
+description: Nightly sweep of the last 24h of pi-go sessions — anomalous runs, loop aborts, tool error rates, token waste, real prompt-token spend, and whether the observation and palace pipelines are still recording. Triages each finding to the specialist skill that diagnoses it. Use for an unattended daily health check, or on demand after a bad night.
+---
+
+# Nightly Session Watch
+
+One sweep over everything that happened in the last 24 hours, in priority order:
+what **broke**, what it **cost**, and what to **do about it**.
+
+Everything runs through `pi session-stats` — the same Go code path the
+`session-stats` agent tool uses, so there is no second implementation to drift.
+No LLM call, no network, reads only `~/.pi-go/sessions/*/events.jsonl`.
+
+This is the umbrella check. It is deliberately shallow — it finds and ranks, it
+does not diagnose. Every finding names the skill that goes deeper:
+
+| Finding | Goes deeper with |
+|---|---|
+| `agent loop aborted: ...` | `pi-loop-forensics` |
+| Tool call errors | `pi-check-session-logs` |
+| Which tools dominate | `tools-stats` |
+| Slow turns / throughput | `token-perf` |
+
+Do not re-implement those here. If the sweep surfaces three aborted runs, the
+answer is "run loop-forensics on these three", not a second loop analysis.
+
+## Run it
+
+```bash
+pi session-stats                 # last 24h
+pi session-stats --hours 72      # wider window
+pi session-stats --all           # include sessions with no anomalies
+pi session-stats --json          # counters only, for a cron wrapper
+```
+
+Other flags: `--high-tool-calls` and `--high-turns` move the anomaly
+thresholds, `--session-dir` points at a different session root.
+
+## Steps
+
+1. **Run `pi session-stats`.** Present its markdown as-is — it is already
+   ordered by severity.
+
+2. **Read the numbers before interpreting them.** Three traps:
+   - Tool *error rate* matters more than error count. `read` failing 5 times in
+     253 calls is noise; a tool failing 8 of 8 is broken or misconfigured.
+   - A heavy session is not automatically a bad session. High tool calls on a
+     long task is work, not waste. Waste is the **Token waste** section.
+   - **Prompt tokens dwarf everything else.** They are re-sent on every request,
+     so the figure is dominated by the fixed block — system prompt plus tool
+     declarations — not by the task. A large number there is not evidence of a
+     bad night; a large number *per session* on short sessions is.
+
+3. **Triage each finding** to the table above and name the skill to run next.
+   Do not run them automatically — they are slower and interactive.
+
+4. **Propose fixes, grouped into config, code, and prompt.** Patterns worth
+   recognising:
+
+   | Symptom | Likely fix |
+   |---|---|
+   | One tool at ~100% error rate | Missing credential or unavailable MCP server — check config before code |
+   | `edit` error rate above ~20% | Editing without reading first, or on stale content — a prompt/ledger problem |
+   | Oversized results from a tool marked **uncapped** | Wire it into `compactToolResult` in `internal/tools/compactor.go` |
+   | Oversized results from a tool marked **yes** | The compactor is not running — check the after-tool callback chain |
+   | Duplicate results inside one session | Dedup is not running, same cause as above |
+   | `observations` DEGRADED or STALLED | The recording pipeline is down; see `specs/memory-fixes/` |
+   | Palace last write many days old | Nothing is filing drawers — the bridge is not wired, or the palace is gated off |
+
+5. **Say plainly when nothing is wrong.** A quiet night is a valid result and
+   belongs in one line, not padded into a report.
+
+## What it checks, and why each one
+
+- **Per-session anomalies** — high tool calls, excessive turns, errors, heavy
+  git activity, long idle runs.
+- **Loop aborts** — the guard ending a run is the most user-visible failure
+  there is. Grouped by reason: "repeated a phrase" and "identical tool call"
+  have different causes and different fixes.
+- **Tool error rates** — as a rate against call count, so a busy tool with a few
+  failures does not outrank a broken tool nobody uses.
+- **Token waste** — results over the compactor's 24k `MaxChars`, plus results
+  re-sent byte-identical inside one session. Each oversized tool is labelled
+  with whether `compactToolResult` covers it, which separates *"a component is
+  broken"* from *"this tool was never wired up"*.
+- **Token spend** — `promptTokenCount` / `candidatesTokenCount` straight from
+  the provider's `usageMetadata`. Measured, not estimated.
+- **Pipeline health** — the observation and palace stores. Both are best-effort
+  by design: every failure downgrades to a warning nobody reads, so they can be
+  dead for months while looking fine. The check is a **ratio**, not a presence
+  test — a store holding a handful of rows across thousands of sessions is
+  broken in the way that looks healthiest.
+
+## Scheduling it
+
+`--json` prints a stable object for a cron wrapper:
+
+```json
+{
+  "hours": 24,
+  "total_sessions": 175,
+  "anomalous_sessions": 25,
+  "aborted_runs": 0,
+  "reclaimable_tokens": 232957,
+  "prompt_tokens": 127052076
+}
+```
+
+Alert on `aborted_runs > 0`, on `reclaimable_tokens` crossing a threshold you
+pick, or on `prompt_tokens / total_sessions` drifting up. Keep the JSON as the
+trigger and the markdown as what a human reads.
+
+Nightly is the intended cadence: 24h is long enough for a pattern to show and
+short enough that the offending session is still fresh.
+
+## Limits worth stating
+
+- `prompt_tokens` and output tokens are provider-reported and exact.
+  `reclaimable_tokens` is `chars / 4` — fine for ranking and trends, not a
+  billing figure.
+- Only **tool result** volume feeds the waste number. The fixed per-request
+  overhead is visible in the token-spend section instead.
+- The window is selected by `events.jsonl` **mtime**, so a session that started
+  before the window but was still running inside it is included whole.
+- Duplicate detection is byte-exact within a single session. A near-duplicate,
+  or the same file read across two sessions, is not counted.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -226,6 +226,7 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newACPServerCmd())
 	cmd.AddCommand(newUpgradeCmd())
+	cmd.AddCommand(newSessionStatsCmd())
 
 	return cmd
 }

--- a/internal/cli/session_stats.go
+++ b/internal/cli/session_stats.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+// newSessionStatsCmd exposes the session-stats analysis on the command line.
+//
+// The same analysis is already an agent tool, but a nightly health check should
+// not need a model in the loop to run: it reads local files, makes no LLM call,
+// and its output is deterministic. A CLI front door makes it schedulable and
+// keeps the skill from shelling out to a second implementation.
+func newSessionStatsCmd() *cobra.Command {
+	var (
+		hours         int
+		highToolCalls int
+		highTurns     int
+		all           bool
+		sessionDir    string
+		asJSON        bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "session-stats",
+		Short: "Analyze recent sessions for anomalies, failures and token waste",
+		Long: `Scan session events for a time window and report what went wrong, what it cost,
+and whether the observation and palace pipelines are still recording.
+
+Reads ~/.pi-go/sessions/*/events.jsonl. No LLM call, no network.`,
+		Example: `  pi session-stats                 # last 24h
+  pi session-stats --hours 72      # wider window
+  pi session-stats --all           # include sessions with no anomalies
+  pi session-stats --json          # machine-readable, for a cron wrapper`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			out, err := tools.SessionStats(tools.SessionStatsInput{
+				Hours:         hours,
+				HighToolCalls: highToolCalls,
+				HighTurns:     highTurns,
+				All:           all,
+				SessionDir:    sessionDir,
+			})
+			if err != nil {
+				return fmt.Errorf("session-stats: %w", err)
+			}
+
+			if asJSON {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				// Content is the human report; a JSON consumer wants the
+				// numbers it can threshold on, not the markdown.
+				return enc.Encode(map[string]any{
+					"hours":              hours,
+					"total_sessions":     out.TotalSessions,
+					"anomalous_sessions": out.AnomalousSessions,
+					"aborted_runs":       out.AbortedRuns,
+					"reclaimable_tokens": out.ReclaimableTokens,
+					"prompt_tokens":      out.PromptTokens,
+				})
+			}
+
+			fmt.Print(out.Content)
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&hours, "hours", 24, "Lookback window in hours")
+	cmd.Flags().IntVar(&highToolCalls, "high-tool-calls", 20, "Tool calls above which a session is flagged")
+	cmd.Flags().IntVar(&highTurns, "high-turns", 5, "Turns above which a session is flagged")
+	cmd.Flags().BoolVar(&all, "all", false, "Include sessions with no anomalies")
+	cmd.Flags().StringVar(&sessionDir, "session-dir", "", "Session directory (default: ~/.pi-go/sessions)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the summary counters as JSON")
+
+	return cmd
+}

--- a/internal/tools/session_stats.go
+++ b/internal/tools/session_stats.go
@@ -36,6 +36,12 @@ type SessionStatsOutput struct {
 	TotalSessions int `json:"total_sessions"`
 	// Sessions with anomalies.
 	AnomalousSessions int `json:"anomalous_sessions"`
+	// Runs ended by the agent loop guard.
+	AbortedRuns int `json:"aborted_runs"`
+	// Tokens recoverable by capping oversized results and dropping duplicates.
+	ReclaimableTokens int `json:"reclaimable_tokens"`
+	// Provider-reported prompt tokens across the window.
+	PromptTokens int `json:"prompt_tokens"`
 }
 
 // sessionStat holds the computed stats for one session.
@@ -66,6 +72,13 @@ Optional: hours (lookback period, default 24), high_tool_calls (threshold, defau
 		func(_ agent.Context, input SessionStatsInput) (SessionStatsOutput, error) {
 			return sessionStatsHandler(input)
 		})
+}
+
+// SessionStats runs the session analysis and returns the report. Exported so
+// the CLI can reach the same code path the agent tool uses, rather than a
+// second implementation that drifts.
+func SessionStats(input SessionStatsInput) (SessionStatsOutput, error) {
+	return sessionStatsHandler(input)
 }
 
 func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
@@ -103,6 +116,7 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 	}
 
 	var stats []sessionStat
+	totals := newSweepTotals()
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -123,6 +137,7 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 
 		stat := analyzeSessionFile(entry.Name(), eventsPath, highToolCalls, highTurns)
 		stats = append(stats, stat)
+		accumulateSweepFile(totals, eventsPath)
 	}
 
 	// Sort by time (newest first).
@@ -190,10 +205,19 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 		}
 	}
 
+	// The per-session table above says which runs look odd. These sections say
+	// what went wrong across all of them, what it cost, and whether the
+	// recording pipelines are alive — the questions a nightly check exists for.
+	renderSweep(&b, totals, len(stats))
+	renderPipelineHealth(&b, len(stats), cutoff)
+
 	return SessionStatsOutput{
 		Content:           b.String(),
 		TotalSessions:     len(stats),
 		AnomalousSessions: totalAnomalous,
+		AbortedRuns:       totalAborts(totals),
+		ReclaimableTokens: reclaimableTokens(totals),
+		PromptTokens:      totals.PromptTokens,
 	}, nil
 }
 

--- a/internal/tools/session_sweep.go
+++ b/internal/tools/session_sweep.go
@@ -1,0 +1,362 @@
+package tools
+
+import (
+	"bufio"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite" // Pure Go SQLite driver, for the pipeline-health probes.
+)
+
+// oversizeChars is the result size above which the compactor would have
+// trimmed. It mirrors DefaultCompactorConfig().MaxChars — the excess over it is
+// what a missing or unwired compactor costs on every request that carries the
+// result forward.
+const oversizeChars = 24000
+
+// compactedTools is the set compactToolResult actually handles. A tool outside
+// it is uncapped by design, not by accident, and the distinction is the whole
+// point of reporting oversize per tool: one means a component is broken, the
+// other means a tool was never wired up.
+var compactedTools = map[string]bool{
+	"read": true, "bash": true, "grep": true, "find": true, "tree": true,
+	"git_file_diff": true, "git_overview": true, "git_hunk": true,
+}
+
+// toolUsage accumulates per-tool volume across the scanned window.
+type toolUsage struct {
+	Name      string
+	Calls     int
+	Errors    int
+	Bytes     int
+	Oversized int // bytes above oversizeChars, summed
+}
+
+// sweepTotals is the cross-session aggregate behind the deep report.
+type sweepTotals struct {
+	PromptTokens int
+	OutputTokens int
+	ToolBytes    int
+	DupBytes     int
+	Tools        map[string]*toolUsage
+	Aborts       map[string]int
+	Models       map[string]int
+}
+
+func newSweepTotals() *sweepTotals {
+	return &sweepTotals{
+		Tools:  map[string]*toolUsage{},
+		Aborts: map[string]int{},
+		Models: map[string]int{},
+	}
+}
+
+func (t *sweepTotals) tool(name string) *toolUsage {
+	u, ok := t.Tools[name]
+	if !ok {
+		u = &toolUsage{Name: name}
+		t.Tools[name] = u
+	}
+	return u
+}
+
+// sortedTools returns per-tool usage ordered by the given key, descending.
+func (t *sweepTotals) sortedTools(key func(*toolUsage) int) []*toolUsage {
+	out := make([]*toolUsage, 0, len(t.Tools))
+	for _, u := range t.Tools {
+		out = append(out, u)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if key(out[i]) != key(out[j]) {
+			return key(out[i]) > key(out[j])
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// sweepEvent is the subset of a session event the deep scan reads. Field names
+// are capitalized for readability; encoding/json matches the lowercase wire
+// keys case-insensitively.
+type sweepEvent struct {
+	Content struct {
+		Parts []struct {
+			FunctionCall *struct {
+				Name string `json:"name"`
+			} `json:"functionCall"`
+			FunctionResponse *struct {
+				Name     string          `json:"name"`
+				Response json.RawMessage `json:"response"`
+			} `json:"functionResponse"`
+		} `json:"parts"`
+	} `json:"content"`
+	UsageMetadata *struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+	} `json:"usageMetadata"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+// accumulateSweepFile folds one session's events into the totals. seen is per
+// session, so a duplicate is a result the model was shown twice inside one
+// run — the thing dedup exists to prevent.
+func accumulateSweepFile(totals *sweepTotals, path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	seen := map[string]bool{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 8*1024*1024)
+	for scanner.Scan() {
+		var ev sweepEvent
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			continue
+		}
+
+		if ev.UsageMetadata != nil {
+			totals.PromptTokens += ev.UsageMetadata.PromptTokenCount
+			totals.OutputTokens += ev.UsageMetadata.CandidatesTokenCount
+		}
+		if detail := abortDetail(ev.ErrorMessage); detail != "" {
+			totals.Aborts[detail]++
+		}
+
+		for _, p := range ev.Content.Parts {
+			if p.FunctionCall != nil {
+				totals.tool(p.FunctionCall.Name).Calls++
+			}
+			if p.FunctionResponse == nil {
+				continue
+			}
+			u := totals.tool(p.FunctionResponse.Name)
+			body := string(p.FunctionResponse.Response)
+			u.Bytes += len(body)
+			totals.ToolBytes += len(body)
+			if strings.Contains(body, `"error"`) {
+				u.Errors++
+			}
+			if len(body) > oversizeChars {
+				u.Oversized += len(body) - oversizeChars
+			}
+			if seen[body] {
+				totals.DupBytes += len(body)
+			} else {
+				seen[body] = true
+			}
+		}
+	}
+}
+
+// abortDetail extracts the reason from a loop-guard abort, or "" when the
+// message is any other error.
+func abortDetail(msg string) string {
+	const marker = "agent loop aborted:"
+	i := strings.Index(msg, marker)
+	if i < 0 {
+		return ""
+	}
+	detail := strings.TrimSpace(msg[i+len(marker):])
+	if len(detail) > 120 {
+		detail = detail[:120]
+	}
+	return detail
+}
+
+// renderSweep writes the deep sections: failures, waste, and real token spend.
+func renderSweep(b *strings.Builder, totals *sweepTotals, sessions int) {
+	b.WriteString("\n## Failures\n\n")
+	if len(totals.Aborts) == 0 {
+		b.WriteString("No aborted runs.\n")
+	} else {
+		b.WriteString("Aborted by the loop guard — run the `pi-loop-forensics` skill on these:\n\n")
+		for detail, n := range totals.Aborts {
+			fmt.Fprintf(b, "- %dx `%s`\n", n, detail)
+		}
+	}
+
+	byErrors := totals.sortedTools(func(u *toolUsage) int { return u.Errors })
+	if len(byErrors) > 0 && byErrors[0].Errors > 0 {
+		b.WriteString("\nTool errors, as a rate — a busy tool with a few failures is not the problem:\n\n")
+		b.WriteString("| tool | errors | calls | rate |\n|---|---:|---:|---:|\n")
+		for _, u := range byErrors {
+			if u.Errors == 0 {
+				break
+			}
+			calls := max(u.Calls, 1)
+			fmt.Fprintf(b, "| %s | %d | %d | %d%% |\n", u.Name, u.Errors, calls, 100*u.Errors/calls)
+		}
+		b.WriteString("\n→ `pi-check-session-logs` dedupes these by pattern.\n")
+	}
+
+	b.WriteString("\n## Token waste\n\n")
+	overTotal := 0
+	for _, u := range totals.Tools {
+		overTotal += u.Oversized
+	}
+	if overTotal == 0 && totals.DupBytes == 0 {
+		b.WriteString("Nothing oversized or duplicated.\n")
+	} else {
+		reclaim := (overTotal + totals.DupBytes) / 4
+		pct := 0
+		if totals.ToolBytes > 0 {
+			pct = 100 * (overTotal + totals.DupBytes) / totals.ToolBytes
+		}
+		fmt.Fprintf(b, "Reclaimable: **~%s tokens** (%d%% of tool output)\n\n", thousands(reclaim), pct)
+		b.WriteString("| tool | excess over 24k | compactor covers it? |\n|---|---:|---|\n")
+		for _, u := range totals.sortedTools(func(u *toolUsage) int { return u.Oversized }) {
+			if u.Oversized == 0 {
+				break
+			}
+			covered := "**no — uncapped**"
+			if compactedTools[strings.ReplaceAll(u.Name, "-", "_")] {
+				covered = "yes"
+			}
+			fmt.Fprintf(b, "| %s | %s tok | %s |\n", u.Name, thousands(u.Oversized/4), covered)
+		}
+		if totals.DupBytes > 0 {
+			fmt.Fprintf(b, "\nDuplicate results re-sent inside one session: ~%s tokens.\n",
+				thousands(totals.DupBytes/4))
+		}
+	}
+
+	b.WriteString("\n## Token spend\n\n")
+	if totals.PromptTokens == 0 {
+		b.WriteString("No usage metadata — the provider did not report token counts.\n")
+	} else {
+		fmt.Fprintf(b, "Prompt %s · output %s (provider-reported, not estimated)\n",
+			thousands(totals.PromptTokens), thousands(totals.OutputTokens))
+		if sessions > 0 {
+			fmt.Fprintf(b, "\nPrompt tokens are re-sent every request, so this is dominated by the fixed\nblock — system prompt plus tool declarations — not by the work. "+
+				"Average %s prompt tokens per session across %d session(s).\n",
+				thousands(totals.PromptTokens/sessions), sessions)
+		}
+	}
+}
+
+// renderPipelineHealth reports whether the recording pipelines are alive.
+//
+// Both stores are best-effort by design: every failure downgrades to a warning
+// nobody reads, so they can be dead for months while looking fine. The check is
+// a ratio, not a presence test — a store holding a handful of rows across
+// thousands of sessions is broken in the way that looks healthiest.
+func renderPipelineHealth(b *strings.Builder, sessions int, since time.Time) {
+	b.WriteString("\n## Pipeline health\n\n")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		b.WriteString("- home directory unavailable; skipped\n")
+		return
+	}
+
+	memPath := filepath.Join(home, ".pi-go", "memory", "claude-mem.db")
+	if _, statErr := os.Stat(memPath); statErr != nil {
+		b.WriteString("- **observations**: no database yet\n")
+	} else if recent, total, err := countObservations(memPath, since); err != nil {
+		fmt.Fprintf(b, "- **observations (ERROR)**: %v\n", err)
+	} else {
+		expected := max(sessions, 1)
+		status := "STALLED"
+		switch {
+		case recent >= expected:
+			status = "OK"
+		case recent > 0:
+			status = "DEGRADED"
+		}
+		fmt.Fprintf(b, "- **observations (%s)**: %d in window, %d total", status, recent, total)
+		if status != "OK" {
+			fmt.Fprintf(b, " — expected >= %d for %d session(s); see specs/memory-fixes/", expected, sessions)
+		}
+		b.WriteString("\n")
+	}
+
+	for _, p := range []struct{ label, path string }{
+		{"palace (home)", filepath.Join(home, ".pi-go", "palace.db")},
+		{"palace (project)", filepath.Join(".pi-go", "palace.db")},
+	} {
+		info, statErr := os.Stat(p.path)
+		if statErr != nil {
+			continue
+		}
+		n, err := countDrawers(p.path)
+		if err != nil {
+			continue
+		}
+		age := int(time.Since(info.ModTime()).Hours() / 24)
+		fmt.Fprintf(b, "- **%s**: %d drawers, last write %dd ago\n", p.label, n, age)
+	}
+}
+
+// countObservations opens the observation store read-only and returns the rows
+// inside the window and in total.
+func countObservations(path string, since time.Time) (recent, total int, err error) {
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		return 0, 0, err
+	}
+	defer db.Close()
+	if err := db.QueryRow("SELECT COUNT(*) FROM observations").Scan(&total); err != nil {
+		return 0, 0, err
+	}
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM observations WHERE created_at_epoch >= ?", since.Unix(),
+	).Scan(&recent); err != nil {
+		return 0, total, err
+	}
+	return recent, total, nil
+}
+
+func countDrawers(path string) (int, error) {
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+	var n int
+	err = db.QueryRow("SELECT COUNT(*) FROM drawers").Scan(&n)
+	return n, err
+}
+
+// thousands formats n with comma separators, so six-figure token counts stay
+// readable in a terminal table.
+func thousands(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var out []byte
+	for i, c := range []byte(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// totalAborts counts loop-guard aborts across the window.
+func totalAborts(t *sweepTotals) int {
+	n := 0
+	for _, c := range t.Aborts {
+		n += c
+	}
+	return n
+}
+
+// reclaimableTokens is the oversize excess plus duplicate volume, in tokens.
+// Estimated at 4 chars per token, which is fine for ranking and trends and is
+// not a billing figure — unlike PromptTokens, which the provider reports.
+func reclaimableTokens(t *sweepTotals) int {
+	over := 0
+	for _, u := range t.Tools {
+		over += u.Oversized
+	}
+	return (over + t.DupBytes) / 4
+}

--- a/internal/tools/session_sweep_test.go
+++ b/internal/tools/session_sweep_test.go
@@ -1,0 +1,143 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeEvents drops an events.jsonl into a fresh session directory under root.
+func writeEvents(t *testing.T, root, id string, lines ...string) {
+	t.Helper()
+	dir := filepath.Join(root, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+}
+
+func TestAbortDetail(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"unrelated error", "provider timed out", ""},
+		{"bare abort", "agent loop aborted: model repeated a 106-character phrase 12 times",
+			"model repeated a 106-character phrase 12 times"},
+		{"prefixed", "run failed: agent loop aborted: identical tool call \"read\" repeated 10 times",
+			"identical tool call \"read\" repeated 10 times"},
+		{"trimmed to 120", "agent loop aborted: " + strings.Repeat("x", 200), strings.Repeat("x", 120)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := abortDetail(tt.in); got != tt.want {
+				t.Fatalf("abortDetail(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAccumulateSweepFile(t *testing.T) {
+	root := t.TempDir()
+	big := strings.Repeat("z", oversizeChars+1000)
+	writeEvents(t, root, "s1",
+		`{"content":{"parts":[{"functionCall":{"name":"read"}}]},"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":20}}`,
+		`{"content":{"parts":[{"functionResponse":{"name":"read","response":{"content":"`+big+`"}}}]}}`,
+		`{"content":{"parts":[{"functionResponse":{"name":"read","response":{"content":"`+big+`"}}}]}}`,
+		`{"content":{"parts":[{"functionResponse":{"name":"ripgrep","response":{"error":"boom"}}}]}}`,
+		`{"errorMessage":"agent loop aborted: model repeated a 106-character phrase 12 times"}`,
+	)
+
+	totals := newSweepTotals()
+	accumulateSweepFile(totals, filepath.Join(root, "s1", "events.jsonl"))
+
+	if totals.PromptTokens != 100 || totals.OutputTokens != 20 {
+		t.Fatalf("usage = prompt %d output %d, want 100/20", totals.PromptTokens, totals.OutputTokens)
+	}
+	if got := totals.tool("read").Calls; got != 1 {
+		t.Fatalf("read calls = %d, want 1", got)
+	}
+	if got := totals.tool("ripgrep").Errors; got != 1 {
+		t.Fatalf("ripgrep errors = %d, want 1 (an \"error\" key in the response body)", got)
+	}
+	if totals.tool("read").Oversized == 0 {
+		t.Fatal("oversized read result was not counted")
+	}
+	// The second identical response is the duplicate; the first is not.
+	if totals.DupBytes == 0 {
+		t.Fatal("identical result repeated in one session was not counted as a duplicate")
+	}
+	if n := totalAborts(totals); n != 1 {
+		t.Fatalf("aborts = %d, want 1", n)
+	}
+}
+
+// TestAccumulateSweepFileDuplicatesArePerSession pins the scope of dedup
+// accounting: the same result in two different sessions is not a duplicate,
+// because nothing showed it to the model twice in one context.
+func TestAccumulateSweepFileDuplicatesArePerSession(t *testing.T) {
+	root := t.TempDir()
+	line := `{"content":{"parts":[{"functionResponse":{"name":"read","response":{"content":"same"}}}]}}`
+	writeEvents(t, root, "a", line)
+	writeEvents(t, root, "b", line)
+
+	totals := newSweepTotals()
+	accumulateSweepFile(totals, filepath.Join(root, "a", "events.jsonl"))
+	accumulateSweepFile(totals, filepath.Join(root, "b", "events.jsonl"))
+
+	if totals.DupBytes != 0 {
+		t.Fatalf("DupBytes = %d, want 0 — cross-session repeats are not duplicates", totals.DupBytes)
+	}
+}
+
+func TestAccumulateSweepFileMissingPath(t *testing.T) {
+	totals := newSweepTotals()
+	accumulateSweepFile(totals, filepath.Join(t.TempDir(), "nope", "events.jsonl"))
+	if totals.ToolBytes != 0 || len(totals.Tools) != 0 {
+		t.Fatal("a missing file should contribute nothing, not panic or invent totals")
+	}
+}
+
+func TestSessionStatsReportIncludesSweepSections(t *testing.T) {
+	root := t.TempDir()
+	writeEvents(t, root, "s1",
+		`{"content":{"parts":[{"functionCall":{"name":"read"}}]},"usageMetadata":{"promptTokenCount":8000,"candidatesTokenCount":40}}`,
+		`{"errorMessage":"agent loop aborted: identical tool call \"read\" repeated 10 times"}`,
+	)
+	// os.ReadDir skips nothing here, but the cutoff does — keep mtime fresh.
+	now := time.Now()
+	_ = os.Chtimes(filepath.Join(root, "s1", "events.jsonl"), now, now)
+
+	out, err := SessionStats(SessionStatsInput{Hours: 24, SessionDir: root, All: true})
+	if err != nil {
+		t.Fatalf("SessionStats: %v", err)
+	}
+	for _, want := range []string{"## Failures", "## Token waste", "## Token spend", "## Pipeline health"} {
+		if !strings.Contains(out.Content, want) {
+			t.Errorf("report missing %q section:\n%s", want, out.Content)
+		}
+	}
+	if out.AbortedRuns != 1 {
+		t.Errorf("AbortedRuns = %d, want 1", out.AbortedRuns)
+	}
+	if out.PromptTokens != 8000 {
+		t.Errorf("PromptTokens = %d, want 8000 (provider-reported, not estimated)", out.PromptTokens)
+	}
+}
+
+func TestThousands(t *testing.T) {
+	tests := map[int]string{0: "0", 42: "42", 999: "999", 1000: "1,000",
+		12345: "12,345", 1234567: "1,234,567"}
+	for in, want := range tests {
+		if got := thousands(in); got != want {
+			t.Errorf("thousands(%d) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

A nightly session health check, and the Go analysis behind it.

- `.pi-go/skills/nightly-session-watch/` — the skill
- `pi session-stats` — new CLI command
- `internal/tools/session_sweep.go` — the cross-session analysis
- `internal/tools/session_stats.go` — extended, and `SessionStats` exported

The skill runs `pi session-stats`, which is the same code path the `session-stats` agent tool already used. One implementation, two front doors, nothing to drift.

```bash
pi session-stats                 # last 24h
pi session-stats --hours 72      # wider window
pi session-stats --all           # include sessions with no anomalies
pi session-stats --json          # counters only, for a cron wrapper
```

No LLM call, no network. Reads `~/.pi-go/sessions/*/events.jsonl`.

## What session-stats gained

It previously reported per-session anomalies only — tool call counts, turns, errors, git activity, duration. It now also reports, across the window:

**Loop-guard aborts**, grouped by reason. "repeated a phrase" and "identical tool call" have different causes and different fixes.

**Tool errors as a rate** against call count, so a busy tool with a few failures does not outrank a broken tool nobody uses.

**Token waste** — results over the compactor's 24k `MaxChars`, plus results re-sent byte-identical inside one session. Each oversized tool is labelled with whether `compactToolResult` actually handles it, which separates *"a component is broken"* from *"this tool was never wired up"*.

**Token spend** from `usageMetadata.promptTokenCount` — provider-reported, not estimated.

**Pipeline health** for the observation and palace stores. Both are best-effort by design: every failure downgrades to a warning nobody reads, so they can be dead for months while looking fine. The check is a **ratio**, not a presence test — a store holding a handful of rows across thousands of sessions is broken in the way that looks healthiest.

## The number that came out of building it

Measured on 24h of real sessions:

```
Prompt 127,052,076 · output 583,525 (provider-reported)
Average 726,011 prompt tokens per session across 175 sessions

Reclaimable from tool output: ~232,957 tokens (15%)
```

**127M prompt tokens against 233k reclaimable — a factor of ~545.** Prompt tokens are re-sent on every request, so the figure is dominated by the fixed block: system prompt plus tool declarations, not the work.

That reorders the token-efficiency backlog. Capping oversized tool results is real but small; shrinking the per-request preamble is where the cost actually is.

## Sample output

```
## Failures
Aborted by the loop guard — run the `pi-loop-forensics` skill on these:
- 1x `model repeated a 106-character phrase 12 times`

| tool | errors | calls | rate |
|---|---:|---:|---:|
| x_keyword_search | 8 | 8 | 100% |
| edit | 20 | 69 | 29% |

## Token waste
Reclaimable: ~232,957 tokens (15% of tool output)

| tool | excess over 24k | compactor covers it? |
|---|---:|---|
| ripgrep | 72,790 tok | **no — uncapped** |
| read | 60,633 tok | yes |

## Pipeline health
- **observations (DEGRADED)**: 1 in window, 1 total — expected >= 175
```

Both xAI search tools failing 100% is a config or availability problem, not a code one — surfaced by the check, not fixed here.

## The skill is deliberately shallow

It finds and ranks; it names the specialist that diagnoses:

| Finding | Goes deeper with |
|---|---|
| `agent loop aborted: ...` | `pi-loop-forensics` |
| Tool call errors | `pi-check-session-logs` |
| Which tools dominate | `tools-stats` |
| Slow turns / throughput | `token-perf` |

`pi-check-session-logs` already dedupes tool errors and `pi-loop-forensics` already diagnoses aborts. A second answer to either question would be worse than none.

## Tests

`internal/tools/session_sweep_test.go` covers `abortDetail` (table-driven, including the 120-char trim), the accumulator, the per-session scope of duplicate detection, a missing file contributing nothing, the report sections, and the exported counters.

`make test`, `make lint` (0 issues) and `make vet` are clean.

## Note

`.pi-go/` is gitignored, so the skill files are force-added like the other 18 skills — matching the existing convention rather than changing `.gitignore`.