### PR TITLE
feat: show per-turn token usage summary in the TUI

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -404,6 +404,14 @@ type agentToolResultMsg struct {
 }
 type agentDoneMsg struct{ err error }
 
+// agentUsageMsg carries the per-turn token usage block to the TUI at the end of
+// a successful turn. It arrives after the reply text and before the channel
+// close that synthesizes agentDoneMsg, so the summary renders directly under
+// the answer.
+type agentUsageMsg struct {
+	usage *genai.GenerateContentResponseUsageMetadata
+}
+
 // agentWarningMsg carries a non-fatal problem with the turn into the
 // transcript. The turn keeps running; the user just needs to know the reply
 // they are reading is not the whole reply.
@@ -425,8 +433,70 @@ func (agentThinkingMsg) agentMsg()   {}
 func (agentToolCallMsg) agentMsg()   {}
 func (agentToolResultMsg) agentMsg() {}
 func (agentDoneMsg) agentMsg()       {}
+func (agentUsageMsg) agentMsg()      {}
 func (agentWarningMsg) agentMsg()    {}
 func (agentSubEventMsg) agentMsg()   {}
+
+// addUsage folds one LLM response's usage block into a running per-turn total.
+// It returns dst unchanged when src is nil, so callers need no nil check. A
+// turn is one or more model calls (tool loops, stuck recoveries), and only
+// final responses carry non-nil usage, so summing yields the turn's true token
+// spend rather than the last response's.
+func addUsage(dst, src *genai.GenerateContentResponseUsageMetadata) *genai.GenerateContentResponseUsageMetadata {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		cp := *src
+		return &cp
+	}
+	dst.PromptTokenCount += src.PromptTokenCount
+	dst.CandidatesTokenCount += src.CandidatesTokenCount
+	dst.CachedContentTokenCount += src.CachedContentTokenCount
+	dst.ThoughtsTokenCount += src.ThoughtsTokenCount
+	dst.TotalTokenCount += src.TotalTokenCount
+	return dst
+}
+
+// formatTurnUsage renders a per-turn token summary as one dim line: input,
+// cached reads, output, reasoning, and total. It returns "" when u is nil or
+// all-zero, so a provider that reports no usage shows no line rather than
+// "0 in · 0 out".
+func formatTurnUsage(u *genai.GenerateContentResponseUsageMetadata) string {
+	if u == nil {
+		return ""
+	}
+	in := int64(u.PromptTokenCount)
+	out := int64(u.CandidatesTokenCount)
+	cache := int64(u.CachedContentTokenCount)
+	total := int64(u.TotalTokenCount)
+	if total <= 0 {
+		total = in + out
+	}
+	if in == 0 && out == 0 && cache == 0 && total == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(formatTokenCount(in))
+	b.WriteString(" in")
+	if cache > 0 {
+		b.WriteString(" (")
+		b.WriteString(formatTokenCount(cache))
+		b.WriteString(" cached)")
+	}
+	b.WriteString(" · ")
+	b.WriteString(formatTokenCount(out))
+	b.WriteString(" out")
+	if u.ThoughtsTokenCount > 0 {
+		b.WriteString(" · ")
+		b.WriteString(formatTokenCount(int64(u.ThoughtsTokenCount)))
+		b.WriteString(" reasoning")
+	}
+	b.WriteString(" · ")
+	b.WriteString(formatTokenCount(total))
+	b.WriteString(" total")
+	return b.String()
+}
 
 // waitForAgent returns a Cmd that waits for the next message on the agent channel.
 func waitForAgent(ch chan agentMsg) tea.Cmd {
@@ -718,11 +788,16 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 	// away. The budget is small on purpose — repetition that survives being
 	// named is not going to be fixed by naming it again, and every attempt
 	// costs a full turn.
+	var turnUsage *genai.GenerateContentResponseUsageMetadata
 	for attempt := 0; ; attempt++ {
-		err := m.streamTurn(ctx, ch, prompt, run, groundedSeen, &truncated, log)
+		usage, err := m.streamTurn(ctx, ch, prompt, run, groundedSeen, &truncated, log)
+		turnUsage = addUsage(turnUsage, usage)
 
 		var stuck *stuckError
 		if !errors.As(err, &stuck) {
+			if err == nil && turnUsage != nil {
+				ch <- agentUsageMsg{usage: turnUsage}
+			}
 			if err != nil {
 				fail(err)
 			}
@@ -759,9 +834,10 @@ func (m *model) streamTurn(
 	groundedSeen map[string]bool,
 	truncated *bool,
 	log *logger.Logger,
-) error {
+) (*genai.GenerateContentResponseUsageMetadata, error) {
 	detector := &stuckDetector{}
 	var dedup agent.StreamDedup
+	var turnUsage *genai.GenerateContentResponseUsageMetadata
 
 	// Same retry wrapper the print and RPC front-ends use, so a run that dies
 	// before producing anything is replayed here too instead of ending the turn
@@ -772,11 +848,12 @@ func (m *model) streamTurn(
 		return run.agent.RunStreaming(ctx, run.sessionID, prompt)
 	}) {
 		if err != nil {
-			return err
+			return turnUsage, err
 		}
 		if ev == nil {
 			continue
 		}
+		turnUsage = addUsage(turnUsage, ev.UsageMetadata)
 		// Gemini search grounding runs server-side: it never produces a
 		// FunctionCall part, so without this the search is invisible — the
 		// model just answers with fresh facts and no sign it searched. The only
@@ -788,7 +865,7 @@ func (m *model) streamTurn(
 		// A provider failure is a content-less event, so it has to be caught
 		// before the guard below drops it. See agent.EventError.
 		if evErr := agent.EventError(ev); evErr != nil {
-			return evErr
+			return turnUsage, evErr
 		}
 
 		// A turn cut short at the output cap is otherwise indistinguishable
@@ -806,10 +883,10 @@ func (m *model) streamTurn(
 		}
 		dedup.BeginEvent(ev)
 		if abortErr := m.emitEventParts(ch, ev, &dedup, detector, log); abortErr != nil {
-			return abortErr
+			return turnUsage, abortErr
 		}
 	}
-	return nil
+	return turnUsage, nil
 }
 
 // emitEventParts forwards one event's parts to the TUI channel. It returns a
@@ -939,6 +1016,16 @@ func (m *model) handleAgentThinking(msg agentThinkingMsg) (tea.Model, tea.Cmd) {
 // handleAgentWarning processes an agentWarningMsg.
 func (m *model) handleAgentWarning(msg agentWarningMsg) (tea.Model, tea.Cmd) {
 	m.chatModel.AppendWarning(msg.text)
+	return m, waitForAgent(m.agentCh)
+}
+
+// handleAgentUsage appends the per-turn token summary to the transcript. A nil
+// or all-zero usage block renders nothing, so providers that omit usage are
+// indistinguishable from a turn that happened to report zero.
+func (m *model) handleAgentUsage(msg agentUsageMsg) (tea.Model, tea.Cmd) {
+	if s := formatTurnUsage(msg.usage); s != "" {
+		m.chatModel.AppendMeta(s)
+	}
 	return m, waitForAgent(m.agentCh)
 }
 

--- a/internal/tui/agent_usage_test.go
+++ b/internal/tui/agent_usage_test.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestAddUsage(t *testing.T) {
+	if got := addUsage(nil, nil); got != nil {
+		t.Fatalf("addUsage(nil, nil) = %v, want nil", got)
+	}
+
+	src := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        10,
+		CandidatesTokenCount:    5,
+		CachedContentTokenCount: 4,
+		ThoughtsTokenCount:      2,
+		TotalTokenCount:         15,
+	}
+	got := addUsage(nil, src)
+	if got == src {
+		t.Fatal("addUsage(nil, src) returned src itself; want a copy")
+	}
+	if !reflect.DeepEqual(got, src) {
+		t.Fatalf("addUsage(nil, src) = %+v, want %+v", got, src)
+	}
+	// Mutating the result must not touch src.
+	got.PromptTokenCount = 999
+	if src.PromptTokenCount != 10 {
+		t.Fatalf("mutating the copy changed src: PromptTokenCount = %d, want 10", src.PromptTokenCount)
+	}
+
+	// A nil src leaves dst untouched.
+	dst := &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 7}
+	if out := addUsage(dst, nil); out != dst || dst.PromptTokenCount != 7 {
+		t.Fatalf("addUsage(dst, nil) = %+v (dst %+v), want dst unchanged", out, dst)
+	}
+
+	// Summation across responses (tool loops / stuck recoveries).
+	a := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount: 100, CandidatesTokenCount: 50, CachedContentTokenCount: 30, TotalTokenCount: 150,
+	}
+	b := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount: 20, CandidatesTokenCount: 5, CachedContentTokenCount: 20, TotalTokenCount: 25,
+	}
+	sum := addUsage(a, b)
+	want := genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount: 120, CandidatesTokenCount: 55, CachedContentTokenCount: 50, TotalTokenCount: 175,
+	}
+	if !reflect.DeepEqual(sum, &want) {
+		t.Fatalf("addUsage(a, b) = %+v, want %+v", sum, want)
+	}
+}
+
+func TestFormatTurnUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		u    *genai.GenerateContentResponseUsageMetadata
+		want string
+	}{
+		{"nil", nil, ""},
+		{"all zero", &genai.GenerateContentResponseUsageMetadata{}, ""},
+		{
+			"in and out only",
+			&genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 100, CandidatesTokenCount: 50},
+			"100 in · 50 out · 150 total",
+		},
+		{
+			"with cache read",
+			&genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 100, CandidatesTokenCount: 50, CachedContentTokenCount: 30},
+			"100 in (30 cached) · 50 out · 150 total",
+		},
+		{
+			"with reasoning and explicit total",
+			&genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount: 2000, CandidatesTokenCount: 500, CachedContentTokenCount: 1000,
+				ThoughtsTokenCount: 75, TotalTokenCount: 2500,
+			},
+			"2.0k in (1.0k cached) · 500 out · 75 reasoning · 2.5k total",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatTurnUsage(tt.u); got != tt.want {
+				t.Fatalf("formatTurnUsage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChatModel_RenderMessages_MetaMessage(t *testing.T) {
+	cm := NewChatModel(nil)
+	cm.Messages = append(cm.Messages, message{
+		role:    "assistant",
+		content: "100 in · 50 out · 150 total",
+		isMeta:  true,
+	})
+
+	result := cm.RenderMessages(false)
+	if !strings.Contains(result, "100 in · 50 out · 150 total") {
+		t.Error("expected meta content in output")
+	}
+	if !strings.Contains(result, "Σ") {
+		t.Error("expected a Σ prefix to distinguish the meta line from the reply")
+	}
+	if strings.Contains(result, "◉") {
+		t.Error("did not expect a bullet prefix on a meta line")
+	}
+}
+
+func TestHandleAgentUsage_AppendsSummary(t *testing.T) {
+	m := &model{chatModel: NewChatModel(nil)}
+	m.handleAgentUsage(agentUsageMsg{usage: &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount: 100, CandidatesTokenCount: 50,
+	}})
+	if len(m.chatModel.Messages) != 1 {
+		t.Fatalf("expected 1 meta message, got %d", len(m.chatModel.Messages))
+	}
+	msg := m.chatModel.Messages[0]
+	if !msg.isMeta || msg.role != "assistant" {
+		t.Fatalf("expected a meta assistant message, got %+v", msg)
+	}
+	if msg.content != "100 in · 50 out · 150 total" {
+		t.Fatalf("unexpected summary content: %q", msg.content)
+	}
+
+	// A nil usage block appends nothing.
+	m2 := &model{chatModel: NewChatModel(nil)}
+	m2.handleAgentUsage(agentUsageMsg{})
+	if len(m2.chatModel.Messages) != 0 {
+		t.Fatalf("nil usage should not append a message, got %d", len(m2.chatModel.Messages))
+	}
+}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -101,6 +101,7 @@ type message struct {
 	content   string
 	isWarning bool // if true, render with warning style
 	isError   bool // if true, render with error style (takes precedence)
+	isMeta    bool // if true, render as a dim one-line note (no bullet)
 	// preRendered marks content that is already terminal output — it carries
 	// its own ANSI and must bypass glamour, which treats escape bytes as text
 	// and prints them. Used by /theme's palette preview.
@@ -233,6 +234,9 @@ func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlac
 	if m.pendingRefresh {
 		flags |= 1 << 6
 	}
+	if m.isMeta {
+		flags |= 1 << 7
+	}
 	return fnvByte(h, flags)
 }
 
