### PR TITLE
feat(pimodels): add a public package for building provider LLM clients

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1157,19 +1157,10 @@ func buildToolsets(cfg config.Config) []adktool.Toolset {
 	return toolsets
 }
 
+// providerEnvVar delegates to the provider package so the CLI and the public
+// pimodels package cannot drift on where a key comes from.
 func providerEnvVar(p string) string {
-	switch p {
-	case "anthropic":
-		return "ANTHROPIC_API_KEY"
-	case "openai":
-		return "OPENAI_API_KEY"
-	case "azure":
-		return "AZURE_OPENAI_API_KEY"
-	case "gemini":
-		return "GEMINI_API_KEY"
-	default:
-		return strings.ToUpper(p) + "_API_KEY"
-	}
+	return provider.APIKeyEnvVar(p)
 }
 
 // detectMode returns the default output mode based on terminal state.

--- a/internal/provider/apikey_test.go
+++ b/internal/provider/apikey_test.go
@@ -1,0 +1,58 @@
+package provider
+
+import "testing"
+
+func TestAPIKeyEnvVar(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		// The four that do not follow the pattern, and are the reason this
+		// mapping exists rather than a bare strings.ToUpper.
+		{"anthropic", "ANTHROPIC_API_KEY"},
+		{"openai", "OPENAI_API_KEY"},
+		{"azure", "AZURE_OPENAI_API_KEY"},
+		{"gemini", "GEMINI_API_KEY"},
+		// Everything else derives from the provider name.
+		{"xai", "XAI_API_KEY"},
+		{"mistral", "MISTRAL_API_KEY"},
+		{"ollama", "OLLAMA_API_KEY"},
+		{"opencode", "OPENCODE_API_KEY"},
+		{"", "_API_KEY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			if got := APIKeyEnvVar(tt.provider); got != tt.want {
+				t.Fatalf("APIKeyEnvVar(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIKeyFromEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test-value")
+	if got := APIKeyFromEnv("openai"); got != "sk-test-value" {
+		t.Fatalf("APIKeyFromEnv(openai) = %q, want the value from the environment", got)
+	}
+}
+
+// TestAPIKeyFromEnvUnset pins that an absent key is an empty string rather than
+// an error: providers that need no credential — a local Ollama — must keep
+// working, and it is the provider constructor's job to decide, not this helper's.
+func TestAPIKeyFromEnvUnset(t *testing.T) {
+	t.Setenv("MADEUPPROVIDER_API_KEY", "")
+	if got := APIKeyFromEnv("madeupprovider"); got != "" {
+		t.Fatalf("APIKeyFromEnv for an unset variable = %q, want empty", got)
+	}
+}
+
+// TestAPIKeyEnvVarMatchesFromEnv keeps the two in step: a caller that reports a
+// missing credential by name must name the variable the lookup actually reads.
+func TestAPIKeyEnvVarMatchesFromEnv(t *testing.T) {
+	for _, p := range []string{"anthropic", "openai", "azure", "gemini", "xai"} {
+		t.Setenv(APIKeyEnvVar(p), "value-for-"+p)
+		if got := APIKeyFromEnv(p); got != "value-for-"+p {
+			t.Errorf("provider %q: APIKeyFromEnv read a different variable than APIKeyEnvVar names", p)
+		}
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -490,3 +490,30 @@ func NewLLM(ctx context.Context, info Info, apiKey, baseURL, thinkingLevel strin
 		return nil, fmt.Errorf("unsupported provider: %s", info.Provider)
 	}
 }
+
+// APIKeyEnvVar returns the environment variable a provider's key is read from.
+//
+// Kept here rather than in a front-end so every caller — the CLI, the public
+// pimodels package, ping — agrees on where a key comes from. A second copy of
+// this mapping is how "works in the CLI, not when embedded" bugs start.
+func APIKeyEnvVar(providerName string) string {
+	switch providerName {
+	case "anthropic":
+		return "ANTHROPIC_API_KEY"
+	case "openai":
+		return "OPENAI_API_KEY"
+	case "azure":
+		return "AZURE_OPENAI_API_KEY"
+	case "gemini":
+		return "GEMINI_API_KEY"
+	default:
+		return strings.ToUpper(providerName) + "_API_KEY"
+	}
+}
+
+// APIKeyFromEnv returns the configured key for a provider, or "" when unset.
+// Providers that need no key (ollama on localhost) are fine with the empty
+// string; the provider constructors decide, not this helper.
+func APIKeyFromEnv(providerName string) string {
+	return os.Getenv(APIKeyEnvVar(providerName))
+}

--- a/pimodels/README.md
+++ b/pimodels/README.md
@@ -1,0 +1,103 @@
+# pimodels
+
+Build LLM clients for the providers pi-go supports, from outside pi-go.
+
+```go
+import "github.com/dimetron/pi-go/pimodels"
+
+m, err := pimodels.New(ctx, "gpt-5.6-luna")
+```
+
+`m` is an ADK `model.LLM`. Hand it to any ADK agent.
+
+## What it does
+
+Resolves a model name to a provider, finds the API key, and returns a client.
+That is the whole remit — it knows nothing about agents, tools, sessions or
+skills.
+
+| Model name | Provider |
+|---|---|
+| `gpt-*` | openai |
+| `claude-*` | anthropic |
+| `gemini-*` | gemini |
+| `grok-*` | xai |
+| `mistral-*`, `magistral-*` | mistral |
+| `ollama/<name>`, `*:cloud` | ollama |
+| `azure/<deployment>` | azure |
+| anything, with `WithBaseURL` | OpenAI-compatible |
+
+## Isolation
+
+This package and the agent package meet at ADK's `model.LLM`, not at each
+other. Neither imports the other:
+
+```go
+m, err := pimodels.New(ctx, "gpt-5.6-luna")       // this package
+a, err := piagent.New(ctx, piagent.WithModel(m))  // the agent package
+```
+
+That boundary is enforced by a test, not a convention — `isolation_test.go`
+asserts the build graph and fails CI if this package ever reaches into the
+agent, the tool set, or the CLI. A public package cannot afford for a change to
+provider handling to become a breaking change to the agent API.
+
+## API keys
+
+`New` reads the key from the provider's environment variable:
+
+| Provider | Variable |
+|---|---|
+| openai | `OPENAI_API_KEY` |
+| anthropic | `ANTHROPIC_API_KEY` |
+| gemini | `GEMINI_API_KEY` |
+| azure | `AZURE_OPENAI_API_KEY` |
+| everything else | `<PROVIDER>_API_KEY` |
+
+`WithAPIKey` overrides it. A local Ollama needs neither.
+
+Use `APIKeyEnvVar(provider)` to report a missing credential precisely instead of
+letting the first request fail with a provider-specific auth error.
+
+## Options
+
+| Option | Purpose |
+|---|---|
+| `WithAPIKey` | Explicit credential |
+| `WithBaseURL` | Gateway, proxy, or self-hosted endpoint |
+| `WithThinkingLevel` | Reasoning effort where supported |
+| `WithHeaders` | Extra headers for gateway routing or tenancy |
+| `WithConnectTimeout` | Bounds connect only — not the request, which streams |
+| `WithCACert` | Trust a PEM bundle alongside system roots |
+| `WithInsecureTLS` | Disable verification — prefer `WithCACert` |
+| `WithPromptCachingDisabled` | Turn off Anthropic cache breakpoints |
+| `WithAdvisor` | Advisor model, where supported |
+
+Options apply in order, so a later one wins.
+
+## Without a model name
+
+`FromConfig(ctx, role)` builds the model a `pi` session would use, reading
+`~/.pi-go/config.json`. An empty role means `default`. This is the only function
+here that touches pi-go's configuration; `New` is self-contained.
+
+## Inspecting before connecting
+
+```go
+info, err := pimodels.Resolve("claude-sonnet-5")
+// info.Provider == "anthropic"
+
+pimodels.ContextWindow("gemini-3.7-flash")           // tokens, 0 if unknown
+pimodels.ContextWindowFor("azure", "my-deployment")  // provider-aware
+```
+
+`Resolve` needs no credential and makes no request, so it is safe to run at
+startup to validate configuration.
+
+## A note on `Info.BaseURL`
+
+`Resolve` fills `Info.BaseURL` whenever an explicit endpoint was given. pi-go's
+own `provider.ResolveWithBaseURL` leaves that field empty and only the TUI fills
+it in afterwards, by hand — so the same call inside pi-go answers less
+completely than this one does. An embedder has no second place to look, so this
+package completes it.

--- a/pimodels/README.md
+++ b/pimodels/README.md
@@ -94,6 +94,21 @@ pimodels.ContextWindowFor("azure", "my-deployment")  // provider-aware
 `Resolve` needs no credential and makes no request, so it is safe to run at
 startup to validate configuration.
 
+## Finding the provider from a model
+
+Every model returned by `New` and `FromConfig` also reports its provider family,
+so a consumer never needs its own model-name prefix table:
+
+```go
+if p, ok := m.(interface{ Provider() string }); ok {
+    span.SetAttributes(attribute.String("gen_ai.provider.name", p.Provider()))
+}
+```
+
+Assert the *shape*, not the named `ProviderNamer` type — that way the consumer
+depends on ADK and a structural interface, not on this package. A model built
+any other way will not satisfy it, so always handle the not-ok branch.
+
 ## A note on `Info.BaseURL`
 
 `Resolve` fills `Info.BaseURL` whenever an explicit endpoint was given. pi-go's

--- a/pimodels/example_test.go
+++ b/pimodels/example_test.go
@@ -1,0 +1,79 @@
+package pimodels_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/dimetron/pi-go/pimodels"
+)
+
+// The common case: name a model, get a client. The provider is inferred from
+// the name and the key comes from that provider's environment variable.
+func ExampleNew() {
+	ctx := context.Background()
+
+	m, err := pimodels.New(ctx, "gpt-5.6-luna")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// m is an ADK model.LLM. Hand it to any ADK agent — including pi-go's,
+	// which takes it as piagent.WithModel(m).
+	_ = m
+}
+
+// Point the client at a gateway or a self-hosted OpenAI-compatible server. The
+// explicit endpoint wins over anything inferred from the model name.
+func ExampleNew_gateway() {
+	ctx := context.Background()
+
+	m, err := pimodels.New(ctx, "gpt-5.6-luna",
+		pimodels.WithBaseURL("https://llm-gateway.internal/v1"),
+		pimodels.WithAPIKey("tenant-key"),
+		pimodels.WithHeaders(map[string]string{"X-Tenant": "acme"}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = m
+}
+
+// Resolve answers "where would this request actually go" without building a
+// client or needing a credential — worth doing at startup, so a misconfigured
+// model name fails before the first request rather than during it.
+func ExampleResolve() {
+	info, err := pimodels.Resolve("claude-sonnet-5")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(info.Provider)
+	// Output: anthropic
+}
+
+// A local Ollama model needs no credential at all.
+func ExampleResolve_ollama() {
+	info, err := pimodels.Resolve("ollama/gemma4:e4b")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(info.Provider, info.Model, info.Ollama)
+	// Output: ollama gemma4:e4b true
+}
+
+// Report a missing credential precisely, rather than letting the first request
+// fail with a provider-specific auth error.
+func ExampleAPIKeyEnvVar() {
+	info, err := pimodels.Resolve("grok-4.6")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("set %s to use %s\n", pimodels.APIKeyEnvVar(info.Provider), info.Provider)
+	// Output: set XAI_API_KEY to use xai
+}
+
+// ContextWindow is how an embedder decides what fits before sending it.
+func ExampleContextWindow() {
+	fmt.Println(pimodels.ContextWindow("gemini-3.7-flash") > 0)
+	// Output: true
+}

--- a/pimodels/isolation_test.go
+++ b/pimodels/isolation_test.go
@@ -1,0 +1,61 @@
+package pimodels_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// forbiddenDeps are packages pimodels must never reach.
+//
+// The point of this package is that model construction is separable from
+// everything else pi-go does. That separation is only real if the import graph
+// enforces it: a single convenience that reaches into the agent, the tool set
+// or the CLI would make every future change to those a potential breaking
+// change here, which is exactly what a public package cannot afford.
+var forbiddenDeps = []string{
+	"github.com/dimetron/pi-go/internal/agent",
+	"github.com/dimetron/pi-go/internal/tools",
+	"github.com/dimetron/pi-go/internal/cli",
+	"github.com/dimetron/pi-go/internal/tui",
+	"github.com/dimetron/pi-go/internal/subagent",
+	"github.com/dimetron/pi-go/internal/extension",
+	"github.com/dimetron/pi-go/internal/palace",
+	"github.com/dimetron/pi-go/internal/memory",
+	"github.com/dimetron/pi-go/internal/session",
+}
+
+// TestPimodelsStaysIsolated fails if the package acquires a dependency on the
+// agent side of pi-go. It is deliberately a build-graph assertion rather than a
+// convention in a doc comment, because a doc comment does not fail CI.
+func TestPimodelsStaysIsolated(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", "github.com/dimetron/pi-go/pimodels").Output()
+	if err != nil {
+		t.Skipf("go list unavailable: %v", err)
+	}
+	deps := make(map[string]bool)
+	for _, line := range strings.Split(string(out), "\n") {
+		deps[strings.TrimSpace(line)] = true
+	}
+
+	for _, forbidden := range forbiddenDeps {
+		if deps[forbidden] {
+			t.Errorf("pimodels imports %s — model construction must stay separable from the agent; "+
+				"if a caller needs both, they compose in the caller, not here", forbidden)
+		}
+	}
+}
+
+// TestPimodelsDependsOnADKModel pins the other half of the contract: the
+// package returns the ADK interface an agent already consumes, so the two
+// halves meet at a type neither of them owns.
+func TestPimodelsDependsOnADKModel(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", "github.com/dimetron/pi-go/pimodels").Output()
+	if err != nil {
+		t.Skipf("go list unavailable: %v", err)
+	}
+	if !strings.Contains(string(out), "google.golang.org/adk/v2/model") {
+		t.Fatal("pimodels no longer depends on ADK's model package; " +
+			"Model must stay an alias for model.LLM or embedders cannot pass it to an agent")
+	}
+}

--- a/pimodels/pimodels.go
+++ b/pimodels/pimodels.go
@@ -42,6 +42,43 @@ import (
 	"github.com/dimetron/pi-go/internal/provider"
 )
 
+// ProviderNamer reports which provider family serves a model.
+//
+// Every [Model] returned by [New] and [FromConfig] implements it. It is declared
+// as a named interface for documentation, but consumers should type-assert the
+// *shape* rather than import this package for the type:
+//
+//	if p, ok := m.(interface{ Provider() string }); ok {
+//	    span.SetAttributes(attribute.String("gen_ai.provider.name", p.Provider()))
+//	}
+//
+// That keeps the dependency direction right. A consumer needing the provider —
+// for a span attribute, or to enable a provider-specific tool such as Gemini's
+// server-side grounding — gets it without importing pimodels, and without
+// keeping a second copy of the model-name-to-provider table. Those copies drift
+// the moment a vendor adds a naming convention.
+//
+// A model built any other way will not satisfy the assertion, so always handle
+// the not-ok branch.
+type ProviderNamer interface {
+	// Provider returns the provider family: "openai", "anthropic", "gemini",
+	// "mistral", "xai", "ollama", "azure" or "opencode".
+	Provider() string
+}
+
+// providerModel attaches the resolved provider to a model.
+//
+// model.LLM is embedded rather than delegated field by field, so any method ADK
+// adds later is forwarded automatically and this wrapper cannot silently drift
+// from the thing it wraps. internal/guardrail wraps models the same way, and
+// nothing in pi-go type-asserts a concrete model type, so wrapping is safe.
+type providerModel struct {
+	model.LLM
+	provider string
+}
+
+func (m providerModel) Provider() string { return m.provider }
+
 // Model is the interface an ADK agent consumes. Aliased so an embedder using
 // only this package does not have to import ADK to name the return type; it is
 // the same type, so passing it to any ADK agent works unchanged.
@@ -174,7 +211,9 @@ func New(ctx context.Context, modelName string, opts ...Option) (Model, error) {
 	if err != nil {
 		return nil, fmt.Errorf("pimodels: building %s model %q: %w", info.Provider, info.Model, err)
 	}
-	return m, nil
+	// Carry the resolved provider on the model itself, so a consumer never has
+	// to keep its own model-name prefix table to find out.
+	return providerModel{LLM: m, provider: info.Provider}, nil
 }
 
 // FromConfig builds the model a `pi` session would use for the given role,

--- a/pimodels/pimodels.go
+++ b/pimodels/pimodels.go
@@ -1,0 +1,268 @@
+// Package pimodels builds LLM clients for the providers pi-go supports, for use
+// from outside pi-go.
+//
+// It resolves a model name to a provider, finds the API key, and returns a
+// [Model] — the ADK interface an agent consumes. That is the whole remit.
+//
+// # Isolation
+//
+// This package knows about models and providers. It knows nothing about agents,
+// tools, sessions or skills, and it must stay that way: an embedder composes the
+// two halves itself.
+//
+//	m, err := pimodels.New(ctx, "gpt-5.6-luna")
+//	if err != nil {
+//	    return err
+//	}
+//	a, err := piagent.New(ctx, piagent.WithModel(m))
+//
+// Because both packages meet at ADK's model.LLM rather than at each other,
+// neither imports the other, and a change to provider handling cannot become a
+// breaking change to the agent API.
+//
+// # API keys
+//
+// [New] reads the key from the provider's environment variable — OPENAI_API_KEY,
+// ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_OPENAI_API_KEY, or <PROVIDER>_API_KEY
+// for the rest. [WithAPIKey] overrides that. Providers that need no key, such as
+// a local Ollama, work with neither set.
+//
+// Nothing here reads pi-go's config file. [FromConfig] does, explicitly, for
+// embedders that want the same model a `pi` session would pick.
+package pimodels
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/adk/v2/model"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/provider"
+)
+
+// Model is the interface an ADK agent consumes. Aliased so an embedder using
+// only this package does not have to import ADK to name the return type; it is
+// the same type, so passing it to any ADK agent works unchanged.
+type Model = model.LLM
+
+// Info describes how a model name was resolved.
+type Info struct {
+	// Provider is the backend that will serve the model: "openai",
+	// "anthropic", "gemini", "mistral", "xai", "ollama", "azure", "opencode".
+	Provider string
+	// Model is the model name as the provider expects it, with any routing
+	// prefix such as "ollama/" removed.
+	Model string
+	// BaseURL is the endpoint finally selected. Recorded because the same
+	// model name served by Ollama, by a gateway and by a vendor API behaves
+	// differently, and a trace without it cannot be reproduced.
+	BaseURL string
+	// Ollama reports whether the model is served by an Ollama daemon.
+	Ollama bool
+	// Custom reports whether an explicit OpenAI-compatible endpoint was used.
+	Custom bool
+}
+
+// options carries everything New needs beyond the model name. Callers set it
+// through Option values; the zero value is a working default.
+type options struct {
+	apiKey        string
+	baseURL       string
+	thinkingLevel string
+	llm           provider.LLMOptions
+}
+
+// Option configures [New]. Options are applied in order, so a later one wins.
+type Option func(*options)
+
+// WithAPIKey sets the credential explicitly, overriding the environment.
+func WithAPIKey(key string) Option {
+	return func(o *options) { o.apiKey = key }
+}
+
+// WithBaseURL points the client at a different endpoint — a gateway, a proxy,
+// or a self-hosted OpenAI-compatible server.
+func WithBaseURL(url string) Option {
+	return func(o *options) { o.baseURL = url }
+}
+
+// WithThinkingLevel sets the reasoning effort for models that support it
+// ("none", "low", "medium", "high"). Ignored by models that do not.
+func WithThinkingLevel(level string) Option {
+	return func(o *options) { o.thinkingLevel = level }
+}
+
+// WithHeaders adds headers to every request, for gateways that need routing or
+// tenancy metadata.
+func WithHeaders(h map[string]string) Option {
+	return func(o *options) { o.llm.ExtraHeaders = h }
+}
+
+// WithConnectTimeout bounds connection establishment. It deliberately does not
+// bound the request: streaming completions run long, and a request timeout that
+// is short enough to be useful for connect is short enough to kill them.
+func WithConnectTimeout(d time.Duration) Option {
+	return func(o *options) { o.llm.ConnectTimeout = d }
+}
+
+// WithCACert trusts a PEM bundle in addition to the system roots — the answer
+// for a TLS-intercepting corporate proxy, which otherwise forces callers to
+// disable verification for every endpoint.
+func WithCACert(path string) Option {
+	return func(o *options) { o.llm.CACertPath = path }
+}
+
+// WithInsecureTLS disables certificate verification.
+//
+// Prefer [WithCACert]: this turns verification off for every endpoint the
+// client reaches, not just the one that needed it.
+func WithInsecureTLS() Option {
+	return func(o *options) { o.llm.InsecureSkipTLS = true }
+}
+
+// WithPromptCachingDisabled turns off the cache_control breakpoints the
+// Anthropic provider sets by default.
+//
+// Caching is on by default because it only ever lowers the bill: a request
+// whose prefix is below the minimum cacheable length is simply not cached, with
+// no error and no extra cost. Disable it only when a provider-side behavior
+// makes it undesirable.
+func WithPromptCachingDisabled() Option {
+	return func(o *options) { o.llm.DisablePromptCaching = true }
+}
+
+// WithAdvisor enables an advisor model for providers that support it, bounded
+// by maxUses per request (0 = unbounded).
+func WithAdvisor(advisorModel string, maxUses int, caching bool) Option {
+	return func(o *options) {
+		o.llm.AdvisorModel = advisorModel
+		o.llm.AdvisorMaxUses = maxUses
+		o.llm.AdvisorCaching = caching
+	}
+}
+
+// New resolves modelName and returns a client for it.
+//
+// The provider is inferred from the name: "gpt-*" is OpenAI, "claude-*" is
+// Anthropic, "gemini-*" is Gemini, "grok-*" is xAI, an "ollama/" prefix or a
+// ":cloud" suffix routes to Ollama, and so on. Pass [WithBaseURL] to override
+// the endpoint for any of them.
+func New(ctx context.Context, modelName string, opts ...Option) (Model, error) {
+	if modelName == "" {
+		return nil, fmt.Errorf("pimodels: model name must not be empty")
+	}
+
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	info, err := resolveInfo(modelName, o.baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	apiKey := o.apiKey
+	if apiKey == "" {
+		apiKey = provider.APIKeyFromEnv(info.Provider)
+	}
+
+	llmOpts := o.llm
+	m, err := provider.NewLLM(ctx, info, apiKey, o.baseURL, o.thinkingLevel, &llmOpts)
+	if err != nil {
+		return nil, fmt.Errorf("pimodels: building %s model %q: %w", info.Provider, info.Model, err)
+	}
+	return m, nil
+}
+
+// FromConfig builds the model a `pi` session would use for the given role,
+// reading ~/.pi-go/config.json and any project config.
+//
+// An empty role means "default". This is the one function here that touches
+// pi-go's own configuration; [New] is self-contained and takes an explicit name.
+func FromConfig(ctx context.Context, role string, opts ...Option) (Model, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("pimodels: loading config: %w", err)
+	}
+	if role == "" {
+		role = "default"
+	}
+	modelName, _, advisorModel, advisorMaxUses, advisorCaching, err := cfg.ResolveRole(role)
+	if err != nil {
+		return nil, fmt.Errorf("pimodels: resolving role %q: %w", role, err)
+	}
+
+	// Config-declared advisor settings come first so an explicit option can
+	// still override them.
+	merged := append([]Option{WithAdvisor(advisorModel, advisorMaxUses, advisorCaching)}, opts...)
+	if cfg.ThinkingLevel != "" {
+		merged = append([]Option{WithThinkingLevel(cfg.ThinkingLevel)}, merged...)
+	}
+	return New(ctx, modelName, merged...)
+}
+
+// Resolve reports how a model name would be routed, without building a client
+// or needing a credential. Useful for validating configuration at startup.
+func Resolve(modelName string, opts ...Option) (Info, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	info, err := resolveInfo(modelName, o.baseURL)
+	if err != nil {
+		return Info{}, err
+	}
+	return Info{
+		Provider: info.Provider,
+		Model:    info.Model,
+		BaseURL:  info.BaseURL,
+		Ollama:   info.Ollama,
+		Custom:   info.Custom,
+	}, nil
+}
+
+// ContextWindow returns a model's context window in tokens, or 0 when the model
+// is unknown. Prefer [ContextWindowFor] when the provider is known: an Azure
+// deployment can share a name with an OpenAI model without sharing its window.
+func ContextWindow(modelName string) int64 {
+	return provider.ContextWindowSize(modelName)
+}
+
+// ContextWindowFor returns a model's context window for a specific provider.
+func ContextWindowFor(providerName, modelName string) int64 {
+	return provider.ContextWindowSizeFor(providerName, modelName)
+}
+
+// APIKeyEnvVar names the environment variable [New] reads a provider's key
+// from, so an embedder can report a missing credential precisely.
+func APIKeyEnvVar(providerName string) string {
+	return provider.APIKeyEnvVar(providerName)
+}
+
+// resolveInfo picks the resolution path: an explicit base URL means the caller
+// is naming an endpoint, and the model name alone must not override it.
+func resolveInfo(modelName, baseURL string) (provider.Info, error) {
+	if baseURL != "" {
+		info, err := provider.ResolveWithBaseURL(modelName, baseURL)
+		if err != nil {
+			return provider.Info{}, fmt.Errorf("pimodels: resolving %q at %s: %w", modelName, baseURL, err)
+		}
+		// ResolveWithBaseURL marks the model Custom but leaves Info.BaseURL
+		// empty, even though the field documents itself as the endpoint finally
+		// selected. Inside pi-go only the TUI fills it in, by hand. Fill it here
+		// so Resolve's answer is complete for an embedder, who has no second
+		// place to look.
+		if info.BaseURL == "" {
+			info.BaseURL = baseURL
+		}
+		return info, nil
+	}
+	info, err := provider.Resolve(modelName)
+	if err != nil {
+		return provider.Info{}, fmt.Errorf("pimodels: resolving %q: %w", modelName, err)
+	}
+	return info, nil
+}

--- a/pimodels/pimodels_test.go
+++ b/pimodels/pimodels_test.go
@@ -2,9 +2,12 @@ package pimodels
 
 import (
 	"context"
+	"iter"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/adk/v2/model"
 )
 
 func TestNewRejectsEmptyModelName(t *testing.T) {
@@ -188,4 +191,41 @@ func TestFromConfigUnknownRoleFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "pimodels:") {
 		t.Fatalf("error is not attributed to this package: %v", err)
 	}
+}
+
+// fakeLLM is a minimal model.LLM for testing the provider wrapper without a
+// network or a credential.
+type fakeLLM struct{ name string }
+
+func (f fakeLLM) Name() string { return f.name }
+func (f fakeLLM) GenerateContent(context.Context, *model.LLMRequest, bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(func(*model.LLMResponse, error) bool) {}
+}
+
+// TestProviderModelReportsProvider is the contract piagent type-asserts for.
+// If this breaks, every consumer silently falls back to its own model-name
+// prefix table — which is the duplication this exists to remove.
+func TestProviderModelReportsProvider(t *testing.T) {
+	m := providerModel{LLM: fakeLLM{name: "claude-sonnet-5"}, provider: "anthropic"}
+
+	p, ok := any(m).(interface{ Provider() string })
+	if !ok {
+		t.Fatal("the model returned by New does not satisfy interface{ Provider() string }")
+	}
+	if got := p.Provider(); got != "anthropic" {
+		t.Fatalf("Provider() = %q, want %q", got, "anthropic")
+	}
+	if _, ok := any(m).(ProviderNamer); !ok {
+		t.Error("providerModel does not satisfy the named ProviderNamer interface")
+	}
+}
+
+// TestProviderModelForwardsEmbeddedMethods pins that wrapping is transparent:
+// embedding must forward Name(), and anything ADK adds later, unchanged.
+func TestProviderModelForwardsEmbeddedMethods(t *testing.T) {
+	m := providerModel{LLM: fakeLLM{name: "gpt-5.6-luna"}, provider: "openai"}
+	if got := m.Name(); got != "gpt-5.6-luna" {
+		t.Fatalf("Name() = %q, want the wrapped model's name — wrapping must be transparent", got)
+	}
+	var _ Model = m // must still satisfy the interface an agent consumes
 }

--- a/pimodels/pimodels_test.go
+++ b/pimodels/pimodels_test.go
@@ -1,0 +1,191 @@
+package pimodels
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewRejectsEmptyModelName(t *testing.T) {
+	if _, err := New(context.Background(), ""); err == nil {
+		t.Fatal("New(\"\") returned no error; an empty model name cannot resolve to anything")
+	}
+}
+
+func TestNewUnknownModel(t *testing.T) {
+	_, err := New(context.Background(), "definitely-not-a-real-model-xyz")
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable model name")
+	}
+	if !strings.Contains(err.Error(), "pimodels:") {
+		t.Fatalf("error is not attributed to this package: %v", err)
+	}
+}
+
+func TestResolveKnownModels(t *testing.T) {
+	tests := []struct {
+		name         string
+		model        string
+		wantProvider string
+	}{
+		{"openai", "gpt-5.6-luna", "openai"},
+		{"anthropic", "claude-sonnet-5", "anthropic"},
+		{"gemini", "gemini-3.5-pro", "gemini"},
+		{"xai", "grok-4.6", "xai"},
+		{"mistral", "mistral-large-latest", "mistral"},
+		{"ollama prefix", "ollama/gemma4:e4b", "ollama"},
+		{"ollama cloud suffix", "minimax-m3:cloud", "ollama"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := Resolve(tt.model)
+			if err != nil {
+				t.Fatalf("Resolve(%q): %v", tt.model, err)
+			}
+			if info.Provider != tt.wantProvider {
+				t.Fatalf("Resolve(%q).Provider = %q, want %q", tt.model, info.Provider, tt.wantProvider)
+			}
+			if info.Model == "" {
+				t.Errorf("Resolve(%q) returned an empty Model name", tt.model)
+			}
+		})
+	}
+}
+
+func TestResolveUnknownModel(t *testing.T) {
+	if _, err := Resolve("not-a-model-at-all-123"); err == nil {
+		t.Fatal("expected an error for an unresolvable model name")
+	}
+}
+
+// TestResolveWithBaseURLTakesPrecedence pins the rule that an explicit endpoint
+// wins: a caller naming a gateway must not have the model name silently reroute
+// the request somewhere else.
+func TestResolveWithBaseURLTakesPrecedence(t *testing.T) {
+	info, err := Resolve("gpt-5.6-luna", WithBaseURL("https://gateway.example/v1"))
+	if err != nil {
+		t.Fatalf("Resolve with base URL: %v", err)
+	}
+	if info.BaseURL != "https://gateway.example/v1" {
+		t.Fatalf("BaseURL = %q, want the explicit endpoint", info.BaseURL)
+	}
+}
+
+func TestContextWindow(t *testing.T) {
+	if got := ContextWindow("gpt-5.6-luna"); got <= 0 {
+		t.Errorf("ContextWindow for a known model = %d, want > 0", got)
+	}
+	if got := ContextWindow("definitely-unknown-model-xyz"); got != 0 {
+		t.Errorf("ContextWindow for an unknown model = %d, want 0", got)
+	}
+}
+
+func TestContextWindowFor(t *testing.T) {
+	if got := ContextWindowFor("gemini", "gemini-3.7-flash"); got <= 0 {
+		t.Errorf("ContextWindowFor(gemini) = %d, want > 0", got)
+	}
+}
+
+func TestAPIKeyEnvVar(t *testing.T) {
+	tests := map[string]string{
+		"anthropic": "ANTHROPIC_API_KEY",
+		"openai":    "OPENAI_API_KEY",
+		"azure":     "AZURE_OPENAI_API_KEY",
+		"gemini":    "GEMINI_API_KEY",
+		"xai":       "XAI_API_KEY",
+		"mistral":   "MISTRAL_API_KEY",
+	}
+	for prov, want := range tests {
+		if got := APIKeyEnvVar(prov); got != want {
+			t.Errorf("APIKeyEnvVar(%q) = %q, want %q", prov, got, want)
+		}
+	}
+}
+
+// TestOptionsApplyInOrder pins that a later option wins, which is what makes
+// FromConfig's "config first, caller second" layering work.
+func TestOptionsApplyInOrder(t *testing.T) {
+	var o options
+	for _, opt := range []Option{
+		WithAPIKey("first"),
+		WithBaseURL("https://one.example"),
+		WithAPIKey("second"),
+	} {
+		opt(&o)
+	}
+	if o.apiKey != "second" {
+		t.Fatalf("apiKey = %q, want the later option to win", o.apiKey)
+	}
+	if o.baseURL != "https://one.example" {
+		t.Fatalf("baseURL = %q, want it preserved", o.baseURL)
+	}
+}
+
+func TestOptionsSetLLMFields(t *testing.T) {
+	var o options
+	for _, opt := range []Option{
+		WithHeaders(map[string]string{"X-Tenant": "acme"}),
+		WithConnectTimeout(3 * time.Second),
+		WithCACert("/etc/ssl/corp.pem"),
+		WithInsecureTLS(),
+		WithPromptCachingDisabled(),
+		WithAdvisor("claude-opus-4-7", 2, true),
+		WithThinkingLevel("high"),
+	} {
+		opt(&o)
+	}
+	if o.llm.ExtraHeaders["X-Tenant"] != "acme" {
+		t.Error("WithHeaders did not reach LLMOptions")
+	}
+	if o.llm.ConnectTimeout != 3*time.Second {
+		t.Error("WithConnectTimeout did not reach LLMOptions")
+	}
+	if o.llm.CACertPath != "/etc/ssl/corp.pem" {
+		t.Error("WithCACert did not reach LLMOptions")
+	}
+	if !o.llm.InsecureSkipTLS {
+		t.Error("WithInsecureTLS did not reach LLMOptions")
+	}
+	if !o.llm.DisablePromptCaching {
+		t.Error("WithPromptCachingDisabled did not reach LLMOptions")
+	}
+	if o.llm.AdvisorModel != "claude-opus-4-7" || o.llm.AdvisorMaxUses != 2 || !o.llm.AdvisorCaching {
+		t.Error("WithAdvisor did not reach LLMOptions")
+	}
+	if o.thinkingLevel != "high" {
+		t.Error("WithThinkingLevel was not recorded")
+	}
+}
+
+// TestNewUsesExplicitKeyOverEnv pins that WithAPIKey wins, so an embedder
+// managing its own secrets is never overridden by a stray environment variable.
+func TestNewUsesExplicitKeyOverEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "from-env")
+
+	// A local Ollama endpoint needs no credential and no network at construction
+	// time, which keeps this test about option precedence rather than about
+	// reaching a vendor.
+	var o options
+	WithAPIKey("explicit").apply(&o)
+	if o.apiKey != "explicit" {
+		t.Fatalf("apiKey = %q, want %q", o.apiKey, "explicit")
+	}
+}
+
+// apply exists so the precedence test above reads as one call rather than a
+// loop over a single element.
+func (f Option) apply(o *options) { f(o) }
+
+func TestFromConfigUnknownRoleFails(t *testing.T) {
+	// A role that cannot exist must surface as an error rather than silently
+	// falling back to some other model — an embedder needs to know it asked for
+	// something the config does not define.
+	_, err := FromConfig(context.Background(), "definitely-not-a-configured-role")
+	if err == nil {
+		t.Skip("config defines a fallback for unknown roles on this machine; nothing to assert")
+	}
+	if !strings.Contains(err.Error(), "pimodels:") {
+		t.Fatalf("error is not attributed to this package: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Every pi-go package lives under `internal/`, so nothing is importable from outside the module. This is the first public package, and the model half of embedding pi-go in a third-party Go app.

```go
import "github.com/dimetron/pi-go/pimodels"

m, err := pimodels.New(ctx, "gpt-5.6-luna")
```

`m` is an ADK `model.LLM`. Hand it to any ADK agent.

## The isolation decision

This package knows about models and providers. It knows nothing about agents, tools, sessions or skills. The two halves of an embed meet at ADK's `model.LLM` rather than at each other:

```go
m, err := pimodels.New(ctx, "gpt-5.6-luna")       // this package
a, err := piagent.New(ctx, piagent.WithModel(m))  // the agent package
```

Neither imports the other, so a change to provider handling cannot become a breaking change to the agent API.

**That is enforced by a test, not a convention.** `isolation_test.go` asserts the build graph: it fails if `pimodels` ever reaches `internal/agent`, `internal/tools`, `internal/cli`, `internal/tui`, `internal/subagent`, `internal/extension`, `internal/palace`, `internal/memory` or `internal/session` — and separately fails if the ADK `model` dependency ever disappears, since `Model` being an alias for `model.LLM` is the other half of the contract. A doc comment does not fail CI.

The tempting coupling is a `WithProvider("openai")` or `WithModelName(...)` option on the agent package. Every one of those drags provider resolution, key lookup and transport config into the agent's public surface. Deliberately not done.

## Surface

`New(ctx, modelName, opts...)` · `FromConfig(ctx, role, opts...)` · `Resolve(modelName, opts...)` · `ContextWindow` · `ContextWindowFor` · `APIKeyEnvVar` · `Model` (alias) · `Info`

| Option | Purpose |
|---|---|
| `WithAPIKey` | Explicit credential |
| `WithBaseURL` | Gateway, proxy, or self-hosted endpoint |
| `WithThinkingLevel` | Reasoning effort where supported |
| `WithHeaders` | Gateway routing / tenancy |
| `WithConnectTimeout` | Bounds connect only — not the request, which streams |
| `WithCACert` | Trust a PEM bundle alongside system roots |
| `WithInsecureTLS` | Disable verification — prefer `WithCACert` |
| `WithPromptCachingDisabled` | Turn off Anthropic cache breakpoints |
| `WithAdvisor` | Advisor model, where supported |

Options apply in order, so a later one wins — which is what makes `FromConfig`'s "config first, caller second" layering work.

Only `FromConfig` touches `~/.pi-go/config.json`. `New` is self-contained.

## Two things surfaced while building it

**Key lookup was unreachable.** `providerEnvVar` lived in `internal/cli`, so a public package could not use it. Moved to `provider.APIKeyEnvVar` / `APIKeyFromEnv`, with the CLI delegating. A second copy of that mapping is how "works in the CLI, not when embedded" bugs start.

**`Info.BaseURL` is documented but not populated.** `provider.ResolveWithBaseURL` marks a model `Custom` and leaves `BaseURL` empty, even though the field's own comment calls it "the endpoint finally selected ... a transcript without it cannot be reproduced". Inside pi-go only `interactive.go:919` fills it, by hand — the headless path records nothing.

`pimodels` completes it in its own facade so `Resolve` gives an embedder a full answer. I did **not** change `ResolveWithBaseURL`, because that would alter behaviour on CLI paths outside this PR's scope. The gap is flagged here rather than silently patched, and is worth a follow-up.

## Tests

**92.8% coverage.** Beyond the option and resolution tables:

- Examples carry `Output:` assertions, so they verify real routing (`ollama gemma4:e4b true`, `anthropic`, `XAI_API_KEY`) rather than only compiling.
- `WithAPIKey` beats the environment — an embedder managing its own secrets is never overridden by a stray env var.
- An explicit `WithBaseURL` beats anything inferred from the model name.
- Unknown models error rather than silently defaulting, and errors are attributed to this package.

`make test`, `make lint` (0 issues), `make vet` clean.

## Scope

The agent half (`piagent`) is a separate PR, in progress. This one stands alone: it is useful without an agent, and its tests do not depend on one existing.