### PR TITLE
feat(piagent): before- and after-turn hooks

### DIFF
--- a/piagent/README.md
+++ b/piagent/README.md
@@ -106,6 +106,7 @@ ag, err := piagent.New(ctx,
 | `WithInstruction(s)` | Replace the built-in system prompt |
 | `WithExtraInstruction(s)` | Append your own text to the assembled prompt |
 | `WithTools(...)` / `WithToolsets(...)` | Add your own tools |
+| `WithBeforeTurn(...)` / `WithAfterTurn(...)` | Bracket whole turns — admission control and metrics |
 | `WithBeforeToolCallbacks(...)` / `WithAfterToolCallbacks(...)` | Observe or rewrite tool calls |
 | `WithBeforeModelCallbacks(...)` / `WithAfterModelCallbacks(...)` | Observe or rewrite LLM calls |
 | `WithLSP(mode)` | `LSPOff`, `LSPMin` (default) or `LSPFull` |
@@ -170,8 +171,52 @@ session log. Always defer it.
   and would have to be extracted first; install your own via ADK if you need it.
 - A process-global HTTP trace sink. A library has no business claiming one.
 - The daily-token guardrail, which wraps the model rather than the agent.
+- Config-driven shell hooks as a programmatic option. They still load from
+  `~/.pi-go/config.json`, but an embedder writing Go gets a Go func rather than
+  a subprocess.
 - The subagent orchestrator. Subagents are reachable as tools; direct
   orchestration would be a much larger compatibility commitment.
+
+## Turn hooks
+
+Tool and model callbacks fire *inside* a turn. `WithBeforeTurn` and
+`WithAfterTurn` bracket the whole thing, which is the level metrics, audit
+trails and admission control actually work at.
+
+```go
+piagent.New(ctx,
+	piagent.WithModel(m),
+
+	// Admission control: returning an error aborts the turn before it
+	// reaches the model.
+	piagent.WithBeforeTurn(func(ctx context.Context, sessionID, message string) error {
+		return budget.Check(sessionID)
+	}),
+
+	// Metrics and audit. Cannot change the outcome.
+	piagent.WithAfterTurn(func(ctx context.Context, i piagent.TurnInfo) {
+		metrics.Record(i.SessionID, i.Duration, i.ToolCalls, i.Err)
+	}),
+)
+```
+
+`TurnInfo` carries `SessionID`, `Message`, `Duration`, `Events`, `ToolCalls`,
+`Err` and `Abandoned`.
+
+Three behaviours worth knowing, because each is a bug if you assume otherwise:
+
+- **They fire on iteration, not on the `Run` call.** A sequence nobody ranges
+  over is not a turn, and recording one would put a turn that never happened
+  into your metrics.
+- **An abandoned turn still reports.** Break out of the range loop and the
+  after-turn hook still runs, with `Abandoned: true` — a caller that stops
+  consuming has still spent the tokens.
+- **An aborted turn does not.** If a before-turn hook denies the turn, no
+  request is made and there is nothing to report, so the after-turn hook is
+  not called.
+
+This is the headless equivalent of pi-go's `turn_complete` lifecycle hook,
+which is otherwise dispatched only from the TUI.
 
 ## One deliberate difference from the CLI
 

--- a/piagent/agent.go
+++ b/piagent/agent.go
@@ -44,6 +44,8 @@ type Agent struct {
 	// onNewSession arms the subsystems that can only be told a session ID
 	// after the session exists — memory recording and the ACP event log.
 	onNewSession func(sessionID string)
+	beforeTurn   []BeforeTurnFunc
+	afterTurn    []AfterTurnFunc
 	closers      []func() error
 }
 
@@ -84,8 +86,10 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 	llm := o.model
 	providerName := providerOf(llm)
 	a := &Agent{
-		workDir:   workDir,
-		modelName: llm.Name(),
+		workDir:    workDir,
+		modelName:  llm.Name(),
+		beforeTurn: o.beforeTurn,
+		afterTurn:  o.afterTurn,
 	}
 
 	sandbox, err := buildSandbox(workDir, o.extraSandbox)
@@ -267,14 +271,14 @@ func (a *Agent) NewSession(ctx context.Context) (string, error) {
 // Run sends a message and returns the turn's ADK events. Iterate the sequence
 // to completion, or stop early to abandon the turn.
 func (a *Agent) Run(ctx context.Context, sessionID, message string) iter.Seq2[*session.Event, error] {
-	return a.inner.Run(ctx, sessionID, message)
+	return a.observeTurn(ctx, sessionID, message, a.inner.Run)
 }
 
 // RunStreaming is [Agent.Run] with SSE streaming, so text arrives as deltas.
 // The final aggregate event repeats the whole reply; a caller that prints
 // deltas must skip it.
 func (a *Agent) RunStreaming(ctx context.Context, sessionID, message string) iter.Seq2[*session.Event, error] {
-	return a.inner.RunStreaming(ctx, sessionID, message)
+	return a.observeTurn(ctx, sessionID, message, a.inner.RunStreaming)
 }
 
 // Ask runs one turn and returns the assistant's text, discarding tool calls,

--- a/piagent/doc.go
+++ b/piagent/doc.go
@@ -104,6 +104,27 @@
 // Before-tool and model callbacks are passed to ADK as slices: for those,
 // ADK's "run until one intervenes" semantics are already what you want.
 //
+// # Turn hooks
+//
+// Tool and model callbacks fire inside a turn. [WithBeforeTurn] and
+// [WithAfterTurn] bracket the whole turn instead, which is the level metrics,
+// audit trails and admission control actually work at:
+//
+//   - A before-turn hook sees the session ID and the outgoing message, and
+//     returning an error aborts the turn before it reaches the model. Budget
+//     checks, rate limits and moderation belong here.
+//   - An after-turn hook receives a [TurnInfo] — duration, event and tool-call
+//     counts, the failure if there was one, and whether the caller abandoned
+//     the turn by breaking out of the loop early.
+//
+// Both fire when the caller starts iterating, not when Run returns: a sequence
+// nobody ranges over is not a turn, and recording one would be a lie in
+// whatever the hook writes down. An abandoned turn still reports, because a
+// caller that stops consuming has still spent the tokens.
+//
+// This is the headless equivalent of pi-go's turn_complete lifecycle hook,
+// which is otherwise dispatched only from the TUI.
+//
 // # Lifetime
 //
 // [Agent.Close] releases everything [New] acquired — sandbox, bash supervisor
@@ -122,6 +143,11 @@
 //
 // A process-global HTTP trace sink, because a library has no business
 // claiming one.
+//
+// Config-driven shell hooks as a programmatic option. Those still load from
+// ~/.pi-go/config.json and run for tool calls, but an embedder writing Go gets
+// a Go func rather than a subprocess: [WithBeforeTurn] and
+// [WithAfterToolCallbacks] do the same work without the fork.
 //
 // The daily-token guardrail, which wraps the model rather than the agent and
 // so belongs with whoever built the model.

--- a/piagent/example_test.go
+++ b/piagent/example_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync/atomic"
 
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
@@ -136,4 +137,39 @@ func ExampleAgent_Run() {
 			}
 		}
 	}
