### PR TITLE
fix(tui): stop Windows startup hang in the terminal drain

### DIFF
--- a/internal/tui/drain_windows.go
+++ b/internal/tui/drain_windows.go
@@ -2,7 +2,27 @@
 
 package tui
 
-import "os"
+import (
+	"errors"
+	"os"
+)
 
-func setNonBlock(_ *os.File) error { return nil }
-func setBlock(_ *os.File) error    { return nil }
+// Windows has no equivalent of syscall.SetNonblock for a console handle: the
+// console is read through ReadConsole/ReadFile, which block until the user
+// presses Enter, and there is no fcntl(O_NONBLOCK) to switch that off.
+//
+// So these report failure rather than succeeding silently. That matters
+// because drainTerminalResponses treats a setNonBlock error as "cannot drain,
+// skip it" and returns early. A stub returning nil instead promised a
+// non-blocking stdin it had not delivered, so the drain went on to call
+// os.Stdin.Read on a still-blocking console handle. Its 50ms deadline is
+// checked only between reads, never during one, so the read parked forever and
+// pi hung — at startup with nothing yet printed, because prepareTerminal drains
+// before it writes anything. See TestSetNonBlock_ReportsUnsupported.
+//
+// Skipping the drain on Windows is the right trade: it exists only to swallow
+// unix terminal query replies (CPR, DECRQM) that would otherwise be parsed as
+// keystrokes, so forgoing it costs at most a few stray characters in the input
+// box, against a hard hang.
+func setNonBlock(_ *os.File) error { return errors.ErrUnsupported }
+func setBlock(_ *os.File) error    { return errors.ErrUnsupported }

--- a/internal/tui/drain_windows_test.go
+++ b/internal/tui/drain_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package tui
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSetNonBlock_ReportsUnsupported pins the contract that makes
+// drainTerminalResponses safe on Windows. A console handle cannot be switched
+// to non-blocking, so setNonBlock must say so: the drain skips itself only on
+// an error, and a stub returning nil sends it into a blocking os.Stdin.Read
+// that never returns, hanging pi at startup before anything is printed.
+func TestSetNonBlock_ReportsUnsupported(t *testing.T) {
+	if err := setNonBlock(os.Stdin); err == nil {
+		t.Fatal("setNonBlock returned nil: the drain will proceed to a blocking console read and hang pi at startup")
+	} else if !errors.Is(err, errors.ErrUnsupported) {
+		t.Errorf("setNonBlock error = %v, want errors.ErrUnsupported", err)
+	}
+
+	if err := setBlock(os.Stdin); !errors.Is(err, errors.ErrUnsupported) {
+		t.Errorf("setBlock error = %v, want errors.ErrUnsupported", err)
+	}
+}
+
+// TestDrainTerminalResponses_SkippedOnWindows is the end-to-end guard: whatever
+// stdin is, the drain must return promptly rather than block on it. Stdin is
+// left as the real handle deliberately, since that is what hung in issue #175.
+func TestDrainTerminalResponses_SkippedOnWindows(t *testing.T) {
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		drainTerminalResponses()
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		if elapsed > time.Second {
+			t.Errorf("drain took %v, want near-instant return", elapsed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainTerminalResponses blocked: regression of the issue #175 startup hang")
+	}
+}


### PR DESCRIPTION
Fixes #175.

## The bug

`drainTerminalResponses` switches stdin to non-blocking, then reads until a 50ms deadline. The deadline is checked *between* reads, never during one, so the switch has to actually work or the first read never returns.

On Windows it did not. `setNonBlock` was a stub returning `nil` — reporting success without doing anything, because a console handle read through `ReadConsole`/`ReadFile` has no `fcntl(O_NONBLOCK)` equivalent:

```go
func setNonBlock(_ *os.File) error { return nil }   // does nothing, reports OK
```

The drain took that as permission to proceed and parked in `os.Stdin.Read` until the user pressed Enter.

## Why it presents as "doesn't start" with no output

`prepareTerminal` drains **before** the `term.IsTerminal` guard and **before** the RIS write, and runs two lines ahead of `tea.NewProgram` (`tui.go:532` vs `:534`). Nothing has been written to the terminal when it blocks — no banner, no error, no stack trace. Which is exactly what the reporter described.

## Regression window

Since **v0.0.48** (`ee50ee6`, "terminal reset and context gauze"), which added `terminal_prepare.go` and put a second copy of the drain on the startup path. Before that the drain only ran after `p.Run()`, so Windows hung on *exit* instead — easy to miss. Current release is v0.0.73.

## The fix

Return `errors.ErrUnsupported`, so the existing early return fires and the drain skips itself on Windows. The return happens before `defer setBlock(f)` is registered, so no unbalanced state.

Skipping the drain is the right trade: it exists only to swallow unix terminal query replies (CPR, DECRQM) that would otherwise be parsed as keystrokes. Forgoing it costs at most a few stray characters in the input box, against a hard hang.

## On testing

The existing drain tests use `os.Pipe` with the write end closed, so reads hit EOF immediately and pass on either platform — they never exercised the blocking case.

I tried to write a cross-platform regression test using a pipe with **no data and the write end open**. It hangs on macOS too: `os.Pipe` fds are registered with Go's runtime poller, so `SetNonblock` never yields `EAGAIN`. Landing that would have hung unix CI for an unrelated reason, so the new test is Windows-only.

That leaves a real gap: **CI runs every job on `ubuntu-latest`**, so the new test does not run anywhere today. Worth noting a `pi --help` smoke test on `windows-latest` would *not* have caught this either — help never reaches `prepareTerminal`. Catching it needs `go test ./internal/tui/` on a Windows runner. Not included here since I can't verify the rest of the suite passes on Windows first.

## Verification

- `GOOS=windows GOARCH=amd64` build, vet, and test-compile — all exit 0
- macOS build and vet — clean
- `make test` — 0 failures
- `make lint` — 0 issues

Runtime behavior on Windows is unverified: I have no Windows machine. The mechanism is confirmed by code reading; the decisive check is that `pigo.exe` starts after pressing Enter once, and that `pigo.exe --mode print "hi"` works while bare `pigo.exe` hangs.

## Not in this PR

Separate Windows bugs confirmed while investigating, each its own symptom:

- `pi upgrade` 404s — `internal/cli/upgrade.go:19` fetches `scripts/install.ps1`, which does not exist in the repo
- `/restart` silently kills pi — `internal/tui/restart.go:27` calls `syscall.Exec`, which returns `EWINDOWS` on Windows; the error is `//nolint:errcheck`-discarded and control falls to `os.Exit(1)`
- `internal/cli/cli.go:75` builds `lastSessionFile` from `os.Getenv("HOME")` at package init; `HOME` is unset on Windows, so it becomes the relative path `.pi-go\last-session.json`. It's the lone outlier among ~40 sites that correctly use `os.UserHomeDir()`
- #174 (agent assumes Linux) needs a larger change: OS/arch/shell in the prompt's Runtime Environment block, plus per-platform shell selection
