### PR TITLE
docs(specs): show the signature that makes defect 2 visible

### DIFF
--- a/specs/memory-fixes/research/findings.md
+++ b/specs/memory-fixes/research/findings.md
@@ -9,21 +9,29 @@ running the binary. Line references are against `69b4d03`.
 
 ### Upstream semantics
 
-`$(go env GOMODCACHE)/google.golang.org/adk/v2@v2.0.0/internal/llminternal/base_flow.go:1296`
+`$(go env GOMODCACHE)/google.golang.org/adk/v2@v2.0.0/internal/llminternal/base_flow.go:1296-1309`
+
+The full signature matters here, so it is not elided: `fResult` is a **parameter**
+of this function, which is what makes defect 2 below visible rather than
+something to take on trust.
 
 ```go
-func (f *Flow) invokeAfterToolCallbacks(...) (map[string]any, error) {
+func (f *Flow) invokeAfterToolCallbacks(toolCtx agent.Context, tool toolinternal.FunctionTool,
+	fArgs, fResult map[string]any, fErr error) (map[string]any, error) {
 	for _, callback := range f.AfterToolCallbacks {
 		result, err := callback(toolCtx, tool, fArgs, fResult, fErr)
+		//                                            ^^^^^^^ defect 2: the parameter,
+		//                                            never reassigned by the loop
 		if err != nil {
 			return nil, err
 		}
 		// When a list of callbacks is provided, the callbacks will be called in the
 		// order they are listed while a callback returns nil.
 		if result != nil {
-			return result, nil
+			return result, nil // defect 1: the chain ends here
 		}
 	}
+	// If no callback returned a result/error, return the original result/error.
 	return fResult, fErr
 }
 ```


### PR DESCRIPTION
Follow-up to #168, which landed the claim without the evidence for it.

## The problem

`findings.md` quoted ADK like this:

```go
func (f *Flow) invokeAfterToolCallbacks(...) (map[string]any, error) {
```

The signature was elided. So the document asserted:

> `fResult` is the loop's parameter and is never reassigned

while showing nothing that demonstrates it. A reader had to take the central claim of defect 2 on trust — the opposite of what a findings document is for, and the claim most likely to be doubted, since it is the one that says a fix everyone assumes is sufficient is not.

## The change

Quotes the real signature, verified byte-for-byte against `adk/v2@v2.0.0 internal/llminternal/base_flow.go:1296-1309`, with both defect sites marked where they occur:

```go
func (f *Flow) invokeAfterToolCallbacks(toolCtx agent.Context, tool toolinternal.FunctionTool,
	fArgs, fResult map[string]any, fErr error) (map[string]any, error) {
	for _, callback := range f.AfterToolCallbacks {
		result, err := callback(toolCtx, tool, fArgs, fResult, fErr)
		//                                            ^^^^^^^ defect 2: the parameter,
		//                                            never reassigned by the loop
		...
		if result != nil {
			return result, nil // defect 1: the chain ends here
		}
	}
	// If no callback returned a result/error, return the original result/error.
	return fResult, fErr
}
```

Also restores upstream's own comment on the tail return — *"return the original result/error"* — which is ADK stating the behaviour in its own words rather than mine.

**No claim changed.** The evidence for one of them is now legible.