+}
+
+// ExampleWithAfterTurn brackets whole turns rather than individual tool calls,
+// which is the level metrics and audit logs work at. The before-turn hook is
+// admission control: returning an error aborts the turn before it reaches the
+// model.
+func ExampleWithAfterTurn() {
+	ctx := context.Background()
+
+	var spent atomic.Int64
+	const budget = 500
+
+	m, err := newModel(ctx, "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ag, err := piagent.New(ctx,
+		piagent.WithModel(m),
+		piagent.WithBeforeTurn(func(_ context.Context, sessionID, message string) error {
+			if spent.Load() >= budget {
+				return fmt.Errorf("session %s is over its %d-turn budget", sessionID, budget)
+			}
+			return nil
+		}),
+		piagent.WithAfterTurn(func(_ context.Context, info piagent.TurnInfo) {
+			spent.Add(1)
+			log.Printf("turn: session=%s tools=%d events=%d took=%s abandoned=%t err=%v",
+				info.SessionID, info.ToolCalls, info.Events, info.Duration, info.Abandoned, info.Err)
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ag.Close()
 }

--- a/piagent/options.go
+++ b/piagent/options.go
@@ -42,6 +42,8 @@ type options struct {
 	afterTool       []llmagent.AfterToolCallback
 	beforeModel     []llmagent.BeforeModelCallback
 	afterModel      []llmagent.AfterModelCallback
+	beforeTurn      []BeforeTurnFunc
+	afterTurn       []AfterTurnFunc
 	lspMode         LSPMode
 	memoryEnabled   bool
 	palaceEnabled   bool
@@ -165,6 +167,30 @@ func WithBeforeModelCallbacks(cbs ...llmagent.BeforeModelCallback) Option {
 // WithAfterModelCallbacks adds after-model callbacks after pi-go's own.
 func WithAfterModelCallbacks(cbs ...llmagent.AfterModelCallback) Option {
 	return func(o *options) { o.afterModel = append(o.afterModel, cbs...) }
+}
+
+// WithBeforeTurn adds hooks that run before each turn is dispatched, in the
+// order given. The first to return an error aborts the turn — nothing reaches
+// the model, and the error surfaces through the event sequence.
+//
+// Use it for admission control: budget and quota checks, rate limiting,
+// moderating the outgoing message, or seeding session state.
+//
+// A hook runs when the caller starts iterating, not when Run returns. A
+// sequence nobody ranges over is not a turn.
+func WithBeforeTurn(fns ...BeforeTurnFunc) Option {
+	return func(o *options) { o.beforeTurn = append(o.beforeTurn, fns...) }
+}
+
+// WithAfterTurn adds hooks that run once a turn has finished — including when
+// it failed, and when the caller broke out of the loop early, which
+// [TurnInfo].Abandoned reports. They cannot change the outcome.
+//
+// Use it for metrics, audit trails and persistence. This is the headless
+// equivalent of pi-go's turn_complete lifecycle hook, which otherwise fires
+// only from the TUI.
+func WithAfterTurn(fns ...AfterTurnFunc) Option {
+	return func(o *options) { o.afterTurn = append(o.afterTurn, fns...) }
 }
 
 // WithLSP selects the LSP tool surface. Even [LSPFull] registers nothing when

--- a/piagent/piagent_internal_test.go
+++ b/piagent/piagent_internal_test.go
@@ -65,6 +65,12 @@ func (f *fakeLLM) GenerateContent(_ context.Context, req *model.LLMRequest, _ bo
 	}
 }
 
+func (f *fakeLLM) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
 func (f *fakeLLM) systemPrompt() string {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/piagent/turn.go
+++ b/piagent/turn.go
@@ -1,0 +1,120 @@
+package piagent
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"time"
+
+	"google.golang.org/adk/v2/session"
+
+	"github.com/dimetron/pi-go/internal/agent"
+)
+
+// TurnInfo describes a turn that has finished, and is what an [AfterTurnFunc]
+// receives. It is a snapshot: the hook may keep it, but must not assume the
+// agent is idle by the time it runs.
+type TurnInfo struct {
+	// SessionID is the session the turn belonged to.
+	SessionID string
+
+	// Message is the user message that opened the turn.
+	Message string
+
+	// Duration covers the whole turn, from the first iteration to the last
+	// event — including time the caller spent inside its own loop body.
+	Duration time.Duration
+
+	// Events counts the events the turn produced. Streaming turns report far
+	// more than non-streaming ones for the same reply, because SSE delivers
+	// text as deltas and then repeats it as an aggregate.
+	Events int
+
+	// ToolCalls counts the tool invocations the model requested.
+	ToolCalls int
+
+	// Err is the failure that ended the turn, or nil. It covers both an
+	// iteration error and a provider failure reported on an ordinary event,
+	// which are different channels for the same thing.
+	Err error
+
+	// Abandoned reports that the caller stopped iterating before the turn
+	// finished — a break in the range loop, or a canceled context. The
+	// counts describe what was consumed, not what the model produced.
+	Abandoned bool
+}
+
+// BeforeTurnFunc runs before a turn is dispatched. Returning an error aborts
+// the turn: no request reaches the model, and the error surfaces through the
+// event sequence like any other turn failure.
+//
+// This is the seam for admission control — budget checks, rate limiting,
+// moderation of the outgoing message, injecting session state.
+type BeforeTurnFunc func(ctx context.Context, sessionID, message string) error
+
+// AfterTurnFunc runs once a turn has finished, whether it succeeded, failed or
+// was abandoned. It cannot change the outcome; it is for metrics, audit logs
+// and persistence.
+type AfterTurnFunc func(ctx context.Context, info TurnInfo)
+
+// runner is the shape of [agent.Agent].Run and RunStreaming, so one wrapper
+// serves both.
+type runner func(ctx context.Context, sessionID, message string) iter.Seq2[*session.Event, error]
+
+// observeTurn wraps a turn with the before- and after-turn hooks.
+//
+// Both run inside the returned sequence rather than at call time, because a
+// sequence is lazy: a caller that never ranges over it has not taken a turn,
+// and firing admission control for a turn that never happens would be a lie in
+// whatever the hook writes down.
+func (a *Agent) observeTurn(ctx context.Context, sessionID, message string, run runner) iter.Seq2[*session.Event, error] {
+	if len(a.beforeTurn) == 0 && len(a.afterTurn) == 0 {
+		return run(ctx, sessionID, message)
+	}
+
+	return func(yield func(*session.Event, error) bool) {
+		for _, fn := range a.beforeTurn {
+			if err := fn(ctx, sessionID, message); err != nil {
+				// Matches how internal/agent reports a pre-turn failure: as
+				// the sole element of the sequence, so a caller's existing
+				// error branch handles it without a second code path.
+				yield(nil, fmt.Errorf("piagent: before-turn hook: %w", err))
+				return
+			}
+		}
+
+		info := TurnInfo{SessionID: sessionID, Message: message, Abandoned: true}
+		started := time.Now()
+		// Deferred so the hooks still run when the caller breaks out of its
+		// range loop, which is the case an explicit call at the end misses.
+		defer func() {
+			info.Duration = time.Since(started)
+			for _, fn := range a.afterTurn {
+				fn(ctx, info)
+			}
+		}()
+
+		for ev, err := range run(ctx, sessionID, message) {
+			if err != nil {
+				info.Err = err
+			}
+			if ev != nil {
+				info.Events++
+				if evErr := agent.EventError(ev); evErr != nil && info.Err == nil {
+					info.Err = evErr
+				}
+				if ev.Content != nil {
+					for _, part := range ev.Content.Parts {
+						if part.FunctionCall != nil {
+							info.ToolCalls++
+						}
+					}
+				}
+			}
+			if !yield(ev, err) {
+				return // abandoned; the defer above still reports it
+			}
+		}
+		info.Abandoned = false
+	}
+}

--- a/piagent/turn_test.go
+++ b/piagent/turn_test.go
@@ -1,0 +1,306 @@
+package piagent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// turnRecorder collects what the after-turn hook saw, safely enough to be read
+// after the turn.
+type turnRecorder struct {
+	mu    sync.Mutex
+	turns []TurnInfo
+}
+
+func (r *turnRecorder) hook() AfterTurnFunc {
+	return func(_ context.Context, info TurnInfo) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.turns = append(r.turns, info)
+	}
+}
+
+func (r *turnRecorder) all() []TurnInfo {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]TurnInfo(nil), r.turns...)
+}
+
+func (r *turnRecorder) one(t *testing.T) TurnInfo {
+	t.Helper()
+	got := r.all()
+	if len(got) != 1 {
+		t.Fatalf("after-turn hook ran %d times, want exactly 1", len(got))
+	}
+	return got[0]
+}
+
+func TestAfterTurnReportsACompletedTurn(t *testing.T) {
+	isolate(t)
+	var rec turnRecorder
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "done"}, WithAfterTurn(rec.hook()))
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := ag.Ask(t.Context(), sessionID, "hello"); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+
+	got := rec.one(t)
+	if got.SessionID != sessionID {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, sessionID)
+	}
+	if got.Message != "hello" {
+		t.Errorf("Message = %q, want %q", got.Message, "hello")
+	}
+	if got.Err != nil {
+		t.Errorf("Err = %v, want nil", got.Err)
+	}
+	if got.Abandoned {
+		t.Error("Abandoned = true for a turn that ran to completion")
+	}
+	if got.Events == 0 {
+		t.Error("Events = 0, want the turn's events to be counted")
+	}
+	if got.Duration <= 0 {
+		t.Error("Duration = 0, want the turn to be timed")
+	}
+}
+
+func TestAfterTurnCountsToolCalls(t *testing.T) {
+	isolate(t)
+	workDir := t.TempDir()
+	var rec turnRecorder
+
+	ag := newTestAgent(t, &fakeLLM{
+		name:     "fake",
+		reply:    "one file",
+		toolCall: &genai.FunctionCall{Name: "ls", Args: map[string]any{"path": workDir}},
+	}, WithWorkingDir(workDir), WithAfterTurn(rec.hook()))
+
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := ag.Ask(t.Context(), sessionID, "what is here?"); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+
+	if got := rec.one(t); got.ToolCalls != 1 {
+		t.Errorf("ToolCalls = %d, want 1", got.ToolCalls)
+	}
+}
+
+func TestAfterTurnReportsFailure(t *testing.T) {
+	isolate(t)
+	var rec turnRecorder
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", err: errors.New("provider exploded")},
+		WithAfterTurn(rec.hook()))
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := ag.Ask(t.Context(), sessionID, "hi"); err == nil {
+		t.Fatal("Ask succeeded against a failing provider")
+	}
+
+	got := rec.one(t)
+	if got.Err == nil {
+		t.Fatal("Err = nil, want the provider failure recorded")
+	}
+	if !strings.Contains(got.Err.Error(), "provider exploded") {
+		t.Errorf("Err = %v, want it to carry the provider failure", got.Err)
+	}
+}
+
+// TestAfterTurnFiresOnEarlyBreak is the case an explicit call at the end of the
+// loop would miss: a caller that stops consuming still took a turn, and a
+// metrics or audit hook that never fires for it is worse than useless.
+func TestAfterTurnFiresOnEarlyBreak(t *testing.T) {
+	isolate(t)
+	var rec turnRecorder
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "long reply"}, WithAfterTurn(rec.hook()))
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	for range ag.Run(t.Context(), sessionID, "hi") {
+		break
+	}
+
+	got := rec.one(t)
+	if !got.Abandoned {
+		t.Error("Abandoned = false, want true when the caller broke out early")
+	}
+	if got.Duration <= 0 {
+		t.Error("Duration = 0, want an abandoned turn still timed")
+	}
+}
+
+func TestBeforeTurnAbortsTheTurn(t *testing.T) {
+	isolate(t)
+	var rec turnRecorder
+	llm := &fakeLLM{name: "fake", reply: "should never be produced"}
+	denied := errors.New("over budget")
+
+	ag := newTestAgent(t, llm,
+		WithBeforeTurn(func(context.Context, string, string) error { return denied }),
+		WithAfterTurn(rec.hook()),
+	)
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	_, err = ag.Ask(t.Context(), sessionID, "hi")
+	if err == nil {
+		t.Fatal("Ask succeeded although the before-turn hook denied it")
+	}
+	if !errors.Is(err, denied) {
+		t.Errorf("err = %v, want it to wrap the hook's error", err)
+	}
+	if llm.callCount() != 0 {
+		t.Errorf("the model was called %d times; an aborted turn must not reach it", llm.callCount())
+	}
+	// The turn never started, so there is nothing to report afterwards.
+	if got := rec.all(); len(got) != 0 {
+		t.Errorf("after-turn hook ran %d times for an aborted turn, want 0", len(got))
+	}
+}
+
+func TestBeforeTurnHooksRunInOrderAndStopAtTheFirstError(t *testing.T) {
+	isolate(t)
+	var ran []string
+	stop := errors.New("denied")
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "ok"},
+		WithBeforeTurn(func(context.Context, string, string) error {
+			ran = append(ran, "first")
+			return nil
+		}),
+		WithBeforeTurn(func(context.Context, string, string) error {
+			ran = append(ran, "blocker")
+			return stop
+		}),
+		WithBeforeTurn(func(context.Context, string, string) error {
+			ran = append(ran, "never")
+			return nil
+		}),
+	)
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := ag.Ask(t.Context(), sessionID, "hi"); !errors.Is(err, stop) {
+		t.Fatalf("Ask err = %v, want the blocker's error", err)
+	}
+	if strings.Join(ran, ",") != "first,blocker" {
+		t.Errorf("hooks ran %v, want the chain to stop at the failing one", ran)
+	}
+}
+
+// TestBeforeTurnSeesTheMessage pins the reason these hooks are not built on
+// internal/agent's PreTurnHook, whose signature carries only the session ID:
+// admission control that cannot read the outgoing message cannot moderate it.
+func TestBeforeTurnSeesTheMessage(t *testing.T) {
+	isolate(t)
+	var gotSession, gotMessage string
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "ok"},
+		WithBeforeTurn(func(_ context.Context, sessionID, message string) error {
+			gotSession, gotMessage = sessionID, message
+			return nil
+		}))
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if _, err := ag.Ask(t.Context(), sessionID, "the message"); err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if gotSession != sessionID || gotMessage != "the message" {
+		t.Errorf("hook saw (%q, %q), want (%q, %q)", gotSession, gotMessage, sessionID, "the message")
+	}
+}
+
+// TestTurnHooksDoNotFireUntilIterated pins the laziness: Run returns a
+// sequence, and a sequence nobody ranges over is not a turn. A hook that fired
+// at call time would record turns that never happened.
+func TestTurnHooksDoNotFireUntilIterated(t *testing.T) {
+	isolate(t)
+	var rec turnRecorder
+	before := 0
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "ok"},
+		WithBeforeTurn(func(context.Context, string, string) error { before++; return nil }),
+		WithAfterTurn(rec.hook()))
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	seq := ag.Run(t.Context(), sessionID, "hi")
+	if before != 0 || len(rec.all()) != 0 {
+		t.Fatalf("hooks fired before iteration: before=%d after=%d", before, len(rec.all()))
+	}
+
+	//nolint:revive // draining the sequence is the point
+	for range seq {
+	}
+	if before != 1 {
+		t.Errorf("before-turn ran %d times, want 1", before)
+	}
+	if len(rec.all()) != 1 {
+		t.Errorf("after-turn ran %d times, want 1", len(rec.all()))
+	}
+}
+
+func TestRunStreamingFiresTurnHooksToo(t *testing.T) {
+	isolate(t)
+	var rec turnRecorder
+
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "streamed"}, WithAfterTurn(rec.hook()))
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	//nolint:revive // draining the sequence is the point
+	for range ag.RunStreaming(t.Context(), sessionID, "hi") {
+	}
+
+	if got := rec.one(t); got.Events == 0 {
+		t.Error("Events = 0 for a streaming turn")
+	}
+}
+
+// TestNoHooksLeavesTheSequenceUnwrapped pins that the common case pays nothing:
+// with no hooks registered the agent hands back ADK's own sequence.
+func TestNoHooksLeavesTheSequenceUnwrapped(t *testing.T) {
+	isolate(t)
+	ag := newTestAgent(t, &fakeLLM{name: "fake", reply: "ok"})
+	if len(ag.beforeTurn) != 0 || len(ag.afterTurn) != 0 {
+		t.Fatal("the test agent registered turn hooks; this test needs none")
+	}
+
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	got, err := ag.Ask(t.Context(), sessionID, "hi")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("Ask = %q, want %q", got, "ok")
+	}
+}


