### PR TITLE
feat(tui): animate the terminal title while a turn runs

### DIFF
--- a/internal/tui/terminal_title.go
+++ b/internal/tui/terminal_title.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"strings"
+	"time"
 )
 
 // terminalTitleApp is the constant prefix used when constructing the terminal
@@ -9,6 +10,40 @@ import (
 // internal/tui/face.go); keeping the prefix short leaves room for the
 // prompt-derived title in a typical tab.
 const terminalTitleApp = "π -"
+
+// terminalTitleWorkingSymbols rotate through the prefix's symbol slot while a
+// turn is running, so the tab title itself animates ("π *", "π +", "π ∙",
+// "π -") and a backgrounded session is visibly still working. The set starts
+// on '-' so the idle prefix is one phase of the same cycle rather than a
+// separate shape, and the '∙' is the same dot the status-bar spinner uses
+// (spinnerSymbols in spinner.go) so the two animations read as one thing.
+var terminalTitleWorkingSymbols = []rune{'-', '*', '+', '∙'}
+
+// terminalTitleSpinPeriod is the wall-clock dwell of one symbol. The frame that
+// carries the title is redrawn on the 150ms matrix tick while running, so this
+// only has to be a multiple of that; ~half a second keeps the tab bar readable
+// instead of strobing.
+const terminalTitleSpinPeriod = 500 * time.Millisecond
+
+// terminalTitleSpinIndex maps a wall-clock time onto the symbol cycle. It is
+// called from Update (never View) so the rendered frame stays a pure function
+// of model state.
+func terminalTitleSpinIndex(now time.Time) int {
+	return int(now.UnixMilli()/terminalTitleSpinPeriod.Milliseconds()) % len(terminalTitleWorkingSymbols)
+}
+
+// terminalTitlePrefix returns the prefix for the current turn state: the static
+// "π -" when idle, or "π <symbol>" for the given phase while running.
+func terminalTitlePrefix(running bool, spin int) string {
+	if !running {
+		return terminalTitleApp
+	}
+	n := len(terminalTitleWorkingSymbols)
+	// Defensive modulo: spin comes from the model and a negative or out-of-range
+	// value must not panic the render path.
+	i := ((spin % n) + n) % n
+	return "π " + string(terminalTitleWorkingSymbols[i])
+}
 
 // terminalTitleMax caps the title so it fits on a single terminal line. The
 // terminal itself will truncate anything longer, but doing it here keeps the
@@ -72,6 +107,13 @@ func formatTerminalTitle(title string) string {
 // control-character scrub as formatTerminalTitle so the OSC 0 envelope stays
 // well-formed.
 func formatTerminalTitleWithCWD(title, cwd string) string {
+	return formatTerminalTitleWithPrefix(terminalTitleApp, title, cwd)
+}
+
+// formatTerminalTitleWithPrefix is formatTerminalTitleWithCWD with the leading
+// "π -" made a parameter, so a running turn can swap in the rotating symbol
+// (see terminalTitlePrefix) without duplicating the assembly and scrubbing.
+func formatTerminalTitleWithPrefix(prefix, title, cwd string) string {
 	// Scrub the CWD basename the same way the prompt is scrubbed. On Unix a
 	// directory name may legally contain ESC, BEL, or other C0 controls, and
 	// the OSC 0 envelope treats those as terminators — an unsanitized folder
@@ -84,19 +126,19 @@ func formatTerminalTitleWithCWD(title, cwd string) string {
 		// No CWD context — fall back to the bare prefix shape so callers that
 		// never set WorkDir (notably the unit tests) keep the old behavior.
 		if clean == "" {
-			return terminalTitleApp
+			return prefix
 		}
-		return terminalTitleApp + " " + clean
+		return prefix + " " + clean
 	}
 	if clean == "" {
-		return terminalTitleApp + " " + folder
+		return prefix + " " + folder
 	}
 	// Strip the command portion to terminalTitleCmdMax runes (counted in
 	// runes, not bytes, to match terminalTitleMax's rune-safe behavior).
 	if r := []rune(clean); len(r) > terminalTitleCmdMax {
 		clean = string(r[:terminalTitleCmdMax-1]) + "…"
 	}
-	return terminalTitleApp + " " + folder + " | " + clean
+	return prefix + " " + folder + " | " + clean
 }
 
 // stripControlChars is the shared prefix-cleaner: any C0 control (ESC, BEL,

--- a/internal/tui/terminal_title_test.go
+++ b/internal/tui/terminal_title_test.go
@@ -448,3 +448,91 @@ func TestHandleSlashCommand_ExitAndQuit_DoNotChangeTitle(t *testing.T) {
 		})
 	}
 }
