### PR TITLE
feat(pimodels)!: take a defaultModel in New and Resolve

### DIFF
--- a/piagent/compose_test.go
+++ b/piagent/compose_test.go
@@ -26,7 +26,7 @@ func TestComposeModelIntoAgent(t *testing.T) {
 	// A local Ollama endpoint resolves and constructs without a credential and
 	// without reaching the network, which keeps this about composition rather
 	// than about a vendor being up.
-	m, err := pimodels.New(ctx, "ollama/gemma4:e4b",
+	m, err := pimodels.New(ctx, "ollama/gemma4:e4b", "",
 		pimodels.WithBaseURL("http://127.0.0.1:11434"))
 	if err != nil {
 		t.Fatalf("pimodels.New: %v", err)
@@ -58,7 +58,7 @@ func TestComposeModelIntoAgent(t *testing.T) {
 // that model can read it without importing pimodels. This is what let piagent
 // delete its own model-name prefix table.
 func TestComposeProviderNamerFlowsThrough(t *testing.T) {
-	m, err := pimodels.New(context.Background(), "ollama/gemma4:e4b",
+	m, err := pimodels.New(context.Background(), "ollama/gemma4:e4b", "",
 		pimodels.WithBaseURL("http://127.0.0.1:11434"))
 	if err != nil {
 		t.Fatalf("pimodels.New: %v", err)

--- a/pimodels/README.md
+++ b/pimodels/README.md
@@ -84,7 +84,7 @@ here that touches pi-go's configuration; `New` is self-contained.
 ## Inspecting before connecting
 
 ```go
-info, err := pimodels.Resolve("claude-sonnet-5")
+info, err := pimodels.Resolve("claude-sonnet-5", "")
 // info.Provider == "anthropic"
 
 pimodels.ContextWindow("gemini-3.7-flash")           // tokens, 0 if unknown
@@ -93,6 +93,25 @@ pimodels.ContextWindowFor("azure", "my-deployment")  // provider-aware
 
 `Resolve` needs no credential and makes no request, so it is safe to run at
 startup to validate configuration.
+
+The second argument is the fallback for a **missing** name, so a value read from
+a flag or a config file can go straight through without the caller testing it
+for empty first:
+
+```go
+info, err := pimodels.Resolve(*modelFlag, "claude-sonnet-5")
+```
+
+| `modelName` | `defaultModel` | Result |
+|---|---|---|
+| `""` | `"claude-sonnet-5"` | `anthropic` / `claude-sonnet-5` |
+| `"gpt-5.6-luna"` | `"claude-sonnet-5"` | `openai` / `gpt-5.6-luna` — an explicit name always wins |
+| `"cluade-sonet-5"` | `"claude-sonnet-5"` | error — a typo is not a missing name |
+| `""` | `""` | error |
+
+The asymmetry is deliberate: a default covers a name nobody supplied, not one
+supplied wrongly. Falling back on an unroutable name would send the request to a
+model the caller never wrote, and nothing would say so.
 
 ## Finding the provider from a model
 

--- a/pimodels/README.md
+++ b/pimodels/README.md
@@ -5,8 +5,11 @@ Build LLM clients for the providers pi-go supports, from outside pi-go.
 ```go
 import "github.com/dimetron/pi-go/pimodels"
 
-m, err := pimodels.New(ctx, "gpt-5.6-luna")
+m, err := pimodels.New(ctx, "gpt-5.6-luna", "")
 ```
+
+The second argument is the model to fall back to when the first is empty. Pass
+`""` when the name is always known.
 
 `m` is an ADK `model.LLM`. Hand it to any ADK agent.
 
@@ -33,7 +36,7 @@ This package and the agent package meet at ADK's `model.LLM`, not at each
 other. Neither imports the other:
 
 ```go
-m, err := pimodels.New(ctx, "gpt-5.6-luna")       // this package
+m, err := pimodels.New(ctx, "gpt-5.6-luna", "")   // this package
 a, err := piagent.New(ctx, piagent.WithModel(m))  // the agent package
 ```
 
@@ -94,12 +97,13 @@ pimodels.ContextWindowFor("azure", "my-deployment")  // provider-aware
 `Resolve` needs no credential and makes no request, so it is safe to run at
 startup to validate configuration.
 
-The second argument is the fallback for a **missing** name, so a value read from
-a flag or a config file can go straight through without the caller testing it
-for empty first:
+`New` and `Resolve` both take a fallback for a **missing** name, so a value read
+from a flag or a config file can go straight through without the caller testing
+it for empty first:
 
 ```go
-info, err := pimodels.Resolve(*modelFlag, "claude-sonnet-5")
+info, err := pimodels.Resolve(*modelFlag, "claude-sonnet-5")  // inspect
+m, err := pimodels.New(ctx, *modelFlag, "claude-sonnet-5")    // build
 ```
 
 | `modelName` | `defaultModel` | Result |
@@ -112,6 +116,23 @@ info, err := pimodels.Resolve(*modelFlag, "claude-sonnet-5")
 The asymmetry is deliberate: a default covers a name nobody supplied, not one
 supplied wrongly. Falling back on an unroutable name would send the request to a
 model the caller never wrote, and nothing would say so.
+
+`New` applies the identical rule, so the two never disagree about what an empty
+name means — they share one helper rather than each implementing it.
+
+### Do not chain Resolve into New
+
+`Resolve` moves the routing prefix out of the name and into `Info.Provider`, so
+`Info.Model` is not a name `New` can take back:
+
+```go
+info, _ := pimodels.Resolve("ollama/gemma4:e4b", "")  // -> ollama, "gemma4:e4b"
+m, err := pimodels.New(ctx, info.Model, "")           // ERROR: unknown model
+```
+
+Every `ollama/`, `azure/` and `opencode/` name fails this way. Give `New` the
+name you started with — it resolves internally, which is why it takes the
+fallback itself rather than expecting callers to resolve first.
 
 ## Finding the provider from a model
 

--- a/pimodels/example_test.go
+++ b/pimodels/example_test.go
@@ -13,7 +13,7 @@ import (
 func ExampleNew() {
 	ctx := context.Background()
 
-	m, err := pimodels.New(ctx, "gpt-5.6-luna")
+	m, err := pimodels.New(ctx, "gpt-5.6-luna", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func ExampleNew() {
 func ExampleNew_gateway() {
 	ctx := context.Background()
 
-	m, err := pimodels.New(ctx, "gpt-5.6-luna",
+	m, err := pimodels.New(ctx, "gpt-5.6-luna", "",
 		pimodels.WithBaseURL("https://llm-gateway.internal/v1"),
 		pimodels.WithAPIKey("tenant-key"),
 		pimodels.WithHeaders(map[string]string{"X-Tenant": "acme"}),

--- a/pimodels/example_test.go
+++ b/pimodels/example_test.go
@@ -42,8 +42,11 @@ func ExampleNew_gateway() {
 // Resolve answers "where would this request actually go" without building a
 // client or needing a credential — worth doing at startup, so a misconfigured
 // model name fails before the first request rather than during it.
+//
+// The second argument is the fallback for a missing name; an explicit name
+// always wins.
 func ExampleResolve() {
-	info, err := pimodels.Resolve("claude-sonnet-5")
+	info, err := pimodels.Resolve("claude-sonnet-5", "gpt-5.6-luna")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -53,7 +56,7 @@ func ExampleResolve() {
 
 // A local Ollama model needs no credential at all.
 func ExampleResolve_ollama() {
-	info, err := pimodels.Resolve("ollama/gemma4:e4b")
+	info, err := pimodels.Resolve("ollama/gemma4:e4b", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -61,10 +64,36 @@ func ExampleResolve_ollama() {
 	// Output: ollama gemma4:e4b true
 }
 
+// The point of the default: a name read from a flag or a config file can be
+// passed straight through, empty or not, without the caller branching first.
+//
+// The fallback is for a missing name only. A name that is present but
+// unroutable still fails, so a typo surfaces at startup instead of quietly
+// becoming a different model.
+func ExampleResolve_defaultModel() {
+	const fallback = "claude-sonnet-5"
+
+	for _, flagValue := range []string{"", "gpt-5.6-luna"} {
+		info, err := pimodels.Resolve(flagValue, fallback)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(info.Provider, info.Model)
+	}
+
+	if _, err := pimodels.Resolve("cluade-sonet-5", fallback); err != nil {
+		fmt.Println("typo rejected, not defaulted")
+	}
+	// Output:
+	// anthropic claude-sonnet-5
+	// openai gpt-5.6-luna
+	// typo rejected, not defaulted
+}
+
 // Report a missing credential precisely, rather than letting the first request
 // fail with a provider-specific auth error.
 func ExampleAPIKeyEnvVar() {
-	info, err := pimodels.Resolve("grok-4.6")
+	info, err := pimodels.Resolve("grok-4.6", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pimodels/pimodels.go
+++ b/pimodels/pimodels.go
@@ -245,10 +245,28 @@ func FromConfig(ctx context.Context, role string, opts ...Option) (Model, error)
 
 // Resolve reports how a model name would be routed, without building a client
 // or needing a credential. Useful for validating configuration at startup.
-func Resolve(modelName string, opts ...Option) (Info, error) {
+//
+// An empty modelName falls back to defaultModel, so a caller reading a name
+// from a flag or a config file can pass it straight through instead of
+// branching on the empty string first. Both empty is an error, as is a
+// defaultModel that does not itself resolve.
+//
+// The fallback covers a *missing* name only. A name that is present but
+// unroutable still fails: substituting a different model for a typo hides the
+// mistake until the output or the bill looks wrong.
+func Resolve(modelName, defaultModel string, opts ...Option) (Info, error) {
 	var o options
 	for _, opt := range opts {
 		opt(&o)
+	}
+	if modelName == "" {
+		modelName = defaultModel
+	}
+	// Checked here rather than left to resolveInfo: with WithBaseURL set,
+	// provider.ResolveWithBaseURL treats an unrecognized name as a custom
+	// OpenAI-compatible model and would happily return one with an empty Model.
+	if modelName == "" {
+		return Info{}, fmt.Errorf("pimodels: no model name and no default model given")
 	}
 	info, err := resolveInfo(modelName, o.baseURL)
 	if err != nil {

--- a/pimodels/pimodels.go
+++ b/pimodels/pimodels.go
@@ -10,7 +10,7 @@
 // tools, sessions or skills, and it must stay that way: an embedder composes the
 // two halves itself.
 //
-//	m, err := pimodels.New(ctx, "gpt-5.6-luna")
+//	m, err := pimodels.New(ctx, "gpt-5.6-luna", "")
 //	if err != nil {
 //	    return err
 //	}
@@ -186,9 +186,18 @@ func WithAdvisor(advisorModel string, maxUses int, caching bool) Option {
 // Anthropic, "gemini-*" is Gemini, "grok-*" is xAI, an "ollama/" prefix or a
 // ":cloud" suffix routes to Ollama, and so on. Pass [WithBaseURL] to override
 // the endpoint for any of them.
-func New(ctx context.Context, modelName string, opts ...Option) (Model, error) {
-	if modelName == "" {
-		return nil, fmt.Errorf("pimodels: model name must not be empty")
+//
+// An empty modelName falls back to defaultModel, on the same terms as
+// [Resolve]: the default covers a missing name, never an unroutable one.
+//
+// Taking the default here rather than leaving the caller to call [Resolve]
+// first matters, because Resolve's answer cannot be fed back in. Resolve moves
+// the routing prefix out of the name and into [Info.Provider], so New would see
+// "gemma4:e4b" where the caller wrote "ollama/gemma4:e4b" and fail to route it.
+func New(ctx context.Context, modelName, defaultModel string, opts ...Option) (Model, error) {
+	modelName, err := applyDefault(modelName, defaultModel)
+	if err != nil {
+		return nil, err
 	}
 
 	var o options
@@ -240,7 +249,7 @@ func FromConfig(ctx context.Context, role string, opts ...Option) (Model, error)
 	if cfg.ThinkingLevel != "" {
 		merged = append([]Option{WithThinkingLevel(cfg.ThinkingLevel)}, merged...)
 	}
-	return New(ctx, modelName, merged...)
+	return New(ctx, modelName, "", merged...)
 }
 
 // Resolve reports how a model name would be routed, without building a client
@@ -259,14 +268,9 @@ func Resolve(modelName, defaultModel string, opts ...Option) (Info, error) {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	if modelName == "" {
-		modelName = defaultModel
-	}
-	// Checked here rather than left to resolveInfo: with WithBaseURL set,
-	// provider.ResolveWithBaseURL treats an unrecognized name as a custom
-	// OpenAI-compatible model and would happily return one with an empty Model.
-	if modelName == "" {
-		return Info{}, fmt.Errorf("pimodels: no model name and no default model given")
+	modelName, err := applyDefault(modelName, defaultModel)
+	if err != nil {
+		return Info{}, err
 	}
 	info, err := resolveInfo(modelName, o.baseURL)
 	if err != nil {
@@ -297,6 +301,23 @@ func ContextWindowFor(providerName, modelName string) int64 {
 // from, so an embedder can report a missing credential precisely.
 func APIKeyEnvVar(providerName string) string {
 	return provider.APIKeyEnvVar(providerName)
+}
+
+// applyDefault implements the fallback rule shared by [New] and [Resolve], so
+// the two cannot drift into disagreeing about what an empty name means.
+//
+// The empty result is rejected here rather than left to resolveInfo because
+// resolveInfo does not reliably reject it: with a base URL set,
+// provider.ResolveWithBaseURL treats an unrecognized name as a custom
+// OpenAI-compatible model and returns one with an empty Model and no error.
+func applyDefault(modelName, defaultModel string) (string, error) {
+	if modelName == "" {
+		modelName = defaultModel
+	}
+	if modelName == "" {
+		return "", fmt.Errorf("pimodels: no model name and no default model given")
+	}
+	return modelName, nil
 }
 
 // resolveInfo picks the resolution path: an explicit base URL means the caller

--- a/pimodels/pimodels_test.go
+++ b/pimodels/pimodels_test.go
@@ -11,13 +11,65 @@ import (
 )
 
 func TestNewRejectsEmptyModelName(t *testing.T) {
-	if _, err := New(context.Background(), ""); err == nil {
+	if _, err := New(context.Background(), "", ""); err == nil {
 		t.Fatal("New(\"\") returned no error; an empty model name cannot resolve to anything")
 	}
 }
 
+// TestNewDefaultModel mirrors TestResolveDefaultModel: New must apply the
+// fallback on the same terms, or a caller gets one answer from Resolve and a
+// different one from New for the same pair of names.
+func TestNewDefaultModel(t *testing.T) {
+	m, err := New(context.Background(), "", "claude-sonnet-5")
+	if err != nil {
+		t.Fatalf(`New("", "claude-sonnet-5"): %v`, err)
+	}
+	p, ok := m.(interface{ Provider() string })
+	if !ok {
+		t.Fatal("model does not report its provider")
+	}
+	if got := p.Provider(); got != "anthropic" {
+		t.Fatalf("fallback built a %q model, want anthropic", got)
+	}
+
+	// A present but unroutable name is not a missing one, so the default must
+	// not rescue it.
+	if _, err := New(context.Background(), "not-a-model-at-all-123", "claude-sonnet-5"); err == nil {
+		t.Fatal("expected an unroutable name to fail even with a default given")
+	}
+}
+
+// TestNewNeedsNoResolveRoundTrip pins the reason New takes the default itself.
+// Resolve moves the routing prefix into Info.Provider, so Info.Model cannot be
+// fed back to New -- and every ollama/, azure/ and opencode/ name would break
+// if callers were expected to chain the two.
+func TestNewNeedsNoResolveRoundTrip(t *testing.T) {
+	const name = "ollama/gemma4:e4b"
+
+	info, err := Resolve(name, "")
+	if err != nil {
+		t.Fatalf("Resolve(%q): %v", name, err)
+	}
+	if _, err := Resolve(info.Model, ""); err == nil {
+		t.Skip("Info.Model round-trips again; the round-trip hazard has been fixed elsewhere")
+	}
+
+	// New, given the original name, routes it correctly without the round trip.
+	m, err := New(context.Background(), name, "")
+	if err != nil {
+		t.Fatalf("New(%q): %v", name, err)
+	}
+	p, ok := m.(interface{ Provider() string })
+	if !ok {
+		t.Fatal("model does not report its provider")
+	}
+	if got := p.Provider(); got != "ollama" {
+		t.Fatalf("New(%q) built a %q model, want ollama", name, got)
+	}
+}
+
 func TestNewUnknownModel(t *testing.T) {
-	_, err := New(context.Background(), "definitely-not-a-real-model-xyz")
+	_, err := New(context.Background(), "definitely-not-a-real-model-xyz", "")
 	if err == nil {
 		t.Fatal("expected an error for an unresolvable model name")
 	}

--- a/pimodels/pimodels_test.go
+++ b/pimodels/pimodels_test.go
@@ -42,7 +42,7 @@ func TestResolveKnownModels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			info, err := Resolve(tt.model)
+			info, err := Resolve(tt.model, "")
 			if err != nil {
 				t.Fatalf("Resolve(%q): %v", tt.model, err)
 			}
@@ -57,8 +57,50 @@ func TestResolveKnownModels(t *testing.T) {
 }
 
 func TestResolveUnknownModel(t *testing.T) {
-	if _, err := Resolve("not-a-model-at-all-123"); err == nil {
+	if _, err := Resolve("not-a-model-at-all-123", ""); err == nil {
 		t.Fatal("expected an error for an unresolvable model name")
+	}
+}
+
+// TestResolveDefaultModel covers the fallback: a missing name takes the
+// default, a present name never does.
+func TestResolveDefaultModel(t *testing.T) {
+	info, err := Resolve("", "claude-sonnet-5")
+	if err != nil {
+		t.Fatalf(`Resolve("", "claude-sonnet-5"): %v`, err)
+	}
+	if info.Provider != "anthropic" || info.Model != "claude-sonnet-5" {
+		t.Fatalf("fallback resolved to %s/%s, want anthropic/claude-sonnet-5", info.Provider, info.Model)
+	}
+
+	// An explicit name wins over the default.
+	info, err = Resolve("gpt-5.6-luna", "claude-sonnet-5")
+	if err != nil {
+		t.Fatalf("Resolve with both names: %v", err)
+	}
+	if info.Provider != "openai" {
+		t.Fatalf("explicit name resolved to %q, want openai", info.Provider)
+	}
+}
+
+// TestResolveUnresolvableNameIgnoresDefault pins the deliberate asymmetry: the
+// default covers a missing name, not a wrong one. Falling back on a typo would
+// route to a different model than the caller wrote, silently.
+func TestResolveUnresolvableNameIgnoresDefault(t *testing.T) {
+	if _, err := Resolve("not-a-model-at-all-123", "claude-sonnet-5"); err == nil {
+		t.Fatal("expected an unroutable name to fail even with a default given")
+	}
+}
+
+// TestResolveNoNameAndNoDefault checks the both-empty case, including with a
+// base URL set — where provider.ResolveWithBaseURL would otherwise return a
+// custom model with an empty name rather than an error.
+func TestResolveNoNameAndNoDefault(t *testing.T) {
+	if _, err := Resolve("", ""); err == nil {
+		t.Fatal("expected an error when neither a name nor a default is given")
+	}
+	if _, err := Resolve("", "", WithBaseURL("https://gateway.example/v1")); err == nil {
+		t.Fatal("expected an error when neither a name nor a default is given, with a base URL")
 	}
 }
 
@@ -66,7 +108,7 @@ func TestResolveUnknownModel(t *testing.T) {
 // wins: a caller naming a gateway must not have the model name silently reroute
 // the request somewhere else.
 func TestResolveWithBaseURLTakesPrecedence(t *testing.T) {
-	info, err := Resolve("gpt-5.6-luna", WithBaseURL("https://gateway.example/v1"))
+	info, err := Resolve("gpt-5.6-luna", "", WithBaseURL("https://gateway.example/v1"))
 	if err != nil {
 		t.Fatalf("Resolve with base URL: %v", err)
 	}


### PR DESCRIPTION
## What

`New` and `Resolve` both take a `defaultModel`, used when `modelName` is empty:

```go
func New(ctx context.Context, modelName, defaultModel string, opts ...Option) (Model, error)
func Resolve(modelName, defaultModel string, opts ...Option) (Info, error)
```

A model name read from a flag or a config file goes straight through, empty or
not, without the caller testing it for empty first:

```go
m, err := pimodels.New(ctx, *modelFlag, "claude-sonnet-5")
```

| `modelName` | `defaultModel` | Result |
|---|---|---|
| `""` | `"claude-sonnet-5"` | `anthropic` / `claude-sonnet-5` |
| `"gpt-5.6-luna"` | `"claude-sonnet-5"` | `openai` / `gpt-5.6-luna` — an explicit name always wins |
| `"cluade-sonet-5"` | `"claude-sonnet-5"` | error — a typo is not a missing name |
| `""` | `""` | error |

Both share one `applyDefault` helper, so they cannot drift into disagreeing
about what an empty name means.

## Why the asymmetry

The default covers a name nobody supplied, not one supplied wrongly. Falling
back on an unroutable name would send the request to a model the caller never
wrote, and nothing would say so — the mistake would surface in the output or the
bill, not at startup.

## Why `New` needs the default, not just `Resolve`

`Resolve`'s answer cannot be fed back into `New`. `Resolve` moves the routing
prefix out of the name and into `Info.Provider`, so `Info.Model` is no longer a
name that resolves:

```
claude-sonnet-5        -> anthropic claude-sonnet-5   ok
ollama/gemma4:e4b      -> ollama    gemma4:e4b        ROUND TRIP BROKEN
ollama/my-finetune     -> ollama    my-finetune       ROUND TRIP BROKEN
azure/prod-deployment  -> azure     prod-deployment   ROUND TRIP BROKEN
opencode/kimi-k3       -> opencode  kimi-k3           ROUND TRIP BROKEN
```

Every `ollama/`, `azure/` and `opencode/` name fails, because
`provider.OllamaModelPrefixes` is an empty slice
(`internal/provider/provider.go:174`) and nothing else reconstructs the routing.
Only the vendor-prefix names survive, which is why the hazard is easy to miss.

So before this change a caller holding a possibly-empty name had no correct
one-step option: `New` rejected the empty string, and resolving first to supply
a default corrupted the name on the way back. `New` taking the default itself
closes that gap.

The round-trip hazard itself is **not fixed here** — see the follow-up issue.
`TestNewNeedsNoResolveRoundTrip` pins current behaviour and skips itself if the
round trip is ever repaired.

## The both-empty guard

`New("", "")` and `Resolve("", "")` now error. That case was unreachable in
practice before; now a caller passes a possibly-empty flag on purpose. With
`WithBaseURL` set, `provider.ResolveWithBaseURL` treats an unrecognized name as
a custom OpenAI-compatible model and returns `Info{Provider: "openai",
Model: "", Custom: true}` — no error, empty model name. The explicit check turns
that into a real error.

## Breaking change

`New` and `Resolve` each gain a positional parameter. In-repo callers are
updated (`piagent/compose_test.go`, examples); external embedders on `v0.0.73`
or earlier pass `""` to keep the old behaviour. Worth a line in the release
notes.

## Verification

- `go build ./...`, `go vet`, `go test -count=1 ./pimodels/... ./piagent/...` pass
- `golangci-lint run ./pimodels/... ./piagent/...` — 0 issues
- Exercised from a **separate external module** (own `go.mod`, `replace` to this
  branch) driving a vanilla ADK `llmagent`:

| invocation | result |
|---|---|
| no flag | `provider: anthropic` — default applied |
| `-model gpt-5.6-luna` | `provider: openai` |
| `-model ollama/gemma4:e4b` | `provider: ollama` — the case the round trip broke |
| `-model cluade-sonet-5` | rejected, not defaulted |

https://claude.ai/code/session_018MsiGPng4RQ2Nt8viBj3wB
