### PR TITLE
docs(specs): record the second ADK callback defect in memory-fixes

### DIFF
--- a/specs/memory-fixes/design.md
+++ b/specs/memory-fixes/design.md
@@ -4,9 +4,15 @@
 
 ### Problem
 
-ADK's contract is "first non-nil result wins and ends the chain". pi-go treats
-the slice as a broadcast list. Both readings are defensible; only one is the
-library's. See `research/findings.md` § F1.
+Two defects, not one. ADK's contract is "first non-nil result wins and ends the
+chain", and separately it hands every callback the *original* `fResult` rather
+than the previous callback's output. pi-go treats the slice as a broadcast list
+that also composes; it is neither. See `research/findings.md` § F1.
+
+The second defect is why this design threads the result forward explicitly
+rather than only removing the short-circuit: dedup sits after the compactor so
+it can see post-compaction results, and no amount of un-short-circuiting would
+deliver them.
 
 ### Decision
 

--- a/specs/memory-fixes/requirements.md
+++ b/specs/memory-fixes/requirements.md
@@ -23,7 +23,12 @@ the model sees is the one produced by the last transforming callback.
 - Regression test asserts all of: an observation is enqueued, the compactor
   truncated the output, and the deduper saw the call — for one tool call.
 
-**Rationale:** this is the whole outage. See `research/findings.md` § F1.
+- A callback that transforms a result must have that transformation visible to
+  the next callback. ADK does not do this: it passes the original `fResult` to
+  every callback, so the compactor-then-dedup ordering has never composed.
+
+**Rationale:** this is the whole outage. See `research/findings.md` § F1, which
+records both defects.
 
 ### R2 — Observations survive a short session
 

--- a/specs/memory-fixes/research/findings.md
+++ b/specs/memory-fixes/research/findings.md
@@ -28,8 +28,20 @@ func (f *Flow) invokeAfterToolCallbacks(...) (map[string]any, error) {
 }
 ```
 
-A non-nil return means "override the tool result and stop". It does not mean
-"here is the result, carry on".
+There are **two** defects in this one function, and the second is the worse one.
+
+**Defect 1 — the chain stops.** A non-nil return means "override the tool result
+and stop". It does not mean "here is the result, carry on".
+
+**Defect 2 — results are never threaded.** `fResult` is the loop's parameter and
+is never reassigned, so every callback is handed the *original* tool result
+rather than the previous callback's output. Even with defect 1 fixed, a chain
+still would not compose.
+
+Defect 2 matters because pi-go's ordering already assumes composition: dedup is
+registered *after* the compactor precisely so it sees post-compaction results.
+It never has, and fixing only the short-circuit would not give it them. Any fix
+must thread the result forward itself; ADK will not do it.
 
 ### What pi-go registers
 
@@ -56,6 +68,9 @@ Consequences, all four silent:
 - Tool-output compaction: dead — full untruncated outputs reach the model.
 - Result dedup: dead.
 - Memory observation recording: dead.
+
+And independently of the short-circuit, any two callbacks that both transform a
+result cannot chain, because the second never sees the first's output.
 
 ### Proof by experiment
 


### PR DESCRIPTION
## What

`specs/memory-fixes/` described **one** defect in ADK's `invokeAfterToolCallbacks`. There are two, and the second is the worse one.

## The defect the spec was missing

```go
func (f *Flow) invokeAfterToolCallbacks(toolCtx, tool, fArgs, fResult, fErr) (map[string]any, error) {
	for _, callback := range f.AfterToolCallbacks {
		result, err := callback(toolCtx, tool, fArgs, fResult, fErr)
		//                                            ^^^^^^^
		//                        the loop's parameter, never reassigned
		if result != nil {
			return result, nil          // defect 1: the chain stops
		}
	}
	return fResult, fErr
}
```

`adk/v2@v2.0.0 internal/llminternal/base_flow.go:1296-1309`

1. **The chain stops** at the first callback returning non-nil — already specced.
2. **Results are never threaded.** Every callback receives the *original* `fResult`, not the previous callback's output.

**Even with defect 1 fixed, a chain still would not compose.**

## Why it matters

pi-go's registration order already assumes composition: dedup sits *after* the compactor precisely so it sees post-compaction results. It never has — and removing only the short-circuit would not give it them.

Anyone implementing Slice 1 against the previous description would have fixed the visible half, watched the memory recorder start working, and left dedup quietly operating on uncompacted input.

## Impact on the plan

Slice 1's `ChainAfterTool` semantics were already correct — the design threads the result forward. What changes is the *rationale*: that threading is load-bearing rather than incidental, and the spec now says so in `design.md` § 1, `requirements.md` R1, and `research/findings.md` § F1.

No slice needs reordering.

## Provenance

Surfaced while building `piagent` (#167), whose composed after-tool callback threads results forward and pins it with `TestComposeAfterToolFeedsResultsForward`. Confirmed against the ADK source directly rather than taken second-hand.