### PR TITLE
fix(ollama): route by the model's tag at every call site, not by the key

### DIFF
--- a/internal/acp/server/ollama_endpoint_test.go
+++ b/internal/acp/server/ollama_endpoint_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+)
+
+// buildSessionLLM used to read OLLAMA_API_KEY as a destination: a key exported
+// for some :cloud model sent every locally pulled model to api.ollama.com,
+// which 404s for a name only that machine has. Routing follows the model's tag
+// here exactly as it does in the CLI, and the local-daemon health check must
+// not run against the cloud endpoint.
+func TestBuildSessionLLM_OllamaRoutesByTag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+	t.Setenv("OLLAMA_HOST", "")
+
+	cfg := config.Config{
+		Roles: map[string]config.RoleConfig{
+			"default": {Model: "deepseek-v4-flash:0731-cloud", Provider: "ollama"},
+		},
+	}
+
+	llm, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
+	if err != nil {
+		t.Fatalf("buildSessionLLM: %v", err)
+	}
+	if llm == nil {
+		t.Fatal("nil LLM")
+	}
+	if got := llm.Name(); got != "deepseek-v4-flash:0731-cloud" {
+		t.Errorf("Name() = %q, want the model name unchanged", got)
+	}
+}
+
+// With no key and a local endpoint, the daemon has to answer. Pointing
+// OLLAMA_HOST at a closed port makes the failure deterministic rather than
+// depending on whether a daemon happens to be running on the test machine.
+func TestBuildSessionLLM_OllamaHealthCheckFailureIsReported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "")
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
+
+	cfg := config.Config{
+		Roles: map[string]config.RoleConfig{
+			"default": {Model: "ollama/qwen3.8:27b-mlx", Provider: "ollama"},
+		},
+	}
+
+	_, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
+	if err == nil {
+		t.Fatal("expected an error when the daemon is unreachable")
+	}
+	if !strings.Contains(err.Error(), "ollama health check") {
+		t.Errorf("err = %v, want it to name the health check", err)
+	}
+}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -247,14 +247,10 @@ func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (
 		return nil, fmt.Errorf("no API key found for provider %q (set %s)", info.Provider, providerEnvVar(info.Provider))
 	}
 
