### PR TITLE
fix(bash): floor timeout and idle_timeout at one minute

### DIFF
--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -18,29 +19,58 @@ const (
 	// command: nothing is killed at the threshold, the command keeps running,
 	// and the caller gets a handle to watch it with.
 	//
-	// Thirty seconds is chosen so the common case stays whole — the vast
-	// majority of commands in this repo (git, go vet, a package test run, a
-	// warm build) finish well inside it — while anything genuinely long stops
-	// blocking a turn for two minutes before it says so. A caller that knows
-	// its command is long should raise `timeout` rather than discover this
-	// limit; the idle check then does the real work, firing well before the
-	// raised hard limit.
-	defaultBashTimeout = 30 * time.Second
-	maxBashTimeout     = 10 * time.Minute
+	// One minute is chosen so the common case stays whole — the vast majority
+	// of commands in this repo (git, go vet, a package test run, a warm build)
+	// finish well inside it — while anything genuinely long says so a minute in
+	// rather than running the turn out. It is also minBashTimeout: a caller
+	// that passes nothing and one that passes the smallest accepted value get
+	// the same budget, which is the only defensible relationship between a
+	// default and a floor. A caller that knows its command is long should raise
+	// `timeout` rather than discover this limit; the idle check then does the
+	// real work, firing well before the raised hard limit.
+	defaultBashTimeout = time.Minute
+
+	// minBashTimeout is the floor under both caller-supplied limits.
+	//
+	// It exists because `timeout` and `idle_timeout` are milliseconds, which is
+	// invisible at the call site: a caller writing `timeout: 300` means five
+	// minutes and gets 300ms. Nothing that small can succeed — `make` has not
+	// printed its first line by then — so the command is handed off before it
+	// has done anything, and the caller is left polling a handle to recover
+	// work that would have finished in the foreground.
+	//
+	// Flooring at a minute costs a caller that genuinely wanted a sub-second
+	// budget nothing it can use, since a handoff is not a kill: the command
+	// keeps running either way. What it buys is that every command shorter than
+	// a minute now completes in the foreground, whatever units the caller
+	// thought it was passing.
+	//
+	// Subagent frontmatter had the same bug and took the same view — see
+	// minAgentTimeoutMs in internal/subagent/agents.go, where `timeout: 30`
+	// meant thirty seconds and SIGKILLed the agent 30ms in. That one ignores
+	// the value and falls back to the default; this one floors, because a
+	// handoff is recoverable where a kill is not, and the floor and the default
+	// are the same minute anyway.
+	minBashTimeout = time.Minute
+	maxBashTimeout = 10 * time.Minute
 )
 
 // BashInput defines the parameters for the bash tool.
 type BashInput struct {
 	// The shell command to execute.
 	Command string `json:"command"`
-	// Optional timeout in milliseconds. Default: 30000 (30 seconds). Max: 600000 (10 minutes).
+	// Optional timeout in MILLISECONDS. Default: 60000 (1 minute).
+	// Min: 60000 (1 minute). Max: 600000 (10 minutes).
 	// On expiry the command is moved to the background, not killed. Raise it for
 	// work you already know is long (a full test suite, an image build) so it
-	// finishes in the foreground instead of costing a round trip.
+	// finishes in the foreground instead of costing a round trip. Values below
+	// the minute floor are raised to it, because they are nearly always seconds
+	// written where milliseconds were expected.
 	Timeout int `json:"timeout,omitempty"`
-	// Optional idle timeout in milliseconds. A command that produces no output
+	// Optional idle timeout in MILLISECONDS. A command that produces no output
 	// at all for this long is moved to the background. Default: 90000.
-	// Set it higher for commands that are legitimately quiet for a long time.
+	// Min: 60000 (1 minute). Set it higher for commands that are legitimately
+	// quiet for a long time.
 	IdleTimeout int `json:"idle_timeout,omitempty"`
 }
 