@@ -308,6 +312,18 @@ func (c *ChatModel) AppendWarning(text string) {
 		role:      "assistant",
 		content:   text,
 		isWarning: true,
+	})
+	c.Scroll = 0
+}
+
+// AppendMeta adds a dim, single-line metadata note to the transcript (e.g. the
+// per-turn token summary). It is deliberately low-contrast: it must read as
+// chrome around the reply, not as content.
+func (c *ChatModel) AppendMeta(text string) {
+	c.Messages = append(c.Messages, message{
+		role:    "assistant",
+		content: text,
+		isMeta:  true,
 	})
 	c.Scroll = 0
 }
@@ -740,6 +756,12 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 					warnBullet := lipgloss.NewStyle().Foreground(p.Peach).Bold(true).Render("⚠ ")
 					msgBuf.WriteString(warnBullet)
 					msgBuf.WriteString(warnStyle.Render(content))
+				} else if msg.isMeta {
+					// A dim "Σ" prefix marks the line as a per-turn tally rather
+					// than the model's own words — the reply uses "◉", so the
+					// two must never be confusable.
+					metaStyle := lipgloss.NewStyle().Foreground(p.Dim)
+					msgBuf.WriteString(metaStyle.Render("Σ " + content))
 				} else if msg.preRendered {
 					msgBuf.WriteString(bullet)
 					msgBuf.WriteString(content)

--- a/internal/tui/minimap.go
+++ b/internal/tui/minimap.go
@@ -142,6 +142,9 @@ func kindOf(msg *message) blockKind {
 		if msg.isWarning {
 			return blockWarning
 		}
+		if msg.isMeta {
+			return blockNone
+		}
 		return blockAssistant
 	case "tool":
 		return toolBlockKind(msg.tool)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -778,6 +778,9 @@ func (m *model) updateAgentStream(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case agentWarningMsg:
 		model, cmd := m.handleAgentWarning(msg)
 		return model, cmd, true
+	case agentUsageMsg:
+		model, cmd := m.handleAgentUsage(msg)
+		return model, cmd, true
 	case systemNoticeMsg:
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role:    "assistant",


### PR DESCRIPTION
## What

After each successful turn, the TUI renders a dim `Σ` tally line under the reply:

    Σ 1.2k in (890 cached) · 567 out · 75 reasoning · 1.8k total

## Why

Token usage was already captured — providers normalize it into `genai.GenerateContentResponseUsageMetadata`, and it's persisted to `events.jsonl` and surfaced in `/context`, the daily guardrail, and eval metrics — but the interactive TUI discarded it per turn. This surfaces the actual per-turn spend (input / cache-read / output / reasoning / total) inline, where it's most useful.

## How

- `internal/tui/agent_loop.go` — `streamTurn` now returns accumulated usage; `addUsage` sums every model call in a turn (tool loops + stuck recoveries); `formatTurnUsage` builds the line. A new `agentUsageMsg` is emitted on clean finish, so the existing "clean finish = channel close" contract in `runAgentLoop` is untouched.
- `internal/tui/chat.go` — new `isMeta` message kind + `AppendMeta` + a dim, no-bullet render branch.
- `internal/tui/minimap.go` — meta lines classify as `blockNone`.
- `internal/tui/tui.go` — dispatch `agentUsageMsg`.

Providers that report no usage render nothing (nil/all-zero usage is skipped).

## Tests

`internal/tui/agent_usage_test.go` covers `formatTurnUsage`, `addUsage`, the meta render branch, and `handleAgentUsage` (incl. the nil-usage no-op).
