### PR TITLE
fix(retry): retry Gemini per-minute token limits on their named window

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -128,6 +128,12 @@ func IsTerminal(err error) bool {
 	if err == nil {
 		return false
 	}
+	// A server-supplied retry window means the failure clears when the window
+	// reopens, so it is not terminal even when the prose otherwise reads like
+	// quota exhaustion (see IsTransient for why that happens).
+	if _, ok := ServerDelay(err); ok {
+		return false
+	}
 	return containsAny(strings.ToLower(err.Error()), terminalPatterns)
 }
 
@@ -137,6 +143,18 @@ func IsTransient(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
+
+	// A server-supplied retry window wins over everything else. Providers only
+	// name a window ("retry in 59s", "retryDelay:59s") for failures that clear
+	// — per-minute token limits, throttling — never for the quota/plan
+	// exhaustion that arrives with terminal prose. This beats the terminal
+	// patterns because Gemini's per-minute token limit reuses that prose
+	// verbatim ("You exceeded your current quota", "quota exceeded", "check
+	// your plan and billing") while still telling us exactly when its window
+	// reopens.
+	if _, ok := ServerDelay(err); ok {
+		return true
+	}
 
 	// Terminal wins on a tie: a quota 429 matches both lists.
 	if containsAny(msg, terminalPatterns) {
@@ -169,20 +187,23 @@ func containsAny(msg string, patterns []string) bool {
 }
 
 // durationHintRe matches a Go-parseable duration after a retry hint, covering
-// the "9.422s" and "6m0.339s" forms OpenAI uses.
+// the "9.422s" and "6m0.339s" forms OpenAI uses and the "59.440629838s" form
+// Gemini uses.
 var durationHintRe = regexp.MustCompile(
-	`(?i)(?:try again in|retry[- ]after:?)\s+((?:[0-9]+h)?(?:[0-9]+m)?[0-9]+(?:\.[0-9]+)?(?:ms|s|m|h))`)
+	`(?i)(?:try again in|retry[- ]after:?|retry in|retrydelay:?)\s*((?:[0-9]+h)?(?:[0-9]+m)?[0-9]+(?:\.[0-9]+)?(?:ms|s|m|h))`)
 
 // numberHintRe matches a bare number followed by an optional spelled-out unit,
 // covering "retry after 30 seconds" and a raw Retry-After value.
 var numberHintRe = regexp.MustCompile(
-	`(?i)(?:try again in|retry[- ]after:?)\s+([0-9]+(?:\.[0-9]+)?)\s*(milliseconds?|ms|seconds?|secs?|minutes?|mins?)?`)
+	`(?i)(?:try again in|retry[- ]after:?|retry in|retrydelay:?)\s*([0-9]+(?:\.[0-9]+)?)\s*(milliseconds?|ms|seconds?|secs?|minutes?|mins?)?`)
 
 // ServerDelay extracts the wait the provider asked for, if it named one.
 //
 // A rate-limit body usually carries the exact figure ("Please try again in