+
+// While a turn runs, the title's prefix symbol rotates so a backgrounded tab
+// shows the session is still working. Idle keeps the static "π -".
+func TestTerminalTitlePrefix(t *testing.T) {
+	if got := terminalTitlePrefix(false, 2); got != "π -" {
+		t.Errorf("idle prefix = %q, want %q", got, "π -")
+	}
+	seen := map[string]bool{}
+	for i := range terminalTitleWorkingSymbols {
+		got := terminalTitlePrefix(true, i)
+		if len([]rune(got)) != 3 || !strings.HasPrefix(got, "π ") {
+			t.Errorf("running prefix at spin %d = %q, want %q + one symbol", i, got, "π ")
+		}
+		seen[got] = true
+	}
+	if len(seen) != len(terminalTitleWorkingSymbols) {
+		t.Errorf("running prefixes = %v, want one distinct prefix per symbol", seen)
+	}
+	// An out-of-range phase must wrap rather than panic — spin comes from the
+	// model and the render path has no business panicking on it.
+	if got := terminalTitlePrefix(true, len(terminalTitleWorkingSymbols)); got != terminalTitlePrefix(true, 0) {
+		t.Errorf("prefix did not wrap: %q", got)
+	}
+	if got := terminalTitlePrefix(true, -1); got != terminalTitlePrefix(true, len(terminalTitleWorkingSymbols)-1) {
+		t.Errorf("negative spin did not wrap: %q", got)
+	}
+}
+
+// The phase is a pure function of wall-clock time, so any redraw — whatever
+// triggered it — shows the symbol the elapsed time calls for.
+func TestTerminalTitleSpinIndex_AdvancesWithTime(t *testing.T) {
+	base := time.UnixMilli(0)
+	for i := range terminalTitleWorkingSymbols {
+		at := base.Add(time.Duration(i) * terminalTitleSpinPeriod)
+		if got := terminalTitleSpinIndex(at); got != i {
+			t.Errorf("spin index at +%v = %d, want %d", at.Sub(base), got, i)
+		}
+	}
+	// Within one period the phase holds steady.
+	if got := terminalTitleSpinIndex(base.Add(terminalTitleSpinPeriod - time.Millisecond)); got != 0 {
+		t.Errorf("spin index just before the first rollover = %d, want 0", got)
+	}
+	// And it wraps back to the start of the cycle.
+	full := time.Duration(len(terminalTitleWorkingSymbols)) * terminalTitleSpinPeriod
+	if got := terminalTitleSpinIndex(base.Add(full)); got != 0 {
+		t.Errorf("spin index after a full cycle = %d, want 0", got)
+	}
+}
+
+// The animated prefix has to reach the terminal the same way the static one
+// does — through View().WindowTitle, with the session title still attached.
+func TestView_WindowTitle_AnimatesWhileRunning(t *testing.T) {
+	m, _ := newTitleTestModel(t)
+	m.applySessionTitle("fix the top-level render")
+
+	m.running = true
+	for i := range terminalTitleWorkingSymbols {
+		m.titleSpin = i
+		want := terminalTitlePrefix(true, i) + " fix the top-level render"
+		if got := m.View().WindowTitle; got != want {
+			t.Errorf("running WindowTitle at spin %d = %q, want %q", i, got, want)
+		}
+	}
+
+	// Turn over: the prefix goes back to being static, whatever phase the
+	// animation stopped on.
+	m.running = false
+	if got := m.View().WindowTitle; got != "π - fix the top-level render" {
+		t.Errorf("idle WindowTitle = %q, want %q", got, "π - fix the top-level render")
+	}
+}
+
+// The matrix tick is what drives the animation: it already advances the tool
+// bullet's blink while running, and now the title phase alongside it.
+func TestMatrixTick_AdvancesTitleSpin(t *testing.T) {
+	m, _ := newTitleTestModel(t)
+	m.running = true
+	m.titleSpin = -1
+
+	updated, _ := m.Update(matrixTickMsg{})
+	mm, ok := updated.(*model)
+	if !ok {
+		t.Fatalf("Update returned %T, want *model", updated)
+	}
+	if want := terminalTitleSpinIndex(time.Now()); mm.titleSpin != want {
+		t.Errorf("titleSpin after tick = %d, want %d", mm.titleSpin, want)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -88,6 +88,11 @@ type model struct {
 	// is surfaced to the terminal via View().WindowTitle so Bubble Tea's
 	// renderer emits the escape sequence in-band with the frame it draws.
 	sessionTitle string
+	// titleSpin is the phase of the animated title prefix ("π *", "π +",
+	// "π -") shown while a turn runs. It is advanced in Update from the
+	// matrix tick, next to ToolDisplay.BlinkOn, so View stays a pure
+	// function of model state.
+	titleSpin int
 	// topSectionRows is the number of rows in the top section (messages + sidebar)
 	// before the full-width status bar. The rail and sidebar only cover these rows.
 	topSectionRowsVal int
@@ -707,7 +712,11 @@ func (m *model) updateTerminal(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 			// here, in Update, so View stays a pure function of model state —
 			// the matrix tick (150ms while running) re-renders often enough to
 			// animate it.
-			m.chatModel.ToolDisplay.BlinkOn = time.Now().UnixMilli()/500%2 == 0
+			now := time.Now()
+			m.chatModel.ToolDisplay.BlinkOn = now.UnixMilli()/500%2 == 0
+			// Same idea one level out: the tab title's prefix symbol rotates so
+			// a backgrounded session still shows it is working.
+			m.titleSpin = terminalTitleSpinIndex(now)
 			return m, matrixTickCmd(), true
 		}
 		return m, nil, true
@@ -1615,7 +1624,12 @@ func (m *model) View() tea.View {
 	// through the View is what keeps the sequence ordered against the frame
 	// writes — writing it to os.Stdout directly races the renderer and lands
 	// mid-frame, which corrupts the drawn output.
-	v.WindowTitle = formatTerminalTitleWithCWD(m.sessionTitle, m.cfg.WorkDir)
+	//
+	// While a turn runs the "π -" prefix becomes a rotating
+	// "π * / π + / π ∙ / π -" so the tab shows progress even when the window
+	// is not visible.
+	v.WindowTitle = formatTerminalTitleWithPrefix(
+		terminalTitlePrefix(m.running, m.titleSpin), m.sessionTitle, m.cfg.WorkDir)
 	if inputCursor != nil {
 		inputCursor.Y += inputCursorY
 		v.Cursor = inputCursor


### PR DESCRIPTION
The tab title was the static "π - <cwd> | <prompt>" whether the session was
idle or mid-turn, so a backgrounded window gave no sign that work was still
happening. Rotate the prefix's symbol slot instead — "π -", "π *", "π +",
"π ∙" — on a 500ms wall-clock cycle while m.running, using the same dot the
status-bar spinner uses so the two animations read as one thing.

The phase is derived from wall clock and advanced in Update on the existing
150ms matrix tick, next to ToolDisplay.BlinkOn, so View stays a pure function
of model state and any redraw shows the phase the elapsed time calls for.

formatTerminalTitleWithCWD now delegates to formatTerminalTitleWithPrefix so
the CWD/prompt assembly and the C0 control scrubbing that keeps the OSC 0
envelope well-formed are not duplicated for the animated case.

Claude-Session: https://claude.ai/code/session_01Y4dxh2VRcEbWdgPCjEqLhC
Signed-off-by: dimetron <dimetron@me.com>