### PR DESCRIPTION
Targets `feat/public-embedding-api` (#167), not `main` — this builds on the public packages branch.

## The gap

`piagent` exposed ADK's four callback slots. All of them fire *inside* a turn:
per tool call, per model call. Nothing fired for the turn itself, so an
embedder had nowhere to put the things that work at that level — budget checks,
rate limits, audit trails, per-turn metrics.

pi-go does have a `turn_complete` lifecycle hook, but it is dispatched from
`internal/tui/agent_loop.go:1459`. The headless path never sees it, and neither
did `piagent`.

## What this adds

```go
type BeforeTurnFunc func(ctx context.Context, sessionID, message string) error
type AfterTurnFunc  func(ctx context.Context, info TurnInfo)

type TurnInfo struct {
	SessionID string
	Message   string
	Duration  time.Duration
	Events    int
	ToolCalls int
	Err       error
	Abandoned bool
}

func WithBeforeTurn(fns ...BeforeTurnFunc) Option
func WithAfterTurn(fns ...AfterTurnFunc) Option
```

`WithBeforeTurn` is admission control: an error aborts the turn before it
reaches the model. Hooks run in order and the first error stops the chain,
matching the composition discipline the after-tool chain already uses.

`WithAfterTurn` is observation: it cannot change the outcome.

## Three semantics that are each a bug if assumed otherwise

Each is pinned by a test.

**Hooks fire on iteration, not on the `Run` call.** `Run` returns a lazy
`iter.Seq2`. A sequence nobody ranges over is not a turn, and firing admission
control for it would write a turn that never happened into whatever the hook
records.

**An abandoned turn still reports**, with `Abandoned: true`. A caller that
breaks out of the range loop has still spent the tokens. Reporting from a
deferred call rather than after the loop is what makes this work — I rewrote it
the naive way (report at the end of the loop) and confirmed
`TestAfterTurnFiresOnEarlyBreak` fails with `after-turn hook ran 0 times`.

**An aborted turn does not report.** If a before-turn hook denies the turn, no
request is made, so there is nothing to describe. Verified the model is never
called.

## Two smaller decisions

`TurnInfo.Err` covers **both** channels a failure arrives on — an iteration
error, and a provider failure carried on an ordinary event via
`agent.EventError`. `Ask` already had to handle both; an audit hook that saw
only one would record a failed turn as successful.

**Not built on `internal/agent.PreTurnHook`.** That signature carries only the
session ID, and admission control that cannot read the outgoing message cannot
moderate it. The hooks live in `piagent`'s own `Run`/`RunStreaming` wrappers
instead, which also keeps one mechanism rather than two.

## Cost when unused

`observeTurn` returns ADK's sequence unwrapped when no turn hooks are
registered, so the common path pays nothing.

## Deliberately not added

Config-driven shell hooks as a programmatic option. `HookConfig` still loads
from `~/.pi-go/config.json` and runs for tool calls, but an embedder writing Go
should get a Go func rather than a subprocess — `WithBeforeTurn` and
`WithAfterToolCallbacks` do the same work without the fork.

## Tests

`make test`, `make vet`, `make lint` clean; `-race` clean. `piagent` coverage
**87.4% → 88.1%**, `observeTurn` at 96.3%.

## Why no checks ran on this PR

`ci.yml` triggers on `pull_request: branches: [main]`. This PR targets
`feat/public-embedding-api`, so **the CI workflow does not fire at all** — the
only check you will see is GitGuardian. That is a property of stacked PRs in
this repo, not of this change.

Ran the pipeline locally instead, using the commands from `ci.yml` verbatim:

| Step | Result |
|---|---|
| Coverage (`go list` minus `cmd/`, `hack/`) | pass — **88.6%** total, `piagent` **88.1%** |
| `make lint` | 0 issues |
| `go vet ./...` | clean |
| `go test -race ./piagent/...` | clean |
| Build: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 | pass |
| Build: windows/amd64 | `./piagent/...` passes; the full `./cmd/pi` link did not complete locally (disk exhaustion on my machine, not a code failure) |

Two ways to get real CI on this:

1. Merge #167 first, then retarget this to `main` — the diff becomes just these
   two files plus docs.
2. Widen the `pull_request` branch filter so stacked PRs are checked. Worth
   doing on its own, but it changes every PR in the repo, so it does not belong
   in this one.