-// 9.422s"), and honoring it is the difference between one well-timed retry and
-// a backoff schedule that keeps landing inside the same exhausted window.
+// 9.422s" from OpenAI, "Please retry in 59.440629838s" or a
+// "retryDelay:59s" detail from Gemini), and honoring it is the difference
+// between one well-timed retry and a backoff schedule that keeps landing
+// inside the same exhausted window.
 func ServerDelay(err error) (time.Duration, bool) {
 	if err == nil {
 		return 0, false

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -31,6 +31,13 @@ func TestIsTransient(t *testing.T) {
 		{"rate limit prose", errors.New("rate limit exceeded"), true},
 		{"rate_limit code", errors.New("rate_limit_error"), true},
 
+		// Retryable: Gemini's per-minute token limit. The prose reuses the
+		// quota-exhaustion wording that the terminal list matches, but it also
+		// names its reopening window ("Please retry in 59.44s", retryDelay:59s)
+		// — a window only a clearing failure carries, so it must beat the
+		// terminal prose.
+		{"gemini per-minute token limit", errors.New("Error 429, Message: You exceeded your current quota, please check your plan and billing details. For more information on this error, head to:    https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit.    * Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_paid_tier_input_token_count, limit: 2000000, model: gemini-3.7-flash    Please retry in 59.440629838s., Status: RESOURCE_EXHAUSTED, Details: [map[@type:type.googleapis.com/google.rpc.Help links:[map[description:Learn more about Gemini API quotas    url:https://ai.google.dev/gemini-api/docs/rate-limits]]] map[@type:type.googleapis.com/google.rpc.QuotaFailure violations:[map[quotaDimensions:map[location:global model:gemini-3.7-flash]    quotaId:GenerateContentPaidTierInputTokensPerModelPerMinute quotaMetric:generativelanguage.googleapis.com/generate_content_paid_tier_input_token_count quotaValue:2000000]]]    map[@type:type.googleapis.com/google.rpc.RetryInfo retryDelay:59s]]"), true},
+
 		// Retryable: upstream faults.
 		{"500", errors.New("500 Internal Server Error"), true},
 		{"502", errors.New("502 Bad Gateway"), true},
@@ -110,6 +117,33 @@ func TestIsTransientTerminalBeatsInterface(t *testing.T) {
 	}
 }
 
+// A failure that names a retry window must be transient even when its prose
+// also matches the terminal quota patterns: a provider only tells you when its
+// window reopens if the failure clears when that window closes. This is what
+// Gemini's per-minute token limit does — it carries the plan/billing copy and
+// a "retry in 59.4s" figure at once.
+func TestIsTransientServerWindowBeatsTerminalProse(t *testing.T) {
+	err := providerErr("429 Too Many Requests: you have exceeded your current quota, please check your plan and billing details. Please retry in 59.440629838s.")
+	if !IsTransient(err) {
+		t.Error("a named retry window should make a quota-looking failure transient")
+	}
+	if IsTerminal(err) {
+		t.Error("a named retry window should clear the terminal classification")
+	}
+}
+
+// The terminal list's own quota cases carry no window, so they must stay
+// terminal even with the ServerDelay override in place.
+func TestIsTransientQuotaWithoutWindowStaysTerminal(t *testing.T) {
+	err := providerErr("429 Too Many Requests: you have reached your weekly usage limit, upgrade for higher limits: https://ollama.com/upgrade")
+	if IsTransient(err) {
+		t.Error("quota exhaustion without a retry window should be terminal")
+	}
+	if !IsTerminal(err) {
+		t.Error("quota exhaustion without a retry window should be terminal")
+	}
+}
+
 func TestServerDelay(t *testing.T) {
 	tests := []struct {
 		name string
@@ -124,6 +158,8 @@ func TestServerDelay(t *testing.T) {
 		{"spelled out", "retry after 30 seconds", 30 * time.Second, true},
 		{"spelled minutes", "Retry after 2 minutes", 2 * time.Minute, true},
 		{"bare number is seconds", "Retry-After: 30", 30 * time.Second, true},
+		{"gemini retry in", "Please retry in 59.440629838s.", 59*time.Second + 440629838*time.Nanosecond, true},
+		{"gemini retrydelay detail", "retryDelay:59s", 59 * time.Second, true},
 		{"no hint", "429 Too Many Requests", 0, false},
 		{"empty", "", 0, false},
 	}
@@ -172,6 +208,18 @@ func TestDelayPrefersServerHint(t *testing.T) {
 
 	if got := Delay(cfg, 0, err); got != 9422*time.Millisecond {
 		t.Errorf("Delay = %v, want the server's 9.422s", got)
+	}
+}
+
+// Gemini's retryDelay detail must feed the delay just like any other hint, so
+// the retry lands inside the window the server named rather than a backoff
+// schedule that keeps hitting the same exhausted per-minute window.
+func TestDelayPrefersGeminiServerHint(t *testing.T) {
+	cfg := Config{MaxRetries: 5, InitialDelay: time.Second, MaxDelay: time.Minute}
+	err := providerErr("Please retry in 59.440629838s.")
+
+	if got := Delay(cfg, 0, err); got != 59*time.Second+440629838*time.Nanosecond {
+		t.Errorf("Delay = %v, want the server's 59.44s", got)
 	}
 }
 


### PR DESCRIPTION
Gemini's per-minute token limit (GenerateContentPaidTierInputTokensPerModelPerMinute) arrives as a 429 whose prose reuses the quota-exhaustion copy the terminal list matches ("You exceeded your current quota", "quota exceeded", "check your plan and billing"), so IsTransient classified it terminal and the agent never retried — even though the server explicitly names its reopening window ("Please retry in 59.44s.", retryDelay:59s).

A server-supplied retry window only ever appears on failures that clear when the window closes; genuine quota/plan exhaustion never names one. So ServerDelay now parses Gemini's "retry in N" and "retryDelay:N" forms, and a parsed window wins over the terminal prose in both IsTransient and IsTerminal. Quota errors without a window stay terminal.