@@ -115,7 +145,9 @@ const maxBashWait = 60 * time.Second
 
 const bashDescription = `Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, running tests, building code, git operations, etc.
 
-A command that runs past its timeout (30s by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.`
+A command that runs past its timeout (1m by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.
+
+timeout and idle_timeout are in MILLISECONDS and are floored at 60000 (1 minute): a command that takes less than a minute always finishes in the foreground. Write 300000 for five minutes, not 300.`
 
 func newBashTool(sb *Sandbox, sup *BashSupervisor) (tool.Tool, error) {
 	return newTool("bash", bashDescription, func(ctx agent.Context, input BashInput) (BashOutput, error) {
@@ -146,8 +178,8 @@ func bashHandler(sb *Sandbox, sup *BashSupervisor, ctx agent.Context, input Bash
 	out, err := sup.Run(parentCtx, runRequest{
 		dir:         sb.Dir(),
 		command:     input.Command,
-		timeout:     clampDuration(input.Timeout, defaultBashTimeout, maxBashTimeout),
-		idleTimeout: clampDuration(input.IdleTimeout, 0, maxBashTimeout),
+		timeout:     clampDuration(input.Timeout, defaultBashTimeout, minBashTimeout, maxBashTimeout),
+		idleTimeout: clampDuration(input.IdleTimeout, 0, minBashTimeout, maxBashTimeout),
 	})
 	if err != nil {
 		span.RecordError(err)
@@ -160,16 +192,77 @@ func bashHandler(sb *Sandbox, sup *BashSupervisor, ctx agent.Context, input Bash
 		attribute.Int("bash.stderr_len", len(out.Stderr)),
 		attribute.Bool("bash.backgrounded", out.Running),
 	)
+
+	if n := flooredNote(input); n != "" {
+		out.Note = strings.TrimSpace(out.Note + " " + n)
+	}
 	return out, nil
 }
 
+// flooredNote reports a limit that was raised to minBashTimeout.
+//
+// Silently correcting the value would fix this call and leave the caller
+// repeating the mistake on the next one, so the note names the unit and gives
+// the number that would have meant what the caller wrote. It is deliberately
+// emitted whether or not the command was backgrounded: a caller that wrote
+// `timeout: 300` and got a clean result still asked for something it did not
+// get, and that is the cheapest moment to say so.
+func flooredNote(input BashInput) string {
+	var raised []string
+	var suggested bool
+	for _, f := range []struct {
+		name string
+		ms   int
+	}{{"timeout", input.Timeout}, {"idle_timeout", input.IdleTimeout}} {
+		if f.ms <= 0 || time.Duration(f.ms)*time.Millisecond >= minBashTimeout {
+			continue
+		}
+		desc, ok := describeFloored(f.name, f.ms)
+		raised = append(raised, desc)
+		suggested = suggested || ok
+	}
+	if len(raised) == 0 {
+		return ""
+	}
+	note := fmt.Sprintf("Raised to the %s floor: %s. These limits are in"+
+		" milliseconds.", minBashTimeout, strings.Join(raised, ", "))
+	if suggested {
+		note += " A value this far under the floor is nearly always seconds" +
+			" written where milliseconds were expected."
+	}
+	return note
+}
+
+// describeFloored renders one raised limit, and — where the number reads as a
+// plausible seconds value — what to write instead.
+//
+// The suggestion is withheld once the seconds reading exceeds maxBashTimeout,
+// because past that point it stops being a diagnosis and starts being noise:
+// `idle_timeout: 5000` is a deliberate five seconds, and answering it with
+// "write 5000000 for 1h23m20s" is worse than saying nothing.
+func describeFloored(field string, ms int) (desc string, suggested bool) {
+	asked := time.Duration(ms) * time.Millisecond
+	if meant := time.Duration(ms) * time.Second; meant <= maxBashTimeout {
+		return fmt.Sprintf("%s=%s (write %d for %s)", field, asked, ms*1000, meant), true
+	}
+	return fmt.Sprintf("%s=%s", field, asked), false
+}
+
 // clampDuration converts a millisecond input to a duration, substituting
-// fallback when unset and capping at maxDur.
-func clampDuration(ms int, fallback, maxDur time.Duration) time.Duration {
+// fallback when unset and holding the result within [minDur, maxDur].
+//
+// The floor applies only to a value the caller actually supplied. An unset
+// input takes fallback unchanged, so a caller that passes nothing gets the
+// default that was chosen for it rather than one bent by a floor meant to
+// catch a unit mistake. Pass minDur = 0 where no floor applies.
+func clampDuration(ms int, fallback, minDur, maxDur time.Duration) time.Duration {
 	if ms <= 0 {
 		return fallback
 	}
 	d := time.Duration(ms) * time.Millisecond
+	if d < minDur {
+		return minDur
+	}
 	if d > maxDur {
 		return maxDur
 	}
@@ -189,7 +282,7 @@ func BashControlTools(sup *BashSupervisor) ([]tool.Tool, error) {
 			if input.Handle == "" {
 				return BashStatus{}, fmt.Errorf("handle is required (running: %v)", sup.Handles())
 			}
-			return sup.readOutput(input.Handle, clampDuration(input.WaitMs, maxBashWait, maxBashWait))
+			return sup.readOutput(input.Handle, clampDuration(input.WaitMs, maxBashWait, 0, maxBashWait))
 		})
 	if err != nil {
 		return nil, err

--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -238,26 +238,75 @@ func TestBashHandler_EmptyCommandRejected(t *testing.T) {
 	}
 }
 
-// TestBashHandler_IdleTimeoutIsHonored proves the per-call knob works: a
-// command well inside the default idle window is backgrounded early when the
-// caller asks for it.
-func TestBashHandler_IdleTimeoutIsHonored(t *testing.T) {
+// TestBashHandler_SubMinuteLimitsAreFloored is the regression for a real
+// session: `timeout: 300` meant five minutes, arrived as 300ms, and handed
+// `make test-coverage` to the background 312ms in — before make had printed a
+// line. The command then took two extra round trips to recover work that would
+// have finished in the foreground.
+//
+// A limit under a minute is now raised to one, so the command runs to
+// completion, and the result says what was raised and why.
+func TestBashHandler_SubMinuteLimitsAreFloored(t *testing.T) {
 	sb := testSandbox(t, t.TempDir())
 	sup := testSupervisor(t)
 	sup.heartbeat = 20 * time.Millisecond
 
 	out, err := bashHandler(sb, sup, nil, BashInput{
-		Command:     "sleep 30",
-		IdleTimeout: 150, // ms — far below the 90s default
+		Command:     "sleep 0.4 && echo done",
+		Timeout:     300, // ms — the caller meant 300 seconds
+		IdleTimeout: 150,
 	})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
-	if !out.Running {
-		t.Fatalf("idle_timeout was ignored, got %+v", out)
+	if out.Running {
+		t.Fatalf("a sub-second limit was honored and backgrounded the command: %+v", out)
 	}
-	if _, err := sup.killHandle(out.Handle); err != nil {
-		t.Fatalf("killHandle: %v", err)
+	if !strings.Contains(out.Stdout, "done") {
+		t.Errorf("command should have run to completion, got stdout %q", out.Stdout)
+	}
+	// The note has to teach the unit, or the caller repeats the mistake.
+	for _, want := range []string{"timeout=300ms", "300000", "idle_timeout=150ms", "millisecond"} {
+		if !strings.Contains(out.Note, want) {
+			t.Errorf("Note = %q, want it to contain %q", out.Note, want)
+		}
+	}
+}
+
+// A number too large to be a plausible seconds value gets no "you meant
+// seconds" correction. `idle_timeout: 5000` is a deliberate five seconds, and
+// answering it with "write 5000000 for 1h23m20s" would be worse than silence.
+func TestFlooredNote_WithholdsImplausibleSuggestions(t *testing.T) {
+	note := flooredNote(BashInput{IdleTimeout: 5000})
+
+	if !strings.Contains(note, "idle_timeout=5s") {
+		t.Errorf("note = %q, want it to name the raised limit", note)
+	}
+	for _, unwanted := range []string{"write ", "seconds written"} {
+		if strings.Contains(note, unwanted) {
+			t.Errorf("note = %q, should not contain %q", note, unwanted)
+		}
+	}
+	// A small number keeps the correction, so the two paths stay distinct.
+	if got := flooredNote(BashInput{Timeout: 300}); !strings.Contains(got, "write 300000 for 5m0s") {
+		t.Errorf("note = %q, want the seconds correction", got)
+	}
+}
+
+// A limit the caller meant is left alone: the floor is a unit-mistake guard,
+// not a policy on how long commands may hold the foreground.
+func TestBashHandler_SaneLimitsAreNotAnnotated(t *testing.T) {
+	sb := testSandbox(t, t.TempDir())
+
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
+		Command: "echo hi",
+		Timeout: 120000, // 2m, comfortably above the floor
+	})
+	if err != nil {
+		t.Fatalf("bashHandler: %v", err)
+	}
+	if out.Note != "" {
+		t.Errorf("Note = %q, want none for a limit above the floor", out.Note)
 	}
 }
 
@@ -426,19 +475,32 @@ func TestRoundDur(t *testing.T) {
 
 func TestClampDuration(t *testing.T) {
 	const fallback = 7 * time.Second
+	const minDur = 2 * time.Second
 	const maxDur = 10 * time.Second
 
-	if got := clampDuration(0, fallback, maxDur); got != fallback {
+	if got := clampDuration(0, fallback, minDur, maxDur); got != fallback {
 		t.Errorf("unset input = %v, want the fallback %v", got, fallback)
 	}
-	if got := clampDuration(-5, fallback, maxDur); got != fallback {
+	if got := clampDuration(-5, fallback, minDur, maxDur); got != fallback {
 		t.Errorf("negative input = %v, want the fallback %v", got, fallback)
 	}
-	if got := clampDuration(2000, fallback, maxDur); got != 2*time.Second {
-		t.Errorf("2000ms = %v, want 2s", got)
+	if got := clampDuration(3000, fallback, minDur, maxDur); got != 3*time.Second {
+		t.Errorf("3000ms = %v, want 3s", got)
 	}
-	if got := clampDuration(999999, fallback, maxDur); got != maxDur {
+	if got := clampDuration(50, fallback, minDur, maxDur); got != minDur {
+		t.Errorf("undersized input = %v, want the floor %v", got, minDur)
+	}
+	if got := clampDuration(999999, fallback, minDur, maxDur); got != maxDur {
 		t.Errorf("oversized input = %v, want the cap %v", got, maxDur)
+	}
+	// The floor catches a caller's mistake; it must not bend a default that
+	// was deliberately chosen below it.
+	if got := clampDuration(0, time.Second, minDur, maxDur); got != time.Second {
+		t.Errorf("unset input = %v, want the fallback unbent by the floor", got)
+	}
+	// A zero floor means no floor — bash_wait needs short waits.
+	if got := clampDuration(50, fallback, 0, maxDur); got != 50*time.Millisecond {
+		t.Errorf("50ms with no floor = %v, want 50ms", got)
 	}
 }
 
@@ -471,8 +533,15 @@ func TestSupervisorDefaults(t *testing.T) {
 // enough that the pin matters — a silent bump back to two minutes would put the
 // old round-trip cost back without failing anything else.
 func TestBashDefaultTimeout_IsTheForegroundBudget(t *testing.T) {
-	if defaultBashTimeout != 30*time.Second {
-		t.Errorf("defaultBashTimeout = %s, want 30s", defaultBashTimeout)
+	if defaultBashTimeout != time.Minute {
+		t.Errorf("defaultBashTimeout = %s, want 1m", defaultBashTimeout)
+	}
+	// The default cannot sit below the floor: a caller that passes nothing
+	// would then get a shorter budget than one that asks for the smallest
+	// value the tool accepts, which is indefensible in either direction.
+	if defaultBashTimeout < minBashTimeout {
+		t.Errorf("defaultBashTimeout %s is below the %s floor",
+			defaultBashTimeout, minBashTimeout)
 	}
 	// The idle check only earns its keep while it can fire before the hard
 	// limit, which under defaults it cannot — it exists for callers that raise

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -31,14 +31,15 @@ const (
 	// enough to trip on every build is merely annoying.
 	defaultIdleTimeout = 90 * time.Second
 
-	// shortIdleTimeout is the threshold below which a caller-supplied
-	// idle_timeout is treated as self-defeating and called out in the result.
+	// shortIdleTimeout is the threshold below which an idle limit is treated as
+	// self-defeating and called out in the result.
 	//
-	// Nothing is overridden — a caller that genuinely wants a hair trigger
-	// keeps it. But the heartbeat only samples every 5s, so any value below
-	// that cannot fire sooner than 5s anyway, and values in that range
-	// background every build in this repo on its first quiet moment.
-	shortIdleTimeout = 15 * time.Second
+	// It tracks minBashTimeout, the floor the bash tool applies to both
+	// caller-supplied limits. A value under it cannot arrive through the tool
+	// at all, so what this catches is the other route in: a caller building a
+	// runRequest directly, where nothing clamps anything. Nothing is
+	// overridden on that path — the hint is all the supervisor owes it.
+	shortIdleTimeout = minBashTimeout
 
 	// heartbeatInterval is how often a running command reports that it is still
 	// alive. It drives the "45s, no output" line in the UI, which is the whole
@@ -414,14 +415,19 @@ func (s *BashSupervisor) background(p *bashProc, reason string) BashOutput {
 // lint, and test run in this repo on its first quiet moment, and the only
 // visible consequence is a handle the model then polls dozens of times. Naming
 // the limit turns that into a one-line fix.
+//
+// It names `timeout`, not `idle_timeout`, as the knob to raise. Run clamps the
+// idle limit down to the hard limit, so a small idle window is usually not
+// something the caller asked for — it is the hard limit showing through, and
+// raising idle_timeout alone would be clamped straight back and change nothing.
 func limitsHint(timeout, idle time.Duration) string {
 	hint := fmt.Sprintf("Limits for this command: timeout %s, idle_timeout %s.",
 		roundDur(timeout), roundDur(idle))
 	if idle < shortIdleTimeout {
-		hint += fmt.Sprintf(" An idle_timeout under %s backgrounds ordinary builds and"+
-			" test runs the moment they go quiet — pass a larger idle_timeout"+
-			" (or omit it for the %s default) rather than polling the handle.",
-			roundDur(shortIdleTimeout), roundDur(defaultIdleTimeout))
+		hint += fmt.Sprintf(" An idle limit under %s backgrounds ordinary builds and"+
+			" test runs the moment they go quiet. idle_timeout is clamped to"+
+			" timeout, so raise timeout (both are milliseconds) rather than"+
+			" polling the handle.", roundDur(shortIdleTimeout))
 	}
 	return hint
 }

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -143,17 +143,21 @@ func TestBashHandler_RunsInSandboxDir(t *testing.T) {
 }
 
 // TestBashHandler_TimeoutHandsOffToBackground confirms a command that outruns
-// its timeout is reported as still running, with a handle, rather than killed.
+// its limits is reported as still running, with a handle, rather than killed.
 // Killing it would discard whatever it had produced and tell the model nothing
 // about why it stopped.
+//
+// The handoff is driven by the idle limit on the supervisor rather than a small
+// `timeout` in the input, because minBashTimeout floors anything the caller
+// passes at a minute — which is the whole point of the floor, but leaves the
+// supervisor field as the only way to reach this path inside a test's patience.
 func TestBashHandler_TimeoutHandsOffToBackground(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
-	sup := testSupervisor(t)
+	sup := fastSupervisor(t)
 
 	out, err := bashHandler(sb, sup, nil, BashInput{
 		Command: "sleep 5",
-		Timeout: 200, // 200 ms
 	})
 	if err != nil {
 		t.Fatalf("bashHandler returned error: %v", err)

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -407,8 +407,11 @@ func TestLsHandler(t *testing.T) {
 func TestBashTimeout(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
-	sup := testSupervisor(t)
-	out, err := bashHandler(sb, sup, nil, BashInput{Command: "sleep 10", Timeout: 500})
+	// fastSupervisor, not a small Timeout: caller-supplied limits are floored
+	// at minBashTimeout, so the supervisor's idle limit is what makes a handoff
+	// observable in a unit test.
+	sup := fastSupervisor(t)
+	out, err := bashHandler(sb, sup, nil, BashInput{Command: "sleep 10"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## The bug

`timeout` and `idle_timeout` are **milliseconds**, and nothing at the call site says so. A caller writing `timeout: 300` means five minutes and gets 300ms.

In a real session that handed `make test-coverage` to the background **312ms in** — before `make` had printed a line:

```
◉ bash(make test-coverage 2>&1 | tail -60)
  │ ⏳ 312ms elapsed, 312ms without output
  │ idle_timeout 300ms, timeout 300ms
```

Three things stacked up:

1. **No lower clamp.** `clampDuration` capped the upper bound only, so an impossible budget was accepted and run.
2. **One mistake became two.** `Run` clamps `idleTimeout` down to `timeout`, so a single bad field surfaced as two identical suspicious values in the report.
3. **`limitsHint` blamed the wrong knob.** It advised "pass a larger `idle_timeout`" — but the 300ms idle window *came from* the clamp. Raising `idle_timeout` alone is clamped straight back and changes nothing.

The model followed the advice it was given, went to `bash_wait` instead of re-running with sane limits, and spent two extra round trips recovering work that would have finished in the foreground — plus a real background process holding one of eight `maxBackgroundProcs` slots.

## The fix

**Floor both caller-supplied limits at one minute.** Any command shorter than a minute now completes in the foreground, whatever units the caller thought it was passing. `clampDuration` gained a `minDur` parameter; `bash_wait` passes `0`, since short waits are legitimate there.

**`defaultBashTimeout` moves 30s → 1m** to match. A default below the floor would give a caller who passes *nothing* a smaller budget than one who asks for the least the tool accepts.

**The floor announces itself.** Correcting the value silently fixes one call and lets the caller repeat the mistake forever:

```
Raised to the 1m0s floor: timeout=300ms (write 300000 for 5m0s). These limits
are in milliseconds. A value this far under the floor is nearly always seconds
written where milliseconds were expected.
```

It fires whether or not the command was backgrounded — a caller who wrote `timeout: 300` and got a clean result still asked for something it did not get. The seconds suggestion is **withheld** once that reading exceeds `maxBashTimeout`: `idle_timeout: 5000` is a deliberate five seconds, and answering it with *"write 5000000 for 1h23m20s"* is worse than silence.

**`limitsHint` now points at `timeout`,** names the unit, and no longer recommends a knob the clamp will undo. `shortIdleTimeout` tracks `minBashTimeout` rather than a 15s threshold no tool caller can reach.

## Prior art

Subagent frontmatter had the identical bug — `timeout: 30` meant thirty seconds and SIGKILLed the agent 30ms in (`minAgentTimeoutMs`, `internal/subagent/agents.go:14`). That one ignores the value and falls back to the default; this one floors, because a handoff is recoverable where a kill is not. The two guards now cross-reference each other.

## Testing

- `internal/tools` fully green; `make lint` reports 0 issues; `go vet ./...` clean.
- New: `TestBashHandler_SubMinuteLimitsAreFloored` (the regression), `TestBashHandler_SaneLimitsAreNotAnnotated`, `TestFlooredNote_WithholdsImplausibleSuggestions`. `TestClampDuration` covers the floor, the zero-floor case, and that an unset input takes its fallback unbent.
- Two handoff tests drove sub-second timeouts through `bashHandler` and no longer can, by design. They now use `fastSupervisor`, whose idle field bypasses the tool-boundary clamp — same coverage, still fast.
- Pre-existing failures on `main`, unrelated and untouched: `TestNewPromptHandler_NoAPIKey` (reaches the live API because a key is in the env) and `TestCommitAll_{PreservesUncommittedWork,AbandonedPlanSurvivesShutdown}`. Verified identical on `main`.

## Not done

- No `timeout` → `timeout_ms` rename. It would kill this class of error at the root, but it is a schema break; the floor plus the note handles the failure without one.
- `specs/issues/bash_wait_removal.md:13` still records "Foreground budget 120s → 30s". Left as a historical decision record, but it is stale if those specs are read as current.

https://claude.ai/code/session_01Co76tvL1opWdBEvz1z1nM5
