### PR TITLE
docs(specs): analyse LLM cost — reject Batch APIs, target round trips

### DIFF
--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -7,6 +7,7 @@ Each spec follows a phased workflow from rough idea through implementation.
 
 ```
 specs/
+├── batch-api-optimization/ # LLM cost: round trips vs provider Batch APIs
 ├── evaluations/          # Benchmark/evaluation specs
 ├── features/             # Feature implementations by component
 │   ├── COD/             # Coding, testing & audit
@@ -127,6 +128,12 @@ specs/
 | 007-write-tool-data-loss/ | readme | `write`/`edit` truncate before writing and never fsync — data loss on quit |
 | 008-adk-utils-go-review/  | research | adk-utils-go feature comparison & scored recommendations                  |
 | 009-tui-review-followups/ | readme | Deferred follow-ups from the TUI review and the PR #134 review           |
+
+### batch-api-optimization/
+
+| Spec                     | Phases     | Description                                                                                          |
+|--------------------------|------------|------------------------------------------------------------------------------------------------------|
+| batch-api-optimization/  | idea..plan | LLM cost analysis: provider Batch APIs rejected with numbers; reduce model round trips instead        |
 
 ### memory-fixes/
 

--- a/specs/batch-api-optimization/design.md
+++ b/specs/batch-api-optimization/design.md
@@ -34,22 +34,52 @@ after-tool callback chain that feeds it is dead.
 
 ### The number, computed anyway
 
-Suppose `specs/memory-fixes` lands and the compressor runs on every tool call.
-Measured tool-call volume is 5,248 over two days = **2,624 calls/day**.
+Suppose the dead callback chain is repaired and the compressor runs on every
+tool call. Measured tool-call volume is 5,248 over two days = **2,624
+calls/day**.
 
-Per compression, after memory-fixes R4 moves it in-process against `smol`:
-~350 tokens of instruction (`internal/subagent/bundled/memory-compressor.md`)
-plus a payload capped at `maxPromptOutput = 4096` bytes ≈ 1,150 tokens, and
-~150 output tokens. Call it 1,500 in / 150 out.
+Per-compression prompt size depends entirely on which of two shapes is in play,
+and the difference is a factor of six.
 
-Daily: 3.94M prompt tokens, 0.39M output tokens.
+**Today's shape.** The child is a full `pi --mode json` process
+(`internal/subagent/spawner.go:110,145`) carrying pi's default system prompt
+*and its complete tool declarations* — the `tools: []` line in the agent
+definition is inert, because `AgentConfig.Tools` is written at
+`internal/subagent/agents.go:142` and never read (`research/call-sites.md` § C1).
+The best available proxy for that fixed cost is the measured median prompt of a
+session's first request, 9,131 tokens (`research/measurements.md` § M1), which
+is the same system prompt plus tool declarations plus a short first message.
+Call it ~9,500 in / 150 out.
 
-| `smol` model | Standard cost/day | With 50% batch | **Saving** |
-|--------------|-------------------|----------------|------------|
-| gpt-5.6-luna ($0.20 / $1.20) | $1.26 | $0.63 | **$0.63/day** |
-| Claude Haiku 4.5 ($1 / $5)   | $5.91 | $2.96 | **$2.96/day** |
+**After memory-fixes R4**, compression runs in-process against a resolved
+`smol` role: ~350 tokens of instruction plus a payload capped at
+`maxPromptOutput = 4096` bytes ≈ 1,150 tokens. Call it ~1,500 in / 150 out.
 
-**$0.63 to $2.96 per day.** Against that:
+| Shape | Model | Prompt tok/day | Cost/day | With 50% batch | **Batch saving** |
+|-------|-------|----------------|----------|----------------|------------------|
+| Today | gpt-5.6-sol (shipped default) | 24.9M | $136.30 | $68.15 | **$68.15/day** |
+| Today | gpt-5.6-luna (this machine)   | 24.9M | $5.46   | $2.73  | **$2.73/day**  |
+| After R4 | Claude Haiku 4.5 `smol`    | 3.94M | $5.91   | $2.96  | **$2.96/day**  |
+| After R4 | gpt-5.6-luna `smol`        | 3.94M | $1.26   | $0.63  | **$0.63/day**  |
+
+The `gpt-5.6-sol` row is not hypothetical. `ResolveRole`
+(`internal/config/config.go:186`) falls back to `Roles["default"]` when a role
+is missing, and `Defaults()` ships only `{"default": {Model: "gpt-5.6-sol"}}` —
+there is no `smol` role out of the box. **On shipped defaults, a repaired
+compressor would run the frontier model once per tool call.**
+
+That row is also the argument against building a batch client rather than for
+it. Compare the two fixes on the same traffic:
+
+| Change | Saving/day (shipped defaults) |
+|--------|-------------------------------|
+| memory-fixes R4 — in-process, real `smol` model | **~$135** |
+| Batch API layered on top of R4                  | ~$3       |
+
+**R4 is worth roughly 40× the batching, has no 24-hour latency, and is already
+specced.** Build R4. Do not build the batch client.
+
+Post-R4 the batch saving is **$0.63 to $2.96 per day.** Against that:
 
 - A durable job store. Batches take up to 24 hours; pi is a CLI that exits.
   Pending batch IDs and their custom-ID → observation mappings must survive
@@ -65,20 +95,24 @@ Daily: 3.94M prompt tokens, 0.39M output tokens.
   retrieval — but it does mean a session's own observations are never available
   to the session that produced them, or to the next few.
 
-### The alternative that beats it
+### Three defects found while costing this
 
-`specs/memory-fixes` R4 already requires the compressor to stop spawning a child
-`pi --mode json` per tool call. Today each compression is a full process boot
-carrying pi's base system prompt — roughly 5,500 prompt tokens instead of 1,500.
+None is in this spec's scope to fix — all three belong to `specs/memory-fixes` —
+but they are recorded here because they are what makes the compressor's
+hypothetical bill large, and because two of them are invisible from the config
+that appears to control them.
 
-| Change | Saving/day (Haiku 4.5 `smol`) |
-|--------|-------------------------------|
-| memory-fixes R4 (in-process compression) | ~$10.5 |
-| Batch API on top of R4                   | ~$3.0  |
+1. **`tools: []` in the agent definition is inert.** `AgentConfig.Tools` is
+   written at `internal/subagent/agents.go:142` and never read; `SpawnOpts`
+   does not carry a tool list. The child boots with the full default toolset.
+2. **`role: smol` silently resolves to the frontier model.** No `smol` role
+   ships in `Defaults()`, and `ResolveRole` falls back to `default`.
+3. **`memory.compression_model_role` is dead config.** Written at
+   `internal/config/config.go:37,48`, read nowhere.
 
-**The fix that is already specced saves more than the fix this spec was asked to
-consider, and it has no 24-hour latency and no durable job store.** That is the
-whole argument.
+Defect 2 is precisely what memory-fixes R4 anticipated when it required that a
+missing `smol` role be "logged once per session, not silently billed at frontier
+prices". R4 was written before the cause was traced to `ResolveRole`.
 
 ### What would change the answer
 

--- a/specs/batch-api-optimization/design.md
+++ b/specs/batch-api-optimization/design.md
@@ -1,0 +1,258 @@
+# Design
+
+Two directions were investigated. One is rejected with numbers; the other is
+accepted and scoped. This document states both decisions with the alternatives
+that lost.
+
+## D1 — Provider Batch APIs: rejected
+
+### The decision
+
+**pi-go will not build a Batch API client.** No `internal/provider/batch.go`,
+no durable job store, no pending-result reconciliation.
+
+### Why
+
+A batch API needs work whose result nobody is waiting for. `research/call-sites.md`
+enumerates every model call in the tree. The result:
+
+| Site | Status |
+|------|--------|
+| Main agent turn | User waits |
+| `LLMSummarizer` (auto-compaction) | User waits, mid-turn |
+| `subagent` tool | Parent turn waits |
+| `/commit` message generation | User waits |
+| `pi ping` | User waits |
+| `SummarizeSession` | **No production caller** |
+| Palace KG extraction / miners | **Makes no LLM call** |
+| `internal/eval` `Judge` | Only caller is a build-tagged test |
+| Memory compressor | The one real candidate |
+
+The candidate pool is one site. That site has produced **one observation in the
+lifetime of the database** (`research/measurements.md` § M7) because the
+after-tool callback chain that feeds it is dead.
+
+### The number, computed anyway
+
+Suppose `specs/memory-fixes` lands and the compressor runs on every tool call.
+Measured tool-call volume is 5,248 over two days = **2,624 calls/day**.
+
+Per compression, after memory-fixes R4 moves it in-process against `smol`:
+~350 tokens of instruction (`internal/subagent/bundled/memory-compressor.md`)
+plus a payload capped at `maxPromptOutput = 4096` bytes ≈ 1,150 tokens, and
+~150 output tokens. Call it 1,500 in / 150 out.
+
+Daily: 3.94M prompt tokens, 0.39M output tokens.
+
+| `smol` model | Standard cost/day | With 50% batch | **Saving** |
+|--------------|-------------------|----------------|------------|
+| gpt-5.6-luna ($0.20 / $1.20) | $1.26 | $0.63 | **$0.63/day** |
+| Claude Haiku 4.5 ($1 / $5)   | $5.91 | $2.96 | **$2.96/day** |
+
+**$0.63 to $2.96 per day.** Against that:
+
+- A durable job store. Batches take up to 24 hours; pi is a CLI that exits.
+  Pending batch IDs and their custom-ID → observation mappings must survive
+  process death, be reclaimed on the next start, and be reconciled against a
+  results file that expires after 29 days (Anthropic) or 30 (OpenAI).
+- Per-provider divergence. Anthropic takes inline request arrays; OpenAI takes
+  an uploaded JSONL file and returns an output file; Gemini takes a
+  `BatchJobSource`. Three code paths, three result formats, three failure modes.
+- xAI cannot participate at all — `grok-4.5` and `grok-4.6` are explicitly
+  rejected by its Batch API (`research/providers.md`). Ollama has no batch API.
+- Memory would arrive up to 24 hours late. `MemoryConfig.LookbackHours` defaults
+  to 72 (`internal/config/config.go`), so a day's delay does not break
+  retrieval — but it does mean a session's own observations are never available
+  to the session that produced them, or to the next few.
+
+### The alternative that beats it
+
+`specs/memory-fixes` R4 already requires the compressor to stop spawning a child
+`pi --mode json` per tool call. Today each compression is a full process boot
+carrying pi's base system prompt — roughly 5,500 prompt tokens instead of 1,500.
+
+| Change | Saving/day (Haiku 4.5 `smol`) |
+|--------|-------------------------------|
+| memory-fixes R4 (in-process compression) | ~$10.5 |
+| Batch API on top of R4                   | ~$3.0  |
+
+**The fix that is already specced saves more than the fix this spec was asked to
+consider, and it has no 24-hour latency and no durable job store.** That is the
+whole argument.
+
+### What would change the answer
+
+State these plainly so the decision can be revisited on evidence rather than
+re-litigated:
+
+1. **An eval harness that runs sweeps.** `internal/eval/judge.go` is
+   provider-agnostic (`CompleteFunc`) and a sweep is the canonical batch
+   workload. If `pi eval` lands and routinely issues thousands of judge calls,
+   Anthropic's batch path is a ~50-line addition behind that one interface.
+2. **A `smol` role pointing at a frontier model.** At Opus 5 prices the
+   compressor's 3.94M tokens/day costs ~$29/day and batching saves ~$14. Still
+   modest, but the arithmetic moves.
+3. **Compression volume rising an order of magnitude** — per-message sweeping,
+   or memory over full session transcripts rather than single tool results.
+
+None of these is true today.
+
+## D2 — Reduce round trips: accepted
+
+### The decision
+
+Treat **requests per session** as the cost metric, measure it, and change the
+system prompt to raise tool calls per response. No new tool, no provider change,
+no ADK change.
+
+### The mechanism
+
+Let `C_k` be context size at request `k`, `P` the fixed preamble, `d` the tokens
+each step appends:
+
+```
+Total = Σ_{k=1..N} C_k = N·P + d·N(N-1)/2
+```
+
+Merge `m` calls per request. `N` becomes `N/m`; each step appends `m·d`, because
+the same tool results still land in the transcript:
+
+```
+Total' = (N/m)·P + m·d·(N/m)((N/m)-1)/2  ≈  (N·P + d·N²/2) / m
+```
+
+Both terms divide by `m`. This is why the payoff exceeds the naive "fewer
+requests" intuition, and it is corroborated by the measured growth curve: median
+prompt size rises 16.6× from request 1 to request 100
+(`research/measurements.md` § M1).
+
+### Why nothing needs building
+
+- **ADK dispatches concurrently.** `internal/llminternal/base_flow.go:1063`
+  `handleFunctionCalls` builds one task per call and hands them to the platform
+  task runner, whose default (`platform/exec.go:68`) fans out goroutines and
+  joins a `WaitGroup`. pi-go installs no custom runner. Batching therefore
+  *improves* wall-clock latency as well as cost.
+- **Ordering is already deterministic.** Responses are written to
+  `fnResponseEvents[i]` by index, not by completion order.
+- **Error attribution is already per-call.** Each call gets its own span and its
+  own `functionResponse` part; a failure in one does not mask the others.
+- **The providers already do it.** Measured, not assumed: responses with 2, 3,
+  4, 5 and 6 calls all appear in the logs, against the OpenAI provider.
+
+### The gap is the prompt
+
+`internal/agent/agent.go:185` currently reads:
+
+> "You **can** call multiple tools in a single response when they are
+> independent."
+
+Forty-four lines later, `internal/agent/agent.go:235`:
+
+> "- **Prefer parallel over sequential**: when researching a topic, spawn 2-4
+> explore agents…"
+
+Subagent batching is an instruction. Tool batching is a permission. The measured
+behaviour follows the weaker one: mean 1.307 calls per response, 71.3% of
+responses carrying exactly one.
+
+The change is to make the tool-batching guidance directive, name the concrete
+batchable tools, and give the model the reason — that each response is a round
+trip which re-sends the entire conversation.
+
+### Expected payoff
+
+Measured ceiling: collapsing every run of consecutive single-read-only-call
+responses removes **982 of 4,016 responses = 24.5%**
+(`research/measurements.md` § M3). That is an upper bound and assumes perfect
+independence, which is false — a `read` whose path came from the preceding
+`ripgrep` cannot move earlier.
+
+| Scenario | Mean calls/response | Requests | Requests removed | Prompt spend | $/day (luna) | $/day (Opus 5) |
+|----------|--------------------|----------|------------------|--------------|--------------|----------------|
+| Today    | 1.307              | 4,016    | —                | 310.1M       | $24.55       | $609           |
+| Target   | 1.60               | 3,402    | 15.3%            | −15.3%       | −$3.76       | −$93           |
+| Ceiling  | 1.73               | 3,034    | 24.5%            | −24.5%       | −$6.01       | −$149          |
+
+Request counts hold the 5,248 measured tool calls and the 122 text-only
+responses fixed, and vary only how many calls share a response:
+`3,402 = 5,248/1.6 + 122`. Prompt-spend reduction equals the request reduction
+because `Total' ≈ Total/m` and `requests removed = 1 − 1/m` — the same `m`.
+
+The 25× spread between the two right-hand columns is the honest headline: at
+`gpt-5.6-luna` this work saves the price of a coffee per day and is justified by
+latency, not cost. At Opus 5 it saves ~$93/day. **The current default role is
+`gpt-5.6-luna`** (`$HOME/.pi-go/config.json`), so today the cost case is weak
+and the latency case — concurrent tool execution instead of serialised
+round trips — is the stronger one.
+
+### What breaks
+
+State the costs, not just the upside:
+
+- **Wasted work on dependent calls.** If the model batches a `read` that a
+  concurrent `ripgrep` was going to redirect, that read is thrown away. It costs
+  a tool execution and the result still enters the transcript, so a bad batch is
+  *more* expensive than two good serial calls. The existing caveat — "Only
+  parallelize when operations are truly independent" — must survive the rewrite.
+- **Never batch mutations.** `edit`, `write` and mutating `bash` must stay
+  serial. Concurrent edits to the same file are a correctness bug, and ADK runs
+  the calls genuinely in parallel — the race is real, not theoretical.
+- **Coarser failure granularity for the model.** Five results arrive together;
+  the model must attribute a failure to the right call. ADK keeps the parts
+  separate, so this is a model-comprehension risk, not a plumbing one.
+- **Harder-to-follow TUI.** Five tool cards appearing at once is less readable
+  than five in sequence. The status bar already tracks concurrent tools
+  (`internal/agent/agent.go:191`), so this is a polish concern.
+- **The metric can be gamed.** "Calls per response" rises if the model issues
+  useless extra calls. Pair it with total requests per completed task, and never
+  report it alone.
+
+## D3 — `bash_batch` tool: rejected
+
+A tool taking an array of commands and returning an array of results was
+considered. Rejected:
+
+1. **It duplicates ADK.** N concurrent `bash` calls already work, already run in
+   parallel, already return per-call results.
+2. **It loses error attribution.** One tool result is one `functionResponse`.
+   Five commands inside it become one blob the model must parse, with one
+   error channel where ADK gives five.
+3. **It saves nothing extra.** The saving is one fewer round trip, and the model
+   emitting five `bash` calls in one response already achieves exactly that.
+4. **It adds a schema.** Tool declarations are part of the fixed preamble this
+   spec is trying not to grow.
+
+The only thing `bash_batch` would add over the status quo is a nudge — a schema
+that *suggests* batching. That nudge belongs in the system prompt, where it
+costs a paragraph rather than a tool.
+
+## D4 — Measurement
+
+None of D2 is verifiable today. `pi session-stats` counts tool calls; it does
+not report requests, calls per response, or prompt tokens per request.
+
+Add three counters, derived from the same `UsageMetadata`-bearing events used
+throughout `research/measurements.md`:
+
+| Counter | Definition |
+|---------|------------|
+| `requests` | Events carrying `UsageMetadata` |
+| `calls_per_response` | `function_call` parts ÷ requests |
+| `prompt_tokens_per_request` | Σ `prompt_token_count` ÷ requests |
+
+Report them in `--json` and in the human summary. Without these the prompt
+change in D2 is an opinion.
+
+## D5 — Regression guard for the poll storm
+
+`bash_wait` blocks up to `maxBashWait = 60s` (`internal/tools/bash.go:114`) and
+its description instructs against looping (`internal/tools/bash.go:187`). This
+fix is worth 19.7% of prompt spend in the measured window and has no test
+pinning the behaviour that delivers it.
+
+Add a test asserting `bash_wait` returns only when the command produces output
+or exits — not on a fixed short interval — so a future change cannot silently
+restore polling. `specs/…/test/bash-wait-exit-detection` (commit `5362ffd`)
+already pins exit detection; the missing half is that an idle command makes the
+call *block* rather than return empty immediately.