-	if baseURL == "" && info.Ollama {
-		if apiKey != "" {
-			baseURL = "https://api.ollama.com"
-		} else {
-			baseURL = "http://localhost:11434"
-		}
+	if info.Ollama {
+		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
 	}
-	if info.Ollama && apiKey == "" {
+	if info.Ollama && apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
 		if err := provider.CheckOllama(baseURL); err != nil {
 			return nil, fmt.Errorf("ollama health check: %w", err)
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -329,14 +329,17 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 		return rootRuntime{}, fmt.Errorf("no API key found for provider %q (set %s)", info.Provider, envVar)
 	}
 
-	if baseURL == "" && info.Ollama {
-		if apiKey != "" {
-			baseURL = "https://api.ollama.com"
-		} else {
-			baseURL = "http://localhost:11434"
-		}
+	if info.Ollama {
+		// The model's tag decides the daemon, not whether OLLAMA_API_KEY
+		// happens to be exported: a key set for some :cloud model used to send
+		// locally pulled names like qwen3.8:27b-mlx to api.ollama.com, which
+		// answers 404 for a model only this machine has.
+		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+		// Record the endpoint actually chosen so session metadata names the
+		// backend instead of leaving the model name to be interpreted.
+		info.BaseURL = baseURL
 	}
-	if info.Ollama && apiKey == "" {
+	if info.Ollama && apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
 		if err := provider.CheckOllama(baseURL); err != nil {
 			return rootRuntime{}, fmt.Errorf("ollama health check: %w", err)
 		}
@@ -1590,11 +1593,11 @@ func buildCommitMsgFunc(ctx context.Context, cfg config.Config) func(context.Con
 		baseURLs := cfg.ResolveBaseURLs()
 		baseURL = baseURLs[info.Provider]
 	}
-	if baseURL == "" && info.Ollama {
-		baseURL = "http://localhost:11434"
+	if info.Ollama {
+		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
 	}
 
-	if info.Ollama {
+	if info.Ollama && !provider.IsOllamaCloudEndpoint(baseURL) {
 		if err := provider.CheckOllama(baseURL); err != nil {
 			return nil
 		}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"fmt"
 	"io"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/provider"
 )
 
 // roleFlags lists the roles pi can run as, in the order the footer prints them,
@@ -82,7 +82,7 @@ func writeRoleSummary(w io.Writer) {
 // reporting a missing OLLAMA_API_KEY there would be a false alarm — the key is
 // only required once a :cloud tag routes the request to api.ollama.com.
 func credentialStatus(prov, model string, keys map[string]string) string {
-	if prov == "ollama" && !isOllamaCloudModel(model) {
+	if prov == "ollama" && !provider.IsOllamaCloudModel(model) {
 		return "none (local daemon)"
 	}
 
@@ -91,10 +91,4 @@ func credentialStatus(prov, model string, keys map[string]string) string {
 		return envVar + " (set)"
 	}
 	return envVar + " (MISSING)"
-}
-
-// isOllamaCloudModel reports whether the model tag routes to Ollama Cloud
-// rather than a local daemon. Mirrors provider.Resolve.
-func isOllamaCloudModel(model string) bool {
-	return strings.HasSuffix(model, ":cloud") || strings.HasSuffix(model, "-cloud")
 }

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -905,12 +905,8 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 	keys := config.APIKeys()
 	apiKey := keys[info.Provider]
 
-	if baseURL == "" && info.Ollama {
-		if apiKey != "" {
-			baseURL = "https://api.ollama.com"
-		} else {
-			baseURL = "http://localhost:11434"
-		}
+	if info.Ollama {
+		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
 	}
 
 	// Record the endpoint actually chosen, after every fallback above has had

--- a/internal/cli/ollama_callsite_test.go
+++ b/internal/cli/ollama_callsite_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/guardrail"
+)
+
+// The endpoint decision has to be the same one in every place that builds an
+// Ollama client, not just in the main run path. These two callers each used to
+// decide for themselves — buildSwitchedLLM read the API key as a destination,
+// buildCommitMsgFunc hard-coded localhost — so both are pinned here against a
+// :cloud model, which is the direction each of them used to get wrong.
+
+func TestBuildSwitchedLLM_OllamaRoutesByTag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+	t.Setenv("OLLAMA_HOST", "")
+
+	origURL := flagURL
+	t.Cleanup(func() { flagURL = origURL })
+	flagURL = ""
+
+	cfg := config.Config{
+		Roles: map[string]config.RoleConfig{
+			"default": {Model: "deepseek-v4-flash:0731-cloud", Provider: "ollama"},
+		},
+	}
+
+	// A cloud-tagged model must reach the cloud endpoint without a health
+	// check against a local daemon that need not be running.
+	llm, modelName, providerName, err := buildSwitchedLLM(
+		context.Background(), cfg, guardrail.New(0), "deepseek-v4-flash:0731-cloud")
+	if err != nil {
+		t.Fatalf("buildSwitchedLLM: %v", err)
+	}
+	if llm == nil {
+		t.Fatal("nil LLM")
+	}
+	if providerName != "ollama" {
+		t.Errorf("provider = %q, want ollama", providerName)
+	}
+	if modelName != "deepseek-v4-flash:0731-cloud" {
+		t.Errorf("model = %q, want the name unchanged", modelName)
+	}
+}
+
+// buildCommitMsgFunc used to default every Ollama model to localhost, so a
+// :cloud commit model was sent to a daemon that does not serve it. It returns
+// nil rather than an error when the model cannot be reached, so the assertion
+// is that a cloud tag yields a usable callback with no local daemon present.
+func TestBuildCommitMsgFunc_OllamaCloudTagSkipsLocalDaemon(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+	t.Setenv("OLLAMA_HOST", "")
+
+	origURL := flagURL
+	t.Cleanup(func() { flagURL = origURL })
+	flagURL = ""
+
+	cfg := config.Config{
+		Roles: map[string]config.RoleConfig{
+			"commit": {Model: "deepseek-v4-flash:0731-cloud", Provider: "ollama"},
+		},
+	}
+
+	if fn := buildCommitMsgFunc(context.Background(), cfg); fn == nil {
+		t.Fatal("buildCommitMsgFunc returned nil for a cloud-tagged model; " +
+			"the local-daemon health check should not run against api.ollama.com")
+	}
+}
+
+// ping resolved its own endpoint too, and defaulted every Ollama model to
+// localhost — so `pi ping` against a :cloud model probed a daemon that does
+// not serve it. It now asks the same resolver as everything else.
+func TestResolvePingTarget_OllamaRoutesByTag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+	t.Setenv("OLLAMA_HOST", "")
+
+	origURL, origModel := flagURL, flagModel
+	t.Cleanup(func() { flagURL, flagModel = origURL, origModel })
+	flagURL, flagModel = "", ""
+
+	tests := []struct {
+		name, model, want string
+	}{
+		{"cloud tag reaches the cloud", "deepseek-v4-flash:0731-cloud", "https://api.ollama.com"},
+		{"local tag stays local", "ollama/qwen3.8:27b-mlx", "http://localhost:11434"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				Roles: map[string]config.RoleConfig{
+					"default": {Model: tt.model, Provider: "ollama"},
+				},
+			}
+			target, err := resolvePingTarget(cfg)
+			if err != nil {
+				t.Fatalf("resolvePingTarget: %v", err)
+			}
+			if target.baseURL != tt.want {
+				t.Errorf("baseURL = %q, want %q", target.baseURL, tt.want)
+			}
+		})
+	}
+}
+
+// With no key and a local endpoint the daemon has to actually answer, and the
+// failure has to say so. Pointing OLLAMA_HOST at a closed port makes that
+// deterministic without depending on whether a daemon happens to be running.
+func TestBuildRootRuntime_OllamaHealthCheckFailureIsReported(t *testing.T) {
+	resetGlobalFlags(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "")
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
+
+	flagModel = "ollama/qwen3.8:27b-mlx"
+	flagMode = "print"
+
+	_, err := buildRootRuntime(context.Background(), []string{"hi"})
+	if err == nil {
+		t.Fatal("expected an error when the daemon is unreachable")
+	}
+	if !strings.Contains(err.Error(), "ollama health check") {
+		t.Errorf("err = %v, want it to name the health check", err)
+	}
+}
+
+// buildCommitMsgFunc reports the same condition by returning nil, which is how
+// /commit degrades to no generated message rather than failing the session.
+func TestBuildCommitMsgFunc_OllamaUnreachableDaemonYieldsNil(t *testing.T) {
+	resetGlobalFlags(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "")
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
+
+	cfg := config.Config{
+		Roles: map[string]config.RoleConfig{
+			"commit": {Model: "ollama/qwen3.8:27b-mlx", Provider: "ollama"},
+		},
+	}
+	if fn := buildCommitMsgFunc(context.Background(), cfg); fn != nil {
+		t.Error("expected nil when the local daemon is unreachable")
+	}
+}

--- a/internal/cli/ollama_routing_test.go
+++ b/internal/cli/ollama_routing_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"testing"
+)
+
+// The bug this pins: OLLAMA_API_KEY exported for a :cloud model used to be read
+// as a destination, so a locally pulled name like qwen3.8:27b-mlx was posted to
+// api.ollama.com and came back "model not found" from a server the user never
+// meant to talk to. Routing follows the model's tag; the key is a credential.
+func TestBuildRootRuntime_OllamaKeyDoesNotForceCloud(t *testing.T) {
+	tests := []struct {
+		name    string
+		model   string
+		wantURL string
+	}{
+		{
+			name:    "mlx tag stays on the local daemon",
+			model:   "ollama/qwen3.8:27b-mlx",
+			wantURL: "http://localhost:11434",
+		},
+		{
+			name:    "cloud tag still routes to the cloud",
+			model:   "ollama/deepseek-v4-flash:0731-cloud",
+			wantURL: "https://api.ollama.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobalFlags(t)
+			t.Setenv("HOME", t.TempDir())
+			// Set, as it must be for any cloud model — and irrelevant to where
+			// a local model goes.
+			t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+			t.Setenv("OLLAMA_HOST", "")
+
+			flagModel = tt.model
+			flagMode = "print"
+
+			rt, err := buildRootRuntime(context.Background(), []string{"hi"})
+			if err != nil {
+				t.Fatalf("buildRootRuntime: %v", err)
+			}
+			if rt.info.BaseURL != tt.wantURL {
+				t.Errorf("endpoint = %q, want %q", rt.info.BaseURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+// An explicit OLLAMA_HOST is how someone points at another machine, a
+// container, or an authenticated proxy, so it outranks the tag either way.
+func TestBuildRootRuntime_OllamaHostWinsOverTag(t *testing.T) {
+	resetGlobalFlags(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+	t.Setenv("OLLAMA_HOST", "http://gpu-box.lan:11434")
+
+	flagModel = "ollama/deepseek-v4-flash:0731-cloud"
+	flagMode = "print"
+
+	rt, err := buildRootRuntime(context.Background(), []string{"hi"})
+	if err != nil {
+		t.Fatalf("buildRootRuntime: %v", err)
+	}
+	if want := "http://gpu-box.lan:11434"; rt.info.BaseURL != want {
+		t.Errorf("endpoint = %q, want %q", rt.info.BaseURL, want)
+	}
+}

--- a/internal/cli/ping.go
+++ b/internal/cli/ping.go
@@ -248,8 +248,8 @@ func resolvePingTarget(cfg config.Config) (*pingTarget, error) {
 	}
 
 	apiKey := config.APIKeys()[info.Provider]
-	if baseURL == "" && info.Ollama {
-		baseURL = "http://localhost:11434"
+	if info.Ollama {
+		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
 	}
 	// Azure resolves its endpoint and credential through the same helpers a
 	// real run uses, so a passing ping means the settings a real run would pick

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -31,14 +31,18 @@ const (
 	ollamaCloudURL = "https://api.ollama.com"
 )
 
-// resolveOllamaEndpoint picks the server a model should be sent to.
+// ResolveOllamaEndpoint picks the server a model should be sent to. It is
+// exported because every caller that builds an Ollama client — the CLI, the
+// TUI's /model switch, the ACP server, ping — has to reach the same answer;
+// each one deciding for itself is how the key-as-destination bug survived in
+// three places after this function stopped making that mistake.
 //
 // Routing follows the model's cloud tag, which is the rule the CLI help and
 // every other routing check in the tree already state. It used to follow the
 // presence of an API key instead, and that made OLLAMA_API_KEY a global switch:
 // exporting it once for a :cloud model silently sent every *local* model to
-// api.ollama.com too, where a privately pulled name like muse-glimmer:30b-mlx
-// does not exist. The key is a credential, not a destination.
+// api.ollama.com too, where a privately pulled name like qwen3.8:27b-mlx does
+// not exist. The key is a credential, not a destination.
 //
 // An explicit baseURL (OLLAMA_HOST) always wins — that is how someone points at
 // another machine, a container, or an authenticated proxy.
@@ -47,18 +51,37 @@ const (
 // whatever endpoint is chosen whenever one is set, unchanged, because an
 // authenticated daemon may be reached over loopback as easily as over the
 // network and this function cannot tell the two apart.
-func resolveOllamaEndpoint(modelName, baseURL string) string {
+func ResolveOllamaEndpoint(modelName, baseURL string) string {
 	if endpoint := normalizeBaseURL(baseURL); endpoint != "" {
 		return endpoint
 	}
-	if isOllamaCloudModel(modelName) {
+	if IsOllamaCloudModel(modelName) {
 		return ollamaCloudURL
 	}
 	return ollamaLocalURL
 }
 
+// IsOllamaCloudEndpoint reports whether an already-resolved endpoint is
+// ollama.com's hosted API.
+//
+// Callers need this to tell a reachability problem from a credential problem:
+// the TCP-and-GET health check in CheckOllama is a statement about a daemon on
+// a host someone controls, and running it against api.ollama.com turns a
+// missing OLLAMA_API_KEY into a misleading "ollama not reachable".
+//
+// It matches on host, not on a string compare with ollamaCloudURL, so an
+// OLLAMA_HOST pointed at the cloud API by hand is recognized too.
+func IsOllamaCloudEndpoint(baseURL string) bool {
+	u, err := url.Parse(normalizeBaseURL(baseURL))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "api.ollama.com" || host == "ollama.com"
+}
+
 // NewOllama creates an Ollama model.LLM using the native Ollama Go client.
-// The server is chosen by resolveOllamaEndpoint: an explicit baseURL if given,
+// The server is chosen by ResolveOllamaEndpoint: an explicit baseURL if given,
 // otherwise api.ollama.com for a :cloud/-cloud tagged model and localhost for
 // everything else.
 // thinkingLevel controls extended thinking: "none", "low", "medium", "high".
@@ -66,7 +89,7 @@ func NewOllama(_ context.Context, modelName, apiKey, baseURL, thinkingLevel stri
 	if modelName == "" {
 		return nil, fmt.Errorf("model name is required")
 	}
-	baseURL = resolveOllamaEndpoint(modelName, baseURL)
+	baseURL = ResolveOllamaEndpoint(modelName, baseURL)
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Ollama URL %q: %w", baseURL, err)

--- a/internal/provider/ollama_endpoint_test.go
+++ b/internal/provider/ollama_endpoint_test.go
@@ -136,6 +136,9 @@ func TestIsOllamaCloudEndpoint(t *testing.T) {
 	}
 	local := []string{
 		ollamaLocalURL,
+		// Unparseable: the guard returns false so a malformed OLLAMA_HOST is
+		// treated as a host someone runs, keeping the reachability check.
+		"http://[::1",
 		"http://127.0.0.1:11434",
 		"http://[::1]:11434",
 		"http://gpu-box.lan:11434",

--- a/internal/provider/ollama_endpoint_test.go
+++ b/internal/provider/ollama_endpoint_test.go
@@ -80,8 +80,8 @@ func TestResolveOllamaEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if endpoint := resolveOllamaEndpoint(tt.model, tt.baseURL); endpoint != tt.wantEndpoint {
-				t.Errorf("resolveOllamaEndpoint(%q, %q) = %q, want %q",
+			if endpoint := ResolveOllamaEndpoint(tt.model, tt.baseURL); endpoint != tt.wantEndpoint {
+				t.Errorf("ResolveOllamaEndpoint(%q, %q) = %q, want %q",
 					tt.model, tt.baseURL, endpoint, tt.wantEndpoint)
 			}
 		})
@@ -100,13 +100,13 @@ func TestIsOllamaCloudModel(t *testing.T) {
 	}
 
 	for _, m := range cloud {
-		if !isOllamaCloudModel(m) {
-			t.Errorf("isOllamaCloudModel(%q) = false, want true", m)
+		if !IsOllamaCloudModel(m) {
+			t.Errorf("IsOllamaCloudModel(%q) = false, want true", m)
 		}
 	}
 	for _, m := range local {
-		if isOllamaCloudModel(m) {
-			t.Errorf("isOllamaCloudModel(%q) = true, want false", m)
+		if IsOllamaCloudModel(m) {
+			t.Errorf("IsOllamaCloudModel(%q) = true, want false", m)
 		}
 	}
 }
@@ -120,5 +120,39 @@ func TestNewOllamaAcceptsLocalTaggedModel(t *testing.T) {
 	}
 	if got := llm.Name(); got != "muse-glimmer:30b-mlx" {
 		t.Errorf("Name() = %q, want the model name unchanged", got)
+	}
+}
+
+// Telling the two apart is what keeps a missing OLLAMA_API_KEY from being
+// reported as an unreachable daemon: CheckOllama is only meaningful against a
+// host someone runs themselves.
+func TestIsOllamaCloudEndpoint(t *testing.T) {
+	cloud := []string{
+		ollamaCloudURL,
+		"https://api.ollama.com/",
+		"https://ollama.com",
+		"api.ollama.com", // no scheme, as OLLAMA_HOST is often written
+		"HTTPS://API.OLLAMA.COM",
+	}
+	local := []string{
+		ollamaLocalURL,
+		"http://127.0.0.1:11434",
+		"http://[::1]:11434",
+		"http://gpu-box.lan:11434",
+		"https://ollama.internal.example.com",
+		// A proxy that merely mentions the cloud host is not the cloud host.
+		"https://ollama-proxy.example.com/api.ollama.com",
+		"",
+	}
+
+	for _, u := range cloud {
+		if !IsOllamaCloudEndpoint(u) {
+			t.Errorf("IsOllamaCloudEndpoint(%q) = false, want true", u)
+		}
+	}
+	for _, u := range local {
+		if IsOllamaCloudEndpoint(u) {
+			t.Errorf("IsOllamaCloudEndpoint(%q) = true, want false", u)
+		}
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -173,7 +173,7 @@ var modelPrefixes = map[string]string{
 // ollama/ prefix, or the :cloud tag for Ollama cloud models.
 var OllamaModelPrefixes = []string{}
 
-// isOllamaCloudModel reports whether a model name is tagged for ollama.com's
+// IsOllamaCloudModel reports whether a model name is tagged for ollama.com's
 // hosted service. Ollama publishes both forms — a bare ":cloud" and the
 // ":<size>-cloud" that most of the catalog uses — so a check for one alone
 // silently misses the other.
@@ -181,7 +181,7 @@ var OllamaModelPrefixes = []string{}
 // This is the single fact that decides local versus cloud, and it is the
 // model's name that decides it. Nothing about the caller's environment enters
 // into it.
-func isOllamaCloudModel(modelName string) bool {
+func IsOllamaCloudModel(modelName string) bool {
 	return strings.HasSuffix(modelName, ":cloud") || strings.HasSuffix(modelName, "-cloud")
 }
 
@@ -347,7 +347,7 @@ func Resolve(modelName string) (Info, error) {
 
 	// Detect :cloud or -cloud suffix → native Ollama provider.
 	// Keep the full model name — :cloud and -cloud are valid Ollama model tags.
-	if isOllamaCloudModel(modelName) {
+	if IsOllamaCloudModel(modelName) {
 		return Info{Provider: "ollama", Model: modelName, Ollama: true}, nil
 	}
 


### PR DESCRIPTION
## The bug

With `OLLAMA_API_KEY` exported (this repo's `.pi-go/.env` sets it), every **local** Ollama model was posted to `api.ollama.com`:

```
error: agent run: 404 Not Found: model 'qwen3.8:27b-mlx' not found
```

The model exists locally — `ollama list` shows it — but the request never reached the local daemon. Confirmed from the HTTP trace: `POST https://api.ollama.com/api/chat` → 404.

## Root cause

`provider.ResolveOllamaEndpoint` already routes by the model's tag (aa62345). But three callers decided the endpoint *themselves* first and passed the result down as an explicit `baseURL`, which the provider honours as a deliberate override — so the key-as-destination rule survived:

```go
if apiKey != "" { baseURL = "https://api.ollama.com" } else { baseURL = "http://localhost:11434" }
```

in `buildRootRuntime`, the TUI's model switch, and the ACP server. Two further sites hard-coded `localhost` unconditionally, which sends `:cloud` models to a local daemon — the same bug in the opposite direction.

## The fix

- Export `ResolveOllamaEndpoint` and use it at all five sites, so every caller reaches the same answer. The model's tag decides both directions; an explicit `OLLAMA_HOST` still wins over both.
- Add `IsOllamaCloudEndpoint` to gate `CheckOllama`. The TCP-and-GET health check describes a daemon on a host you run; against `api.ollama.com` it turns a missing key into a misleading "ollama not reachable".
- Drop the duplicate `isOllamaCloudModel` in `cli/help.go`.

## Verification

Rebuilt binary against the local daemon — the request now goes to `http://localhost:11434/api/chat`.

`internal/cli/ollama_routing_test.go` pins it, and I confirmed it **fails against the old logic**:

```
endpoint = "https://api.ollama.com", want "http://localhost:11434"
```

Gates: `gofmt` clean · `go build ./...` · `go test ./...` · `go vet` · `golangci-lint` 0 issues.

## Note on dependencies

An earlier revision of this branch carried a `go get -u ./...` bump. After rebasing onto current `main`, **`main` already carries every one of those versions** — `go list -u -m` reports zero outdated direct dependencies — so `go.mod`/`go.sum` are untouched here and this PR is purely the routing fix.

One finding from that work is worth recording: `go.opentelemetry.io/otel/log` **cannot** go to v0.21.0 while `adk/v2` is at v2.2.0 — v0.21.0 removes `log.Value`/`log.KeyValue`, which `adk/v2@v2.2.0` still uses. A future blanket `-u` will break the build on that one. Separately, `go get -u ./...` now fails outright on current `main`: `github.com/digitorus/pkcs7` requires go >= 1.27.