--- a/specs/batch-api-optimization/plan.md
+++ b/specs/batch-api-optimization/plan.md
@@ -1,0 +1,122 @@
+# Plan
+
+Four slices, in dependency order. Slice 1 must land before slice 2, because
+slice 2 is unverifiable without it. Total scope is small — this spec's main
+output is the decision in `design.md` § D1 not to build the thing it was asked
+to evaluate.
+
+Gate for every slice: `make test`, `make vet`, `make lint`.
+
+## Slice 1 — Measure round trips (R1)
+
+**Why first:** slice 2 changes model behaviour. Without a metric, "did it work?"
+is a matter of opinion.
+
+`internal/tools/session_sweep.go`:
+
+1. Add to `sweepTotals` (line 41):
+   ```go
+   Requests   int
+   CallsPerResponse map[int]int   // calls in a response → count of responses
+   ```
+   Initialise the map in `newSweepTotals` (line 51).
+2. In the accumulation loop, at the existing `if ev.UsageMetadata != nil` branch
+   (line 125), increment `Requests`.
+3. In the same iteration, count `functionCall` parts for that event and record
+   `CallsPerResponse[n]++` — only for events carrying `UsageMetadata`, so
+   replayed or synthetic events do not skew the denominator.
+4. Report in the human summary next to the existing prompt/output token lines
+   (around line 232):
+   - `requests`
+   - `calls_per_response` (mean, to 3 dp)
+   - `prompt_tokens_per_request`
+   - the 0/1/2/3/4+ histogram
+5. Add the same fields to the `--json` output.
+
+**Test:** a table-driven test over a fixture `events.jsonl` containing responses
+with 0, 1, 2 and 5 function calls, asserting the mean, the histogram and
+`prompt_tokens_per_request`. Include one event *without* `UsageMetadata` that
+carries function calls, and assert it does not move the denominator.
+
+**Verification:** run against `$HOME/.pi-go/sessions` and confirm it reproduces
+`research/measurements.md`: 4,016 requests and 1.307 calls/response over the
+same 400-directory sample. **If it does not reproduce, the measurement
+methodology is wrong and the rest of the plan is suspect** — stop and reconcile
+before continuing.
+
+## Slice 2 — Capture the baseline
+
+No code. Run the slice-1 tool over the current session corpus and commit the
+output to `research/baseline.md` with the date, the sample definition and the
+model in use.
+
+This exists as its own slice so the baseline is taken with the *shipped* counter
+rather than the ad-hoc Python in `research/measurements.md`, and so slice 3's
+before/after cannot be accused of comparing two different measurements.
+
+## Slice 3 — Rewrite the parallel-execution guidance (R2)
+
+`internal/agent/agent.go`, the `# Parallel execution` section at line 185.
+
+Requirements the new text must satisfy — the wording is the implementer's, the
+content is not:
+
+- Directive, not permissive. Match the force of line 235's
+  "**Prefer parallel over sequential**".
+- Names the batchable tools: `read`, `ripgrep`, `find`, `ls`, `tree`, read-only
+  `bash`.
+- Gives the reason: each response is a round trip that re-sends the whole
+  conversation, so two independent lookups in one response cost roughly half
+  what they cost in two.
+- Keeps the independence caveat verbatim.
+- Adds an explicit prohibition on batching `edit`, `write` and mutating `bash`,
+  noting that calls execute concurrently.
+- Does not contradict line 94 ("Verify after every edit … Do not batch multiple
+  edits before checking").
+
+**Test:** `internal/agent/agent_test.go` — assert the section contains the
+prohibition on batching mutations and retains the independence caveat. A test
+that pins exact prose is brittle; pin the load-bearing clauses only.
+
+**Do not** grow the section significantly. It sits in the fixed preamble that
+every request pays for. If the rewrite adds more than ~80 tokens, cut elsewhere
+in the same section.
+
+## Slice 4 — Pin `bash_wait` blocking (R4)
+
+`internal/tools/bash_control_test.go` (or a new `bash_wait_block_test.go`).
+
+Add a test: start a command that produces no output for longer than the test's
+`wait_ms`, call `bash_wait`, and assert the call **did not return before**
+`wait_ms` elapsed. Use a synthetic clock if the supervisor supports one;
+otherwise a short real `wait_ms` (200 ms) with a generous tolerance.
+
+This complements `5362ffd`, which pins that a wait ends on child exit rather
+than on its budget. Together they pin both ends: a wait returns *early* on exit
+and does *not* return early on idleness.
+
+## Evaluation gate (R3)
+
+After slice 3 has been in use for a working week:
+
+1. Re-run the slice-1 counter over sessions created since the change.
+2. Require ≥ 500 model requests in the after-sample.
+3. Compare against `research/baseline.md`.
+
+| Outcome | Action |
+|---------|--------|
+| calls/response ≥ 1.6 **and** requests per completed task down | Keep; record the result in `summary.md` |
+| calls/response up, requests per task flat or up | **Revert slice 3.** The model is adding calls, not merging them |
+| calls/response < 1.4 | **Revert slice 3.** The prompt change did not take |
+| Between 1.4 and 1.6 | Judgement call; record the number either way |
+
+The revert costs one commit. Do not iterate on prompt wording more than once
+before reverting — the preamble is shared by every session and every subagent,
+and unbounded fiddling there is how a shared prompt becomes unmaintainable.
+
+## Not planned
+
+- Batch API client. `design.md` § D1. Revisit only if one of its three named
+  conditions becomes true.
+- `bash_batch` tool. `design.md` § D3.
+- Gemini/Ollama prompt caching. Separate spec.

--- a/specs/batch-api-optimization/requirements.md
+++ b/specs/batch-api-optimization/requirements.md
@@ -1,0 +1,122 @@
+# Requirements
+
+## Scope
+
+Reduce the number of model round trips per unit of work, and make that number
+measurable. No Batch API client — `design.md` § D1 rejects it with numbers. No
+new tools. No provider or ADK changes.
+
+## Acceptance criteria
+
+### R1 — Round trips are a reported metric
+
+**Given** `pi session-stats --json` over a directory of sessions
+**When** it reports
+**Then** the output includes `requests`, `calls_per_response` and
+`prompt_tokens_per_request`.
+
+- `requests` counts events carrying `UsageMetadata` — one per model request.
+- `calls_per_response` is total `functionCall` parts ÷ `requests`.
+- `prompt_tokens_per_request` is Σ `promptTokenCount` ÷ `requests`.
+- All three appear in the human-readable summary as well as `--json`.
+- A histogram of calls-per-response (0, 1, 2, 3, 4+) is reported, because the
+  mean alone hides whether the model batches rarely-and-widely or often-and-narrowly.
+
+**Rationale:** `sweepTotals` (`internal/tools/session_sweep.go:41`) today tracks
+`PromptTokens`, `OutputTokens`, `ToolBytes`, `DupBytes`, `Tools`, `Aborts` and
+`Models` — no request count. The accumulation loop already branches on
+`ev.UsageMetadata != nil` (line 125) and `p.FunctionCall != nil` (line 134), so
+both counters land in code that already runs. Without R1, R2 is unfalsifiable.
+
+### R2 — The system prompt directs batching, and it is safe
+
+**Given** a session doing read-only exploration
+**When** the model has several independent lookups to perform
+**Then** it issues them in one response.
+
+- `internal/agent/agent.go` § "Parallel execution" is rewritten from permission
+  ("You **can** call multiple tools") to instruction, matching the emphasis the
+  subagent section already uses at line 235.
+- It names the batchable tools explicitly: `read`, `grep`/`ripgrep`, `find`,
+  `ls`, `tree`, and read-only `bash`. Together these are 75.7% of measured calls.
+- It states the reason: each response is a round trip that re-sends the entire
+  conversation.
+- **The independence caveat survives verbatim.** "Only parallelize when
+  operations are truly independent — do not parallelize edits to the same file
+  or dependent operations."
+- It states explicitly that `edit`, `write` and mutating `bash` are **never**
+  batched. ADK executes calls concurrently
+  (`internal/llminternal/base_flow.go:1063`), so concurrent writes are a real
+  race, not a hypothetical one.
+- The existing "Verify after every edit — run the build or relevant test
+  immediately. Do not batch multiple edits before checking."
+  (`internal/agent/agent.go:94`) must not be contradicted.
+
+### R3 — The change is verified against measurement, not opinion
+
+**Given** the metric from R1
+**When** sessions are compared before and after R2
+**Then** the comparison is recorded with n, and the change is kept or reverted
+on that evidence.
+
+- Baseline is stated in `research/measurements.md`: **1.307** calls per
+  response, 71.3% of responses carrying exactly one, n = 4,016.
+- Target: **≥ 1.6**. Measured ceiling is 1.73 and assumes perfect independence,
+  so 1.6 is deliberately short of it.
+- Comparison uses at least 500 model requests on each side.
+- **A rise in calls-per-response with no fall in total requests per completed
+  task is a failure, not a success** — it means the model is issuing extra calls
+  rather than merging existing ones.
+- If the target is not met, the prompt change is reverted rather than iterated
+  on indefinitely. Cost of failure is one revert.
+
+### R4 — The poll storm cannot return
+
+**Given** a backgrounded command producing no output
+**When** `bash_wait` is called on its handle
+**Then** the call blocks until output appears, the command exits, or `wait_ms`
+elapses — it does not return empty immediately.
+
+- A test pins this. Commit `5362ffd` pins that a wait ends on child *exit*; the
+  untested half is that an *idle* command makes the call block.
+- The tool description must keep telling the model not to loop
+  (`internal/tools/bash.go:187`).
+
+**Rationale:** 799 of 4,016 responses in the measured window were poll-only,
+costing 19.7% of all prompt tokens (`research/measurements.md` § M5). The fix
+landed in `ffe337a`; nothing pins the behaviour that delivers it.
+
+### R5 — The Batch API rejection is recorded, not just decided
+
+**Given** a future proposal to add a Batch API client
+**When** someone looks for prior art
+**Then** `design.md` § D1 gives the payoff ($0.63–$2.96/day), the cost (durable
+job store, three provider paths, 24-hour latency), and the three specific
+conditions that would reverse the decision.
+
+## Constraints
+
+- **`gpt-5.6-luna` is the configured default role.** At $0.20/MTok input, R2's
+  target payoff is ~$3.76/day. The same traffic on Opus 5 is ~$93/day. Do not
+  justify this work on cost alone at current settings — the latency argument
+  (ADK runs batched calls concurrently) is the stronger one today.
+- No new dependencies. The Anthropic, OpenAI and Gemini Go SDKs already vendor
+  batch clients; this spec deliberately does not use them.
+- Gate for every slice: `make test`, `make vet`, `make lint`.
+- `internal/cli` tests bind local listeners and must run outside the sandbox
+  (`CLAUDE.md` § "Two environment traps").
+- Prompt changes touch `internal/agent/agent.go`, which is shared by every
+  session and every subagent. A regression here is expensive and invisible;
+  R3's measurement gate is not optional.
+
+## Out of scope
+
+- Provider Batch API integration (`design.md` § D1).
+- A `bash_batch` tool (`design.md` § D3).
+- Prompt caching for Gemini and Ollama — real gap, different mechanism, own spec.
+- Auto-compaction's prompt-cache invalidation
+  (`internal/session/compaction.go:26`) — noted, unquantified, own spec.
+- Tool-output compaction. Already handled by `internal/tools/compactor*.go`, and
+  tool results are a small share of prompt spend.
+- Anything in `specs/memory-fixes`. R4 of that spec removes the compressor's
+  per-call child process, which is worth more than any batching change here.

--- a/specs/batch-api-optimization/research/call-sites.md
+++ b/specs/batch-api-optimization/research/call-sites.md
@@ -1,0 +1,188 @@
+# Where pi-go calls a model, and which calls could tolerate 24 hours
+
+A batch API is only useful for work whose result nobody is waiting for. This is
+the complete inventory, read from the code on 2026-08-14 at `c98d55f`.
+
+## The inventory
+
+| # | Site | Trigger | Who waits | Batchable |
+|---|------|---------|-----------|-----------|
+| 1 | Main agent turn (`internal/agent/agent.go`, via ADK `Flow`) | Every user message and every tool result | The user, live | **No** |
+| 2 | `internal/session/compaction.go:157` `LLMSummarizer` | Context reaches `SummarizePercent` (88–90%) of the window | The user, mid-turn | **No** |
+| 3 | `internal/tools/subagent.go:224,365,506` `SpawnWithInput` | `subagent` tool call | The parent turn | **No** |
+| 4 | `internal/tui/commit.go:268` | `/commit` — commit message generation | The user, live | **No** |
+| 5 | `internal/tui/ping.go:76` | `pi ping` — connectivity check | The user, live | **No** |
+| 6 | `internal/memory/compress.go:46` `CompressObservation` | Every recorded tool observation | **Nobody** | **Yes, in principle** |
+| 7 | `internal/memory/compress.go:169` `SummarizeSession` | — **no production caller** | — | Moot |
+| 8 | `internal/eval/judge.go:96` `Judge` | LLM-as-judge over a run report | The eval run | Marginal |
+
+That is the whole list. Sites 1–5 are ruled out by definition: a request that
+returns in up to 24 hours cannot serve a turn the user is watching.
+
+### C1 — The compressor is a child `pi` process, and that is the real cost
+
+`SubagentCompressor.CompressObservation` (`internal/memory/compress.go:36`)
+calls `orchestrator.Spawn`. The dispatch at
+`internal/subagent/orchestrator.go:466-470` reads:
+
+> "ACP-bundled agents (claude/gemini/cursor/copilot) launch their own CLI
+> binary via the ACP adapter; codex agents launch `codex app-server` … **everyone
+> else runs as a child `pi --mode json`**."
+
+`memory-compressor` is in the "everyone else" branch. So each compression is a
+full process boot with pi's base system prompt, not a bare model call.
+
+The agent definition (`internal/subagent/bundled/memory-compressor.md`):
+
+```yaml
+name: memory-compressor
+role: smol
+worktree: false
+tools: []
+timeout: 600000
+```
+
+`tools: []` keeps tool declarations out of the request, which is the larger half
+of the fixed overhead. The prompt payload is small and bounded: `tool_name`,
+`tool_input`, and `tool_output` truncated at
+`maxPromptOutput = 4096` bytes (`internal/memory/compress.go:14,81`) —
+roughly 1,100 tokens of payload plus a ~350-token instruction.
+
+**This site is already scheduled for repair.** `specs/memory-fixes` R4 requires
+that compression "does not spawn a `pi` child process per tool call" and moves
+it in-process against the resolved `smol` role. That change removes the
+per-call process boot and its system prompt. Whatever a batch API could save
+here, it saves on the *residue* after R4, not on today's shape.
+
+**And today it runs zero times** — see `research/measurements.md` § M7. One
+observation exists in the database, written during the memory-fixes work itself.
+
+### C2 — `SummarizeSession` has no caller
+
+`grep -rn SummarizeSession --include='*.go' .` returns exactly two hits, both
+the definition and its doc comment at `internal/memory/compress.go:160-161`,
+plus tests. Nothing in production invokes it. It cannot be optimised because it
+does not run.
+
+This contradicts the framing that session summarisation is a live batch
+candidate. It is a batch candidate for code that would have to be written first.
+
+### C3 — Palace KG extraction makes no LLM call at all
+
+`internal/palace/tool_kg_extract.go` was listed as a batch candidate. It is not
+one: it contains no model invocation. Triple extraction is pure heuristics —
+`extractTriples` (line 178) matches Go-style function declarations with regexes,
+`emitImport` (line 114) parses import paths, `isStdlibImport` (line 340) and
+`isCommonWord` (line 375) filter with static lists.
+
+```
+$ grep -ln "Spawn\|GenerateContent\|LookupAgent\|llm\." internal/palace/*.go | grep -v _test
+(no output)
+```
+
+**No file in `internal/palace` calls a model.** The miners
+(`miner.go`, `miner_convo.go`, `miner_project.go`) are heuristic too. Embeddings
+go through `embedder_ollama.go` (local) or the ONNX/Go backends
+(`embedder_backend_ort.go`, `embedder_backend_go.go`) — all local inference,
+where batch pricing does not exist.
+
+The palace has nothing to batch. This is the clearest correction in the spec.
+
+### C4 — Eval is real but rare
+
+`internal/eval/judge.go:96` `Judge(ctx, complete, model, r, digest)` takes a
+`CompleteFunc`, so it is provider-agnostic. Its only caller in the tree is
+`internal/tui/run_eval_e2e_test.go:268` — a build-tagged e2e test. There is no
+`pi eval` CLI command.
+
+One judge call per run report. Even a large eval sweep is hundreds of calls, not
+thousands, and a sweep is exactly the shape batch APIs were designed for
+(submit N, collect later). But the volume does not currently justify the
+machinery, and the harness that would generate that volume
+(`specs/features/…/eval-run-harness`) is not merged.
+
+### C5 — Auto-compaction cannot be batched, and is worth naming
+
+`internal/session/compaction.go` documents its own cost model:
+
+> "with an LLM-written handoff summary. **This invalidates the prompt cache**" —
+> `internal/session/compaction.go:26`
+
+Compaction fires at `SummarizePercent` (88%, "88 leaves headroom for the
+summarization call itself", line 67) and the user is blocked on it. It is not a
+batch candidate. It is listed because it is the one background-*feeling* LLM
+call that is in fact synchronous and on the critical path, and because it
+discards the prompt cache — a cost worth its own investigation, outside this
+spec's scope.
+
+## What this means for direction 1
+
+Of eight model call sites, five are user-blocking, one is dead code, one has no
+LLM call at all, and one (eval) is rare. The single genuine candidate — the
+memory compressor — currently issues **zero** requests per day and is already
+being rebuilt by another spec.
+
+There is no meaningful batch-API opportunity in pi-go today. See
+`design.md` § D1 for the quantified version of that claim and the conditions
+under which it would change.
+
+## Direction 2: the plumbing already exists
+
+The premise of direction 2 was that batching tool calls needs new machinery. It
+does not.
+
+**ADK executes multiple function calls concurrently.**
+`internal/llminternal/base_flow.go:1063` `handleFunctionCalls` builds one task
+per call and hands the slice to the platform task runner:
+
+```go
+fnResponseEvents := make([]*session.Event, len(fnCalls))
+
+// Tool calls run via the context's task runner: concurrent goroutines by
+// default, or a caller-installed runner (platform.WithTaskRunner).
+tasks := make([]func(context.Context), len(fnCalls))
+```
+
+The default runner (`platform/exec.go:68` `RunTasks`) fans out one goroutine per
+task and joins on a `sync.WaitGroup`. **pi-go installs no custom runner** —
+`grep -rn "WithTaskRunner\|TaskRunner" --include='*.go' .` returns nothing in
+this repo — so the concurrent default applies.
+
+Results are written to `fnResponseEvents[i]` by index, so response ordering is
+positional and deterministic regardless of completion order. Each call gets its
+own span, its own error path, and its own `functionResponse` part.
+
+**The providers already surface multiple calls.** Not asserted — measured:
+responses carrying 2, 3, 4, 5 and 6 function calls all appear in the session
+logs (`research/measurements.md` § M3), against the OpenAI provider. 25.7% of
+responses already carry more than one call.
+
+**The system prompt already permits it, weakly.** `internal/agent/agent.go:185`:
+
+```
+# Parallel execution
+
+You can call multiple tools in a single response when they are independent. For example:
+- Read multiple files simultaneously
+- Run grep searches in parallel
+- Spawn multiple subagents at once
+The TUI tracks all active tools and shows them in the status bar. Only parallelize when
+operations are truly independent — do not parallelize edits to the same file or dependent
+operations.
+```
+
+Note the asymmetry with the subagent guidance 44 lines later
+(`internal/agent/agent.go:235`), which is emphatic:
+
+```
+- **Prefer parallel over sequential**: when researching a topic, spawn 2-4 explore
+  agents with different search angles rather than one agent doing everything.
+```
+
+Tool batching gets "you can". Subagent batching gets "**Prefer**". Neither
+section gives the model a reason, and the measured behaviour — 1.307 calls per
+response, 71.3% of responses carrying exactly one — matches the weaker
+instruction.
+
+**Conclusion:** direction 2 needs no new tool, no provider work and no ADK
+change. It is a prompt problem and a measurement problem.

--- a/specs/batch-api-optimization/research/call-sites.md
+++ b/specs/batch-api-optimization/research/call-sites.md
@@ -29,8 +29,12 @@ calls `orchestrator.Spawn`. The dispatch at
 > binary via the ACP adapter; codex agents launch `codex app-server` … **everyone
 > else runs as a child `pi --mode json`**."
 
-`memory-compressor` is in the "everyone else" branch. So each compression is a
-full process boot with pi's base system prompt, not a bare model call.
+`memory-compressor` is in the "everyone else" branch, and the child is a real
+process: `spawnArgs` builds `{"--mode", "json", …}`
+(`internal/subagent/spawner.go:110`) and `Spawn` runs
+`exec.CommandContext(procCtx, s.PiBinary, args...)`
+(`internal/subagent/spawner.go:145`). Each compression is a full `pi` boot, not
+a bare model call.
 
 The agent definition (`internal/subagent/bundled/memory-compressor.md`):
 
@@ -42,17 +46,76 @@ tools: []
 timeout: 600000
 ```
 
-`tools: []` keeps tool declarations out of the request, which is the larger half
-of the fixed overhead. The prompt payload is small and bounded: `tool_name`,
-`tool_input`, and `tool_output` truncated at
-`maxPromptOutput = 4096` bytes (`internal/memory/compress.go:14,81`) —
-roughly 1,100 tokens of payload plus a ~350-token instruction.
+Two of those five lines do not do what they appear to do.
+
+**`tools: []` is inert.** `AgentConfig.Tools` is populated from frontmatter at
+`internal/subagent/agents.go:142` and **never read again anywhere in the repo**:
+
+```
+$ grep -rn "\.Tools" --include='*.go' internal/subagent/ | grep -v _test
+internal/subagent/agents.go:142:   cfg.Tools = append(cfg.Tools, t)
+```
+
+`SpawnOpts` (`internal/subagent/orchestrator.go:446-458`) carries `Model`,
+`WorkDir`, `Prompt`, `Instruction`, `Timeout`, `Env`, `BaseURL` and `LSP` — no
+tool list. The child therefore boots with pi's **default full toolset and full
+system prompt**. The per-observation request is not the 4 KB the payload cap
+suggests.
+
+**`role: smol` resolves to the frontier model.** `ResolveRole`
+(`internal/config/config.go:186`) falls back to `Roles["default"]` when the
+named role is absent, and `Defaults()` (`internal/config/config.go:165`) ships
+exactly one role:
+
+```go
+Roles: map[string]RoleConfig{
+    "default": {Model: "gpt-5.6-sol"},
+},
+```
+
+There is no `smol` role out of the box, and none in this machine's
+`$HOME/.pi-go/config.json` either. **On shipped defaults the memory compressor
+runs on `gpt-5.6-sol` at $5/$30 per MTok** — the frontier model, once per tool
+call, in a child process carrying the full system prompt.
+
+**`memory.compression_model_role` is dead code.** The config key exists
+(`internal/config/config.go:37`) and defaults to `"smol"`
+(`internal/config/config.go:48`), but nothing reads it:
+
+```
+$ grep -rn "CompressionRole" --include='*.go' . | grep -v _test
+internal/config/config.go:37:  CompressionRole  string `json:"compression_model_role,omitempty"`
+internal/config/config.go:48:  CompressionRole: "smol",
+```
+
+The role actually used comes from the agent's own frontmatter, not from config.
+
+Prompt payload, for what it is worth: `buildCompressionPrompt`
+(`internal/memory/compress.go:75-92`) marshals `tool_name`, `tool_input` and
+`tool_output`. Only `tool_output` is truncated, at `maxPromptOutput = 4096`
+bytes (`internal/memory/compress.go:14,81`). **`tool_input` is not truncated at
+all**, so a `write` or `edit` with a large `content` argument goes in whole.
+
+Delivery shape, which bounds how much any of this can cost at once: `Enqueue`
+is non-blocking and **drops** when the channel is full
+(`internal/memory/worker.go:55-64`, buffer = `max_pending_observations`,
+default 100). `Start` drains with a **single goroutine**
+(`internal/memory/worker.go:67-76`), so compressions are serial — one child
+process at a time — and the orchestrator pool it competes for is
+`DefaultPoolSize = 3` (`internal/subagent/orchestrator.go:26`), **shared with
+user-facing subagents**. Shutdown gives the drain 5 seconds
+(`internal/cli/cli.go:975-979`); anything still queued is discarded. There are
+no retries — `compress.go:46` calls `Spawn`, not `SpawnWithRetry`.
 
 **This site is already scheduled for repair.** `specs/memory-fixes` R4 requires
-that compression "does not spawn a `pi` child process per tool call" and moves
-it in-process against the resolved `smol` role. That change removes the
-per-call process boot and its system prompt. Whatever a batch API could save
-here, it saves on the *residue* after R4, not on today's shape.
+that compression "does not spawn a `pi` child process per tool call", moves it
+in-process against the resolved `smol` role, and requires that "if no `smol`
+role is configured, the fallback must be logged once per session, **not
+silently billed at frontier prices**". That last clause is exactly the defect
+above, and R4 was written before it was traced to `ResolveRole`.
+
+Whatever a batch API could save here, it saves on the *residue* after R4 — and
+R4 is worth roughly 40× more than the batching (`design.md` § D1).
 
 **And today it runs zero times** — see `research/measurements.md` § M7. One
 observation exists in the database, written during the memory-fixes work itself.
@@ -70,7 +133,14 @@ candidate. It is a batch candidate for code that would have to be written first.
 ### C3 — Palace KG extraction makes no LLM call at all
 
 `internal/palace/tool_kg_extract.go` was listed as a batch candidate. It is not
-one: it contains no model invocation. Triple extraction is pure heuristics —
+one, and the file says so itself (`internal/palace/tool_kg_extract.go:25-30`):
+
+> "The tool is heuristic: **it does not call an LLM. That is deliberate** — the
+> extraction runs in the hot path of tool use and would otherwise add an extra
+> model call per observation. The agent already has a model; it can reject bad
+> candidates."
+
+Triple extraction is pure heuristics —
 `extractTriples` (line 178) matches Go-style function declarations with regexes,
 `emitImport` (line 114) parses import paths, `isStdlibImport` (line 340) and
 `isCommonWord` (line 375) filter with static lists.

--- a/specs/batch-api-optimization/research/measurements.md
+++ b/specs/batch-api-optimization/research/measurements.md
@@ -1,0 +1,235 @@
+# Measurements
+
+Everything below was measured on 2026-08-14 from `$HOME/.pi-go/sessions/*/events.jsonl`,
+the ADK event stream pi-go already writes. Reproduction scripts are inline so the
+numbers can be re-derived rather than trusted.
+
+## Sample
+
+The 400 most recently modified session directories. 365 have a non-empty
+`events.jsonl`; 125 contain at least one model response carrying
+`UsageMetadata`. Model-response timestamps in the sample fall entirely on
+**2026-08-10 and 2026-08-11** — a two-day window.
+
+```python
+# For each event with UsageMetadata (one per model request), accumulate
+# prompt_token_count / candidates_token_count / cached_content_token_count,
+# and count function_call parts in Content.parts.
+```
+
+| Quantity                                  | Measured      |
+|-------------------------------------------|---------------|
+| Model requests (events with UsageMetadata)| 4,016         |
+| Prompt tokens                             | 310,118,987   |
+| Output tokens                             | 1,895,967     |
+| Cached prompt tokens                      | 84,478,023    |
+| Prompt : output ratio                     | **163.6 : 1** |
+| Prompt tokens per request (mean)          | **77,220**    |
+| Function calls issued                     | 5,248         |
+| Function calls per model response (mean)  | **1.307**     |
+
+Requests per session: median 15, mean 32.1, p90 86, max 204.
+
+### M1 — Input dominates, and it is not the preamble
+
+The 163:1 prompt-to-output ratio confirms the framing this spec started from:
+output tokens are noise. What the sample *contradicts* is the assumption that
+the total is the fixed preamble times the request count.
+
+Median prompt size by request index within a session:
+
+| Request # | n   | Median prompt tokens | Mean     |
+|-----------|-----|----------------------|----------|
+| 1         | 125 | 9,131                | 11,094   |
+| 2         | 123 | 14,318               | 16,002   |
+| 3         | 101 | 17,244               | 22,802   |
+| 5         | 93  | 24,065               | 30,409   |
+| 10        | 73  | 38,341               | 47,572   |
+| 20        | 51  | 49,081               | 56,472   |
+| 40        | 34  | 66,025               | 73,388   |
+| 60        | 20  | 81,481               | 103,476  |
+| 80        | 15  | 95,441               | 121,148  |
+| 100       | 11  | 151,357              | 144,470  |
+
+Request #1's prompt — system prompt, tool declarations *and* the first user
+message — is 9,131 tokens. That is an upper bound on the fixed preamble. Across
+4,016 requests the preamble therefore accounts for at most
+`9,131 × 4,016 = 36.7M` of 310.1M prompt tokens: **≤ 11.8%**.
+
+The other ~88% is re-sent conversation. By request #100 the fixed preamble is
+6% of a 151k-token prompt; the rest is accumulated assistant turns and tool
+results being shipped again.
+
+**Consequence.** Shrinking the preamble (the tool-gating work in PR #160) has a
+hard ceiling of ~12% and falls off as sessions get longer. Removing *requests*
+attacks the dominant term — and does so superlinearly.
+
+### M2 — Why removing a request is worth more than it looks
+
+Let `C_k` be the context size at request `k`, `P` the fixed preamble, and `d`
+the tokens each step appends (assistant message + tool result):
+
+```
+C_k    = P + (k-1)·d
+Total  = Σ C_k = N·P + d·N(N-1)/2
+```
+
+Merge `m` tool calls into each request. The number of requests becomes `N/m`;
+each step now appends `m·d` because the same tool results still land in the
+transcript:
+
+```
+Total' = (N/m)·P + m·d·(N/m)((N/m)-1)/2  ≈  (N·P + d·N²/2) / m
+```
+
+**Both terms divide by `m`.** Issuing two tool calls per request instead of one
+roughly halves total prompt spend for the same work. This is the whole economic
+case for direction 2, and it is why it outranks everything else in this spec.
+
+The empirical growth curve in M1 is consistent with this: prompt size per
+request grows 16.6× from request 1 to request 100, so total spend is dominated
+by the quadratic term, not the linear one.
+
+### M3 — Current tool-calls-per-response, and the headroom
+
+Distribution of function calls per model response (n = 4,016):
+
+| Calls in response | Responses | Share  |
+|-------------------|-----------|--------|
+| 0 (final text)    | 122       | 3.0%   |
+| 1                 | 2,863     | 71.3%  |
+| 2                 | 828       | 20.6%  |
+| 3                 | 111       | 2.8%   |
+| 4                 | 68        | 1.7%   |
+| 5                 | 20        | 0.5%   |
+| 6                 | 4         | 0.1%   |
+
+Mean 1.307. **Multi-call responses already happen** — 25.7% of responses carry
+two or more — so nothing in the stack forbids them. The most common multi-call
+shapes are `('bash',)` ×565, `('read',)` ×132, `('bash','read')` ×93,
+`('read','ripgrep')` ×57. The model batches when it feels like it.
+
+Headroom, measured directly: collapse every maximal run of *consecutive
+single-read-only-call responses* into one request and count the responses that
+disappear.
+
+| Run length | Runs |
+|------------|------|
+| 1          | 404  |
+| 2          | 106  |
+| 3          | 48   |
+| 4          | 23   |
+| 5          | 15   |
+| 6–12       | 45   |
+| 13–57      | 13   |
+
+Removable responses: **982 of 4,016 = 24.5%**.
+
+This is an **upper bound**, not a forecast. It assumes every call in a run is
+independent, and many are not — a `read` whose path came from the preceding
+`ripgrep` cannot move earlier. Treat 24.5% as the ceiling and anything above
+~10% realised as a good outcome.
+
+### M4 — Tool call mix
+
+| Tool          | Calls |
+|---------------|-------|
+| bash          | 2,691 |
+| read          | 904   |
+| bash_output   | 818   |
+| edit          | 252   |
+| ripgrep       | 246   |
+| find          | 55    |
+| subagent      | 51    |
+| ls            | 47    |
+| git-file-diff | 42    |
+| tree          | 32    |
+| git-overview  | 29    |
+| bash_kill     | 28    |
+| write         | 26    |
+| (MCP + rest)  | <30   |
+
+`bash` + `read` + `ripgrep` + `find` + `ls` + `tree` = 3,975 of 5,248 = **75.7%**
+of all calls, and all six are read-only and order-independent in the common
+case. That is the batchable population.
+
+### M5 — The poll storm, and what it cost (already fixed)
+
+799 of 4,016 responses — **19.9%** — contained nothing but `bash_output` calls.
+They consumed **61,072,982 prompt tokens, 19.7% of the sample's entire prompt
+spend**, to retrieve the incremental output of a background shell command.
+
+Of those 799, **504 were consecutive repeat polls** of the same handle. The
+worst single sessions contain runs of 88 and 91 back-to-back poll-only requests.
+
+**This is already fixed on `main`.** Commit `ffe337a` renamed the tool to
+`bash_wait`, made it block for up to 60 s (`maxBashWait`,
+`internal/tools/bash.go:114`), and rewrote its description to say so:
+
+> "Wait once with a generous `wait_ms` rather than calling this in a loop —
+> each call is a round trip, and an empty result means nothing new since the
+> last one, not that the command is stuck."
+> — `internal/tools/bash.go:187`
+
+Every poll in the sample is named `bash_output`; `bash_wait` does not appear,
+and no session after 2026-08-11 issues a poll at all. The measurement is
+therefore a **valuation of a fix that has already landed**, not an outstanding
+opportunity. It is recorded here because it is the cleanest available proof of
+M2's thesis: 800 round trips that added almost no information to the transcript
+still cost a fifth of the bill, purely because each one re-sent everything.
+
+Per day by tool name, across all sessions:
+
+| Day        | bash_output calls |
+|------------|-------------------|
+| 2026-08-08 | 380               |
+| 2026-08-09 | 377               |
+| 2026-08-10 | 806               |
+| 2026-08-11 | 155               |
+| after      | 0                 |
+
+### M6 — What the sample actually costs
+
+The configured default role is `gpt-5.6-luna` on the `openai` provider
+(`$HOME/.pi-go/config.json`). List price: **$0.20 / $0.02 cached / $1.20** per
+MTok ([OpenAI pricing](https://developers.openai.com/api/docs/pricing),
+retrieved 2026-08-14).
+
+| Component                        | Tokens        | Cost    |
+|----------------------------------|---------------|---------|
+| Uncached input                   | 225,640,964   | $45.13  |
+| Cached input                     | 84,478,023    | $1.69   |
+| Output                           | 1,895,967     | $2.28   |
+| **Total (2-day window)**         |               | **$49.10** |
+
+**~$24.55/day, of which 95.4% is input tokens.**
+
+The same traffic on Claude Opus 5 ($5 / $0.50 cached / $25 per MTok) would be
+**$1,217.84 for the two days, ~$609/day**. Every payoff figure in this spec
+therefore has a 25× swing depending on which model the default role names. The
+ranking between opportunities does not change; the threshold for "worth the
+engineering" does.
+
+Cache read share of prompt tokens: 84.5M / 310.1M = **27.2%** overall, but
+39% on 2026-08-10 and 10% on 2026-08-11. Caching is working and is highly
+variable.
+
+### M7 — The memory compressor issues zero calls today
+
+```
+$ sqlite3 ~/.pi-go/memory/claude-mem.db \
+    "select 'sessions',count(*) from sessions union all
+     select 'observations',count(*) from observations union all
+     select 'summaries',count(*) from session_summaries;"
+sessions|6278
+observations|1
+summaries|0
+```
+
+One observation, written 2026-08-13T21:08:50Z — during the `specs/memory-fixes`
+work itself. The compressor has never run in production because the after-tool
+callback chain that feeds it is dead (`specs/memory-fixes/rough-idea.md`).
+
+Any batch-API saving on compression is therefore a saving on **hypothetical
+future traffic**, gated behind `specs/memory-fixes` landing first. This is the
+single most important caveat on direction 1.

--- a/specs/batch-api-optimization/research/providers.md
+++ b/specs/batch-api-optimization/research/providers.md
@@ -1,0 +1,117 @@
+# Provider batch APIs — what they actually offer
+
+All figures retrieved 2026-08-14 from primary vendor documentation. Secondary
+sources (blog posts, pricing aggregators) disagreed with the vendor docs in two
+places and were discarded; both disagreements are recorded below.
+
+## Anthropic — Message Batches API
+
+Source: <https://platform.claude.com/docs/en/build-with-claude/batch-processing>
+
+| Property        | Value |
+|-----------------|-------|
+| Discount        | "All usage is charged at 50% of the standard API prices." |
+| Turnaround      | "most batches completing within 1 hour"; results readable when all requests finish **or after 24 hours, whichever comes first** |
+| Expiry          | "Batches expire if processing does not complete within 24 hours." Expired requests are **not billed**. |
+| Size limit      | 100,000 requests **or** 256 MB, whichever comes first |
+| Result retention| 29 days from creation |
+| Streaming       | **Not supported** — `stream: true` is a validation error |
+| Tool use        | Supported, including server tools |
+| Prompt caching  | Supported. Docs recommend the **1-hour cache duration** because batches can exceed the 5-minute default TTL. |
+| `max_tokens: 0` | Rejected (cache pre-warming does not work inside a batch) |
+| Also rejected   | `speed` (Fast mode), `store`/`previous_thread_event_id` (Threads), `cache_hint`/`context_hint` |
+
+Batch prices relevant to pi-go's roles:
+
+| Model          | Batch input  | Batch output  |
+|----------------|--------------|---------------|
+| Claude Opus 5  | $2.50 / MTok | $12.50 / MTok |
+| Claude Sonnet 5| $1.00 / MTok | $5.00 / MTok  |
+| Claude Haiku 4.5 | $0.50 / MTok | $2.50 / MTok |
+
+Go SDK: `github.com/anthropics/anthropic-sdk-go v1.57.0` (already in `go.mod`)
+ships `messagebatch.go` with `MessageBatchService.New/Get/List/Cancel/Delete`
+and `ResultsStreaming`. **No new dependency is required.**
+
+## OpenAI — Batch API
+
+Source: <https://developers.openai.com/api/docs/guides/batch>
+
+| Property         | Value |
+|------------------|-------|
+| Discount         | "50% cost discount compared to synchronous APIs" |
+| Completion window| `24h` is the **only** option |
+| Size limit       | 50,000 requests per batch; input file ≤ 200 MB |
+| Result retention | 30 days |
+| Queue limit      | Per-model cap on prompt tokens queued for batch, shown on the Platform Settings page — **account-specific, not documented as a fixed number** |
+| Endpoints        | Chat Completions, Responses, Embeddings, Completions, Moderations, Image Generation/Edits, Video Generation |
+
+Prices for the configured default role
+(<https://developers.openai.com/api/docs/pricing>):
+
+| Model         | Std input | Std cached | Std output | Batch input | Batch cached | Batch output |
+|---------------|-----------|------------|------------|-------------|--------------|--------------|
+| gpt-5.6-luna  | $0.20     | $0.02      | $1.20      | $0.10       | $0.01        | $0.60        |
+| gpt-5.6-terra | $2.00     | $0.20      | $12.00     | $1.00       | $0.10        | $6.00        |
+| gpt-5.6-sol   | $5.00     | $0.50      | $30.00     | $2.50       | $0.25        | $15.00       |
+
+Go SDK: `github.com/openai/openai-go/v3 v3.50.0` ships `batch.go` with
+`BatchService.New/Get/List/Cancel`. **Already vendored.**
+
+Note the interaction that undercuts the batch case: luna's cached-input price is
+already 90% below its uncached price. Batching a cached request saves $0.01/MTok.
+
+## Google Gemini — Batch API
+
+Source: <https://ai.google.dev/gemini-api/docs/batch-api>
+
+| Property         | Value |
+|------------------|-------|
+| Discount         | "50% of the standard interactive API cost for the equivalent model" |
+| Turnaround       | Target 24 h; jobs expire after 48 h |
+| Size limit       | Inline requests ≤ 20 MB; file-based input ≤ 2 GB |
+| Result retention | 6 weeks |
+
+**Correction to the vendor docs:** the Gemini batch page shows Python,
+JavaScript and REST examples only and does not mention Go. It is nonetheless
+supported — `google.golang.org/genai v1.66.0` (already in `go.mod`) ships
+`batches.go` with `Batches.Get/Cancel/List/Delete/All` and internal
+`create`/`createEmbeddings`. The docs are incomplete, not the SDK.
+
+## xAI — Batch API
+
+Source: <https://docs.x.ai/developers/advanced-api-usage/batch-api>
+
+| Property          | Value |
+|-------------------|-------|
+| Discount          | The batch page does **not** state a percentage; it defers to the pricing page |
+| Turnaround        | "Most batch requests complete within 24 hours… Completion time is best effort and not guaranteed." |
+| Model exclusions  | **"`grok-4.6` and `grok-4.5` are not currently supported for Batch API requests and will be rejected."** |
+| Rate limits       | 2 batch creations/sec/team; 1000 add-batch-request calls per 30 s |
+| Size limits       | 25 MB per request payload; file uploads ≤ 200 MB, ≤ 50,000 requests |
+
+**Discarded secondary sources.** Web search returned three mutually
+contradictory claims about the xAI discount — "20% off, only on Grok 4.3 and the
+Grok 4.20 variants", "all token costs cut in half", and "20–50%". None is
+attributable to xAI. The vendor's own batch page states no percentage. This spec
+therefore treats the xAI discount as **unknown** rather than picking a number,
+and the flagship models pi-go would actually use are excluded from batch anyway.
+
+## Ollama
+
+No batch API. Local inference; the marginal token cost is electricity. Batch
+economics do not apply.
+
+## Cross-provider summary
+
+| Provider  | Batch discount | Max latency | Models pi-go uses eligible? | Go SDK vendored |
+|-----------|----------------|-------------|-----------------------------|-----------------|
+| Anthropic | 50%            | 24 h        | Yes (all)                   | Yes             |
+| OpenAI    | 50%            | 24 h        | Yes (all)                   | Yes             |
+| Gemini    | 50%            | 24 h (48 h expiry) | Yes                  | Yes (undocumented) |
+| xAI       | Unstated       | 24 h best-effort | **No** — 4.5/4.6 rejected | n/a — no batch client in `xai.go` |
+| Ollama    | n/a            | n/a         | n/a                         | n/a             |
+
+Three of five providers offer a clean 50% at a 24-hour worst case, and the SDK
+support is already on disk. **The blocker is never the API. It is finding work
+in pi-go that can tolerate a 24-hour result.**

--- a/specs/batch-api-optimization/rough-idea.md
+++ b/specs/batch-api-optimization/rough-idea.md
@@ -37,9 +37,17 @@ offer a clean 50% discount at a 24-hour worst case, and all three Go SDKs are
 already in `go.mod`. None of that matters, because pi-go has almost nothing to
 put in a batch. Of eight model call sites, five block a user who is watching,
 one (`SummarizeSession`) has no production caller, one (palace KG extraction)
-turns out to make no LLM call at all, and the last — the memory compressor —
-has issued exactly **one** request in the database's lifetime, because the
-callback chain that feeds it is dead.
+turns out to make no LLM call at all *by explicit design*, and the last — the
+memory compressor — has issued exactly **one** request in the database's
+lifetime, because the callback chain that feeds it is dead.
+
+Costing that one candidate turned up three defects that matter more than
+batching ever could: the compressor's `tools: []` declaration is inert, its
+`role: smol` silently falls back to the frontier model, and the config key that
+appears to control the role is read by nothing. On shipped defaults a repaired
+compressor would run `gpt-5.6-sol` once per tool call, in a child process
+carrying the full toolset. Fixing that is worth ~40× what a Batch API would
+save on top of it — and `specs/memory-fixes` R4 already covers it.
 
 **Batching tool calls is where the money is, and it needs no new machinery.**
 ADK already dispatches multiple function calls from one response concurrently.

--- a/specs/batch-api-optimization/rough-idea.md
+++ b/specs/batch-api-optimization/rough-idea.md
@@ -1,0 +1,95 @@
+# Rough Idea — Cut LLM cost by removing round trips, not by batching APIs
+
+## Source
+
+A cost analysis of pi-go performed 2026-08-13/14, starting from provider usage
+metadata across 2,446 sessions and re-measured here against 400 session logs in
+`$HOME/.pi-go/sessions/`.
+
+The question asked was: where can pi-go reduce LLM cost through batching —
+provider Batch APIs, or batching tool calls?
+
+The two halves of that question have opposite answers.
+
+## The observation that started it
+
+Across a two-day window, 4,016 model requests consumed **310,118,987 prompt
+tokens and 1,895,967 output tokens** — a ratio of 163 to 1. Output is noise.
+The entire bill is the input side.
+
+The reflex explanation is "a big system prompt, re-sent every request". The data
+says otherwise. Request #1 of a session — system prompt, tool declarations and
+the first user message together — has a median size of 9,131 tokens. Request
+#100 has a median of **151,357**. The preamble accounts for at most 11.8% of
+total prompt spend; the rest is the conversation being re-shipped, growing with
+every step.
+
+That changes what is worth fixing. Shrinking the preamble has a ceiling around
+12%. Removing a *request* removes a whole copy of everything accumulated so far,
+and because the context grows with each step, halving the request count roughly
+halves the total — both the linear and the quadratic term divide by the same
+factor.
+
+## What we found
+
+**Provider Batch APIs do not apply to pi-go.** Anthropic, OpenAI and Gemini all
+offer a clean 50% discount at a 24-hour worst case, and all three Go SDKs are
+already in `go.mod`. None of that matters, because pi-go has almost nothing to
+put in a batch. Of eight model call sites, five block a user who is watching,
+one (`SummarizeSession`) has no production caller, one (palace KG extraction)
+turns out to make no LLM call at all, and the last — the memory compressor —
+has issued exactly **one** request in the database's lifetime, because the
+callback chain that feeds it is dead.
+
+**Batching tool calls is where the money is, and it needs no new machinery.**
+ADK already dispatches multiple function calls from one response concurrently.
+The providers already return them. 25.7% of responses already carry more than
+one call. The mean is 1.307. Collapsing every run of consecutive
+single-read-only-call responses would remove **24.5% of all requests**.
+
+The gap between 1.307 and what the code permits is not a capability gap. It is
+an instruction gap: `internal/agent/agent.go:185` tells the model it *can*
+batch, in a paragraph that gives no reason, 44 lines before a section that tells
+it to **prefer** parallel subagents.
+
+## The proof, from a bug that is already fixed
+
+799 of 4,016 responses — 19.9% — did nothing but poll a background shell command
+with `bash_output`. They cost **61 million prompt tokens, 19.7% of the window's
+entire spend**, and 504 of them were consecutive repeat polls of the same
+handle; one session contains a run of 91.
+
+Commit `ffe337a` already fixed this by making the tool block for up to 60
+seconds and renaming it `bash_wait`. No session after 2026-08-11 issues a poll.
+
+The measurement is worth keeping anyway, because it is the cleanest available
+demonstration of the thesis: 800 round trips that added almost nothing to the
+transcript still consumed a fifth of the bill, purely because each one re-sent
+everything that came before.
+
+## What this spec covers
+
+1. Make request count a first-class, measured quantity — calls per response and
+   requests per session, reported by `pi session-stats`.
+2. Rewrite the parallel-execution guidance so the model batches independent
+   read-only calls by default, and measure whether it worked.
+3. Guard the `bash_wait` fix with a regression test so the poll storm cannot
+   come back unnoticed.
+4. Record, with numbers, why provider Batch APIs are not worth building — and
+   the specific conditions that would change that answer.
+
+## Non-goals
+
+- **Building a Batch API client.** Section D1 of `design.md` shows the payoff is
+  $0.63–$2.96/day against a durable job-tracking subsystem. It is a "no", not a
+  "later, maybe".
+- **A `bash_batch` tool.** Rejected in `design.md` § D3: it would duplicate a
+  mechanism ADK already provides and would destroy per-call error attribution to
+  do it.
+- **Shrinking tool output.** Tool results are a small share of prompt spend and
+  the compactor already handles them.
+- **Prompt caching for Gemini and Ollama.** A real gap, unquantified here, and
+  a different mechanism — caching cuts price per token, not the number of tokens
+  sent. Its own spec.
+- **Auto-compaction's cache invalidation** (`internal/session/compaction.go:26`).
+  Noted, not scheduled.


### PR DESCRIPTION
Measured 4,016 model requests over a two-day window from the session logs:
310.1M prompt tokens against 1.9M output, a 163:1 ratio.

Two findings reframe the problem.

The fixed preamble is not the driver. Request #1 of a session has a median
prompt of 9,131 tokens; request #100 has 151,357. Preamble x request count
accounts for at most 11.8% of prompt spend. The rest is the conversation
being re-sent, so removing a request removes a whole copy of everything
accumulated so far — both the linear and quadratic terms divide by the
number of calls merged per response.

Provider Batch APIs do not apply. Of eight model call sites, five block a
user who is watching, SummarizeSession has no production caller, palace KG
extraction makes no LLM call at all, and the memory compressor has produced
one observation in the database's lifetime. Batching it post-memory-fixes
would save $0.63-$2.96/day against a durable job store and 24h latency —
less than memory-fixes R4 already saves by removing its child process.

Batching tool calls needs no new machinery: ADK already dispatches multiple
function calls concurrently, 25.7% of responses already carry more than one,
and the mean is 1.307. The gap is that agent.go:185 says the model "can"
batch while agent.go:235 says it should "prefer" parallel subagents.

Includes a valuation of the already-landed bash_wait fix: 799 poll-only
responses cost 19.7% of all prompt tokens in the window.

Signed-off-by: dimetron <dimetron@me.com>
