### PR TITLE
refactor: cut cyclomatic complexity across nine packages

### DIFF
--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -141,138 +141,24 @@ func deferredInit(
 	res *initResources,
 ) {
 	initTotal := deferredInitTotal(cfg)
-	send := func(item string, done bool) {
+	send := initProgress(func(item string, done bool) {
 		ch <- tui.InitEvent{Item: item, Done: done, Total: initTotal}
-	}
+	})
 	fail := func(err error) {
 		ch <- tui.InitEvent{Err: err}
 	}
 
 	// --- Phase 1: Core tools (fast, needed by everything) ---
 	send("tools", false)
-
-	sandbox, err := tools.NewSandbox(sandboxRoot, worktreeDir)
+	coreTools, err := initCoreTools(sandboxRoot, worktreeDir, res)
 	if err != nil {
-		fail(fmt.Errorf("creating sandbox: %w", err))
+		fail(err)
 		return
 	}
-	res.sandbox = sandbox
-
-	// Allow agent tools to access ~/.pi-go/ (logs, sessions, config).
-	if home, hErr := os.UserHomeDir(); hErr == nil {
-		_ = sandbox.AddExtraDir(filepath.Join(home, ".pi-go"))
-	}
-
-	// The supervisor is built here, before the UI event channel exists, because
-	// the bash tool needs it at construction time. Its sink is attached later,
-	// once there is somewhere to stream to.
-	bashSup := tools.NewBashSupervisor()
-	res.bashSup = bashSup
-
-	coreTools, err := tools.CoreTools(sandbox, tools.WithBashSupervisor(bashSup))
-	if err != nil {
-		fail(fmt.Errorf("creating core tools: %w", err))
-		return
-	}
-	bashCtlTools, err := tools.BashControlTools(bashSup)
-	if err != nil {
-		fail(fmt.Errorf("creating bash control tools: %w", err))
-		return
-	}
-	coreTools = append(coreTools, bashCtlTools...)
-
 	send("tools", true)
 
 	// --- Phase 2: Parallel subsystems ---
-	type parallelState struct {
-		mu sync.Mutex
-
-		// Git + subagents
-		repoRoot     string
-		agentConfigs []subagent.AgentConfig
-		gitBranch    string
-		diffAdded    int
-		diffRemoved  int
-
-		// LSP
-		lspMgr   *lsp.Manager
-		lspTools []adktool.Tool
-
-		// MCP
-		mcpToolsets []adktool.Toolset
-
-		// Skills
-		skills    []extension.Skill
-		skillDirs []string
-	}
-	var ps parallelState
-	var wg sync.WaitGroup
-
-	// Git + subagent discovery
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		send("git", false)
-		ps.repoRoot = detectGitRoot(ctx, cwd)
-		discovery, _ := subagent.DiscoverAgents(cwd, subagent.ScopeBoth)
-		if discovery != nil {
-			ps.agentConfigs = discovery.All
-		}
-		ps.gitBranch = detectBranch(ctx, cwd)
-		ps.diffAdded, ps.diffRemoved = computeDiffStats(ctx, cwd)
-		send("git", true)
-	}()
-
-	// LSP
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		send("lsp", false)
-		mgr := lsp.NewManager(nil)
-		// Only advertise the LSP tools when a server can actually answer them —
-		// see the matching note in cli.go. The manager itself is always kept:
-		// the after-tool callback and diagnostics plumbing cost nothing idle.
-		var lt []adktool.Tool
-		if mgr.AnyAvailable() {
-			lt, _ = tools.LSPToolsFor(mgr, resolveLSPMode())
-		}
-		ps.mu.Lock()
-		ps.lspMgr = mgr
-		ps.lspTools = lt
-		ps.mu.Unlock()
-		send("lsp", true)
-	}()
-
-	// MCP
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if cfg.MCP == nil || len(cfg.MCP.Servers) == 0 {
-			return
-		}
-		send("mcp", false)
-		ts, _ := extension.BuildMCPToolsets(buildMCPServerConfigs(cfg))
-		ps.mu.Lock()
-		ps.mcpToolsets = ts
-		ps.mu.Unlock()
-		send("mcp", true)
-	}()
-
-	// Skills
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		send("skills", false)
-		dirs := extension.DefaultSkillDirs()
-		sk, _ := extension.LoadSkills(dirs...)
-		ps.mu.Lock()
-		ps.skills = sk
-		ps.skillDirs = dirs
-		ps.mu.Unlock()
-		send("skills", true)
-	}()
-
-	wg.Wait()
+	ps := discoverSubsystems(ctx, cfg, cwd, send)
 
 	// --- Phase 3: Sequential finalization ---
 	send("agent", false)
@@ -288,10 +174,7 @@ func deferredInit(
 	// Build agent event channel and tools.
 	agentEventCh := make(chan tui.AgentSubEvent, 128)
 	agentEventCB := func(agentID, eventType, content string) {
-		select {
-		case agentEventCh <- tui.AgentSubEvent{AgentID: agentID, Kind: eventType, Content: content}:
-		default:
-		}
+		trySend(agentEventCh, tui.AgentSubEvent{AgentID: agentID, Kind: eventType, Content: content})
 	}
 	agentTools, _ := tools.AgentTools(orch, agentEventCB)
 	coreTools = append(coreTools, agentTools...)
@@ -299,7 +182,7 @@ func deferredInit(
 	// Stream live shell output to the same channel the subagent cards use. The
 	// prefix keeps the two streams apart; the non-blocking send in agentEventCB
 	// is what keeps a slow UI from stalling a running command.
-	bashSup.SetSink(func(execID, kind, content string) {
+	res.bashSup.SetSink(func(execID, kind, content string) {
 		agentEventCB(execID, tui.BashEventKind(kind), content)
 	})
 
@@ -309,70 +192,22 @@ func deferredInit(
 	}
 
 	memEnabled := deferredMemoryEnabled(cfg)
-	var memStore *lazyMemoryStore
-	var memRecorder *deferredMemoryRecorder
-	if memEnabled {
-		memStore = newLazyMemoryStore()
-		if memTools, memErr := tools.MemoryTools(memStore); memErr == nil {
-			coreTools = append(coreTools, memTools...)
-		}
-		memRecorder = newDeferredMemoryRecorder(cfg, cwd)
-	}
+	memTools, memStore, memRecorder := deferredMemoryTools(cfg, cwd, memEnabled)
+	coreTools = append(coreTools, memTools...)
 
 	// Build system instruction. The parts are kept so the context gauge can
 	// attribute overhead to each section; composing them here is what keeps the
 	// breakdown honest — instruction is literally parts.String().
-	var (
-		instruction      string
-		instructionParts agent.InstructionParts
-	)
-	if flagSystem != "" {
-		instructionParts = agent.InstructionParts{Base: flagSystem}
-	} else {
-		instructionParts = agent.LoadInstructionParts(agent.SystemInstruction)
-	}
-	instruction = instructionParts.String()
+	instructionParts := deferredInstructionParts()
+	instruction := instructionParts.String()
 
 	// Build callbacks.
-	compactorCfg := compactorConfigFrom(cfg)
-	compactMetrics := tools.NewCompactMetrics()
-	compactorCB := tools.BuildCompactorCallback(compactorCfg, compactMetrics)
-	resultDeduper := tools.NewResultDeduper()
-
-	hooks := convertHooks(cfg.Hooks)
-	beforeCBs := extension.BuildBeforeToolCallbacks(hooks)
-	afterCBs := extension.BuildAfterToolCallbacks(hooks)
-
-	// Always add OTEL tracing callbacks so all tool calls are traced.
-	tracingBefore, tracingAfter := extension.BuildTracingCallbacks()
-	beforeCBs = append(beforeCBs, tracingBefore...)
-	afterCBs = append(afterCBs, tracingAfter...)
-	if ps.lspMgr != nil {
-		afterCBs = append(afterCBs, lsp.BuildLSPAfterToolCallback(ps.lspMgr))
-	}
-	// Dedup runs after the compactor so both calls are compared in their final,
-	// post-compaction form.
-	afterCBs = append(afterCBs, compactorCB, tools.BuildDedupCallback(resultDeduper))
-
-	// LLM tracing: before/after model callbacks emit spans per LLM invocation.
-	llmBefore, llmAfter := extension.BuildLLMTracingCallbacks(providerName)
-
-	// Inject image bytes (screenshots) as visible InlineData parts for the model.
-	llmBefore = append(llmBefore, extension.BuildReadImageCallback(sandbox))
-
-	if memRecorder != nil {
-		afterCBs = append(afterCBs, memRecorder.afterTool)
-	}
+	cbs := buildDeferredCallbacks(cfg, providerName, res.sandbox, ps.lspMgr, memRecorder)
 
 	// Session service.
-	sessionsPath, err := sessionsDir()
+	sessionsPath, sessionSvc, err := openSessionService()
 	if err != nil {
 		fail(err)
-		return
-	}
-	sessionSvc, err := pisession.NewFileService(sessionsPath)
-	if err != nil {
-		fail(fmt.Errorf("creating session service: %w", err))
 		return
 	}
 
@@ -412,10 +247,10 @@ func deferredInit(
 		Toolsets:             mcpToolsets,
 		Instruction:          instruction,
 		SessionService:       sessionSvc,
-		BeforeToolCallbacks:  beforeCBs,
-		AfterToolCallbacks:   afterCBs,
-		BeforeModelCallbacks: llmBefore,
-		AfterModelCallbacks:  llmAfter,
+		BeforeToolCallbacks:  cbs.beforeTool,
+		AfterToolCallbacks:   cbs.afterTool,
+		BeforeModelCallbacks: cbs.beforeModel,
+		AfterModelCallbacks:  cbs.afterModel,
 		Logger:               sessionLog,
 	})
 	if err != nil {
@@ -423,61 +258,36 @@ func deferredInit(
 		return
 	}
 
-	// Resolve session (--continue is resolved in fast path, flagSession is set).
-	sessionID := flagSession
-	resumed := sessionID != ""
-	var defaultTitle string
-	if sessionID == "" {
-		sessionID, defaultTitle, err = ag.CreateSession(ctx)
-		if err != nil {
-			fail(fmt.Errorf("creating session: %w", err))
-			return
-		}
+	sess, err := resolveDeferredSession(ctx, ag, sessionSvc, llm, providerName, baseURL)
+	if err != nil {
+		fail(err)
+		return
 	}
-
-	// Keep the recorded model honest. meta.Model used to be written once, at
-	// creation, so a session resumed under a different model (via --model) kept
-	// advertising the old one — and the next resume would restore that instead
-	// of what the session actually last ran with.
-	if resumed {
-		_ = sessionSvc.SetSessionModel(sessionID, llm.Name()) // best-effort metadata
-	}
-	// Record the backend for every session, resumed or fresh. The model name on
-	// its own does not identify what actually served the request, which is the
-	// first thing anyone needs when reading a transcript back.
-	_ = sessionSvc.SetSessionProvider(sessionID, providerName, baseURL) // best-effort metadata
 
 	// Store session ID for resume hint on exit.
-	res.sessionID = sessionID
+	res.sessionID = sess.id
 
 	// Two-stage auto-compaction, installed as a pre-turn hook so history is
 	// only ever rewritten between turns. Buffered so a compaction notice never
 	// blocks the turn if the TUI is momentarily busy.
 	noticeCh := make(chan string, 8)
-	if hook := buildAutoCompactHook(autoCompactDeps{
+	installAutoCompactHook(ag, autoCompactDeps{
 		SessionSvc:    sessionSvc,
 		Tracker:       tokenTracker,
-		Deduper:       resultDeduper,
+		Deduper:       cbs.deduper,
 		Cfg:           autoCompactConfigFrom(cfg),
 		Log:           sessionLog,
 		SummarizerLLM: llm,
-		Notify: func(msg string) {
-			select {
-			case noticeCh <- msg:
-			default:
-			}
-		},
-	}); hook != nil {
-		ag.SetPreTurnHook(hook)
-	}
+		Notify:        func(msg string) { trySend(noticeCh, msg) },
+	})
 
 	// Capture ACP subagent events (claude, gemini) under the session dir.
-	res.orch.SetACPLogPath(filepath.Join(sessionsPath, sessionID, "acp.jsonl"))
+	res.orch.SetACPLogPath(filepath.Join(sessionsPath, sess.id, "acp.jsonl"))
 
 	// Session logger was created above; record the session start now that the
 	// session ID is known.
 	if logErr == nil {
-		sessionLog.SessionStart(sessionID, llm.Name(), "interactive")
+		sessionLog.SessionStart(sess.id, llm.Name(), "interactive")
 	}
 
 	// Commit message function.
@@ -490,9 +300,9 @@ func deferredInit(
 		Done: true,
 		Result: &tui.InitResult{
 			Agent:             ag,
-			SessionID:         sessionID,
-			SessionTitle:      defaultTitle,
-			Resumed:           resumed,
+			SessionID:         sess.id,
+			SessionTitle:      sess.title,
+			Resumed:           sess.resumed,
 			SessionService:    sessionSvc,
 			Orchestrator:      orch,
 			Logger:            sessionLog,
@@ -504,7 +314,7 @@ func deferredInit(
 			ContextBreakdown: buildContextBreakdown(
 				instructionParts, coreTools, mcpToolsets, ps.skills, ps.agentConfigs),
 			TokenTracker:   tokenTracker,
-			CompactMetrics: compactMetrics,
+			CompactMetrics: cbs.metrics,
 			GitBranch:      ps.gitBranch,
 			DiffAdded:      ps.diffAdded,
 			DiffRemoved:    ps.diffRemoved,
@@ -514,7 +324,296 @@ func deferredInit(
 	}
 
 	if memEnabled {
-		initMemoryAfterUI(ctx, cfg, cwd, sessionID, orch, memStore, memRecorder, res)
+		initMemoryAfterUI(ctx, cfg, cwd, sess.id, orch, memStore, memRecorder, res)
+	}
+}
+
+// initProgress reports an init step starting (done=false) or finishing.
+type initProgress func(item string, done bool)
+
+// trySend delivers v on ch and drops it when the buffer is full. Every UI-bound
+// channel here is buffered precisely so that a TUI busy elsewhere cannot stall
+// the goroutine that produced the event.
+func trySend[T any](ch chan<- T, v T) {
+	select {
+	case ch <- v:
+	default:
+	}
+}
+
+// initCoreTools creates the sandbox, the bash supervisor and the core tool set.
+// Both resources are recorded in res the moment they exist, so a failure later
+// in this function still leaves the caller's cleanup owning them.
+func initCoreTools(sandboxRoot, worktreeDir string, res *initResources) ([]adktool.Tool, error) {
+	sandbox, err := tools.NewSandbox(sandboxRoot, worktreeDir)
+	if err != nil {
+		return nil, fmt.Errorf("creating sandbox: %w", err)
+	}
+	res.sandbox = sandbox
+
+	// Allow agent tools to access ~/.pi-go/ (logs, sessions, config).
+	if home, hErr := os.UserHomeDir(); hErr == nil {
+		_ = sandbox.AddExtraDir(filepath.Join(home, ".pi-go"))
+	}
+
+	// The supervisor is built here, before the UI event channel exists, because
+	// the bash tool needs it at construction time. Its sink is attached later,
+	// once there is somewhere to stream to.
+	bashSup := tools.NewBashSupervisor()
+	res.bashSup = bashSup
+
+	coreTools, err := tools.CoreTools(sandbox, tools.WithBashSupervisor(bashSup))
+	if err != nil {
+		return nil, fmt.Errorf("creating core tools: %w", err)
+	}
+	bashCtlTools, err := tools.BashControlTools(bashSup)
+	if err != nil {
+		return nil, fmt.Errorf("creating bash control tools: %w", err)
+	}
+	return append(coreTools, bashCtlTools...), nil
+}
+
+// deferredSubsystems collects what the parallel init jobs discover. Each job
+// owns its own fields; the mutex guards the ones written after a slow call so
+// the writes are ordered against each other as well as against wg.Wait.
+type deferredSubsystems struct {
+	mu sync.Mutex
+
+	// Git + subagents
+	repoRoot     string
+	agentConfigs []subagent.AgentConfig
+	gitBranch    string
+	diffAdded    int
+	diffRemoved  int
+
+	// LSP
+	lspMgr   *lsp.Manager
+	lspTools []adktool.Tool
+
+	// MCP
+	mcpToolsets []adktool.Toolset
+
+	// Skills
+	skills    []extension.Skill
+	skillDirs []string
+}
+
+// discoverSubsystems runs the four independent discovery jobs concurrently and
+// returns once every one of them has finished. Each job reports its own
+// progress, so the order steps appear in the UI is the order they complete.
+func discoverSubsystems(ctx context.Context, cfg config.Config, cwd string, send initProgress) *deferredSubsystems {
+	var ps deferredSubsystems
+	var wg sync.WaitGroup
+
+	// Git + subagent discovery
+	wg.Go(func() {
+		send("git", false)
+		ps.repoRoot = detectGitRoot(ctx, cwd)
+		discovery, _ := subagent.DiscoverAgents(cwd, subagent.ScopeBoth)
+		if discovery != nil {
+			ps.agentConfigs = discovery.All
+		}
+		ps.gitBranch = detectBranch(ctx, cwd)
+		ps.diffAdded, ps.diffRemoved = computeDiffStats(ctx, cwd)
+		send("git", true)
+	})
+
+	// LSP
+	wg.Go(func() {
+		send("lsp", false)
+		mgr := lsp.NewManager(nil)
+		// Only advertise the LSP tools when a server can actually answer them —
+		// see the matching note in cli.go. The manager itself is always kept:
+		// the after-tool callback and diagnostics plumbing cost nothing idle.
+		var lt []adktool.Tool
+		if mgr.AnyAvailable() {
+			lt, _ = tools.LSPToolsFor(mgr, resolveLSPMode())
+		}
+		ps.mu.Lock()
+		ps.lspMgr = mgr
+		ps.lspTools = lt
+		ps.mu.Unlock()
+		send("lsp", true)
+	})
+
+	// MCP
+	wg.Go(func() {
+		if cfg.MCP == nil || len(cfg.MCP.Servers) == 0 {
+			return
+		}
+		send("mcp", false)
+		ts, _ := extension.BuildMCPToolsets(buildMCPServerConfigs(cfg))
+		ps.mu.Lock()
+		ps.mcpToolsets = ts
+		ps.mu.Unlock()
+		send("mcp", true)
+	})
+
+	// Skills
+	wg.Go(func() {
+		send("skills", false)
+		dirs := extension.DefaultSkillDirs()
+		sk, _ := extension.LoadSkills(dirs...)
+		ps.mu.Lock()
+		ps.skills = sk
+		ps.skillDirs = dirs
+		ps.mu.Unlock()
+		send("skills", true)
+	})
+
+	wg.Wait()
+	return &ps
+}
+
+// deferredMemoryTools returns the memory tools to add to the agent, the lazy
+// store standing in for the database until it opens, and the recorder that
+// forwards tool results to the worker. All three are nil when memory is off,
+// and the tools are nil when they cannot be built — memory is best-effort.
+func deferredMemoryTools(cfg config.Config, cwd string, enabled bool) ([]adktool.Tool, *lazyMemoryStore, *deferredMemoryRecorder) {
+	if !enabled {
+		return nil, nil, nil
+	}
+	store := newLazyMemoryStore()
+	memTools, err := tools.MemoryTools(store)
+	if err != nil {
+		memTools = nil
+	}
+	return memTools, store, newDeferredMemoryRecorder(cfg, cwd)
+}
+
+// deferredInstructionParts returns the system instruction sections: the
+// --system override as a single base part, or the loaded defaults.
+func deferredInstructionParts() agent.InstructionParts {
+	if flagSystem != "" {
+		return agent.InstructionParts{Base: flagSystem}
+	}
+	return agent.LoadInstructionParts(agent.SystemInstruction)
+}
+
+// deferredCallbacks holds the callback chains the agent is built with, plus the
+// two objects the caller keeps using afterwards: the compaction metrics the UI
+// displays and the deduper the auto-compact hook shares.
+type deferredCallbacks struct {
+	beforeTool  []agent.BeforeToolCallback
+	afterTool   []agent.AfterToolCallback
+	beforeModel []agent.BeforeModelCallback
+	afterModel  []agent.AfterModelCallback
+	metrics     *tools.CompactMetrics
+	deduper     *tools.ResultDeduper
+}
+
+// buildDeferredCallbacks assembles the tool and model callback chains in the
+// order they must run. The order is the contract here: dedup compares results
+// only after the compactor has rewritten them, and the memory recorder sees
+// what the model will see.
+func buildDeferredCallbacks(
+	cfg config.Config,
+	providerName string,
+	sandbox *tools.Sandbox,
+	lspMgr *lsp.Manager,
+	memRecorder *deferredMemoryRecorder,
+) deferredCallbacks {
+	compactMetrics := tools.NewCompactMetrics()
+	resultDeduper := tools.NewResultDeduper()
+
+	hooks := convertHooks(cfg.Hooks)
+	beforeCBs := extension.BuildBeforeToolCallbacks(hooks)
+	afterCBs := extension.BuildAfterToolCallbacks(hooks)
+
+	// Always add OTEL tracing callbacks so all tool calls are traced.
+	tracingBefore, tracingAfter := extension.BuildTracingCallbacks()
+	beforeCBs = append(beforeCBs, tracingBefore...)
+	afterCBs = append(afterCBs, tracingAfter...)
+	if lspMgr != nil {
+		afterCBs = append(afterCBs, lsp.BuildLSPAfterToolCallback(lspMgr))
+	}
+	// Dedup runs after the compactor so both calls are compared in their final,
+	// post-compaction form.
+	afterCBs = append(afterCBs,
+		tools.BuildCompactorCallback(compactorConfigFrom(cfg), compactMetrics),
+		tools.BuildDedupCallback(resultDeduper))
+	if memRecorder != nil {
+		afterCBs = append(afterCBs, memRecorder.afterTool)
+	}
+
+	// LLM tracing: before/after model callbacks emit spans per LLM invocation.
+	llmBefore, llmAfter := extension.BuildLLMTracingCallbacks(providerName)
+
+	// Inject image bytes (screenshots) as visible InlineData parts for the model.
+	llmBefore = append(llmBefore, extension.BuildReadImageCallback(sandbox))
+
+	return deferredCallbacks{
+		beforeTool:  beforeCBs,
+		afterTool:   afterCBs,
+		beforeModel: llmBefore,
+		afterModel:  llmAfter,
+		metrics:     compactMetrics,
+		deduper:     resultDeduper,
+	}
+}
+
+// openSessionService resolves the sessions directory and opens the file-backed
+// session service over it, returning both because the directory is also where
+// per-session side files (the ACP log) are written.
+func openSessionService() (string, *pisession.FileService, error) {
+	path, err := sessionsDir()
+	if err != nil {
+		return "", nil, err
+	}
+	svc, err := pisession.NewFileService(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating session service: %w", err)
+	}
+	return path, svc, nil
+}
+
+// deferredSession identifies the session the TUI attaches to.
+type deferredSession struct {
+	id string
+	// title is the generated default title, and is empty for a resumed session
+	// because that session already has one.
+	title   string
+	resumed bool
+}
+
+// resolveDeferredSession returns the session named by --session/--continue, or
+// creates a fresh one, and records the model and backend that served it.
+func resolveDeferredSession(
+	ctx context.Context,
+	ag *agent.Agent,
+	svc *pisession.FileService,
+	llm adkmodel.LLM,
+	providerName, baseURL string,
+) (deferredSession, error) {
+	// --continue is resolved in the fast path, which sets flagSession.
+	sess := deferredSession{id: flagSession, resumed: flagSession != ""}
+	if !sess.resumed {
+		id, title, err := ag.CreateSession(ctx)
+		if err != nil {
+			return deferredSession{}, fmt.Errorf("creating session: %w", err)
+		}
+		sess.id, sess.title = id, title
+	}
+
+	// Keep the recorded model honest. meta.Model used to be written once, at
+	// creation, so a session resumed under a different model (via --model) kept
+	// advertising the old one — and the next resume would restore that instead
+	// of what the session actually last ran with.
+	if sess.resumed {
+		_ = svc.SetSessionModel(sess.id, llm.Name()) // best-effort metadata
+	}
+	// Record the backend for every session, resumed or fresh. The model name on
+	// its own does not identify what actually served the request, which is the
+	// first thing anyone needs when reading a transcript back.
+	_ = svc.SetSessionProvider(sess.id, providerName, baseURL) // best-effort metadata
+	return sess, nil
+}
+
+// installAutoCompactHook installs the pre-turn compaction hook, unless the
+// configuration asks for no compaction at all.
+func installAutoCompactHook(ag *agent.Agent, deps autoCompactDeps) {
+	if hook := buildAutoCompactHook(deps); hook != nil {
+		ag.SetPreTurnHook(hook)
 	}
 }
 

--- a/internal/cli/interactive_seams_test.go
+++ b/internal/cli/interactive_seams_test.go
@@ -1,0 +1,363 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/lsp"
+	pisession "github.com/dimetron/pi-go/internal/session"
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+// ---------------------------------------------------------------------------
+// trySend
+// ---------------------------------------------------------------------------
+
+func TestTrySend(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		capacity int
+		prefill  int
+		wantLen  int
+	}{
+		{name: "empty buffer takes the value", capacity: 1, prefill: 0, wantLen: 1},
+		{name: "room left takes the value", capacity: 4, prefill: 2, wantLen: 3},
+		{name: "full buffer drops the value", capacity: 2, prefill: 2, wantLen: 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ch := make(chan string, tc.capacity)
+			for i := range tc.prefill {
+				ch <- string(rune('a' + i))
+			}
+
+			// A full channel must drop rather than block: this call returning at
+			// all is the assertion that matters.
+			trySend(ch, "new")
+
+			if got := len(ch); got != tc.wantLen {
+				t.Fatalf("len(ch) = %d, want %d", got, tc.wantLen)
+			}
+		})
+	}
+}
+
+func TestTrySendDeliversTheValue(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan int, 1)
+	trySend(ch, 42)
+	if got := <-ch; got != 42 {
+		t.Fatalf("received %d, want 42", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// initCoreTools
+// ---------------------------------------------------------------------------
+
+func TestInitCoreTools(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	var res initResources
+	defer res.cleanup()
+
+	coreTools, err := initCoreTools(tmp, "", &res)
+	if err != nil {
+		t.Fatalf("initCoreTools() error = %v", err)
+	}
+	if len(coreTools) == 0 {
+		t.Error("initCoreTools() returned no tools")
+	}
+	// Both resources have to be recorded for cleanup before anything can fail
+	// later in init, otherwise a mid-init error leaks them.
+	if res.sandbox == nil {
+		t.Error("res.sandbox not recorded")
+	}
+	if res.bashSup == nil {
+		t.Error("res.bashSup not recorded")
+	}
+
+	names := make(map[string]bool, len(coreTools))
+	for _, tool := range coreTools {
+		names[tool.Name()] = true
+	}
+	for _, want := range []string{"bash", "read"} {
+		if !names[want] {
+			t.Errorf("core tool %q missing; got %v", want, names)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// discoverSubsystems
+// ---------------------------------------------------------------------------
+
+func TestDiscoverSubsystems(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	cases := []struct {
+		name        string
+		cfg         config.Config
+		wantStarted []string
+		notStarted  []string
+	}{
+		{
+			name:        "no MCP servers skips the MCP step entirely",
+			cfg:         config.Config{},
+			wantStarted: []string{"git", "lsp", "skills"},
+			notStarted:  []string{"mcp"},
+		},
+		{
+			name: "a configured MCP server reports progress",
+			cfg: config.Config{MCP: &config.MCPConfig{
+				Servers: []config.MCPServer{{Name: "none", Command: "/nonexistent-mcp-binary"}},
+			}},
+			wantStarted: []string{"git", "lsp", "skills", "mcp"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			started := map[string]bool{}
+			send := initProgress(func(item string, done bool) {
+				mu.Lock()
+				defer mu.Unlock()
+				if !done {
+					started[item] = true
+				}
+			})
+
+			ps := discoverSubsystems(t.Context(), tc.cfg, tmp, send)
+			if ps == nil {
+				t.Fatal("discoverSubsystems() = nil")
+			}
+			// discoverSubsystems only returns once every job has finished, so
+			// reading the map here needs no further synchronization.
+			mu.Lock()
+			defer mu.Unlock()
+			for _, item := range tc.wantStarted {
+				if !started[item] {
+					t.Errorf("step %q never reported progress; got %v", item, started)
+				}
+			}
+			for _, item := range tc.notStarted {
+				if started[item] {
+					t.Errorf("step %q reported progress but should have been skipped", item)
+				}
+			}
+			// The manager is kept even when no language server is installed —
+			// the diagnostics plumbing costs nothing idle.
+			if ps.lspMgr == nil {
+				t.Error("lspMgr is nil; the manager is meant to be kept unconditionally")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deferredMemoryTools
+// ---------------------------------------------------------------------------
+
+func TestDeferredMemoryTools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled yields nothing to clean up", func(t *testing.T) {
+		t.Parallel()
+		memTools, store, recorder := deferredMemoryTools(config.Config{}, "/tmp", false)
+		if memTools != nil || store != nil || recorder != nil {
+			t.Fatalf("deferredMemoryTools(disabled) = (%v, %v, %v), want all nil", memTools, store, recorder)
+		}
+	})
+
+	t.Run("enabled yields tools backed by the lazy store", func(t *testing.T) {
+		t.Parallel()
+		memTools, store, recorder := deferredMemoryTools(config.Config{}, "/tmp", true)
+		if len(memTools) == 0 {
+			t.Error("no memory tools returned")
+		}
+		if store == nil {
+			t.Fatal("lazy store is nil")
+		}
+		if recorder == nil {
+			t.Fatal("recorder is nil")
+		}
+		if recorder.project != "/tmp" {
+			t.Errorf("recorder.project = %q, want %q", recorder.project, "/tmp")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// deferredInstructionParts
+// ---------------------------------------------------------------------------
+
+func TestDeferredInstructionParts(t *testing.T) {
+	orig := flagSystem
+	t.Cleanup(func() { flagSystem = orig })
+
+	flagSystem = "be terse"
+	parts := deferredInstructionParts()
+	if parts.Base != "be terse" {
+		t.Errorf("--system override: Base = %q, want %q", parts.Base, "be terse")
+	}
+
+	flagSystem = ""
+	parts = deferredInstructionParts()
+	if parts.String() == "" {
+		t.Error("default instruction is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildDeferredCallbacks
+// ---------------------------------------------------------------------------
+
+func TestBuildDeferredCallbacks(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	sandbox, err := tools.NewSandbox(tmp, "")
+	if err != nil {
+		t.Fatalf("NewSandbox() error = %v", err)
+	}
+	defer func() { _ = sandbox.Close() }()
+
+	base := buildDeferredCallbacks(config.Config{}, "openai", sandbox, nil, nil)
+	if base.metrics == nil || base.deduper == nil {
+		t.Fatal("compaction metrics and deduper must always be created")
+	}
+	if len(base.beforeModel) == 0 {
+		t.Error("the read-image callback should always be installed")
+	}
+
+	cases := []struct {
+		name        string
+		lspMgr      *lsp.Manager
+		memRecorder *deferredMemoryRecorder
+		wantExtra   int
+	}{
+		{name: "no lsp and no memory", wantExtra: 0},
+		{name: "lsp adds its diagnostics callback", lspMgr: lsp.NewManager(nil), wantExtra: 1},
+		{name: "memory adds its recorder", memRecorder: newDeferredMemoryRecorder(config.Config{}, tmp), wantExtra: 1},
+		{
+			name:        "both add one each",
+			lspMgr:      lsp.NewManager(nil),
+			memRecorder: newDeferredMemoryRecorder(config.Config{}, tmp),
+			wantExtra:   2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDeferredCallbacks(config.Config{}, "openai", sandbox, tc.lspMgr, tc.memRecorder)
+			if want := len(base.afterTool) + tc.wantExtra; len(got.afterTool) != want {
+				t.Errorf("len(afterTool) = %d, want %d", len(got.afterTool), want)
+			}
+			if len(got.beforeTool) != len(base.beforeTool) {
+				t.Errorf("len(beforeTool) = %d, want %d — neither option touches the before chain",
+					len(got.beforeTool), len(base.beforeTool))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// openSessionService
+// ---------------------------------------------------------------------------
+
+func TestOpenSessionService(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	path, svc, err := openSessionService()
+	if err != nil {
+		t.Fatalf("openSessionService() error = %v", err)
+	}
+	if svc == nil {
+		t.Fatal("session service is nil")
+	}
+	if want := filepath.Join(tmp, ".pi-go", "sessions"); path != want {
+		t.Errorf("sessions path = %q, want %q", path, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveDeferredSession
+// ---------------------------------------------------------------------------
+
+func TestResolveDeferredSessionResumed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	orig := flagSession
+	t.Cleanup(func() { flagSession = orig })
+	flagSession = "existing-session"
+
+	svc, err := pisession.NewFileService(filepath.Join(tmp, "sessions"))
+	if err != nil {
+		t.Fatalf("NewFileService() error = %v", err)
+	}
+
+	// The agent is deliberately nil: a resumed session must never reach
+	// ag.CreateSession, and a nil pointer is the loudest way to prove it.
+	sess, err := resolveDeferredSession(t.Context(), nil, svc, &cliMockLLM{name: "m"}, "openai", "https://api.example")
+	if err != nil {
+		t.Fatalf("resolveDeferredSession() error = %v", err)
+	}
+	if sess.id != "existing-session" {
+		t.Errorf("id = %q, want %q", sess.id, "existing-session")
+	}
+	if !sess.resumed {
+		t.Error("resumed = false, want true")
+	}
+	if sess.title != "" {
+		t.Errorf("title = %q, want empty — a resumed session keeps its own title", sess.title)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// installAutoCompactHook
+// ---------------------------------------------------------------------------
+
+func TestInstallAutoCompactHookNoOpWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	// With no session service and no tracker, buildAutoCompactHook returns nil
+	// and the agent must not be touched — passing a nil agent asserts that.
+	installAutoCompactHook(nil, autoCompactDeps{})
+}
+
+// ---------------------------------------------------------------------------
+// initResources.cleanup
+// ---------------------------------------------------------------------------
+
+func TestInitResourcesCleanupIsSafeWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Every field is optional: init can fail before any of them exist, and the
+	// caller defers cleanup unconditionally.
+	var res initResources
+	res.cleanup()
+}
+
+// TestDeferredMemoryToolsNamesAreMemoryScoped guards the append in deferredInit:
+// only the memory tool set may ride in on this return value, because the caller
+// adds it to the agent's tools unconditionally.
+func TestDeferredMemoryToolsNamesAreMemoryScoped(t *testing.T) {
+	t.Parallel()
+
+	memTools, _, _ := deferredMemoryTools(config.Config{}, "/tmp", true)
+	for _, tool := range memTools {
+		if !strings.HasPrefix(tool.Name(), "mem") {
+			t.Errorf("tool %q does not look like a memory tool", tool.Name())
+		}
+	}
+}

--- a/internal/cli/ping.go
+++ b/internal/cli/ping.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -793,20 +794,15 @@ func allowSoftNonStreamFailure(provider string) bool {
 	return provider == "azure"
 }
 
-// modelPing sends a prompt to the model and traces the full response.
-// Used for cloud providers (Anthropic, OpenAI, Gemini, Azure).
-// Tests both non-streaming and streaming modes with detailed event tracing.
-// For Azure, a non-stream failure is soft: ping continues with stream=true,
-// matching the path interactive chat actually exercises.
-func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong bool, provider string) (string, error) {
-	w := func(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) }
-
+// pingRequest builds the request both ping paths send: one user turn carrying
+// prompt, under a system instruction that asks for a terse reply. The
+// Prompt:Prompt variant pins the expected answer so the reply can be checked.
+func pingRequest(prompt string, isPingPong bool) *llmmodel.LLMRequest {
 	systemMsg := "You are a connectivity test. Reply briefly and concisely."
 	if isPingPong {
 		systemMsg = `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`
 	}
-
-	req := &llmmodel.LLMRequest{
+	return &llmmodel.LLMRequest{
 		Contents: []*genai.Content{
 			genai.NewContentFromText(prompt, genai.RoleUser),
 		},
@@ -814,22 +810,59 @@ func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong 
 			SystemInstruction: genai.NewContentFromText(systemMsg, genai.RoleUser),
 		},
 	}
+}
 
-	// --- Non-streaming test ---
+// modelPing sends a prompt to the model and traces the full response.
+// Used for cloud providers (Anthropic, OpenAI, Gemini, Azure).
+// Tests both non-streaming and streaming modes with detailed event tracing.
+// For Azure, a non-stream failure is soft: ping continues with stream=true,
+// matching the path interactive chat actually exercises.
+func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong bool, provider string) (string, error) {
+	w := pingWriter(func(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) })
+	req := pingRequest(prompt, isPingPong)
+
+	nsReply, nsErr := modelPingNonStream(ctx, llm, req, w)
+	if nsErr != nil {
+		if !allowSoftNonStreamFailure(provider) {
+			return "", nsErr
+		}
+		w("*   %s⚠ Non-stream failed; Azure gateways often only serve stream=true for Responses — continuing with stream test%s\n",
+			colorYellow, colorReset)
+	}
+
+	sReply, err := modelPingStream(ctx, llm, req, w)
+	if err != nil {
+		// Whatever the non-streaming probe collected still goes back alongside
+		// the error: a stream failure does not invalidate the text that already
+		// arrived, and callers report it.
+		return nsReply, err
+	}
+
+	// Prefer the non-streaming result, falling back to the streaming one.
+	reply := cmp.Or(strings.TrimSpace(nsReply), strings.TrimSpace(sReply))
+	if reply == "" {
+		return "", fmt.Errorf("model returned empty response in both streaming and non-streaming modes")
+	}
+	return reply, nil
+}
+
+// modelPingNonStream runs the stream=false probe, tracing every event. It
+// returns the text accumulated before a failure as well as the error, so a
+// provider whose non-streaming route is soft-failing (Azure) can still have its
+// partial reply counted.
+func modelPingNonStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
 	w("*   %s[non-stream]%s Calling GenerateContent(stream=false)...\n", colorGray, colorReset)
-	nsStart := time.Now()
-	var nsResult strings.Builder
-	nsEvents := 0
-	var nsErr error
+	start := time.Now()
+	var result strings.Builder
+	events := 0
 	for resp, err := range llm.GenerateContent(ctx, req, false) {
-		nsEvents++
+		events++
 		if err != nil {
-			w("*   %s[non-stream]%s ERROR at event %d: %v\n", colorGray, colorReset, nsEvents, err)
-			nsErr = fmt.Errorf("non-streaming LLM error: %w", err)
-			break
+			w("*   %s[non-stream]%s ERROR at event %d: %v\n", colorGray, colorReset, events, err)
+			return result.String(), fmt.Errorf("non-streaming LLM error: %w", err)
 		}
 		w("*   %s[non-stream]%s event %d: partial=%v turnComplete=%v finish=%v",
-			colorGray, colorReset, nsEvents, resp.Partial, resp.TurnComplete, resp.FinishReason)
+			colorGray, colorReset, events, resp.Partial, resp.TurnComplete, resp.FinishReason)
 		if resp.ErrorCode != "" {
 			w(" errorCode=%s errorMsg=%s", resp.ErrorCode, resp.ErrorMessage)
 		}
@@ -839,146 +872,155 @@ func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong 
 		w("\n")
 		if resp.Content != nil {
 			w("*   %s[non-stream]%s   role=%s parts=%d\n", colorGray, colorReset, resp.Content.Role, len(resp.Content.Parts))
-			for i, part := range resp.Content.Parts {
-				if part.Text != "" {
-					preview := part.Text
-					if len(preview) > 120 {
-						preview = preview[:120] + "..."
-					}
-					w("*   %s[non-stream]%s   part[%d] text(%d chars): %s\n", colorGray, colorReset, i, len(part.Text), preview)
-					nsResult.WriteString(part.Text)
-				}
-				if part.FunctionCall != nil {
-					w("*   %s[non-stream]%s   part[%d] tool_call: %s\n", colorGray, colorReset, i, part.FunctionCall.Name)
-				}
-				if part.Thought {
-					w("*   %s[non-stream]%s   part[%d] thought=true\n", colorGray, colorReset, i)
-				}
-			}
+			result.WriteString(traceNonStreamParts(w, resp.Content.Parts))
 		}
 	}
-	if nsErr != nil {
-		if !allowSoftNonStreamFailure(provider) {
-			return "", nsErr
-		}
-		w("*   %s⚠ Non-stream failed; Azure gateways often only serve stream=true for Responses — continuing with stream test%s\n",
-			colorYellow, colorReset)
-	} else {
-		nsDur := time.Since(nsStart)
-		w("*   %s[non-stream]%s Done: %d events, %s%s%s\n", colorGray, colorReset, nsEvents, colorGray, nsDur.Round(time.Millisecond), colorReset)
-	}
+	w("*   %s[non-stream]%s Done: %d events, %s%s%s\n",
+		colorGray, colorReset, events, colorGray, time.Since(start).Round(time.Millisecond), colorReset)
+	return result.String(), nil
+}
 
-	// --- Streaming test ---
+// traceNonStreamParts prints one trace line per part — text, tool call or
+// thought — and returns the text they contribute to the reply.
+func traceNonStreamParts(w pingWriter, parts []*genai.Part) string {
+	var text strings.Builder
+	for i, part := range parts {
+		if part.Text != "" {
+			w("*   %s[non-stream]%s   part[%d] text(%d chars): %s\n",
+				colorGray, colorReset, i, len(part.Text), truncate(part.Text, 120))
+			text.WriteString(part.Text)
+		}
+		if part.FunctionCall != nil {
+			w("*   %s[non-stream]%s   part[%d] tool_call: %s\n", colorGray, colorReset, i, part.FunctionCall.Name)
+		}
+		if part.Thought {
+			w("*   %s[non-stream]%s   part[%d] thought=true\n", colorGray, colorReset, i)
+		}
+	}
+	return text.String()
+}
+
+// modelPingStream runs the stream=true probe, accumulating assistant text while
+// counting thinking chunks separately — a model that only emits thinking has
+// answered nothing, and the counts are what make that visible.
+func modelPingStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
 	w("*   %s[stream]%s Calling GenerateContent(stream=true)...\n", colorGray, colorReset)
-	sStart := time.Now()
-	var sResult strings.Builder
-	sEvents := 0
-	sThinkingChunks := 0
-	sTextChunks := 0
+	start := time.Now()
+	var result strings.Builder
+	events, thinkingChunks, textChunks := 0, 0, 0
 	for resp, err := range llm.GenerateContent(ctx, req, true) {
-		sEvents++
+		events++
 		if err != nil {
-			w("*   %s[stream]%s ERROR at event %d: %v\n", colorGray, colorReset, sEvents, err)
-			return nsResult.String(), fmt.Errorf("streaming LLM error: %w", err)
+			w("*   %s[stream]%s ERROR at event %d: %v\n", colorGray, colorReset, events, err)
+			return result.String(), fmt.Errorf("streaming LLM error: %w", err)
 		}
 		if resp.ErrorCode != "" {
-			w("*   %s[stream]%s event %d: errorCode=%s errorMsg=%s\n", colorGray, colorReset, sEvents, resp.ErrorCode, resp.ErrorMessage)
+			w("*   %s[stream]%s event %d: errorCode=%s errorMsg=%s\n", colorGray, colorReset, events, resp.ErrorCode, resp.ErrorMessage)
 			continue
 		}
 		if resp.Content != nil {
 			role := resp.Content.Role
 			for _, part := range resp.Content.Parts {
-				if part.Text != "" {
-					if role == "thinking" {
-						sThinkingChunks++
-					} else {
-						sTextChunks++
-						sResult.WriteString(part.Text)
-					}
+				if part.Text == "" {
+					continue
 				}
+				if role == "thinking" {
+					thinkingChunks++
+					continue
+				}
+				textChunks++
+				result.WriteString(part.Text)
 			}
 		}
 		// Print summary for non-partial final event.
 		if !resp.Partial {
-			w("*   %s[stream]%s final event %d: turnComplete=%v finish=%v", colorGray, colorReset, sEvents, resp.TurnComplete, resp.FinishReason)
+			w("*   %s[stream]%s final event %d: turnComplete=%v finish=%v", colorGray, colorReset, events, resp.TurnComplete, resp.FinishReason)
 			if resp.UsageMetadata != nil {
 				w(" tokens(in=%d out=%d)", resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
 			}
 			w("\n")
 		}
 	}
-	sDur := time.Since(sStart)
 	w("*   %s[stream]%s Done: %d events (%d thinking, %d text chunks), %s%s%s\n",
-		colorGray, colorReset, sEvents, sThinkingChunks, sTextChunks, colorGray, sDur.Round(time.Millisecond), colorReset)
+		colorGray, colorReset, events, thinkingChunks, textChunks, colorGray, time.Since(start).Round(time.Millisecond), colorReset)
 
-	if sResult.Len() > 0 {
-		preview := sResult.String()
-		if len(preview) > 200 {
-			preview = preview[:200] + "..."
-		}
-		w("*   %s[stream]%s Reply: %s\n", colorGray, colorReset, preview)
+	if result.Len() > 0 {
+		w("*   %s[stream]%s Reply: %s\n", colorGray, colorReset, truncate(result.String(), 200))
 	}
-
-	// Return non-streaming result (or streaming if non-streaming was empty).
-	reply := strings.TrimSpace(nsResult.String())
-	if reply == "" {
-		reply = strings.TrimSpace(sResult.String())
-	}
-	if reply == "" {
-		return "", fmt.Errorf("model returned empty response in both streaming and non-streaming modes")
-	}
-	return reply, nil
+	return result.String(), nil
 }
 
 // ollamaPingFull performs a complete Ollama ping: lists models, checks availability,
 // then runs non-streaming and streaming tests using the native Ollama provider.
 // No artificial timeout — local models can be slow (thinking, model loading).
-func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPingPong bool, w func(string, ...any)) (string, error) {
-	// Step 1: List available models.
-	models, err := provider.OllamaListModels(ctx, baseURL)
-	if err != nil {
-		return "", fmt.Errorf("list models: %w", err)
+func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPingPong bool, w pingWriter) (string, error) {
+	// Step 1: List available models and confirm ours is one of them.
+	if err := ollamaCheckModel(ctx, baseURL, modelName, w); err != nil {
+		return "", err
 	}
-	w("*   Available models: %s\n", strings.Join(models, ", "))
 
-	// Check if our model is available.
-	modelBase := strings.Split(modelName, ":")[0]
-	found := false
-	for _, m := range models {
-		if m == modelName || strings.HasPrefix(m, modelBase) {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return "", fmt.Errorf("model %q not found in available models", modelName)
-	}
-	w("*   Model %s: %sfound ✓%s\n", modelName, colorGreen, colorReset)
-
-	// Step 2: Create native Ollama LLM.
+	// Step 2: Create native Ollama LLM. The empty API key is deliberate here
+	// and also a limitation: with no credential this can only reach a local
+	// Ollama, never an Ollama Cloud model.
 	llm, err := provider.NewOllama(ctx, modelName, "", baseURL, "none", nil)
 	if err != nil {
 		return "", fmt.Errorf("create client: %w", err)
 	}
-
-	systemMsg := "You are a connectivity test. Reply briefly and concisely."
-	if isPingPong {
-		systemMsg = `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`
-	}
-
-	req := &llmmodel.LLMRequest{
-		Contents: []*genai.Content{
-			genai.NewContentFromText(prompt, genai.RoleUser),
-		},
-		Config: &genai.GenerateContentConfig{
-			SystemInstruction: genai.NewContentFromText(systemMsg, genai.RoleUser),
-		},
-	}
+	req := pingRequest(prompt, isPingPong)
 
 	// Step 3: Non-streaming test.
+	nsText, err := ollamaPingNonStream(ctx, llm, req, w)
+	if err != nil {
+		return "", err
+	}
+
+	// Step 4: Streaming test.
+	sText, err := ollamaPingStream(ctx, llm, req, w)
+	if err != nil {
+		// A streaming failure after the non-streaming probe already produced
+		// text does not mean the model is unreachable — report what came back.
+		if nsText != "" {
+			w("*   %s[stream]%s Falling back to non-streaming result\n", colorGray, colorReset)
+			return nsText, nil
+		}
+		return "", err
+	}
+
+	// Return non-streaming result (preferred) or streaming fallback.
+	reply := cmp.Or(nsText, sText)
+	if reply == "" {
+		return "", fmt.Errorf("model returned empty response in both modes")
+	}
+	return reply, nil
+}
+
+// ollamaCheckModel lists what the endpoint serves and reports whether modelName
+// is among them, accepting either the exact tag or any tag of the same model.
+//
+// The listing goes out with no credential (provider.OllamaListModels takes
+// none), which is the reason ping only ever reaches a local Ollama.
+func ollamaCheckModel(ctx context.Context, baseURL, modelName string, w pingWriter) error {
+	models, err := provider.OllamaListModels(ctx, baseURL)
+	if err != nil {
+		return fmt.Errorf("list models: %w", err)
+	}
+	w("*   Available models: %s\n", strings.Join(models, ", "))
+
+	modelBase := strings.Split(modelName, ":")[0]
+	if !slices.ContainsFunc(models, func(m string) bool {
+		return m == modelName || strings.HasPrefix(m, modelBase)
+	}) {
+		return fmt.Errorf("model %q not found in available models", modelName)
+	}
+	w("*   Model %s: %sfound ✓%s\n", modelName, colorGreen, colorReset)
+	return nil
+}
+
+// ollamaPingNonStream runs the stream=false probe and returns the trimmed reply.
+func ollamaPingNonStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
 	w("*   %s[non-stream]%s Calling Ollama chat (stream=false)...\n", colorGray, colorReset)
-	nsStart := time.Now()
-	var nsResult strings.Builder
+	start := time.Now()
+	var result strings.Builder
 	for resp, err := range llm.GenerateContent(ctx, req, false) {
 		if err != nil {
 			w("*   %s[non-stream]%s ERROR: %v\n", colorGray, colorReset, err)
@@ -987,7 +1029,7 @@ func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPi
 		if resp.Content != nil {
 			for _, part := range resp.Content.Parts {
 				if part.Text != "" {
-					nsResult.WriteString(part.Text)
+					result.WriteString(part.Text)
 				}
 			}
 		}
@@ -996,29 +1038,30 @@ func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPi
 				colorGray, colorReset, resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
 		}
 	}
-	nsDur := time.Since(nsStart)
-	nsText := strings.TrimSpace(nsResult.String())
-	w("*   %s[non-stream]%s Done %s(%s)%s: %s\n", colorGray, colorReset, colorGray, nsDur.Round(time.Millisecond), colorReset, truncate(nsText, 120))
+	text := strings.TrimSpace(result.String())
+	w("*   %s[non-stream]%s Done %s(%s)%s: %s\n",
+		colorGray, colorReset, colorGray, time.Since(start).Round(time.Millisecond), colorReset, truncate(text, 120))
+	return text, nil
+}
 
-	// Step 4: Streaming test.
+// ollamaPingStream runs the stream=true probe and returns the trimmed reply,
+// counting only the chunks a user would see — thinking output is traced by the
+// model but is not the answer.
+func ollamaPingStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
 	w("*   %s[stream]%s Calling Ollama chat (stream=true)...\n", colorGray, colorReset)
-	sStart := time.Now()
-	var sResult strings.Builder
-	sChunks := 0
+	start := time.Now()
+	var result strings.Builder
+	chunks := 0
 	for resp, err := range llm.GenerateContent(ctx, req, true) {
 		if err != nil {
 			w("*   %s[stream]%s ERROR: %v\n", colorGray, colorReset, err)
-			if nsText != "" {
-				w("*   %s[stream]%s Falling back to non-streaming result\n", colorGray, colorReset)
-				return nsText, nil
-			}
 			return "", fmt.Errorf("streaming: %w", err)
 		}
 		if resp.Content != nil {
 			for _, part := range resp.Content.Parts {
 				if part.Text != "" && resp.Content.Role != "thinking" {
-					sResult.WriteString(part.Text)
-					sChunks++
+					result.WriteString(part.Text)
+					chunks++
 				}
 			}
 		}
@@ -1027,19 +1070,10 @@ func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPi
 				colorGray, colorReset, resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
 		}
 	}
-	sDur := time.Since(sStart)
-	sText := strings.TrimSpace(sResult.String())
-	w("*   %s[stream]%s Done %s(%s)%s, %d chunks: %s\n", colorGray, colorReset, colorGray, sDur.Round(time.Millisecond), colorReset, sChunks, truncate(sText, 120))
-
-	// Return non-streaming result (preferred) or streaming fallback.
-	reply := nsText
-	if reply == "" {
-		reply = sText
-	}
-	if reply == "" {
-		return "", fmt.Errorf("model returned empty response in both modes")
-	}
-	return reply, nil
+	text := strings.TrimSpace(result.String())
+	w("*   %s[stream]%s Done %s(%s)%s, %d chunks: %s\n",
+		colorGray, colorReset, colorGray, time.Since(start).Round(time.Millisecond), colorReset, chunks, truncate(text, 120))
+	return text, nil
 }
 
 func truncate(s string, n int) string {

--- a/internal/cli/ping_seams_test.go
+++ b/internal/cli/ping_seams_test.go
@@ -1,0 +1,322 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// ---------------------------------------------------------------------------
+// pingRequest
+// ---------------------------------------------------------------------------
+
+func TestPingRequest(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		prompt      string
+		isPingPong  bool
+		wantSysHas  string
+		wantPromptA string
+	}{
+		{
+			name:        "ping pong pins the expected answer",
+			prompt:      "prompt-prompt",
+			isPingPong:  true,
+			wantSysHas:  `reply with exactly "prompt-prompt"`,
+			wantPromptA: "prompt-prompt",
+		},
+		{
+			name:        "custom prompt asks only for brevity",
+			prompt:      "2+2",
+			isPingPong:  false,
+			wantSysHas:  "Reply briefly and concisely",
+			wantPromptA: "2+2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := pingRequest(tc.prompt, tc.isPingPong)
+
+			if len(req.Contents) != 1 || len(req.Contents[0].Parts) != 1 {
+				t.Fatalf("Contents = %#v, want one part in one content", req.Contents)
+			}
+			if got := req.Contents[0].Parts[0].Text; got != tc.wantPromptA {
+				t.Errorf("prompt text = %q, want %q", got, tc.wantPromptA)
+			}
+			if got := req.Contents[0].Role; got != genai.RoleUser {
+				t.Errorf("prompt role = %q, want %q", got, genai.RoleUser)
+			}
+
+			sys := req.Config.SystemInstruction
+			if sys == nil || len(sys.Parts) != 1 {
+				t.Fatalf("SystemInstruction = %#v, want one part", sys)
+			}
+			if got := sys.Parts[0].Text; !strings.Contains(got, tc.wantSysHas) {
+				t.Errorf("system instruction = %q, want it to contain %q", got, tc.wantSysHas)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// traceNonStreamParts
+// ---------------------------------------------------------------------------
+
+func TestTraceNonStreamParts(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("x", 130)
+
+	cases := []struct {
+		name     string
+		parts    []*genai.Part
+		wantText string
+		wantOut  []string
+		notOut   []string
+	}{
+		{
+			name:     "no parts traces nothing",
+			parts:    nil,
+			wantText: "",
+		},
+		{
+			name:     "text parts concatenate in order",
+			parts:    []*genai.Part{{Text: "he"}, {Text: "llo"}},
+			wantText: "hello",
+			wantOut:  []string{"part[0] text(2 chars): he", "part[1] text(3 chars): llo"},
+		},
+		{
+			name: "long text is truncated in the trace but not in the reply",
+			// The trace caps the preview at 120 runes; the accumulated reply
+			// keeps every byte, which is what the verdict is judged on.
+			parts:    []*genai.Part{{Text: long}},
+			wantText: long,
+			wantOut:  []string{fmt.Sprintf("text(130 chars): %s...", long[:120])},
+		},
+		{
+			name:     "tool call contributes no text",
+			parts:    []*genai.Part{{FunctionCall: &genai.FunctionCall{Name: "read"}}},
+			wantText: "",
+			wantOut:  []string{"part[0] tool_call: read"},
+			notOut:   []string{"text("},
+		},
+		{
+			name:     "thought is flagged and its text still counts",
+			parts:    []*genai.Part{{Text: "hm", Thought: true}},
+			wantText: "hm",
+			wantOut:  []string{"part[0] thought=true", "part[0] text(2 chars): hm"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out strings.Builder
+			w := pingWriter(func(format string, a ...any) { fmt.Fprintf(&out, format, a...) })
+
+			if got := traceNonStreamParts(w, tc.parts); got != tc.wantText {
+				t.Errorf("traceNonStreamParts() = %q, want %q", got, tc.wantText)
+			}
+			for _, want := range tc.wantOut {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("trace output missing %q:\n%s", want, out.String())
+				}
+			}
+			for _, unwanted := range tc.notOut {
+				if strings.Contains(out.String(), unwanted) {
+					t.Errorf("trace output should not contain %q:\n%s", unwanted, out.String())
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// modelPingNonStream / modelPingStream
+// ---------------------------------------------------------------------------
+
+func TestModelPingNonStream(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+
+	cases := []struct {
+		name      string
+		llm       model.LLM
+		wantReply string
+		wantErr   bool
+		wantOut   []string
+	}{
+		{
+			name:      "text is accumulated and the phase reports done",
+			llm:       &cliMockLLM{name: "m", response: "hi"},
+			wantReply: "hi",
+			wantOut:   []string{"Calling GenerateContent(stream=false)", "Done: 1 events"},
+		},
+		{
+			name:    "an error stops the phase without a done line",
+			llm:     &cliErrorLLM{name: "m", err: boom},
+			wantErr: true,
+			wantOut: []string{"ERROR at event 1: boom"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out strings.Builder
+			w := pingWriter(func(format string, a ...any) { fmt.Fprintf(&out, format, a...) })
+
+			reply, err := modelPingNonStream(context.Background(), tc.llm, pingRequest("p", false), w)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("modelPingNonStream() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if reply != tc.wantReply {
+				t.Errorf("reply = %q, want %q", reply, tc.wantReply)
+			}
+			if tc.wantErr && strings.Contains(out.String(), "Done:") {
+				t.Errorf("a failed phase must not print its done line:\n%s", out.String())
+			}
+			for _, want := range tc.wantOut {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("output missing %q:\n%s", want, out.String())
+				}
+			}
+		})
+	}
+}
+
+func TestModelPingStream(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		llm       model.LLM
+		wantReply string
+		wantErr   bool
+		wantOut   []string
+	}{
+		{
+			name:      "assistant text is the reply",
+			llm:       &cliMockLLM{name: "m", response: "hello"},
+			wantReply: "hello",
+			wantOut:   []string{"1 text chunks", "Reply: hello"},
+		},
+		{
+			name: "thinking chunks are counted apart from the reply",
+			llm: &cliThinkingLLM{
+				name:         "m",
+				thoughtText:  "pondering",
+				responseText: "answer",
+			},
+			wantReply: "answer",
+			wantOut:   []string{"(1 thinking, 1 text chunks)"},
+		},
+		{
+			name:    "an error ends the phase",
+			llm:     &cliErrorLLM{name: "m", err: errors.New("nope")},
+			wantErr: true,
+			wantOut: []string{"ERROR at event 1: nope"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out strings.Builder
+			w := pingWriter(func(format string, a ...any) { fmt.Fprintf(&out, format, a...) })
+
+			reply, err := modelPingStream(context.Background(), tc.llm, pingRequest("p", false), w)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("modelPingStream() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if reply != tc.wantReply {
+				t.Errorf("reply = %q, want %q", reply, tc.wantReply)
+			}
+			for _, want := range tc.wantOut {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("output missing %q:\n%s", want, out.String())
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ollamaCheckModel
+// ---------------------------------------------------------------------------
+
+func TestOllamaCheckModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		served    []string
+		requested string
+		wantErr   string
+	}{
+		{
+			name:      "exact tag matches",
+			served:    []string{"llama3:8b", "qwen2.5:7b"},
+			requested: "llama3:8b",
+		},
+		{
+			name:      "bare name matches a tagged model",
+			served:    []string{"llama3:8b"},
+			requested: "llama3",
+		},
+		{
+			name:      "a different tag of the same model matches",
+			served:    []string{"llama3:70b"},
+			requested: "llama3:8b",
+		},
+		{
+			name:      "unknown model is reported",
+			served:    []string{"llama3:8b"},
+			requested: "mistral",
+			wantErr:   `model "mistral" not found`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := mockOllamaPingServer(t, tc.served, "unused")
+			defer srv.Close()
+
+			var out strings.Builder
+			w := pingWriter(func(format string, a ...any) { fmt.Fprintf(&out, format, a...) })
+
+			err := ollamaCheckModel(context.Background(), srv.URL, tc.requested, w)
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("ollamaCheckModel() error = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("ollamaCheckModel() = nil, want error containing %q", tc.wantErr)
+			case tc.wantErr != "":
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if !strings.Contains(out.String(), "found ✓") {
+				t.Errorf("a resolved model should be reported as found:\n%s", out.String())
+			}
+		})
+	}
+}
+
+func TestOllamaCheckModelListError(t *testing.T) {
+	t.Parallel()
+
+	// An endpoint nothing is listening on: the listing itself must fail, and the
+	// error has to name the step so a ping transcript stays readable.
+	err := ollamaCheckModel(context.Background(), "http://127.0.0.1:1", "llama3", func(string, ...any) {})
+	if err == nil || !strings.Contains(err.Error(), "list models") {
+		t.Fatalf("ollamaCheckModel() error = %v, want it to mention \"list models\"", err)
+	}
+}

--- a/internal/extension/skills.go
+++ b/internal/extension/skills.go
@@ -63,110 +63,27 @@ func LoadSkillsWithOptions(opts LoadOptions, dirs ...string) ([]Skill, error) {
 	var skills []Skill
 	var blocked []string
 
-	// Load bundled skills first (lowest priority).
-	bundledMap, err := LoadBundledSkills()
-	if err == nil {
-		for skillName, files := range bundledMap {
-			var mainFile []byte
-			for _, f := range files {
-				if f.RelPath == "bundled_skills/"+skillName+"/SKILL.md" {
-					mainFile = f.Content
-					break
-				}
-			}
-			if len(mainFile) == 0 && len(files) > 0 {
-				mainFile = files[0].Content
-			}
-			if len(mainFile) == 0 {
-				continue
-			}
-			skill, body, err := parseSkillContent(string(mainFile), skillName)
-			if err != nil {
-				continue
-			}
-			skill.Source = "bundled"
-			skillName := skill.Name
-			seen[skillName] = len(skills)
-			// Body is already in memory for bundled skills — cache it so
-			// LoadSkillBody doesn't need to re-read the embed fs.
-			if body != "" {
-				bundledBodyCache.Store(skillName, body)
-			}
-			skills = append(skills, skill)
-		}
+	// Bundled skills load first, at the lowest priority: a user or project
+	// skill of the same name replaces them in place below.
+	for _, skill := range bundledSkills() {
+		seen[skill.Name] = len(skills)
+		skills = append(skills, skill)
 	}
 
 	for _, dir := range dirs {
-		entries, err := os.ReadDir(dir)
+		dirSkills, dirBlocked, err := loadDirSkills(dir, opts)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("reading skills dir %s: %w", dir, err)
+			return nil, err
 		}
-
-		skillFiles := []struct {
-			path        string
-			defaultName string
-		}{
-			{path: filepath.Join(dir, "SKILL.md"), defaultName: filepath.Base(dir)},
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			skillFile := filepath.Join(dir, entry.Name(), "SKILL.md")
-			if _, err := os.Stat(skillFile); err != nil {
-				continue
-			}
-			skillFiles = append(skillFiles, struct {
-				path        string
-				defaultName string
-			}{path: skillFile, defaultName: entry.Name()})
-		}
-
-		for _, skillInfo := range skillFiles {
-			if _, err := os.Stat(skillInfo.path); err != nil {
-				continue
-			}
-
-			// Audit the skill file before loading.
-			if opts.AuditMode != AuditSkip {
-				scanResult, scanErr := audit.ScanFile(skillInfo.path)
-				if scanErr != nil {
-					fmt.Fprintf(os.Stderr, "pi-go: warning: audit scan failed for %s: %v\n", skillInfo.path, scanErr)
-				} else if scanResult.HasCritical() {
-					if opts.AuditMode == AuditBlock {
-						blocked = append(blocked, skillInfo.path)
-						fmt.Fprintf(os.Stderr, "pi-go: BLOCKED skill %s — critical hidden characters detected\n", skillInfo.defaultName)
-						continue
-					}
-					// AuditWarn: log but continue loading.
-					fmt.Fprintf(os.Stderr, "pi-go: WARNING: skill %s has critical hidden characters\n", skillInfo.defaultName)
-				}
-			}
-
-			skill, err := parseSkillFile(skillInfo.path)
-			if err != nil {
-				return nil, fmt.Errorf("parsing %s: %w", skillInfo.path, err)
-			}
-			// Default name from directory if not set in frontmatter
-			if skill.Name == "" {
-				skill.Name = skillInfo.defaultName
-			}
-			// Determine source based on whether the path is absolute.
-			source := "user"
-			if !filepath.IsAbs(dir) {
-				source = "project"
-			}
-			skill.Source = source
+		blocked = append(blocked, dirBlocked...)
+		for _, skill := range dirSkills {
 			if idx, ok := seen[skill.Name]; ok {
 				// Override with project/user-level skill.
 				skills[idx] = skill
-			} else {
-				seen[skill.Name] = len(skills)
-				skills = append(skills, skill)
+				continue
 			}
+			seen[skill.Name] = len(skills)
+			skills = append(skills, skill)
 		}
 	}
 
@@ -175,6 +92,147 @@ func LoadSkillsWithOptions(opts LoadOptions, dirs ...string) ([]Skill, error) {
 	}
 
 	return skills, nil
+}
+
+// bundledSkills parses the skills embedded in the binary. They are the
+// lowest-priority layer and are entirely optional, so a failure to open the
+// embed fs — or to parse any single skill — yields fewer skills rather than an
+// error.
+func bundledSkills() []Skill {
+	bundledMap, err := LoadBundledSkills()
+	if err != nil {
+		return nil
+	}
+
+	skills := make([]Skill, 0, len(bundledMap))
+	for skillName, files := range bundledMap {
+		mainFile := bundledSkillMain(files, skillName)
+		if len(mainFile) == 0 {
+			continue
+		}
+		skill, body, err := parseSkillContent(string(mainFile), skillName)
+		if err != nil {
+			continue
+		}
+		skill.Source = "bundled"
+		// Body is already in memory for bundled skills — cache it so
+		// LoadSkillBody doesn't need to re-read the embed fs.
+		if body != "" {
+			bundledBodyCache.Store(skill.Name, body)
+		}
+		skills = append(skills, skill)
+	}
+	return skills
+}
+
+// bundledSkillMain picks a bundled skill's SKILL.md out of its files. A missing
+// *or empty* SKILL.md falls back to the first file bundled under that name.
+func bundledSkillMain(files []BundledSkillFile, skillName string) []byte {
+	want := "bundled_skills/" + skillName + "/SKILL.md"
+	var mainFile []byte
+	for _, f := range files {
+		if f.RelPath == want {
+			mainFile = f.Content
+			break
+		}
+	}
+	if len(mainFile) == 0 && len(files) > 0 {
+		mainFile = files[0].Content
+	}
+	return mainFile
+}
+
+// skillFileRef locates one SKILL.md and the name it falls back to when the
+// file's frontmatter does not declare one.
+type skillFileRef struct {
+	path        string
+	defaultName string
+}
+
+// skillFileRefs lists the SKILL.md files a skills directory offers: the
+// directory's own, plus one per immediate subdirectory that has one.
+func skillFileRefs(dir string, entries []os.DirEntry) []skillFileRef {
+	refs := []skillFileRef{
+		{path: filepath.Join(dir, "SKILL.md"), defaultName: filepath.Base(dir)},
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(dir, entry.Name(), "SKILL.md")
+		if _, err := os.Stat(skillFile); err != nil {
+			continue
+		}
+		refs = append(refs, skillFileRef{path: skillFile, defaultName: entry.Name()})
+	}
+	return refs
+}
+
+// auditBlocksSkill scans a SKILL.md for hidden-character attacks and reports
+// whether it must be skipped. Only AuditBlock plus a critical finding blocks;
+// a scan that fails, or AuditWarn, warns on stderr and lets the skill load.
+func auditBlocksSkill(ref skillFileRef, mode AuditMode) bool {
+	if mode == AuditSkip {
+		return false
+	}
+	scanResult, scanErr := audit.ScanFile(ref.path)
+	if scanErr != nil {
+		fmt.Fprintf(os.Stderr, "pi-go: warning: audit scan failed for %s: %v\n", ref.path, scanErr)
+		return false
+	}
+	if !scanResult.HasCritical() {
+		return false
+	}
+	if mode == AuditBlock {
+		fmt.Fprintf(os.Stderr, "pi-go: BLOCKED skill %s — critical hidden characters detected\n", ref.defaultName)
+		return true
+	}
+	// AuditWarn: log but continue loading.
+	fmt.Fprintf(os.Stderr, "pi-go: WARNING: skill %s has critical hidden characters\n", ref.defaultName)
+	return false
+}
+
+// loadDirSkills loads every skill under dir, returning the parsed skills and
+// the paths the audit blocked. A directory that does not exist yields nothing
+// rather than an error; anything else wrong with it is an error, as is a
+// SKILL.md that fails to parse.
+func loadDirSkills(dir string, opts LoadOptions) ([]Skill, []string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("reading skills dir %s: %w", dir, err)
+	}
+
+	// Determine source based on whether the path is absolute.
+	source := "user"
+	if !filepath.IsAbs(dir) {
+		source = "project"
+	}
+
+	var skills []Skill
+	var blocked []string
+	for _, ref := range skillFileRefs(dir, entries) {
+		if _, err := os.Stat(ref.path); err != nil {
+			continue
+		}
+		if auditBlocksSkill(ref, opts.AuditMode) {
+			blocked = append(blocked, ref.path)
+			continue
+		}
+		skill, err := parseSkillFile(ref.path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing %s: %w", ref.path, err)
+		}
+		// Default name from directory if not set in frontmatter
+		if skill.Name == "" {
+			skill.Name = ref.defaultName
+		}
+		skill.Source = source
+		skills = append(skills, skill)
+	}
+	return skills, blocked, nil
 }
 
 // parseSkillFile reads a SKILL.md file and returns its metadata. The body is

--- a/internal/extension/skills_seams_test.go
+++ b/internal/extension/skills_seams_test.go
@@ -1,0 +1,260 @@
+package extension
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBundledSkillMain(t *testing.T) {
+	t.Parallel()
+
+	main := BundledSkillFile{RelPath: "bundled_skills/x/SKILL.md", Content: []byte("main")}
+	other := BundledSkillFile{RelPath: "bundled_skills/x/ref.md", Content: []byte("ref")}
+	emptyMain := BundledSkillFile{RelPath: "bundled_skills/x/SKILL.md"}
+
+	tests := []struct {
+		name  string
+		files []BundledSkillFile
+		want  string
+	}{
+		{"no files", nil, ""},
+		{"exact match wins", []BundledSkillFile{other, main}, "main"},
+		{"missing SKILL.md falls back to the first file", []BundledSkillFile{other}, "ref"},
+		{"empty SKILL.md falls back to the first file", []BundledSkillFile{other, emptyMain}, "ref"},
+		{"empty SKILL.md alone stays empty", []BundledSkillFile{emptyMain}, ""},
+		{"other skill's SKILL.md is not a match", []BundledSkillFile{{RelPath: "bundled_skills/y/SKILL.md", Content: []byte("y")}}, "y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, string(bundledSkillMain(tt.files, "x"))); diff != "" {
+				t.Errorf("bundledSkillMain mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSkillFileRefs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A skill in a subdirectory, a subdirectory without one, and a stray file.
+	setupSkillWithContent(t, dir, "alpha", "---\nname: alpha\n---\nbody")
+	if err := os.MkdirAll(filepath.Join(dir, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "loose.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := skillFileRefs(dir, entries)
+	want := []skillFileRef{
+		// The directory's own SKILL.md is listed first even when absent; the
+		// caller stats it before use.
+		{path: filepath.Join(dir, "SKILL.md"), defaultName: filepath.Base(dir)},
+		{path: filepath.Join(dir, "alpha", "SKILL.md"), defaultName: "alpha"},
+	}
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(skillFileRef{})); diff != "" {
+		t.Errorf("skillFileRefs mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAuditBlocksSkill(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	setupSkillWithContent(t, dir, "clean", "---\nname: clean\n---\nClean body.")
+	// U+202E (BiDi override) is a critical finding.
+	setupSkillWithContent(t, dir, "dirty", "---\nname: dirty\n---\nHidden \u202E text.")
+
+	clean := skillFileRef{path: filepath.Join(dir, "clean", "SKILL.md"), defaultName: "clean"}
+	dirty := skillFileRef{path: filepath.Join(dir, "dirty", "SKILL.md"), defaultName: "dirty"}
+	missing := skillFileRef{path: filepath.Join(dir, "gone", "SKILL.md"), defaultName: "gone"}
+
+	tests := []struct {
+		name string
+		ref  skillFileRef
+		mode AuditMode
+		want bool
+	}{
+		{"skip mode never blocks", dirty, AuditSkip, false},
+		{"clean file in block mode", clean, AuditBlock, false},
+		{"critical file in block mode", dirty, AuditBlock, true},
+		{"critical file in warn mode", dirty, AuditWarn, false},
+		{"unreadable file only warns", missing, AuditBlock, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := auditBlocksSkill(tt.ref, tt.mode); got != tt.want {
+				t.Errorf("auditBlocksSkill(%s, %s) = %v, want %v", tt.ref.defaultName, tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadDirSkills(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing directory is not an error", func(t *testing.T) {
+		t.Parallel()
+		skills, blocked, err := loadDirSkills(filepath.Join(t.TempDir(), "nope"), LoadOptions{AuditMode: AuditSkip})
+		if err != nil {
+			t.Fatalf("loadDirSkills: %v", err)
+		}
+		if len(skills) != 0 || len(blocked) != 0 {
+			t.Errorf("got %d skills and %d blocked, want none", len(skills), len(blocked))
+		}
+	})
+
+	t.Run("a file where a directory is expected is an error", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "skills")
+		if err := os.WriteFile(path, []byte("not a dir"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := loadDirSkills(path, LoadOptions{AuditMode: AuditSkip})
+		if err == nil {
+			t.Fatal("loadDirSkills() = nil error, want a read failure")
+		}
+		if !strings.Contains(err.Error(), "reading skills dir") {
+			t.Errorf("error = %q, want it to mention reading skills dir", err)
+		}
+	})
+
+	t.Run("name falls back to the directory name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		setupSkillWithContent(t, dir, "unnamed", "---\ndescription: no name key\n---\nbody")
+
+		skills, _, err := loadDirSkills(dir, LoadOptions{AuditMode: AuditSkip})
+		if err != nil {
+			t.Fatalf("loadDirSkills: %v", err)
+		}
+		if len(skills) != 1 {
+			t.Fatalf("got %d skills, want 1", len(skills))
+		}
+		if skills[0].Name != "unnamed" {
+			t.Errorf("Name = %q, want %q", skills[0].Name, "unnamed")
+		}
+	})
+
+	t.Run("critical skill is reported as blocked, not returned", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		setupSkillWithContent(t, dir, "clean", "---\nname: clean\n---\nClean body.")
+		setupSkillWithContent(t, dir, "dirty", "---\nname: dirty\n---\nHidden \u202E text.")
+
+		skills, blocked, err := loadDirSkills(dir, LoadOptions{AuditMode: AuditBlock})
+		if err != nil {
+			t.Fatalf("loadDirSkills: %v", err)
+		}
+		if len(skills) != 1 || skills[0].Name != "clean" {
+			t.Fatalf("got %+v, want only the clean skill", skills)
+		}
+		want := []string{filepath.Join(dir, "dirty", "SKILL.md")}
+		if diff := cmp.Diff(want, blocked); diff != "" {
+			t.Errorf("blocked mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("the directory's own SKILL.md loads too", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "self-named")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\ndescription: d\n---\nbody"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		skills, _, err := loadDirSkills(dir, LoadOptions{AuditMode: AuditSkip})
+		if err != nil {
+			t.Fatalf("loadDirSkills: %v", err)
+		}
+		if len(skills) != 1 || skills[0].Name != "self-named" {
+			t.Fatalf("got %+v, want one skill named self-named", skills)
+		}
+	})
+}
+
+// TestLoadDirSkillsSource pins how a skill's Source is derived: an absolute
+// directory is user-level, a relative one is project-level. It cannot be
+// parallel — t.Chdir forbids it.
+func TestLoadDirSkillsSource(t *testing.T) {
+	dir := t.TempDir()
+	setupSkillWithContent(t, dir, "alpha", "---\nname: alpha\ndescription: d\n---\nbody")
+
+	skills, _, err := loadDirSkills(dir, LoadOptions{AuditMode: AuditSkip})
+	if err != nil {
+		t.Fatalf("loadDirSkills: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Source != "user" {
+		t.Fatalf("got %+v, want one skill with Source=user", skills)
+	}
+
+	// Re-read the same tree through a relative path.
+	t.Chdir(dir)
+	relSkills, _, err := loadDirSkills(".", LoadOptions{AuditMode: AuditSkip})
+	if err != nil {
+		t.Fatalf("loadDirSkills(.): %v", err)
+	}
+	if len(relSkills) != 1 || relSkills[0].Source != "project" {
+		t.Fatalf("got %+v, want one skill with Source=project", relSkills)
+	}
+}
+
+// TestLoadSkillsWithOptionsOverrideOrder pins the layering LoadSkillsWithOptions
+// implements: later directories replace earlier ones in place, keeping the
+// original slice position rather than appending a duplicate.
+func TestLoadSkillsWithOptionsOverrideOrder(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+	setupSkillWithContent(t, userDir, "shared", "---\nname: shared\ndescription: from user\n---\nu")
+	setupSkillWithContent(t, userDir, "user-only", "---\nname: user-only\ndescription: u\n---\nu")
+	setupSkillWithContent(t, projectDir, "shared", "---\nname: shared\ndescription: from project\n---\np")
+
+	skills, err := LoadSkillsWithOptions(LoadOptions{AuditMode: AuditSkip}, userDir, projectDir)
+	if err != nil {
+		t.Fatalf("LoadSkillsWithOptions: %v", err)
+	}
+
+	var got []Skill
+	for _, s := range skills {
+		if s.Name == "shared" || s.Name == "user-only" {
+			got = append(got, s)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d matching skills, want 2: %+v", len(got), got)
+	}
+	if got[0].Name != "shared" {
+		t.Errorf("first skill = %q, want the overridden %q to keep its slot", got[0].Name, "shared")
+	}
+	if got[0].Description != "from project" {
+		t.Errorf("Description = %q, want the project skill to win", got[0].Description)
+	}
+}
+
+// TestLoadSkillsWithOptionsErrorFromDir checks that a directory-level failure
+// aborts the whole load rather than being skipped.
+func TestLoadSkillsWithOptionsErrorFromDir(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "skills")
+	if err := os.WriteFile(path, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadSkillsWithOptions(LoadOptions{AuditMode: AuditSkip}, path); err == nil {
+		t.Fatal("LoadSkillsWithOptions() = nil error, want a read failure")
+	}
+}

--- a/internal/palace/drawer_service.go
+++ b/internal/palace/drawer_service.go
@@ -116,9 +116,14 @@ func (ds *DrawerService) AddDrawer(ctx context.Context, input DrawerInput) (*Dra
 }
 
 // Search performs a combined search using both semantic vector similarity and
-// FTS5 keyword matching. When the embedder is available, results from both methods
-// are merged and deduplicated by drawer ID, with semantic results prioritized.
-// Returns results sorted by combined relevance score.
+// FTS5 keyword matching. When the embedder is available, results from both
+// methods are merged and deduplicated by drawer ID, with semantic results
+// prioritized — the order is semantic-first, not score-first, so a
+// keyword-only hit can carry a higher score than the semantic hit above it.
+//
+// The keyword half is best-effort: a failing FTS5 query degrades to no keyword
+// hits. The semantic half is not, and a failure to read the stored embeddings
+// fails the search.
 func (ds *DrawerService) Search(ctx context.Context, q SearchQuery) ([]SearchResult, error) {
 	if q.Query == "" {
 		return nil, fmt.Errorf("palace: search query must not be empty")
@@ -139,111 +144,143 @@ func (ds *DrawerService) Search(ctx context.Context, q SearchQuery) ([]SearchRes
 		ftsResults = nil
 	}
 
-	// If no embedder, return FTS5 results only.
 	if ds.embedder == nil {
-		// Ensure FTS5 results have proper similarity scores.
-		maxRank := 1
-		for _, r := range ftsResults {
-			if r.Rank > maxRank {
-				maxRank = r.Rank
-			}
-		}
-		if maxRank == 0 {
-			maxRank = 1
-		}
-		for i := range ftsResults {
-			if ftsResults[i].Rank != 0 {
-				ftsResults[i].Similarity = float32(0.5 + (0.5 * float64(maxRank-ftsResults[i].Rank) / float64(maxRank)))
-			}
-		}
-		if len(ftsResults) > q.Limit {
-			ftsResults = ftsResults[:q.Limit]
-		}
+		return keywordOnlyResults(ftsResults, q.Limit), nil
+	}
+
+	// A query with no usable vector degrades to the keyword hits exactly as
+	// the store returned them: unscored, untrimmed, and not merged.
+	vec, ok := ds.queryVector(q.Query)
+	if !ok {
 		return ftsResults, nil
 	}
 
-	// Semantic search.
-	vecs, err := ds.embedder.Embed([]string{q.Query})
+	semantic, err := ds.semanticResults(ctx, vec, filter, q.Limit*3)
+	if err != nil {
+		return nil, err
+	}
+	return mergeSearchResults(semantic, ftsResults, q.Limit), nil
+}
+
+// queryVector embeds the query text for the semantic half of Search. It
+// reports false rather than an error for both of its failure modes, because
+// both are recoverable: the caller degrades to keyword results instead of
+// failing the search.
+func (ds *DrawerService) queryVector(query string) ([]float32, bool) {
+	vecs, err := ds.embedder.Embed([]string{query})
 	if err != nil {
 		slog.Warn("palace: search embedding failed, falling back to keyword", "error", err)
-		return ftsResults, nil
+		return nil, false
 	}
 	if len(vecs) == 0 {
-		return ftsResults, nil
+		return nil, false
 	}
+	return vecs[0], true
+}
 
+// semanticResults ranks the stored embeddings matching filter against vec and
+// loads the drawer behind each hit, keeping rank order. A drawer that ranks but
+// cannot be loaded is dropped rather than failing the search — the ranking came
+// from the embeddings table and the row may since have gone.
+func (ds *DrawerService) semanticResults(ctx context.Context, vec []float32, filter DrawerFilter, limit int) ([]SearchResult, error) {
 	candidates, err := ds.candidates(ctx, filter)
 	if err != nil {
 		return nil, fmt.Errorf("palace: search get embeddings: %w", err)
 	}
 
-	ranked := RankBySimilarity(vecs[0], candidates, q.Limit*3)
-
-	// Build a map of semantic results keyed by drawer ID.
-	semanticMap := make(map[string]SearchResult)
+	ranked := RankBySimilarity(vec, candidates, limit)
+	results := make([]SearchResult, 0, len(ranked))
 	for _, sr := range ranked {
 		drawer, err := ds.store.GetDrawer(ctx, sr.DrawerID)
 		if err != nil {
 			continue
 		}
-		semanticMap[sr.DrawerID] = SearchResult{
+		results = append(results, SearchResult{
 			Drawer:     *drawer,
 			Similarity: sr.Similarity,
+		})
+	}
+	return results, nil
+}
+
+// keywordOnlyResults scores and trims the keyword hits for the no-embedder
+// path, in place.
+//
+// A hit at rank 0 keeps whatever Similarity it arrived with instead of being
+// scored. That is the one place this path differs from mergeSearchResults,
+// which scores every keyword hit including those at rank 0.
+func keywordOnlyResults(results []SearchResult, limit int) []SearchResult {
+	maxRank := maxKeywordRank(results)
+	for i := range results {
+		if results[i].Rank != 0 {
+			results[i].Similarity = keywordSimilarity(results[i].Rank, maxRank)
 		}
 	}
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results
+}
 
-	// Merge FTS5 results into semantic map.
-	// FTS5 results get a boosted score: 0.5 + (0.5 * normalizedRank)
-	// This ensures exact keyword matches rank high but semantic still matters.
+// mergeSearchResults returns the semantic hits followed by the keyword hits
+// they did not already cover, trimmed to limit.
+//
+// Semantic hits keep their true cosine similarity and their rank order;
+// keyword-only hits follow with a boosted score. A drawer found by both sides
+// appears once, with its cosine score, because the semantic pass claims the ID
+// first.
+func mergeSearchResults(semantic, keyword []SearchResult, limit int) []SearchResult {
+	merged := make([]SearchResult, 0, len(semantic)+len(keyword))
+	seen := make(map[string]bool, len(semantic)+len(keyword))
+
+	for _, sr := range semantic {
+		merged = append(merged, sr)
+		seen[sr.Drawer.ID] = true
+	}
+
+	maxRank := maxKeywordRank(keyword)
+	for _, kw := range keyword {
+		if seen[kw.Drawer.ID] {
+			continue
+		}
+		seen[kw.Drawer.ID] = true
+		merged = append(merged, SearchResult{
+			Drawer:     kw.Drawer,
+			Similarity: keywordSimilarity(kw.Rank, maxRank),
+			Rank:       kw.Rank,
+		})
+	}
+
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged
+}
+
+// maxKeywordRank returns the largest FTS5 rank in results, floored at 1 so it
+// is always safe to divide by.
+//
+// The floor is not a corner case. SQLite's bm25 rank is negative — more
+// negative means more relevant — so the maximum is normally the floor itself,
+// and keywordSimilarity then scores a negative rank above 1. That contradicts
+// the 0-1 range SearchResult.Similarity documents, and is pinned as-is by
+// TestDrawerServiceSearch_KeywordOnlyScoring rather than fixed here.
+func maxKeywordRank(results []SearchResult) int {
 	maxRank := 1
-	for _, r := range ftsResults {
+	for _, r := range results {
 		if r.Rank > maxRank {
 			maxRank = r.Rank
 		}
 	}
-	if maxRank == 0 {
-		maxRank = 1
-	}
+	return maxRank
+}
 
-	merged := make([]SearchResult, 0, len(semanticMap)+len(ftsResults))
-	seen := make(map[string]bool)
-
-	// Add semantic results first (they have true similarity scores).
-	for _, sr := range ranked {
-		if result, ok := semanticMap[sr.DrawerID]; ok {
-			merged = append(merged, result)
-			seen[sr.DrawerID] = true
-		}
-	}
-
-	// Add FTS5 results not already in semantic results.
-	for _, fts := range ftsResults {
-		if seen[fts.Drawer.ID] {
-			continue
-		}
-		// Convert FTS5 rank to a relevance score (higher = better).
-		// FTS5 rank is negative (more negative = more relevant), so we normalize.
-		var ftsScore float64
-		if maxRank > 0 {
-			// Normalize: most negative = highest score
-			ftsScore = 0.5 + (0.5 * float64(maxRank-fts.Rank) / float64(maxRank))
-		} else {
-			ftsScore = 0.5
-		}
-		merged = append(merged, SearchResult{
-			Drawer:     fts.Drawer,
-			Similarity: float32(ftsScore),
-			Rank:       fts.Rank,
-		})
-		seen[fts.Drawer.ID] = true
-	}
-
-	// Trim to requested limit.
-	if len(merged) > q.Limit {
-		merged = merged[:q.Limit]
-	}
-
-	return merged, nil
+// keywordSimilarity converts an FTS5 rank into a score in the same space as
+// cosine similarity, so keyword and semantic hits can share one list: rank 0
+// scores 1 and the worst observed rank scores 0.5. maxRank must come from
+// maxKeywordRank, which guarantees a non-zero divisor.
+func keywordSimilarity(rank, maxRank int) float32 {
+	return float32(0.5 + (0.5 * float64(maxRank-rank) / float64(maxRank)))
 }
 
 // DeleteDrawer removes a drawer by ID.

--- a/internal/palace/drawer_service_search_merge_test.go
+++ b/internal/palace/drawer_service_search_merge_test.go
@@ -1,0 +1,490 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// scriptedStore wraps a real store so one method at a time can be made to fail
+// or return canned rows. Embedding PalaceStore keeps the ~25 methods this test
+// does not care about delegating to the real SQLite store.
+type scriptedStore struct {
+	PalaceStore
+	keywordResults []SearchResult
+	keywordErr     error
+	embeddingsErr  error
+	getDrawerErr   map[string]error
+}
+
+func (s *scriptedStore) KeywordSearch(ctx context.Context, query string, filter DrawerFilter, limit int) ([]SearchResult, error) {
+	if s.keywordErr != nil {
+		return nil, s.keywordErr
+	}
+	if s.keywordResults != nil {
+		return s.keywordResults, nil
+	}
+	return s.PalaceStore.KeywordSearch(ctx, query, filter, limit)
+}
+
+func (s *scriptedStore) GetAllEmbeddings(ctx context.Context, filter DrawerFilter) ([]EmbeddingRow, error) {
+	if s.embeddingsErr != nil {
+		return nil, s.embeddingsErr
+	}
+	return s.PalaceStore.GetAllEmbeddings(ctx, filter)
+}
+
+func (s *scriptedStore) GetDrawer(ctx context.Context, id string) (*Drawer, error) {
+	if err, ok := s.getDrawerErr[id]; ok {
+		return nil, err
+	}
+	return s.PalaceStore.GetDrawer(ctx, id)
+}
+
+// searchFixture builds a store holding two embedded drawers (alpha, beta) and
+// one unembedded drawer (gamma), so a test can tell semantic hits from
+// keyword-only hits by ID alone.
+//
+// With a query vector of {1, 0}: alpha scores 1.0 and beta scores 0.6. Gamma
+// has no embedding, so it can only ever arrive through the keyword side.
+func searchFixture(t *testing.T) *scriptedStore {
+	t.Helper()
+
+	store := &scriptedStore{PalaceStore: newTestStore(t)}
+	ctx := context.Background()
+
+	alpha := makeDrawer("d_alpha", "tech", "go", "alpha content about goroutines")
+	alpha.Embedding = []float32{1, 0}
+	beta := makeDrawer("d_beta", "tech", "go", "beta content about goroutines")
+	beta.Embedding = []float32{0.6, 0.8}
+	gamma := makeDrawer("d_gamma", "tech", "go", "gamma content about goroutines")
+
+	for _, d := range []*Drawer{alpha, beta, gamma} {
+		if err := store.InsertDrawer(ctx, d); err != nil {
+			t.Fatalf("InsertDrawer(%s): %v", d.ID, err)
+		}
+	}
+	return store
+}
+
+// queryEmbedder answers every Embed call with {1, 0}, the vector searchFixture
+// documents its similarity scores against.
+func queryEmbedder() Embedder {
+	return &fixedEmbedder{fallback: []float32{1, 0}}
+}
+
+func resultIDs(results []SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, r := range results {
+		ids = append(ids, r.Drawer.ID)
+	}
+	return ids
+}
+
+func equalIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func closeEnough(got, want float32) bool {
+	const tolerance = 1e-6
+	d := got - want
+	return d < tolerance && d > -tolerance
+}
+
+// TestDrawerServiceSearch_KeywordOnlyScoring pins the score the keyword-only
+// path (no embedder) writes onto each result.
+//
+// Two things are load-bearing and easy to lose in a refactor. A result whose
+// Rank is 0 keeps whatever Similarity it arrived with — it is not scored at
+// all. And the normalizer's denominator floors at 1, never at the observed
+// rank, so the negative ranks SQLite's bm25 actually produces push the score
+// above 1 rather than clamping to it.
+func TestDrawerServiceSearch_KeywordOnlyScoring(t *testing.T) {
+	tests := []struct {
+		name  string
+		ranks []int
+		want  []float32
+	}{
+		{
+			name:  "rank zero is left unscored",
+			ranks: []int{0, 0},
+			want:  []float32{0, 0},
+		},
+		{
+			name:  "positive ranks normalize against the largest",
+			ranks: []int{1, 2, 4},
+			want:  []float32{0.875, 0.75, 0.5},
+		},
+		{
+			name:  "negative ranks score above one because the divisor floors at 1",
+			ranks: []int{-1, -3, 0},
+			want:  []float32{1.5, 2.5, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &scriptedStore{PalaceStore: newTestStore(t)}
+			for i, rank := range tt.ranks {
+				store.keywordResults = append(store.keywordResults, SearchResult{
+					Drawer: *makeDrawer(string(rune('a'+i)), "tech", "go", "content"),
+					Rank:   rank,
+				})
+			}
+
+			ds := NewDrawerService(store, nil, DefaultConfig())
+			got, err := ds.Search(context.Background(), SearchQuery{Query: "content", Limit: 10})
+			if err != nil {
+				t.Fatalf("Search: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d results, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if !closeEnough(got[i].Similarity, tt.want[i]) {
+					t.Errorf("result %d (rank %d) similarity = %v, want %v",
+						i, tt.ranks[i], got[i].Similarity, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDrawerServiceSearch_KeywordOnlyTrimsToLimit(t *testing.T) {
+	store := &scriptedStore{PalaceStore: newTestStore(t)}
+	for i := range 6 {
+		store.keywordResults = append(store.keywordResults, SearchResult{
+			Drawer: *makeDrawer(string(rune('a'+i)), "tech", "go", "content"),
+			Rank:   i + 1,
+		})
+	}
+
+	ds := NewDrawerService(store, nil, DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "content", Limit: 2})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !equalIDs(resultIDs(got), []string{"a", "b"}) {
+		t.Errorf("got %v, want the first two keyword results", resultIDs(got))
+	}
+}
+
+// TestDrawerServiceSearch_MergeOrdersSemanticFirst pins the merge order, which
+// is not the score order: semantic hits come first in similarity order, then
+// keyword hits the semantic pass did not already produce — even when the
+// keyword hit's boosted score is higher.
+func TestDrawerServiceSearch_MergeOrdersSemanticFirst(t *testing.T) {
+	store := searchFixture(t)
+	beta, err := store.GetDrawer(context.Background(), "d_beta")
+	if err != nil {
+		t.Fatalf("GetDrawer: %v", err)
+	}
+	gamma, err := store.GetDrawer(context.Background(), "d_gamma")
+	if err != nil {
+		t.Fatalf("GetDrawer: %v", err)
+	}
+	// beta is also a semantic hit and must not be duplicated; gamma is
+	// keyword-only.
+	store.keywordResults = []SearchResult{
+		{Drawer: *gamma, Rank: 0},
+		{Drawer: *beta, Rank: 0},
+	}
+
+	ds := NewDrawerService(store, queryEmbedder(), DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "goroutines", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if !equalIDs(resultIDs(got), []string{"d_alpha", "d_beta", "d_gamma"}) {
+		t.Fatalf("got %v, want [d_alpha d_beta d_gamma]", resultIDs(got))
+	}
+	if !closeEnough(got[0].Similarity, 1) {
+		t.Errorf("d_alpha similarity = %v, want 1 (identical vector)", got[0].Similarity)
+	}
+	if !closeEnough(got[1].Similarity, 0.6) {
+		t.Errorf("d_beta similarity = %v, want 0.6 (cosine, not the keyword boost)", got[1].Similarity)
+	}
+	if !closeEnough(got[2].Similarity, 1) {
+		t.Errorf("d_gamma similarity = %v, want 1 (keyword boost at rank 0)", got[2].Similarity)
+	}
+}
+
+func TestDrawerServiceSearch_MergeTrimsToLimit(t *testing.T) {
+	store := searchFixture(t)
+	gamma, err := store.GetDrawer(context.Background(), "d_gamma")
+	if err != nil {
+		t.Fatalf("GetDrawer: %v", err)
+	}
+	store.keywordResults = []SearchResult{{Drawer: *gamma, Rank: 0}}
+
+	ds := NewDrawerService(store, queryEmbedder(), DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "goroutines", Limit: 2})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !equalIDs(resultIDs(got), []string{"d_alpha", "d_beta"}) {
+		t.Errorf("got %v, want the two semantic hits and no room for the keyword hit", resultIDs(got))
+	}
+}
+
+// TestDrawerServiceSearch_DropsRankedDrawersThatWillNotLoad pins the quiet
+// skip: a drawer that ranks but cannot be fetched is dropped from the results
+// rather than failing the search.
+func TestDrawerServiceSearch_DropsRankedDrawersThatWillNotLoad(t *testing.T) {
+	store := searchFixture(t)
+	store.getDrawerErr = map[string]error{"d_alpha": errors.New("boom")}
+	store.keywordResults = []SearchResult{}
+
+	ds := NewDrawerService(store, queryEmbedder(), DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "goroutines", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !equalIDs(resultIDs(got), []string{"d_beta"}) {
+		t.Errorf("got %v, want [d_beta] with the unloadable d_alpha dropped", resultIDs(got))
+	}
+}
+
+// TestDrawerServiceSearch_ContinuesWhenKeywordSearchFails pins the asymmetry: a
+// keyword failure is downgraded to "no keyword hits" and the semantic half
+// still runs, where an embeddings-fetch failure fails the whole search.
+func TestDrawerServiceSearch_ContinuesWhenKeywordSearchFails(t *testing.T) {
+	store := searchFixture(t)
+	store.keywordErr = errors.New("fts is down")
+
+	ds := NewDrawerService(store, queryEmbedder(), DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "goroutines", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !equalIDs(resultIDs(got), []string{"d_alpha", "d_beta"}) {
+		t.Errorf("got %v, want the semantic hits only", resultIDs(got))
+	}
+}
+
+func TestDrawerServiceSearch_FailsWhenEmbeddingsCannotBeFetched(t *testing.T) {
+	store := searchFixture(t)
+	store.embeddingsErr = errors.New("disk gone")
+
+	ds := NewDrawerService(store, queryEmbedder(), DefaultConfig())
+	_, err := ds.Search(context.Background(), SearchQuery{Query: "goroutines", Limit: 10})
+	if err == nil {
+		t.Fatal("Search: want an error when embeddings cannot be fetched")
+	}
+	if !errors.Is(err, store.embeddingsErr) {
+		t.Errorf("Search error = %v, want it to wrap the store error", err)
+	}
+}
+
+func TestDrawerServiceSearch_DefaultsLimitToFive(t *testing.T) {
+	store := &scriptedStore{PalaceStore: newTestStore(t)}
+	for i := range 8 {
+		store.keywordResults = append(store.keywordResults, SearchResult{
+			Drawer: *makeDrawer(string(rune('a'+i)), "tech", "go", "content"),
+			Rank:   i + 1,
+		})
+	}
+
+	ds := NewDrawerService(store, nil, DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "content"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 5 {
+		t.Errorf("got %d results, want the default limit of 5", len(got))
+	}
+}
+
+// TestDrawerServiceSearch_MergeNormalizesKeywordRanks pins the second, separate
+// rank normalization — the one applied to keyword hits that survive the merge.
+// It uses the same formula as the keyword-only path but scores every hit,
+// including those at rank 0.
+func TestDrawerServiceSearch_MergeNormalizesKeywordRanks(t *testing.T) {
+	store := searchFixture(t)
+	// Neither drawer is in the store: the merge path reads FTS rows straight
+	// through without a lookup, which is itself worth pinning.
+	store.keywordResults = []SearchResult{
+		{Drawer: *makeDrawer("d_delta", "tech", "go", "delta"), Rank: 1},
+		{Drawer: *makeDrawer("d_epsilon", "tech", "go", "epsilon"), Rank: 4},
+	}
+
+	ds := NewDrawerService(store, queryEmbedder(), DefaultConfig())
+	got, err := ds.Search(context.Background(), SearchQuery{Query: "goroutines", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if !equalIDs(resultIDs(got), []string{"d_alpha", "d_beta", "d_delta", "d_epsilon"}) {
+		t.Fatalf("got %v", resultIDs(got))
+	}
+	// maxRank is 4, so rank 1 scores 0.5+0.5*3/4 and rank 4 scores 0.5.
+	if !closeEnough(got[2].Similarity, 0.875) {
+		t.Errorf("d_delta similarity = %v, want 0.875", got[2].Similarity)
+	}
+	if !closeEnough(got[3].Similarity, 0.5) {
+		t.Errorf("d_epsilon similarity = %v, want 0.5", got[3].Similarity)
+	}
+	if got[2].Rank != 1 || got[3].Rank != 4 {
+		t.Errorf("merged keyword hits lost their Rank: %d, %d", got[2].Rank, got[3].Rank)
+	}
+}
+
+func TestMaxKeywordRank(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		ranks []int
+		want  int
+	}{
+		{name: "no results floors at 1", ranks: nil, want: 1},
+		{name: "all zero floors at 1", ranks: []int{0, 0}, want: 1},
+		{name: "all negative floors at 1", ranks: []int{-1, -7, -3}, want: 1},
+		{name: "largest positive wins", ranks: []int{1, 9, 4}, want: 9},
+		{name: "mixed signs take the positive max", ranks: []int{-5, 3, 0}, want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			results := make([]SearchResult, 0, len(tt.ranks))
+			for _, rank := range tt.ranks {
+				results = append(results, SearchResult{Rank: rank})
+			}
+			if got := maxKeywordRank(results); got != tt.want {
+				t.Errorf("maxKeywordRank(%v) = %d, want %d", tt.ranks, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeywordSimilarity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rank    int
+		maxRank int
+		want    float32
+	}{
+		{name: "rank zero is the best score", rank: 0, maxRank: 4, want: 1},
+		{name: "the worst rank is the floor score", rank: 4, maxRank: 4, want: 0.5},
+		{name: "midway", rank: 2, maxRank: 4, want: 0.75},
+		{name: "single result at rank 1", rank: 1, maxRank: 1, want: 0.5},
+		{name: "negative rank exceeds 1", rank: -1, maxRank: 1, want: 1.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := keywordSimilarity(tt.rank, tt.maxRank); !closeEnough(got, tt.want) {
+				t.Errorf("keywordSimilarity(%d, %d) = %v, want %v", tt.rank, tt.maxRank, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeSearchResults(t *testing.T) {
+	t.Parallel()
+
+	hit := func(id string, sim float32, rank int) SearchResult {
+		return SearchResult{Drawer: Drawer{ID: id}, Similarity: sim, Rank: rank}
+	}
+
+	tests := []struct {
+		name     string
+		semantic []SearchResult
+		keyword  []SearchResult
+		limit    int
+		wantIDs  []string
+	}{
+		{
+			name:    "keyword only",
+			keyword: []SearchResult{hit("a", 0, 1), hit("b", 0, 2)},
+			limit:   5,
+			wantIDs: []string{"a", "b"},
+		},
+		{
+			name:     "semantic only",
+			semantic: []SearchResult{hit("a", 0.9, 0)},
+			limit:    5,
+			wantIDs:  []string{"a"},
+		},
+		{
+			name:     "semantic comes first regardless of score",
+			semantic: []SearchResult{hit("a", 0.1, 0)},
+			keyword:  []SearchResult{hit("b", 0, 0)},
+			limit:    5,
+			wantIDs:  []string{"a", "b"},
+		},
+		{
+			name:     "a drawer on both sides appears once",
+			semantic: []SearchResult{hit("a", 0.9, 0)},
+			keyword:  []SearchResult{hit("a", 0, 1), hit("b", 0, 2)},
+			limit:    5,
+			wantIDs:  []string{"a", "b"},
+		},
+		{
+			name:    "a drawer repeated on the keyword side appears once",
+			keyword: []SearchResult{hit("a", 0, 1), hit("a", 0, 2)},
+			limit:   5,
+			wantIDs: []string{"a"},
+		},
+		{
+			name:     "limit trims from the tail, dropping keyword hits first",
+			semantic: []SearchResult{hit("a", 0.9, 0), hit("b", 0.8, 0)},
+			keyword:  []SearchResult{hit("c", 0, 1)},
+			limit:    2,
+			wantIDs:  []string{"a", "b"},
+		},
+		{
+			name:    "empty input yields an empty, non-nil slice",
+			limit:   5,
+			wantIDs: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeSearchResults(tt.semantic, tt.keyword, tt.limit)
+			if got == nil {
+				t.Fatal("mergeSearchResults returned nil, want an empty slice")
+			}
+			if !equalIDs(resultIDs(got), tt.wantIDs) {
+				t.Errorf("got %v, want %v", resultIDs(got), tt.wantIDs)
+			}
+		})
+	}
+}
+
+// TestMergeSearchResults_KeepsSemanticScores pins that merging does not
+// re-score a semantic hit with the keyword formula when the same drawer also
+// came back from FTS5.
+func TestMergeSearchResults_KeepsSemanticScores(t *testing.T) {
+	t.Parallel()
+
+	semantic := []SearchResult{{Drawer: Drawer{ID: "a"}, Similarity: 0.42}}
+	keyword := []SearchResult{{Drawer: Drawer{ID: "a"}, Rank: 3}}
+
+	got := mergeSearchResults(semantic, keyword, 5)
+	if len(got) != 1 {
+		t.Fatalf("got %d results, want 1", len(got))
+	}
+	if !closeEnough(got[0].Similarity, 0.42) {
+		t.Errorf("similarity = %v, want the cosine score 0.42", got[0].Similarity)
+	}
+	if got[0].Rank != 0 {
+		t.Errorf("rank = %d, want 0: the semantic hit's copy has no FTS rank", got[0].Rank)
+	}
+}

--- a/internal/palace/tool_kg_extract.go
+++ b/internal/palace/tool_kg_extract.go
@@ -111,15 +111,15 @@ func palaceKGExtractHandler(_ context.Context, _ *Palace, input KGExtractToolInp
 // appropriate confidence based on whether the chunk has a source file.
 // Stdlib paths are filtered out: they are noise in a project knowledge
 // graph.
-func emitImport(text, path, sourceFile string, add func(subj, pred, obj, reason string, conf float64)) {
-	if path == "" || isStdlibImport(path) {
+func emitImport(path, sourceFile string, ts *tripleSet) {
+	if isStdlibImport(path) {
 		return
 	}
 	if sourceFile != "" {
-		add(fileBase(sourceFile), "imports", path, "import statement, anchored to source file", 0.95)
+		ts.add(fileBase(sourceFile), "imports", path, "import statement, anchored to source file", 0.95)
 		return
 	}
-	add("codebase", "imports", path, "import statement (no source file anchor)", 0.50)
+	ts.add("codebase", "imports", path, "import statement (no source file anchor)", 0.50)
 }
 
 // --- heuristics ---
@@ -166,6 +166,65 @@ var (
 	filePathRe = regexp.MustCompile(`(?:^|[\s"'(\[])([a-zA-Z0-9_./-]+/[a-zA-Z0-9_.-]+\.[a-z]{1,8})(?:\b|["')])`)
 )
 
+// declPattern is one declaration-matching heuristic: a regex whose first
+// capture group is the declared name, the reason recorded on the emitted
+// triple, and whether English noise words should be filtered out.
+//
+// Only the generic pattern sets skipNoise. Its keywords (`const`, `let`,
+// `var`) routinely introduce identifiers like `err` or `result`, where a Go
+// `func` or `type` declaration named that is rare enough not to be worth
+// losing the real ones over.
+type declPattern struct {
+	re        *regexp.Regexp
+	reason    string
+	skipNoise bool
+}
+
+// declPatterns runs in order, and order is visible in the output: the first
+// pattern to produce a given (subject, predicate, object) owns its reason.
+var declPatterns = []declPattern{
+	{re: goFuncDeclRe, reason: "Go func declaration in source file"},
+	{re: goTypeDeclRe, reason: "Go type declaration in source file"},
+	{re: genericDeclRe, reason: "declaration in source file", skipNoise: true},
+}
+
+// tripleSet accumulates candidate triples and enforces the rules every
+// heuristic shares: a triple needs all three parts present, needs a subject
+// that differs from its object, and must not already be in the set.
+//
+// Dedup is case-insensitive over the whole (subject, predicate, object) key,
+// and first write wins — so when two heuristics find the same fact, the one
+// that ran first owns the confidence and the reason.
+type tripleSet struct {
+	out  []ExtractedTriple
+	seen map[string]bool
+}
+
+func newTripleSet() *tripleSet {
+	return &tripleSet{seen: make(map[string]bool)}
+}
+
+func (ts *tripleSet) add(subj, pred, obj, reason string, conf float64) {
+	s := strings.TrimSpace(subj)
+	p := strings.TrimSpace(pred)
+	o := strings.TrimSpace(obj)
+	if s == "" || p == "" || o == "" || strings.EqualFold(s, o) {
+		return
+	}
+	key := strings.ToLower(s) + "|" + strings.ToLower(p) + "|" + strings.ToLower(o)
+	if ts.seen[key] {
+		return
+	}
+	ts.seen[key] = true
+	ts.out = append(ts.out, ExtractedTriple{
+		Subject:    s,
+		Predicate:  normalizePredicate(p),
+		Object:     o,
+		Confidence: conf,
+		Reason:     reason,
+	})
+}
+
 // extractTriples runs the heuristic pass over text and returns candidate
 // triples. The result is unsorted; the caller sorts and truncates.
 //
@@ -176,121 +235,97 @@ var (
 //	0.50 — heuristic pair from free-form identifiers
 //	0.30 — bare identifier pair with no anchor
 func extractTriples(text, sourceFile string) []ExtractedTriple {
-	var out []ExtractedTriple
-	seen := make(map[string]bool) // dedupe by (subj|pred|obj)
+	ts := newTripleSet()
+	extractImportTriples(text, sourceFile, ts)
+	extractDeclTriples(text, sourceFile, ts)
+	extractSiblingPathTriples(text, sourceFile, ts)
+	return ts.out
+}
 
-	add := func(subj, pred, obj, reason string, conf float64) {
-		s := strings.TrimSpace(subj)
-		p := strings.TrimSpace(pred)
-		o := strings.TrimSpace(obj)
-		if s == "" || p == "" || o == "" || strings.EqualFold(s, o) {
-			return
-		}
-		key := strings.ToLower(s) + "|" + strings.ToLower(p) + "|" + strings.ToLower(o)
-		if seen[key] {
-			return
-		}
-		seen[key] = true
-		out = append(out, ExtractedTriple{
-			Subject:    s,
-			Predicate:  normalizePredicate(p),
-			Object:     o,
-			Confidence: conf,
-			Reason:     reason,
-		})
-	}
-
-	// Code-level extraction: imports.
-	//
-	// Two passes. The first catches imports written on a single line —
-	// `import "path"`, `from "path"`, `require("path")`, with the keyword
-	// and the literal on the same line. The second catches Go's
-	// parenthesized form: `import ( ... "path" ... )` where the keyword
-	// is on one line and the literal is on a later line. The single-line
-	// regex cannot match that form because the quote is not on the same
-	// line as the `import` keyword, and tightening the alternation to
-	// allow a `( )` block just shifts the problem: the `import (` would
-	// then have to be followed by a quote on the same line, which it
-	// never is.
-	seenInImport := make(map[string]bool)
+// extractImportTriples emits one "imports" triple per non-stdlib import path
+// found in text.
+//
+// Two passes. The first catches imports written on a single line —
+// `import "path"`, `from "path"`, `require("path")`, with the keyword and the
+// literal on the same line. The second catches Go's parenthesized form:
+// `import ( ... "path" ... )` where the keyword is on one line and the literal
+// is on a later line. The single-line regex cannot match that form because the
+// quote is not on the same line as the `import` keyword, and tightening the
+// alternation to allow a `( )` block just shifts the problem: the `import (`
+// would then have to be followed by a quote on the same line, which it never
+// is.
+//
+// A path seen in the first pass is skipped in the second, so a package
+// imported both ways keeps the reason from the single-line pass.
+func extractImportTriples(text, sourceFile string, ts *tripleSet) {
+	seenPath := make(map[string]bool)
 	for _, m := range importPathRe.FindAllStringSubmatch(text, -1) {
-		seenInImport[m[1]] = true
-		emitImport(text, m[1], sourceFile, add)
+		seenPath[m[1]] = true
+		emitImport(m[1], sourceFile, ts)
 	}
-
-	// Parenthesized import block: find the `import (` opener, then collect
-	// every quoted string between it and the matching `)`. The matching
-	// paren is found by line — Go does not allow nested parens in an
-	// import block, so the first `)` at column 0 is reliable.
-	for _, openIdx := range importBlockOpenRe.FindAllStringIndex(text, -1) {
-		blockStart := openIdx[1] // just after the `(`
-		rest := text[blockStart:]
-		closeRel := strings.Index(rest, "\n)")
-		var blockEnd int
-		if closeRel < 0 {
-			blockEnd = len(rest)
-		} else {
-			blockEnd = closeRel
-		}
-		block := text[blockStart : blockStart+blockEnd]
+	for _, block := range goImportBlocks(text) {
 		for _, m := range quotedStringRe.FindAllStringSubmatch(block, -1) {
-			if seenInImport[m[1]] {
+			if seenPath[m[1]] {
 				continue
 			}
-			seenInImport[m[1]] = true
-			emitImport(text, m[1], sourceFile, add)
+			seenPath[m[1]] = true
+			emitImport(m[1], sourceFile, ts)
 		}
 	}
+}
 
-	// Code-level extraction: Go function declarations.
-	for _, m := range goFuncDeclRe.FindAllStringSubmatch(text, -1) {
-		name := m[1]
-		if name == "" {
-			continue
+// goImportBlocks returns the body of every Go parenthesized import block in
+// text: the span between the `import (` opener and the matching `)`, with
+// neither delimiter included.
+//
+// The closer is found by line rather than by counting parens — Go does not
+// allow nested parens in an import block, so the first `)` at the start of a
+// line reliably ends it. A block with no closer, which is what a truncated
+// chunk looks like, runs to the end of the text rather than being discarded.
+func goImportBlocks(text string) []string {
+	var blocks []string
+	for _, open := range importBlockOpenRe.FindAllStringIndex(text, -1) {
+		body := text[open[1]:] // just after the `(`
+		if end := strings.Index(body, "\n)"); end >= 0 {
+			body = body[:end]
 		}
-		if sourceFile != "" {
-			add(name, "defined_in", sourceFile, "Go func declaration in source file", 0.95)
-		}
+		blocks = append(blocks, body)
 	}
+	return blocks
+}
 
-	// Code-level extraction: Go type declarations.
-	for _, m := range goTypeDeclRe.FindAllStringSubmatch(text, -1) {
-		name := m[1]
-		if name == "" {
-			continue
-		}
-		if sourceFile != "" {
-			add(name, "defined_in", sourceFile, "Go type declaration in source file", 0.95)
-		}
+// extractDeclTriples emits a "defined_in" triple per declaration matched by
+// declPatterns. Every such triple points at sourceFile, so an unanchored chunk
+// yields none at all and the whole pass is skipped.
+func extractDeclTriples(text, sourceFile string, ts *tripleSet) {
+	if sourceFile == "" {
+		return
 	}
-
-	// Code-level extraction: generic declarations (Python, JS, etc).
-	for _, m := range genericDeclRe.FindAllStringSubmatch(text, -1) {
-		name := m[1]
-		if name == "" || isCommonWord(name) {
-			continue
-		}
-		if sourceFile != "" {
-			add(name, "defined_in", sourceFile, "declaration in source file", 0.95)
-		}
-	}
-
-	// Path-aware: every path mentioned alongside a source file gets a
-	// "part_of" candidate if it shares a directory.
-	if sourceFile != "" {
-		srcDir := pathDir(sourceFile)
-		for _, m := range filePathRe.FindAllStringSubmatch(text, -1) {
-			p := m[1]
-			if p == "" || p == sourceFile {
+	for _, pat := range declPatterns {
+		for _, m := range pat.re.FindAllStringSubmatch(text, -1) {
+			if pat.skipNoise && isCommonWord(m[1]) {
 				continue
 			}
-			if pathDir(p) == srcDir {
-				add(p, "part_of", fileBase(sourceFile), "shares directory with source file", 0.70)
-			}
+			ts.add(m[1], "defined_in", sourceFile, pat.reason, 0.95)
 		}
 	}
+}
 
-	return out
+// extractSiblingPathTriples emits a "part_of" triple for every path mentioned
+// in text that lives in the same directory as sourceFile. The source file's
+// own path is not part of itself, and without a source file there is nothing
+// to be part of.
+func extractSiblingPathTriples(text, sourceFile string, ts *tripleSet) {
+	if sourceFile == "" {
+		return
+	}
+	srcDir := pathDir(sourceFile)
+	for _, m := range filePathRe.FindAllStringSubmatch(text, -1) {
+		if m[1] == sourceFile || pathDir(m[1]) != srcDir {
+			continue
+		}
+		ts.add(m[1], "part_of", fileBase(sourceFile), "shares directory with source file", 0.70)
+	}
 }
 
 // formatExtractedTriples renders the candidates as a markdown block the agent

--- a/internal/palace/tool_kg_extract_branches_test.go
+++ b/internal/palace/tool_kg_extract_branches_test.go
@@ -1,0 +1,366 @@
+package palace
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// tripleKey renders a triple as "subject|predicate|object" so a test can state
+// its expectation as a plain string instead of a struct literal.
+func tripleKey(t ExtractedTriple) string {
+	return t.Subject + "|" + t.Predicate + "|" + t.Object
+}
+
+func tripleKeys(triples []ExtractedTriple) []string {
+	keys := make([]string, 0, len(triples))
+	for _, t := range triples {
+		keys = append(keys, tripleKey(t))
+	}
+	return keys
+}
+
+// TestExtractTriples_Branches characterizes the input shapes that reach the
+// heuristics' guard clauses. These are the branches the sorted/truncated tool
+// output does not exercise, so they are pinned here directly against
+// extractTriples.
+func TestExtractTriples_Branches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		text       string
+		sourceFile string
+		want       []string // every triple, as subject|predicate|object
+	}{
+		{
+			name:       "stdlib imports are dropped as noise",
+			text:       "import \"fmt\"\nimport \"strings\"\n",
+			sourceFile: "internal/palace/kg.go",
+			want:       nil,
+		},
+		{
+			name:       "relative imports are dropped as noise",
+			text:       "import \"./sibling\"\nimport \"../parent\"\n",
+			sourceFile: "internal/palace/kg.go",
+			want:       nil,
+		},
+		{
+			name: "imports without a source file anchor to codebase",
+			text: "import \"github.com/dimetron/pi-go/internal/palace\"\n",
+			want: []string{"codebase|imports|github.com/dimetron/pi-go/internal/palace"},
+		},
+		{
+			name:       "the same import twice yields one triple",
+			text:       "import \"github.com/spf13/cobra\"\nimport \"github.com/spf13/cobra\"\n",
+			sourceFile: "cmd/root.go",
+			want:       []string{"root.go|imports|github.com/spf13/cobra"},
+		},
+		{
+			name:       "an import of the source file itself is self-referential and dropped",
+			text:       "import \"root.go\"\n",
+			sourceFile: "root.go",
+			want:       nil,
+		},
+		{
+			name:       "a parenthesized import block is scanned line by line",
+			text:       "import (\n\t\"fmt\"\n\t\"github.com/spf13/cobra\"\n)\n",
+			sourceFile: "cmd/root.go",
+			want:       []string{"root.go|imports|github.com/spf13/cobra"},
+		},
+		{
+			name:       "an unterminated import block runs to end of text",
+			text:       "import (\n\t\"github.com/spf13/cobra\"\n\t\"github.com/spf13/pflag\"\n",
+			sourceFile: "cmd/root.go",
+			want: []string{
+				"root.go|imports|github.com/spf13/cobra",
+				"root.go|imports|github.com/spf13/pflag",
+			},
+		},
+		{
+			name:       "a path already seen on a single-line import is not re-emitted from the block",
+			text:       "import \"github.com/spf13/cobra\"\n\nimport (\n\t\"github.com/spf13/cobra\"\n)\n",
+			sourceFile: "cmd/root.go",
+			want:       []string{"root.go|imports|github.com/spf13/cobra"},
+		},
+		{
+			name:       "duplicates inside one block collapse to a single triple",
+			text:       "import (\n\t\"github.com/spf13/cobra\"\n\t\"github.com/spf13/cobra\"\n)\n",
+			sourceFile: "cmd/root.go",
+			want:       []string{"root.go|imports|github.com/spf13/cobra"},
+		},
+		{
+			name: "declarations without a source file yield nothing",
+			text: "func Handle() {}\ntype Server struct {\n}\nclass Widget:\n",
+			want: nil,
+		},
+		{
+			name:       "generic declarations of common words are filtered",
+			text:       "const err = 1\nvar result = 2\nlet ctx = 3\nconst Router = 4\n",
+			sourceFile: "web/app.js",
+			want:       []string{"Router|defined_in|web/app.js"},
+		},
+		{
+			name:       "a func and a type of the same name collapse to one triple",
+			text:       "func Server() {}\ntype Server struct {\n}\n",
+			sourceFile: "internal/api/server.go",
+			want:       []string{"Server|defined_in|internal/api/server.go"},
+		},
+		{
+			name:       "sibling paths in the same directory become part_of",
+			text:       "See internal/auth/token.go and internal/auth/handler.go for details.",
+			sourceFile: "internal/auth/handler.go",
+			want:       []string{"internal/auth/token.go|part_of|handler.go"},
+		},
+		{
+			name:       "paths in a different directory are not part_of the source file",
+			text:       "See internal/other/thing.go for details.",
+			sourceFile: "internal/auth/handler.go",
+			want:       nil,
+		},
+		{
+			name: "paths without a source file yield nothing",
+			text: "See internal/auth/token.go for details.",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tripleKeys(extractTriples(tt.text, tt.sourceFile))
+			sort.Strings(got)
+			want := append([]string(nil), tt.want...)
+			sort.Strings(want)
+
+			if strings.Join(got, "\n") != strings.Join(want, "\n") {
+				t.Errorf("extractTriples(%q, %q):\n got %v\nwant %v", tt.text, tt.sourceFile, got, want)
+			}
+		})
+	}
+}
+
+// TestExtractTriples_ConfidenceAndReason pins the confidence tier and reason
+// attached to each heuristic's output, since the tool sorts on confidence and
+// the agent reads the reason.
+func TestExtractTriples_ConfidenceAndReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		text       string
+		sourceFile string
+		key        string
+		wantConf   float64
+		wantReason string
+	}{
+		{
+			name:       "anchored import",
+			text:       "import \"github.com/spf13/cobra\"\n",
+			sourceFile: "cmd/root.go",
+			key:        "root.go|imports|github.com/spf13/cobra",
+			wantConf:   0.95,
+			wantReason: "import statement, anchored to source file",
+		},
+		{
+			name:       "unanchored import",
+			text:       "import \"github.com/spf13/cobra\"\n",
+			key:        "codebase|imports|github.com/spf13/cobra",
+			wantConf:   0.50,
+			wantReason: "import statement (no source file anchor)",
+		},
+		{
+			name:       "go func declaration",
+			text:       "func Handle() {}\n",
+			sourceFile: "internal/api/server.go",
+			key:        "Handle|defined_in|internal/api/server.go",
+			wantConf:   0.95,
+			wantReason: "Go func declaration in source file",
+		},
+		{
+			name:       "go type declaration",
+			text:       "type Server struct {\n}\n",
+			sourceFile: "internal/api/server.go",
+			key:        "Server|defined_in|internal/api/server.go",
+			wantConf:   0.95,
+			wantReason: "Go type declaration in source file",
+		},
+		{
+			name:       "generic declaration",
+			text:       "class Widget:\n",
+			sourceFile: "web/widget.py",
+			key:        "Widget|defined_in|web/widget.py",
+			wantConf:   0.95,
+			wantReason: "declaration in source file",
+		},
+		{
+			name:       "sibling path",
+			text:       "See internal/auth/token.go for details.",
+			sourceFile: "internal/auth/handler.go",
+			key:        "internal/auth/token.go|part_of|handler.go",
+			wantConf:   0.70,
+			wantReason: "shares directory with source file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, got := range extractTriples(tt.text, tt.sourceFile) {
+				if tripleKey(got) != tt.key {
+					continue
+				}
+				if got.Confidence != tt.wantConf {
+					t.Errorf("confidence = %v, want %v", got.Confidence, tt.wantConf)
+				}
+				if got.Reason != tt.wantReason {
+					t.Errorf("reason = %q, want %q", got.Reason, tt.wantReason)
+				}
+				return
+			}
+			t.Fatalf("triple %q not extracted from %q", tt.key, tt.text)
+		})
+	}
+}
+
+// TestExtractTriples_FirstHeuristicOwnsTheTriple pins the dedup tie-break: the
+// same (subject, predicate, object) found twice keeps the confidence and reason
+// of whichever heuristic ran first, not the highest-confidence one.
+func TestExtractTriples_FirstHeuristicOwnsTheTriple(t *testing.T) {
+	t.Parallel()
+
+	// "cobra" is imported on a single line and again inside a block; the
+	// single-line pass runs first and owns the reason.
+	const text = "import \"github.com/spf13/cobra\"\n\nimport (\n\t\"github.com/spf13/cobra\"\n)\n"
+
+	triples := extractTriples(text, "cmd/root.go")
+	if len(triples) != 1 {
+		t.Fatalf("got %d triples, want 1: %v", len(triples), tripleKeys(triples))
+	}
+	if triples[0].Reason != "import statement, anchored to source file" {
+		t.Errorf("reason = %q", triples[0].Reason)
+	}
+}
+
+func TestIsStdlibImport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"", true},
+		{"fmt", true},
+		{"net/http", true},
+		{"./local", true},
+		{"../parent", true},
+		{"github.com/spf13/cobra", false},
+		{"gopkg.in/yaml.v3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			if got := isStdlibImport(tt.path); got != tt.want {
+				t.Errorf("isStdlibImport(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileBaseAndPathDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     string
+		wantBase string
+		wantDir  string
+	}{
+		{"internal/palace/kg.go", "kg.go", "internal/palace"},
+		{"main.go", "main.go", ""},
+		{"", "", ""},
+		{"/abs/path.go", "path.go", "/abs"},
+		{"trailing/", "", "trailing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			if got := fileBase(tt.path); got != tt.wantBase {
+				t.Errorf("fileBase(%q) = %q, want %q", tt.path, got, tt.wantBase)
+			}
+			if got := pathDir(tt.path); got != tt.wantDir {
+				t.Errorf("pathDir(%q) = %q, want %q", tt.path, got, tt.wantDir)
+			}
+		})
+	}
+}
+
+func TestIsCommonWord(t *testing.T) {
+	t.Parallel()
+
+	for _, word := range []string{"this", "ERR", "Ctx", "result", "temp"} {
+		if !isCommonWord(word) {
+			t.Errorf("isCommonWord(%q) = false, want true", word)
+		}
+	}
+	for _, word := range []string{"Router", "Handle", "Server", "errors"} {
+		if isCommonWord(word) {
+			t.Errorf("isCommonWord(%q) = true, want false", word)
+		}
+	}
+}
+
+func TestGoImportBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "no import block",
+			text: "package main\n\nimport \"fmt\"\n",
+			want: nil,
+		},
+		{
+			name: "one closed block",
+			text: "import (\n\t\"fmt\"\n)\n\nfunc main() {}\n",
+			want: []string{"\n\t\"fmt\""},
+		},
+		{
+			name: "unterminated block runs to end of text",
+			text: "import (\n\t\"fmt\"\n",
+			want: []string{"\n\t\"fmt\"\n"},
+		},
+		{
+			name: "two blocks",
+			text: "import (\n\t\"fmt\"\n)\nimport (\n\t\"os\"\n)\n",
+			want: []string{"\n\t\"fmt\"", "\n\t\"os\""},
+		},
+		{
+			name: "a closing paren mid-line does not end the block",
+			text: "import (\n\t\"fmt\" // f(x)\n\t\"os\"\n)\n",
+			want: []string{"\n\t\"fmt\" // f(x)\n\t\"os\""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := goImportBlocks(tt.text)
+			if len(got) != len(tt.want) {
+				t.Fatalf("goImportBlocks(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("block %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -309,29 +309,8 @@ func antStopReasonToGenai(reason anthropic.StopReason) genai.FinishReason {
 }
 
 func antContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]anthropic.MessageParam, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemPrompt := strings.TrimSpace(systemBuilder.String())
-
-	// Collect function responses for matching
-	functionResponses := make(map[string]*genai.FunctionResponse)
-	for _, c := range contents {
-		if c == nil || c.Parts == nil {
-			continue
-		}
-		for _, p := range c.Parts {
-			if p != nil && p.FunctionResponse != nil {
-				functionResponses[p.FunctionResponse.ID] = p.FunctionResponse
-			}
-		}
-	}
+	systemPrompt := genaiSystemInstruction(config)
+	functionResponses := genaiFunctionResponses(contents)
 
 	var messages []anthropic.MessageParam
 	for _, content := range contents {
@@ -342,65 +321,19 @@ func antContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 		if role == "system" {
 			continue
 		}
+		textParts, functionCalls := genaiSplitParts(content)
 
-		var textParts []string
-		var functionCalls []*genai.FunctionCall
-
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.Text != "" {
-				textParts = append(textParts, part.Text)
-			} else if part.FunctionCall != nil {
-				functionCalls = append(functionCalls, part.FunctionCall)
-			}
-		}
-
-		if len(functionCalls) > 0 && (role == "model" || role == "assistant") {
-			// Assistant message with tool use blocks
-			var contentBlocks []anthropic.ContentBlockParamUnion
-			if len(textParts) > 0 {
-				contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
-			}
-			for _, fc := range functionCalls {
-				argsJSON, _ := json.Marshal(fc.Args)
-				var inputMap map[string]any
-				_ = json.Unmarshal(argsJSON, &inputMap)
-				if inputMap == nil {
-					inputMap = make(map[string]any)
-				}
-				contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(fc.ID, inputMap, fc.Name))
-			}
-			messages = append(messages, anthropic.MessageParam{
-				Role:    anthropic.MessageParamRoleAssistant,
-				Content: contentBlocks,
-			})
-
-			// Tool results as user message
-			var toolResultBlocks []anthropic.ContentBlockParamUnion
-			for _, fc := range functionCalls {
-				contentStr := "No response available for this function call."
-				if fr := functionResponses[fc.ID]; fr != nil {
-					contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
-				}
-				toolResultBlocks = append(toolResultBlocks, anthropic.NewToolResultBlock(fc.ID, contentStr, false))
-			}
-			messages = append(messages, anthropic.MessageParam{
-				Role:    anthropic.MessageParamRoleUser,
-				Content: toolResultBlocks,
-			})
-		} else if len(textParts) > 0 {
-			msgRole := anthropic.MessageParamRoleUser
-			if role == "model" || role == "assistant" {
-				msgRole = anthropic.MessageParamRoleAssistant
-			}
-			var contentBlocks []anthropic.ContentBlockParamUnion
-			contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
-			messages = append(messages, anthropic.MessageParam{
-				Role:    msgRole,
-				Content: contentBlocks,
-			})
+		switch {
+		case len(functionCalls) > 0 && genaiRoleIsAssistant(role):
+			// Anthropic wants the calls and their results as two messages:
+			// the assistant turn holding tool_use blocks, then a user turn
+			// holding the matching tool_result blocks.
+			messages = append(messages,
+				antToolUseMessage(textParts, functionCalls),
+				antToolResultMessage(functionCalls, functionResponses),
+			)
+		case len(textParts) > 0:
+			messages = append(messages, antTextMessage(role, textParts))
 		}
 	}
 
@@ -415,6 +348,64 @@ func antContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 	}
 
 	return messages, systemPrompt
+}
+
+// antToolUseMessage renders an assistant turn that made tool calls: any text
+// the model produced first, then one tool_use block per call. Arguments that
+// do not round-trip through JSON as an object become an empty object rather
+// than a null input, which the Messages API rejects.
+func antToolUseMessage(textParts []string, functionCalls []*genai.FunctionCall) anthropic.MessageParam {
+	var contentBlocks []anthropic.ContentBlockParamUnion
+	if len(textParts) > 0 {
+		contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
+	}
+	for _, fc := range functionCalls {
+		argsJSON, _ := json.Marshal(fc.Args)
+		var inputMap map[string]any
+		_ = json.Unmarshal(argsJSON, &inputMap)
+		if inputMap == nil {
+			inputMap = make(map[string]any)
+		}
+		contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(fc.ID, inputMap, fc.Name))
+	}
+	return anthropic.MessageParam{
+		Role:    anthropic.MessageParamRoleAssistant,
+		Content: contentBlocks,
+	}
+}
+
+// antToolResultMessage renders the user turn carrying one tool_result block
+// per call. A call whose result is missing still gets a block, with
+// placeholder text, so no tool_use is left unanswered.
+func antToolResultMessage(
+	functionCalls []*genai.FunctionCall,
+	functionResponses map[string]*genai.FunctionResponse,
+) anthropic.MessageParam {
+	var toolResultBlocks []anthropic.ContentBlockParamUnion
+	for _, fc := range functionCalls {
+		contentStr := "No response available for this function call."
+		if fr := functionResponses[fc.ID]; fr != nil {
+			contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
+		}
+		toolResultBlocks = append(toolResultBlocks, anthropic.NewToolResultBlock(fc.ID, contentStr, false))
+	}
+	return anthropic.MessageParam{
+		Role:    anthropic.MessageParamRoleUser,
+		Content: toolResultBlocks,
+	}
+}
+
+// antTextMessage renders a plain text turn, mapping genai's "model" role onto
+// Anthropic's "assistant" and everything else onto "user".
+func antTextMessage(role string, textParts []string) anthropic.MessageParam {
+	msgRole := anthropic.MessageParamRoleUser
+	if genaiRoleIsAssistant(role) {
+		msgRole = anthropic.MessageParamRoleAssistant
+	}
+	return anthropic.MessageParam{
+		Role:    msgRole,
+		Content: []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock(strings.Join(textParts, "\n"))},
+	}
 }
 
 func antGenaiToolsToAnthropic(tools []*genai.Tool) []anthropic.ToolUnionParam {
@@ -553,78 +544,124 @@ func antRunStreaming(ctx context.Context, client *anthropic.Client, params anthr
 	state := &antStreamState{toolUse: make(map[int]antToolUseAcc)}
 
 	for stream.Next() {
-		event := stream.Current()
-
-		switch e := event.AsAny().(type) {
+		switch e := stream.Current().AsAny().(type) {
 		case anthropic.MessageStartEvent:
 			state.inputTokens = e.Message.Usage.InputTokens
 			state.cacheReadTokens = e.Message.Usage.CacheReadInputTokens
 			state.cacheCreationTokens = e.Message.Usage.CacheCreationInputTokens
 		case anthropic.ContentBlockStartEvent:
-			idx := int(e.Index)
-			if e.ContentBlock.Type == "tool_use" {
-				if toolUse, ok := e.ContentBlock.AsAny().(anthropic.ToolUseBlock); ok {
-					state.toolUse[idx] = antToolUseAcc{id: toolUse.ID, name: toolUse.Name}
-				}
-			}
+			antApplyContentBlockStart(state, e)
 		case anthropic.ContentBlockDeltaEvent:
-			idx := int(e.Index)
-			delta := e.Delta
-			switch delta.Type {
-			case "text_delta":
-				if textDelta, ok := delta.AsAny().(anthropic.TextDelta); ok {
-					state.text += textDelta.Text
-					if !yield(&model.LLMResponse{
-						Partial:      true,
-						TurnComplete: false,
-						Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
-					}, nil) {
-						return
-					}
-				}
-			case "thinking_delta":
-				if thinkingDelta, ok := delta.AsAny().(anthropic.ThinkingDelta); ok {
-					if !yield(&model.LLMResponse{
-						Partial:      true,
-						TurnComplete: false,
-						Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
-					}, nil) {
-						return
-					}
-				}
-			case "input_json_delta":
-				if jsonDelta, ok := delta.AsAny().(anthropic.InputJSONDelta); ok {
-					if block, exists := state.toolUse[idx]; exists {
-						block.inputJSON += jsonDelta.PartialJSON
-						state.toolUse[idx] = block
-					}
-				}
+			if stop := antApplyContentBlockDelta(state, e, yield); stop {
+				return
 			}
 		case anthropic.MessageDeltaEvent:
-			state.stopReason = e.Delta.StopReason
-			state.outputTokens = e.Usage.OutputTokens
-			// Anthropic may also surface cache deltas in message_delta;
-			// take the last reported value (it's monotonically increasing
-			// across a single response).
-			if v := e.Usage.CacheReadInputTokens; v > state.cacheReadTokens {
-				state.cacheReadTokens = v
-			}
-			if v := e.Usage.CacheCreationInputTokens; v > state.cacheCreationTokens {
-				state.cacheCreationTokens = v
-			}
+			antApplyMessageDelta(state, e)
 		}
 	}
 
-	if err := stream.Err(); err != nil {
+	antFinishStream(ctx, stream.Err(), state, yield)
+}
+
+// antFinishStream emits the terminal response for a streaming Anthropic call.
+// A stream error becomes a cancellation response when the context was
+// canceled and a STREAM_ERROR response otherwise; a clean stream yields the
+// assembled final message. Shared by the standard and beta streaming paths,
+// which differ in the events they accumulate but not in how they finish.
+func antFinishStream(ctx context.Context, streamErr error, state *antStreamState, yield func(*model.LLMResponse, error) bool) {
+	if streamErr != nil {
 		if ctx.Err() == context.Canceled {
 			_ = yield(canceledResponse(), nil)
 			return
 		}
-		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: streamErr.Error()}, nil)
 		return
 	}
-
 	_ = yield(buildAntFinalResponse(state), nil)
+}
+
+// antApplyContentBlockStart records the id and name of a tool_use block as it
+// opens, so the input_json deltas that follow have somewhere to accumulate.
+// Every other block type opens with nothing worth keeping.
+func antApplyContentBlockStart(state *antStreamState, e anthropic.ContentBlockStartEvent) {
+	if e.ContentBlock.Type != "tool_use" {
+		return
+	}
+	if toolUse, ok := e.ContentBlock.AsAny().(anthropic.ToolUseBlock); ok {
+		state.toolUse[int(e.Index)] = antToolUseAcc{id: toolUse.ID, name: toolUse.Name}
+	}
+}
+
+// antApplyContentBlockDelta folds one content block delta into the state,
+// forwarding text and thinking tokens to the caller as they arrive. It
+// reports whether the consumer stopped consuming, in which case the stream
+// must be abandoned. Tool input JSON is accumulated rather than forwarded:
+// it is only useful once complete.
+func antApplyContentBlockDelta(state *antStreamState, e anthropic.ContentBlockDeltaEvent, yield func(*model.LLMResponse, error) bool) (stop bool) {
+	delta := e.Delta
+	switch delta.Type {
+	case "text_delta":
+		textDelta, ok := delta.AsAny().(anthropic.TextDelta)
+		if !ok {
+			return false
+		}
+		state.text += textDelta.Text
+		return !yield(antPartialResponse(string(genai.RoleModel), textDelta.Text), nil)
+
+	case "thinking_delta":
+		thinkingDelta, ok := delta.AsAny().(anthropic.ThinkingDelta)
+		if !ok {
+			return false
+		}
+		return !yield(antPartialResponse("thinking", thinkingDelta.Thinking), nil)
+
+	case "input_json_delta":
+		jsonDelta, ok := delta.AsAny().(anthropic.InputJSONDelta)
+		if !ok {
+			return false
+		}
+		antAppendToolInput(state, int(e.Index), jsonDelta.PartialJSON)
+	}
+	return false
+}
+
+// antApplyMessageDelta records the stop reason and the usage counts that only
+// arrive with the closing message delta.
+func antApplyMessageDelta(state *antStreamState, e anthropic.MessageDeltaEvent) {
+	state.stopReason = e.Delta.StopReason
+	state.outputTokens = e.Usage.OutputTokens
+	// Anthropic may also surface cache deltas in message_delta;
+	// take the last reported value (it's monotonically increasing
+	// across a single response).
+	if v := e.Usage.CacheReadInputTokens; v > state.cacheReadTokens {
+		state.cacheReadTokens = v
+	}
+	if v := e.Usage.CacheCreationInputTokens; v > state.cacheCreationTokens {
+		state.cacheCreationTokens = v
+	}
+}
+
+// antAppendToolInput appends streamed JSON to the tool call open at idx.
+// A delta for a block that never opened is dropped: there is no id or name to
+// attach it to.
+func antAppendToolInput(state *antStreamState, idx int, partialJSON string) {
+	block, exists := state.toolUse[idx]
+	if !exists {
+		return
+	}
+	block.inputJSON += partialJSON
+	state.toolUse[idx] = block
+}
+
+// antPartialResponse wraps one streamed delta as a partial response under the
+// given role — "thinking" for reasoning, "advisor" for advisor tool results,
+// the model role for answer text.
+func antPartialResponse(role, text string) *model.LLMResponse {
+	return &model.LLMResponse{
+		Partial:      true,
+		TurnComplete: false,
+		Content:      &genai.Content{Role: role, Parts: []*genai.Part{{Text: text}}},
+	}
 }
 
 func antRunNonStreaming(ctx context.Context, client *anthropic.Client, params anthropic.MessageNewParams, yield func(*model.LLMResponse, error) bool) {
@@ -686,64 +723,16 @@ func antRunStreamingBeta(ctx context.Context, client *anthropic.BetaService, par
 	state := &antStreamState{toolUse: make(map[int]antToolUseAcc)}
 
 	for stream.Next() {
-		event := stream.Current()
-
-		switch e := event.AsAny().(type) {
+		switch e := stream.Current().AsAny().(type) {
 		case anthropic.BetaRawMessageStartEvent:
 			state.inputTokens = e.Message.Usage.InputTokens
 		case anthropic.BetaRawContentBlockStartEvent:
-			idx := int(e.Index)
-			switch e.ContentBlock.Type {
-			case "tool_use":
-				if toolUse, ok := e.ContentBlock.AsAny().(anthropic.BetaToolUseBlock); ok {
-					state.toolUse[idx] = antToolUseAcc{id: toolUse.ID, name: toolUse.Name}
-				}
-			case "advisor_tool_result":
-				// Advisor result arrives fully formed in a single event.
-				// Yield it as a text part so the executor sees the advice.
-				if advResult, ok := e.ContentBlock.AsAny().(anthropic.BetaAdvisorToolResultBlock); ok {
-					advText := extractAdvisorResultText(advResult)
-					if advText != "" {
-						// Yield as a special "advisor" role to distinguish from regular text.
-						if !yield(&model.LLMResponse{
-							Partial:      true,
-							TurnComplete: false,
-							Content:      &genai.Content{Role: "advisor", Parts: []*genai.Part{{Text: advText}}},
-						}, nil) {
-							return
-						}
-					}
-				}
+			if stop := antApplyBetaContentBlockStart(state, e, yield); stop {
+				return
 			}
 		case anthropic.BetaRawContentBlockDeltaEvent:
-			idx := int(e.Index)
-			delta := e.Delta
-			switch delta.Type {
-			case "text_delta":
-				textDelta := delta.AsTextDelta()
-				state.text += textDelta.Text
-				if !yield(&model.LLMResponse{
-					Partial:      true,
-					TurnComplete: false,
-					Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
-				}, nil) {
-					return
-				}
-			case "thinking_delta":
-				thinkingDelta := delta.AsThinkingDelta()
-				if !yield(&model.LLMResponse{
-					Partial:      true,
-					TurnComplete: false,
-					Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
-				}, nil) {
-					return
-				}
-			case "input_json_delta":
-				jsonDelta := delta.AsInputJSONDelta()
-				if block, exists := state.toolUse[idx]; exists {
-					block.inputJSON += jsonDelta.PartialJSON
-					state.toolUse[idx] = block
-				}
+			if stop := antApplyBetaContentBlockDelta(state, e, yield); stop {
+				return
 			}
 		case anthropic.BetaRawMessageDeltaEvent:
 			state.stopReason = anthropic.StopReason(e.Delta.StopReason)
@@ -751,16 +740,55 @@ func antRunStreamingBeta(ctx context.Context, client *anthropic.BetaService, par
 		}
 	}
 
-	if err := stream.Err(); err != nil {
-		if ctx.Err() == context.Canceled {
-			_ = yield(canceledResponse(), nil)
-			return
-		}
-		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
-		return
-	}
+	antFinishStream(ctx, stream.Err(), state, yield)
+}
 
-	_ = yield(buildAntFinalResponse(state), nil)
+// antApplyBetaContentBlockStart handles a block opening on the beta stream.
+// A tool_use block records its id and name for the deltas that follow; an
+// advisor_tool_result arrives fully formed in this one event and is forwarded
+// immediately under the "advisor" role, which distinguishes it from regular
+// answer text. It reports whether the consumer stopped consuming.
+func antApplyBetaContentBlockStart(state *antStreamState, e anthropic.BetaRawContentBlockStartEvent, yield func(*model.LLMResponse, error) bool) (stop bool) {
+	switch e.ContentBlock.Type {
+	case "tool_use":
+		if toolUse, ok := e.ContentBlock.AsAny().(anthropic.BetaToolUseBlock); ok {
+			state.toolUse[int(e.Index)] = antToolUseAcc{id: toolUse.ID, name: toolUse.Name}
+		}
+
+	case "advisor_tool_result":
+		advResult, ok := e.ContentBlock.AsAny().(anthropic.BetaAdvisorToolResultBlock)
+		if !ok {
+			return false
+		}
+		advText := extractAdvisorResultText(advResult)
+		if advText == "" {
+			return false
+		}
+		return !yield(antPartialResponse("advisor", advText), nil)
+	}
+	return false
+}
+
+// antApplyBetaContentBlockDelta folds one beta content block delta into the
+// state, forwarding text and thinking tokens as they arrive and reporting
+// whether the consumer stopped consuming. The beta delta accessors return a
+// zero value rather than an ok flag, so there is no type assertion to guard
+// here — unlike the standard stream's equivalent.
+func antApplyBetaContentBlockDelta(state *antStreamState, e anthropic.BetaRawContentBlockDeltaEvent, yield func(*model.LLMResponse, error) bool) (stop bool) {
+	delta := e.Delta
+	switch delta.Type {
+	case "text_delta":
+		textDelta := delta.AsTextDelta()
+		state.text += textDelta.Text
+		return !yield(antPartialResponse(string(genai.RoleModel), textDelta.Text), nil)
+
+	case "thinking_delta":
+		return !yield(antPartialResponse("thinking", delta.AsThinkingDelta().Thinking), nil)
+
+	case "input_json_delta":
+		antAppendToolInput(state, int(e.Index), delta.AsInputJSONDelta().PartialJSON)
+	}
+	return false
 }
 
 // antRunNonStreamingBeta handles non-streaming with the beta API (advisor tool support).

--- a/internal/provider/anthropic_test.go
+++ b/internal/provider/anthropic_test.go
@@ -1362,3 +1362,442 @@ func TestAnthropicNonStreamingPropagatesCacheRead(t *testing.T) {
 		t.Errorf("CachedContentTokenCount = %d, want 75 (cache_read_input_tokens)", final.UsageMetadata.CachedContentTokenCount)
 	}
 }
+
+func TestAntTextMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		role     string
+		wantRole anthropic.MessageParamRole
+	}{
+		{name: "model maps to assistant", role: "model", wantRole: anthropic.MessageParamRoleAssistant},
+		{name: "assistant stays assistant", role: "assistant", wantRole: anthropic.MessageParamRoleAssistant},
+		{name: "user maps to user", role: "user", wantRole: anthropic.MessageParamRoleUser},
+		{name: "unknown role maps to user", role: "narrator", wantRole: anthropic.MessageParamRoleUser},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := antTextMessage(tt.role, []string{"one", "two"})
+			if got.Role != tt.wantRole {
+				t.Errorf("role = %q, want %q", got.Role, tt.wantRole)
+			}
+			if len(got.Content) != 1 {
+				t.Fatalf("content has %d blocks, want a single text block", len(got.Content))
+			}
+			if got.Content[0].OfText == nil {
+				t.Fatal("content block is not a text block")
+			}
+			if text := got.Content[0].OfText.Text; text != "one\ntwo" {
+				t.Errorf("text = %q, want the parts joined by a newline", text)
+			}
+		})
+	}
+}
+
+func TestAntToolUseMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		textParts  []string
+		calls      []*genai.FunctionCall
+		wantBlocks int
+		wantText   string
+	}{
+		{
+			name:       "text block precedes the tool_use blocks",
+			textParts:  []string{"thinking"},
+			calls:      []*genai.FunctionCall{{ID: "a", Name: "f", Args: map[string]any{"k": "v"}}},
+			wantBlocks: 2,
+			wantText:   "thinking",
+		},
+		{
+			name:       "no text yields tool_use blocks only",
+			calls:      []*genai.FunctionCall{{ID: "a", Name: "f"}, {ID: "b", Name: "g"}},
+			wantBlocks: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := antToolUseMessage(tt.textParts, tt.calls)
+			if got.Role != anthropic.MessageParamRoleAssistant {
+				t.Errorf("role = %q, want %q", got.Role, anthropic.MessageParamRoleAssistant)
+			}
+			if len(got.Content) != tt.wantBlocks {
+				t.Fatalf("content has %d blocks, want %d", len(got.Content), tt.wantBlocks)
+			}
+			if tt.wantText == "" {
+				if got.Content[0].OfToolUse == nil {
+					t.Error("first block is not a tool_use block")
+				}
+				return
+			}
+			if got.Content[0].OfText == nil || got.Content[0].OfText.Text != tt.wantText {
+				t.Errorf("first block = %+v, want text %q", got.Content[0], tt.wantText)
+			}
+		})
+	}
+}
+
+func TestAntToolUseMessageNilArgsBecomeEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	// A nil Args map marshals to JSON null, which unmarshals back to a nil
+	// map. The Messages API rejects a null tool_use input, so it must become
+	// an empty object instead.
+	got := antToolUseMessage(nil, []*genai.FunctionCall{{ID: "a", Name: "f", Args: nil}})
+	if len(got.Content) != 1 {
+		t.Fatalf("content has %d blocks, want 1", len(got.Content))
+	}
+	block := got.Content[0].OfToolUse
+	if block == nil {
+		t.Fatal("content block is not a tool_use block")
+	}
+	input, ok := block.Input.(map[string]any)
+	if !ok {
+		t.Fatalf("tool_use input is %T, want map[string]any", block.Input)
+	}
+	if input == nil {
+		t.Error("tool_use input is a nil map, want an empty non-nil map")
+	}
+	if len(input) != 0 {
+		t.Errorf("tool_use input = %v, want it empty", input)
+	}
+}
+
+func TestAntToolResultMessage(t *testing.T) {
+	t.Parallel()
+
+	calls := []*genai.FunctionCall{
+		{ID: "answered", Name: "f"},
+		{ID: "unanswered", Name: "g"},
+	}
+	responses := map[string]*genai.FunctionResponse{
+		"answered": {ID: "answered", Response: map[string]any{"result": "ok"}},
+	}
+
+	got := antToolResultMessage(calls, responses)
+
+	if got.Role != anthropic.MessageParamRoleUser {
+		t.Errorf("role = %q, want %q", got.Role, anthropic.MessageParamRoleUser)
+	}
+	if len(got.Content) != 2 {
+		t.Fatalf("content has %d blocks, want one per call", len(got.Content))
+	}
+	for i, block := range got.Content {
+		if block.OfToolResult == nil {
+			t.Fatalf("block %d is not a tool_result block", i)
+		}
+	}
+	if id := got.Content[0].OfToolResult.ToolUseID; id != "answered" {
+		t.Errorf("first tool_use_id = %q, want %q", id, "answered")
+	}
+
+	// Anthropic substitutes placeholder text for a missing result, where the
+	// Ollama converter leaves the content empty.
+	want := "No response available for this function call."
+	unanswered := got.Content[1].OfToolResult.Content
+	if len(unanswered) != 1 || unanswered[0].OfText == nil || unanswered[0].OfText.Text != want {
+		t.Errorf("unanswered tool_result content = %+v, want the placeholder %q", unanswered, want)
+	}
+}
+
+func TestAntFinishStream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		streamErr     error
+		ctxCanceled   bool
+		wantErrorCode string
+		wantFinish    genai.FinishReason
+	}{
+		{
+			name:       "clean stream yields the assembled response",
+			wantFinish: genai.FinishReasonStop,
+		},
+		{
+			// A canceled context is the user interrupting, not a failure:
+			// it must not surface as STREAM_ERROR.
+			name:        "canceled context yields the cancellation response",
+			streamErr:   io.ErrUnexpectedEOF,
+			ctxCanceled: true,
+			wantFinish:  genai.FinishReasonOther,
+		},
+		{
+			name:          "transport failure yields STREAM_ERROR",
+			streamErr:     io.ErrUnexpectedEOF,
+			wantErrorCode: "STREAM_ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			if tt.ctxCanceled {
+				canceled, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = canceled
+			}
+
+			var got []*model.LLMResponse
+			antFinishStream(ctx, tt.streamErr, &antStreamState{toolUse: map[int]antToolUseAcc{}},
+				func(r *model.LLMResponse, _ error) bool {
+					got = append(got, r)
+					return true
+				})
+
+			if len(got) != 1 {
+				t.Fatalf("antFinishStream() yielded %d responses, want 1", len(got))
+			}
+			if got[0].ErrorCode != tt.wantErrorCode {
+				t.Errorf("ErrorCode = %q, want %q", got[0].ErrorCode, tt.wantErrorCode)
+			}
+			if tt.wantErrorCode == "" && got[0].FinishReason != tt.wantFinish {
+				t.Errorf("FinishReason = %q, want %q", got[0].FinishReason, tt.wantFinish)
+			}
+		})
+	}
+}
+
+func TestAntAppendToolInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("appends to an open block", func(t *testing.T) {
+		t.Parallel()
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{0: {id: "a", inputJSON: `{"k`}}}
+		antAppendToolInput(state, 0, `":1}`)
+		if got := state.toolUse[0].inputJSON; got != `{"k":1}` {
+			t.Errorf("inputJSON = %q, want the concatenated deltas", got)
+		}
+	})
+
+	t.Run("drops a delta for a block that never opened", func(t *testing.T) {
+		t.Parallel()
+		// There is no id or name to attach the JSON to, so the delta has
+		// nowhere to go and must not create a phantom accumulator entry.
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		antAppendToolInput(state, 7, `{"orphan":true}`)
+		if len(state.toolUse) != 0 {
+			t.Errorf("toolUse = %+v, want no entries", state.toolUse)
+		}
+	})
+}
+
+func TestAntPartialResponse(t *testing.T) {
+	t.Parallel()
+
+	for _, role := range []string{"thinking", "advisor", string(genai.RoleModel)} {
+		t.Run("role="+role, func(t *testing.T) {
+			t.Parallel()
+			got := antPartialResponse(role, "tok")
+			if !got.Partial || got.TurnComplete {
+				t.Errorf("Partial=%v TurnComplete=%v, want true/false", got.Partial, got.TurnComplete)
+			}
+			if got.Content.Role != role {
+				t.Errorf("role = %q, want %q", got.Content.Role, role)
+			}
+			if len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "tok" {
+				t.Errorf("parts = %v, want a single %q part", got.Content.Parts, "tok")
+			}
+		})
+	}
+}
+
+// antEventFromJSON decodes a wire payload into an Anthropic stream event.
+// The delta unions carry their source JSON in an unexported field and their
+// As*() accessors read it, so an event has to be unmarshalled rather than
+// built with a struct literal.
+func antEventFromJSON[E any](t *testing.T, payload string) E {
+	t.Helper()
+	var e E
+	if err := json.Unmarshal([]byte(payload), &e); err != nil {
+		t.Fatalf("decode %T from %s: %v", e, payload, err)
+	}
+	return e
+}
+
+func TestAntApplyMessageDelta(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		initial           antStreamState
+		payload           string
+		wantStop          anthropic.StopReason
+		wantOutput        int64
+		wantCacheRead     int64
+		wantCacheCreation int64
+	}{
+		{
+			name:     "stop reason and usage are recorded",
+			payload:  `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`,
+			wantStop: anthropic.StopReasonEndTurn, wantOutput: 42,
+			wantCacheRead: 10, wantCacheCreation: 5,
+		},
+		{
+			// Cache counts are monotonically increasing across a response, so
+			// a lower value in a later delta must not overwrite a higher one.
+			name:     "a smaller cache count does not overwrite a larger one",
+			initial:  antStreamState{cacheReadTokens: 99, cacheCreationTokens: 88},
+			payload:  `{"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":7,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`,
+			wantStop: anthropic.StopReasonMaxTokens, wantOutput: 7,
+			wantCacheRead: 99, wantCacheCreation: 88,
+		},
+		{
+			name:     "a larger cache count is taken",
+			initial:  antStreamState{cacheReadTokens: 1, cacheCreationTokens: 1},
+			payload:  `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`,
+			wantStop: anthropic.StopReasonToolUse, wantOutput: 7,
+			wantCacheRead: 10, wantCacheCreation: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state := tt.initial
+			state.toolUse = map[int]antToolUseAcc{}
+			antApplyMessageDelta(&state, antEventFromJSON[anthropic.MessageDeltaEvent](t, tt.payload))
+
+			if state.stopReason != tt.wantStop {
+				t.Errorf("stopReason = %q, want %q", state.stopReason, tt.wantStop)
+			}
+			if state.outputTokens != tt.wantOutput {
+				t.Errorf("outputTokens = %d, want %d", state.outputTokens, tt.wantOutput)
+			}
+			if state.cacheReadTokens != tt.wantCacheRead {
+				t.Errorf("cacheReadTokens = %d, want %d", state.cacheReadTokens, tt.wantCacheRead)
+			}
+			if state.cacheCreationTokens != tt.wantCacheCreation {
+				t.Errorf("cacheCreationTokens = %d, want %d", state.cacheCreationTokens, tt.wantCacheCreation)
+			}
+		})
+	}
+}
+
+func TestAntApplyContentBlockStart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		payload  string
+		wantOpen bool
+	}{
+		{
+			name:     "a tool_use block is recorded",
+			payload:  `{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"tu_1","name":"bash","input":{}}}`,
+			wantOpen: true,
+		},
+		{
+			name:    "a text block opens nothing",
+			payload: `{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`,
+		},
+		{
+			name:    "a thinking block opens nothing",
+			payload: `{"type":"content_block_start","index":2,"content_block":{"type":"thinking","thinking":""}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+			antApplyContentBlockStart(state, antEventFromJSON[anthropic.ContentBlockStartEvent](t, tt.payload))
+
+			block, open := state.toolUse[2]
+			if open != tt.wantOpen {
+				t.Fatalf("tool call open at index 2 = %v, want %v", open, tt.wantOpen)
+			}
+			if !tt.wantOpen {
+				return
+			}
+			if block.id != "tu_1" || block.name != "bash" {
+				t.Errorf("accumulator = %+v, want id=tu_1 name=bash", block)
+			}
+		})
+	}
+}
+
+func TestAntApplyContentBlockDelta(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		payload      string
+		stopConsumer bool
+		wantText     string
+		wantRole     string
+		wantJSON     string
+		wantStop     bool
+	}{
+		{
+			name:     "text delta accumulates and is forwarded",
+			payload:  `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+			wantText: "hi", wantRole: string(genai.RoleModel),
+		},
+		{
+			// Reasoning is forwarded but deliberately not accumulated into
+			// state.text: it is not part of the answer.
+			name:     "thinking delta is forwarded but not accumulated",
+			payload:  `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}`,
+			wantRole: "thinking",
+		},
+		{
+			name:     "input json delta accumulates and is not forwarded",
+			payload:  `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"k\":1}"}}`,
+			wantJSON: `{"k":1}`,
+		},
+		{
+			name:         "a consumer that stops is reported",
+			payload:      `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+			stopConsumer: true,
+			wantText:     "hi", wantRole: string(genai.RoleModel), wantStop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := &antStreamState{toolUse: map[int]antToolUseAcc{0: {id: "tu_1", name: "bash"}}}
+			var got []*model.LLMResponse
+			stop := antApplyContentBlockDelta(state,
+				antEventFromJSON[anthropic.ContentBlockDeltaEvent](t, tt.payload),
+				func(r *model.LLMResponse, _ error) bool {
+					got = append(got, r)
+					return !tt.stopConsumer
+				})
+
+			if stop != tt.wantStop {
+				t.Errorf("stop = %v, want %v", stop, tt.wantStop)
+			}
+			if state.text != tt.wantText {
+				t.Errorf("state.text = %q, want %q", state.text, tt.wantText)
+			}
+			if state.toolUse[0].inputJSON != tt.wantJSON {
+				t.Errorf("inputJSON = %q, want %q", state.toolUse[0].inputJSON, tt.wantJSON)
+			}
+
+			if tt.wantRole == "" {
+				if len(got) != 0 {
+					t.Errorf("forwarded %d responses, want none", len(got))
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("forwarded %d responses, want 1", len(got))
+			}
+			if got[0].Content.Role != tt.wantRole {
+				t.Errorf("forwarded role = %q, want %q", got[0].Content.Role, tt.wantRole)
+			}
+		})
+	}
+}

--- a/internal/provider/genai_content.go
+++ b/internal/provider/genai_content.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"strings"
+
+	"google.golang.org/genai"
+)
+
+// This file holds the provider-neutral half of the Contents-to-messages
+// conversion. Every provider converter — Anthropic, Ollama, OpenAI Chat
+// Completions and OpenAI Responses — walks the same genai.Content slice and
+// needs the same four answers out of it: the system prompt, an index of
+// function responses, the text/function-call split of one content, and whether
+// a role is the model's own turn.
+//
+// Nothing below knows about any provider. The part that does — how a turn
+// becomes wire-format messages — stays in each provider's own file, because
+// the providers genuinely diverge there (placeholder text for a missing tool
+// result, whether a blank call ID is dropped, one message or two) and those
+// differences are worth seeing at the call site rather than behind a shared
+// abstraction.
+
+// genaiSystemInstruction joins the text parts of a request's system
+// instruction into one prompt. Empty and nil parts are skipped and the result
+// is trimmed, so a config carrying no usable text yields "".
+func genaiSystemInstruction(config *genai.GenerateContentConfig) string {
+	if config == nil || config.SystemInstruction == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range config.SystemInstruction.Parts {
+		if p != nil && p.Text != "" {
+			b.WriteString(p.Text)
+			b.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// genaiFunctionResponses indexes every function response in contents by its
+// call ID, so a converter walking the conversation in order can pair a
+// function call with a result that appears in a later content. When two
+// responses share an ID the last one wins.
+func genaiFunctionResponses(contents []*genai.Content) map[string]*genai.FunctionResponse {
+	out := make(map[string]*genai.FunctionResponse)
+	for _, c := range contents {
+		if c == nil || c.Parts == nil {
+			continue
+		}
+		for _, p := range c.Parts {
+			if p != nil && p.FunctionResponse != nil {
+				out[p.FunctionResponse.ID] = p.FunctionResponse
+			}
+		}
+	}
+	return out
+}
+
+// genaiSplitParts separates one content's parts into its text runs and its
+// function calls. A part carrying text counts as text even if it also carries
+// a function call — the precedence every provider converter has always used.
+func genaiSplitParts(content *genai.Content) (textParts []string, functionCalls []*genai.FunctionCall) {
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		if part.Text != "" {
+			textParts = append(textParts, part.Text)
+		} else if part.FunctionCall != nil {
+			functionCalls = append(functionCalls, part.FunctionCall)
+		}
+	}
+	return textParts, functionCalls
+}
+
+// genaiRoleIsAssistant reports whether a content role denotes the model's own
+// turn. genai names it "model"; histories that round-tripped through an
+// OpenAI-shaped store carry "assistant" instead. The role is compared as
+// given, so callers trim it first.
+func genaiRoleIsAssistant(role string) bool {
+	return role == "model" || role == "assistant"
+}

--- a/internal/provider/genai_content_test.go
+++ b/internal/provider/genai_content_test.go
@@ -1,0 +1,193 @@
+package provider
+
+import (
+	"slices"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestGenaiSystemInstruction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config *genai.GenerateContentConfig
+		want   string
+	}{
+		{
+			name:   "nil config",
+			config: nil,
+			want:   "",
+		},
+		{
+			name:   "nil system instruction",
+			config: &genai.GenerateContentConfig{},
+			want:   "",
+		},
+		{
+			name:   "no parts",
+			config: &genai.GenerateContentConfig{SystemInstruction: &genai.Content{}},
+			want:   "",
+		},
+		{
+			name: "nil and empty parts are skipped",
+			config: &genai.GenerateContentConfig{SystemInstruction: &genai.Content{
+				Parts: []*genai.Part{nil, {Text: ""}, {Text: "be brief"}},
+			}},
+			want: "be brief",
+		},
+		{
+			// Trimming applies to the joined result, so leading whitespace on
+			// the first part goes too — only interior spacing survives.
+			name: "parts joined by newline, result trimmed at both ends",
+			config: &genai.GenerateContentConfig{SystemInstruction: &genai.Content{
+				Parts: []*genai.Part{{Text: "  first"}, {Text: "  second  "}},
+			}},
+			want: "first\n  second",
+		},
+		{
+			name: "whitespace-only text collapses to empty",
+			config: &genai.GenerateContentConfig{SystemInstruction: &genai.Content{
+				Parts: []*genai.Part{{Text: "   "}},
+			}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := genaiSystemInstruction(tt.config); got != tt.want {
+				t.Errorf("genaiSystemInstruction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenaiFunctionResponses(t *testing.T) {
+	t.Parallel()
+
+	first := &genai.FunctionResponse{ID: "dup", Name: "first"}
+	last := &genai.FunctionResponse{ID: "dup", Name: "last"}
+
+	contents := []*genai.Content{
+		nil,
+		{Parts: nil},
+		{Parts: []*genai.Part{nil, {Text: "no response here"}}},
+		{Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: "a", Name: "alpha"}}}},
+		{Parts: []*genai.Part{{FunctionResponse: first}, {FunctionResponse: last}}},
+	}
+
+	got := genaiFunctionResponses(contents)
+	if len(got) != 2 {
+		t.Fatalf("genaiFunctionResponses() has %d entries, want 2: %v", len(got), got)
+	}
+	if got["a"] == nil || got["a"].Name != "alpha" {
+		t.Errorf("entry %q = %v, want the alpha response", "a", got["a"])
+	}
+	if got["dup"] != last {
+		t.Errorf("entry %q = %v, want the last response for a repeated ID", "dup", got["dup"])
+	}
+}
+
+func TestGenaiFunctionResponsesEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := genaiFunctionResponses(nil)
+	if got == nil {
+		t.Fatal("genaiFunctionResponses(nil) = nil, want an empty non-nil map")
+	}
+	if len(got) != 0 {
+		t.Errorf("genaiFunctionResponses(nil) has %d entries, want 0", len(got))
+	}
+}
+
+func TestGenaiSplitParts(t *testing.T) {
+	t.Parallel()
+
+	callA := &genai.FunctionCall{ID: "a", Name: "alpha"}
+	callB := &genai.FunctionCall{ID: "b", Name: "beta"}
+
+	tests := []struct {
+		name      string
+		content   *genai.Content
+		wantText  []string
+		wantCalls []*genai.FunctionCall
+	}{
+		{
+			name:    "no parts",
+			content: &genai.Content{},
+		},
+		{
+			name:     "nil parts skipped",
+			content:  &genai.Content{Parts: []*genai.Part{nil, {Text: "hi"}, nil}},
+			wantText: []string{"hi"},
+		},
+		{
+			name: "text and calls separated in order",
+			content: &genai.Content{Parts: []*genai.Part{
+				{Text: "one"},
+				{FunctionCall: callA},
+				{Text: "two"},
+				{FunctionCall: callB},
+			}},
+			wantText:  []string{"one", "two"},
+			wantCalls: []*genai.FunctionCall{callA, callB},
+		},
+		{
+			// Text wins when a part carries both — the precedence every
+			// provider converter has always used.
+			name: "text takes precedence over a call on the same part",
+			content: &genai.Content{Parts: []*genai.Part{
+				{Text: "inline", FunctionCall: callA},
+			}},
+			wantText: []string{"inline"},
+		},
+		{
+			name: "function response parts are ignored",
+			content: &genai.Content{Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: "a"}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotText, gotCalls := genaiSplitParts(tt.content)
+			if !slices.Equal(gotText, tt.wantText) {
+				t.Errorf("text = %q, want %q", gotText, tt.wantText)
+			}
+			if !slices.Equal(gotCalls, tt.wantCalls) {
+				t.Errorf("calls = %v, want %v", gotCalls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestGenaiRoleIsAssistant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		role string
+		want bool
+	}{
+		{"model", true},
+		{"assistant", true},
+		{"user", false},
+		{"tool", false},
+		{"", false},
+		{"Model", false},      // compared verbatim, no case folding
+		{" assistant", false}, // callers trim before calling
+	}
+
+	for _, tt := range tests {
+		t.Run("role="+tt.role, func(t *testing.T) {
+			t.Parallel()
+			if got := genaiRoleIsAssistant(tt.role); got != tt.want {
+				t.Errorf("genaiRoleIsAssistant(%q) = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -293,29 +293,8 @@ func ollamaFinishReasonToGenai(reason string) genai.FinishReason {
 
 // ollamaContentsToMessages converts genai.Content to Ollama messages.
 func ollamaContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]ollamaapi.Message, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemPrompt := strings.TrimSpace(systemBuilder.String())
-
-	// Collect function responses for matching.
-	functionResponses := make(map[string]*genai.FunctionResponse)
-	for _, c := range contents {
-		if c == nil || c.Parts == nil {
-			continue
-		}
-		for _, p := range c.Parts {
-			if p != nil && p.FunctionResponse != nil {
-				functionResponses[p.FunctionResponse.ID] = p.FunctionResponse
-			}
-		}
-	}
+	systemPrompt := genaiSystemInstruction(config)
+	functionResponses := genaiFunctionResponses(contents)
 
 	var messages []ollamaapi.Message
 	for _, content := range contents {
@@ -326,68 +305,13 @@ func ollamaContentsToMessages(contents []*genai.Content, config *genai.GenerateC
 		if role == "system" {
 			continue
 		}
+		textParts, functionCalls := genaiSplitParts(content)
 
-		var textParts []string
-		var functionCalls []*genai.FunctionCall
-
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.Text != "" {
-				textParts = append(textParts, part.Text)
-			} else if part.FunctionCall != nil {
-				functionCalls = append(functionCalls, part.FunctionCall)
-			}
-		}
-
-		if len(functionCalls) > 0 && (role == "model" || role == "assistant") {
-			// Assistant message with tool calls.
-			toolCalls := make([]ollamaapi.ToolCall, 0, len(functionCalls))
-			for _, fc := range functionCalls {
-				args := ollamaapi.NewToolCallFunctionArguments()
-				for k, v := range fc.Args {
-					args.Set(k, v)
-				}
-				toolCalls = append(toolCalls, ollamaapi.ToolCall{
-					ID: fc.ID,
-					Function: ollamaapi.ToolCallFunction{
-						Name:      fc.Name,
-						Arguments: args,
-					},
-				})
-			}
-
-			msg := ollamaapi.Message{
-				Role:      "assistant",
-				ToolCalls: toolCalls,
-			}
-			if len(textParts) > 0 {
-				msg.Content = strings.Join(textParts, "\n")
-			}
-			messages = append(messages, msg)
-
-			// Tool results as separate messages.
-			for _, fc := range functionCalls {
-				contentStr := ""
-				if fr := functionResponses[fc.ID]; fr != nil {
-					contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
-				}
-				messages = append(messages, ollamaapi.Message{
-					Role:       "tool",
-					Content:    contentStr,
-					ToolCallID: fc.ID,
-				})
-			}
-		} else if len(textParts) > 0 {
-			msgRole := "user"
-			if role == "model" || role == "assistant" {
-				msgRole = "assistant"
-			}
-			messages = append(messages, ollamaapi.Message{
-				Role:    msgRole,
-				Content: strings.Join(textParts, "\n"),
-			})
+		switch {
+		case len(functionCalls) > 0 && genaiRoleIsAssistant(role):
+			messages = append(messages, ollamaToolCallMessages(textParts, functionCalls, functionResponses)...)
+		case len(textParts) > 0:
+			messages = append(messages, ollamaTextMessage(role, textParts))
 		}
 	}
 
@@ -400,6 +324,69 @@ func ollamaContentsToMessages(contents []*genai.Content, config *genai.GenerateC
 	}
 
 	return messages, systemPrompt
+}
+
+// ollamaToolCallMessages renders an assistant turn that made tool calls: the
+// assistant message carrying the calls, followed by one "tool" message per
+// call holding its result. A call with no matching response gets empty
+// content rather than being dropped, so the call/result pairing stays intact.
+// Note this differs from the OpenAI and Anthropic converters, which substitute
+// placeholder text for a missing result.
+func ollamaToolCallMessages(
+	textParts []string,
+	functionCalls []*genai.FunctionCall,
+	functionResponses map[string]*genai.FunctionResponse,
+) []ollamaapi.Message {
+	toolCalls := make([]ollamaapi.ToolCall, 0, len(functionCalls))
+	for _, fc := range functionCalls {
+		args := ollamaapi.NewToolCallFunctionArguments()
+		for k, v := range fc.Args {
+			args.Set(k, v)
+		}
+		toolCalls = append(toolCalls, ollamaapi.ToolCall{
+			ID: fc.ID,
+			Function: ollamaapi.ToolCallFunction{
+				Name:      fc.Name,
+				Arguments: args,
+			},
+		})
+	}
+
+	msg := ollamaapi.Message{
+		Role:      "assistant",
+		ToolCalls: toolCalls,
+	}
+	if len(textParts) > 0 {
+		msg.Content = strings.Join(textParts, "\n")
+	}
+
+	messages := make([]ollamaapi.Message, 0, 1+len(functionCalls))
+	messages = append(messages, msg)
+	for _, fc := range functionCalls {
+		contentStr := ""
+		if fr := functionResponses[fc.ID]; fr != nil {
+			contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
+		}
+		messages = append(messages, ollamaapi.Message{
+			Role:       "tool",
+			Content:    contentStr,
+			ToolCallID: fc.ID,
+		})
+	}
+	return messages
+}
+
+// ollamaTextMessage renders a plain text turn, mapping genai's "model" role
+// onto Ollama's "assistant" and everything else onto "user".
+func ollamaTextMessage(role string, textParts []string) ollamaapi.Message {
+	msgRole := "user"
+	if genaiRoleIsAssistant(role) {
+		msgRole = "assistant"
+	}
+	return ollamaapi.Message{
+		Role:    msgRole,
+		Content: strings.Join(textParts, "\n"),
+	}
 }
 
 // ollamaGenaiToolsToOllama converts genai tools to Ollama native tool format.
@@ -492,90 +479,156 @@ func convertToToolProperty(raw any) ollamaapi.ToolProperty {
 	return prop
 }
 
-func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *ollamaapi.ChatRequest, yield func(*model.LLMResponse, error) bool) {
-	var aggregatedText string
-	var aggregatedThinking string
-	var toolCalls []ollamaapi.ToolCall
-	var doneReason string
-	var promptTokens, evalTokens int
-	var splitter thinkSplitter
+// ollamaStreamAccumulator collects one streaming Ollama chat into the pieces
+// the terminal response is built from. It owns the yield callback because the
+// text and reasoning streams are forwarded as they arrive rather than at the
+// end, and it owns the think splitter because inline <think> tags can span
+// chunk boundaries.
+type ollamaStreamAccumulator struct {
+	yield    func(*model.LLMResponse, error) bool
+	splitter thinkSplitter
 
-	emitThinking := func(text string) error {
-		if text == "" {
-			return nil
-		}
-		aggregatedThinking += text
-		if !yield(&model.LLMResponse{
-			Partial:      true,
-			TurnComplete: false,
-			Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: text}}},
-		}, nil) {
-			return fmt.Errorf("yield canceled")
-		}
+	text         string
+	thinking     string
+	toolCalls    []ollamaapi.ToolCall
+	doneReason   string
+	promptTokens int
+	evalTokens   int
+}
+
+// emit forwards one chunk under the given role, reporting an error when the
+// consumer stopped consuming so that client.Chat unwinds.
+func (a *ollamaStreamAccumulator) emit(role, text string) error {
+	if !a.yield(&model.LLMResponse{
+		Partial:      true,
+		TurnComplete: false,
+		Content:      &genai.Content{Role: role, Parts: []*genai.Part{{Text: text}}},
+	}, nil) {
+		return fmt.Errorf("yield canceled")
+	}
+	return nil
+}
+
+// emitThinking forwards reasoning text and accumulates it for the fallback in
+// answerText. Empty text is not forwarded.
+func (a *ollamaStreamAccumulator) emitThinking(text string) error {
+	if text == "" {
 		return nil
 	}
+	a.thinking += text
+	return a.emit("thinking", text)
+}
 
-	emitText := func(text string) error {
-		if text == "" {
-			return nil
-		}
-		aggregatedText += text
-		if !yield(&model.LLMResponse{
-			Partial:      true,
-			TurnComplete: false,
-			Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: text}}},
-		}, nil) {
-			return fmt.Errorf("yield canceled")
-		}
+// emitText forwards answer text and accumulates it for the final response.
+// Empty text is not forwarded.
+func (a *ollamaStreamAccumulator) emitText(text string) error {
+	if text == "" {
 		return nil
 	}
+	a.text += text
+	return a.emit(string(genai.RoleModel), text)
+}
 
-	err := client.Chat(ctx, chatReq, func(resp ollamaapi.ChatResponse) error {
-		msg := resp.Message
+// emitSplit forwards a (thinking, text) pair as returned by the think
+// splitter, reasoning first so it precedes the answer it explains.
+func (a *ollamaStreamAccumulator) emitSplit(inlineThinking, text string) error {
+	if err := a.emitThinking(inlineThinking); err != nil {
+		return err
+	}
+	return a.emitText(text)
+}
 
-		// Reasoning that Ollama already separated out.
-		if err := emitThinking(msg.Thinking); err != nil {
+// handleChunk folds one streaming chat response into the accumulator.
+// Returning an error unwinds client.Chat, which is how a consumer that
+// stopped consuming cancels the request.
+func (a *ollamaStreamAccumulator) handleChunk(resp ollamaapi.ChatResponse) error {
+	msg := resp.Message
+
+	// Reasoning that Ollama already separated out.
+	if err := a.emitThinking(msg.Thinking); err != nil {
+		return err
+	}
+
+	// Reasoning the model left inline as <think>...</think> is routed to
+	// the thinking stream instead of surfacing as the answer.
+	if msg.Content != "" {
+		if err := a.emitSplit(a.splitter.split(msg.Content)); err != nil {
 			return err
 		}
+	}
 
-		// Reasoning the model left inline as <think>...</think> is routed to
-		// the thinking stream instead of surfacing as the answer.
-		if msg.Content != "" {
-			inlineThinking, text := splitter.split(msg.Content)
-			if err := emitThinking(inlineThinking); err != nil {
-				return err
-			}
-			if err := emitText(text); err != nil {
-				return err
-			}
+	if resp.Done {
+		if err := a.emitSplit(a.splitter.flush()); err != nil {
+			return err
 		}
+	}
 
-		if resp.Done {
-			inlineThinking, text := splitter.flush()
-			if err := emitThinking(inlineThinking); err != nil {
-				return err
-			}
-			if err := emitText(text); err != nil {
-				return err
-			}
-		}
+	// Accumulate tool calls. Appending an empty slice is a no-op, so this
+	// needs no length guard.
+	a.toolCalls = append(a.toolCalls, msg.ToolCalls...)
 
-		// Accumulate tool calls.
-		if len(msg.ToolCalls) > 0 {
-			toolCalls = append(toolCalls, msg.ToolCalls...)
-		}
+	// Capture metrics from final response.
+	if resp.Done {
+		a.doneReason = resp.DoneReason
+		a.promptTokens = resp.PromptEvalCount
+		a.evalTokens = resp.EvalCount
+	}
 
-		// Capture metrics from final response.
-		if resp.Done {
-			doneReason = resp.DoneReason
-			promptTokens = resp.PromptEvalCount
-			evalTokens = resp.EvalCount
-		}
+	return nil
+}
 
+// answerText picks the text of the terminal response. Normally that is the
+// accumulated answer, but a model that responded entirely via thinking tokens
+// (e.g. thinking forced on a nothink model) would otherwise return nothing,
+// so its reasoning is surfaced as the answer instead.
+//
+// The fallback applies only when the turn produced no tool call. A turn that
+// thinks and then calls a tool has already said something, so the fallback
+// isn't needed — and firing it there restates the reasoning as if it were the
+// answer (seen with minimax-m3:cloud: "The user wants me to run a bash
+// command..." printed above the real reply).
+func (a *ollamaStreamAccumulator) answerText() string {
+	if a.text != "" {
+		return a.text
+	}
+	if len(a.toolCalls) == 0 {
+		return a.thinking
+	}
+	return ""
+}
+
+// finalParts assembles the parts of the terminal response: the answer text,
+// if any, followed by one part per accumulated tool call.
+func (a *ollamaStreamAccumulator) finalParts() []*genai.Part {
+	parts := make([]*genai.Part, 0, 1+len(a.toolCalls))
+	if text := a.answerText(); text != "" {
+		parts = append(parts, &genai.Part{Text: text})
+	}
+	for _, tc := range a.toolCalls {
+		args := tc.Function.Arguments.ToMap()
+		p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
+		p.FunctionCall.ID = tc.ID
+		parts = append(parts, p)
+	}
+	return parts
+}
+
+// usage converts the accumulated token counts into genai usage metadata,
+// reporting nil when the stream carried no counts at all.
+func (a *ollamaStreamAccumulator) usage() *genai.GenerateContentResponseUsageMetadata {
+	if a.promptTokens <= 0 && a.evalTokens <= 0 {
 		return nil
-	})
+	}
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     int32(a.promptTokens),
+		CandidatesTokenCount: int32(a.evalTokens),
+	}
+}
 
-	if err != nil {
+func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *ollamaapi.ChatRequest, yield func(*model.LLMResponse, error) bool) {
+	acc := &ollamaStreamAccumulator{yield: yield}
+
+	if err := client.Chat(ctx, chatReq, acc.handleChunk); err != nil {
 		if ctx.Err() == context.Canceled {
 			_ = yield(canceledResponse(), nil)
 			return
@@ -584,39 +637,12 @@ func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *
 		return
 	}
 
-	// Build final response.
-	finalParts := make([]*genai.Part, 0, 1+len(toolCalls))
-	if aggregatedText != "" {
-		finalParts = append(finalParts, &genai.Part{Text: aggregatedText})
-	} else if aggregatedThinking != "" && len(toolCalls) == 0 {
-		// Fallback: model responded entirely via thinking tokens (e.g. thinking forced
-		// on a nothink model). Surface the thinking content rather than returning nothing.
-		//
-		// Only when the turn produced no tool call. A turn that thinks and then
-		// calls a tool has already said something, so the fallback isn't needed
-		// — and firing it there restates the reasoning as if it were the answer
-		// (seen with minimax-m3:cloud: "The user wants me to run a bash
-		// command..." printed above the real reply).
-		finalParts = append(finalParts, &genai.Part{Text: aggregatedThinking})
-	}
-	for _, tc := range toolCalls {
-		args := tc.Function.Arguments.ToMap()
-		p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
-		p.FunctionCall.ID = tc.ID
-		finalParts = append(finalParts, p)
-	}
-
-	var usage *genai.GenerateContentResponseUsageMetadata
-	if promptTokens > 0 || evalTokens > 0 {
-		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(promptTokens),
-			CandidatesTokenCount: int32(evalTokens),
-		}
-	}
+	finalParts := acc.finalParts()
+	usage := acc.usage()
 	_ = yield(&model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
-		FinishReason:  ollamaFinishReasonToGenai(doneReason),
+		FinishReason:  ollamaFinishReasonToGenai(acc.doneReason),
 		UsageMetadata: usage,
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
 	}, nil)

--- a/internal/provider/ollama_test.go
+++ b/internal/provider/ollama_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	ollamaapi "github.com/ollama/ollama/api"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/genai"
 )
@@ -1663,4 +1664,281 @@ func TestBearerTransport(t *testing.T) {
 			t.Errorf("expected no Authorization header, got %q", gotAuth)
 		}
 	})
+}
+
+func TestOllamaTextMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		role     string
+		wantRole string
+	}{
+		{name: "model maps to assistant", role: "model", wantRole: "assistant"},
+		{name: "assistant stays assistant", role: "assistant", wantRole: "assistant"},
+		{name: "user maps to user", role: "user", wantRole: "user"},
+		{name: "unknown role maps to user", role: "narrator", wantRole: "user"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ollamaTextMessage(tt.role, []string{"one", "two"})
+			if got.Role != tt.wantRole {
+				t.Errorf("role = %q, want %q", got.Role, tt.wantRole)
+			}
+			if got.Content != "one\ntwo" {
+				t.Errorf("content = %q, want the parts joined by a newline", got.Content)
+			}
+		})
+	}
+}
+
+func TestOllamaToolCallMessages(t *testing.T) {
+	t.Parallel()
+
+	calls := []*genai.FunctionCall{
+		{ID: "answered", Name: "f", Args: map[string]any{"k": "v"}},
+		{ID: "unanswered", Name: "g"},
+	}
+	responses := map[string]*genai.FunctionResponse{
+		"answered": {ID: "answered", Response: map[string]any{"result": "ok"}},
+	}
+
+	got := ollamaToolCallMessages([]string{"calling tools"}, calls, responses)
+
+	if len(got) != 3 {
+		t.Fatalf("ollamaToolCallMessages() returned %d messages, want assistant plus one per call", len(got))
+	}
+
+	asst := got[0]
+	if asst.Role != "assistant" {
+		t.Errorf("first message role = %q, want %q", asst.Role, "assistant")
+	}
+	if asst.Content != "calling tools" {
+		t.Errorf("assistant content = %q, want the joined text parts", asst.Content)
+	}
+	if len(asst.ToolCalls) != 2 {
+		t.Fatalf("assistant carries %d tool calls, want 2", len(asst.ToolCalls))
+	}
+	if asst.ToolCalls[0].ID != "answered" || asst.ToolCalls[0].Function.Name != "f" {
+		t.Errorf("first tool call = %+v, want id=answered name=f", asst.ToolCalls[0])
+	}
+
+	if got[1].Role != "tool" || got[1].ToolCallID != "answered" {
+		t.Errorf("second message = %+v, want a tool message for %q", got[1], "answered")
+	}
+	if got[1].Content == "" {
+		t.Error("answered tool message has empty content, want the rendered response")
+	}
+
+	// Ollama leaves a missing result empty rather than substituting the
+	// placeholder text the OpenAI and Anthropic converters use.
+	if got[2].ToolCallID != "unanswered" {
+		t.Fatalf("third message = %+v, want a tool message for %q", got[2], "unanswered")
+	}
+	if got[2].Content != "" {
+		t.Errorf("unanswered tool content = %q, want it empty", got[2].Content)
+	}
+}
+
+func TestOllamaToolCallMessagesNoText(t *testing.T) {
+	t.Parallel()
+
+	got := ollamaToolCallMessages(nil, []*genai.FunctionCall{{ID: "a", Name: "f"}}, nil)
+	if len(got) != 2 {
+		t.Fatalf("ollamaToolCallMessages() returned %d messages, want 2", len(got))
+	}
+	if got[0].Content != "" {
+		t.Errorf("assistant content = %q, want it empty when there are no text parts", got[0].Content)
+	}
+}
+
+// collectYield returns a yield func that appends every response it receives,
+// and stops consuming after stopAfter calls (0 means never stop).
+func collectYield(got *[]*model.LLMResponse, stopAfter int) func(*model.LLMResponse, error) bool {
+	return func(r *model.LLMResponse, _ error) bool {
+		*got = append(*got, r)
+		return stopAfter == 0 || len(*got) < stopAfter
+	}
+}
+
+func TestOllamaStreamAccumulatorAnswerText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		text      string
+		thinking  string
+		toolCalls []ollamaapi.ToolCall
+		want      string
+	}{
+		{
+			name: "nothing accumulated",
+		},
+		{
+			name: "answer text wins",
+			text: "the answer", thinking: "reasoning",
+			want: "the answer",
+		},
+		{
+			// A nothink model forced to think returns only thinking tokens;
+			// surfacing them beats returning nothing.
+			name:     "thinking is the fallback when there is no answer",
+			thinking: "reasoning",
+			want:     "reasoning",
+		},
+		{
+			// The minimax-m3:cloud regression: a turn that thinks and then
+			// calls a tool has already said something, so restating the
+			// reasoning as the answer would print it above the real reply.
+			name:      "no fallback when the turn produced a tool call",
+			thinking:  "The user wants me to run a bash command...",
+			toolCalls: []ollamaapi.ToolCall{{ID: "a"}},
+			want:      "",
+		},
+		{
+			name: "answer text still wins alongside a tool call",
+			text: "answer", thinking: "reasoning",
+			toolCalls: []ollamaapi.ToolCall{{ID: "a"}},
+			want:      "answer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			acc := &ollamaStreamAccumulator{text: tt.text, thinking: tt.thinking, toolCalls: tt.toolCalls}
+			if got := acc.answerText(); got != tt.want {
+				t.Errorf("answerText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOllamaStreamAccumulatorUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prompt  int
+		eval    int
+		wantNil bool
+	}{
+		{name: "no counts", wantNil: true},
+		{name: "prompt only", prompt: 3},
+		{name: "eval only", eval: 4},
+		{name: "both", prompt: 3, eval: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			acc := &ollamaStreamAccumulator{promptTokens: tt.prompt, evalTokens: tt.eval}
+			got := acc.usage()
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("usage() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("usage() = nil, want usage metadata")
+			}
+			if int(got.PromptTokenCount) != tt.prompt || int(got.CandidatesTokenCount) != tt.eval {
+				t.Errorf("usage() = %+v, want prompt=%d eval=%d", got, tt.prompt, tt.eval)
+			}
+		})
+	}
+}
+
+func TestOllamaStreamAccumulatorHandleChunk(t *testing.T) {
+	t.Parallel()
+
+	var got []*model.LLMResponse
+	acc := &ollamaStreamAccumulator{yield: collectYield(&got, 0)}
+
+	if err := acc.handleChunk(ollamaapi.ChatResponse{
+		Message: ollamaapi.Message{Thinking: "pondering", Content: "hello "},
+	}); err != nil {
+		t.Fatalf("handleChunk() error: %v", err)
+	}
+	if err := acc.handleChunk(ollamaapi.ChatResponse{
+		Message:    ollamaapi.Message{Content: "world", ToolCalls: []ollamaapi.ToolCall{{ID: "t1"}}},
+		Done:       true,
+		DoneReason: "stop",
+		Metrics:    ollamaapi.Metrics{PromptEvalCount: 11, EvalCount: 22},
+	}); err != nil {
+		t.Fatalf("handleChunk() error: %v", err)
+	}
+
+	if acc.text != "hello world" {
+		t.Errorf("text = %q, want %q", acc.text, "hello world")
+	}
+	if acc.thinking != "pondering" {
+		t.Errorf("thinking = %q, want %q", acc.thinking, "pondering")
+	}
+	if len(acc.toolCalls) != 1 || acc.toolCalls[0].ID != "t1" {
+		t.Errorf("toolCalls = %+v, want one call with id t1", acc.toolCalls)
+	}
+	if acc.doneReason != "stop" || acc.promptTokens != 11 || acc.evalTokens != 22 {
+		t.Errorf("done metrics = %q/%d/%d, want stop/11/22", acc.doneReason, acc.promptTokens, acc.evalTokens)
+	}
+
+	// Reasoning is forwarded under the thinking role, answer text under the
+	// model role, and empty chunks are never forwarded at all.
+	if len(got) != 3 {
+		t.Fatalf("forwarded %d responses, want 3", len(got))
+	}
+	if got[0].Content.Role != "thinking" {
+		t.Errorf("first forwarded role = %q, want %q", got[0].Content.Role, "thinking")
+	}
+	for _, r := range got[1:] {
+		if r.Content.Role != string(genai.RoleModel) {
+			t.Errorf("forwarded role = %q, want %q", r.Content.Role, string(genai.RoleModel))
+		}
+	}
+}
+
+func TestOllamaStreamAccumulatorHandleChunkStopsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	var got []*model.LLMResponse
+	acc := &ollamaStreamAccumulator{yield: collectYield(&got, 1)} // refuse after the first
+
+	err := acc.handleChunk(ollamaapi.ChatResponse{
+		Message: ollamaapi.Message{Thinking: "a", Content: "b"},
+	})
+	if err == nil {
+		t.Fatal("handleChunk() = nil, want an error so client.Chat unwinds")
+	}
+}
+
+func TestOllamaStreamAccumulatorFinalParts(t *testing.T) {
+	t.Parallel()
+
+	acc := &ollamaStreamAccumulator{
+		text:      "answer",
+		toolCalls: []ollamaapi.ToolCall{{ID: "t1", Function: ollamaapi.ToolCallFunction{Name: "f"}}},
+	}
+	parts := acc.finalParts()
+
+	if len(parts) != 2 {
+		t.Fatalf("finalParts() returned %d parts, want text plus one call", len(parts))
+	}
+	if parts[0].Text != "answer" {
+		t.Errorf("first part text = %q, want %q", parts[0].Text, "answer")
+	}
+	if parts[1].FunctionCall == nil || parts[1].FunctionCall.ID != "t1" || parts[1].FunctionCall.Name != "f" {
+		t.Errorf("second part = %+v, want a function call t1/f", parts[1])
+	}
+}
+
+func TestOllamaStreamAccumulatorFinalPartsEmpty(t *testing.T) {
+	t.Parallel()
+
+	parts := (&ollamaStreamAccumulator{}).finalParts()
+	if len(parts) != 0 {
+		t.Errorf("finalParts() = %+v, want no parts when nothing accumulated", parts)
+	}
 }

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -50,97 +50,89 @@ func (m *openaiModel) generateChat(ctx context.Context, req *model.LLMRequest, m
 
 // oaiContentsToMessages converts genai.Content to OpenAI messages (Chat Completions path).
 func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]openai.ChatCompletionMessageParamUnion, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemInstruction := strings.TrimSpace(systemBuilder.String())
-
-	// Collect function responses for matching with function calls.
-	functionResponses := make(map[string]*genai.FunctionResponse)
-	for _, c := range contents {
-		if c == nil || c.Parts == nil {
-			continue
-		}
-		for _, p := range c.Parts {
-			if p != nil && p.FunctionResponse != nil {
-				functionResponses[p.FunctionResponse.ID] = p.FunctionResponse
-			}
-		}
-	}
+	systemInstruction := genaiSystemInstruction(config)
+	functionResponses := genaiFunctionResponses(contents)
 
 	var messages []openai.ChatCompletionMessageParamUnion
 	for _, content := range contents {
-		if content == nil || strings.TrimSpace(content.Role) == "system" {
+		if content == nil {
 			continue
 		}
 		role := strings.TrimSpace(content.Role)
-		var textParts []string
-		var functionCalls []*genai.FunctionCall
-
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.Text != "" {
-				textParts = append(textParts, part.Text)
-			} else if part.FunctionCall != nil {
-				functionCalls = append(functionCalls, part.FunctionCall)
-			}
+		if role == "system" {
+			continue
 		}
+		textParts, functionCalls := genaiSplitParts(content)
 
-		if len(functionCalls) > 0 && (role == "model" || role == "assistant") {
-			toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(functionCalls))
-			var toolResponseMessages []openai.ChatCompletionMessageParamUnion
-			for _, fc := range functionCalls {
-				if fc == nil || strings.TrimSpace(fc.ID) == "" {
-					continue
-				}
-				argsJSON, _ := json.Marshal(fc.Args)
-				toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
-					OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-						ID:   fc.ID,
-						Type: constant.Function("function"),
-						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-							Name:      fc.Name,
-							Arguments: string(argsJSON),
-						},
-					},
-				})
-				contentStr := "No response available for this function call."
-				if fr := functionResponses[fc.ID]; fr != nil {
-					contentStr = oaiFunctionResponseContent(fr.Response)
-				}
-				toolResponseMessages = append(toolResponseMessages, openai.ToolMessage(contentStr, fc.ID))
-			}
-			asst := openai.ChatCompletionAssistantMessageParam{
-				Role:      constant.Assistant("assistant"),
-				ToolCalls: toolCalls,
-			}
-			if len(textParts) > 0 {
-				asst.Content.OfString = param.NewOpt(strings.Join(textParts, "\n"))
-			}
-			messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
-			messages = append(messages, toolResponseMessages...)
-		} else if len(textParts) > 0 {
-			text := strings.Join(textParts, "\n")
-			if role == "model" || role == "assistant" {
-				asst := openai.ChatCompletionAssistantMessageParam{
-					Role: constant.Assistant("assistant"),
-				}
-				asst.Content.OfString = param.NewOpt(text)
-				messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
-			} else {
-				messages = append(messages, openai.UserMessage(text))
-			}
+		switch {
+		case len(functionCalls) > 0 && genaiRoleIsAssistant(role):
+			messages = append(messages, oaiToolCallMessages(textParts, functionCalls, functionResponses)...)
+		case len(textParts) > 0:
+			messages = append(messages, oaiTextMessage(role, strings.Join(textParts, "\n")))
 		}
 	}
 	return messages, systemInstruction
+}
+
+// oaiToolCallMessages renders an assistant turn that made tool calls: the
+// assistant message carrying the tool_calls array, followed by one tool
+// message per call holding its result. A call with no ID is dropped entirely —
+// Chat Completions rejects a tool call without one, and there would be no way
+// to pair a result with it. A call whose result is missing still gets a tool
+// message, with placeholder text, so every tool call stays answered.
+func oaiToolCallMessages(
+	textParts []string,
+	functionCalls []*genai.FunctionCall,
+	functionResponses map[string]*genai.FunctionResponse,
+) []openai.ChatCompletionMessageParamUnion {
+	toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(functionCalls))
+	var toolResponseMessages []openai.ChatCompletionMessageParamUnion
+	for _, fc := range functionCalls {
+		if fc == nil || strings.TrimSpace(fc.ID) == "" {
+			continue
+		}
+		argsJSON, _ := json.Marshal(fc.Args)
+		toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+			OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+				ID:   fc.ID,
+				Type: constant.Function("function"),
+				Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+					Name:      fc.Name,
+					Arguments: string(argsJSON),
+				},
+			},
+		})
+		contentStr := "No response available for this function call."
+		if fr := functionResponses[fc.ID]; fr != nil {
+			contentStr = oaiFunctionResponseContent(fr.Response)
+		}
+		toolResponseMessages = append(toolResponseMessages, openai.ToolMessage(contentStr, fc.ID))
+	}
+
+	asst := openai.ChatCompletionAssistantMessageParam{
+		Role:      constant.Assistant("assistant"),
+		ToolCalls: toolCalls,
+	}
+	if len(textParts) > 0 {
+		asst.Content.OfString = param.NewOpt(strings.Join(textParts, "\n"))
+	}
+
+	messages := make([]openai.ChatCompletionMessageParamUnion, 0, 1+len(toolResponseMessages))
+	messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
+	return append(messages, toolResponseMessages...)
+}
+
+// oaiTextMessage renders a plain text turn, mapping genai's "model" role onto
+// OpenAI's "assistant" and everything else onto "user".
+func oaiTextMessage(role, text string) openai.ChatCompletionMessageParamUnion {
+	if !genaiRoleIsAssistant(role) {
+		return openai.UserMessage(text)
+	}
+	asst := openai.ChatCompletionAssistantMessageParam{
+		Role: constant.Assistant("assistant"),
+	}
+	asst.Content.OfString = param.NewOpt(text)
+	return openai.ChatCompletionMessageParamUnion{OfAssistant: &asst}
 }
 
 func oaiGenaiToolsToOpenAI(tools []*genai.Tool) []openai.ChatCompletionToolUnionParam {

--- a/internal/provider/openai_completions_test.go
+++ b/internal/provider/openai_completions_test.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestOaiTextMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		role          string
+		wantAssistant bool
+	}{
+		{name: "model maps to assistant", role: "model", wantAssistant: true},
+		{name: "assistant stays assistant", role: "assistant", wantAssistant: true},
+		{name: "user maps to user", role: "user"},
+		{name: "unknown role maps to user", role: "narrator"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := oaiTextMessage(tt.role, "hello")
+			if tt.wantAssistant {
+				if got.OfAssistant == nil {
+					t.Fatalf("oaiTextMessage(%q) produced no assistant message", tt.role)
+				}
+				if text := got.OfAssistant.Content.OfString.Value; text != "hello" {
+					t.Errorf("assistant content = %q, want %q", text, "hello")
+				}
+				return
+			}
+			if got.OfAssistant != nil {
+				t.Fatalf("oaiTextMessage(%q) produced an assistant message, want user", tt.role)
+			}
+			if got.OfUser == nil {
+				t.Fatalf("oaiTextMessage(%q) produced no user message", tt.role)
+			}
+		})
+	}
+}
+
+func TestOaiToolCallMessagesSkipsCallsWithoutID(t *testing.T) {
+	t.Parallel()
+
+	calls := []*genai.FunctionCall{
+		nil,
+		{ID: "   ", Name: "blank"},
+		{ID: "keep", Name: "kept"},
+	}
+
+	got := oaiToolCallMessages(nil, calls, nil)
+
+	// One assistant message plus one tool message for the single usable call.
+	if len(got) != 2 {
+		t.Fatalf("oaiToolCallMessages() returned %d messages, want 2", len(got))
+	}
+	asst := got[0].OfAssistant
+	if asst == nil {
+		t.Fatal("first message is not an assistant message")
+	}
+	if len(asst.ToolCalls) != 1 {
+		t.Fatalf("assistant carries %d tool calls, want 1", len(asst.ToolCalls))
+	}
+	if id := asst.ToolCalls[0].OfFunction.ID; id != "keep" {
+		t.Errorf("tool call ID = %q, want %q", id, "keep")
+	}
+	if asst.Content.OfString.Valid() {
+		t.Errorf("assistant content = %q, want it unset when there is no text",
+			asst.Content.OfString.Value)
+	}
+	if got[1].OfTool == nil {
+		t.Fatal("second message is not a tool message")
+	}
+}
+
+func TestOaiToolCallMessagesMissingResponsePlaceholder(t *testing.T) {
+	t.Parallel()
+
+	calls := []*genai.FunctionCall{{ID: "unanswered", Name: "f"}}
+	got := oaiToolCallMessages([]string{"thinking out loud"}, calls, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("oaiToolCallMessages() returned %d messages, want 2", len(got))
+	}
+	if text := got[0].OfAssistant.Content.OfString.Value; text != "thinking out loud" {
+		t.Errorf("assistant content = %q, want the joined text parts", text)
+	}
+	want := "No response available for this function call."
+	if got := got[1].OfTool.Content.OfString.Value; got != want {
+		t.Errorf("tool content = %q, want the placeholder %q", got, want)
+	}
+}

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -42,105 +42,142 @@ func (m *openaiModel) generateResponses(ctx context.Context, req *model.LLMReque
 		state := m.responseState
 		m.mu.Unlock()
 
-		input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
-		if err != nil {
-			_ = yield(nil, fmt.Errorf("responses input: %w", err))
-			return
-		}
+		input, instructions := oaiContentsToResponsesInput(req.Contents, req.Config)
 
-		params := responses.ResponseNewParams{
-			Model: modelName,
-			Input: input,
-			// Default to store=false so we never persist LLM responses
-			// server-side without an explicit opt-in. Multi-turn continues
-			// to work on the platform Responses API via full conversation
-			// replay (params.Input carries the whole thread).
-			Store: param.NewOpt(false),
-		}
-		if instructions != "" {
-			params.Instructions = param.NewOpt(instructions)
-		}
-
-		// The ChatGPT codex backend is stateless — it rejects requests that
-		// expect server-side persistence and requires clients to opt in to
-		// encrypted reasoning echo so multi-turn context can round-trip on
-		// the client side. Matches pi-mono's openai-codex-responses body.
-		if m.codexBackend {
-			params.Include = []responses.ResponseIncludable{
-				responses.ResponseIncludableReasoningEncryptedContent,
-			}
-		}
-
-		// previous_response_id requires OpenAI to retain responses
-		// server-side, which conflicts with store=false. Skip threading
-		// the pointer; the full conversation in params.Input is sufficient.
-		sentPreviousResponseID := shouldSendPreviousResponseID(params.Store.Value, m.codexBackend, state)
-		if sentPreviousResponseID {
-			params.PreviousResponseID = param.NewOpt(state.previousResponseID)
-		}
-
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = oaiGenaiToolsToResponses(req.Config.Tools)
-		}
-
-		// Apply reasoning effort if configured via ThinkingConfig.BudgetTokens.
-		// Low tokens (100-500) → low effort; medium (2000-4000) → medium; high (8000+) → high.
-		if req.Config != nil && req.Config.ThinkingConfig != nil && req.Config.ThinkingConfig.ThinkingBudget != nil {
-			bt := *req.Config.ThinkingConfig.ThinkingBudget
-			switch {
-			case bt >= 8000:
-				params.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffortHigh}
-			case bt >= 2000:
-				params.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffortMedium}
-			case bt > 0:
-				params.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffortLow}
-			}
-		}
+		params, sentPreviousResponseID := m.buildResponsesParams(req, modelName, input, instructions, state)
 
 		// send performs the request once, including the previous_response_id
-		// recovery below. It takes its own yield so retryStream can re-run it.
+		// recovery. It takes its own yield so retryStream can re-run it, and
+		// params by pointer so that clearing a rejected previous_response_id
+		// persists into any later attempt retryStream makes.
 		send := func(y func(*model.LLMResponse, error) bool) {
-			runOnce := func(p responses.ResponseNewParams) (bool, error) {
-				if stream {
-					return m.runResponsesStreaming(ctx, p, y)
-				}
-				return m.runResponsesNonStreaming(ctx, p, y)
-			}
-
-			emitted, err := runOnce(params)
-
-			// A stored previous_response_id can stop resolving upstream at any
-			// point: a proxy or load balancer routing the next turn to a different
-			// deployment, `store=false` (zero-data-retention accounts), expiry, or
-			// a model switch. The full conversation is already in params.Input —
-			// previous_response_id is only an optimisation here — so retrying
-			// without it is lossless. Only retry when nothing was streamed yet,
-			// otherwise the caller would see the turn's text twice.
-			if err != nil && sentPreviousResponseID && !emitted && isPreviousResponseNotFound(err) {
-				m.clearPreviousResponseID()
-				params.PreviousResponseID = param.Opt[string]{}
-				// The retry is the last attempt, so its emitted flag is moot.
-				_, err = runOnce(params)
-			}
-
-			if err != nil {
-				// Clear the stale pointer so the next turn starts fresh rather
-				// than replaying the same rejected id.
-				m.clearPreviousResponseID()
-				if stream {
-					_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
-					return
-				}
-				_ = y(nil, fmt.Errorf("OpenAI Responses API failed: %w", err))
-			}
+			m.sendResponses(ctx, &params, stream, sentPreviousResponseID, y)
 		}
 
 		if stream {
 			retryStream(ctx, streamRetryConfig(), yield, send)
-		} else {
-			send(yield)
+			return
+		}
+		send(yield)
+	}
+}
+
+// buildResponsesParams assembles the parameters for one Responses call. It
+// also reports whether a previous_response_id was attached, which the caller
+// needs in order to decide whether a rejection is worth retrying without it.
+func (m *openaiModel) buildResponsesParams(
+	req *model.LLMRequest,
+	modelName string,
+	input responses.ResponseNewParamsInputUnion,
+	instructions string,
+	state *responsesState,
+) (responses.ResponseNewParams, bool) {
+	params := responses.ResponseNewParams{
+		Model: modelName,
+		Input: input,
+		// Default to store=false so we never persist LLM responses
+		// server-side without an explicit opt-in. Multi-turn continues
+		// to work on the platform Responses API via full conversation
+		// replay (params.Input carries the whole thread).
+		Store: param.NewOpt(false),
+	}
+	if instructions != "" {
+		params.Instructions = param.NewOpt(instructions)
+	}
+
+	// The ChatGPT codex backend is stateless — it rejects requests that
+	// expect server-side persistence and requires clients to opt in to
+	// encrypted reasoning echo so multi-turn context can round-trip on
+	// the client side. Matches pi-mono's openai-codex-responses body.
+	if m.codexBackend {
+		params.Include = []responses.ResponseIncludable{
+			responses.ResponseIncludableReasoningEncryptedContent,
 		}
 	}
+
+	// previous_response_id requires OpenAI to retain responses
+	// server-side, which conflicts with store=false. Skip threading
+	// the pointer; the full conversation in params.Input is sufficient.
+	sentPreviousResponseID := shouldSendPreviousResponseID(params.Store.Value, m.codexBackend, state)
+	if sentPreviousResponseID {
+		params.PreviousResponseID = param.NewOpt(state.previousResponseID)
+	}
+
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		params.Tools = oaiGenaiToolsToResponses(req.Config.Tools)
+	}
+
+	if effort, ok := responsesReasoningEffort(req.Config); ok {
+		params.Reasoning = shared.ReasoningParam{Effort: effort}
+	}
+
+	return params, sentPreviousResponseID
+}
+
+// responsesReasoningEffort maps a configured thinking budget onto a Responses
+// reasoning effort, reporting false when no budget is set or the budget is not
+// positive — in which case the request carries no reasoning parameter at all.
+// Low tokens (100-500) → low effort; medium (2000-4000) → medium; high (8000+) → high.
+func responsesReasoningEffort(config *genai.GenerateContentConfig) (shared.ReasoningEffort, bool) {
+	if config == nil || config.ThinkingConfig == nil || config.ThinkingConfig.ThinkingBudget == nil {
+		return "", false
+	}
+	switch bt := *config.ThinkingConfig.ThinkingBudget; {
+	case bt >= 8000:
+		return shared.ReasoningEffortHigh, true
+	case bt >= 2000:
+		return shared.ReasoningEffortMedium, true
+	case bt > 0:
+		return shared.ReasoningEffortLow, true
+	default:
+		return "", false
+	}
+}
+
+// sendResponses performs one Responses request, recovering from a rejected
+// previous_response_id. params is a pointer because clearing that pointer must
+// persist into any later attempt the caller makes.
+func (m *openaiModel) sendResponses(
+	ctx context.Context,
+	params *responses.ResponseNewParams,
+	stream, sentPreviousResponseID bool,
+	y func(*model.LLMResponse, error) bool,
+) {
+	runOnce := func() (bool, error) {
+		if stream {
+			return m.runResponsesStreaming(ctx, *params, y)
+		}
+		return m.runResponsesNonStreaming(ctx, *params, y)
+	}
+
+	emitted, err := runOnce()
+
+	// A stored previous_response_id can stop resolving upstream at any
+	// point: a proxy or load balancer routing the next turn to a different
+	// deployment, `store=false` (zero-data-retention accounts), expiry, or
+	// a model switch. The full conversation is already in params.Input —
+	// previous_response_id is only an optimisation here — so retrying
+	// without it is lossless. Only retry when nothing was streamed yet,
+	// otherwise the caller would see the turn's text twice.
+	if err != nil && sentPreviousResponseID && !emitted && isPreviousResponseNotFound(err) {
+		m.clearPreviousResponseID()
+		params.PreviousResponseID = param.Opt[string]{}
+		// The retry is the last attempt, so its emitted flag is moot.
+		_, err = runOnce()
+	}
+
+	if err == nil {
+		return
+	}
+
+	// Clear the stale pointer so the next turn starts fresh rather
+	// than replaying the same rejected id.
+	m.clearPreviousResponseID()
+	if stream {
+		_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+		return
+	}
+	_ = y(nil, fmt.Errorf("OpenAI Responses API failed: %w", err))
 }
 
 // shouldSendPreviousResponseID reports whether a retained response pointer can
@@ -184,24 +221,35 @@ func (m *openaiModel) clearPreviousResponseID() {
 // oaiContentsToResponsesInput converts ADK contents to Responses API input and instructions.
 // Always returns list form — the ChatGPT codex backend rejects bare strings with
 // `{"detail":"Input must be a list"}`, and the platform Responses API accepts lists too.
-func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.GenerateContentConfig) (responses.ResponseNewParamsInputUnion, string, error) {
-	// Extract system instruction.
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	instructions := strings.TrimSpace(systemBuilder.String())
+func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.GenerateContentConfig) (responses.ResponseNewParamsInputUnion, string) {
+	instructions := genaiSystemInstruction(config)
+	callIDs, responseIDs := oaiResponsesPairedIDs(contents)
 
-	// A canceled turn can persist a function call before its tool result is
-	// emitted. Responses requires calls and outputs to be paired, so omit either
-	// half of an incomplete pair when replaying conversation history.
-	callIDs := make(map[string]struct{})
-	responseIDs := make(map[string]struct{})
+	// Always build a list of input items. The ChatGPT codex backend
+	// (/backend-api/codex/responses) rejects a bare string with
+	// `{"detail":"Input must be a list"}`. The platform Responses API
+	// (/v1/responses) accepts either form, so the list shape is safe
+	// for both endpoints.
+	items := make(responses.ResponseInputParam, 0, len(contents))
+	for _, content := range contents {
+		if content == nil || strings.TrimSpace(content.Role) == "system" {
+			continue
+		}
+		items = oaiAppendResponsesItems(items, content, callIDs, responseIDs)
+	}
+
+	return responses.ResponseNewParamsInputUnion{OfInputItemList: items}, instructions
+}
+
+// oaiResponsesPairedIDs indexes the function call and function response IDs
+// present in contents, so the item builder can tell a complete call/result
+// pair from a half of one. A canceled turn can persist a function call before
+// its tool result is emitted, and Responses requires calls and outputs to be
+// paired, so replaying history must omit whichever half has no partner.
+// Blank IDs are ignored: they cannot pair with anything.
+func oaiResponsesPairedIDs(contents []*genai.Content) (callIDs, responseIDs map[string]struct{}) {
+	callIDs = make(map[string]struct{})
+	responseIDs = make(map[string]struct{})
 	for _, content := range contents {
 		if content == nil {
 			continue
@@ -222,61 +270,61 @@ func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.Genera
 			}
 		}
 	}
+	return callIDs, responseIDs
+}
 
-	// Always build a list of input items. The ChatGPT codex backend
-	// (/backend-api/codex/responses) rejects a bare string with
-	// `{"detail":"Input must be a list"}`. The platform Responses API
-	// (/v1/responses) accepts either form, so the list shape is safe
-	// for both endpoints.
-	items := make(responses.ResponseInputParam, 0, len(contents))
-	for _, content := range contents {
-		if content == nil || strings.TrimSpace(content.Role) == "system" {
-			continue
+// oaiAppendResponsesItems appends one content's parts to the Responses input
+// list and returns the grown list. Consecutive text parts coalesce into a
+// single message item, flushed before each function call or output so the
+// emitted items keep the order the parts appeared in. An unpaired call or
+// output is skipped — see oaiResponsesPairedIDs.
+func oaiAppendResponsesItems(
+	items responses.ResponseInputParam,
+	content *genai.Content,
+	callIDs, responseIDs map[string]struct{},
+) responses.ResponseInputParam {
+	role := oaiResponsesRole(content.Role)
+	var textParts []string
+	flushText := func() {
+		if len(textParts) == 0 {
+			return
 		}
-		role := oaiResponsesRole(content.Role)
-		var textParts []string
-		flushText := func() {
-			if len(textParts) == 0 {
-				return
-			}
-			items = append(items, responses.ResponseInputItemParamOfMessage(strings.Join(textParts, "\n"), role))
-			textParts = nil
-		}
-
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			switch {
-			case part.Text != "":
-				textParts = append(textParts, part.Text)
-			case part.FunctionCall != nil:
-				flushText()
-				fc := part.FunctionCall
-				if strings.TrimSpace(fc.ID) == "" {
-					continue
-				}
-				if _, ok := responseIDs[fc.ID]; !ok {
-					continue
-				}
-				argsJSON, _ := json.Marshal(fc.Args)
-				items = append(items, responses.ResponseInputItemParamOfFunctionCall(string(argsJSON), fc.ID, fc.Name))
-			case part.FunctionResponse != nil:
-				flushText()
-				fr := part.FunctionResponse
-				if strings.TrimSpace(fr.ID) == "" {
-					continue
-				}
-				if _, ok := callIDs[fr.ID]; !ok {
-					continue
-				}
-				items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(fr.ID, oaiFunctionResponseContent(fr.Response)))
-			}
-		}
-		flushText()
+		items = append(items, responses.ResponseInputItemParamOfMessage(strings.Join(textParts, "\n"), role))
+		textParts = nil
 	}
 
-	return responses.ResponseNewParamsInputUnion{OfInputItemList: items}, instructions, nil
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		switch {
+		case part.Text != "":
+			textParts = append(textParts, part.Text)
+		case part.FunctionCall != nil:
+			flushText()
+			fc := part.FunctionCall
+			if strings.TrimSpace(fc.ID) == "" {
+				continue
+			}
+			if _, ok := responseIDs[fc.ID]; !ok {
+				continue
+			}
+			argsJSON, _ := json.Marshal(fc.Args)
+			items = append(items, responses.ResponseInputItemParamOfFunctionCall(string(argsJSON), fc.ID, fc.Name))
+		case part.FunctionResponse != nil:
+			flushText()
+			fr := part.FunctionResponse
+			if strings.TrimSpace(fr.ID) == "" {
+				continue
+			}
+			if _, ok := callIDs[fr.ID]; !ok {
+				continue
+			}
+			items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(fr.ID, oaiFunctionResponseContent(fr.Response)))
+		}
+	}
+	flushText()
+	return items
 }
 
 func oaiResponsesRole(role string) responses.EasyInputMessageRole {
@@ -328,7 +376,6 @@ type responsesStreamState struct {
 	promptTokens     int64
 	completionTokens int64
 	cachedTokens     int64
-	responseID       string
 }
 
 type toolCallAcc struct {
@@ -371,85 +418,36 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 
 	for stream.Next() {
 		evt := stream.Current()
-		evtType := evt.Type
 
+		switch evt.Type {
 		// response.completed — capture final response with usage and status.
-		if evtType == "response.completed" {
+		case "response.completed":
 			finalResp = &evt.Response
-			if evt.Response.ID != "" {
-				state.responseID = evt.Response.ID
-			}
-			if evt.Response.Usage.InputTokens > 0 {
-				state.promptTokens = evt.Response.Usage.InputTokens
-			}
-			if evt.Response.Usage.OutputTokens > 0 {
-				state.completionTokens = evt.Response.Usage.OutputTokens
-			}
-			if c := evt.Response.Usage.InputTokensDetails.CachedTokens; c > 0 {
-				state.cachedTokens = c
-			}
-			state.finishReason = string(evt.Response.Status)
-			continue
-		}
+			applyResponsesCompleted(state, &evt.Response)
 
 		// response.error — surface as LLM error.
-		if evtType == "error" {
+		case "error":
 			_ = yield(&model.LLMResponse{ErrorCode: evt.Code, ErrorMessage: evt.Message}, nil)
 			return true, nil
-		}
 
 		// response.output_text.delta — text token.
-		if evtType == "response.output_text.delta" {
+		case "response.output_text.delta":
 			state.text += evt.Delta
 			emitted = true
-			if !yield(&model.LLMResponse{
-				Partial:      true,
-				TurnComplete: false,
-				Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: evt.Delta}}},
-			}, nil) {
+			if !yield(responsesPartialResponse(string(genai.RoleModel), evt.Delta), nil) {
 				return emitted, nil
 			}
-		}
 
 		// response.reasoning_text.delta — reasoning token.
-		if evtType == "response.reasoning_text.delta" {
+		case "response.reasoning_text.delta":
 			state.reasoning.WriteString(evt.Delta)
 			emitted = true
-			if !yield(&model.LLMResponse{
-				Partial:      true,
-				TurnComplete: false,
-				Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: evt.Delta}}},
-			}, nil) {
+			if !yield(responsesPartialResponse("thinking", evt.Delta), nil) {
 				return emitted, nil
 			}
-		}
 
-		// response.function_call_arguments.delta — streaming function call args.
-		// response.output_item.* carries the function call header (id, name),
-		// and may carry the final arguments depending on backend/SDK mapping.
-		// The per-chunk argument text is in evt.Delta; evt.Arguments is only set
-		// on the `.done` event (as the full summary string).
-		if evtType == "response.function_call_arguments.delta" {
-			updateResponsesToolCall(state, evt.OutputIndex, "", "", evt.Delta, true)
-		}
-		// response.function_call_arguments.done — final full arguments string.
-		// Use it as a safety net: if deltas were missed, overwrite with the
-		// authoritative complete arguments payload.
-		if evtType == "response.function_call_arguments.done" {
-			updateResponsesToolCall(state, evt.OutputIndex, "", evt.Name, evt.Arguments, false)
-		}
-
-		// response.output_item.added — function call item header.
-		if evtType == "response.output_item.added" {
-			fc := evt.Item.AsFunctionCall()
-			updateResponsesToolCall(state, evt.OutputIndex, fc.CallID, fc.Name, "", false)
-		}
-
-		// response.output_item.done — final fallback arguments. Some Responses
-		// streams only populate arguments here.
-		if evtType == "response.output_item.done" {
-			fc := evt.Item.AsFunctionCall()
-			updateResponsesToolCall(state, evt.OutputIndex, fc.CallID, fc.Name, fc.Arguments, false)
+		default:
+			applyResponsesToolCallEvent(state, &evt)
 		}
 	}
 
@@ -463,18 +461,87 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 		return emitted, err
 	}
 
-	// Build final response parts.
-	finalParts := buildResponsesFinalParts(state)
-	var usage *genai.GenerateContentResponseUsageMetadata
-	if state.promptTokens > 0 || state.completionTokens > 0 {
-		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:        int32(state.promptTokens),
-			CandidatesTokenCount:    int32(state.completionTokens),
-			CachedContentTokenCount: int32(state.cachedTokens),
-		}
-	}
+	m.finishResponsesStream(state, finalResp, yield)
+	return true, nil
+}
 
-	// Save response ID for multi-turn continuation.
+// applyResponsesCompleted folds the terminal response.completed event into the
+// accumulated state. Zero-valued usage fields are left alone, so a backend
+// that omits a count in the final event does not clear a value seen earlier.
+func applyResponsesCompleted(s *responsesStreamState, resp *responses.Response) {
+	if resp.Usage.InputTokens > 0 {
+		s.promptTokens = resp.Usage.InputTokens
+	}
+	if resp.Usage.OutputTokens > 0 {
+		s.completionTokens = resp.Usage.OutputTokens
+	}
+	if c := resp.Usage.InputTokensDetails.CachedTokens; c > 0 {
+		s.cachedTokens = c
+	}
+	s.finishReason = string(resp.Status)
+}
+
+// applyResponsesToolCallEvent folds the four event types that carry function
+// call data into the accumulator, ignoring every other event type. The call
+// header (id, name) arrives on response.output_item.added; argument text
+// streams in on response.function_call_arguments.delta, and both `.done`
+// events supply an authoritative complete arguments string as a safety net
+// for deltas that were missed.
+func applyResponsesToolCallEvent(s *responsesStreamState, evt *responses.ResponseStreamEventUnion) {
+	switch evt.Type {
+	case "response.function_call_arguments.delta":
+		updateResponsesToolCall(s, evt.OutputIndex, "", "", evt.Delta, true)
+
+	case "response.function_call_arguments.done":
+		updateResponsesToolCall(s, evt.OutputIndex, "", evt.Name, evt.Arguments, false)
+
+	// The header event carries no arguments to trust: pass "" so a partially
+	// populated Item cannot clobber argument text already accumulated.
+	case "response.output_item.added":
+		fc := evt.Item.AsFunctionCall()
+		updateResponsesToolCall(s, evt.OutputIndex, fc.CallID, fc.Name, "", false)
+
+	// Some Responses streams only populate arguments here.
+	case "response.output_item.done":
+		fc := evt.Item.AsFunctionCall()
+		updateResponsesToolCall(s, evt.OutputIndex, fc.CallID, fc.Name, fc.Arguments, false)
+	}
+}
+
+// responsesPartialResponse wraps one streamed delta as a partial response
+// under the given role — "thinking" for reasoning tokens, the model role for
+// output text.
+func responsesPartialResponse(role, delta string) *model.LLMResponse {
+	return &model.LLMResponse{
+		Partial:      true,
+		TurnComplete: false,
+		Content:      &genai.Content{Role: role, Parts: []*genai.Part{{Text: delta}}},
+	}
+}
+
+// responsesUsageMetadata converts the accumulated token counts into genai
+// usage metadata, reporting nil when the stream carried no usage at all.
+func responsesUsageMetadata(s *responsesStreamState) *genai.GenerateContentResponseUsageMetadata {
+	if s.promptTokens <= 0 && s.completionTokens <= 0 {
+		return nil
+	}
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        int32(s.promptTokens),
+		CandidatesTokenCount:    int32(s.completionTokens),
+		CachedContentTokenCount: int32(s.cachedTokens),
+	}
+}
+
+// finishResponsesStream emits the aggregated terminal response and records the
+// response ID so the next turn can continue the server-side conversation.
+func (m *openaiModel) finishResponsesStream(
+	s *responsesStreamState,
+	finalResp *responses.Response,
+	yield func(*model.LLMResponse, error) bool,
+) {
+	finalParts := buildResponsesFinalParts(s)
+	usage := responsesUsageMetadata(s)
+
 	if finalResp != nil && finalResp.ID != "" {
 		m.mu.Lock()
 		if m.responseState == nil {
@@ -487,11 +554,10 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 	_ = yield(&model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
-		FinishReason:  oaiFinishReasonToGenai(state.finishReason),
+		FinishReason:  oaiFinishReasonToGenai(s.finishReason),
 		UsageMetadata: usage,
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
 	}, nil)
-	return true, nil
 }
 
 // buildResponsesFinalParts assembles the final parts from streaming state.

--- a/internal/provider/openai_responses_test.go
+++ b/internal/provider/openai_responses_test.go
@@ -1,0 +1,380 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/genai"
+)
+
+func TestOaiResponsesPairedIDs(t *testing.T) {
+	t.Parallel()
+
+	contents := []*genai.Content{
+		nil,
+		{Parts: []*genai.Part{nil}},
+		{Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{ID: "paired"}},
+			{FunctionCall: &genai.FunctionCall{ID: "  "}}, // blank: ignored
+			{FunctionCall: &genai.FunctionCall{ID: "orphan-call"}},
+		}},
+		{Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{ID: "paired"}},
+			{FunctionResponse: &genai.FunctionResponse{ID: ""}}, // blank: ignored
+			{FunctionResponse: &genai.FunctionResponse{ID: "orphan-output"}},
+		}},
+	}
+
+	callIDs, responseIDs := oaiResponsesPairedIDs(contents)
+
+	wantCalls := []string{"paired", "orphan-call"}
+	if len(callIDs) != len(wantCalls) {
+		t.Errorf("callIDs = %v, want exactly %v", callIDs, wantCalls)
+	}
+	for _, id := range wantCalls {
+		if _, ok := callIDs[id]; !ok {
+			t.Errorf("callIDs is missing %q", id)
+		}
+	}
+
+	wantResponses := []string{"paired", "orphan-output"}
+	if len(responseIDs) != len(wantResponses) {
+		t.Errorf("responseIDs = %v, want exactly %v", responseIDs, wantResponses)
+	}
+	for _, id := range wantResponses {
+		if _, ok := responseIDs[id]; !ok {
+			t.Errorf("responseIDs is missing %q", id)
+		}
+	}
+}
+
+func TestOaiAppendResponsesItems(t *testing.T) {
+	t.Parallel()
+
+	paired := map[string]struct{}{"paired": {}}
+
+	tests := []struct {
+		name        string
+		content     *genai.Content
+		callIDs     map[string]struct{}
+		responseIDs map[string]struct{}
+		wantItems   int
+	}{
+		{
+			name:      "consecutive text parts coalesce into one message",
+			content:   &genai.Content{Role: "user", Parts: []*genai.Part{{Text: "a"}, {Text: "b"}}},
+			wantItems: 1,
+		},
+		{
+			name:      "nil parts are skipped",
+			content:   &genai.Content{Role: "user", Parts: []*genai.Part{nil, {Text: "a"}, nil}},
+			wantItems: 1,
+		},
+		{
+			name:      "content with no parts emits nothing",
+			content:   &genai.Content{Role: "user"},
+			wantItems: 0,
+		},
+		{
+			name: "a call flushes pending text, so text precedes the call",
+			content: &genai.Content{Role: "model", Parts: []*genai.Part{
+				{Text: "before"},
+				{FunctionCall: &genai.FunctionCall{ID: "paired", Name: "f"}},
+				{Text: "after"},
+			}},
+			responseIDs: paired,
+			wantItems:   3, // text, call, text
+		},
+		{
+			name: "an unpaired call is dropped but its text still flushes",
+			content: &genai.Content{Role: "model", Parts: []*genai.Part{
+				{Text: "before"},
+				{FunctionCall: &genai.FunctionCall{ID: "orphan", Name: "f"}},
+			}},
+			responseIDs: paired,
+			wantItems:   1, // just the text
+		},
+		{
+			name: "a call with a blank ID is dropped",
+			content: &genai.Content{Role: "model", Parts: []*genai.Part{
+				{FunctionCall: &genai.FunctionCall{ID: "  ", Name: "f"}},
+			}},
+			responseIDs: paired,
+			wantItems:   0,
+		},
+		{
+			name: "a paired output is emitted",
+			content: &genai.Content{Role: "user", Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: "paired"}},
+			}},
+			callIDs:   paired,
+			wantItems: 1,
+		},
+		{
+			name: "an unpaired output is dropped",
+			content: &genai.Content{Role: "user", Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: "orphan"}},
+			}},
+			callIDs:   paired,
+			wantItems: 0,
+		},
+		{
+			name: "an output with a blank ID is dropped",
+			content: &genai.Content{Role: "user", Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: ""}},
+			}},
+			callIDs:   paired,
+			wantItems: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := oaiAppendResponsesItems(nil, tt.content, tt.callIDs, tt.responseIDs)
+			if len(got) != tt.wantItems {
+				t.Errorf("oaiAppendResponsesItems() produced %d items, want %d", len(got), tt.wantItems)
+			}
+		})
+	}
+}
+
+func TestOaiAppendResponsesItemsGrowsExistingList(t *testing.T) {
+	t.Parallel()
+
+	seed := oaiAppendResponsesItems(nil, &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{{Text: "first"}},
+	}, nil, nil)
+
+	got := oaiAppendResponsesItems(seed, &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: "second"}},
+	}, nil, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("second call produced %d items, want the seed item plus one", len(got))
+	}
+}
+
+func TestApplyResponsesCompleted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		initial responsesStreamState
+		resp    responses.Response
+		want    responsesStreamState
+	}{
+		{
+			name: "usage and status are recorded",
+			resp: responses.Response{
+				Status: "completed",
+				Usage: responses.ResponseUsage{
+					InputTokens:        10,
+					OutputTokens:       20,
+					InputTokensDetails: responses.ResponseUsageInputTokensDetails{CachedTokens: 5},
+				},
+			},
+			want: responsesStreamState{
+				promptTokens: 10, completionTokens: 20, cachedTokens: 5, finishReason: "completed",
+			},
+		},
+		{
+			// A backend that omits counts in the final event must not wipe
+			// counts already accumulated.
+			name:    "zero counts do not clobber earlier values",
+			initial: responsesStreamState{promptTokens: 7, completionTokens: 8, cachedTokens: 9},
+			resp:    responses.Response{Status: "incomplete"},
+			want: responsesStreamState{
+				promptTokens: 7, completionTokens: 8, cachedTokens: 9, finishReason: "incomplete",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.initial
+			applyResponsesCompleted(&got, &tt.resp)
+			if got.promptTokens != tt.want.promptTokens ||
+				got.completionTokens != tt.want.completionTokens ||
+				got.cachedTokens != tt.want.cachedTokens ||
+				got.finishReason != tt.want.finishReason {
+				t.Errorf("applyResponsesCompleted() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponsesUsageMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		state   responsesStreamState
+		wantNil bool
+	}{
+		{name: "no usage reported", state: responsesStreamState{}, wantNil: true},
+		{
+			// Cached tokens alone are not usage: the original guard only ever
+			// looked at prompt and completion counts.
+			name:    "cached tokens alone are not usage",
+			state:   responsesStreamState{cachedTokens: 5},
+			wantNil: true,
+		},
+		{name: "prompt tokens only", state: responsesStreamState{promptTokens: 3}},
+		{name: "completion tokens only", state: responsesStreamState{completionTokens: 4}},
+		{name: "both", state: responsesStreamState{promptTokens: 3, completionTokens: 4, cachedTokens: 1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := responsesUsageMetadata(&tt.state)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("responsesUsageMetadata() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("responsesUsageMetadata() = nil, want usage metadata")
+			}
+			if int64(got.PromptTokenCount) != tt.state.promptTokens {
+				t.Errorf("PromptTokenCount = %d, want %d", got.PromptTokenCount, tt.state.promptTokens)
+			}
+			if int64(got.CandidatesTokenCount) != tt.state.completionTokens {
+				t.Errorf("CandidatesTokenCount = %d, want %d", got.CandidatesTokenCount, tt.state.completionTokens)
+			}
+			if int64(got.CachedContentTokenCount) != tt.state.cachedTokens {
+				t.Errorf("CachedContentTokenCount = %d, want %d", got.CachedContentTokenCount, tt.state.cachedTokens)
+			}
+		})
+	}
+}
+
+func TestResponsesPartialResponse(t *testing.T) {
+	t.Parallel()
+
+	got := responsesPartialResponse("thinking", "tok")
+	if !got.Partial || got.TurnComplete {
+		t.Errorf("Partial=%v TurnComplete=%v, want true/false", got.Partial, got.TurnComplete)
+	}
+	if got.Content.Role != "thinking" {
+		t.Errorf("role = %q, want %q", got.Content.Role, "thinking")
+	}
+	if len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "tok" {
+		t.Errorf("parts = %v, want a single %q part", got.Content.Parts, "tok")
+	}
+}
+
+func TestApplyResponsesToolCallEvent(t *testing.T) {
+	t.Parallel()
+
+	newState := func() *responsesStreamState {
+		return &responsesStreamState{toolCalls: make(map[int64]toolCallAcc)}
+	}
+
+	t.Run("argument deltas accumulate", func(t *testing.T) {
+		t.Parallel()
+		s := newState()
+		for _, delta := range []string{`{"a`, `":1`, `}`} {
+			applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{
+				Type:        "response.function_call_arguments.delta",
+				OutputIndex: 0,
+				Delta:       delta,
+			})
+		}
+		if got := s.toolCalls[0].arguments; got != `{"a":1}` {
+			t.Errorf("arguments = %q, want the concatenated deltas", got)
+		}
+	})
+
+	t.Run("arguments done overwrites accumulated deltas", func(t *testing.T) {
+		t.Parallel()
+		s := newState()
+		applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{
+			Type: "response.function_call_arguments.delta", Delta: "part",
+		})
+		applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{
+			Type: "response.function_call_arguments.done", Name: "f", Arguments: `{"whole":true}`,
+		})
+		if got := s.toolCalls[0].arguments; got != `{"whole":true}` {
+			t.Errorf("arguments = %q, want the authoritative complete payload", got)
+		}
+		if got := s.toolCalls[0].name; got != "f" {
+			t.Errorf("name = %q, want %q", got, "f")
+		}
+	})
+
+	t.Run("output_item.added does not clobber accumulated arguments", func(t *testing.T) {
+		t.Parallel()
+		s := newState()
+		applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{
+			Type: "response.function_call_arguments.delta", Delta: `{"kept":1}`,
+		})
+		applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{
+			Type: "response.output_item.added",
+		})
+		if got := s.toolCalls[0].arguments; got != `{"kept":1}` {
+			t.Errorf("arguments = %q, want the deltas left untouched by the header event", got)
+		}
+	})
+
+	t.Run("unknown event types are ignored", func(t *testing.T) {
+		t.Parallel()
+		s := newState()
+		applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{Type: "response.created"})
+		applyResponsesToolCallEvent(s, &responses.ResponseStreamEventUnion{Type: "response.output_text.done"})
+		if len(s.toolCalls) != 0 {
+			t.Errorf("toolCalls = %v, want no accumulator entries", s.toolCalls)
+		}
+	})
+}
+
+func TestResponsesReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	budget := func(n int32) *genai.GenerateContentConfig {
+		return &genai.GenerateContentConfig{
+			ThinkingConfig: &genai.ThinkingConfig{ThinkingBudget: &n},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		config    *genai.GenerateContentConfig
+		want      shared.ReasoningEffort
+		wantFound bool
+	}{
+		{name: "nil config", config: nil},
+		{name: "no thinking config", config: &genai.GenerateContentConfig{}},
+		{
+			name:   "thinking config without a budget",
+			config: &genai.GenerateContentConfig{ThinkingConfig: &genai.ThinkingConfig{}},
+		},
+		{name: "zero budget carries no effort", config: budget(0)},
+		{name: "negative budget carries no effort", config: budget(-1)},
+		{name: "just above zero is low", config: budget(1), want: shared.ReasoningEffortLow, wantFound: true},
+		{name: "upper edge of low", config: budget(1999), want: shared.ReasoningEffortLow, wantFound: true},
+		{name: "lower edge of medium", config: budget(2000), want: shared.ReasoningEffortMedium, wantFound: true},
+		{name: "upper edge of medium", config: budget(7999), want: shared.ReasoningEffortMedium, wantFound: true},
+		{name: "lower edge of high", config: budget(8000), want: shared.ReasoningEffortHigh, wantFound: true},
+		{name: "well above high", config: budget(100000), want: shared.ReasoningEffortHigh, wantFound: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, found := responsesReasoningEffort(tt.config)
+			if found != tt.wantFound {
+				t.Fatalf("found = %v, want %v", found, tt.wantFound)
+			}
+			if got != tt.want {
+				t.Errorf("effort = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1384,10 +1384,7 @@ func TestOaiContentsToResponsesInput_SimpleText(t *testing.T) {
 		{Role: "user", Parts: []*genai.Part{{Text: "Hello world"}}},
 	}
 
-	input, instructions, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, instructions := oaiContentsToResponsesInput(contents, nil)
 	if instructions != "" {
 		t.Errorf("instructions = %q, want empty", instructions)
 	}
@@ -1408,10 +1405,7 @@ func TestOaiContentsToResponsesInput_PreservesMessageOrderAndRoles(t *testing.T)
 		{Role: "user", Parts: []*genai.Part{{Text: "second"}}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	items := input.OfInputItemList
 	if len(items) != 3 {
 		t.Fatalf("expected 3 input items, got %d", len(items))
@@ -1446,10 +1440,7 @@ func TestOaiContentsToResponsesInput_WithSystemInstruction(t *testing.T) {
 		{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
 	}
 
-	_, instructions, err := oaiContentsToResponsesInput(contents, config)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	_, instructions := oaiContentsToResponsesInput(contents, config)
 	if instructions != "You are a helpful assistant." {
 		t.Errorf("instructions = %q, want %q", instructions, "You are a helpful assistant.")
 	}
@@ -1473,10 +1464,7 @@ func TestOaiContentsToResponsesInput_WithFunctionCalls(t *testing.T) {
 		{Role: "user", Parts: []*genai.Part{fr}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	if input.OfInputItemList == nil {
 		t.Fatal("expected input item list")
 	}
@@ -1507,10 +1495,7 @@ func TestOaiContentsToResponsesInput_SkipsFunctionCallsWithoutResponse(t *testin
 		{Role: "model", Parts: []*genai.Part{fc}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	items := input.OfInputItemList
 	if len(items) != 1 {
 		t.Fatalf("expected orphaned function call to be omitted, got %d items", len(items))
@@ -1533,10 +1518,7 @@ func TestOaiContentsToResponsesInput_SkipsFunctionResponseWithoutCall(t *testing
 		{Role: "user", Parts: []*genai.Part{fr}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	items := input.OfInputItemList
 	if len(items) != 1 {
 		t.Fatalf("expected orphaned function response to be omitted, got %d items", len(items))
@@ -1555,10 +1537,7 @@ func TestOaiContentsToResponsesInput_SkipsFunctionCallsWithoutID(t *testing.T) {
 		{Role: "model", Parts: []*genai.Part{fc}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	if input.OfInputItemList == nil {
 		t.Fatal("expected input item list")
 	}
@@ -1585,10 +1564,7 @@ func TestOaiContentsToResponsesInput_SkipsFunctionResponseWithoutID(t *testing.T
 		{Role: "user", Parts: []*genai.Part{fr}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	items := input.OfInputItemList
 	if len(items) != 1 {
 		t.Fatalf("expected only user message item, got %d", len(items))
@@ -1602,10 +1578,7 @@ func TestOaiContentsToResponsesInput_NilConfig(t *testing.T) {
 	contents := []*genai.Content{
 		{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}},
 	}
-	_, instructions, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	_, instructions := oaiContentsToResponsesInput(contents, nil)
 	if instructions != "" {
 		t.Errorf("instructions = %q, want empty", instructions)
 	}
@@ -1618,10 +1591,7 @@ func TestOaiContentsToResponsesInput_SkipsNilContentAndParts(t *testing.T) {
 		{Role: "system", Parts: []*genai.Part{{Text: "ignored"}}},
 	}
 
-	input, _, err := oaiContentsToResponsesInput(contents, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	input, _ := oaiContentsToResponsesInput(contents, nil)
 	items := input.OfInputItemList
 	if len(items) != 1 {
 		t.Fatalf("expected only the user message, got %d items", len(items))
@@ -1788,13 +1758,10 @@ func TestOpenAIResponsesRequestUsesPreviousResponseID(t *testing.T) {
 		},
 	}
 
-	input, instructions, err := oaiContentsToResponsesInput([]*genai.Content{{
+	input, instructions := oaiContentsToResponsesInput([]*genai.Content{{
 		Role:  string(genai.RoleUser),
 		Parts: []*genai.Part{{Text: "review this"}},
 	}}, nil)
-	if err != nil {
-		t.Fatalf("oaiContentsToResponsesInput() error: %v", err)
-	}
 
 	params := responses.ResponseNewParams{
 		Model: m.modelName,

--- a/internal/provider/xai.go
+++ b/internal/provider/xai.go
@@ -92,11 +92,7 @@ func (m *xaiModel) GenerateContent(ctx context.Context, req *model.LLMRequest, s
 			_ = yield(nil, fmt.Errorf("xAI responses: nil LLM request"))
 			return
 		}
-		input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
-		if err != nil {
-			_ = yield(nil, fmt.Errorf("xAI responses input: %w", err))
-			return
-		}
+		input, instructions := oaiContentsToResponsesInput(req.Contents, req.Config)
 
 		modelName := req.Model
 		if modelName == "" {

--- a/internal/subagent/agent_acp_seams_test.go
+++ b/internal/subagent/agent_acp_seams_test.go
@@ -1,0 +1,406 @@
+package subagent
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	sharedacp "github.com/dimetron/pi-go/internal/acp"
+)
+
+func TestApplyAgentFrontmatterKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		start AgentConfig
+		key   string
+		value string
+		want  AgentConfig
+	}{
+		{"name", AgentConfig{Name: "from-file"}, "name", "explore", AgentConfig{Name: "explore"}},
+		{"description", AgentConfig{}, "description", "does things", AgentConfig{Description: "does things"}},
+		{"role", AgentConfig{}, "role", "smol", AgentConfig{Role: "smol"}},
+		{"worktree true", AgentConfig{}, "worktree", "true", AgentConfig{Worktree: true}},
+		{"worktree is case-insensitive", AgentConfig{}, "worktree", "TRUE", AgentConfig{Worktree: true}},
+		{"worktree anything else is false", AgentConfig{}, "worktree", "yes", AgentConfig{}},
+		{"worktree false clears a prior true", AgentConfig{Worktree: true}, "worktree", "false", AgentConfig{}},
+		{"lsp is lowercased", AgentConfig{}, "lsp", "  Full  ", AgentConfig{LSP: "full"}},
+		{"tools split and trimmed", AgentConfig{}, "tools", "read, write ,edit", AgentConfig{Tools: []string{"read", "write", "edit"}}},
+		{"tools drops empty entries", AgentConfig{}, "tools", "read,,  ,edit", AgentConfig{Tools: []string{"read", "edit"}}},
+		{"tools appends to existing", AgentConfig{Tools: []string{"bash"}}, "tools", "read", AgentConfig{Tools: []string{"bash", "read"}}},
+		{"timeout applied", AgentConfig{}, "timeout", "5000", AgentConfig{Timeout: 5000}},
+		{"unknown key is ignored", AgentConfig{Name: "x"}, "nonsense", "blue", AgentConfig{Name: "x"}},
+		{"empty key is ignored", AgentConfig{Name: "x"}, "", "v", AgentConfig{Name: "x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.start
+			applyAgentFrontmatterKey(&got, tt.key, tt.value)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("applyAgentFrontmatterKey mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestAgentTimeoutFrom pins the milliseconds-vs-seconds guard: a bundled agent
+// once shipped `timeout: 30` and was SIGKILLed 30ms in, every run.
+func TestAgentTimeoutFrom(t *testing.T) {
+	t.Parallel()
+
+	const current = 7777
+
+	tests := []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{"plausible value applied", "5000", 5000},
+		{"exactly the floor is applied", "1000", minAgentTimeoutMs},
+		{"just under the floor is ignored", "999", current},
+		{"seconds-looking value is ignored", "30", current},
+		{"zero is ignored", "0", current},
+		{"negative is ignored", "-1", current},
+		{"non-numeric is ignored", "30s", current},
+		{"empty is ignored", "", current},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := agentTimeoutFrom(tt.value, "test-agent", current); got != tt.want {
+				t.Errorf("agentTimeoutFrom(%q, current=%d) = %d, want %d", tt.value, current, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseAgentContentTimeoutRoundTrip checks the extracted helpers still
+// compose the way the whole-file parser needs them to.
+func TestParseAgentContentTimeoutRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	content := "---\n" +
+		"name: explore\n" +
+		"description: look around\n" +
+		"role: smol\n" +
+		"worktree: true\n" +
+		"timeout: 30\n" + // implausible: must be ignored
+		"lsp: FULL\n" +
+		"tools: read, write\n" +
+		"---\n" +
+		"Body line one.\n"
+
+	cfg, err := parseAgentContent(content, "/agents/fallback.md")
+	if err != nil {
+		t.Fatalf("parseAgentContent: %v", err)
+	}
+	want := AgentConfig{
+		Name:        "explore",
+		Description: "look around",
+		Role:        "smol",
+		Worktree:    true,
+		LSP:         "full",
+		Tools:       []string{"read", "write"},
+		Instruction: "Body line one.",
+	}
+	if diff := cmp.Diff(want, cfg); diff != "" {
+		t.Errorf("parseAgentContent mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestACPEventFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   sharedacp.Event
+		want Event
+	}{
+		{
+			name: "message becomes text_delta",
+			in:   sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "hi", SessionID: "s"},
+			want: Event{Type: "text_delta", Content: "hi", SessionID: "s"},
+		},
+		{
+			name: "progress becomes tool_call",
+			in:   sharedacp.Event{Type: sharedacp.EventTypeProgress, Content: "step", SessionID: "s"},
+			want: Event{Type: "tool_call", Content: "step", SessionID: "s"},
+		},
+		{
+			name: "tool becomes tool_call",
+			in:   sharedacp.Event{Type: sharedacp.EventTypeTool, Content: "grep", SessionID: "s"},
+			want: Event{Type: "tool_call", Content: "grep", SessionID: "s"},
+		},
+		{
+			name: "stderr keeps its own type",
+			in:   sharedacp.Event{Type: sharedacp.EventTypeStderr, Content: "warn", SessionID: "s"},
+			want: Event{Type: "stderr", Content: "warn", SessionID: "s"},
+		},
+		{
+			name: "error carries Error, not Content",
+			in:   sharedacp.Event{Type: sharedacp.EventTypeError, Error: "boom", Content: "ignored", SessionID: "s"},
+			want: Event{Type: "error", Error: "boom", SessionID: "s"},
+		},
+		{
+			name: "unknown type passes through",
+			in:   sharedacp.Event{Type: "thinking", Content: "hmm", SessionID: "s"},
+			want: Event{Type: "thinking", Content: "hmm", SessionID: "s"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, acpEventFor(tt.in)); diff != "" {
+				t.Errorf("acpEventFor mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyGracefulCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   sharedacp.RunResult
+		want sharedacp.RunResult
+	}{
+		{
+			name: "kill error is coerced to success and sentinel stripped",
+			in: sharedacp.RunResult{
+				Status: sharedacp.StatusError,
+				Error:  "signal: killed",
+				Result: "all done " + acpCompletionSentinel,
+			},
+			want: sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: "all done"},
+		},
+		{
+			name: "loose sentinel form is stripped too",
+			in:   sharedacp.RunResult{Result: "done " + acpCompletionMatcher},
+			want: sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: "done"},
+		},
+		{
+			name: "other fields are preserved",
+			in:   sharedacp.RunResult{SessionID: "s", StopReason: "end_turn", Stderr: "noise", Result: "x"},
+			want: sharedacp.RunResult{Status: sharedacp.StatusSuccess, SessionID: "s", StopReason: "end_turn", Stderr: "noise", Result: "x"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, applyGracefulCompletion(tt.in)); diff != "" {
+				t.Errorf("applyGracefulCompletion mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestACPErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   sharedacp.RunResult
+		want string
+	}{
+		{"error only", sharedacp.RunResult{Error: "boom"}, "boom"},
+		{"stderr only", sharedacp.RunResult{Stderr: "trace"}, "stderr: trace"},
+		{"both are joined", sharedacp.RunResult{Error: "boom", Stderr: "trace"}, "boom\nstderr: trace"},
+		{"neither gets a fallback", sharedacp.RunResult{}, "subprocess failed"},
+		{"whitespace-only stderr is not appended", sharedacp.RunResult{Error: "boom", Stderr: "   \n "}, "boom"},
+		{"whitespace-only everything gets the fallback", sharedacp.RunResult{Error: "  ", Stderr: " "}, "subprocess failed"},
+		{"fields are trimmed", sharedacp.RunResult{Error: "  boom  ", Stderr: "  trace  "}, "boom\nstderr: trace"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, acpErrorMessage(tt.in)); diff != "" {
+				t.Errorf("acpErrorMessage mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestStashBeforeWorktree exercises the stash seam against a throwaway repo
+// created by initTestRepo. It never touches the real checkout.
+func TestStashBeforeWorktree(t *testing.T) {
+	t.Run("clean tree stashes nothing", func(t *testing.T) {
+		repo := initTestRepo(t)
+		m := NewWorktreeManager(repo)
+
+		msg, stashed, err := m.stashBeforeWorktree("agent-1")
+		if err != nil {
+			t.Fatalf("stashBeforeWorktree: %v", err)
+		}
+		if stashed {
+			t.Error("stashed = true on a clean tree, want false")
+		}
+		if !strings.Contains(msg, "agent-1") {
+			t.Errorf("stash message %q does not identify the agent", msg)
+		}
+		if out, _ := m.git("stash", "list"); strings.TrimSpace(out) != "" {
+			t.Errorf("stash list = %q, want empty", out)
+		}
+	})
+
+	t.Run("dirty tree stashes and is recoverable by message", func(t *testing.T) {
+		repo := initTestRepo(t)
+		m := NewWorktreeManager(repo)
+		if err := os.WriteFile(filepath.Join(repo, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		msg, stashed, err := m.stashBeforeWorktree("agent-2")
+		if err != nil {
+			t.Fatalf("stashBeforeWorktree: %v", err)
+		}
+		if !stashed {
+			t.Fatal("stashed = false on a dirty tree, want true")
+		}
+		// The untracked file must have been swept up (-u) and be restorable.
+		if _, statErr := os.Stat(filepath.Join(repo, "dirty.txt")); !os.IsNotExist(statErr) {
+			t.Errorf("dirty.txt still present after stash, stat err = %v", statErr)
+		}
+		out, _ := m.git("stash", "list")
+		if !strings.Contains(out, msg) {
+			t.Errorf("stash list %q does not contain the unique message %q", out, msg)
+		}
+		if err := m.popStashByMessage(msg); err != nil {
+			t.Fatalf("popStashByMessage: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(repo, "dirty.txt")); statErr != nil {
+			t.Errorf("dirty.txt not restored after pop: %v", statErr)
+		}
+	})
+
+	t.Run("non-repo is a fatal error, not a clean tree", func(t *testing.T) {
+		m := NewWorktreeManager(t.TempDir())
+
+		_, stashed, err := m.stashBeforeWorktree("agent-3")
+		if err == nil {
+			t.Fatal("stashBeforeWorktree() = nil error outside a git repo, want a failure")
+		}
+		if !strings.Contains(err.Error(), "git stash before worktree") {
+			t.Errorf("error = %q, want it to name the stash step", err)
+		}
+		if stashed {
+			t.Error("stashed = true on failure, want false")
+		}
+	})
+}
+
+func TestAddWorktree(t *testing.T) {
+	t.Run("creates a new branch when it does not exist", func(t *testing.T) {
+		repo := initTestRepo(t)
+		m := NewWorktreeManager(repo)
+		wtPath := filepath.Join(repo, ".pi-go", "tasks", "fresh")
+
+		if _, err := m.addWorktree("pi-agent-fresh", wtPath, false); err != nil {
+			t.Fatalf("addWorktree: %v", err)
+		}
+		if !m.branchExists("pi-agent-fresh") {
+			t.Error("branch was not created")
+		}
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Errorf("worktree dir missing: %v", err)
+		}
+	})
+
+	t.Run("attaches an existing branch without -b", func(t *testing.T) {
+		repo := initTestRepo(t)
+		m := NewWorktreeManager(repo)
+		cmd := exec.Command("git", "branch", "prebuilt")
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git branch: %v: %s", err, out)
+		}
+		wtPath := filepath.Join(repo, ".pi-go", "tasks", "attached")
+
+		// The -b form would fail here with "a branch named X already exists".
+		if _, err := m.addWorktree("prebuilt", wtPath, true); err != nil {
+			t.Fatalf("addWorktree on an existing branch: %v", err)
+		}
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Errorf("worktree dir missing: %v", err)
+		}
+	})
+}
+
+// TestMergeAgentLayer pins the precedence rule DiscoverAgents relies on: a
+// later layer replaces a same-named agent IN PLACE, so the merged order is the
+// order names were first seen, not the order the winning layer supplied them.
+func TestMergeAgentLayer(t *testing.T) {
+	t.Parallel()
+
+	agent := func(name, source string) AgentConfig {
+		return AgentConfig{Name: name, Source: source}
+	}
+
+	tests := []struct {
+		name   string
+		layers [][]AgentConfig
+		want   []AgentConfig
+	}{
+		{
+			name:   "no layers",
+			layers: nil,
+			want:   nil,
+		},
+		{
+			name:   "single layer passes through",
+			layers: [][]AgentConfig{{agent("a", "bundled"), agent("b", "bundled")}},
+			want:   []AgentConfig{agent("a", "bundled"), agent("b", "bundled")},
+		},
+		{
+			name: "later layer overrides in place, keeping first-seen order",
+			layers: [][]AgentConfig{
+				{agent("a", "bundled"), agent("b", "bundled")},
+				{agent("b", "user")},
+			},
+			want: []AgentConfig{agent("a", "bundled"), agent("b", "user")},
+		},
+		{
+			name: "project beats user beats bundled",
+			layers: [][]AgentConfig{
+				{agent("x", "bundled")},
+				{agent("x", "user")},
+				{agent("x", "project")},
+			},
+			want: []AgentConfig{agent("x", "project")},
+		},
+		{
+			name: "new names append after the ones already seen",
+			layers: [][]AgentConfig{
+				{agent("a", "bundled")},
+				{agent("z", "user"), agent("a", "user")},
+			},
+			want: []AgentConfig{agent("a", "user"), agent("z", "user")},
+		},
+		{
+			name: "a duplicate within one layer takes the last occurrence",
+			layers: [][]AgentConfig{
+				{agent("a", "first"), agent("a", "second")},
+			},
+			want: []AgentConfig{agent("a", "second")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var all []AgentConfig
+			seen := make(map[string]int)
+			for _, layer := range tt.layers {
+				all = mergeAgentLayer(all, seen, layer)
+			}
+			if diff := cmp.Diff(tt.want, all); diff != "" {
+				t.Errorf("mergeAgentLayer mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/subagent/agents.go
+++ b/internal/subagent/agents.go
@@ -109,40 +109,7 @@ func parseAgentContent(content, path string) (AgentConfig, error) {
 			if !ok {
 				continue
 			}
-			switch key {
-			case "name":
-				cfg.Name = value
-			case "description":
-				cfg.Description = value
-			case "role":
-				cfg.Role = value
-			case "worktree":
-				cfg.Worktree = strings.ToLower(value) == "true"
-			case "timeout":
-				if ms, err := strconv.Atoi(value); err == nil && ms > 0 {
-					// The unit is milliseconds, which reads as seconds at a
-					// glance — a bundled agent shipped `timeout: 30` and was
-					// SIGKILLed 30ms in, every time, unable to emit a single
-					// token. Anything under a second cannot be deliberate, so
-					// treat it as the unit mistake it is rather than honoring a
-					// value that guarantees the agent never runs.
-					if ms < minAgentTimeoutMs {
-						slog.Warn("subagent: implausibly small timeout ignored; the unit is milliseconds",
-							"agent", cfg.Name, "timeout_ms", ms, "using", "default")
-					} else {
-						cfg.Timeout = ms
-					}
-				}
-			case "lsp":
-				cfg.LSP = strings.ToLower(strings.TrimSpace(value))
-			case "tools":
-				for _, t := range strings.Split(value, ",") {
-					t = strings.TrimSpace(t)
-					if t != "" {
-						cfg.Tools = append(cfg.Tools, t)
-					}
-				}
-			}
+			applyAgentFrontmatterKey(&cfg, key, value)
 		} else {
 			body.WriteString(line)
 			body.WriteString("\n")
@@ -155,6 +122,54 @@ func parseAgentContent(content, path string) (AgentConfig, error) {
 
 	cfg.Instruction = strings.TrimSpace(body.String())
 	return cfg, nil
+}
+
+// applyAgentFrontmatterKey applies one parsed frontmatter key to cfg.
+// An unrecognized key is ignored, as is a value that fails its own validation,
+// so a malformed field degrades to the default rather than failing the parse.
+func applyAgentFrontmatterKey(cfg *AgentConfig, key, value string) {
+	switch key {
+	case "name":
+		cfg.Name = value
+	case "description":
+		cfg.Description = value
+	case "role":
+		cfg.Role = value
+	case "worktree":
+		cfg.Worktree = strings.ToLower(value) == "true"
+	case "timeout":
+		cfg.Timeout = agentTimeoutFrom(value, cfg.Name, cfg.Timeout)
+	case "lsp":
+		cfg.LSP = strings.ToLower(strings.TrimSpace(value))
+	case "tools":
+		for _, t := range strings.Split(value, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				cfg.Tools = append(cfg.Tools, t)
+			}
+		}
+	}
+}
+
+// agentTimeoutFrom parses a `timeout:` frontmatter value in milliseconds,
+// returning current unchanged when the value is unusable.
+//
+// The unit is milliseconds, which reads as seconds at a glance — a bundled
+// agent shipped `timeout: 30` and was SIGKILLed 30ms in, every time, unable to
+// emit a single token. Anything under a second cannot be deliberate, so treat
+// it as the unit mistake it is rather than honoring a value that guarantees the
+// agent never runs.
+func agentTimeoutFrom(value, agentName string, current int) int {
+	ms, err := strconv.Atoi(value)
+	if err != nil || ms <= 0 {
+		return current
+	}
+	if ms < minAgentTimeoutMs {
+		slog.Warn("subagent: implausibly small timeout ignored; the unit is milliseconds",
+			"agent", agentName, "timeout_ms", ms, "using", "default")
+		return current
+	}
+	return ms
 }
 
 // parseAgentFrontmatterLine parses "key: value" from a frontmatter line.
@@ -211,6 +226,22 @@ func findNearestProjectAgentsDir(cwd string) (string, error) {
 
 // DiscoverAgents loads agents from bundled, user, and project directories.
 // Priority: project > user > bundled (later sources override earlier ones by name).
+// mergeAgentLayer merges one priority layer into all, keyed by agent name.
+// An agent whose name is already present replaces it in place, so the merged
+// slice keeps the order in which names were first seen; seen is updated with
+// any new names. The caller applies layers lowest priority first.
+func mergeAgentLayer(all []AgentConfig, seen map[string]int, layer []AgentConfig) []AgentConfig {
+	for _, agent := range layer {
+		if idx, ok := seen[agent.Name]; ok {
+			all[idx] = agent
+			continue
+		}
+		seen[agent.Name] = len(all)
+		all = append(all, agent)
+	}
+	return all
+}
+
 func DiscoverAgents(cwd string, scope AgentScope) (*AgentDiscoveryResult, error) {
 	result := &AgentDiscoveryResult{}
 
@@ -248,31 +279,11 @@ func DiscoverAgents(cwd string, scope AgentScope) (*AgentDiscoveryResult, error)
 		result.Project = projectAgents
 	}
 
-	// Merge all agents with priority: project > user > bundled
+	// Merge all agents with priority: project > user > bundled. Applying the
+	// layers lowest-priority-first means each one overrides what came before.
 	seen := make(map[string]int) // name → index in All
-	for _, agent := range result.Bundled {
-		if idx, ok := seen[agent.Name]; ok {
-			result.All[idx] = agent // bundled is lowest priority
-		} else {
-			seen[agent.Name] = len(result.All)
-			result.All = append(result.All, agent)
-		}
-	}
-	for _, agent := range result.User {
-		if idx, ok := seen[agent.Name]; ok {
-			result.All[idx] = agent // user overrides bundled
-		} else {
-			seen[agent.Name] = len(result.All)
-			result.All = append(result.All, agent)
-		}
-	}
-	for _, agent := range result.Project {
-		if idx, ok := seen[agent.Name]; ok {
-			result.All[idx] = agent // project overrides user
-		} else {
-			seen[agent.Name] = len(result.All)
-			result.All = append(result.All, agent)
-		}
+	for _, layer := range [][]AgentConfig{result.Bundled, result.User, result.Project} {
+		result.All = mergeAgentLayer(result.All, seen, layer)
 	}
 
 	// Filter based on scope

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -343,30 +343,16 @@ func (o *Orchestrator) SpawnWithRetry(ctx context.Context, input SpawnInput) (<-
 		}
 
 		// Wait for the subagent to complete and check status.
-		var status string
-		for ev := range events {
-			// Forward events to caller (consume the channel).
-			if ev.Type == "message_end" || ev.Type == "error" {
-				// Check agent state.
-				o.mu.Lock()
-				state := o.agents[agentID]
-				if state != nil {
-					status = state.Status
-				}
-				o.mu.Unlock()
-
-				if status == "failed" || status == "killed" {
-					// Crash detected — retry if we have attempts left.
-					if attempt < maxRetries {
-						break
-					}
-					return nil, agentID, fmt.Errorf("subagent %s crashed after %d attempts", agentID, attempt+1)
-				}
-				return finalEvents, finalAgentID, nil
-			}
+		outcome := o.awaitOutcome(events, agentID)
+		if outcome == outcomeOK {
+			return finalEvents, finalAgentID, nil
+		}
+		if outcome == outcomeCrashed && attempt >= maxRetries {
+			return nil, agentID, fmt.Errorf("subagent %s crashed after %d attempts", agentID, attempt+1)
 		}
 
-		// If we broke out of the loop for retry, continue to next attempt.
+		// Crashed with attempts left, or the stream ended without ever
+		// reporting a terminal event: retry while we can.
 		if attempt < maxRetries {
 			continue
 		}
@@ -374,6 +360,44 @@ func (o *Orchestrator) SpawnWithRetry(ctx context.Context, input SpawnInput) (<-
 	}
 
 	return finalEvents, finalAgentID, lastErr
+}
+
+// runOutcome is what awaiting a spawned subagent's event stream concluded.
+type runOutcome int
+
+const (
+	// outcomeOK: a terminal event arrived and the agent was not in a crash state.
+	outcomeOK runOutcome = iota
+	// outcomeCrashed: a terminal event arrived with status "failed" or "killed".
+	outcomeCrashed
+	// outcomeSilent: the stream closed without ever reporting a terminal event.
+	// Treated as retryable, but unlike a crash it is not an error on the last
+	// attempt — the caller still gets the channel back.
+	outcomeSilent
+)
+
+// awaitOutcome consumes events until the subagent reports it is done, and
+// classifies how it ended. Events are drained rather than forwarded: the caller
+// hands the same channel back, so anything after the terminal event is still
+// readable by whoever it is returned to.
+func (o *Orchestrator) awaitOutcome(events <-chan Event, agentID string) runOutcome {
+	for ev := range events {
+		if ev.Type != "message_end" && ev.Type != "error" {
+			continue
+		}
+		o.mu.Lock()
+		var status string
+		if state := o.agents[agentID]; state != nil {
+			status = state.Status
+		}
+		o.mu.Unlock()
+
+		if status == "failed" || status == "killed" {
+			return outcomeCrashed
+		}
+		return outcomeOK
+	}
+	return outcomeSilent
 }
 
 // Spawn starts a new subagent and returns an event channel.
@@ -409,30 +433,21 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 	// Generate agent ID.
 	agentID := fmt.Sprintf("%s-%d", agent.Name, time.Now().UnixNano())
 
-	// Determine if worktree is needed.
-	useWorktree := resolveWorktreeUsage(agent.Worktree, input.Worktree, input.WorkDir)
-
-	workDir := o.repoRoot // default to project root so subagents run in the right directory
-	if input.WorkDir != "" {
-		workDir = input.WorkDir
-	} else if useWorktree && o.worktree != nil {
-		wtPath, err := o.worktree.Create(agentID, input.WorktreeName)
-		if err != nil {
-			o.pool.Release()
-			return nil, "", fmt.Errorf("creating worktree: %w", err)
-		}
-		workDir = wtPath
+	workDir, useWorktree, err := o.prepareWorkDir(agentID, input)
+	if err != nil {
+		o.pool.Release()
+		return nil, "", err
 	}
 
-	// Pass repo root to subagent so its sandbox covers the full repo,
-	// not just the worktree directory.
-	env := input.Env
-	if o.worktree != nil {
-		env = append(append([]string(nil), env...), "PI_SANDBOX_ROOT="+o.worktree.RepoRoot())
-		// Also pass the worktree path so subagent can normalize relative paths
-		if workDir != "" {
-			env = append(env, "PI_WORKTREE_ROOT="+workDir)
+	// releaseSpawn undoes everything acquired above. It is safe to call on any
+	// failure path from here on, and is deliberately *not* deferred: on the
+	// success path the pool slot is released by the forwarding goroutine when
+	// the subagent finishes, long after Spawn has returned.
+	releaseSpawn := func() {
+		if useWorktree && o.worktree != nil {
+			_ = o.worktree.Cleanup(agentID)
 		}
+		o.pool.Release()
 	}
 
 	// An explicit spawn timeout overrides the agent definition; otherwise use
@@ -450,31 +465,16 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 		Prompt:      input.Prompt,
 		Instruction: agent.Instruction,
 		Timeout:     timeout,
-		Env:         env,
+		Env:         o.subagentEnv(input.Env, workDir),
 		BaseURL:     o.BaseURL,
 		Insecure:    o.Insecure,
 		Headers:     o.Headers,
 		LSP:         agent.LSP,
 	}
 
-	// ACP-bundled agents (claude/gemini/cursor/copilot) launch their own CLI
-	// binary via the ACP adapter; codex agents launch `codex app-server` and
-	// speak its JSON-RPC protocol directly; everyone else runs as a child
-	// pi --mode json.
-	var proc *Process
-	switch {
-	case isACPAgent(agent.Name):
-		proc, err = dispatchACP(ctx, spawnOpts, agent.Name)
-	case isCodexAgent(agent.Name):
-		proc, err = dispatchCodex(ctx, spawnOpts, agent.Name)
-	default:
-		proc, err = o.spawner.Spawn(ctx, spawnOpts)
-	}
+	proc, err := o.dispatchProcess(ctx, spawnOpts, agent.Name)
 	if err != nil {
-		if useWorktree && o.worktree != nil {
-			_ = o.worktree.Cleanup(agentID)
-		}
-		o.pool.Release()
+		releaseSpawn()
 		return nil, "", fmt.Errorf("spawning agent: %w", err)
 	}
 
@@ -494,10 +494,7 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 		o.mu.Unlock()
 		// Orchestrator shut down while we were setting up — clean up and bail.
 		proc.Cancel()
-		if useWorktree && o.worktree != nil {
-			_ = o.worktree.Cleanup(agentID)
-		}
-		o.pool.Release()
+		releaseSpawn()
 		return nil, "", fmt.Errorf("orchestrator is shut down")
 	}
 	o.agents[agentID] = state
@@ -509,55 +506,118 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 	// records external-CLI subagent event streams, and the Event shape is the
 	// same regardless of which protocol produced it.
 	logACP := isACPAgent(agent.Name) || isCodexAgent(agent.Name)
-	go func() {
-		defer close(events)
-		defer o.pool.Release()
-
-		for ev := range proc.Events() {
-			if logACP {
-				o.writeACPEvent(agentID, agent.Name, ev)
-			}
-			events <- ev
-		}
-
-		// Process done — update state.
-		_, waitErr := proc.Wait()
-
-		o.mu.Lock()
-		if state.Status == "running" {
-			// Distinguish a timeout from a crash from an exit-code failure. A
-			// timeout is reported first because it also arrives as a signal
-			// kill — the spawner SIGKILLs the group — and would otherwise be
-			// indistinguishable from an OOM.
-			switch {
-			case errors.Is(waitErr, ErrSubagentTimeout):
-				state.Status = "timeout"
-			case waitErr != nil && isKilledBySignal(waitErr):
-				state.Status = "killed"
-			case waitErr != nil:
-				state.Status = "failed"
-			default:
-				state.Status = "completed"
-			}
-			state.FinishedAt = time.Now()
-		}
-		finalStatus := state.Status
-		o.evictCompletedAgentsLocked()
-		o.mu.Unlock()
-
-		// Publish the terminal status before closing the channel. Consumers must
-		// use this snapshot rather than querying the evictable status map.
-		events <- Event{Type: "run_done", Status: finalStatus}
-
-		// Worktree cleanup is intentionally NOT done here. Deletion is
-		// deferred to the caller (e.g. the TUI /run flow calls
-		// wm.Cleanup after a successful merge) or to Shutdown via
-		// CleanupAll. Auto-cleaning on process exit raced with the
-		// merge step, causing "no worktree found" merge failures.
-		_ = state.SkipCleanup // kept for API stability; no longer gated here
-	}()
+	go o.forwardEvents(proc, state, events, logACP)
 
 	return events, agentID, nil
+}
+
+// prepareWorkDir decides where the subagent runs and creates its worktree when
+// one is called for. It returns the working directory and whether a worktree
+// was requested — the latter drives cleanup on the failure paths, so it is
+// reported even when no manager is configured to act on it.
+func (o *Orchestrator) prepareWorkDir(agentID string, input SpawnInput) (string, bool, error) {
+	useWorktree := resolveWorktreeUsage(input.Agent.Worktree, input.Worktree, input.WorkDir)
+
+	if input.WorkDir != "" {
+		return input.WorkDir, useWorktree, nil
+	}
+	if useWorktree && o.worktree != nil {
+		wtPath, err := o.worktree.Create(agentID, input.WorktreeName)
+		if err != nil {
+			return "", useWorktree, fmt.Errorf("creating worktree: %w", err)
+		}
+		return wtPath, useWorktree, nil
+	}
+	// Default to project root so subagents run in the right directory.
+	return o.repoRoot, useWorktree, nil
+}
+
+// subagentEnv extends the caller's environment with the roots a child needs to
+// resolve paths: the repo root, so its sandbox covers the whole repository
+// rather than just the worktree, and the worktree path so it can normalize
+// relative paths against it.
+func (o *Orchestrator) subagentEnv(env []string, workDir string) []string {
+	if o.worktree == nil {
+		return env
+	}
+	env = append(append([]string(nil), env...), "PI_SANDBOX_ROOT="+o.worktree.RepoRoot())
+	if workDir != "" {
+		env = append(env, "PI_WORKTREE_ROOT="+workDir)
+	}
+	return env
+}
+
+// dispatchProcess starts the child process for the named agent.
+//
+// ACP-bundled agents (claude/gemini/cursor/copilot) launch their own CLI binary
+// via the ACP adapter; codex agents launch `codex app-server` and speak its
+// JSON-RPC protocol directly; everyone else runs as a child pi --mode json.
+func (o *Orchestrator) dispatchProcess(ctx context.Context, opts SpawnOpts, agentName string) (*Process, error) {
+	switch {
+	case isACPAgent(agentName):
+		return dispatchACP(ctx, opts, agentName)
+	case isCodexAgent(agentName):
+		return dispatchCodex(ctx, opts, agentName)
+	default:
+		return o.spawner.Spawn(ctx, opts)
+	}
+}
+
+// forwardEvents relays the child's events to the caller's channel, then records
+// the terminal status and releases the pool slot. It runs as the goroutine that
+// owns the spawn for the rest of the subagent's life, so it — not Spawn —
+// closes events and releases the slot.
+func (o *Orchestrator) forwardEvents(proc *Process, state *agentState, events chan Event, logACP bool) {
+	defer close(events)
+	defer o.pool.Release()
+
+	for ev := range proc.Events() {
+		if logACP {
+			o.writeACPEvent(state.ID, state.Type, ev)
+		}
+		events <- ev
+	}
+
+	// Process done — update state.
+	_, waitErr := proc.Wait()
+
+	o.mu.Lock()
+	if state.Status == "running" {
+		state.Status = terminalStatus(waitErr)
+		state.FinishedAt = time.Now()
+	}
+	finalStatus := state.Status
+	o.evictCompletedAgentsLocked()
+	o.mu.Unlock()
+
+	// Publish the terminal status before closing the channel. Consumers must
+	// use this snapshot rather than querying the evictable status map.
+	events <- Event{Type: "run_done", Status: finalStatus}
+
+	// Worktree cleanup is intentionally NOT done here. Deletion is
+	// deferred to the caller (e.g. the TUI /run flow calls
+	// wm.Cleanup after a successful merge) or to Shutdown via
+	// CleanupAll. Auto-cleaning on process exit raced with the
+	// merge step, causing "no worktree found" merge failures.
+	_ = state.SkipCleanup // kept for API stability; no longer gated here
+}
+
+// terminalStatus classifies how a subagent process ended.
+//
+// It distinguishes a timeout from a crash from an exit-code failure. A timeout
+// is reported first because it also arrives as a signal kill — the spawner
+// SIGKILLs the group — and would otherwise be indistinguishable from an OOM.
+func terminalStatus(waitErr error) string {
+	switch {
+	case errors.Is(waitErr, ErrSubagentTimeout):
+		return "timeout"
+	case waitErr != nil && isKilledBySignal(waitErr):
+		return "killed"
+	case waitErr != nil:
+		return "failed"
+	default:
+		return "completed"
+	}
 }
 
 // isKilledBySignal returns true if the error indicates the process was killed by a signal

--- a/internal/subagent/spawn_seams_test.go
+++ b/internal/subagent/spawn_seams_test.go
@@ -1,0 +1,678 @@
+package subagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	sharedacp "github.com/dimetron/pi-go/internal/acp"
+)
+
+func TestTerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	// A timeout also surfaces as a signal kill, so it must be classified as a
+	// timeout even when wrapped alongside one.
+	killed := exec.Command("false").Run() // *exec.ExitError, unsuccessful
+
+	tests := []struct {
+		name    string
+		waitErr error
+		want    string
+	}{
+		{"clean exit", nil, "completed"},
+		{"timeout sentinel", ErrSubagentTimeout, "timeout"},
+		{"wrapped timeout", fmt.Errorf("pi subagent: %w", ErrSubagentTimeout), "timeout"},
+		{"signal kill", killed, "killed"},
+		{"signal-worded error", errors.New("signal: killed"), "killed"},
+		{"plain failure", errors.New("boom"), "failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := terminalStatus(tt.waitErr); got != tt.want {
+				t.Errorf("terminalStatus(%v) = %q, want %q", tt.waitErr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpawnFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg := TimeoutConfig{Absolute: 90 * time.Second, Inactivity: 30 * time.Second}
+	waitErr := errors.New("exit status 2")
+
+	tests := []struct {
+		name         string
+		timedOutIdle bool
+		procCtxErr   error
+		waitErr      error
+		stderr       string
+		wantNil      bool
+		wantTimeout  bool     // errors.Is(err, ErrSubagentTimeout)
+		wantContains []string // substrings the message must carry
+	}{
+		{
+			name:    "clean exit",
+			wantNil: true,
+		},
+		{
+			// A clean exit wins over stderr chatter: warnings are not failures.
+			name:    "stderr without wait error",
+			stderr:  "warning: something",
+			wantNil: true,
+		},
+		{
+			name:         "inactivity beats everything",
+			timedOutIdle: true,
+			procCtxErr:   context.DeadlineExceeded,
+			waitErr:      waitErr,
+			stderr:       "noise",
+			wantTimeout:  true,
+			wantContains: []string{"produced no output for 30s", timeoutHint},
+		},
+		{
+			name:         "absolute deadline",
+			procCtxErr:   context.DeadlineExceeded,
+			waitErr:      waitErr,
+			wantTimeout:  true,
+			wantContains: []string{"exceeded its 1m30s time limit", timeoutHint},
+		},
+		{
+			// Cancellation is not a deadline, so it falls through to the exit status.
+			name:         "canceled context falls through",
+			procCtxErr:   context.Canceled,
+			waitErr:      waitErr,
+			wantContains: []string{"pi process failed", "exit status 2"},
+		},
+		{
+			name:         "failure with stderr",
+			waitErr:      waitErr,
+			stderr:       "panic: nil map",
+			wantContains: []string{"pi process failed", "exit status 2", "panic: nil map"},
+		},
+		{
+			name:         "failure without stderr",
+			waitErr:      waitErr,
+			wantContains: []string{"pi process failed", "exit status 2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := spawnFailure(cfg, tt.timedOutIdle, tt.procCtxErr, tt.waitErr, tt.stderr)
+			if tt.wantNil {
+				if err != nil {
+					t.Fatalf("spawnFailure() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("spawnFailure() = nil, want error")
+			}
+			if got := errors.Is(err, ErrSubagentTimeout); got != tt.wantTimeout {
+				t.Errorf("errors.Is(err, ErrSubagentTimeout) = %v, want %v (err=%v)", got, tt.wantTimeout, err)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("spawnFailure() = %q, want it to contain %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONEventToEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   jsonEvent
+		want Event
+	}{
+		{
+			name: "text delta carries delta, not content",
+			in:   jsonEvent{Type: "text_delta", Delta: "hi", Content: "ignored"},
+			want: Event{Type: "text_delta", Content: "hi"},
+		},
+		{
+			name: "tool call carries name and input",
+			in:   jsonEvent{Type: "tool_call", ToolName: "grep", ToolInput: map[string]any{"q": "x"}},
+			want: Event{Type: "tool_call", Content: "grep", ToolArgs: map[string]any{"q": "x"}},
+		},
+		{
+			name: "tool result carries content",
+			in:   jsonEvent{Type: "tool_result", Content: "{}", Delta: "ignored"},
+			want: Event{Type: "tool_result", Content: "{}"},
+		},
+		{
+			name: "message start carries session id only",
+			in:   jsonEvent{Type: "message_start", SessionID: "s1", Content: "ignored"},
+			want: Event{Type: "message_start", SessionID: "s1"},
+		},
+		{
+			name: "message end is bare",
+			in:   jsonEvent{Type: "message_end", Content: "ignored", SessionID: "ignored"},
+			want: Event{Type: "message_end"},
+		},
+		{
+			name: "unknown type concatenates delta and content",
+			in:   jsonEvent{Type: "thinking", Delta: "a", Content: "b"},
+			want: Event{Type: "thinking", Content: "ab"},
+		},
+		{
+			name: "empty type stays empty",
+			in:   jsonEvent{},
+			want: Event{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, tt.in.toEvent()); diff != "" {
+				t.Errorf("toEvent() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStderrCaptureBounded(t *testing.T) {
+	t.Parallel()
+
+	c := &stderrCapture{}
+	line := strings.Repeat("x", 1024)
+	// Writes stop once the buffer is at or over the cap, so the total settles
+	// just past maxStderrCapture rather than exactly on it.
+	for range (maxStderrCapture / len(line)) + 10 {
+		c.writeLine(line)
+	}
+	got := len(c.String())
+	if got < maxStderrCapture {
+		t.Errorf("captured %d bytes, want at least %d", got, maxStderrCapture)
+	}
+	if got > maxStderrCapture+len(line)+1 {
+		t.Errorf("captured %d bytes, want no more than %d", got, maxStderrCapture+len(line)+1)
+	}
+}
+
+func TestStderrCaptureTrimsAndSeparates(t *testing.T) {
+	t.Parallel()
+
+	c := &stderrCapture{}
+	if got := c.String(); got != "" {
+		t.Errorf("empty capture = %q, want %q", got, "")
+	}
+	c.writeLine("first")
+	c.writeLine("second")
+	if diff := cmp.Diff("first\nsecond", c.String()); diff != "" {
+		t.Errorf("String() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDrainStderr(t *testing.T) {
+	t.Parallel()
+
+	capture, done := drainStderr(strings.NewReader("one\ntwo\n"))
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainStderr did not signal EOF")
+	}
+	if diff := cmp.Diff("one\ntwo", capture.String()); diff != "" {
+		t.Errorf("capture mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestScanLines(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+	for line := range scanLines(strings.NewReader("a\n\nb\n")) {
+		got = append(got, line)
+	}
+	// Blank lines survive the scan; readEvents is what skips them.
+	if diff := cmp.Diff([]string{"a", "", "b"}, got); diff != "" {
+		t.Errorf("scanLines mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProcessReadEvents(t *testing.T) {
+	t.Parallel()
+
+	lines := make(chan string, 8)
+	for _, l := range []string{
+		`{"type":"text_delta","delta":"he"}`,
+		"", // skipped
+		`not json at all`,
+		`{"type":"text_delta","delta":"llo"}`,
+		`{"type":"message_end"}`,
+	} {
+		lines <- l
+	}
+	close(lines)
+
+	proc := &Process{events: make(chan Event, 64)}
+	result, timedOut := proc.readEvents(lines, func() {}, time.Minute)
+	close(proc.events)
+
+	if timedOut {
+		t.Error("timedOutIdle = true, want false")
+	}
+	if diff := cmp.Diff("hello", result); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+
+	var got []Event
+	for ev := range proc.events {
+		got = append(got, ev)
+	}
+	want := []Event{
+		{Type: "text_delta", Content: "he"},
+		{Type: "text_delta", Content: "not json at all"},
+		{Type: "text_delta", Content: "llo"},
+		{Type: "message_end"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("events mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProcessReadEventsInactivity(t *testing.T) {
+	t.Parallel()
+
+	// Never closed and never written to: only the inactivity timer can end this.
+	lines := make(chan string)
+	proc := &Process{events: make(chan Event, 8)}
+
+	canceled := make(chan struct{})
+	result, timedOut := proc.readEvents(lines, func() { close(canceled); close(lines) }, time.Millisecond)
+
+	if !timedOut {
+		t.Error("timedOutIdle = false, want true")
+	}
+	if result != "" {
+		t.Errorf("result = %q, want empty", result)
+	}
+	select {
+	case <-canceled:
+	default:
+		t.Error("readEvents did not cancel the process group on inactivity")
+	}
+}
+
+func TestOrchestratorSubagentEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		repoRoot string
+		env      []string
+		workDir  string
+		want     []string
+	}{
+		{
+			name:    "no worktree manager leaves env untouched",
+			env:     []string{"A=1"},
+			workDir: "/wt",
+			want:    []string{"A=1"},
+		},
+		{
+			name:     "adds sandbox and worktree roots",
+			repoRoot: "/repo",
+			env:      []string{"A=1"},
+			workDir:  "/wt",
+			want:     []string{"A=1", "PI_SANDBOX_ROOT=/repo", "PI_WORKTREE_ROOT=/wt"},
+		},
+		{
+			name:     "empty work dir omits the worktree root",
+			repoRoot: "/repo",
+			env:      []string{"A=1"},
+			want:     []string{"A=1", "PI_SANDBOX_ROOT=/repo"},
+		},
+		{
+			name:     "nil env still gets the roots",
+			repoRoot: "/repo",
+			workDir:  "/wt",
+			want:     []string{"PI_SANDBOX_ROOT=/repo", "PI_WORKTREE_ROOT=/wt"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orch := NewOrchestrator(testConfig(), tt.repoRoot, nil)
+			got := orch.subagentEnv(tt.env, tt.workDir)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("subagentEnv mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestOrchestratorSubagentEnvDoesNotAliasInput guards the copy in subagentEnv:
+// the caller's slice must not gain the sandbox roots when it has spare capacity.
+func TestOrchestratorSubagentEnvDoesNotAliasInput(t *testing.T) {
+	t.Parallel()
+
+	orch := NewOrchestrator(testConfig(), "/repo", nil)
+	env := make([]string, 1, 8)
+	env[0] = "A=1"
+
+	orch.subagentEnv(env, "/wt")
+
+	if diff := cmp.Diff([]string{"A=1"}, env); diff != "" {
+		t.Errorf("caller env was mutated (-want +got):\n%s", diff)
+	}
+}
+
+func TestOrchestratorPrepareWorkDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		repoRoot     string
+		input        SpawnInput
+		wantDir      string
+		wantWorktree bool
+	}{
+		{
+			name:         "explicit work dir wins and disables the worktree",
+			repoRoot:     "/repo",
+			input:        SpawnInput{WorkDir: "/elsewhere", Agent: AgentConfig{Worktree: true}},
+			wantDir:      "/elsewhere",
+			wantWorktree: false,
+		},
+		{
+			name:         "no worktree falls back to the repo root",
+			repoRoot:     "/repo",
+			input:        SpawnInput{Agent: AgentConfig{Worktree: false}},
+			wantDir:      "/repo",
+			wantWorktree: false,
+		},
+		{
+			name:         "worktree wanted but no manager configured",
+			repoRoot:     "",
+			input:        SpawnInput{Agent: AgentConfig{Worktree: true}},
+			wantDir:      "",
+			wantWorktree: true,
+		},
+		{
+			name:         "input override beats the agent default",
+			repoRoot:     "/repo",
+			input:        SpawnInput{Agent: AgentConfig{Worktree: true}, Worktree: new(false)},
+			wantDir:      "/repo",
+			wantWorktree: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orch := NewOrchestrator(testConfig(), tt.repoRoot, nil)
+			dir, useWorktree, err := orch.prepareWorkDir("agent-1", tt.input)
+			if err != nil {
+				t.Fatalf("prepareWorkDir: %v", err)
+			}
+			if dir != tt.wantDir {
+				t.Errorf("workDir = %q, want %q", dir, tt.wantDir)
+			}
+			if useWorktree != tt.wantWorktree {
+				t.Errorf("useWorktree = %v, want %v", useWorktree, tt.wantWorktree)
+			}
+		})
+	}
+}
+
+// TestOrchestratorPrepareWorkDirCreatesWorktree covers the branch that actually
+// touches git, and the error branch below it.
+func TestOrchestratorPrepareWorkDirCreatesWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	orch := NewOrchestrator(testConfig(), repo, nil)
+	defer orch.Shutdown()
+
+	dir, useWorktree, err := orch.prepareWorkDir("agent-1", SpawnInput{Agent: AgentConfig{Worktree: true}})
+	if err != nil {
+		t.Fatalf("prepareWorkDir: %v", err)
+	}
+	if !useWorktree {
+		t.Error("useWorktree = false, want true")
+	}
+	if dir == repo || dir == "" {
+		t.Errorf("workDir = %q, want a worktree path under %q", dir, repo)
+	}
+	if orch.worktree.Active() != 1 {
+		t.Errorf("active worktrees = %d, want 1", orch.worktree.Active())
+	}
+}
+
+func TestOrchestratorPrepareWorkDirCreateError(t *testing.T) {
+	t.Parallel()
+
+	// A repo root that is not a git repository makes `git worktree add` fail.
+	orch := NewOrchestrator(testConfig(), t.TempDir(), nil)
+
+	_, useWorktree, err := orch.prepareWorkDir("agent-1", SpawnInput{Agent: AgentConfig{Worktree: true}})
+	if err == nil {
+		t.Fatal("prepareWorkDir() = nil error, want a worktree creation failure")
+	}
+	if !strings.Contains(err.Error(), "creating worktree") {
+		t.Errorf("error = %q, want it to mention creating worktree", err)
+	}
+	// Reported even on failure, so the caller knows to run worktree cleanup.
+	if !useWorktree {
+		t.Error("useWorktree = false, want true even on error")
+	}
+}
+
+func TestOrchestratorAwaitOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string // "" means the agent is not tracked at all
+		events []Event
+		want   runOutcome
+	}{
+		{
+			name:   "stream closes with no terminal event",
+			status: "completed",
+			events: []Event{{Type: "text_delta"}},
+			want:   outcomeSilent,
+		},
+		{
+			name:   "empty stream",
+			status: "completed",
+			want:   outcomeSilent,
+		},
+		{
+			name:   "message_end on a completed agent",
+			status: "completed",
+			events: []Event{{Type: "text_delta"}, {Type: "message_end"}},
+			want:   outcomeOK,
+		},
+		{
+			name:   "error event on a failed agent",
+			status: "failed",
+			events: []Event{{Type: "error"}},
+			want:   outcomeCrashed,
+		},
+		{
+			name:   "message_end on a killed agent",
+			status: "killed",
+			events: []Event{{Type: "message_end"}},
+			want:   outcomeCrashed,
+		},
+		{
+			name:   "timeout is not a crash",
+			status: "timeout",
+			events: []Event{{Type: "message_end"}},
+			want:   outcomeOK,
+		},
+		{
+			name:   "untracked agent reads as OK",
+			status: "",
+			events: []Event{{Type: "message_end"}},
+			want:   outcomeOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orch := NewOrchestrator(testConfig(), "", nil)
+			const agentID = "agent-1"
+			if tt.status != "" {
+				orch.SetStatusForTest(agentID, tt.status)
+			}
+
+			events := make(chan Event, len(tt.events)+1)
+			for _, ev := range tt.events {
+				events <- ev
+			}
+			close(events)
+
+			if got := orch.awaitOutcome(events, agentID); got != tt.want {
+				t.Errorf("awaitOutcome() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpawnerBuildCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    SpawnOpts
+		wantDir string
+		wantEnv string // an entry the environment must carry, "" to skip
+	}{
+		{
+			name:    "work dir is applied",
+			opts:    SpawnOpts{Prompt: "p", WorkDir: "/tmp"},
+			wantDir: "/tmp",
+		},
+		{
+			name:    "empty work dir is left unset",
+			opts:    SpawnOpts{Prompt: "p"},
+			wantDir: "",
+		},
+		{
+			name:    "extra env is appended to the filtered base env",
+			opts:    SpawnOpts{Prompt: "p", Env: []string{"PI_TEST_MARKER=1"}},
+			wantEnv: "PI_TEST_MARKER=1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Spawner{PiBinary: "/bin/true"}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			cmd := s.buildCommand(ctx, tt.opts)
+			if cmd.Dir != tt.wantDir {
+				t.Errorf("cmd.Dir = %q, want %q", cmd.Dir, tt.wantDir)
+			}
+			if cmd.WaitDelay != 3*time.Second {
+				t.Errorf("cmd.WaitDelay = %v, want 3s", cmd.WaitDelay)
+			}
+			if len(cmd.Env) == 0 {
+				t.Fatal("cmd.Env is empty, want the filtered base env")
+			}
+			if tt.wantEnv != "" && !slices.Contains(cmd.Env, tt.wantEnv) {
+				t.Errorf("cmd.Env is missing %q", tt.wantEnv)
+			}
+		})
+	}
+}
+
+func TestStartPiProcess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing binary fails to start", func(t *testing.T) {
+		t.Parallel()
+		cmd := exec.Command("/nonexistent/pi-binary")
+		_, _, err := startPiProcess(cmd)
+		if err == nil {
+			t.Fatal("startPiProcess() = nil error, want a start failure")
+		}
+		if !strings.Contains(err.Error(), "starting pi process") {
+			t.Errorf("error = %q, want it to mention starting pi process", err)
+		}
+	})
+
+	t.Run("pipes are wired for a real command", func(t *testing.T) {
+		t.Parallel()
+		cmd := exec.Command("/bin/echo", "hi")
+		stdout, stderr, err := startPiProcess(cmd)
+		if err != nil {
+			t.Fatalf("startPiProcess: %v", err)
+		}
+		if stdout == nil || stderr == nil {
+			t.Fatal("startPiProcess returned a nil pipe")
+		}
+		var got []string
+		for line := range scanLines(stdout) {
+			got = append(got, line)
+		}
+		capture, done := drainStderr(stderr)
+		<-done
+		if err := cmd.Wait(); err != nil {
+			t.Fatalf("cmd.Wait: %v", err)
+		}
+		if diff := cmp.Diff([]string{"hi"}, got); diff != "" {
+			t.Errorf("stdout mismatch (-want +got):\n%s", diff)
+		}
+		if capture.String() != "" {
+			t.Errorf("stderr = %q, want empty", capture.String())
+		}
+	})
+}
+
+// TestOrchestratorSpawnWithRetryStopsOnFirstSuccess pins the retry loop against
+// spurious re-spawns: a terminal event on an agent that is not in a crash state
+// ends the loop, so a healthy run costs exactly one spawn even with a retry
+// budget available.
+func TestOrchestratorSpawnWithRetryStopsOnFirstSuccess(t *testing.T) {
+	var starts atomic.Int32
+	prev := startACPSessionFn
+	startACPSessionFn = func(_ context.Context, _, _ string, _ SpawnOpts) (acpSession, error) {
+		starts.Add(1)
+		sess := newFakeACPSession()
+		go sess.finish(sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: "ok", SessionID: "s"})
+		return sess, nil
+	}
+	t.Cleanup(func() { startACPSessionFn = prev })
+
+	orch := NewOrchestrator(testConfig(), "", nil)
+	defer orch.Shutdown()
+
+	events, agentID, err := orch.SpawnWithRetry(t.Context(), SpawnInput{
+		Agent:      AgentConfig{Name: "claude", Role: "smol"},
+		Prompt:     "hi",
+		MaxRetries: 1,
+	})
+	if err != nil {
+		t.Fatalf("SpawnWithRetry: %v", err)
+	}
+	if agentID == "" {
+		t.Error("agentID is empty, want the spawned agent's id")
+	}
+	if events == nil {
+		t.Fatal("events channel is nil, want the spawned agent's channel")
+	}
+	if got := starts.Load(); got != 1 {
+		t.Errorf("spawn attempts = %d, want 1 (no retry after a clean run)", got)
+	}
+
+	// Drain so the forwarding goroutine can finish.
+	for range events { //nolint:revive // drain
+	}
+}

--- a/internal/subagent/spawner.go
+++ b/internal/subagent/spawner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -130,19 +131,11 @@ func spawnArgs(opts SpawnOpts) []string {
 	return append(args, opts.Prompt)
 }
 
-// Spawn starts a pi subprocess in JSON mode and returns a Process handle for streaming events.
-func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
-	if opts.Prompt == "" {
-		return nil, fmt.Errorf("prompt is required")
-	}
-
-	// Resolve timeout configuration (applies defaults if not set).
-	timeoutCfg := ResolveTimeout(opts.Timeout)
-	procCtx, cancel := context.WithTimeout(ctx, timeoutCfg.Absolute)
-
-	args := spawnArgs(opts)
-
-	cmd := exec.CommandContext(procCtx, s.PiBinary, args...)
+// buildCommand wires the child pi command: its arguments, environment, working
+// directory and the platform attributes that make canceling procCtx kill the
+// whole process group rather than just the immediate child.
+func (s *Spawner) buildCommand(procCtx context.Context, opts SpawnOpts) *exec.Cmd {
+	cmd := exec.CommandContext(procCtx, s.PiBinary, spawnArgs(opts)...)
 
 	// Set up environment: filtered process env + additional env vars. The
 	// child's concurrency budget is this process's share, not a copy of it —
@@ -160,22 +153,50 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 	if opts.WorkDir != "" {
 		cmd.Dir = opts.WorkDir
 	}
+	return cmd
+}
 
+// startPiProcess opens the child's stdout and stderr pipes and starts it.
+//
+// Canceling the process context stays the caller's job: on error nothing was
+// started, so there is no process to tear down here.
+func startPiProcess(cmd *exec.Cmd) (io.ReadCloser, io.ReadCloser, error) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("creating stdout pipe: %w", err)
+		return nil, nil, fmt.Errorf("creating stdout pipe: %w", err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("creating stderr pipe: %w", err)
+		return nil, nil, fmt.Errorf("creating stderr pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("starting pi process: %w", err)
+	}
+	return stdout, stderr, nil
+}
+
+// Spawn starts a pi subprocess in JSON mode and returns a Process handle for streaming events.
+func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
+	if opts.Prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	// Resolve timeout configuration (applies defaults if not set).
+	//
+	// procCtx and its cancel deliberately stay in this scope: the process
+	// outlives Spawn, so cancel is handed to the Process (Process.Cancel) and
+	// to the reader goroutine, never deferred here.
+	timeoutCfg := ResolveTimeout(opts.Timeout)
+	procCtx, cancel := context.WithTimeout(ctx, timeoutCfg.Absolute)
+
+	cmd := s.buildCommand(procCtx, opts)
+
+	stdout, stderr, err := startPiProcess(cmd)
+	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("starting pi process: %w", err)
+		return nil, err
 	}
 
 	proc := &Process{
@@ -194,96 +215,19 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 	// stdout scan and never reaches the stderr read. The child then sits there
 	// until a timeout kills it, and because stderr was never drained the error
 	// arrives with no diagnostic text attached at all.
-	var (
-		stderrMu   sync.Mutex
-		stderrBuf  strings.Builder
-		stderrDone = make(chan struct{})
-	)
-	go func() {
-		defer close(stderrDone)
-		sc := bufio.NewScanner(stderr)
-		for sc.Scan() {
-			stderrMu.Lock()
-			if stderrBuf.Len() < maxStderrCapture {
-				stderrBuf.WriteString(sc.Text())
-				stderrBuf.WriteByte('\n')
-			}
-			stderrMu.Unlock()
-		}
-	}()
+	stderrCap, stderrDone := drainStderr(stderr)
 
 	// Feed stdout lines to the reader below rather than scanning inline, so the
 	// reader can wait on "a line arrived" and "nothing has arrived in a while"
 	// at the same time. A bare `for scanner.Scan()` can only block.
-	lines := make(chan string, 64)
-	go func() {
-		defer close(lines)
-		sc := bufio.NewScanner(stdout)
-		sc.Buffer(make([]byte, 0, 256*1024), 1024*1024) // up to 1MB lines
-		for sc.Scan() {
-			lines <- sc.Text()
-		}
-	}()
+	lines := scanLines(stdout)
 
 	// Reader goroutine: parse JSONL from stdout, send events.
 	go func() {
 		defer close(proc.done)
 		defer close(proc.events)
 
-		var resultBuilder strings.Builder
-
-		// The inactivity timer is what separates "slow" from "wedged". Without
-		// it the absolute cap is the only limit, so a long but productive agent
-		// is killed on the same rule as one that has hung — which is precisely
-		// the failure this fixes.
-		idle := NewInactivityTimer(timeoutCfg.Inactivity)
-		defer idle.Stop()
-
-		timedOutIdle := false
-
-	read:
-		for {
-			select {
-			case line, ok := <-lines:
-				if !ok {
-					break read
-				}
-				idle.Reset()
-				if line == "" {
-					continue
-				}
-
-				var ev jsonEvent
-				if err := json.Unmarshal([]byte(line), &ev); err != nil {
-					// Non-JSON output; emit as text.
-					proc.sendEvent(Event{Type: "text_delta", Content: line})
-					continue
-				}
-
-				switch ev.Type {
-				case "text_delta":
-					resultBuilder.WriteString(ev.Delta)
-					proc.sendEvent(Event{Type: "text_delta", Content: ev.Delta})
-				case "tool_call":
-					proc.sendEvent(Event{Type: "tool_call", Content: ev.ToolName, ToolArgs: ev.ToolInput})
-				case "tool_result":
-					proc.sendEvent(Event{Type: "tool_result", Content: ev.Content})
-				case "message_start":
-					proc.sendEvent(Event{Type: "message_start", SessionID: ev.SessionID})
-				case "message_end":
-					proc.sendEvent(Event{Type: "message_end"})
-				default:
-					proc.sendEvent(Event{Type: ev.Type, Content: ev.Delta + ev.Content})
-				}
-
-			case <-idle.C():
-				timedOutIdle = true
-				cancel()          // kills the process group; stdout closes, so lines drains
-				for range lines { //nolint:revive // drain so the scanner goroutine can exit
-				}
-				break read
-			}
-		}
+		result, timedOutIdle := proc.readEvents(lines, cancel, timeoutCfg.Inactivity)
 
 		// Both pipes must be at EOF before Wait, and stderr is wanted for the
 		// error message below.
@@ -293,24 +237,8 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 		waitErr := cmd.Wait()
 
 		proc.mu.Lock()
-		proc.result = resultBuilder.String()
-
-		stderrMu.Lock()
-		stderrStr := strings.TrimSpace(stderrBuf.String())
-		stderrMu.Unlock()
-
-		switch {
-		case timedOutIdle:
-			proc.err = fmt.Errorf("pi subagent produced no output for %s: %w (%s)",
-				timeoutCfg.Inactivity, ErrSubagentTimeout, timeoutHint)
-		case errors.Is(procCtx.Err(), context.DeadlineExceeded):
-			proc.err = fmt.Errorf("pi subagent exceeded its %s time limit: %w (%s)",
-				timeoutCfg.Absolute, ErrSubagentTimeout, timeoutHint)
-		case waitErr != nil && stderrStr != "":
-			proc.err = fmt.Errorf("pi process failed: %w: %s", waitErr, stderrStr)
-		case waitErr != nil:
-			proc.err = fmt.Errorf("pi process failed: %w", waitErr)
-		}
+		proc.result = result
+		proc.err = spawnFailure(timeoutCfg, timedOutIdle, procCtx.Err(), waitErr, stderrCap.String())
 		if proc.err != nil {
 			proc.sendEvent(Event{Type: "error", Error: proc.err.Error()})
 		}
@@ -318,6 +246,138 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 	}()
 
 	return proc, nil
+}
+
+// stderrCapture accumulates a child's stderr, bounded at maxStderrCapture. The
+// draining goroutine writes while the reader goroutine reads, so it carries its
+// own lock.
+type stderrCapture struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+// writeLine appends a line and its newline, dropping everything past the cap.
+func (c *stderrCapture) writeLine(line string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.buf.Len() < maxStderrCapture {
+		c.buf.WriteString(line)
+		c.buf.WriteByte('\n')
+	}
+}
+
+// String returns the captured stderr with surrounding whitespace trimmed.
+func (c *stderrCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.TrimSpace(c.buf.String())
+}
+
+// drainStderr consumes r in the background into a bounded buffer. The returned
+// channel is closed once r reaches EOF, which is the signal that the pipe is
+// drained and cmd.Wait may run.
+func drainStderr(r io.Reader) (*stderrCapture, <-chan struct{}) {
+	capture := &stderrCapture{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			capture.writeLine(sc.Text())
+		}
+	}()
+	return capture, done
+}
+
+// scanLines feeds r's lines to a buffered channel in the background, closing it
+// at EOF. Lines up to 1MB are tolerated; anything longer ends the scan.
+func scanLines(r io.Reader) <-chan string {
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, 256*1024), 1024*1024) // up to 1MB lines
+		for sc.Scan() {
+			lines <- sc.Text()
+		}
+	}()
+	return lines
+}
+
+// readEvents forwards the child's JSONL stdout as events until the stream ends
+// or the child goes quiet for longer than inactivity. It returns the
+// accumulated assistant text and whether the inactivity limit fired.
+//
+// On inactivity it cancels the process group itself and drains lines so the
+// scanner goroutine can exit; the caller must go straight to cmd.Wait.
+func (p *Process) readEvents(lines <-chan string, cancel context.CancelFunc, inactivity time.Duration) (string, bool) {
+	var resultBuilder strings.Builder
+
+	// The inactivity timer is what separates "slow" from "wedged". Without
+	// it the absolute cap is the only limit, so a long but productive agent
+	// is killed on the same rule as one that has hung — which is precisely
+	// the failure this fixes.
+	idle := NewInactivityTimer(inactivity)
+	defer idle.Stop()
+
+	timedOutIdle := false
+
+read:
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				break read
+			}
+			idle.Reset()
+			if line == "" {
+				continue
+			}
+
+			var ev jsonEvent
+			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				// Non-JSON output; emit as text.
+				p.sendEvent(Event{Type: "text_delta", Content: line})
+				continue
+			}
+
+			if ev.Type == "text_delta" {
+				resultBuilder.WriteString(ev.Delta)
+			}
+			p.sendEvent(ev.toEvent())
+
+		case <-idle.C():
+			timedOutIdle = true
+			cancel()          // kills the process group; stdout closes, so lines drains
+			for range lines { //nolint:revive // drain so the scanner goroutine can exit
+			}
+			break read
+		}
+	}
+
+	return resultBuilder.String(), timedOutIdle
+}
+
+// spawnFailure classifies how the child ended into the error Wait reports.
+// A nil result means it exited cleanly.
+//
+// A timeout is reported ahead of the exit status because it also arrives as a
+// signal kill — the process group is SIGKILLed — and would otherwise be
+// indistinguishable from a crash.
+func spawnFailure(cfg TimeoutConfig, timedOutIdle bool, procCtxErr, waitErr error, stderrStr string) error {
+	switch {
+	case timedOutIdle:
+		return fmt.Errorf("pi subagent produced no output for %s: %w (%s)",
+			cfg.Inactivity, ErrSubagentTimeout, timeoutHint)
+	case errors.Is(procCtxErr, context.DeadlineExceeded):
+		return fmt.Errorf("pi subagent exceeded its %s time limit: %w (%s)",
+			cfg.Absolute, ErrSubagentTimeout, timeoutHint)
+	case waitErr != nil && stderrStr != "":
+		return fmt.Errorf("pi process failed: %w: %s", waitErr, stderrStr)
+	case waitErr != nil:
+		return fmt.Errorf("pi process failed: %w", waitErr)
+	}
+	return nil
 }
 
 // sendEvent sends an event to the channel without blocking.
@@ -339,4 +399,25 @@ type jsonEvent struct {
 	ToolName  string `json:"tool_name,omitempty"`
 	ToolInput any    `json:"tool_input,omitempty"`
 	SessionID string `json:"session_id,omitempty"`
+}
+
+// toEvent maps a decoded child event onto the Event forwarded to the
+// orchestrator. Each known type carries a different field across, which is why
+// this is a switch and not a struct copy; an unknown type keeps its name and
+// whichever of delta/content the child populated.
+func (ev jsonEvent) toEvent() Event {
+	switch ev.Type {
+	case "text_delta":
+		return Event{Type: "text_delta", Content: ev.Delta}
+	case "tool_call":
+		return Event{Type: "tool_call", Content: ev.ToolName, ToolArgs: ev.ToolInput}
+	case "tool_result":
+		return Event{Type: "tool_result", Content: ev.Content}
+	case "message_start":
+		return Event{Type: "message_start", SessionID: ev.SessionID}
+	case "message_end":
+		return Event{Type: "message_end"}
+	default:
+		return Event{Type: ev.Type, Content: ev.Delta + ev.Content}
+	}
 }

--- a/internal/subagent/spawner_acp.go
+++ b/internal/subagent/spawner_acp.go
@@ -164,24 +164,14 @@ func pumpACPSession(sess acpSession, proc *Process, agentName string) {
 			sendProcEvent(proc, Event{Type: "message_start", SessionID: ev.SessionID})
 			sentStart = true
 		}
-		switch ev.Type {
-		case sharedacp.EventTypeMessage:
-			sendProcEvent(proc, Event{Type: "text_delta", Content: ev.Content, SessionID: ev.SessionID})
-			if !gracefulCompletion {
-				textAcc.WriteString(ev.Content)
-				if strings.Contains(textAcc.String(), acpCompletionMatcher) {
-					gracefulCompletion = true
-					_ = sess.Cancel()
-				}
+		sendProcEvent(proc, acpEventFor(ev))
+
+		if ev.Type == sharedacp.EventTypeMessage && !gracefulCompletion {
+			textAcc.WriteString(ev.Content)
+			if strings.Contains(textAcc.String(), acpCompletionMatcher) {
+				gracefulCompletion = true
+				_ = sess.Cancel()
 			}
-		case sharedacp.EventTypeProgress, sharedacp.EventTypeTool:
-			sendProcEvent(proc, Event{Type: "tool_call", Content: ev.Content, SessionID: ev.SessionID})
-		case sharedacp.EventTypeStderr:
-			sendProcEvent(proc, Event{Type: "stderr", Content: ev.Content, SessionID: ev.SessionID})
-		case sharedacp.EventTypeError:
-			sendProcEvent(proc, Event{Type: "error", Error: ev.Error, SessionID: ev.SessionID})
-		default:
-			sendProcEvent(proc, Event{Type: ev.Type, Content: ev.Content, SessionID: ev.SessionID})
 		}
 	}
 
@@ -192,44 +182,81 @@ func pumpACPSession(sess acpSession, proc *Process, agentName string) {
 	}
 
 	if gracefulCompletion {
-		// The Cancel() above will typically make the runner surface a kill
-		// error; override so the caller sees a clean completion and strip
-		// both the strict and the loose sentinel form from the final text.
-		result.Status = sharedacp.StatusSuccess
-		result.Error = ""
-		r := result.Result
-		r = strings.ReplaceAll(r, acpCompletionSentinel, "")
-		r = strings.ReplaceAll(r, acpCompletionMatcher, "")
-		result.Result = strings.TrimSpace(r)
+		result = applyGracefulCompletion(result)
 	}
 
+	// Capture the error text under the lock rather than re-reading proc.err
+	// after unlocking, so the send below touches no shared state.
 	proc.mu.Lock()
 	proc.result = result.Result
+	var errText string
 	if result.Status == sharedacp.StatusError {
-		errMsg := strings.TrimSpace(result.Error)
-		// Always append stderr for diagnostics, especially on timeout/kill.
-		// The RunResult may contain stderr content from the subprocess.
-		if result.Stderr != "" {
-			stderrMsg := strings.TrimSpace(result.Stderr)
-			if stderrMsg != "" {
-				if errMsg != "" {
-					errMsg = fmt.Sprintf("%s\nstderr: %s", errMsg, stderrMsg)
-				} else {
-					errMsg = fmt.Sprintf("stderr: %s", stderrMsg)
-				}
-			}
-		}
-		if errMsg == "" {
-			errMsg = "subprocess failed"
-		}
-		proc.err = fmt.Errorf("%s ACP %s", agentName, errMsg)
-		proc.mu.Unlock()
-		sendProcEvent(proc, Event{Type: "error", Error: proc.err.Error(), SessionID: result.SessionID})
-	} else {
-		proc.mu.Unlock()
+		proc.err = fmt.Errorf("%s ACP %s", agentName, acpErrorMessage(result))
+		errText = proc.err.Error()
+	}
+	proc.mu.Unlock()
+
+	if errText != "" {
+		sendProcEvent(proc, Event{Type: "error", Error: errText, SessionID: result.SessionID})
 	}
 
+	// message_end MUST stay the final send: consumers treat it as the terminal
+	// event of the stream. Do not add sends below this line.
 	sendProcEvent(proc, Event{Type: "message_end", SessionID: result.SessionID, StopReason: result.StopReason})
+}
+
+// acpEventFor maps an ACP session event onto the orchestrator Event that
+// carries it. Each kind moves a different field across, which is why this is a
+// switch and not a struct copy; an unknown kind keeps its own type name.
+func acpEventFor(ev sharedacp.Event) Event {
+	switch ev.Type {
+	case sharedacp.EventTypeMessage:
+		return Event{Type: "text_delta", Content: ev.Content, SessionID: ev.SessionID}
+	case sharedacp.EventTypeProgress, sharedacp.EventTypeTool:
+		return Event{Type: "tool_call", Content: ev.Content, SessionID: ev.SessionID}
+	case sharedacp.EventTypeStderr:
+		return Event{Type: "stderr", Content: ev.Content, SessionID: ev.SessionID}
+	case sharedacp.EventTypeError:
+		return Event{Type: "error", Error: ev.Error, SessionID: ev.SessionID}
+	default:
+		return Event{Type: ev.Type, Content: ev.Content, SessionID: ev.SessionID}
+	}
+}
+
+// applyGracefulCompletion rewrites a result whose agent announced it was done
+// via the <Task Completed>! sentinel. The sess.Cancel() that announcement
+// triggers will typically make the runner surface a kill error; override it so
+// the caller sees a clean completion, and strip both the strict and the loose
+// sentinel form from the final text.
+func applyGracefulCompletion(result sharedacp.RunResult) sharedacp.RunResult {
+	result.Status = sharedacp.StatusSuccess
+	result.Error = ""
+	r := result.Result
+	r = strings.ReplaceAll(r, acpCompletionSentinel, "")
+	r = strings.ReplaceAll(r, acpCompletionMatcher, "")
+	result.Result = strings.TrimSpace(r)
+	return result
+}
+
+// acpErrorMessage builds the diagnostic text for a failed ACP run. Stderr is
+// always appended when present — on a timeout or a kill it is often the only
+// thing that says what happened — and a run that failed with nothing to say at
+// all still gets a non-empty message.
+func acpErrorMessage(result sharedacp.RunResult) string {
+	errMsg := strings.TrimSpace(result.Error)
+	stderrMsg := strings.TrimSpace(result.Stderr)
+	switch {
+	case stderrMsg == "":
+		// nothing to append
+	case errMsg == "":
+		errMsg = fmt.Sprintf("stderr: %s", stderrMsg)
+	default:
+		errMsg = fmt.Sprintf("%s\nstderr: %s", errMsg, stderrMsg)
+	}
+	if errMsg == "" {
+		return "subprocess failed"
+	}
+	return errMsg
 }
 
 // sendProcEvent enqueues an event without blocking; events are dropped if

--- a/internal/subagent/worktree.go
+++ b/internal/subagent/worktree.go
@@ -109,6 +109,50 @@ func (m *WorktreeManager) popStashByMessage(msg string) error {
 	return nil
 }
 
+// stashBeforeWorktree stashes uncommitted changes in the primary checkout,
+// because `git worktree add HEAD` fails on a dirty tree. It reports the unique
+// stash message and whether an entry was actually created.
+//
+// Exit code semantics (stable across git versions and locales):
+//
+//	0   — changes stashed
+//	1   — nothing to stash (clean tree)
+//	128 — fatal (e.g. not a git repo, corrupt repo)
+//
+// "Did stash happen" is decided by counting stash entries before and after
+// rather than by string-matching the (locale-dependent) output.
+//
+// On success the entry deliberately SURVIVES: the caller records the message in
+// worktreeInfo so MergeBack/Cleanup can pop it later. Dropping it is the
+// caller's job on its own failure path — which is why this returns the flag
+// instead of offering a cleanup closure to defer.
+func (m *WorktreeManager) stashBeforeWorktree(agentID string) (string, bool, error) {
+	// Use -u to also stash untracked files.
+	stashMsg := stashMessage(agentID)
+	beforeCount, _ := m.stashIndexAfter()
+	stashOut, stashErr := m.git("stash", "push", "-u", "-m", stashMsg)
+	if stashErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(stashErr, &exitErr) || exitErr.ExitCode() != 1 {
+			return "", false, fmt.Errorf("git stash before worktree: %w (output: %s)", stashErr, stashOut)
+		}
+		// Nothing to stash — proceed without tracking a stash entry.
+		stashErr = nil
+	}
+	afterCount, _ := m.stashIndexAfter()
+	return stashMsg, stashErr == nil && afterCount > beforeCount, nil
+}
+
+// addWorktree runs `git worktree add`. A branch that already exists but is not
+// checked out anywhere is attached without `-b`; otherwise a fresh branch is
+// created from HEAD.
+func (m *WorktreeManager) addWorktree(branch, wtPath string, branchExists bool) (string, error) {
+	if branchExists {
+		return m.git("worktree", "add", wtPath, branch)
+	}
+	return m.git("worktree", "add", "-b", branch, wtPath, "HEAD")
+}
+
 // Create creates a new git worktree for the given agent ID.
 // If the current branch has uncommitted changes, they are stashed before
 // creating the worktree and tracked in `pendingStash` so that MergeBack
@@ -165,46 +209,17 @@ func (m *WorktreeManager) Create(agentID string, requestedName ...string) (strin
 		_ = os.RemoveAll(wtPath)
 	}
 
-	// Stash any uncommitted changes before creating the worktree.
-	// git worktree add HEAD fails if the working tree is dirty.
-	// Use -u to also stash untracked files.
-	//
-	// Exit code semantics (stable across git versions and locales):
-	//   0   — changes stashed
-	//   1   — nothing to stash (clean tree)
-	//   128 — fatal (e.g. not a git repo, corrupt repo)
-	//
-	// We detect "did stash happen" by counting stash entries before/after
-	// rather than by string-matching the (locale-dependent) output.
-	stashMsg := stashMessage(agentID)
-	beforeCount, _ := m.stashIndexAfter()
-	stashOut, stashErr := m.git("stash", "push", "-u", "-m", stashMsg)
-	if stashErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(stashErr, &exitErr) && exitErr.ExitCode() == 1 {
-			// Nothing to stash — proceed without tracking a stash entry.
-			stashErr = nil
-		} else {
-			return "", fmt.Errorf("git stash before worktree: %w (output: %s)", stashErr, stashOut)
-		}
-	}
-	afterCount, _ := m.stashIndexAfter()
-	stashedSomething := stashErr == nil && afterCount > beforeCount
-
-	// If the branch already exists but is not checked out anywhere, attach
-	// it without `-b`. Otherwise create a fresh branch from HEAD.
-	var out string
-	var err error
-	if branchExists {
-		out, err = m.git("worktree", "add", wtPath, branch)
-	} else {
-		out, err = m.git("worktree", "add", "-b", branch, wtPath, "HEAD")
-	}
+	stashMsg, stashedSomething, err := m.stashBeforeWorktree(agentID)
 	if err != nil {
-		// Restore stashed changes on failure. We do this regardless of
-		// whether `beforeCount` showed entries — if anything landed in
-		// the stash list, drop it so the user isn't left with orphaned
-		// entries after a failed Create.
+		return "", err
+	}
+
+	out, err := m.addWorktree(branch, wtPath, branchExists)
+	if err != nil {
+		// Drop the stash we just pushed, so the user isn't left with an
+		// orphaned entry after a failed Create. Only when stashBeforeWorktree
+		// reported it actually created one — a clean tree stashes nothing, and
+		// dropping then would discard some unrelated entry at stash@{0}.
 		if stashedSomething {
 			_, _ = m.git("stash", "drop", "--quiet", "stash@{0}")
 		}

--- a/internal/tools/compactor_bash.go
+++ b/internal/tools/compactor_bash.go
@@ -196,47 +196,68 @@ var goTestResultPattern = regexp.MustCompile(`^(ok|FAIL)\s+\S+\s+[\d.]+s`)
 // goTestFailPattern matches Go test failure output headers.
 var goTestFailPattern = regexp.MustCompile(`^--- FAIL: (\S+)`)
 
-// aggregateTestOutput compacts test output into a summary with failure details.
-func aggregateTestOutput(s string, cfg CompactorConfig) (string, bool) {
-	lines := strings.Split(s, "\n")
-	if len(lines) < 20 {
-		return s, false // too short to benefit
-	}
+// testRunSummary is what one scan of `go test` output yields: the counts, the
+// per-package result lines, and the captured detail for the first
+// MaxTestFailures failures. failedTests keeps counting past that cap so the
+// renderer can report how many failures were not shown.
+type testRunSummary struct {
+	passCount   int
+	failCount   int
+	skipCount   int
+	failedTests []string
+	failDetails []string
+	resultLines []string
+}
 
+// parsed reports whether the scan recognized the input as test output at all.
+// Only a package result line moves either counter, so an input with none of
+// them is something other than `go test` output and is left untouched.
+func (t testRunSummary) parsed() bool {
+	return t.passCount != 0 || t.failCount != 0
+}
+
+// scanTestOutput folds `go test` output into a summary. Failure detail is
+// captured as a run: a "--- FAIL:" header opens one and the next
+// MaxTestFailLines lines become its body, so any unrelated line in that window
+// — an "=== RUN" for the following test, say — is absorbed into the detail.
+func scanTestOutput(lines []string, cfg CompactorConfig) testRunSummary {
 	var (
-		passCount, failCount, skipCount int
-		failedTests                     []string
-		failDetails                     []string
-		resultLines                     []string
-		inFail                          bool
-		failLines                       int
-		currentFailDetail               []string
+		summary           testRunSummary
+		inFail            bool
+		failLines         int
+		currentFailDetail []string
 	)
+
+	// flushFail records the run that just ended, if there is still room. Note
+	// the asymmetry with failedTests, which is never capped: the cap limits how
+	// much detail is kept, not how many failures are counted.
+	flushFail := func() {
+		if len(currentFailDetail) > 0 && len(summary.failDetails) < cfg.MaxTestFailures {
+			summary.failDetails = append(summary.failDetails, strings.Join(currentFailDetail, "\n"))
+		}
+	}
 
 	for _, line := range lines {
 		// Go test result lines
 		if goTestResultPattern.MatchString(line) {
-			resultLines = append(resultLines, line)
+			summary.resultLines = append(summary.resultLines, line)
 			if strings.HasPrefix(line, "FAIL") {
-				failCount++
+				summary.failCount++
 			} else {
-				passCount++
+				summary.passCount++
 			}
 			continue
 		}
 
 		if strings.Contains(line, "--- SKIP") {
-			skipCount++
+			summary.skipCount++
 			continue
 		}
 
 		// Capture failure details
 		if m := goTestFailPattern.FindStringSubmatch(line); m != nil {
-			// Flush previous fail
-			if len(currentFailDetail) > 0 && len(failDetails) < cfg.MaxTestFailures {
-				failDetails = append(failDetails, strings.Join(currentFailDetail, "\n"))
-			}
-			failedTests = append(failedTests, m[1])
+			flushFail()
+			summary.failedTests = append(summary.failedTests, m[1])
 			currentFailDetail = []string{line}
 			inFail = true
 			failLines = 0
@@ -253,37 +274,51 @@ func aggregateTestOutput(s string, cfg CompactorConfig) (string, bool) {
 	}
 
 	// Flush last failure
-	if len(currentFailDetail) > 0 && len(failDetails) < cfg.MaxTestFailures {
-		failDetails = append(failDetails, strings.Join(currentFailDetail, "\n"))
-	}
+	flushFail()
+	return summary
+}
 
-	if passCount == 0 && failCount == 0 {
-		return s, false // couldn't parse test output
-	}
-
+// renderTestSummary formats a scanned summary as markdown. A section with
+// nothing to show is omitted entirely rather than rendered with an empty body.
+func renderTestSummary(summary testRunSummary, cfg CompactorConfig) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Test Summary: PASS=%d FAIL=%d SKIP=%d\n", passCount, failCount, skipCount)
+	fmt.Fprintf(&b, "Test Summary: PASS=%d FAIL=%d SKIP=%d\n",
+		summary.passCount, summary.failCount, summary.skipCount)
 
-	if len(failDetails) > 0 {
+	if len(summary.failDetails) > 0 {
 		fmt.Fprintf(&b, "\nFailure Details:\n")
-		for _, d := range failDetails {
+		for _, d := range summary.failDetails {
 			b.WriteString(d)
 			b.WriteString("\n\n")
 		}
-		if len(failedTests) > cfg.MaxTestFailures {
-			fmt.Fprintf(&b, "... and %d more failures\n", len(failedTests)-cfg.MaxTestFailures)
+		if len(summary.failedTests) > cfg.MaxTestFailures {
+			fmt.Fprintf(&b, "... and %d more failures\n", len(summary.failedTests)-cfg.MaxTestFailures)
 		}
 	}
 
-	if len(resultLines) > 0 {
+	if len(summary.resultLines) > 0 {
 		fmt.Fprintf(&b, "\nPackage Results:\n")
-		for _, r := range resultLines {
+		for _, r := range summary.resultLines {
 			b.WriteString(r)
 			b.WriteString("\n")
 		}
 	}
+	return b.String()
+}
 
-	result := b.String()
+// aggregateTestOutput compacts test output into a summary with failure details.
+func aggregateTestOutput(s string, cfg CompactorConfig) (string, bool) {
+	lines := strings.Split(s, "\n")
+	if len(lines) < 20 {
+		return s, false // too short to benefit
+	}
+
+	summary := scanTestOutput(lines, cfg)
+	if !summary.parsed() {
+		return s, false // couldn't parse test output
+	}
+
+	result := renderTestSummary(summary, cfg)
 	if len(result) >= len(s) {
 		return s, false
 	}
@@ -378,6 +413,54 @@ func aggregateLinterOutput(s string, cfg CompactorConfig) (string, bool) {
 	return result, true
 }
 
+// lineScore ranks a line by how much it would cost to drop: failures outrank
+// warnings, which outrank declarations, and blank lines are free to drop.
+func lineScore(line string) int {
+	lower := strings.ToLower(line)
+	switch {
+	// High priority: errors, failures, important markers
+	case strings.Contains(lower, "error"), strings.Contains(lower, "fail"),
+		strings.Contains(lower, "panic"), strings.Contains(lower, "fatal"):
+		return 10
+	case strings.Contains(lower, "warning"):
+		return 7
+	case strings.HasPrefix(line, "import"), strings.HasPrefix(line, "package"),
+		strings.HasPrefix(line, "func "), strings.HasPrefix(line, "type "):
+		return 5
+	case strings.TrimSpace(line) == "":
+		return 0 // blank lines are lowest priority
+	}
+	return 1 // default priority
+}
+
+// selectMiddle picks at most want lines out of the middle of the output,
+// scoring first and taking the high-priority lines before the rest. Blank
+// lines are dropped outright. A note recording how many lines were cut is
+// always appended, since the caller only reaches here when middle overflows.
+func selectMiddle(middle []string, want int) []string {
+	// Collect high-priority lines first
+	var highPri, lowPri []string
+	for _, line := range middle {
+		switch score := lineScore(line); {
+		case score >= 5:
+			highPri = append(highPri, line)
+		case score > 0:
+			lowPri = append(lowPri, line)
+		}
+	}
+
+	picked := make([]string, 0, want+1)
+	for _, group := range [][]string{highPri, lowPri} {
+		for _, line := range group {
+			if len(picked) >= want {
+				break
+			}
+			picked = append(picked, line)
+		}
+	}
+	return append(picked, fmt.Sprintf("... (%d lines omitted)", len(middle)-want))
+}
+
 // smartTruncate applies priority-based line selection to keep the most important content.
 func smartTruncate(s string, cfg CompactorConfig) (string, bool) {
 	lines := strings.Split(s, "\n")
@@ -385,87 +468,17 @@ func smartTruncate(s string, cfg CompactorConfig) (string, bool) {
 		return s, false
 	}
 
-	// Priority scoring: errors/failures > imports/declarations > other content
-	type scored struct {
-		line  string
-		score int
-	}
-
-	scoredLines := make([]scored, len(lines))
-	for i, line := range lines {
-		score := 1 // default priority
-		lower := strings.ToLower(line)
-
-		// High priority: errors, failures, important markers
-		if strings.Contains(lower, "error") || strings.Contains(lower, "fail") ||
-			strings.Contains(lower, "panic") || strings.Contains(lower, "fatal") {
-			score = 10
-		} else if strings.Contains(lower, "warning") {
-			score = 7
-		} else if strings.HasPrefix(line, "import") || strings.HasPrefix(line, "package") ||
-			strings.HasPrefix(line, "func ") || strings.HasPrefix(line, "type ") {
-			score = 5
-		} else if strings.TrimSpace(line) == "" {
-			score = 0 // blank lines are lowest priority
-		}
-
-		scoredLines[i] = scored{line: line, score: score}
-	}
-
-	// Keep first and last 10% unconditionally for context
+	// Keep first and last 10% unconditionally for context. Because the guard
+	// above already established len(lines) > MaxLines, the middle always
+	// overflows and always needs selecting.
 	headSize := cfg.MaxLines / 10
 	tailSize := cfg.MaxLines / 10
 	middleSize := cfg.MaxLines - headSize - tailSize
 
-	var result []string
-
-	// Head
-	for i := 0; i < headSize && i < len(scoredLines); i++ {
-		result = append(result, scoredLines[i].line)
-	}
-
-	// Middle: select by priority
-	middle := scoredLines[headSize : len(scoredLines)-tailSize]
-	if len(middle) > middleSize {
-		// Collect high-priority lines first
-		var highPri, lowPri []string
-		for _, sl := range middle {
-			if sl.score >= 5 {
-				highPri = append(highPri, sl.line)
-			} else if sl.score > 0 {
-				lowPri = append(lowPri, sl.line)
-			}
-		}
-		remaining := middleSize
-		for _, l := range highPri {
-			if remaining <= 0 {
-				break
-			}
-			result = append(result, l)
-			remaining--
-		}
-		for _, l := range lowPri {
-			if remaining <= 0 {
-				break
-			}
-			result = append(result, l)
-			remaining--
-		}
-		if remaining < len(middle)-len(result)+headSize {
-			result = append(result, fmt.Sprintf("... (%d lines omitted)", len(middle)-middleSize))
-		}
-	} else {
-		for _, sl := range middle {
-			result = append(result, sl.line)
-		}
-	}
-
-	// Tail
-	for i := len(scoredLines) - tailSize; i < len(scoredLines); i++ {
-		if i >= 0 {
-			result = append(result, scoredLines[i].line)
-		}
-	}
+	result := make([]string, 0, cfg.MaxLines+1)
+	result = append(result, lines[:headSize]...)
+	result = append(result, selectMiddle(lines[headSize:len(lines)-tailSize], middleSize)...)
+	result = append(result, lines[len(lines)-tailSize:]...)
 
 	output := strings.Join(result, "\n")
 	return output, len(output) < len(s)

--- a/internal/tools/compactor_test.go
+++ b/internal/tools/compactor_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // ---------------------------------------------------------------------------
@@ -1432,5 +1434,563 @@ func TestBuildCompactorCallback_KnownToolCompacts(t *testing.T) {
 	summary := metrics.Summary()
 	if summary.TotalOrig == 0 {
 		t.Errorf("expected compactor metrics to record compaction, got empty summary")
+	}
+}
+
+func TestLineScore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want int
+	}{
+		{"error anywhere", "  the ERROR was here", 10},
+		{"fail substring", "--- FAIL: TestX", 10},
+		{"failure counts as fail", "one failure", 10},
+		{"panic", "panic: nil deref", 10},
+		{"fatal", "Fatal: cannot continue", 10},
+		{"error outranks warning", "warning: error inside", 10},
+		{"warning", "warning: deprecated", 7},
+		{"warning outranks declaration", "package with a Warning", 7},
+		{"import declaration", `import "fmt"`, 5},
+		{"package declaration", "package tools", 5},
+		{"func needs trailing space", "func Foo() {", 5},
+		{"type needs trailing space", "type Bar struct {", 5},
+		{"declaration prefix is case sensitive", "Package tools", 1},
+		{"bare func is not a declaration", "func", 1},
+		{"declaration must be at line start", "  func Foo() {", 1},
+		{"empty line", "", 0},
+		{"whitespace-only line", " \t ", 0},
+		{"plain line", "ok  pkg  0.1s", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := lineScore(tt.line); got != tt.want {
+				t.Errorf("lineScore(%q) = %d, want %d", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectMiddle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		middle []string
+		want   int
+		out    []string
+	}{
+		{
+			name:   "high priority wins over plain lines",
+			middle: []string{"a", "b", "error: x", "c"},
+			want:   2,
+			out:    []string{"error: x", "a", "... (2 lines omitted)"},
+		},
+		{
+			name:   "blank lines are dropped entirely",
+			middle: []string{"", "  ", "keep"},
+			want:   2,
+			out:    []string{"keep", "... (1 lines omitted)"},
+		},
+		{
+			name:   "want zero keeps nothing but the note",
+			middle: []string{"error: x", "a"},
+			want:   0,
+			out:    []string{"... (2 lines omitted)"},
+		},
+		{
+			name:   "note counts against want, not against what was kept",
+			middle: []string{"", "", "a"},
+			want:   1,
+			out:    []string{"a", "... (2 lines omitted)"},
+		},
+		{
+			name:   "original order preserved within a priority band",
+			middle: []string{"warning: w", "func F() {", "error: e"},
+			want:   3,
+			out:    []string{"warning: w", "func F() {", "error: e", "... (0 lines omitted)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := selectMiddle(tt.middle, tt.want)
+			if diff := cmp.Diff(tt.out, got); diff != "" {
+				t.Errorf("selectMiddle mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestSmartTruncate_Golden pins the exact composed output, so a change to the
+// head/middle/tail split shows up as a diff rather than a line-count check.
+func TestSmartTruncate_Golden(t *testing.T) {
+	t.Parallel()
+
+	var lines []string
+	for i := range 40 {
+		switch i % 7 {
+		case 3:
+			lines = append(lines, fmt.Sprintf("error: failure number %d occurred", i))
+		case 5:
+			lines = append(lines, "")
+		default:
+			lines = append(lines, fmt.Sprintf("ordinary output line number %d", i))
+		}
+	}
+
+	got, applied := smartTruncate(strings.Join(lines, "\n"), CompactorConfig{MaxLines: 20})
+	if !applied {
+		t.Fatal("smartTruncate(applied) = false, want true")
+	}
+
+	want := strings.Join([]string{
+		// Head: MaxLines/10 == 2 lines, kept verbatim.
+		"ordinary output line number 0",
+		"ordinary output line number 1",
+		// Middle: 16 slots, errors first, then plain lines; blanks dropped.
+		"error: failure number 3 occurred",
+		"error: failure number 10 occurred",
+		"error: failure number 17 occurred",
+		"error: failure number 24 occurred",
+		"error: failure number 31 occurred",
+		"ordinary output line number 2",
+		"ordinary output line number 4",
+		"ordinary output line number 6",
+		"ordinary output line number 7",
+		"ordinary output line number 8",
+		"ordinary output line number 9",
+		"ordinary output line number 11",
+		"ordinary output line number 13",
+		"ordinary output line number 14",
+		"ordinary output line number 15",
+		"ordinary output line number 16",
+		"... (20 lines omitted)",
+		// Tail: MaxLines/10 == 2 lines, kept verbatim.
+		"error: failure number 38 occurred",
+		"ordinary output line number 39",
+	}, "\n")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("smartTruncate mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestSmartTruncate_ReportsNotAppliedWhenOutputGrows pins a long-standing
+// quirk: applied is a byte-length comparison, so on a short input the omitted
+// note can make the result longer than the original and smartTruncate reports
+// false even though it dropped lines. Callers then keep the untruncated text.
+func TestSmartTruncate_ReportsNotAppliedWhenOutputGrows(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		"h0", "h1", "h2",
+		"plain a", "", "error: boom", "plain b", "warning: w",
+		"func F() {", "plain c", "", "plain d",
+		"t0", "t1", "t2",
+	}, "\n")
+
+	got, applied := smartTruncate(input, CompactorConfig{MaxLines: 12})
+	if applied {
+		t.Error("smartTruncate(applied) = true, want false when the result grows")
+	}
+	if len(got) <= len(input) {
+		t.Errorf("len(got) = %d, want > len(input) = %d", len(got), len(input))
+	}
+}
+
+// TestSmartTruncate_ShorterThanMaxLines covers the untouched path: the input is
+// returned byte-for-byte and applied is false.
+func TestSmartTruncate_ShorterThanMaxLines(t *testing.T) {
+	t.Parallel()
+
+	input := "a\nb\nc"
+	got, applied := smartTruncate(input, CompactorConfig{MaxLines: 3})
+	if applied || got != input {
+		t.Errorf("smartTruncate = (%q, %v), want (%q, false)", got, applied, input)
+	}
+}
+
+// aggTestLines builds a padded block of `go test` output. Padding exists only
+// to clear the 20-line floor; every pad line is an "=== RUN" line, which the
+// scanner treats as ordinary context.
+func aggTestLines(t *testing.T, head []string, padCount int, tail ...string) string {
+	t.Helper()
+	lines := append([]string(nil), head...)
+	for i := range padCount {
+		lines = append(lines, fmt.Sprintf("=== RUN   TestPad%d", i))
+	}
+	return strings.Join(append(lines, tail...), "\n")
+}
+
+// TestAggregateTestOutput_Golden pins the exact rendered report. The existing
+// tests only assert that a few substrings appear; this one fixes the layout,
+// the blank-line separators, and which input lines get swallowed into a
+// failure's detail block.
+func TestAggregateTestOutput_Golden(t *testing.T) {
+	t.Parallel()
+
+	input := aggTestLines(t, []string{
+		"=== RUN   TestA",
+		"--- PASS: TestA (0.00s)",
+		"=== RUN   TestB",
+		"--- FAIL: TestB (0.01s)",
+		"    b_test.go:15: expected 42, got 0",
+		"    b_test.go:16: more detail",
+		"=== RUN   TestC",
+		"--- SKIP: TestC (0.00s)",
+		"=== RUN   TestD",
+		"--- FAIL: TestD (0.02s)",
+		"    d_test.go:9: boom",
+	}, 12, "ok  \tpkg/foo\t0.5s", "FAIL\tpkg/bar\t0.1s")
+
+	got, applied := aggregateTestOutput(input, CompactorConfig{MaxTestFailures: 10, MaxTestFailLines: 8})
+	if !applied {
+		t.Fatal("aggregateTestOutput(applied) = false, want true")
+	}
+
+	want := strings.Join([]string{
+		"Test Summary: PASS=1 FAIL=1 SKIP=1",
+		"",
+		"Failure Details:",
+		// TestB's detail absorbs everything up to the next FAIL header,
+		// including unrelated "=== RUN" lines. Only "--- SKIP" is filtered.
+		"--- FAIL: TestB (0.01s)",
+		"    b_test.go:15: expected 42, got 0",
+		"    b_test.go:16: more detail",
+		"=== RUN   TestC",
+		"=== RUN   TestD",
+		"",
+		// TestD's detail runs to the MaxTestFailLines cap of 8.
+		"--- FAIL: TestD (0.02s)",
+		"    d_test.go:9: boom",
+		"=== RUN   TestPad0",
+		"=== RUN   TestPad1",
+		"=== RUN   TestPad2",
+		"=== RUN   TestPad3",
+		"=== RUN   TestPad4",
+		"=== RUN   TestPad5",
+		"=== RUN   TestPad6",
+		"",
+		"",
+		"Package Results:",
+		"ok  \tpkg/foo\t0.5s",
+		"FAIL\tpkg/bar\t0.1s",
+		"",
+	}, "\n")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("aggregateTestOutput mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestAggregateTestOutput_FailureCap pins the overflow note: detail is kept
+// for the first MaxTestFailures failures only, while the header count keeps
+// running so the "and N more" line stays honest.
+func TestAggregateTestOutput_FailureCap(t *testing.T) {
+	t.Parallel()
+
+	var head []string
+	for i := range 3 {
+		head = append(head,
+			fmt.Sprintf("--- FAIL: TestF%d (0.01s)", i),
+			fmt.Sprintf("    f_test.go:%d: detail", i))
+	}
+	input := aggTestLines(t, head, 16, "FAIL\tpkg/x\t0.1s")
+
+	got, applied := aggregateTestOutput(input, CompactorConfig{MaxTestFailures: 2, MaxTestFailLines: 8})
+	if !applied {
+		t.Fatal("aggregateTestOutput(applied) = false, want true")
+	}
+
+	want := strings.Join([]string{
+		"Test Summary: PASS=0 FAIL=1 SKIP=0",
+		"",
+		"Failure Details:",
+		"--- FAIL: TestF0 (0.01s)",
+		"    f_test.go:0: detail",
+		"",
+		"--- FAIL: TestF1 (0.01s)",
+		"    f_test.go:1: detail",
+		"",
+		"... and 1 more failures",
+		"",
+		"Package Results:",
+		"FAIL\tpkg/x\t0.1s",
+		"",
+	}, "\n")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("aggregateTestOutput mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestAggregateTestOutput_FailLineCap pins the per-failure line budget: once
+// MaxTestFailLines context lines are captured the run closes, and later lines
+// are dropped until the next failure header.
+func TestAggregateTestOutput_FailLineCap(t *testing.T) {
+	t.Parallel()
+
+	head := []string{"--- FAIL: TestLong (0.01s)"}
+	for i := range 5 {
+		head = append(head, fmt.Sprintf("    long_test.go:%d: line", i))
+	}
+	input := aggTestLines(t, head, 16, "FAIL\tpkg/y\t0.1s")
+
+	got, applied := aggregateTestOutput(input, CompactorConfig{MaxTestFailures: 10, MaxTestFailLines: 2})
+	if !applied {
+		t.Fatal("aggregateTestOutput(applied) = false, want true")
+	}
+
+	want := strings.Join([]string{
+		"Test Summary: PASS=0 FAIL=1 SKIP=0",
+		"",
+		"Failure Details:",
+		"--- FAIL: TestLong (0.01s)",
+		"    long_test.go:0: line",
+		"    long_test.go:1: line",
+		"",
+		"",
+		"Package Results:",
+		"FAIL\tpkg/y\t0.1s",
+		"",
+	}, "\n")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("aggregateTestOutput mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTestRunSummary_Parsed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		summary testRunSummary
+		want    bool
+	}{
+		{"empty", testRunSummary{}, false},
+		{"passes only", testRunSummary{passCount: 1}, true},
+		{"failures only", testRunSummary{failCount: 1}, true},
+		{"both", testRunSummary{passCount: 1, failCount: 1}, true},
+		{"skips alone do not count as parsed", testRunSummary{skipCount: 3}, false},
+		{
+			name:    "captured failure detail alone does not count as parsed",
+			summary: testRunSummary{failedTests: []string{"TestX"}, failDetails: []string{"..."}},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.summary.parsed(); got != tt.want {
+				t.Errorf("parsed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRenderTestSummary drives the renderer straight from struct literals,
+// which is the point of the scan/render split: no synthetic `go test` output
+// is needed to assert on formatting.
+func TestRenderTestSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		summary testRunSummary
+		cfg     CompactorConfig
+		want    string
+	}{
+		{
+			name:    "counts only, both optional sections omitted",
+			summary: testRunSummary{passCount: 3, failCount: 1, skipCount: 2},
+			cfg:     CompactorConfig{MaxTestFailures: 10},
+			want:    "Test Summary: PASS=3 FAIL=1 SKIP=2\n",
+		},
+		{
+			name: "failure details are separated by a blank line",
+			summary: testRunSummary{
+				failCount:   2,
+				failedTests: []string{"TestA", "TestB"},
+				failDetails: []string{"--- FAIL: TestA\n  detail a", "--- FAIL: TestB\n  detail b"},
+			},
+			cfg: CompactorConfig{MaxTestFailures: 10},
+			want: "Test Summary: PASS=0 FAIL=2 SKIP=0\n" +
+				"\nFailure Details:\n" +
+				"--- FAIL: TestA\n  detail a\n\n" +
+				"--- FAIL: TestB\n  detail b\n\n",
+		},
+		{
+			name: "overflow note counts headers beyond the detail cap",
+			summary: testRunSummary{
+				failCount:   5,
+				failedTests: []string{"T1", "T2", "T3", "T4", "T5"},
+				failDetails: []string{"--- FAIL: T1"},
+			},
+			cfg: CompactorConfig{MaxTestFailures: 1},
+			want: "Test Summary: PASS=0 FAIL=5 SKIP=0\n" +
+				"\nFailure Details:\n" +
+				"--- FAIL: T1\n\n" +
+				"... and 4 more failures\n",
+		},
+		{
+			name: "no overflow note when the headers fit the cap",
+			summary: testRunSummary{
+				failCount:   1,
+				failedTests: []string{"T1"},
+				failDetails: []string{"--- FAIL: T1"},
+			},
+			cfg: CompactorConfig{MaxTestFailures: 10},
+			want: "Test Summary: PASS=0 FAIL=1 SKIP=0\n" +
+				"\nFailure Details:\n" +
+				"--- FAIL: T1\n\n",
+		},
+		{
+			// Unreachable via aggregateTestOutput, which only gets here when a
+			// package result line was seen, but the renderer is now callable on
+			// its own so the guard is worth holding to.
+			name:    "package results are omitted when there are none",
+			summary: testRunSummary{passCount: 1},
+			cfg:     CompactorConfig{MaxTestFailures: 10},
+			want:    "Test Summary: PASS=1 FAIL=0 SKIP=0\n",
+		},
+		{
+			name:    "package results section",
+			summary: testRunSummary{passCount: 1, resultLines: []string{"ok  \tpkg/a\t0.1s"}},
+			cfg:     CompactorConfig{MaxTestFailures: 10},
+			want: "Test Summary: PASS=1 FAIL=0 SKIP=0\n" +
+				"\nPackage Results:\nok  \tpkg/a\t0.1s\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, renderTestSummary(tt.summary, tt.cfg)); diff != "" {
+				t.Errorf("renderTestSummary mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestScanTestOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// maxFailures overrides the detail cap; zero means the default of 10.
+		maxFailures int
+		lines       []string
+		want        testRunSummary
+	}{
+		{
+			name:  "no test lines at all",
+			lines: []string{"just", "some", "output"},
+			want:  testRunSummary{},
+		},
+		{
+			name:  "ok line counts as a pass",
+			lines: []string{"ok  \tpkg/a\t0.1s"},
+			want:  testRunSummary{passCount: 1, resultLines: []string{"ok  \tpkg/a\t0.1s"}},
+		},
+		{
+			name:  "FAIL line counts as a fail",
+			lines: []string{"FAIL\tpkg/a\t0.1s"},
+			want:  testRunSummary{failCount: 1, resultLines: []string{"FAIL\tpkg/a\t0.1s"}},
+		},
+		{
+			name:  "skips are counted but never captured",
+			lines: []string{"--- SKIP: TestA (0.00s)", "--- SKIP: TestB (0.00s)"},
+			want:  testRunSummary{skipCount: 2},
+		},
+		{
+			name:  "a failure header opens a run that the following lines fill",
+			lines: []string{"--- FAIL: TestA (0.01s)", "  detail one", "  detail two"},
+			want: testRunSummary{
+				failedTests: []string{"TestA"},
+				failDetails: []string{"--- FAIL: TestA (0.01s)\n  detail one\n  detail two"},
+			},
+		},
+		{
+			name: "the run closes at MaxTestFailLines and later lines are dropped",
+			lines: []string{
+				"--- FAIL: TestA (0.01s)",
+				"  one", "  two", "  three", "  dropped", "  also dropped",
+			},
+			want: testRunSummary{
+				failedTests: []string{"TestA"},
+				failDetails: []string{"--- FAIL: TestA (0.01s)\n  one\n  two\n  three"},
+			},
+		},
+		{
+			name: "a new header flushes the previous run",
+			lines: []string{
+				"--- FAIL: TestA (0.01s)", "  a detail",
+				"--- FAIL: TestB (0.02s)", "  b detail",
+			},
+			want: testRunSummary{
+				failedTests: []string{"TestA", "TestB"},
+				failDetails: []string{
+					"--- FAIL: TestA (0.01s)\n  a detail",
+					"--- FAIL: TestB (0.02s)\n  b detail",
+				},
+			},
+		},
+		{
+			name: "a skip inside an open run is counted, not captured",
+			lines: []string{
+				"--- FAIL: TestA (0.01s)", "  detail", "--- SKIP: TestS (0.00s)", "  more detail",
+			},
+			want: testRunSummary{
+				skipCount:   1,
+				failedTests: []string{"TestA"},
+				failDetails: []string{"--- FAIL: TestA (0.01s)\n  detail\n  more detail"},
+			},
+		},
+		{
+			// A package result line inside an open run is diverted to
+			// resultLines, so it never lands in the failure detail.
+			name: "a result line inside an open run is not captured as detail",
+			lines: []string{
+				"--- FAIL: TestA (0.01s)", "  detail", "FAIL\tpkg/a\t0.1s", "  more detail",
+			},
+			want: testRunSummary{
+				failCount:   1,
+				resultLines: []string{"FAIL\tpkg/a\t0.1s"},
+				failedTests: []string{"TestA"},
+				failDetails: []string{"--- FAIL: TestA (0.01s)\n  detail\n  more detail"},
+			},
+		},
+		{
+			name:        "detail beyond MaxTestFailures is dropped but headers keep counting",
+			maxFailures: 2,
+			lines: []string{
+				"--- FAIL: T1 (0.01s)", "  one",
+				"--- FAIL: T2 (0.01s)", "  two",
+				"--- FAIL: T3 (0.01s)", "  three",
+			},
+			want: testRunSummary{
+				failedTests: []string{"T1", "T2", "T3"},
+				failDetails: []string{"--- FAIL: T1 (0.01s)\n  one", "--- FAIL: T2 (0.01s)\n  two"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			maxFailures := tt.maxFailures
+			if maxFailures == 0 {
+				maxFailures = 10
+			}
+			cfg := CompactorConfig{MaxTestFailures: maxFailures, MaxTestFailLines: 3}
+			got := scanTestOutput(tt.lines, cfg)
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(testRunSummary{})); diff != "" {
+				t.Errorf("scanTestOutput mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -158,90 +158,116 @@ func grepHandler(sb *Sandbox, input GrepInput) (GrepOutput, error) {
 		// Fall back to Go implementation on error
 	}
 
-	// Build cache key including case-insensitive flag
-	cacheKey := input.Pattern
+	re, err := grepPattern(input)
+	if err != nil {
+		return GrepOutput{}, err
+	}
+
+	if !info.IsDir() {
+		return grepSingleFile(sb, re, searchPath), nil
+	}
+	return grepTree(sb, input, re, searchPath)
+}
+
+// grepPattern compiles the search pattern, reusing the shared cache. The
+// case-insensitive flag is part of the cache key because it is compiled into
+// the expression rather than applied at match time.
+func grepPattern(input GrepInput) (*regexp.Regexp, error) {
+	flags := ""
 	if input.CaseInsensitive {
-		cacheKey = "(?i)" + cacheKey
+		flags = "(?i)"
 	}
+	cacheKey := flags + input.Pattern
 
-	// Try cache first
-	re := grepRegexCache.get(cacheKey)
-	if re == nil {
-		flags := ""
-		if input.CaseInsensitive {
-			flags = "(?i)"
-		}
-		var err error
-		re, err = regexp.Compile(flags + input.Pattern)
-		if err != nil {
-			return GrepOutput{}, fmt.Errorf("invalid regex pattern: %w", err)
-		}
-		grepRegexCache.put(cacheKey, re)
+	if re := grepRegexCache.get(cacheKey); re != nil {
+		return re, nil
 	}
+	re, err := regexp.Compile(cacheKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex pattern: %w", err)
+	}
+	grepRegexCache.put(cacheKey, re)
+	return re, nil
+}
 
-	// Load .gitignore patterns
+// grepSingleFile searches one file. TotalMatches reports every match found
+// even when the returned slice is capped, so the caller can see what it lost.
+func grepSingleFile(sb *Sandbox, re *regexp.Regexp, path string) GrepOutput {
+	matches := grepFileSandbox(sb, re, path)
+	total := len(matches)
+	if len(matches) > maxGrepMatches {
+		matches = matches[:maxGrepMatches]
+	}
+	return GrepOutput{
+		Matches:      matches,
+		TotalMatches: total,
+		Truncated:    total > len(matches),
+	}
+}
+
+// grepTree walks searchPath through the sandbox FS, skipping ignored
+// directories and files. Walk errors are swallowed so one unreadable
+// directory does not cost the rest of the results.
+func grepTree(sb *Sandbox, input GrepInput, re *regexp.Regexp, searchPath string) (GrepOutput, error) {
+	// .gitignore is advisory here: an unreadable one means search everything.
 	patterns, err := sb.LoadGitignorePatterns()
 	if err != nil {
 		patterns = nil
 	}
 
+	// Use sandbox ReadDir recursively via fs.WalkDir on the Root's FS
+	rel, err := sb.Resolve(searchPath)
+	if err != nil {
+		return GrepOutput{}, err
+	}
+
 	var matches []GrepMatch
 	total := 0
-
-	if info.IsDir() {
-		walkFn := func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return nil // skip errors
-			}
-			if d.IsDir() {
-				if shouldSkipDir(d.Name()) {
-					return filepath.SkipDir
-				}
-				if shouldSkipPath(path, d, patterns) {
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			if shouldSkipPath(path, d, patterns) {
-				return nil
-			}
-			if input.Glob != "" {
-				matched, _ := filepath.Match(input.Glob, d.Name())
-				if !matched {
-					return nil
-				}
-			}
-			fileMatches := grepFileSandbox(sb, re, path)
-			total += len(fileMatches)
-			if len(matches) < maxGrepMatches {
-				remaining := maxGrepMatches - len(matches)
-				if len(fileMatches) > remaining {
-					fileMatches = fileMatches[:remaining]
-				}
-				matches = append(matches, fileMatches...)
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip errors
+		}
+		if d.IsDir() {
+			if shouldSkipDir(d.Name()) || shouldSkipPath(path, d, patterns) {
+				return filepath.SkipDir
 			}
 			return nil
 		}
-		// Use sandbox ReadDir recursively via fs.WalkDir on the Root's FS
-		fsys := sb.FS()
-		rel, resolveErr := sb.Resolve(searchPath)
-		if resolveErr != nil {
-			return GrepOutput{}, resolveErr
+		if skipGrepFile(input.Glob, path, d, patterns) {
+			return nil
 		}
-		_ = fs.WalkDir(fsys, rel, walkFn)
-	} else {
-		matches = grepFileSandbox(sb, re, searchPath)
-		total = len(matches)
-		if len(matches) > maxGrepMatches {
-			matches = matches[:maxGrepMatches]
+		fileMatches := grepFileSandbox(sb, re, path)
+		total += len(fileMatches)
+		if len(matches) < maxGrepMatches {
+			remaining := maxGrepMatches - len(matches)
+			if len(fileMatches) > remaining {
+				fileMatches = fileMatches[:remaining]
+			}
+			matches = append(matches, fileMatches...)
 		}
+		return nil
 	}
+	_ = fs.WalkDir(sb.FS(), rel, walkFn)
 
 	return GrepOutput{
 		Matches:      matches,
 		TotalMatches: total,
 		Truncated:    total > len(matches),
 	}, nil
+}
+
+// skipGrepFile reports whether a walked file is excluded from the search,
+// either by an ignore pattern or by the caller's glob. An empty glob matches
+// every file rather than none.
+func skipGrepFile(glob, path string, d fs.DirEntry, patterns []GitignorePattern) bool {
+	if shouldSkipPath(path, d, patterns) {
+		return true
+	}
+	if glob == "" {
+		return false
+	}
+	matched, _ := filepath.Match(glob, d.Name())
+	return !matched
 }
 
 func grepFileSandbox(sb *Sandbox, re *regexp.Regexp, path string) []GrepMatch {

--- a/internal/tools/grep_test.go
+++ b/internal/tools/grep_test.go
@@ -1,6 +1,11 @@
 package tools
 
 import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -162,4 +167,181 @@ func TestMaxGrepMatches(t *testing.T) {
 	if maxGrepMatches != 200 {
 		t.Errorf("maxGrepMatches = %d, want 200", maxGrepMatches)
 	}
+}
+
+func TestGrepPattern(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     GrepInput
+		wantMatch string
+		wantSkip  string
+		wantErr   bool
+	}{
+		{
+			name:      "plain pattern is case sensitive",
+			input:     GrepInput{Pattern: "Needle"},
+			wantMatch: "a Needle here",
+			wantSkip:  "a needle here",
+		},
+		{
+			name:      "case-insensitive flag is compiled in",
+			input:     GrepInput{Pattern: "Needle", CaseInsensitive: true},
+			wantMatch: "a needle here",
+			wantSkip:  "nothing",
+		},
+		{
+			name:    "invalid regex is an error",
+			input:   GrepInput{Pattern: "("},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re, err := grepPattern(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("grepPattern: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("grepPattern: %v", err)
+			}
+			if !re.MatchString(tt.wantMatch) {
+				t.Errorf("pattern did not match %q", tt.wantMatch)
+			}
+			if re.MatchString(tt.wantSkip) {
+				t.Errorf("pattern unexpectedly matched %q", tt.wantSkip)
+			}
+		})
+	}
+}
+
+// TestGrepPattern_CaseVariantsDoNotShareCacheEntry guards the cache key: the
+// case-insensitive flag is part of the compiled expression, so the sensitive
+// and insensitive forms of one pattern must not alias each other.
+func TestGrepPattern_CaseVariantsDoNotShareCacheEntry(t *testing.T) {
+	pattern := "GrepPatternCacheKeyProbe"
+
+	sensitive, err := grepPattern(GrepInput{Pattern: pattern})
+	if err != nil {
+		t.Fatalf("grepPattern: %v", err)
+	}
+	insensitive, err := grepPattern(GrepInput{Pattern: pattern, CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("grepPattern: %v", err)
+	}
+
+	lower := strings.ToLower(pattern)
+	if sensitive.MatchString(lower) {
+		t.Error("case-sensitive pattern matched the lowercased input")
+	}
+	if !insensitive.MatchString(lower) {
+		t.Error("case-insensitive pattern did not match the lowercased input")
+	}
+}
+
+// stubDirEntry is a minimal fs.DirEntry for exercising the skip decision
+// without touching the filesystem.
+type stubDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (e stubDirEntry) Name() string               { return e.name }
+func (e stubDirEntry) IsDir() bool                { return e.dir }
+func (e stubDirEntry) Type() fs.FileMode          { return 0 }
+func (e stubDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+
+func TestSkipGrepFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		glob string
+		path string
+		want bool
+	}{
+		{"empty glob keeps every file", "", "main.go", false},
+		{"matching glob keeps the file", "*.go", "main.go", false},
+		{"non-matching glob skips the file", "*.ts", "main.go", true},
+		{"glob matches the base name, not the path", "*.go", "sub/main.go", false},
+		{"brace glob is not supported by filepath.Match", "*.{ts,tsx}", "main.ts", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := stubDirEntry{name: filepath.Base(tt.path)}
+			if got := skipGrepFile(tt.glob, tt.path, d, nil); got != tt.want {
+				t.Errorf("skipGrepFile(%q, %q) = %v, want %v", tt.glob, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGrepHandler_SingleFile covers the non-directory branch, including the
+// cap: Matches is truncated to maxGrepMatches while TotalMatches still reports
+// everything found.
+func TestGrepHandler_SingleFile(t *testing.T) {
+	dir := t.TempDir()
+	sb := testSandbox(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "small.txt"),
+		[]byte("alpha\nbeta\nalpha again\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var big strings.Builder
+	for i := range maxGrepMatches + 50 {
+		fmt.Fprintf(&big, "hit %d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "big.txt"), []byte(big.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("under the cap", func(t *testing.T) {
+		out, err := grepHandler(sb, GrepInput{Pattern: "alpha", Path: "small.txt"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.TotalMatches != 2 || len(out.Matches) != 2 {
+			t.Fatalf("TotalMatches=%d len(Matches)=%d, want 2 and 2", out.TotalMatches, len(out.Matches))
+		}
+		if out.Truncated {
+			t.Error("Truncated = true, want false")
+		}
+		if out.Matches[0].Line != 1 || out.Matches[1].Line != 3 {
+			t.Errorf("line numbers = %d, %d, want 1, 3", out.Matches[0].Line, out.Matches[1].Line)
+		}
+	})
+
+	t.Run("over the cap", func(t *testing.T) {
+		out, err := grepHandler(sb, GrepInput{Pattern: "hit", Path: "big.txt"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Matches) != maxGrepMatches {
+			t.Errorf("len(Matches) = %d, want %d", len(out.Matches), maxGrepMatches)
+		}
+		if out.TotalMatches != maxGrepMatches+50 {
+			t.Errorf("TotalMatches = %d, want %d", out.TotalMatches, maxGrepMatches+50)
+		}
+		if !out.Truncated {
+			t.Error("Truncated = false, want true")
+		}
+	})
+
+	t.Run("missing path is an error", func(t *testing.T) {
+		if _, err := grepHandler(sb, GrepInput{Pattern: "x", Path: "nope.txt"}); err == nil {
+			t.Error("expected an error for a missing path")
+		}
+	})
+
+	t.Run("empty pattern is an error", func(t *testing.T) {
+		if _, err := grepHandler(sb, GrepInput{}); err == nil {
+			t.Error("expected an error for an empty pattern")
+		}
+	})
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -376,9 +376,8 @@ func (c *coercingTool) coerceArrayItem(arr []any, idx int, parentPath string) {
 	item := arr[idx]
 
 	// Check if array itself needs coercion (e.g., string -> array)
-	itemPath := parentPath
-	if c.jsonProps[itemPath] {
-		if coerced := c.tryCoerce(item, itemPath); coerced != nil {
+	if c.jsonProps[parentPath] {
+		if coerced := c.tryCoerce(item, parentPath); coerced != nil {
 			arr[idx] = coerced
 			item = coerced
 		}
@@ -388,33 +387,8 @@ func (c *coercingTool) coerceArrayItem(arr []any, idx int, parentPath string) {
 	switch vv := item.(type) {
 	case map[string]any:
 		// Array of objects - check each property against parent.$ paths
-		for nestedK, nestedV := range vv {
-			// Check both the nested key itself and parent.$ nestedK
-			nestedPath := parentPath + "." + nestedK
-			parentItemPath := parentPath + ".$." + nestedK
-
-			// Try to coerce using the full nested path
-			if c.intProps[nestedPath] || c.boolProps[nestedPath] || c.jsonProps[nestedPath] {
-				if coerced := c.tryCoerce(nestedV, nestedPath); coerced != nil {
-					vv[nestedK] = coerced
-				}
-			}
-			// Also check parent.$ paths (for array item properties)
-			if c.intProps[parentItemPath] || c.boolProps[parentItemPath] || c.jsonProps[parentItemPath] {
-				if coerced := c.tryCoerce(nestedV, parentItemPath); coerced != nil {
-					vv[nestedK] = coerced
-				}
-			}
-
-			// Recurse into nested objects/arrays
-			switch nv := vv[nestedK].(type) {
-			case map[string]any:
-				c.coerceValueAtKey(nv, nestedK)
-			case []any:
-				for i := range nv {
-					c.coerceArrayItem(nv, i, nestedPath)
-				}
-			}
+		for nestedK := range vv {
+			c.coerceItemField(vv, nestedK, parentPath)
 		}
 	case []any:
 		// Nested array
@@ -424,57 +398,123 @@ func (c *coercingTool) coerceArrayItem(arr []any, idx int, parentPath string) {
 	}
 }
 
+// coerceItemField coerces one field of an object that sits inside an array,
+// then recurses into whatever that field holds. The field is tried against two
+// candidate schema paths because collectFromSchema registers array item
+// properties under a ".$" segment as well as under the plain dotted path.
+func (c *coercingTool) coerceItemField(item map[string]any, key, parentPath string) {
+	nestedPath := parentPath + "." + key
+	parentItemPath := parentPath + ".$." + key
+
+	// Both passes read the ORIGINAL value rather than what the previous pass
+	// wrote, so a key registered under two different property classes ends up
+	// holding whatever the ".$" pass produced.
+	original := item[key]
+	for _, path := range [...]string{nestedPath, parentItemPath} {
+		if !c.intProps[path] && !c.boolProps[path] && !c.jsonProps[path] {
+			continue
+		}
+		if coerced := c.tryCoerce(original, path); coerced != nil {
+			item[key] = coerced
+		}
+	}
+
+	// Recurse into nested objects/arrays
+	switch nv := item[key].(type) {
+	case map[string]any:
+		c.coerceValueAtKey(nv, key)
+	case []any:
+		for i := range nv {
+			c.coerceArrayItem(nv, i, nestedPath)
+		}
+	}
+}
+
 // tryCoerce attempts to coerce a value based on the property path.
 // Returns the coerced value or nil if coercion was not applied.
 func (c *coercingTool) tryCoerce(val any, path string) any {
 	switch v := val.(type) {
 	case string:
-		if c.intProps[path] {
-			if i, err := strconv.ParseInt(v, 10, 64); err == nil {
-				return float64(i) // JSON numbers are float64 in Go maps
-			} else if f, err := strconv.ParseFloat(v, 64); err == nil {
-				return f
-			}
-		} else if c.boolProps[path] {
-			if b, err := strconv.ParseBool(v); err == nil {
-				return b
-			}
-		} else if c.jsonProps[path] {
-			// LLMs sometimes stringify JSON arrays/objects. Parse them back.
-			v = strings.TrimSpace(v)
-			if (strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]")) ||
-				(strings.HasPrefix(v, "{") && strings.HasSuffix(v, "}")) {
-				var parsed any
-				if err := json.Unmarshal([]byte(v), &parsed); err == nil {
-					return parsed
-				}
-			}
-		}
+		return c.coerceString(v, path)
 	case float64:
-		// Already float64 from JSON
+		// Already float64 from JSON.
 		return nil
 	case float32, int, int64, int32:
-		// Numbers - keep as-is for intProps, convert to float64
-		if c.intProps[path] {
-			switch n := v.(type) {
-			case float64:
-				return n
-			case float32:
-				return float64(n)
-			case int:
-				return float64(n)
-			case int64:
-				return float64(n)
-			case int32:
-				return float64(n)
-			}
+		if !c.intProps[path] {
+			return nil
 		}
+		return widenToFloat64(v)
 	case json.Number:
-		if c.intProps[path] {
-			if f, err := v.Float64(); err == nil {
-				return f
-			}
+		if !c.intProps[path] {
+			return nil
 		}
+		if f, err := v.Float64(); err == nil {
+			return f
+		}
+	}
+	return nil
+}
+
+// coerceString converts a stringified argument to the type its schema declares.
+// The property classes are tried in order, so a path registered in more than
+// one class is coerced as an integer first, then a bool, then JSON — and a
+// class that matches but cannot parse declines rather than falling through.
+func (c *coercingTool) coerceString(v, path string) any {
+	switch {
+	case c.intProps[path]:
+		return parseNumericString(v)
+	case c.boolProps[path]:
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+	case c.jsonProps[path]:
+		return parseStringifiedJSON(v)
+	}
+	return nil
+}
+
+// parseNumericString parses an integer-typed argument that arrived as a string,
+// falling back to a float parse so a value like "3.5" is still recovered.
+// Returns nil when the string is not a number at all.
+func parseNumericString(v string) any {
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return float64(i) // JSON numbers are float64 in Go maps
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return f
+	}
+	return nil
+}
+
+// parseStringifiedJSON parses an array or object that an LLM stringified.
+// Input that is not bracketed, or that fails to parse, is declined so the
+// caller keeps the original string.
+func parseStringifiedJSON(v string) any {
+	v = strings.TrimSpace(v)
+	bracketed := (strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]")) ||
+		(strings.HasPrefix(v, "{") && strings.HasSuffix(v, "}"))
+	if !bracketed {
+		return nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(v), &parsed); err != nil {
+		return nil
+	}
+	return parsed
+}
+
+// widenToFloat64 widens the numeric kinds a decoder can hand back to the
+// float64 that JSON object maps use. Returns nil for any other kind.
+func widenToFloat64(v any) any {
+	switch n := v.(type) {
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case int32:
+		return float64(n)
 	}
 	return nil
 }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
@@ -521,5 +523,285 @@ func TestAliasArgs_CommonLLMMistakes(t *testing.T) {
 				t.Errorf("aliasArgs: %s should be removed but still exists", tt.wantRemoved)
 			}
 		})
+	}
+}
+
+// TestTryCoerce characterizes every branch of tryCoerce: which value kinds are
+// converted for which property class, and which are declined (nil) so the
+// caller leaves the original value in place.
+func TestTryCoerce(t *testing.T) {
+	t.Parallel()
+
+	c := &coercingTool{
+		intProps:  map[string]bool{"n": true},
+		boolProps: map[string]bool{"b": true},
+		jsonProps: map[string]bool{"j": true},
+	}
+
+	tests := []struct {
+		name string
+		val  any
+		path string
+		want any
+	}{
+		// Strings against an integer property.
+		{"string int", "42", "n", float64(42)},
+		{"string negative int", "-7", "n", float64(-7)},
+		{"string float falls back to ParseFloat", "3.5", "n", 3.5},
+		{"string exponent falls back to ParseFloat", "1e3", "n", float64(1000)},
+		{"string non-numeric declined", "abc", "n", nil},
+		{"string empty declined", "", "n", nil},
+
+		// Strings against a boolean property.
+		{"string true", "true", "b", true},
+		{"string 1 is bool true", "1", "b", true},
+		{"string False", "False", "b", false},
+		{"string non-bool declined", "yes", "b", nil},
+
+		// Strings against a JSON property.
+		{"stringified array", `[1,2]`, "j", []any{float64(1), float64(2)}},
+		{"stringified object", `{"a":1}`, "j", map[string]any{"a": float64(1)}},
+		{"stringified array with surrounding space", "  [1]  ", "j", []any{float64(1)}},
+		{"malformed JSON array declined", `[1,`, "j", nil},
+		{"unbracketed JSON declined", `1,2`, "j", nil},
+		{"mismatched brackets declined", `[1}`, "j", nil},
+
+		// Strings against an unknown property.
+		{"unknown path declined", "42", "other", nil},
+
+		// Numbers.
+		{"float64 always declined", float64(1), "n", nil},
+		{"float64 declined for unknown path", float64(1), "other", nil},
+		{"int to float64", int(5), "n", float64(5)},
+		{"int32 to float64", int32(5), "n", float64(5)},
+		{"int64 to float64", int64(5), "n", float64(5)},
+		{"float32 to float64", float32(2.5), "n", float64(2.5)},
+		{"int declined for non-int prop", int(5), "b", nil},
+		{"json.Number to float64", json.Number("12"), "n", float64(12)},
+		{"json.Number invalid declined", json.Number("nope"), "n", nil},
+		{"json.Number declined for non-int prop", json.Number("12"), "b", nil},
+
+		// Everything else.
+		{"bool declined", true, "b", nil},
+		{"nil declined", nil, "n", nil},
+		{"slice declined", []any{1}, "j", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := c.tryCoerce(tt.val, tt.path)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("tryCoerce(%#v, %q) mismatch (-want +got):\n%s", tt.val, tt.path, diff)
+			}
+		})
+	}
+}
+
+// TestTryCoerce_PropClassPrecedence pins the else-if ordering: a path listed in
+// more than one class is coerced as an integer first, then bool, then JSON.
+func TestTryCoerce_PropClassPrecedence(t *testing.T) {
+	t.Parallel()
+
+	c := &coercingTool{
+		intProps:  map[string]bool{"x": true},
+		boolProps: map[string]bool{"x": true, "y": true},
+		jsonProps: map[string]bool{"x": true, "y": true},
+	}
+
+	// "1" parses as both an int and a bool; intProps wins.
+	if got := c.tryCoerce("1", "x"); got != float64(1) {
+		t.Errorf(`tryCoerce("1", "x") = %#v, want float64(1)`, got)
+	}
+	// "[1]" is valid JSON but not a bool; boolProps still shadows jsonProps, so
+	// the value is declined rather than parsed.
+	if got := c.tryCoerce("[1]", "y"); got != nil {
+		t.Errorf(`tryCoerce("[1]", "y") = %#v, want nil`, got)
+	}
+}
+
+// TestCoerceArrayItem characterizes the recursive array walk: which schema
+// paths reach an array element, and what happens to elements the walk cannot
+// name. Written against the existing behavior, quirks included.
+func TestCoerceArrayItem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tool *coercingTool
+		in   map[string]any
+		want map[string]any
+	}{
+		{
+			name: "array item properties match the parent.$ path",
+			tool: &coercingTool{intProps: map[string]bool{"tasks.$.depth": true}},
+			in:   map[string]any{"tasks": []any{map[string]any{"depth": "5"}}},
+			want: map[string]any{"tasks": []any{map[string]any{"depth": float64(5)}}},
+		},
+		{
+			name: "array item properties also match the plain dotted path",
+			tool: &coercingTool{intProps: map[string]bool{"tasks.depth": true}},
+			in:   map[string]any{"tasks": []any{map[string]any{"depth": "5"}}},
+			want: map[string]any{"tasks": []any{map[string]any{"depth": float64(5)}}},
+		},
+		{
+			name: "bool array item property",
+			tool: &coercingTool{boolProps: map[string]bool{"tasks.$.on": true}},
+			in:   map[string]any{"tasks": []any{map[string]any{"on": "true"}}},
+			want: map[string]any{"tasks": []any{map[string]any{"on": true}}},
+		},
+		{
+			name: "unregistered array item property is left alone",
+			tool: &coercingTool{intProps: map[string]bool{"other": true}},
+			in:   map[string]any{"tasks": []any{map[string]any{"depth": "5"}}},
+			want: map[string]any{"tasks": []any{map[string]any{"depth": "5"}}},
+		},
+		{
+			name: "every element of the array is visited",
+			tool: &coercingTool{intProps: map[string]bool{"tasks.$.depth": true}},
+			in: map[string]any{"tasks": []any{
+				map[string]any{"depth": "1"},
+				map[string]any{"depth": "2"},
+				map[string]any{"depth": "3"},
+			}},
+			want: map[string]any{"tasks": []any{
+				map[string]any{"depth": float64(1)},
+				map[string]any{"depth": float64(2)},
+				map[string]any{"depth": float64(3)},
+			}},
+		},
+		{
+			name: "scalar array elements are untouched without a json prop",
+			tool: &coercingTool{intProps: map[string]bool{"nums": true}},
+			in:   map[string]any{"nums": []any{"1", "2"}},
+			want: map[string]any{"nums": []any{"1", "2"}},
+		},
+		{
+			name: "a stringified object inside an array is parsed via the array's json prop",
+			tool: &coercingTool{jsonProps: map[string]bool{"tasks": true}},
+			in:   map[string]any{"tasks": []any{`{"a":1}`}},
+			want: map[string]any{"tasks": []any{map[string]any{"a": float64(1)}}},
+		},
+		{
+			name: "an element parsed from a string is then walked as an object",
+			tool: &coercingTool{
+				jsonProps: map[string]bool{"tasks": true},
+				intProps:  map[string]bool{"tasks.$.depth": true},
+			},
+			in:   map[string]any{"tasks": []any{`{"depth":"5"}`}},
+			want: map[string]any{"tasks": []any{map[string]any{"depth": float64(5)}}},
+		},
+		{
+			name: "arrays of arrays reuse the parent path for the inner elements",
+			tool: &coercingTool{intProps: map[string]bool{"grid.$.depth": true}},
+			in:   map[string]any{"grid": []any{[]any{map[string]any{"depth": "7"}}}},
+			want: map[string]any{"grid": []any{[]any{map[string]any{"depth": float64(7)}}}},
+		},
+		{
+			name: "an array nested under an array item property is walked",
+			tool: &coercingTool{intProps: map[string]bool{"tasks.steps.$.n": true}},
+			in: map[string]any{"tasks": []any{
+				map[string]any{"steps": []any{map[string]any{"n": "9"}}},
+			}},
+			want: map[string]any{"tasks": []any{
+				map[string]any{"steps": []any{map[string]any{"n": float64(9)}}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.tool.coerceArgs(tt.in)
+			if diff := cmp.Diff(tt.want, tt.in); diff != "" {
+				t.Errorf("coerceArgs mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestCoerceArrayItem_ObjectNestedInArrayItem pins a real quirk: when an array
+// element holds a nested object, the walk recurses with the PARENT's key
+// instead of iterating the child's own keys. So only a child field that
+// happens to repeat the parent key name is ever reached.
+func TestCoerceArrayItem_ObjectNestedInArrayItem(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a differently named child field is never visited", func(t *testing.T) {
+		t.Parallel()
+		c := &coercingTool{intProps: map[string]bool{
+			"depth": true, "opts.depth": true, "tasks.opts.depth": true, "tasks.$.opts.depth": true,
+		}}
+		m := map[string]any{"tasks": []any{
+			map[string]any{"opts": map[string]any{"depth": "5"}},
+		}}
+		c.coerceArgs(m)
+
+		opts := m["tasks"].([]any)[0].(map[string]any)["opts"].(map[string]any)
+		if opts["depth"] != "5" {
+			t.Errorf("depth = %#v, want the untouched string \"5\"; "+
+				"the nested-object recursion now reaches differently named fields", opts["depth"])
+		}
+	})
+
+	t.Run("a child field repeating the parent key name is visited", func(t *testing.T) {
+		t.Parallel()
+		c := &coercingTool{intProps: map[string]bool{"opts": true}}
+		m := map[string]any{"tasks": []any{
+			map[string]any{"opts": map[string]any{"opts": "5"}},
+		}}
+		c.coerceArgs(m)
+
+		opts := m["tasks"].([]any)[0].(map[string]any)["opts"].(map[string]any)
+		if opts["opts"] != float64(5) {
+			t.Errorf("opts.opts = %#v, want float64(5)", opts["opts"])
+		}
+	})
+}
+
+// TestCoerceArrayItem_BothPathsRegistered pins the double-coercion order: the
+// dotted path is applied first and the parent.$ path second, and the second
+// pass re-reads the ORIGINAL value rather than the result of the first. When
+// the two paths sit in different property classes the parent.$ class wins.
+func TestCoerceArrayItem_BothPathsRegistered(t *testing.T) {
+	t.Parallel()
+
+	c := &coercingTool{
+		intProps:  map[string]bool{"tasks.flag": true},
+		boolProps: map[string]bool{"tasks.$.flag": true},
+	}
+	m := map[string]any{"tasks": []any{map[string]any{"flag": "1"}}}
+	c.coerceArgs(m)
+
+	got := m["tasks"].([]any)[0].(map[string]any)["flag"]
+	if got != true {
+		t.Errorf("flag = %#v (%T), want bool true: the parent.$ pass runs second and overwrites", got, got)
+	}
+}
+
+// TestCoerceValueAtKey_NestedObject covers the top-level object recursion:
+// a nested map is walked key by key, and each key is matched against the bare
+// property name that collectFromSchema also registers for nested properties.
+func TestCoerceValueAtKey_NestedObject(t *testing.T) {
+	t.Parallel()
+
+	c := &coercingTool{
+		intProps:  map[string]bool{"depth": true},
+		boolProps: map[string]bool{"verbose": true},
+	}
+	m := map[string]any{"opts": map[string]any{
+		"depth":   "5",
+		"verbose": "true",
+		"name":    "keep me",
+	}}
+	c.coerceArgs(m)
+
+	want := map[string]any{"opts": map[string]any{
+		"depth":   float64(5),
+		"verbose": true,
+		"name":    "keep me",
+	}}
+	if diff := cmp.Diff(want, m); diff != "" {
+		t.Errorf("coerceArgs mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/tools/session_stats.go
+++ b/internal/tools/session_stats.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -81,62 +82,73 @@ func SessionStats(input SessionStatsInput) (SessionStatsOutput, error) {
 	return sessionStatsHandler(input)
 }
 
-func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
-	// Resolve session directory.
-	sessionDir := input.SessionDir
-	if sessionDir == "" {
+// sessionStatsSettings holds the resolved inputs for one scan: every optional
+// field of SessionStatsInput filled in with its default.
+type sessionStatsSettings struct {
+	dir           string
+	highToolCalls int
+	highTurns     int
+	hours         int
+	cutoff        time.Time
+}
+
+// resolveSessionStatsSettings fills in a default for every unset input field.
+// A non-positive threshold counts as unset, so a negative value from a model
+// does not disable the check it belongs to.
+func resolveSessionStatsSettings(input SessionStatsInput) (sessionStatsSettings, error) {
+	settings := sessionStatsSettings{
+		dir:           input.SessionDir,
+		highToolCalls: input.HighToolCalls,
+		highTurns:     input.HighTurns,
+		hours:         input.Hours,
+	}
+	if settings.dir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return SessionStatsOutput{}, fmt.Errorf("getting home dir: %w", err)
+			return sessionStatsSettings{}, fmt.Errorf("getting home dir: %w", err)
 		}
-		sessionDir = filepath.Join(home, ".pi-go", "sessions")
+		settings.dir = filepath.Join(home, ".pi-go", "sessions")
 	}
+	if settings.highToolCalls <= 0 {
+		settings.highToolCalls = 20
+	}
+	if settings.highTurns <= 0 {
+		settings.highTurns = 5
+	}
+	if settings.hours <= 0 {
+		settings.hours = 24
+	}
+	settings.cutoff = time.Now().Add(-time.Duration(settings.hours) * time.Hour)
+	return settings, nil
+}
 
-	// Resolve thresholds.
-	highToolCalls := input.HighToolCalls
-	if highToolCalls <= 0 {
-		highToolCalls = 20
-	}
-	highTurns := input.HighTurns
-	if highTurns <= 0 {
-		highTurns = 5
-	}
-
-	// Resolve lookback.
-	hours := input.Hours
-	if hours <= 0 {
-		hours = 24
-	}
-	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
-
-	// Scan session directories.
-	entries, err := os.ReadDir(sessionDir)
+// collectSessionStats analyzes every session directory touched since the
+// cutoff and returns the stats newest-first, alongside the sweep totals
+// gathered from the same files. Entries that are not directories, the archive
+// directory, and sessions with no readable events.jsonl are skipped.
+func collectSessionStats(settings sessionStatsSettings) ([]sessionStat, *sweepTotals, error) {
+	entries, err := os.ReadDir(settings.dir)
 	if err != nil {
-		return SessionStatsOutput{}, fmt.Errorf("reading sessions dir: %w", err)
+		return nil, nil, fmt.Errorf("reading sessions dir: %w", err)
 	}
 
 	var stats []sessionStat
 	totals := newSweepTotals()
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !entry.IsDir() || entry.Name() == "archive" {
 			continue
 		}
-		// Skip archive directory.
-		if entry.Name() == "archive" {
-			continue
-		}
-		eventsPath := filepath.Join(sessionDir, entry.Name(), "events.jsonl")
+		eventsPath := filepath.Join(settings.dir, entry.Name(), "events.jsonl")
 		info, err := os.Stat(eventsPath)
 		if err != nil {
 			continue
 		}
 		// Skip sessions older than cutoff.
-		if info.ModTime().Before(cutoff) {
+		if info.ModTime().Before(settings.cutoff) {
 			continue
 		}
 
-		stat := analyzeSessionFile(entry.Name(), eventsPath, highToolCalls, highTurns)
-		stats = append(stats, stat)
+		stats = append(stats, analyzeSessionFile(entry.Name(), eventsPath, settings.highToolCalls, settings.highTurns))
 		accumulateSweepFile(totals, eventsPath)
 	}
 
@@ -144,17 +156,75 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 	sort.Slice(stats, func(i, j int) bool {
 		return stats[i].LastTime.After(stats[j].LastTime)
 	})
+	return stats, totals, nil
+}
 
-	// Build report.
-	var b strings.Builder
-	totalAnomalous := 0
-	for _, s := range stats {
-		if len(s.Anomalies) > 0 {
-			totalAnomalous++
+// countAnomalousSessions reports how many sessions carry at least one anomaly.
+func countAnomalousSessions(stats []sessionStat) int {
+	n := 0
+	for _, stat := range stats {
+		if len(stat.Anomalies) > 0 {
+			n++
 		}
 	}
+	return n
+}
 
-	fmt.Fprintf(&b, "## Session Stats (last %d hours)\n\n", hours)
+// writeSessionTable appends the summary table. Unless all is set, sessions
+// without anomalies are counted in the header but omitted from the rows.
+func writeSessionTable(b *strings.Builder, stats []sessionStat, all bool) {
+	b.WriteString("| Session | Lines | Tool Calls | Turns | Errors | Duration | Anomalies |\n")
+	b.WriteString("|---------|-------|------------|-------|--------|----------|-----------|\n")
+	for _, s := range stats {
+		if !all && len(s.Anomalies) == 0 {
+			continue
+		}
+		dur := s.Duration.Truncate(time.Second)
+		anomalyStr := strings.Join(s.Anomalies, ", ")
+		if anomalyStr == "" {
+			anomalyStr = "—"
+		}
+		fmt.Fprintf(b, "| %s | %d | %d | %d | %d | %s | %s |\n",
+			s.ID, s.Lines, s.ToolCalls, s.Turns, s.Errors, dur, anomalyStr)
+	}
+}
+
+// writeAnomalyDetails appends the per-session breakdown for anomalous
+// sessions. Nothing at all is written — not even the heading — when every
+// session looks normal.
+func writeAnomalyDetails(b *strings.Builder, stats []sessionStat) {
+	anomalous := func(s sessionStat) bool { return len(s.Anomalies) > 0 }
+	if !slices.ContainsFunc(stats, anomalous) {
+		return
+	}
+
+	b.WriteString("\n### Anomaly Details\n\n")
+	for _, s := range stats {
+		if !anomalous(s) {
+			continue
+		}
+		fmt.Fprintf(b, "**%s**\n", s.ID)
+		fmt.Fprintf(b, "- Lines: %d, Tool calls: %d, Turns: %d, Errors: %d\n",
+			s.Lines, s.ToolCalls, s.Turns, s.Errors)
+		fmt.Fprintf(b, "- Duration: %s\n", s.Duration.Truncate(time.Second))
+		fmt.Fprintf(b, "- Anomalies: %s\n\n", strings.Join(s.Anomalies, "; "))
+	}
+}
+
+func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
+	settings, err := resolveSessionStatsSettings(input)
+	if err != nil {
+		return SessionStatsOutput{}, err
+	}
+
+	stats, totals, err := collectSessionStats(settings)
+	if err != nil {
+		return SessionStatsOutput{}, err
+	}
+
+	var b strings.Builder
+	totalAnomalous := countAnomalousSessions(stats)
+	fmt.Fprintf(&b, "## Session Stats (last %d hours)\n\n", settings.hours)
 	fmt.Fprintf(&b, "Scanned %d sessions, %d with anomalies.\n\n", len(stats), totalAnomalous)
 
 	if len(stats) == 0 {
@@ -166,50 +236,14 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 		}, nil
 	}
 
-	// Summary table.
-	b.WriteString("| Session | Lines | Tool Calls | Turns | Errors | Duration | Anomalies |\n")
-	b.WriteString("|---------|-------|------------|-------|--------|----------|-----------|\n")
-	for _, s := range stats {
-		if !input.All && len(s.Anomalies) == 0 {
-			continue
-		}
-		dur := s.Duration.Truncate(time.Second)
-		anomalyStr := strings.Join(s.Anomalies, ", ")
-		if anomalyStr == "" {
-			anomalyStr = "—"
-		}
-		fmt.Fprintf(&b, "| %s | %d | %d | %d | %d | %s | %s |\n",
-			s.ID, s.Lines, s.ToolCalls, s.Turns, s.Errors, dur, anomalyStr)
-	}
-
-	// Detailed breakdown for anomalous sessions.
-	hasAnomalies := false
-	for _, s := range stats {
-		if len(s.Anomalies) == 0 {
-			continue
-		}
-		hasAnomalies = true
-		break
-	}
-	if hasAnomalies {
-		b.WriteString("\n### Anomaly Details\n\n")
-		for _, s := range stats {
-			if len(s.Anomalies) == 0 {
-				continue
-			}
-			fmt.Fprintf(&b, "**%s**\n", s.ID)
-			fmt.Fprintf(&b, "- Lines: %d, Tool calls: %d, Turns: %d, Errors: %d\n",
-				s.Lines, s.ToolCalls, s.Turns, s.Errors)
-			fmt.Fprintf(&b, "- Duration: %s\n", s.Duration.Truncate(time.Second))
-			fmt.Fprintf(&b, "- Anomalies: %s\n\n", strings.Join(s.Anomalies, "; "))
-		}
-	}
+	writeSessionTable(&b, stats, input.All)
+	writeAnomalyDetails(&b, stats)
 
 	// The per-session table above says which runs look odd. These sections say
 	// what went wrong across all of them, what it cost, and whether the
 	// recording pipelines are alive — the questions a nightly check exists for.
 	renderSweep(&b, totals, len(stats))
-	renderPipelineHealth(&b, len(stats), cutoff)
+	renderPipelineHealth(&b, len(stats), settings.cutoff)
 
 	return SessionStatsOutput{
 		Content:           b.String(),
@@ -221,6 +255,33 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 	}, nil
 }
 
+// sessionEvent is the subset of an events.jsonl record the scan reads.
+type sessionEvent struct {
+	Content      any    `json:"Content"`
+	Partial      bool   `json:"Partial"`
+	TurnComplete bool   `json:"TurnComplete"`
+	Interrupted  bool   `json:"Interrupted"`
+	ErrorCode    string `json:"ErrorCode"`
+	ErrorMessage string `json:"ErrorMessage"`
+	FinishReason string `json:"FinishReason"`
+	ID           string `json:"ID"`
+	Timestamp    string `json:"Timestamp"`
+	Author       string `json:"Author"`
+}
+
+// sessionCounters accumulates the tallies for one session file as its events
+// are scanned. The zero value is ready to use.
+type sessionCounters struct {
+	lines       int
+	toolCalls   int
+	toolResults int
+	turns       int
+	errors      int
+	gitOps      int
+	firstTS     time.Time
+	lastTS      time.Time
+}
+
 // analyzeSessionFile reads a single events.jsonl and computes stats.
 func analyzeSessionFile(sessionID, path string, highToolCalls, highTurns int) sessionStat {
 	f, err := os.Open(path)
@@ -229,117 +290,132 @@ func analyzeSessionFile(sessionID, path string, highToolCalls, highTurns int) se
 	}
 	defer f.Close()
 
-	stat := sessionStat{ID: sessionID}
+	var c sessionCounters
 	scanner := bufio.NewScanner(f)
 	// Increase scan buffer for potentially large JSON lines.
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
-
-	var firstTS, lastTS time.Time
-	var toolCallCount, toolResultCount, turnCount, errorCount, gitOpCount int
-	var lineCount int
-
 	for scanner.Scan() {
-		line := scanner.Bytes()
-		lineCount++
+		c.observe(scanner.Bytes())
+	}
 
-		// Parse the event.
-		var ev struct {
-			Content      any    `json:"Content"`
-			Partial      bool   `json:"Partial"`
-			TurnComplete bool   `json:"TurnComplete"`
-			Interrupted  bool   `json:"Interrupted"`
-			ErrorCode    string `json:"ErrorCode"`
-			ErrorMessage string `json:"ErrorMessage"`
-			FinishReason string `json:"FinishReason"`
-			ID           string `json:"ID"`
-			Timestamp    string `json:"Timestamp"`
-			Author       string `json:"Author"`
-		}
+	stat := c.stat(sessionID)
+	stat.Anomalies = sessionAnomalies(stat, highToolCalls, highTurns)
+	return stat
+}
 
-		if err := json.Unmarshal(line, &ev); err != nil {
+// observe folds one events.jsonl line into the running tallies. A line that is
+// not valid JSON still counts toward the line total, because the total
+// describes the file rather than the events that parsed out of it.
+func (c *sessionCounters) observe(line []byte) {
+	c.lines++
+
+	var ev sessionEvent
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return
+	}
+
+	c.observeTimestamp(ev.Timestamp)
+	c.observeParts(ev.Content)
+
+	// Count turns: TurnComplete events from the model.
+	if ev.TurnComplete && ev.Author != "user" {
+		c.turns++
+	}
+
+	// Count errors: a single event is at most one error, even if both
+	// ErrorCode/ErrorMessage and Interrupted are set.
+	if ev.ErrorCode != "" || ev.ErrorMessage != "" || ev.Interrupted {
+		c.errors++
+	}
+}
+
+// observeTimestamp widens the session time range. Absent and unparseable
+// timestamps are ignored rather than treated as the zero time.
+func (c *sessionCounters) observeTimestamp(raw string) {
+	if raw == "" {
+		return
+	}
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return
+	}
+	if c.firstTS.IsZero() || ts.Before(c.firstTS) {
+		c.firstTS = ts
+	}
+	if ts.After(c.lastTS) {
+		c.lastTS = ts
+	}
+}
+
+// observeParts counts the functionCall and functionResponse parts of one
+// event. Content is decoded as any because events.jsonl stores the wire form,
+// where each part is a single-key object.
+func (c *sessionCounters) observeParts(content any) {
+	contentMap, ok := content.(map[string]any)
+	if !ok {
+		return
+	}
+	parts, ok := contentMap["parts"].([]any)
+	if !ok {
+		return
+	}
+	for _, p := range parts {
+		pm, ok := p.(map[string]any)
+		if !ok {
 			continue
 		}
-
-		// Track time range.
-		if ev.Timestamp != "" {
-			ts, err := time.Parse(time.RFC3339Nano, ev.Timestamp)
-			if err == nil {
-				if firstTS.IsZero() || ts.Before(firstTS) {
-					firstTS = ts
-				}
-				if ts.After(lastTS) {
-					lastTS = ts
-				}
+		if fc, ok := pm["functionCall"].(map[string]any); ok {
+			c.toolCalls++
+			if isGitOperation(fc) {
+				c.gitOps++
 			}
 		}
-
-		// Count tool calls: events with FunctionCall parts in Content.
-		if ev.Content != nil {
-			contentMap, ok := ev.Content.(map[string]any)
-			if ok {
-				if parts, ok := contentMap["parts"].([]any); ok {
-					for _, p := range parts {
-						pm, ok := p.(map[string]any)
-						if !ok {
-							continue
-						}
-						if fc, ok := pm["functionCall"].(map[string]any); ok {
-							toolCallCount++
-							if isGitOperation(fc) {
-								gitOpCount++
-							}
-						}
-						if _, ok := pm["functionResponse"]; ok {
-							toolResultCount++
-						}
-					}
-				}
-			}
-		}
-
-		// Count turns: TurnComplete events from the model.
-		if ev.TurnComplete && ev.Author != "user" {
-			turnCount++
-		}
-
-		// Count errors: a single event is at most one error, even if both
-		// ErrorCode/ErrorMessage and Interrupted are set.
-		if ev.ErrorCode != "" || ev.ErrorMessage != "" || ev.Interrupted {
-			errorCount++
+		if _, ok := pm["functionResponse"]; ok {
+			c.toolResults++
 		}
 	}
+}
 
-	stat.Lines = lineCount
-	stat.ToolCalls = toolCallCount
-	stat.ToolResults = toolResultCount
-	stat.Turns = turnCount
-	stat.Errors = errorCount
-	stat.GitOps = gitOpCount
-	stat.FirstTime = firstTS
-	stat.LastTime = lastTS
-
-	if !firstTS.IsZero() && !lastTS.IsZero() {
-		stat.Duration = lastTS.Sub(firstTS)
+// stat converts the tallies into a sessionStat. Duration stays zero unless
+// both ends of the time range were seen.
+func (c *sessionCounters) stat(sessionID string) sessionStat {
+	stat := sessionStat{
+		ID:          sessionID,
+		Lines:       c.lines,
+		ToolCalls:   c.toolCalls,
+		ToolResults: c.toolResults,
+		Turns:       c.turns,
+		Errors:      c.errors,
+		GitOps:      c.gitOps,
+		FirstTime:   c.firstTS,
+		LastTime:    c.lastTS,
 	}
-
-	// Detect anomalies.
-	if toolCallCount > highToolCalls {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("high tool calls (%d)", toolCallCount))
+	if !c.firstTS.IsZero() && !c.lastTS.IsZero() {
+		stat.Duration = c.lastTS.Sub(c.firstTS)
 	}
-	if turnCount > highTurns {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("excessive turns (%d)", turnCount))
-	}
-	if errorCount > 0 {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("errors (%d)", errorCount))
-	}
-	if gitOpCount > defaultHighGitOps {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("many git operations (%d)", gitOpCount))
-	}
-	if stat.Duration > 30*time.Minute && toolCallCount < 5 {
-		stat.Anomalies = append(stat.Anomalies, "long idle session")
-	}
-
 	return stat
+}
+
+// sessionAnomalies lists the reasons a session is worth a second look. The
+// order is the order the report prints them in; an empty result means normal.
+func sessionAnomalies(stat sessionStat, highToolCalls, highTurns int) []string {
+	var anomalies []string
+	if stat.ToolCalls > highToolCalls {
+		anomalies = append(anomalies, fmt.Sprintf("high tool calls (%d)", stat.ToolCalls))
+	}
+	if stat.Turns > highTurns {
+		anomalies = append(anomalies, fmt.Sprintf("excessive turns (%d)", stat.Turns))
+	}
+	if stat.Errors > 0 {
+		anomalies = append(anomalies, fmt.Sprintf("errors (%d)", stat.Errors))
+	}
+	if stat.GitOps > defaultHighGitOps {
+		anomalies = append(anomalies, fmt.Sprintf("many git operations (%d)", stat.GitOps))
+	}
+	if stat.Duration > 30*time.Minute && stat.ToolCalls < 5 {
+		anomalies = append(anomalies, "long idle session")
+	}
+	return anomalies
 }
 
 // isGitOperation reports whether a functionCall part represents a git

--- a/internal/tools/session_stats_test.go
+++ b/internal/tools/session_stats_test.go
@@ -2,11 +2,14 @@ package tools
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSessionStatsHandler(t *testing.T) {
@@ -724,4 +727,210 @@ func itoa(n int) string {
 		buf[i] = '-'
 	}
 	return string(buf[i:])
+}
+
+func TestResolveSessionStatsSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		input             SessionStatsInput
+		wantHighToolCalls int
+		wantHighTurns     int
+		wantHours         int
+	}{
+		{"all unset take defaults", SessionStatsInput{SessionDir: "/x"}, 20, 5, 24},
+		{
+			name:              "explicit values are kept",
+			input:             SessionStatsInput{SessionDir: "/x", HighToolCalls: 3, HighTurns: 2, Hours: 1},
+			wantHighToolCalls: 3, wantHighTurns: 2, wantHours: 1,
+		},
+		{
+			name:              "non-positive counts as unset",
+			input:             SessionStatsInput{SessionDir: "/x", HighToolCalls: -1, HighTurns: -1, Hours: -1},
+			wantHighToolCalls: 20, wantHighTurns: 5, wantHours: 24,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveSessionStatsSettings(tt.input)
+			if err != nil {
+				t.Fatalf("resolveSessionStatsSettings: %v", err)
+			}
+			if got.dir != tt.input.SessionDir {
+				t.Errorf("dir = %q, want %q", got.dir, tt.input.SessionDir)
+			}
+			if got.highToolCalls != tt.wantHighToolCalls {
+				t.Errorf("highToolCalls = %d, want %d", got.highToolCalls, tt.wantHighToolCalls)
+			}
+			if got.highTurns != tt.wantHighTurns {
+				t.Errorf("highTurns = %d, want %d", got.highTurns, tt.wantHighTurns)
+			}
+			if got.hours != tt.wantHours {
+				t.Errorf("hours = %d, want %d", got.hours, tt.wantHours)
+			}
+			wantCutoff := time.Now().Add(-time.Duration(tt.wantHours) * time.Hour)
+			if d := got.cutoff.Sub(wantCutoff); d > time.Minute || d < -time.Minute {
+				t.Errorf("cutoff = %v, want within a minute of %v", got.cutoff, wantCutoff)
+			}
+		})
+	}
+}
+
+// TestResolveSessionStatsSettings_DefaultDir covers the branch that derives the
+// session directory from the home directory when the input leaves it blank.
+func TestResolveSessionStatsSettings_DefaultDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	got, err := resolveSessionStatsSettings(SessionStatsInput{})
+	if err != nil {
+		t.Fatalf("resolveSessionStatsSettings: %v", err)
+	}
+	if want := filepath.Join(home, ".pi-go", "sessions"); got.dir != want {
+		t.Errorf("dir = %q, want %q", got.dir, want)
+	}
+}
+
+func TestSessionAnomalies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		stat sessionStat
+		want []string
+	}{
+		{"clean session", sessionStat{ToolCalls: 1, Turns: 1}, nil},
+		{"at threshold is not an anomaly", sessionStat{ToolCalls: 20, Turns: 5}, nil},
+		{"high tool calls", sessionStat{ToolCalls: 21}, []string{"high tool calls (21)"}},
+		{"excessive turns", sessionStat{ToolCalls: 1, Turns: 6}, []string{"excessive turns (6)"}},
+		{"a single error is flagged", sessionStat{ToolCalls: 1, Errors: 1}, []string{"errors (1)"}},
+		{
+			name: "git ops over the fixed threshold",
+			stat: sessionStat{ToolCalls: 1, GitOps: defaultHighGitOps + 1},
+			want: []string{fmt.Sprintf("many git operations (%d)", defaultHighGitOps+1)},
+		},
+		{
+			name: "long idle needs both a long duration and few calls",
+			stat: sessionStat{ToolCalls: 4, Duration: 31 * time.Minute},
+			want: []string{"long idle session"},
+		},
+		{
+			name: "long but busy is not idle",
+			stat: sessionStat{ToolCalls: 5, Duration: 31 * time.Minute},
+			want: nil,
+		},
+		{
+			name: "anomalies report in a fixed order",
+			stat: sessionStat{ToolCalls: 21, Turns: 6, Errors: 2, GitOps: 100},
+			want: []string{
+				"high tool calls (21)", "excessive turns (6)",
+				"errors (2)", "many git operations (100)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sessionAnomalies(tt.stat, 20, 5)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("sessionAnomalies mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCountAnomalousSessions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		stats []sessionStat
+		want  int
+	}{
+		{"no sessions", nil, 0},
+		{"all clean", []sessionStat{{ID: "a"}, {ID: "b"}}, 0},
+		{
+			name:  "mixed",
+			stats: []sessionStat{{ID: "a", Anomalies: []string{"x"}}, {ID: "b"}, {ID: "c", Anomalies: []string{"y", "z"}}},
+			want:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := countAnomalousSessions(tt.stats); got != tt.want {
+				t.Errorf("countAnomalousSessions = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteAnomalyDetails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes nothing when every session is clean", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		writeAnomalyDetails(&b, []sessionStat{{ID: "a"}, {ID: "b"}})
+		if b.Len() != 0 {
+			t.Errorf("wrote %q, want nothing (not even the heading)", b.String())
+		}
+	})
+
+	t.Run("lists only the anomalous sessions", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		writeAnomalyDetails(&b, []sessionStat{
+			{ID: "clean"},
+			{ID: "noisy", Lines: 4, ToolCalls: 3, Turns: 2, Errors: 1, Anomalies: []string{"errors (1)"}},
+		})
+		out := b.String()
+		if !strings.Contains(out, "### Anomaly Details") {
+			t.Errorf("missing heading in %q", out)
+		}
+		if !strings.Contains(out, "**noisy**") {
+			t.Errorf("missing anomalous session in %q", out)
+		}
+		if strings.Contains(out, "clean") {
+			t.Errorf("clean session should not appear in %q", out)
+		}
+	})
+}
+
+func TestWriteSessionTable(t *testing.T) {
+	t.Parallel()
+
+	stats := []sessionStat{
+		{ID: "clean", Duration: 2 * time.Second},
+		{ID: "noisy", Errors: 1, Anomalies: []string{"errors (1)"}},
+	}
+
+	t.Run("all=false lists only anomalous rows", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		writeSessionTable(&b, stats, false)
+		out := b.String()
+		if strings.Contains(out, "| clean |") {
+			t.Errorf("clean session should be omitted from %q", out)
+		}
+		if !strings.Contains(out, "| noisy |") {
+			t.Errorf("missing anomalous row in %q", out)
+		}
+	})
+
+	t.Run("all=true lists every row with an em dash for no anomalies", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		writeSessionTable(&b, stats, true)
+		out := b.String()
+		if !strings.Contains(out, "| clean | 0 | 0 | 0 | 0 | 2s | — |") {
+			t.Errorf("missing clean row in %q", out)
+		}
+	})
 }

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -636,7 +636,10 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 	}
 
 	dim := lipgloss.NewStyle().Foreground(p.Dim)
-	bullet := lipgloss.NewStyle().Foreground(p.Accent).Bold(true).Render("◉ ")
+	in := messageRenderInput{
+		palette: p,
+		bullet:  lipgloss.NewStyle().Foreground(p.Accent).Bold(true).Render("◉ "),
+	}
 	sepWidth := c.Width
 	if sepWidth < 20 {
 		sepWidth = 20
@@ -649,132 +652,22 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 	for i := range c.Messages {
 		msg := &c.Messages[i]
 
-		isLastAndStreaming := running && i == lastIdx
-		key := msg.renderKey(c.Width, c.ToolDisplay.CompactTools, i > 0, isLastAndStreaming, themeKey, c.ToolDisplay.BlinkOn)
+		in.streaming = running && i == lastIdx
+		// The rule above a user message only separates it from what came
+		// before, so the first message in the transcript gets none.
+		in.separator = ""
+		if i > 0 {
+			in.separator = separator
+		}
+
+		key := msg.renderKey(c.Width, c.ToolDisplay.CompactTools, i > 0, in.streaming, themeKey, c.ToolDisplay.BlinkOn)
 		if msg.renderCached && msg.renderCacheKey == key {
 			b.WriteString(msg.renderCache)
 			kinds = appendKind(kinds, kindOf(msg), strings.Count(msg.renderCache, "\n"))
 			continue
 		}
 
-		var msgBuf strings.Builder
-		switch msg.role {
-		case "user":
-			if i > 0 {
-				msgBuf.WriteString(separator)
-				msgBuf.WriteString("\n")
-			}
-			label := lipgloss.NewStyle().
-				Foreground(p.Primary).
-				Bold(true).
-				Render("> ")
-			msgBuf.WriteString(label)
-			contentWidth := c.Width - 3 // "> " = 3 visible chars
-			if contentWidth < 20 {
-				contentWidth = 20
-			}
-			wrapped := wordWrap(msg.content, contentWidth)
-			for j, line := range wrapped {
-				if j > 0 {
-					msgBuf.WriteString("\n   ")
-				}
-				msgBuf.WriteString(line)
-			}
-			msgBuf.WriteString("\n")
-
-		case "tool":
-			msgBuf.WriteString("\n")
-			msgBuf.WriteString(c.ToolDisplay.RenderToolMessage(*msg))
-
-		case "thinking":
-			if msg.content != "" {
-				thinkStyle := lipgloss.NewStyle().Foreground(p.Faint).Italic(true)
-				thinkBullet := lipgloss.NewStyle().Foreground(p.Faint).Render("💭 ")
-				msgBuf.WriteString("\n")
-				msgBuf.WriteString(thinkBullet)
-				// Show last few lines of thinking to keep it compact.
-				lines := strings.Split(msg.content, "\n")
-				maxLines := 6
-				if len(lines) > maxLines {
-					lines = lines[len(lines)-maxLines:]
-				}
-				// Content width accounting for the bullet prefix.
-				contentWidth := c.Width - 3 // "💭 " = 3 visible chars
-				if contentWidth < 20 {
-					contentWidth = 20
-				}
-				for j, line := range lines {
-					if j > 0 {
-						msgBuf.WriteString("   ")
-					}
-					// Wrap each line to fit available width.
-					wrapped := wordWrap(line, contentWidth)
-					for k, wl := range wrapped {
-						if k > 0 {
-							msgBuf.WriteString("\n")
-						}
-						msgBuf.WriteString(thinkStyle.Render(wl))
-					}
-					if j < len(lines)-1 {
-						msgBuf.WriteString("\n")
-					}
-				}
-				msgBuf.WriteString("\n")
-			}
-
-		case "assistant":
-			content := msg.content
-			if content == "" && isLastAndStreaming {
-				content = "..."
-			}
-			if content != "" {
-				msgBuf.WriteString("\n")
-				if msg.isError {
-					errStyle := lipgloss.NewStyle().Foreground(p.Error).Bold(true)
-					msgBuf.WriteString(errStyle.Render("✖ "))
-					// Provider errors carry the raw JSON body, which is far
-					// wider than the pane. Wrap it like the user/thinking
-					// blocks do — an error truncated by the terminal is barely
-					// better than the silent failure this replaces.
-					contentWidth := c.Width - 3 // "✖ " plus the hanging indent
-					if contentWidth < 20 {
-						contentWidth = 20
-					}
-					for j, line := range wordWrap(content, contentWidth) {
-						if j > 0 {
-							msgBuf.WriteString("\n   ")
-						}
-						msgBuf.WriteString(errStyle.Render(line))
-					}
-				} else if msg.isWarning {
-					// Peach, not Warning: the warning role is a yellow, and
-					// yellow is the classic light-theme casualty — it washes
-					// out to nothing on white. Orange carries the same "look
-					// here, but nothing broke" weight and stays legible on both
-					// backgrounds.
-					warnStyle := lipgloss.NewStyle().Foreground(p.Peach).Bold(true)
-					warnBullet := lipgloss.NewStyle().Foreground(p.Peach).Bold(true).Render("⚠ ")
-					msgBuf.WriteString(warnBullet)
-					msgBuf.WriteString(warnStyle.Render(content))
-				} else if msg.isMeta {
-					// A dim "Σ" prefix marks the line as a per-turn tally rather
-					// than the model's own words — the reply uses "◉", so the
-					// two must never be confusable.
-					metaStyle := lipgloss.NewStyle().Foreground(p.Dim)
-					msgBuf.WriteString(metaStyle.Render("Σ " + content))
-				} else if msg.preRendered {
-					msgBuf.WriteString(bullet)
-					msgBuf.WriteString(content)
-				} else {
-					msgBuf.WriteString(bullet)
-					rendered := c.RenderMarkdown(content)
-					msgBuf.WriteString(rendered)
-				}
-				msgBuf.WriteString("\n")
-			}
-		}
-
-		rendered := msgBuf.String()
+		rendered := c.renderMessageBody(msg, in)
 		b.WriteString(rendered)
 		kinds = appendKind(kinds, kindOf(msg), strings.Count(rendered, "\n"))
 
@@ -791,6 +684,164 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 	// lines between blocks — visually noisy when several subagents run in
 	// parallel. Collapse to at most one blank line between content.
 	return collapseBlankLines(b.String(), kinds)
+}
+
+// messageRenderInput is the per-message context a role renderer needs: the
+// resolved palette, the rule to draw above a user message (empty for the first
+// message in the transcript), the assistant's bullet, and whether this message
+// is the one currently streaming.
+type messageRenderInput struct {
+	palette   Palette
+	separator string
+	bullet    string
+	streaming bool
+}
+
+// renderMessageBody renders one message in the style its role calls for. A role
+// with nothing to show — an empty thinking block, an empty assistant turn that
+// is not streaming, an unrecognized role — renders no lines at all.
+func (c *ChatModel) renderMessageBody(msg *message, in messageRenderInput) string {
+	switch msg.role {
+	case "user":
+		return c.renderUserMessage(msg, in)
+	case "tool":
+		return "\n" + c.ToolDisplay.RenderToolMessage(*msg)
+	case "thinking":
+		return c.renderThinkingMessage(msg, in.palette)
+	case "assistant":
+		return c.renderAssistantMessage(msg, in)
+	default:
+		return ""
+	}
+}
+
+// renderUserMessage renders the "> " prompt block, hanging-indented under the
+// marker so wrapped lines stay aligned with the first.
+func (c *ChatModel) renderUserMessage(msg *message, in messageRenderInput) string {
+	var b strings.Builder
+	if in.separator != "" {
+		b.WriteString(in.separator)
+		b.WriteString("\n")
+	}
+	b.WriteString(lipgloss.NewStyle().
+		Foreground(in.palette.Primary).
+		Bold(true).
+		Render("> "))
+
+	for j, line := range wordWrap(msg.content, hangingContentWidth(c.Width)) {
+		if j > 0 {
+			b.WriteString("\n   ")
+		}
+		b.WriteString(line)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderThinkingMessage renders the last few lines of the model's reasoning
+// behind a 💭 bullet. Only a tail is shown, to keep the block compact.
+func (c *ChatModel) renderThinkingMessage(msg *message, p Palette) string {
+	if msg.content == "" {
+		return ""
+	}
+
+	thinkStyle := lipgloss.NewStyle().Foreground(p.Faint).Italic(true)
+	thinkBullet := lipgloss.NewStyle().Foreground(p.Faint).Render("💭 ")
+
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(thinkBullet)
+
+	lines := strings.Split(msg.content, "\n")
+	const maxLines = 6
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	// "💭 " is 3 visible cells, same reservation as the "> " block.
+	contentWidth := hangingContentWidth(c.Width)
+	for j, line := range lines {
+		if j > 0 {
+			b.WriteString("   ")
+		}
+		for k, wl := range wordWrap(line, contentWidth) {
+			if k > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(thinkStyle.Render(wl))
+		}
+		if j < len(lines)-1 {
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderAssistantMessage renders one assistant turn, wrapped in the blank lines
+// that separate it from its neighbors. An empty turn renders nothing unless it
+// is the one still streaming, which shows an ellipsis placeholder instead.
+func (c *ChatModel) renderAssistantMessage(msg *message, in messageRenderInput) string {
+	content := msg.content
+	if content == "" && in.streaming {
+		content = "..."
+	}
+	if content == "" {
+		return ""
+	}
+	return "\n" + c.assistantBody(msg, content, in) + "\n"
+}
+
+// assistantBody renders the assistant's content in whichever of the five styles
+// its flags select. The order matters: the flags are not mutually exclusive in
+// the type, and error outranks warning outranks tally.
+func (c *ChatModel) assistantBody(msg *message, content string, in messageRenderInput) string {
+	p := in.palette
+	switch {
+	case msg.isError:
+		return renderErrorBody(content, p, c.Width)
+	case msg.isWarning:
+		// Peach, not Warning: the warning role is a yellow, and yellow is the
+		// classic light-theme casualty — it washes out to nothing on white.
+		// Orange carries the same "look here, but nothing broke" weight and
+		// stays legible on both backgrounds.
+		warnStyle := lipgloss.NewStyle().Foreground(p.Peach).Bold(true)
+		return warnStyle.Render("⚠ ") + warnStyle.Render(content)
+	case msg.isMeta:
+		// A dim "Σ" prefix marks the line as a per-turn tally rather than the
+		// model's own words — the reply uses "◉", so the two must never be
+		// confusable.
+		return lipgloss.NewStyle().Foreground(p.Dim).Render("Σ " + content)
+	case msg.preRendered:
+		return in.bullet + content
+	default:
+		return in.bullet + c.RenderMarkdown(content)
+	}
+}
+
+// renderErrorBody wraps and styles a failed turn. Provider errors carry the raw
+// JSON body, which is far wider than the pane, so it wraps like the user and
+// thinking blocks do — an error truncated by the terminal is barely better than
+// the silent failure this replaces.
+func renderErrorBody(content string, p Palette, width int) string {
+	errStyle := lipgloss.NewStyle().Foreground(p.Error).Bold(true)
+
+	var b strings.Builder
+	b.WriteString(errStyle.Render("✖ "))
+	for j, line := range wordWrap(content, hangingContentWidth(width)) {
+		if j > 0 {
+			b.WriteString("\n   ")
+		}
+		b.WriteString(errStyle.Render(line))
+	}
+	return b.String()
+}
+
+// hangingContentWidth is the wrap width for a block behind a 2-cell marker and
+// a space ("> ", "💭 ", "✖ "), which the continuation lines re-indent under.
+// It never drops below 20: a pane too narrow to wrap into is better overflowed
+// than reduced to one word per line.
+func hangingContentWidth(width int) int {
+	return max(width-3, 20)
 }
 
 // appendKind records that a message opened n lines of output.

--- a/internal/tui/chat_message_body_test.go
+++ b/internal/tui/chat_message_body_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestHangingContentWidth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		width int
+		want  int
+	}{
+		// The marker ("> ", "💭 ", "✖ ") costs three cells on the first line and
+		// the continuation lines re-indent under it, so the wrap width is three
+		// less than the pane.
+		{name: "wide pane reserves the marker", width: 120, want: 117},
+		{name: "exactly at the floor", width: 23, want: 20},
+		{name: "below the floor stays at 20", width: 10, want: 20},
+		{name: "zero width stays at 20", width: 0, want: 20},
+		{name: "negative width stays at 20", width: -5, want: 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hangingContentWidth(tt.width); got != tt.want {
+				t.Errorf("hangingContentWidth(%d) = %d, want %d", tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderMessageBodyByRole(t *testing.T) {
+	t.Parallel()
+
+	in := messageRenderInput{palette: darkPalette, bullet: "◉ "}
+
+	tests := []struct {
+		name string
+		msg  message
+		want string // substring of the ANSI-stripped body; "" means no output
+	}{
+		{name: "user", msg: message{role: "user", content: "hello"}, want: "> hello"},
+		{name: "thinking", msg: message{role: "thinking", content: "pondering"}, want: "💭 pondering"},
+		{name: "assistant", msg: message{role: "assistant", content: "hi"}, want: "hi"},
+		{name: "tool", msg: message{role: "tool", tool: "bash", content: "ok"}, want: "bash"},
+		{name: "empty thinking renders nothing", msg: message{role: "thinking"}, want: ""},
+		{name: "empty assistant renders nothing", msg: message{role: "assistant"}, want: ""},
+		// An unrecognized role must claim no lines at all: the kinds slice is
+		// built from the line count, so a stray line would desync the minimap.
+		{name: "unknown role renders nothing", msg: message{role: "banana", content: "x"}, want: ""},
+		{name: "empty role renders nothing", msg: message{content: "x"}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewChatModel(nil)
+			c.Width = 80
+			c.ToolDisplay.Width = 80
+
+			got := ansi.Strip(c.renderMessageBody(&tt.msg, in))
+			if tt.want == "" {
+				if got != "" {
+					t.Errorf("renderMessageBody() = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("renderMessageBody() = %q, want it to contain %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The streaming placeholder only stands in for an assistant turn that has not
+// produced its first token yet.
+func TestRenderAssistantMessageStreamingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		content   string
+		streaming bool
+		want      string
+	}{
+		{name: "empty and streaming shows an ellipsis", content: "", streaming: true, want: "..."},
+		{name: "empty and idle shows nothing", content: "", streaming: false, want: ""},
+		{name: "content wins over the placeholder", content: "real", streaming: true, want: "real"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewChatModel(nil)
+			c.Width = 80
+			msg := message{role: "assistant", content: tt.content}
+			got := ansi.Strip(c.renderAssistantMessage(&msg,
+				messageRenderInput{palette: darkPalette, bullet: "◉ ", streaming: tt.streaming}))
+
+			if tt.want == "" {
+				if got != "" {
+					t.Errorf("renderAssistantMessage() = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("renderAssistantMessage() = %q, want it to contain %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The style flags are independent booleans on the message, so their precedence
+// has to be pinned: error outranks warning outranks tally outranks pre-rendered.
+func TestAssistantBodyFlagPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msg  message
+		want string
+	}{
+		{name: "plain", msg: message{}, want: "◉ plain text"},
+		{name: "pre-rendered skips markdown", msg: message{preRendered: true}, want: "◉ plain text"},
+		{name: "meta", msg: message{isMeta: true}, want: "Σ plain text"},
+		{name: "warning", msg: message{isWarning: true}, want: "⚠ plain text"},
+		{name: "error", msg: message{isError: true}, want: "✖ plain text"},
+		{name: "error beats warning", msg: message{isError: true, isWarning: true}, want: "✖ plain text"},
+		{name: "warning beats meta", msg: message{isWarning: true, isMeta: true}, want: "⚠ plain text"},
+		{name: "meta beats pre-rendered", msg: message{isMeta: true, preRendered: true}, want: "Σ plain text"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewChatModel(nil) // nil renderer: markdown passes through
+			c.Width = 80
+			got := ansi.Strip(c.assistantBody(&tt.msg, "plain text",
+				messageRenderInput{palette: darkPalette, bullet: "◉ "}))
+			if got != tt.want {
+				t.Errorf("assistantBody() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A provider error arrives as one very long JSON line. It has to wrap to the
+// pane and hang-indent under the ✖, or the terminal truncates it and the user
+// learns nothing about the failure.
+func TestRenderErrorBodyWrapsAndIndents(t *testing.T) {
+	t.Parallel()
+
+	content := strings.Repeat("failure detail ", 40)
+	got := ansi.Strip(renderErrorBody(content, darkPalette, 60))
+	lines := strings.Split(got, "\n")
+
+	if len(lines) < 2 {
+		t.Fatalf("expected the error to wrap, got one line: %q", got)
+	}
+	if !strings.HasPrefix(lines[0], "✖ ") {
+		t.Errorf("first line %q does not start with the error marker", lines[0])
+	}
+	for i, line := range lines[1:] {
+		if !strings.HasPrefix(line, "   ") {
+			t.Errorf("continuation line %d is not indented under the marker: %q", i+1, line)
+		}
+		if w := ansi.StringWidth(line); w > hangingContentWidth(60)+3 {
+			t.Errorf("continuation line %d is %d cells wide, wider than the pane: %q", i+1, w, line)
+		}
+	}
+}
+
+// Reasoning blocks can run long, so only the tail is shown.
+func TestRenderThinkingMessageShowsOnlyTheTail(t *testing.T) {
+	t.Parallel()
+
+	c := NewChatModel(nil)
+	c.Width = 80
+
+	msg := message{role: "thinking", content: "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8"}
+	got := ansi.Strip(c.renderThinkingMessage(&msg, darkPalette))
+
+	for _, dropped := range []string{"l1", "l2"} {
+		if strings.Contains(got, dropped) {
+			t.Errorf("expected %q to be trimmed from the head, got:\n%s", dropped, got)
+		}
+	}
+	for _, kept := range []string{"l3", "l4", "l5", "l6", "l7", "l8"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("expected %q to survive, got:\n%s", kept, got)
+		}
+	}
+}
+
+// The rule above a user message separates it from what came before, so the
+// first message in a transcript must not draw one.
+func TestRenderUserMessageSeparator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		separator string
+		wantRule  bool
+	}{
+		{name: "first message has no rule", separator: "", wantRule: false},
+		{name: "later message draws the rule", separator: strings.Repeat("─", 20), wantRule: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewChatModel(nil)
+			c.Width = 80
+			msg := message{role: "user", content: "hello"}
+			got := ansi.Strip(c.renderUserMessage(&msg,
+				messageRenderInput{palette: darkPalette, separator: tt.separator}))
+
+			if hasRule := strings.Contains(got, "─"); hasRule != tt.wantRule {
+				t.Errorf("separator drawn = %v, want %v; got %q", hasRule, tt.wantRule, got)
+			}
+			if !strings.Contains(got, "> hello") {
+				t.Errorf("missing the prompt marker in %q", got)
+			}
+		})
+	}
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -539,33 +539,46 @@ func saveModelToConfig(modelName, provider string) {
 }
 
 // formatContextUsage builds a context usage display similar to Claude Code's /context.
+//
+// Each section renders independently and returns "" when it has nothing to say,
+// so the body is a straight concatenation in display order.
 func (m *model) formatContextUsage() string {
+	rt := estimateRoleTokens(m.chatModel.Messages)
+
 	var b strings.Builder
-
-	// The breakdown answers "what is filling the window", which is the question
-	// a user asks before deciding what to trim. Lead with it.
-	if bd := m.cfg.ContextBreakdown; bd != nil {
-		used := int64(0)
-		window := int64(0)
-		if tt := m.cfg.TokenTracker; tt != nil {
-			used = tt.LastPromptTokens()
-			window = tt.ContextWindowSize()
-		}
-		if used == 0 {
-			used = estimateContextTokenCount(m.chatModel.Messages) + bd.FixedTotal()
-		}
-		if window <= 0 {
-			window = autoRangeWindow(used)
-		}
-		b.WriteString("*Context usage*\n\n")
-		b.WriteString(RenderContextBreakdown(
-			bd.withConversationFrom(used), window, min(m.chatWidth()-4, 64), m.palette))
-		b.WriteString("\n\n")
+	for _, section := range []string{
+		// The breakdown answers "what is filling the window", which is the
+		// question a user asks before deciding what to trim. Lead with it.
+		m.contextBreakdownSection(),
+		m.contextHeadlineSection(rt.total),
+		m.contextCategorySection(rt),
+		m.contextDailySection(),
+		m.contextWindowSection(),
+		m.contextSkillsSection(),
+		m.contextSubagentSection(),
+		m.contextCompactionSection(),
+	} {
+		b.WriteString(section)
 	}
+	return b.String()
+}
 
-	// Same estimate as the status bar's, split by role.
+// roleTokens is the conversation's estimated size, split by who produced it.
+// total is estimated from the combined character count rather than summed from
+// the three parts, so it matches the status bar's number exactly instead of
+// accumulating three separate roundings.
+type roleTokens struct {
+	user      int64
+	assistant int64
+	tool      int64
+	total     int64
+}
+
+// estimateRoleTokens splits the transcript by role. Anything that is neither a
+// user nor an assistant message counts as tool output.
+func estimateRoleTokens(msgs []message) roleTokens {
 	userChars, assistantChars, toolChars := 0, 0, 0
-	for _, msg := range m.chatModel.Messages {
+	for _, msg := range msgs {
 		size := messageChars(msg)
 		switch msg.role {
 		case "user":
@@ -576,16 +589,46 @@ func (m *model) formatContextUsage() string {
 			toolChars += size
 		}
 	}
-	totalTokens := estimateTokens(userChars + assistantChars + toolChars)
-	userTokens := estimateTokens(userChars)
-	assistantTokens := estimateTokens(assistantChars)
-	toolTokens := estimateTokens(toolChars)
+	return roleTokens{
+		user:      estimateTokens(userChars),
+		assistant: estimateTokens(assistantChars),
+		tool:      estimateTokens(toolChars),
+		total:     estimateTokens(userChars + assistantChars + toolChars),
+	}
+}
 
-	// Header.
-	b.WriteString("**Context Usage**\n\n")
+// contextBreakdownSection renders the segmented gauge attributing the window to
+// its origins. Empty when no breakdown was measured.
+func (m *model) contextBreakdownSection() string {
+	bd := m.cfg.ContextBreakdown
+	if bd == nil {
+		return ""
+	}
 
-	// Progress bar (20 blocks).
+	used, window := int64(0), int64(0)
+	if tt := m.cfg.TokenTracker; tt != nil {
+		used = tt.LastPromptTokens()
+		window = tt.ContextWindowSize()
+	}
+	if used == 0 {
+		used = estimateContextTokenCount(m.chatModel.Messages) + bd.FixedTotal()
+	}
+	if window <= 0 {
+		window = autoRangeWindow(used)
+	}
+
+	// The gauge is inset by 4 from the chat content width and capped at 64 so
+	// it stays a readable block on a wide terminal.
+	return "*Context usage*\n\n" + RenderContextBreakdown(
+		bd.withConversationFrom(used), window, min(m.chatWidth()-4, 64), m.palette) + "\n\n"
+}
+
+// contextHeadlineSection renders the header and the daily-budget bar beside the
+// model label. totalTokens is the estimated conversation size, used only when
+// there is no daily limit to measure against.
+func (m *model) contextHeadlineSection(totalTokens int64) string {
 	const barLen = 20
+
 	var usedBlocks int
 	var limitTokens int64
 	if tt := m.cfg.TokenTracker; tt != nil && tt.Limit() > 0 {
@@ -602,11 +645,13 @@ func (m *model) formatContextUsage() string {
 	}
 	bar := barGlyphs(usedBlocks, barLen)
 
-	// Model line with bar.
 	modelLabel := m.cfg.ModelName
 	if m.cfg.ProviderName != "" {
 		modelLabel = m.cfg.ProviderName + " | " + modelLabel
 	}
+
+	var b strings.Builder
+	b.WriteString("**Context Usage**\n\n")
 	if limitTokens > 0 {
 		tt := m.cfg.TokenTracker
 		fmt.Fprintf(&b, "`%s`  %s · %s/%s tokens (%.0f%%)\n\n",
@@ -616,141 +661,188 @@ func (m *model) formatContextUsage() string {
 		fmt.Fprintf(&b, "`%s`  %s · ctx ~%s tokens\n\n",
 			bar, modelLabel, formatTokenCount(totalTokens))
 	}
+	return b.String()
+}
 
-	// Category breakdown.
+// contextCategorySection lists the estimated per-role split of the transcript.
+func (m *model) contextCategorySection(rt roleTokens) string {
+	msgs := m.chatModel.Messages
+
+	var b strings.Builder
 	b.WriteString("*Estimated usage by category*\n")
 	fmt.Fprintf(&b, "- **User messages**: ~%s tokens (%d msgs)\n",
-		formatTokenCount(userTokens), countByRole(m.chatModel.Messages, "user"))
+		formatTokenCount(rt.user), countByRole(msgs, "user"))
 	fmt.Fprintf(&b, "- **Assistant messages**: ~%s tokens (%d msgs)\n",
-		formatTokenCount(assistantTokens), countByRole(m.chatModel.Messages, "assistant"))
+		formatTokenCount(rt.assistant), countByRole(msgs, "assistant"))
 	fmt.Fprintf(&b, "- **Tool calls**: ~%s tokens (%d calls)\n",
-		formatTokenCount(toolTokens), countByRole(m.chatModel.Messages, "tool"))
+		formatTokenCount(rt.tool), countByRole(msgs, "tool"))
 	fmt.Fprintf(&b, "- **Total context**: ~%s tokens (%d messages)\n",
-		formatTokenCount(totalTokens), len(m.chatModel.Messages))
-
-	// Daily token usage (actual, not estimated).
-	if tt := m.cfg.TokenTracker; tt != nil {
-		total := tt.TotalUsed()
-		if total > 0 {
-			b.WriteString("\n*Daily token usage*\n")
-			fmt.Fprintf(&b, "- **Consumed today**: %s tokens\n", formatTokenCount(total))
-			if tt.Limit() > 0 {
-				fmt.Fprintf(&b, "- **Remaining**: %s tokens\n", formatTokenCount(tt.Remaining()))
-			}
-		}
-	}
-
-	// Context window usage (from last LLM response).
-	if tt := m.cfg.TokenTracker; tt != nil && tt.LastPromptTokens() > 0 {
-		promptTokens := tt.LastPromptTokens()
-		ctxWindow := tt.ContextWindowSize()
-
-		b.WriteString("\n*Context window*\n")
-		if ctxWindow > 0 {
-			pct := tt.ContextPercentUsed()
-			freeTokens := ctxWindow - promptTokens
-			if freeTokens < 0 {
-				freeTokens = 0
-			}
-
-			const ctxBarLen = 20
-			ctxBar := barGlyphs(barFill(pct/100, ctxBarLen), ctxBarLen)
-
-			fmt.Fprintf(&b, "`%s`  %s / %s (%.0f%%)\n",
-				ctxBar,
-				formatTokenCount(promptTokens), formatTokenCount(ctxWindow), pct)
-			fmt.Fprintf(&b, "- **Used**: %s tokens\n", formatTokenCount(promptTokens))
-			fmt.Fprintf(&b, "- **Free**: %s tokens (%.0f%%)\n",
-				formatTokenCount(freeTokens), 100-pct)
-		} else {
-			fmt.Fprintf(&b, "- **Last prompt**: %s tokens (window size unknown)\n",
-				formatTokenCount(promptTokens))
-		}
-
-		// Prompt cache. Reported explicitly even at zero hits — a silent
-		// section reads the same whether caching works or is entirely absent.
-		b.WriteString("\n*Prompt cache*\n")
-		cached := tt.LastCachedTokens()
-		if cached > 0 {
-			fmt.Fprintf(&b, "- **Last request**: %s of %s prompt tokens cached (%.0f%%)\n",
-				formatTokenCount(cached), formatTokenCount(promptTokens),
-				float64(cached)/float64(promptTokens)*100)
-		} else {
-			b.WriteString("- **Last request**: no cache hit\n")
-		}
-		if today := tt.CachedTokensToday(); today > 0 {
-			fmt.Fprintf(&b, "- **Today**: %s tokens read from cache (%.0f%% of input)\n",
-				formatTokenCount(today), tt.CacheHitRateToday())
-		}
-		if prefix := tt.CachePrefixTokens(); prefix > 0 {
-			fmt.Fprintf(&b, "- **Stable prefix**: %s tokens · **body since**: %s tokens\n",
-				formatTokenCount(prefix), formatTokenCount(tt.BodyTokens()))
-		}
-	}
-
-	// Skills.
-	if len(m.cfg.Skills) > 0 {
-		b.WriteString("\n*Skills* ")
-		fmt.Fprintf(&b, "(%d loaded)\n", len(m.cfg.Skills))
-		// Stable, alphabetical listing for predictable /context output.
-		names := make([]string, 0, len(m.cfg.Skills))
-		byName := make(map[string]extension.Skill, len(m.cfg.Skills))
-		for _, s := range m.cfg.Skills {
-			names = append(names, s.Name)
-			byName[s.Name] = s
-		}
-		sort.Strings(names)
-		for _, name := range names {
-			s := byName[name]
-			source := s.Source
-			if source == "" {
-				source = "user"
-			}
-			var bodyDesc string
-			if size, ok := extension.SkillBodySize(m.cfg.Skills, s.Name); ok {
-				bodyDesc = fmt.Sprintf("body: %s", formatTokenCount(int64(size)))
-			} else {
-				bodyDesc = "body: not loaded"
-			}
-			desc := s.Description
-			if desc == "" {
-				desc = "(no description)"
-			}
-			fmt.Fprintf(&b, "- /%s — %s [%s]  %s\n", s.Name, desc, source, bodyDesc)
-		}
-	}
-
-	// Subagents.
-	if m.cfg.Orchestrator != nil {
-		agents := m.cfg.Orchestrator.List()
-		if len(agents) > 0 {
-			running, done, failed := 0, 0, 0
-			for _, a := range agents {
-				switch a.Status {
-				case "running":
-					running++
-				case "failed":
-					failed++
-				default:
-					done++
-				}
-			}
-			b.WriteString("\n*Subagents*\n")
-			fmt.Fprintf(&b, "- **Total**: %d (running: %d, done: %d, failed: %d)\n",
-				len(agents), running, done, failed)
-		}
-	}
-
-	// Compaction stats.
-	if cm := m.cfg.CompactMetrics; cm != nil {
-		stats := cm.FormatStats()
-		if stats != "" {
-			b.WriteString("\n*Output compaction*\n")
-			b.WriteString(stats)
-		}
-	}
-
+		formatTokenCount(rt.total), len(msgs))
 	return b.String()
+}
+
+// contextDailySection reports the day's actual (not estimated) consumption.
+func (m *model) contextDailySection() string {
+	tt := m.cfg.TokenTracker
+	if tt == nil {
+		return ""
+	}
+	total := tt.TotalUsed()
+	if total <= 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n*Daily token usage*\n")
+	fmt.Fprintf(&b, "- **Consumed today**: %s tokens\n", formatTokenCount(total))
+	if tt.Limit() > 0 {
+		fmt.Fprintf(&b, "- **Remaining**: %s tokens\n", formatTokenCount(tt.Remaining()))
+	}
+	return b.String()
+}
+
+// contextWindowSection reports the window occupancy of the last LLM response,
+// followed by the prompt-cache numbers for the same request.
+func (m *model) contextWindowSection() string {
+	tt := m.cfg.TokenTracker
+	if tt == nil || tt.LastPromptTokens() <= 0 {
+		return ""
+	}
+	promptTokens := tt.LastPromptTokens()
+	ctxWindow := tt.ContextWindowSize()
+
+	var b strings.Builder
+	b.WriteString("\n*Context window*\n")
+	if ctxWindow > 0 {
+		pct := tt.ContextPercentUsed()
+		freeTokens := max(ctxWindow-promptTokens, 0)
+
+		const ctxBarLen = 20
+		ctxBar := barGlyphs(barFill(pct/100, ctxBarLen), ctxBarLen)
+
+		fmt.Fprintf(&b, "`%s`  %s / %s (%.0f%%)\n",
+			ctxBar,
+			formatTokenCount(promptTokens), formatTokenCount(ctxWindow), pct)
+		fmt.Fprintf(&b, "- **Used**: %s tokens\n", formatTokenCount(promptTokens))
+		fmt.Fprintf(&b, "- **Free**: %s tokens (%.0f%%)\n",
+			formatTokenCount(freeTokens), 100-pct)
+	} else {
+		fmt.Fprintf(&b, "- **Last prompt**: %s tokens (window size unknown)\n",
+			formatTokenCount(promptTokens))
+	}
+	b.WriteString(contextCacheSection(tt, promptTokens))
+	return b.String()
+}
+
+// contextCacheSection reports prompt caching for the last request. It is
+// reported explicitly even at zero hits — a silent section reads the same
+// whether caching works or is entirely absent.
+func contextCacheSection(tt TokenTracker, promptTokens int64) string {
+	var b strings.Builder
+	b.WriteString("\n*Prompt cache*\n")
+
+	if cached := tt.LastCachedTokens(); cached > 0 {
+		fmt.Fprintf(&b, "- **Last request**: %s of %s prompt tokens cached (%.0f%%)\n",
+			formatTokenCount(cached), formatTokenCount(promptTokens),
+			float64(cached)/float64(promptTokens)*100)
+	} else {
+		b.WriteString("- **Last request**: no cache hit\n")
+	}
+	if today := tt.CachedTokensToday(); today > 0 {
+		fmt.Fprintf(&b, "- **Today**: %s tokens read from cache (%.0f%% of input)\n",
+			formatTokenCount(today), tt.CacheHitRateToday())
+	}
+	if prefix := tt.CachePrefixTokens(); prefix > 0 {
+		fmt.Fprintf(&b, "- **Stable prefix**: %s tokens · **body since**: %s tokens\n",
+			formatTokenCount(prefix), formatTokenCount(tt.BodyTokens()))
+	}
+	return b.String()
+}
+
+// contextSkillsSection lists the loaded skills alphabetically, so /context
+// output is stable between runs.
+func (m *model) contextSkillsSection() string {
+	if len(m.cfg.Skills) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n*Skills* ")
+	fmt.Fprintf(&b, "(%d loaded)\n", len(m.cfg.Skills))
+
+	names := make([]string, 0, len(m.cfg.Skills))
+	byName := make(map[string]extension.Skill, len(m.cfg.Skills))
+	for _, s := range m.cfg.Skills {
+		names = append(names, s.Name)
+		byName[s.Name] = s
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		s := byName[name]
+		source := s.Source
+		if source == "" {
+			source = "user"
+		}
+		bodyDesc := "body: not loaded"
+		if size, ok := extension.SkillBodySize(m.cfg.Skills, s.Name); ok {
+			bodyDesc = fmt.Sprintf("body: %s", formatTokenCount(int64(size)))
+		}
+		desc := s.Description
+		if desc == "" {
+			desc = "(no description)"
+		}
+		fmt.Fprintf(&b, "- /%s — %s [%s]  %s\n", s.Name, desc, source, bodyDesc)
+	}
+	return b.String()
+}
+
+// contextSubagentSection tallies spawned subagents by status.
+func (m *model) contextSubagentSection() string {
+	if m.cfg.Orchestrator == nil {
+		return ""
+	}
+	agents := m.cfg.Orchestrator.List()
+	if len(agents) == 0 {
+		return ""
+	}
+
+	running, done, failed := countAgentStatuses(agents)
+
+	var b strings.Builder
+	b.WriteString("\n*Subagents*\n")
+	fmt.Fprintf(&b, "- **Total**: %d (running: %d, done: %d, failed: %d)\n",
+		len(agents), running, done, failed)
+	return b.String()
+}
+
+// countAgentStatuses buckets subagent statuses into the three the summary
+// shows. Every status that is neither "running" nor "failed" — completed,
+// canceled, killed, timeout — counts as done.
+func countAgentStatuses(agents []subagent.AgentStatus) (running, done, failed int) {
+	for _, a := range agents {
+		switch a.Status {
+		case "running":
+			running++
+		case "failed":
+			failed++
+		default:
+			done++
+		}
+	}
+	return running, done, failed
+}
+
+// contextCompactionSection reports how much tool output compaction saved.
+func (m *model) contextCompactionSection() string {
+	cm := m.cfg.CompactMetrics
+	if cm == nil {
+		return ""
+	}
+	stats := cm.FormatStats()
+	if stats == "" {
+		return ""
+	}
+	return "\n*Output compaction*\n" + stats
 }
 
 // showCommandList displays available slash commands as an assistant message.

--- a/internal/tui/context_usage_char_test.go
+++ b/internal/tui/context_usage_char_test.go
@@ -1,0 +1,323 @@
+package tui
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/dimetron/pi-go/internal/extension"
+)
+
+// updateContextUsageGolden regenerates testdata/context_usage/*.golden.
+// Run with: go test ./internal/tui/ -run ContextUsageGolden -update-context-usage
+var updateContextUsageGolden = flag.Bool("update-context-usage", false,
+	"rewrite the /context golden files from the current implementation")
+
+// contextUsageCase pins one /context rendering. The set is chosen to reach
+// every branch of formatContextUsage: the breakdown gauge with and without a
+// tracker, the daily-usage bar with and without a limit, the context-window
+// section with a known and an unknown window, the cache lines at zero and at
+// non-zero, plus the skills and compaction sections.
+type contextUsageCase struct {
+	name  string
+	build func() *model
+}
+
+// chatMessages builds a transcript with one message of each role, sized so the
+// per-role token estimates differ from each other.
+func chatMessages() []message {
+	return []message{
+		{role: "user", content: strings.Repeat("u", 400)},
+		{role: "assistant", content: strings.Repeat("a", 800)},
+		{role: "tool", tool: "bash", toolIn: "ls -la", content: strings.Repeat("t", 1200)},
+		{role: "user", content: "and one more question"},
+	}
+}
+
+func contextUsageCases() []contextUsageCase {
+	return []contextUsageCase{
+		{
+			// No tracker, no messages: usedBlocks stays 0 and every optional
+			// section is skipped.
+			name: "empty",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: nil},
+					cfg:       Config{ModelName: "test-model"},
+				}
+			},
+		},
+		{
+			// No tracker but a short conversation: the nominal-100k branch
+			// floors the bar at one block.
+			name: "no_tracker_small",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg:       Config{ModelName: "gpt-4", ProviderName: "openai"},
+				}
+			},
+		},
+		{
+			// Over 10k estimated tokens, so the bar scales against 100k.
+			name: "no_tracker_large",
+			build: func() *model {
+				return &model{
+					width: 120,
+					chatModel: ChatModel{Messages: []message{
+						{role: "user", content: strings.Repeat("x", 90_000)},
+						{role: "assistant", content: strings.Repeat("y", 30_000)},
+					}},
+					cfg: Config{ModelName: "gpt-4", ProviderName: "openai"},
+				}
+			},
+		},
+		{
+			name: "tracker_limit_full_sections",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName:    "claude-sonnet",
+						ProviderName: "anthropic",
+						TokenTracker: fakeTokenTracker{
+							limit: 100_000, remaining: 43_210, pctUsed: 56.79,
+							totalUsed: 56_790, lastPromptTok: 20_000,
+							ctxWindowSize: 200_000, ctxPercentUsed: 10,
+							lastCachedTok: 15_000, cachedToday: 123_456,
+							cacheHitRate: 42.5, bodyTokens: 4_321,
+							cachePrefixTok: 15_679,
+						},
+					},
+				}
+			},
+		},
+		{
+			// Tracker present but no limit: the model line falls to the
+			// "ctx ~N tokens" form and Remaining is suppressed.
+			name: "tracker_no_limit",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName:    "local-model",
+						TokenTracker: fakeTokenTracker{totalUsed: 1_000},
+					},
+				}
+			},
+		},
+		{
+			// Usage past the limit: barFill clamps and the percentage is >100.
+			name: "tracker_overflow",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: nil},
+					cfg: Config{
+						ModelName: "test-model",
+						TokenTracker: fakeTokenTracker{
+							limit: 100_000, totalUsed: 200_000, pctUsed: 200,
+						},
+					},
+				}
+			},
+		},
+		{
+			// Last prompt known, window size unknown.
+			name: "ctx_window_unknown",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName: "test-model",
+						TokenTracker: fakeTokenTracker{
+							limit: 50_000, totalUsed: 10_000, pctUsed: 20,
+							lastPromptTok: 7_500,
+						},
+					},
+				}
+			},
+		},
+		{
+			// Prompt larger than the window: free tokens clamp at zero and the
+			// free percentage goes negative.
+			name: "ctx_window_overfull",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName: "test-model",
+						TokenTracker: fakeTokenTracker{
+							limit: 500_000, totalUsed: 260_000, pctUsed: 52,
+							lastPromptTok: 250_000, ctxWindowSize: 200_000,
+							ctxPercentUsed: 125,
+						},
+					},
+				}
+			},
+		},
+		{
+			// Cache section with no hit at all and no stable prefix.
+			name: "cache_miss",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName: "test-model",
+						TokenTracker: fakeTokenTracker{
+							limit: 100_000, totalUsed: 20_000, pctUsed: 20,
+							lastPromptTok: 9_000, ctxWindowSize: 128_000,
+							ctxPercentUsed: 7,
+						},
+					},
+				}
+			},
+		},
+		{
+			// Breakdown gauge driven by the tracker's reported prompt size.
+			name: "breakdown_with_tracker",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName:        "claude-sonnet",
+						ProviderName:     "anthropic",
+						ContextBreakdown: sampleBreakdown(),
+						TokenTracker: fakeTokenTracker{
+							limit: 100_000, totalUsed: 40_000, pctUsed: 40,
+							lastPromptTok: 60_000, ctxWindowSize: 200_000,
+							ctxPercentUsed: 30,
+						},
+					},
+				}
+			},
+		},
+		{
+			// Breakdown with no tracker: used falls back to the message
+			// estimate plus fixed overhead, window to autoRangeWindow.
+			name: "breakdown_no_tracker",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg:       Config{ModelName: "test-model", ContextBreakdown: sampleBreakdown()},
+				}
+			},
+		},
+		{
+			// Narrow terminal: the breakdown width is the clamped chat width
+			// rather than the 64-cell cap.
+			name: "breakdown_narrow",
+			build: func() *model {
+				return &model{
+					width:     44,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg:       Config{ModelName: "test-model", ContextBreakdown: sampleBreakdown()},
+				}
+			},
+		},
+		{
+			// Skills sort alphabetically; the empty source and empty
+			// description fall back to "user" and "(no description)".
+			name: "skills",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: nil},
+					cfg: Config{
+						ModelName: "test-model",
+						Skills: []extension.Skill{
+							{Name: "zebra", Description: "Last alphabetically", Source: "project"},
+							{Name: "alpha", Description: "First skill", Source: "bundled"},
+							{Name: "nosource"},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "compact_metrics",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: chatMessages()},
+					cfg: Config{
+						ModelName:      "test-model",
+						CompactMetrics: &mockCompactStats{stats: "- **Saved**: 42% of tool output\n"},
+					},
+				}
+			},
+		},
+		{
+			// Empty stats suppress the whole compaction section.
+			name: "compact_metrics_empty",
+			build: func() *model {
+				return &model{
+					width:     120,
+					chatModel: ChatModel{Messages: nil},
+					cfg: Config{
+						ModelName:      "test-model",
+						CompactMetrics: &mockCompactStats{stats: ""},
+					},
+				}
+			},
+		},
+	}
+}
+
+func sampleBreakdown() *ContextBreakdown {
+	return &ContextBreakdown{
+		SystemPrompt: 3_500,
+		ToolDefs:     7_200,
+		Rules:        1_100,
+		Skills:       900,
+		MCPTools:     2_400,
+		Subagents:    650,
+	}
+}
+
+// TestFormatContextUsageGolden pins the rendered /context text. The goldens
+// hold the ANSI-stripped output so they stay portable across terminals while
+// still catching any change to wording, ordering, or column widths.
+func TestFormatContextUsageGolden(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range contextUsageCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ansi.Strip(tc.build().formatContextUsage())
+			path := filepath.Join("testdata", "context_usage", tc.name+".golden")
+
+			if *updateContextUsageGolden {
+				if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(got), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+
+			want, err := os.ReadFile(path) //nolint:gosec // fixed test-local path
+			if err != nil {
+				t.Fatalf("read golden: %v (rerun with -update-context-usage)", err)
+			}
+			if got != string(want) {
+				t.Errorf("output drifted from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+			}
+		})
+	}
+}

--- a/internal/tui/context_usage_sections_test.go
+++ b/internal/tui/context_usage_sections_test.go
@@ -1,0 +1,375 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+func TestEstimateRoleTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msgs []message
+		want roleTokens
+	}{
+		{
+			name: "empty transcript",
+			msgs: nil,
+			want: roleTokens{},
+		},
+		{
+			name: "user only",
+			msgs: []message{{role: "user", content: strings.Repeat("u", 400)}},
+			want: roleTokens{user: 100, total: 100},
+		},
+		{
+			name: "one of each role",
+			msgs: []message{
+				{role: "user", content: strings.Repeat("u", 400)},
+				{role: "assistant", content: strings.Repeat("a", 800)},
+				{role: "tool", content: strings.Repeat("t", 1200)},
+			},
+			want: roleTokens{user: 100, assistant: 200, tool: 300, total: 600},
+		},
+		{
+			name: "unrecognized roles count as tool output",
+			msgs: []message{
+				{role: "thinking", content: strings.Repeat("x", 400)},
+				{role: "", content: strings.Repeat("y", 400)},
+			},
+			want: roleTokens{tool: 200, total: 200},
+		},
+		{
+			// The total is estimated from the combined character count, so it
+			// does not have to equal the sum of the three rounded parts.
+			name: "total is not the sum of the rounded parts",
+			msgs: []message{
+				{role: "user", content: "aa"},
+				{role: "assistant", content: "bb"},
+				{role: "tool", content: "cc"},
+			},
+			want: roleTokens{user: 0, assistant: 0, tool: 0, total: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := estimateRoleTokens(tt.msgs); got != tt.want {
+				t.Errorf("estimateRoleTokens() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountAgentStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                        string
+		statuses                    []string
+		running, done, wantedFailed int
+	}{
+		{name: "none", statuses: nil},
+		{name: "all running", statuses: []string{"running", "running"}, running: 2},
+		{name: "all failed", statuses: []string{"failed"}, wantedFailed: 1},
+		{
+			// Anything that is neither running nor failed is done: completed,
+			// canceled, killed, timeout, and the zero value alike.
+			name:     "everything else counts as done",
+			statuses: []string{"completed", "canceled", "killed", "timeout", ""},
+			done:     5,
+		},
+		{
+			name:         "mixed",
+			statuses:     []string{"running", "completed", "failed", "running", "timeout"},
+			running:      2,
+			done:         2,
+			wantedFailed: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			agents := make([]subagent.AgentStatus, len(tt.statuses))
+			for i, s := range tt.statuses {
+				agents[i] = subagent.AgentStatus{Status: s}
+			}
+
+			running, done, failed := countAgentStatuses(agents)
+			if running != tt.running || done != tt.done || failed != tt.wantedFailed {
+				t.Errorf("countAgentStatuses() = (running %d, done %d, failed %d), want (%d, %d, %d)",
+					running, done, failed, tt.running, tt.done, tt.wantedFailed)
+			}
+		})
+	}
+}
+
+func TestContextCacheSection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		tracker      fakeTokenTracker
+		promptTokens int64
+		want         []string
+		notWant      []string
+	}{
+		{
+			name:         "no cache activity still reports",
+			tracker:      fakeTokenTracker{},
+			promptTokens: 10_000,
+			want:         []string{"*Prompt cache*", "- **Last request**: no cache hit\n"},
+			notWant:      []string{"**Today**", "**Stable prefix**"},
+		},
+		{
+			name:         "hit reports its share of the prompt",
+			tracker:      fakeTokenTracker{lastCachedTok: 5_000},
+			promptTokens: 10_000,
+			want:         []string{"- **Last request**: 5.0k of 10.0k prompt tokens cached (50%)"},
+		},
+		{
+			name:         "daily line appears only above zero",
+			tracker:      fakeTokenTracker{cachedToday: 123_456, cacheHitRate: 42.5},
+			promptTokens: 10_000,
+			want:         []string{"- **Today**: 123.5k tokens read from cache (42% of input)"},
+		},
+		{
+			name:         "stable prefix pairs with the body size",
+			tracker:      fakeTokenTracker{cachePrefixTok: 15_679, bodyTokens: 4_321},
+			promptTokens: 10_000,
+			want:         []string{"- **Stable prefix**: 15.7k tokens · **body since**: 4.3k tokens"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := contextCacheSection(tt.tracker, tt.promptTokens)
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("missing %q in:\n%s", w, got)
+				}
+			}
+			for _, w := range tt.notWant {
+				if strings.Contains(got, w) {
+					t.Errorf("unexpected %q in:\n%s", w, got)
+				}
+			}
+		})
+	}
+}
+
+// Each section owns one question and must stay silent when it has no answer —
+// otherwise /context grows empty headers as subsystems go missing.
+func TestContextSectionsAreEmptyWhenTheyHaveNothingToSay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		section func(*model) string
+	}{
+		{
+			name:    "breakdown without a measurement",
+			cfg:     Config{},
+			section: (*model).contextBreakdownSection,
+		},
+		{
+			name:    "daily usage without a tracker",
+			cfg:     Config{},
+			section: (*model).contextDailySection,
+		},
+		{
+			name:    "daily usage with a tracker that has spent nothing",
+			cfg:     Config{TokenTracker: fakeTokenTracker{limit: 100_000}},
+			section: (*model).contextDailySection,
+		},
+		{
+			name:    "context window without a tracker",
+			cfg:     Config{},
+			section: (*model).contextWindowSection,
+		},
+		{
+			name:    "context window before the first response",
+			cfg:     Config{TokenTracker: fakeTokenTracker{totalUsed: 500}},
+			section: (*model).contextWindowSection,
+		},
+		{
+			name:    "skills when none are loaded",
+			cfg:     Config{},
+			section: (*model).contextSkillsSection,
+		},
+		{
+			name:    "subagents without an orchestrator",
+			cfg:     Config{},
+			section: (*model).contextSubagentSection,
+		},
+		{
+			name:    "subagents when none have been spawned",
+			cfg:     Config{Orchestrator: subagent.NewOrchestrator(&config.Config{}, "", nil)},
+			section: (*model).contextSubagentSection,
+		},
+		{
+			name:    "compaction without metrics",
+			cfg:     Config{},
+			section: (*model).contextCompactionSection,
+		},
+		{
+			name:    "compaction with empty stats",
+			cfg:     Config{CompactMetrics: &mockCompactStats{stats: ""}},
+			section: (*model).contextCompactionSection,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &model{width: 120, cfg: tt.cfg}
+			if got := tt.section(m); got != "" {
+				t.Errorf("section rendered %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestContextSkillsSection(t *testing.T) {
+	t.Parallel()
+
+	m := &model{
+		width: 120,
+		cfg: Config{Skills: []extension.Skill{
+			{Name: "zebra", Description: "Last alphabetically", Source: "project"},
+			{Name: "alpha", Description: "First skill", Source: "bundled"},
+			{Name: "bare"},
+		}},
+	}
+
+	got := m.contextSkillsSection()
+
+	if !strings.Contains(got, "(3 loaded)") {
+		t.Errorf("missing the loaded count in:\n%s", got)
+	}
+	// A missing source reads as a user skill, a missing description says so
+	// explicitly, and an unread body is called out rather than reported as 0.
+	if !strings.Contains(got, "- /bare — (no description) [user]  body: not loaded") {
+		t.Errorf("missing the fallback line in:\n%s", got)
+	}
+	if alpha, zebra := strings.Index(got, "/alpha"), strings.Index(got, "/zebra"); alpha > zebra {
+		t.Errorf("skills are not alphabetical: alpha at %d, zebra at %d", alpha, zebra)
+	}
+}
+
+func TestContextHeadlineSection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         Config
+		totalTokens int64
+		want        string
+	}{
+		{
+			name:        "no tracker and no conversation leaves the bar empty",
+			cfg:         Config{ModelName: "m"},
+			totalTokens: 0,
+			want:        "`░░░░░░░░░░░░░░░░░░░░`  m · ctx ~0 tokens",
+		},
+		{
+			// Under the 10k threshold the bar is floored at one block so a short
+			// conversation still reads as "something is in here".
+			name:        "short conversation floors at one block",
+			cfg:         Config{ModelName: "m"},
+			totalTokens: 500,
+			want:        "`█░░░░░░░░░░░░░░░░░░░`  m · ctx ~500 tokens",
+		},
+		{
+			name:        "long conversation scales against a nominal 100k",
+			cfg:         Config{ModelName: "m"},
+			totalTokens: 50_000,
+			want:        "`██████████░░░░░░░░░░`  m · ctx ~50.0k tokens",
+		},
+		{
+			name: "a daily limit switches the line to used/limit",
+			cfg: Config{
+				ModelName:    "m",
+				ProviderName: "p",
+				TokenTracker: fakeTokenTracker{limit: 100_000, totalUsed: 25_000, pctUsed: 25},
+			},
+			totalTokens: 500,
+			want:        "`█████░░░░░░░░░░░░░░░`  p | m · 25.0k/100.0k tokens (25%)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &model{width: 120, cfg: tt.cfg}
+			got := m.contextHeadlineSection(tt.totalTokens)
+			if !strings.HasPrefix(got, "**Context Usage**\n\n") {
+				t.Errorf("missing the header in:\n%s", got)
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("missing %q in:\n%s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestContextWindowSection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tracker fakeTokenTracker
+		want    []string
+	}{
+		{
+			name:    "unknown window falls back to the raw prompt size",
+			tracker: fakeTokenTracker{lastPromptTok: 7_500},
+			want:    []string{"- **Last prompt**: 7.5k tokens (window size unknown)"},
+		},
+		{
+			name:    "known window reports used and free",
+			tracker: fakeTokenTracker{lastPromptTok: 20_000, ctxWindowSize: 200_000, ctxPercentUsed: 10},
+			want: []string{
+				"`██░░░░░░░░░░░░░░░░░░`  20.0k / 200.0k (10%)",
+				"- **Used**: 20.0k tokens",
+				"- **Free**: 180.0k tokens (90%)",
+			},
+		},
+		{
+			// A prompt bigger than the window clamps free at zero rather than
+			// printing a negative token count.
+			name:    "an overfull window clamps free tokens at zero",
+			tracker: fakeTokenTracker{lastPromptTok: 250_000, ctxWindowSize: 200_000, ctxPercentUsed: 125},
+			want:    []string{"- **Free**: 0 tokens (-25%)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &model{width: 120, cfg: Config{TokenTracker: tt.tracker}}
+			got := m.contextWindowSection()
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("missing %q in:\n%s", w, got)
+				}
+			}
+			// The cache lines always follow the window, on every branch.
+			if !strings.Contains(got, "*Prompt cache*") {
+				t.Errorf("missing the prompt cache section in:\n%s", got)
+			}
+		})
+	}
+}

--- a/internal/tui/matrix.go
+++ b/internal/tui/matrix.go
@@ -220,6 +220,25 @@ func (ms *matrixState) render() string {
 }
 
 // tick advances the matrix animation by one step using time-based entropy.
+//
+// It mixes time.Now().UnixNano() into the seed, so the rain glyphs differ on
+// every call. That is the point for an animation, but it has a consequence
+// worth knowing before you write a test: **View is not reproducible run to
+// run**. Rendering the same model state twice produces two different frames.
+// spinnerVerb (see its call site in status.go) is a second, independent source
+// of the same thing while a turn is running.
+//
+// So a golden-frame test of View cannot work without pinning both. That is why
+// render_integrity_test.go asserts invariants — every row is exactly the
+// terminal width, the rail owns its column, no escape leaked into the visible
+// text — rather than comparing frames.
+//
+// If you need a byte-for-byte frame comparison anyway, as a throwaway check
+// that a refactor changed nothing: set ms.seed to a constant and rebuild the
+// grid under it (reproducing the geometry below, so only the glyph choice is
+// pinned and not the layout), pin the spinner state too, and confirm two
+// consecutive runs match before you trust a single diff. Skipping that last
+// step is how you spend an hour reading noise as a regression.
 func (ms *matrixState) tick(width int) {
 	if !ms.active {
 		return

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -601,96 +601,152 @@ func waitForRunAgent(events <-chan subagent.Event, agentID string) tea.Cmd {
 }
 
 // handleRunAgentEvent processes a streaming event from the /run subagent.
+// Every event kind is applied for its side effect on the model; the command
+// returned is always the one that keeps the stream draining.
 func (m *model) handleRunAgentEvent(msg runAgentEventMsg) (tea.Model, tea.Cmd) {
 	ev := msg.event
-
-	// Feed the matrix rain widget so it visibly reacts to ACP subagent output.
-	if ev.Content != "" {
-		m.matrix.feed(ev.Content, m.mainWidth())
-	} else if ev.Type != "" {
-		m.matrix.feed(ev.Type, m.mainWidth())
-	}
+	m.feedMatrixFromRunEvent(ev)
 
 	switch ev.Type {
 	case "text_delta":
-		m.chatModel.Streaming += ev.Content
-		// Update the last assistant message with accumulated text.
-		for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
-			if m.chatModel.Messages[i].role == "assistant" {
-				m.chatModel.Messages[i].content = m.chatModel.Streaming
-				break
-			}
-		}
-		m.chatModel.Scroll = 0
-		// Trace.
-		if len(m.chatModel.TraceLog) > 0 && m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1].kind == "llm" {
-			m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1].detail = m.chatModel.Streaming
-		} else {
-			m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-				time: time.Now(), kind: "llm", summary: "agent response", detail: ev.Content,
-			})
-		}
-
+		m.applyRunTextDelta(ev)
 	case "tool_call":
-		m.statusModel.ActiveTool = ev.Content
-		m.statusModel.ToolStart = time.Now()
-		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-			time: time.Now(), kind: "tool_call", summary: fmt.Sprintf(">>> %s", ev.Content),
-		})
-		// Compute a one-liner from the tool args so the chat card can render
-		// the file path / command alongside the tool name — without this the
-		// header would only show the bare tool name (e.g. "read") in gray,
-		// while the parent path (see agent_loop.go) already fills toolIn.
-		var toolIn string
-		if args, ok := ev.ToolArgs.(map[string]any); ok {
-			toolIn = toolCallSummary(ev.Content, args)
-		}
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role: "tool", tool: ev.Content, toolIn: toolIn,
-		})
-
+		m.applyRunToolCall(ev)
 	case "tool_result":
-		prevTool := m.statusModel.ActiveTool
-		m.statusModel.ActiveTool = ""
-		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-			time: time.Now(), kind: "tool_result", summary: "<<< result",
-			detail: ev.Content,
-		})
-		// Update the last tool message with the result.
-		for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
-			if m.chatModel.Messages[i].role == "tool" && m.chatModel.Messages[i].content == "" {
-				m.chatModel.Messages[i].content = toolResultSummary(ev.Content)
-				break
-			}
-		}
-
-		// Refresh checklist after write/edit operations — the agent may have
-		// updated plan.md checkboxes. This is a cheap disk read.
-		if m.run != nil && (prevTool == "write" || prevTool == "edit") {
-			m.refreshRunChecklist()
-		}
-
+		m.applyRunToolResult(ev)
 	case "message_start":
 		// New message from the agent — add an empty assistant placeholder.
 		m.chatModel.Streaming = ""
 		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: ""})
-
 	case "message_end":
 		// Message completed — reset streaming accumulator for the next message.
 		m.chatModel.Streaming = ""
-
 	case "error":
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role:    "assistant",
-			content: fmt.Sprintf("Agent error: %s", ev.Error),
-		})
-		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-			time: time.Now(), kind: "error", summary: "agent error", detail: ev.Error,
-		})
+		m.applyRunError(ev)
 	}
 
 	// Keep consuming events from the subagent.
 	return m, m.waitForRunEvents()
+}
+
+// feedMatrixFromRunEvent drives the matrix rain widget so it visibly reacts to
+// ACP subagent output. An event carrying no content still counts: its type
+// name keeps the rain moving, so a quiet stream does not look like a stalled
+// one. An event with neither feeds nothing.
+func (m *model) feedMatrixFromRunEvent(ev subagent.Event) {
+	switch {
+	case ev.Content != "":
+		m.matrix.feed(ev.Content, m.mainWidth())
+	case ev.Type != "":
+		m.matrix.feed(ev.Type, m.mainWidth())
+	}
+}
+
+// applyRunTextDelta appends streamed text to the open assistant message.
+func (m *model) applyRunTextDelta(ev subagent.Event) {
+	m.chatModel.Streaming += ev.Content
+
+	// Update the last assistant message with accumulated text.
+	if msg := lastMessageMatching(m.chatModel.Messages, func(msg *message) bool {
+		return msg.role == "assistant"
+	}); msg != nil {
+		msg.content = m.chatModel.Streaming
+	}
+	m.chatModel.Scroll = 0
+
+	m.recordRunStreamingTrace(ev.Content)
+}
+
+// recordRunStreamingTrace keeps one trace entry per contiguous model turn: it
+// extends the open "llm" entry with the accumulated text, or starts a new one
+// when something else (a tool call) interrupted the stream. The new entry
+// records only the delta that opened it, matching what the trace shows for a
+// turn that starts mid-stream.
+func (m *model) recordRunStreamingTrace(delta string) {
+	if n := len(m.chatModel.TraceLog); n > 0 && m.chatModel.TraceLog[n-1].kind == "llm" {
+		m.chatModel.TraceLog[n-1].detail = m.chatModel.Streaming
+		return
+	}
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "llm", summary: "agent response", detail: delta,
+	})
+}
+
+// applyRunToolCall opens a tool card for a call the subagent just started.
+func (m *model) applyRunToolCall(ev subagent.Event) {
+	m.statusModel.ActiveTool = ev.Content
+	m.statusModel.ToolStart = time.Now()
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "tool_call", summary: fmt.Sprintf(">>> %s", ev.Content),
+	})
+
+	// Compute a one-liner from the tool args so the chat card can render
+	// the file path / command alongside the tool name — without this the
+	// header would only show the bare tool name (e.g. "read") in gray,
+	// while the parent path (see agent_loop.go) already fills toolIn.
+	var toolIn string
+	if args, ok := ev.ToolArgs.(map[string]any); ok {
+		toolIn = toolCallSummary(ev.Content, args)
+	}
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role: "tool", tool: ev.Content, toolIn: toolIn,
+	})
+}
+
+// applyRunToolResult closes the open tool card with its result.
+func (m *model) applyRunToolResult(ev subagent.Event) {
+	prevTool := m.statusModel.ActiveTool
+	m.statusModel.ActiveTool = ""
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "tool_result", summary: "<<< result",
+		detail: ev.Content,
+	})
+
+	// Update the last tool message with the result.
+	if msg := lastMessageMatching(m.chatModel.Messages, func(msg *message) bool {
+		return msg.role == "tool" && msg.content == ""
+	}); msg != nil {
+		msg.content = toolResultSummary(ev.Content)
+	}
+
+	// Refresh checklist after write/edit operations — the agent may have
+	// updated plan.md checkboxes. This is a cheap disk read.
+	if m.run != nil && toolMayTickChecklist(prevTool) {
+		m.refreshRunChecklist()
+	}
+}
+
+// toolMayTickChecklist reports whether a finished tool call could have ticked
+// a plan.md checkbox, which is what makes re-reading the plan worth the disk
+// hit. Only the tools that write files qualify.
+func toolMayTickChecklist(tool string) bool {
+	return tool == "write" || tool == "edit"
+}
+
+// applyRunError surfaces a subagent error in the transcript and the trace.
+func (m *model) applyRunError(ev subagent.Event) {
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: fmt.Sprintf("Agent error: %s", ev.Error),
+	})
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "error", summary: "agent error", detail: ev.Error,
+	})
+}
+
+// lastMessageMatching returns a pointer to the most recent message satisfying
+// pred, or nil when none does. A stream always updates the newest matching
+// card — an older one has already been closed out and must not be rewritten.
+//
+// The pointer aliases the slice, so the caller must not append to Messages
+// while holding it.
+func lastMessageMatching(msgs []message, pred func(*message) bool) *message {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if pred(&msgs[i]) {
+			return &msgs[i]
+		}
+	}
+	return nil
 }
 
 // handleRunAgentDone is called when a subagent events channel closes.
@@ -1309,12 +1365,30 @@ func (m *model) writeRunSummary(outcome string) (string, error) {
 }
 
 // buildRunSummaryReport generates a markdown summary of a /run execution.
+//
+// Each section renders independently and returns "" when it has nothing to
+// report, so the body is a straight concatenation in document order.
 func buildRunSummaryReport(rs *runState, outcome string) string {
 	var b strings.Builder
 
 	b.WriteString("# Run Summary\n\n")
+	for _, section := range []string{
+		runSummaryMetadata(rs, outcome),
+		runSummaryGates(rs),
+		runSummaryUnfinished(rs),
+		runSummaryResult(rs, outcome),
+	} {
+		b.WriteString(section)
+	}
+	return b.String()
+}
 
-	// Metadata.
+// runSummaryMetadata renders the identifying table: which spec, which agent,
+// how it ended, and how long it took. Slice and timing rows appear only when
+// there was a checklist and a recorded start.
+func runSummaryMetadata(rs *runState, outcome string) string {
+	var b strings.Builder
+
 	b.WriteString("## Metadata\n\n")
 	b.WriteString("| Field | Value |\n")
 	b.WriteString("|-------|-------|\n")
@@ -1330,53 +1404,93 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 		fmt.Fprintf(&b, "| Duration | %s |\n", time.Since(rs.startTime).Truncate(time.Second))
 	}
 	b.WriteString("\n")
+	return b.String()
+}
 
-	// Gate results.
+// runSummaryGates renders the gate section. The three cases are meaningfully
+// different to a reader: no gates were configured at all, gates were
+// configured but the run never reached them, or gates actually ran.
+func runSummaryGates(rs *runState) string {
+	var b strings.Builder
 	b.WriteString("## Gates\n\n")
-	if len(rs.gateResults) == 0 && len(rs.gates) == 0 {
+
+	switch {
+	case len(rs.gateResults) == 0 && len(rs.gates) == 0:
 		b.WriteString("No gates defined.\n\n")
-	} else if len(rs.gateResults) == 0 {
+	case len(rs.gateResults) == 0:
 		b.WriteString("Gates were defined but not executed.\n\n")
 		for _, g := range rs.gates {
 			fmt.Fprintf(&b, "- **%s**: `%s`\n", g.Name, g.Command)
 		}
 		b.WriteString("\n")
+	default:
+		b.WriteString(runSummaryGateResults(rs.gateResults))
+	}
+	return b.String()
+}
+
+// runSummaryGateResults lists each executed gate with its verdict, quoting the
+// output of the ones that failed, and closes with the overall verdict.
+func runSummaryGateResults(results []GateResult) string {
+	var b strings.Builder
+
+	allPassed := true
+	for _, r := range results {
+		status := "PASS"
+		if !r.Passed {
+			status = "FAIL"
+			allPassed = false
+		}
+		fmt.Fprintf(&b, "- **%s** (`%s`): **%s**\n", r.Name, r.Command, status)
+		if !r.Passed && r.Output != "" {
+			fmt.Fprintf(&b, "  ```\n  %s\n  ```\n", truncateGateOutput(r.Output))
+		}
+	}
+	b.WriteString("\n")
+
+	if allPassed {
+		b.WriteString("All gates **passed**.\n\n")
 	} else {
-		allPassed := true
-		for _, r := range rs.gateResults {
-			status := "PASS"
-			if !r.Passed {
-				status = "FAIL"
-				allPassed = false
-			}
-			fmt.Fprintf(&b, "- **%s** (`%s`): **%s**\n", r.Name, r.Command, status)
-			if !r.Passed && r.Output != "" {
-				out := strings.TrimSpace(r.Output)
-				if len(out) > 1000 {
-					out = out[:1000] + "\n...(truncated)"
-				}
-				fmt.Fprintf(&b, "  ```\n  %s\n  ```\n", out)
-			}
-		}
-		b.WriteString("\n")
-		if allPassed {
-			b.WriteString("All gates **passed**.\n\n")
-		} else {
-			b.WriteString("Some gates **failed**.\n\n")
-		}
+		b.WriteString("Some gates **failed**.\n\n")
+	}
+	return b.String()
+}
+
+// truncateGateOutput trims a gate's captured output and caps it, so a runaway
+// test log cannot bury the rest of the report.
+func truncateGateOutput(output string) string {
+	const maxGateOutput = 1000
+	out := strings.TrimSpace(output)
+	if len(out) > maxGateOutput {
+		out = out[:maxGateOutput] + "\n...(truncated)"
+	}
+	return out
+}
+
+// runSummaryUnfinished lists the plan steps the run never ticked. Empty when
+// the run finished the checklist.
+func runSummaryUnfinished(rs *runState) string {
+	pending := rs.unfinishedSlices()
+	if len(pending) == 0 {
+		return ""
 	}
 
-	// Unfinished slices, when the run stopped short of the plan.
-	if pending := rs.unfinishedSlices(); len(pending) > 0 {
-		b.WriteString("## Unfinished Slices\n\n")
-		for _, p := range pending {
-			fmt.Fprintf(&b, "- %s\n", p)
-		}
-		b.WriteString("\n")
+	var b strings.Builder
+	b.WriteString("## Unfinished Slices\n\n")
+	for _, p := range pending {
+		fmt.Fprintf(&b, "- %s\n", p)
 	}
+	b.WriteString("\n")
+	return b.String()
+}
 
-	// Outcome details.
+// runSummaryResult explains the outcome in prose, including what was left
+// behind — which worktree survived, and why — so the reader knows what to do
+// next without reconstructing it from the gate table.
+func runSummaryResult(rs *runState, outcome string) string {
+	var b strings.Builder
 	b.WriteString("## Result\n\n")
+
 	switch outcome {
 	case "completed":
 		b.WriteString("All gates passed, the plan checklist was complete, and changes were merged successfully.\n")
@@ -1391,7 +1505,6 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 	default:
 		fmt.Fprintf(&b, "Run ended with status: %s\n", outcome)
 	}
-
 	return b.String()
 }
 

--- a/internal/tui/run_event_char_test.go
+++ b/internal/tui/run_event_char_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// runEventCase drives a sequence of subagent events through handleRunAgentEvent
+// and pins the model state they produce. handleRunAgentEvent renders nothing —
+// its whole output is the mutation it performs — so the state snapshot is the
+// equivalent of a rendered golden here.
+type runEventCase struct {
+	name   string
+	build  func() *model
+	events []subagent.Event
+}
+
+// newRunEventModel is the baseline model the cases start from: a live run with
+// one empty assistant placeholder, which is what the stream arrives into.
+func newRunEventModel(t *testing.T, msgs []message, run *runState) *model {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &model{
+		ctx:       ctx,
+		cancel:    cancel,
+		width:     120,
+		height:    40,
+		chatModel: ChatModel{Messages: msgs},
+		run:       run,
+		running:   true,
+	}
+}
+
+func runEventCases(t *testing.T) []runEventCase {
+	t.Helper()
+
+	assistantPlaceholder := func() []message {
+		return []message{{role: "assistant", content: ""}}
+	}
+	liveRun := func() *runState {
+		return &runState{specName: "test-spec", agentID: "task-1", phase: "running"}
+	}
+
+	return []runEventCase{
+		{
+			name:   "text_delta accumulates into the last assistant message",
+			build:  func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{{Type: "text_delta", Content: "Hello "}, {Type: "text_delta", Content: "world"}},
+		},
+		{
+			// No assistant message to land in: the reverse scan finds nothing
+			// and the delta survives only in Streaming.
+			name:   "text_delta with no assistant message to update",
+			build:  func() *model { return newRunEventModel(t, []message{{role: "user", content: "go"}}, liveRun()) },
+			events: []subagent.Event{{Type: "text_delta", Content: "orphan"}},
+		},
+		{
+			// A tool_call pushes a non-llm entry onto the trace, so the next
+			// delta appends a fresh llm entry instead of extending the last.
+			name:  "text_delta appends a new trace entry after a tool_call",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{
+				{Type: "text_delta", Content: "first"},
+				{Type: "tool_call", Content: "read"},
+				{Type: "text_delta", Content: "second"},
+			},
+		},
+		{
+			name:  "tool_call arg shapes",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{
+				{Type: "tool_call", Content: "read", ToolArgs: map[string]any{"file_path": "internal/tui/run.go"}},
+				{Type: "tool_call", Content: "bash", ToolArgs: map[string]any{"command": "go test ./..."}},
+				{Type: "tool_call", Content: "grep"},
+				// A non-map ToolArgs must not panic and must leave toolIn empty.
+				{Type: "tool_call", Content: "edit", ToolArgs: "not-a-map"},
+			},
+		},
+		{
+			// Several assistant turns are on screen. The delta belongs to the
+			// newest one; writing to an older card would rewrite a turn the
+			// user has already read.
+			name: "text_delta updates the newest of several assistant messages",
+			build: func() *model {
+				return newRunEventModel(t, []message{
+					{role: "assistant", content: "older turn"},
+					{role: "tool", tool: "bash", content: "done"},
+					{role: "assistant", content: ""},
+				}, liveRun())
+			},
+			events: []subagent.Event{{Type: "text_delta", Content: "newest"}},
+		},
+		{
+			// Two tool cards are still open. The result closes the newest.
+			name: "tool_result fills the newest of several open tool cards",
+			build: func() *model {
+				return newRunEventModel(t, []message{
+					{role: "tool", tool: "read", content: ""},
+					{role: "tool", tool: "bash", content: ""},
+				}, liveRun())
+			},
+			events: []subagent.Event{{Type: "tool_result", Content: "second result"}},
+		},
+		{
+			name:  "tool_result fills the last empty tool message",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{
+				{Type: "tool_call", Content: "bash"},
+				{Type: "tool_result", Content: `{"exit_code": 0, "stdout": "ok"}`},
+			},
+		},
+		{
+			// Already-filled tool messages are skipped; with none empty the
+			// result lands nowhere but still clears the active tool.
+			name: "tool_result with no empty tool message to fill",
+			build: func() *model {
+				return newRunEventModel(t, []message{{role: "tool", tool: "bash", content: "done"}}, liveRun())
+			},
+			events: []subagent.Event{{Type: "tool_result", Content: "orphan result"}},
+		},
+		{
+			// write and edit trigger a checklist refresh; other tools do not.
+			// With no orchestrator the refresh is a no-op, so this pins the
+			// surrounding state rather than the read itself.
+			name:  "tool_result after a write",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{
+				{Type: "tool_call", Content: "write"},
+				{Type: "tool_result", Content: "wrote 12 lines"},
+			},
+		},
+		{
+			name:  "tool_result after a write with no live run",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), nil) },
+			events: []subagent.Event{
+				{Type: "tool_call", Content: "write"},
+				{Type: "tool_result", Content: "wrote 12 lines"},
+			},
+		},
+		{
+			name:  "message_start opens a fresh assistant placeholder",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{
+				{Type: "text_delta", Content: "leftover"},
+				{Type: "message_start"},
+			},
+		},
+		{
+			name:  "message_end clears the streaming accumulator",
+			build: func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{
+				{Type: "text_delta", Content: "leftover"},
+				{Type: "message_end"},
+			},
+		},
+		{
+			name:   "error appends a message and a trace entry",
+			build:  func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{{Type: "error", Error: "connection reset by peer"}},
+		},
+		{
+			// An unrecognized type must change nothing except the matrix feed.
+			name:   "unknown event type is inert",
+			build:  func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{{Type: "heartbeat", Content: "tick"}},
+		},
+		{
+			// Empty content falls back to feeding the type name, so the rain
+			// still reacts to a content-free event.
+			name:   "matrix falls back to the event type when content is empty",
+			build:  func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{{Type: "message_end"}},
+		},
+		{
+			// Neither content nor type: nothing is fed at all.
+			name:   "matrix is not fed when content and type are both empty",
+			build:  func() *model { return newRunEventModel(t, assistantPlaceholder(), liveRun()) },
+			events: []subagent.Event{{}},
+		},
+	}
+}
+
+// snapshotRunEventState serializes everything handleRunAgentEvent can touch,
+// leaving out wall-clock fields (traceEntry.time, statusModel.ToolStart) which
+// are recorded only as set/unset so the snapshot stays reproducible.
+func snapshotRunEventState(m *model) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "streaming=%q scroll=%d activeTool=%q toolStartSet=%v\n",
+		m.chatModel.Streaming, m.chatModel.Scroll, m.statusModel.ActiveTool,
+		!m.statusModel.ToolStart.IsZero())
+	fmt.Fprintf(&b, "matrix active=%v seed=%d\n", m.matrix.active, m.matrix.seed)
+
+	b.WriteString("messages:\n")
+	for i, msg := range m.chatModel.Messages {
+		fmt.Fprintf(&b, "  [%d] role=%q tool=%q toolIn=%q content=%q\n",
+			i, msg.role, msg.tool, msg.toolIn, msg.content)
+	}
+
+	b.WriteString("trace:\n")
+	for i, e := range m.chatModel.TraceLog {
+		fmt.Fprintf(&b, "  [%d] kind=%q summary=%q detail=%q timeSet=%v\n",
+			i, e.kind, e.summary, e.detail, !e.time.IsZero())
+	}
+
+	if m.run == nil {
+		b.WriteString("run=nil\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "run phase=%q checklist=%d\n", m.run.phase, len(m.run.checklist))
+	return b.String()
+}
+
+// TestHandleRunAgentEventStateGolden pins the model mutation each event kind
+// performs. It is the characterization net for the handler split: the handler
+// produces no text, so its state is the thing that must not drift.
+func TestHandleRunAgentEventStateGolden(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range runEventCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := tc.build()
+			for _, ev := range tc.events {
+				m.handleRunAgentEvent(runAgentEventMsg{event: ev, agentID: "task-1"})
+			}
+			assertRunGolden(t, "run_events", tc.name, snapshotRunEventState(m))
+		})
+	}
+}

--- a/internal/tui/run_event_seams_test.go
+++ b/internal/tui/run_event_seams_test.go
@@ -1,0 +1,283 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+func TestToolMayTickChecklist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tool string
+		want bool
+	}{
+		// Only the tools that write files can have ticked a checkbox.
+		{name: "write", tool: "write", want: true},
+		{name: "edit", tool: "edit", want: true},
+		{name: "read does not", tool: "read", want: false},
+		{name: "bash does not", tool: "bash", want: false},
+		{name: "grep does not", tool: "grep", want: false},
+		{name: "no active tool", tool: "", want: false},
+		// The check is exact, not a prefix or substring match.
+		{name: "write_file is a different tool", tool: "write_file", want: false},
+		{name: "case is significant", tool: "Write", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := toolMayTickChecklist(tt.tool); got != tt.want {
+				t.Errorf("toolMayTickChecklist(%q) = %v, want %v", tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLastMessageMatching(t *testing.T) {
+	t.Parallel()
+
+	msgs := []message{
+		{role: "assistant", content: "first"},
+		{role: "tool", tool: "bash", content: "done"},
+		{role: "assistant", content: "second"},
+		{role: "tool", tool: "read", content: ""},
+	}
+
+	tests := []struct {
+		name string
+		pred func(*message) bool
+		want string // matched message's content; "\x00" means no match expected
+	}{
+		{
+			// The newest match wins: an older card has already been closed
+			// out and must not be rewritten by a later event.
+			name: "picks the newest assistant, not the oldest",
+			pred: func(m *message) bool { return m.role == "assistant" },
+			want: "second",
+		},
+		{
+			name: "an open tool card is found by its empty content",
+			pred: func(m *message) bool { return m.role == "tool" && m.content == "" },
+			want: "",
+		},
+		{
+			name: "no match returns nil",
+			pred: func(m *message) bool { return m.role == "system" },
+			want: "\x00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := lastMessageMatching(msgs, tt.pred)
+			if tt.want == "\x00" {
+				if got != nil {
+					t.Errorf("lastMessageMatching() = %+v, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("lastMessageMatching() = nil, want the message with content %q", tt.want)
+			}
+			if got.content != tt.want {
+				t.Errorf("matched content = %q, want %q", got.content, tt.want)
+			}
+		})
+	}
+}
+
+// The returned pointer has to alias the slice — the streaming handlers update
+// the transcript through it.
+func TestLastMessageMatchingAliasesTheSlice(t *testing.T) {
+	t.Parallel()
+
+	msgs := []message{{role: "assistant", content: "before"}}
+	got := lastMessageMatching(msgs, func(m *message) bool { return m.role == "assistant" })
+	if got == nil {
+		t.Fatal("expected a match")
+	}
+	got.content = "after"
+
+	if msgs[0].content != "after" {
+		t.Errorf("writing through the pointer did not reach the slice: %q", msgs[0].content)
+	}
+}
+
+func TestLastMessageMatchingEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := lastMessageMatching(nil, func(*message) bool { return true }); got != nil {
+		t.Errorf("lastMessageMatching(nil) = %+v, want nil", *got)
+	}
+}
+
+// A checklist refresh is a disk read on a live worktree, so it is driven here
+// through a real worktree rather than a nil orchestrator. This is the branch
+// that had no coverage before: that a write refreshes the plan view, and that
+// a read leaves it alone.
+func TestApplyRunToolResultRefreshesChecklistAfterWrites(t *testing.T) {
+	tests := []struct {
+		name     string
+		tool     string
+		wantDone bool
+	}{
+		{name: "write refreshes", tool: "write", wantDone: true},
+		{name: "edit refreshes", tool: "edit", wantDone: true},
+		{name: "read leaves the stale view alone", tool: "read", wantDone: false},
+		{name: "bash leaves the stale view alone", tool: "bash", wantDone: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initRunTestRepo(t)
+			orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)
+			t.Cleanup(orch.Shutdown)
+
+			const agentID = "task-checklist-1"
+			wtPath, err := orch.Worktree().Create(agentID)
+			if err != nil {
+				t.Fatalf("creating worktree: %v", err)
+			}
+
+			// The agent has ticked the box on disk; the model still holds the
+			// pre-write view.
+			writePlanMD(t, wtPath, "my-spec", "- [x] Step 1: parse the config\n")
+
+			m := &model{
+				width: 120,
+				cfg:   Config{Orchestrator: orch},
+				chatModel: ChatModel{Messages: []message{
+					{role: "tool", tool: tt.tool, content: ""},
+				}},
+				statusModel: StatusModel{ActiveTool: tt.tool},
+				run: &runState{
+					specName:        "my-spec",
+					agentID:         agentID,
+					worktreeAgentID: agentID,
+					checklist:       []ChecklistStep{{Title: "Step 1: parse the config", Done: false}},
+				},
+			}
+
+			m.applyRunToolResult(subagent.Event{Type: "tool_result", Content: "wrote 1 line"})
+
+			if len(m.run.checklist) != 1 {
+				t.Fatalf("checklist length = %d, want 1", len(m.run.checklist))
+			}
+			if got := m.run.checklist[0].Done; got != tt.wantDone {
+				t.Errorf("after a %q result, checklist[0].Done = %v, want %v", tt.tool, got, tt.wantDone)
+			}
+		})
+	}
+}
+
+// writePlanMD lays down specs/<spec>/plan.md inside a worktree.
+func writePlanMD(t *testing.T, dir, specName, body string) {
+	t.Helper()
+	specDir := filepath.Join(dir, "specs", specName)
+	if err := os.MkdirAll(specDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "plan.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecordRunStreamingTrace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		existing    []traceEntry
+		streaming   string
+		delta       string
+		wantEntries int
+		wantDetail  string
+	}{
+		{
+			// Nothing open: the delta opens a new entry and is its own detail.
+			name:        "opens the first entry",
+			streaming:   "hello",
+			delta:       "hello",
+			wantEntries: 1,
+			wantDetail:  "hello",
+		},
+		{
+			// An open llm entry absorbs the accumulated text, not the delta.
+			name:        "extends an open llm entry with the accumulation",
+			existing:    []traceEntry{{kind: "llm", detail: "hello"}},
+			streaming:   "hello world",
+			delta:       " world",
+			wantEntries: 1,
+			wantDetail:  "hello world",
+		},
+		{
+			// A tool call closed the turn, so the next delta starts a fresh
+			// entry carrying only what arrived after the interruption.
+			name:        "starts a new entry after a tool call",
+			existing:    []traceEntry{{kind: "llm", detail: "hello"}, {kind: "tool_call", summary: ">>> read"}},
+			streaming:   "hello resumed",
+			delta:       " resumed",
+			wantEntries: 3,
+			wantDetail:  " resumed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &model{chatModel: ChatModel{TraceLog: tt.existing, Streaming: tt.streaming}}
+			m.recordRunStreamingTrace(tt.delta)
+
+			if got := len(m.chatModel.TraceLog); got != tt.wantEntries {
+				t.Fatalf("trace has %d entries, want %d", got, tt.wantEntries)
+			}
+			last := m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1]
+			if last.kind != "llm" {
+				t.Errorf("last entry kind = %q, want %q", last.kind, "llm")
+			}
+			if last.detail != tt.wantDetail {
+				t.Errorf("last entry detail = %q, want %q", last.detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestFeedMatrixFromRunEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		event      subagent.Event
+		wantActive bool
+	}{
+		{name: "content drives the rain", event: subagent.Event{Type: "text_delta", Content: "tokens"}, wantActive: true},
+		// A content-free event still counts: a quiet stream must not look
+		// like a stalled one.
+		{name: "type stands in for missing content", event: subagent.Event{Type: "message_end"}, wantActive: true},
+		{name: "an empty event feeds nothing", event: subagent.Event{}, wantActive: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &model{width: 120}
+			m.feedMatrixFromRunEvent(tt.event)
+
+			if got := m.matrix.active; got != tt.wantActive {
+				t.Errorf("matrix active = %v, want %v", got, tt.wantActive)
+			}
+			if tt.wantActive && m.matrix.seed == 0 {
+				t.Error("matrix seed was not advanced by the feed")
+			}
+		})
+	}
+}

--- a/internal/tui/run_golden_test.go
+++ b/internal/tui/run_golden_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// updateRunGolden regenerates the run.go golden files. Run with:
+//
+//	go test ./internal/tui/ -run 'Golden' -update-run-golden
+var updateRunGolden = flag.Bool("update-run-golden", false,
+	"rewrite the run.go golden files from the current implementation")
+
+// assertRunGolden compares got against testdata/<group>/<name>.golden, or
+// rewrites it under -update-run-golden. name is a test case name, so it is
+// slugified into something safe to put on disk.
+func assertRunGolden(t *testing.T, group, name, got string) {
+	t.Helper()
+
+	path := filepath.Join("testdata", group, goldenSlug(name)+".golden")
+
+	if *updateRunGolden {
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(path) //nolint:gosec // fixed test-local path
+	if err != nil {
+		t.Fatalf("read golden: %v (rerun with -update-run-golden)", err)
+	}
+	if got != string(want) {
+		t.Errorf("output drifted from %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}
+
+// goldenSlug turns a test case name into a filename: lower case, with every
+// run of non-alphanumeric characters collapsed to a single underscore.
+func goldenSlug(name string) string {
+	var b strings.Builder
+	lastUnderscore := true // trims any leading separator
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastUnderscore = false
+		case !lastUnderscore:
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.TrimSuffix(b.String(), "_")
+}

--- a/internal/tui/run_summary_char_test.go
+++ b/internal/tui/run_summary_char_test.go
@@ -1,0 +1,192 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedRunStart is a stable instant for the Started metadata row. The Duration
+// row derived from it is wall-clock dependent and gets normalized out below.
+var fixedRunStart = time.Date(2026, 3, 14, 9, 26, 53, 0, time.UTC)
+
+// durationRow matches the one row of the report that cannot be pinned:
+// Duration is time.Since(startTime), so it grows between runs.
+var durationRow = regexp.MustCompile(`(?m)^\| Duration \| .*$`)
+
+// normalizeRunSummary replaces the wall-clock Duration value with a fixed
+// marker, leaving the row itself in place so its presence is still pinned.
+func normalizeRunSummary(report string) string {
+	return durationRow.ReplaceAllString(report, "| Duration | <elapsed> |")
+}
+
+type runSummaryCase struct {
+	name    string
+	state   func() *runState
+	outcome string
+}
+
+func runSummaryCases() []runSummaryCase {
+	twoGates := []Gate{
+		{Name: "build", Command: "go build ./..."},
+		{Name: "test", Command: "go test ./..."},
+	}
+	base := func() *runState {
+		return &runState{
+			specName:   "rate-limiter",
+			agentID:    "task-42",
+			phase:      "done",
+			retries:    1,
+			maxRetries: 3,
+			startTime:  fixedRunStart,
+		}
+	}
+	withChecklist := func(rs *runState) *runState {
+		rs.checklist = []ChecklistStep{
+			{Title: "parse the config", Done: true},
+			{Title: "wire the limiter", Done: true},
+			{Title: "add metrics", Done: false},
+		}
+		return rs
+	}
+
+	return []runSummaryCase{
+		{
+			// Nothing optional present: no gates, no checklist, no start time.
+			name:    "minimal",
+			outcome: "completed",
+			state: func() *runState {
+				return &runState{specName: "bare", agentID: "task-0", maxRetries: 3}
+			},
+		},
+		{
+			name:    "gates defined but never executed",
+			outcome: "agent_failed",
+			state: func() *runState {
+				rs := base()
+				rs.gates = twoGates
+				return rs
+			},
+		},
+		{
+			name:    "all gates passed",
+			outcome: "completed",
+			state: func() *runState {
+				rs := withChecklist(base())
+				rs.checklist[2].Done = true
+				rs.gates = twoGates
+				rs.gateResults = []GateResult{
+					{Name: "build", Command: "go build ./...", Passed: true},
+					{Name: "test", Command: "go test ./...", Passed: true},
+				}
+				return rs
+			},
+		},
+		{
+			name:    "a gate failed with output",
+			outcome: "gate_failed",
+			state: func() *runState {
+				rs := withChecklist(base())
+				rs.gates = twoGates
+				rs.gateResults = []GateResult{
+					{Name: "build", Command: "go build ./...", Passed: true},
+					{Name: "test", Command: "go test ./...", Passed: false,
+						Output: "  \n--- FAIL: TestThing (0.01s)\n    thing_test.go:42: want 1, got 2\nFAIL\n  "},
+				}
+				return rs
+			},
+		},
+		{
+			// Output past 1000 characters is truncated with a marker.
+			name:    "gate output is truncated past the cap",
+			outcome: "gate_failed",
+			state: func() *runState {
+				rs := base()
+				rs.gates = twoGates
+				long := ""
+				for range 200 {
+					long += "failing line\n"
+				}
+				rs.gateResults = []GateResult{
+					{Name: "test", Command: "go test ./...", Passed: false, Output: long},
+				}
+				return rs
+			},
+		},
+		{
+			// A failed gate with no captured output must not emit an empty
+			// fence.
+			name:    "failed gate with no output",
+			outcome: "gate_failed",
+			state: func() *runState {
+				rs := base()
+				rs.gateResults = []GateResult{{Name: "lint", Command: "golangci-lint run", Passed: false}}
+				return rs
+			},
+		},
+		{
+			name:    "unfinished slices are listed",
+			outcome: "verify_failed",
+			state:   func() *runState { return withChecklist(base()) },
+		},
+		{
+			name:    "merge failed",
+			outcome: "merge_failed",
+			state:   func() *runState { return withChecklist(base()) },
+		},
+		{
+			// The default arm of the outcome switch — an outcome the report
+			// has no prose for still has to say something.
+			name:    "unrecognized outcome falls through to the default",
+			outcome: "interrupted_by_user",
+			state:   func() *runState { return base() },
+		},
+	}
+}
+
+// TestBuildRunSummaryReportGolden pins the whole rendered SUMMARY.md. This is
+// the characterization net for splitting the report into sections: it catches
+// a dropped blank line or a reordered section, which a Contains-style
+// assertion cannot.
+func TestBuildRunSummaryReportGolden(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range runSummaryCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeRunSummary(buildRunSummaryReport(tc.state(), tc.outcome))
+			assertRunGolden(t, "run_summary", tc.name, got)
+		})
+	}
+}
+
+// The Duration row is normalized out of the goldens, so its format is pinned
+// here instead: it must be present whenever a start time was recorded, and
+// absent when one was not.
+func TestBuildRunSummaryReportDurationRow(t *testing.T) {
+	t.Parallel()
+
+	withStart := buildRunSummaryReport(&runState{specName: "s", startTime: fixedRunStart}, "completed")
+	if !durationRow.MatchString(withStart) {
+		t.Errorf("expected a Duration row when startTime is set, got:\n%s", withStart)
+	}
+	// The goldens normalize the elapsed value away, so its granularity is
+	// pinned here instead: the duration is truncated to whole seconds, and a
+	// sub-second unit in the output means that truncation was lost.
+	value := durationRow.FindString(withStart)
+	for _, subSecond := range []string{".", "ms", "µs", "ns"} {
+		if strings.Contains(strings.TrimSuffix(value, " |"), subSecond) {
+			t.Errorf("Duration row %q carries sub-second precision (%q); it must be truncated to seconds",
+				value, subSecond)
+		}
+	}
+	if !regexp.MustCompile(`\| Started \| 2026-03-14T09:26:53Z \|`).MatchString(withStart) {
+		t.Errorf("expected the RFC3339 Started row, got:\n%s", withStart)
+	}
+
+	noStart := buildRunSummaryReport(&runState{specName: "s"}, "completed")
+	if durationRow.MatchString(noStart) {
+		t.Errorf("expected no Duration row without a startTime, got:\n%s", noStart)
+	}
+}

--- a/internal/tui/search_popup_key_test.go
+++ b/internal/tui/search_popup_key_test.go
@@ -1,0 +1,300 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// searchItems builds n placeholder entries named cmd-0..cmd-(n-1).
+func searchItems(n int) []SearchItem {
+	items := make([]SearchItem, n)
+	for i := range items {
+		items[i] = SearchItem{Text: fmt.Sprintf("cmd-%d", i), Description: fmt.Sprintf("desc-%d", i)}
+	}
+	return items
+}
+
+// newSearchPopupModel builds a model whose prompt reads "PRE" and whose popup
+// is in the requested state, so a test can tell an untouched prompt from one
+// the popup wrote to.
+func newSearchPopupModel(t *testing.T, mode searchMode, n, selected int, search string, height, scrollOff int) *model {
+	t.Helper()
+	m := &model{cfg: Config{}, inputModel: NewInputModel(nil, nil, nil, ""), width: 80, height: 40}
+	m.inputModel.SetText("PRE")
+	items := searchItems(n)
+	m.searchPopup = &searchPopupState{
+		mode:      mode,
+		entries:   items,
+		filtered:  items,
+		selected:  selected,
+		search:    search,
+		height:    height,
+		scrollOff: scrollOff,
+	}
+	return m
+}
+
+func TestSearchPopupSelectPrev(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                           string
+		n, selected, height, scrollOff int
+		wantSelected, wantScrollOff    int
+	}{
+		{"mid list steps up and follows the window", 10, 4, 3, 3, 3, 1},
+		{"inside the window does not scroll", 10, 2, 3, 0, 1, 0},
+		{"from the first wraps to the last and scrolls there", 10, 0, 3, 0, 9, 7},
+		{"single item stays put", 1, 0, 3, 0, 0, 0},
+		{"empty list stays put", 0, 0, 3, 0, 0, 0},
+		{"near the top clamps scrollOff at zero", 10, 1, 3, 0, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sp := newSearchPopupModel(t, searchModeCommands, tt.n, tt.selected, "", tt.height, tt.scrollOff).searchPopup
+			sp.selectPrev()
+			if sp.selected != tt.wantSelected || sp.scrollOff != tt.wantScrollOff {
+				t.Errorf("selectPrev() = (sel %d, off %d), want (sel %d, off %d)",
+					sp.selected, sp.scrollOff, tt.wantSelected, tt.wantScrollOff)
+			}
+		})
+	}
+}
+
+func TestSearchPopupSelectNext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                           string
+		n, selected, height, scrollOff int
+		wantSelected, wantScrollOff    int
+	}{
+		{"steps down without scrolling inside the window", 10, 0, 3, 0, 1, 0},
+		{"steps down and pushes the window", 10, 2, 3, 0, 3, 1},
+		{"already scrolled stays consistent", 10, 4, 3, 3, 5, 3},
+		{"single item stays put", 1, 0, 3, 0, 0, 0},
+		{"empty list stays put", 0, 0, 3, 0, 0, 0},
+		// KNOWN QUIRK, pinned deliberately: wrapping from the last item back to
+		// the first moves the highlight to 0 but leaves scrollOff where it was,
+		// so the highlight lands outside the visible window. selectPrev has no
+		// such gap because it recomputes scrollOff unconditionally. Preserved as
+		// found; if this is ever fixed, this expectation is the one to change.
+		{"wrap to first leaves scrollOff stale", 10, 9, 3, 7, 0, 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sp := newSearchPopupModel(t, searchModeCommands, tt.n, tt.selected, "", tt.height, tt.scrollOff).searchPopup
+			sp.selectNext()
+			if sp.selected != tt.wantSelected || sp.scrollOff != tt.wantScrollOff {
+				t.Errorf("selectNext() = (sel %d, off %d), want (sel %d, off %d)",
+					sp.selected, sp.scrollOff, tt.wantSelected, tt.wantScrollOff)
+			}
+		})
+	}
+}
+
+func TestSearchPopupSelectByTab(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                           string
+		shift                          bool
+		n, selected, height, scrollOff int
+		wantSelected, wantScrollOff    int
+	}{
+		{"tab advances", false, 10, 0, 3, 0, 1, 0},
+		{"tab advances and scrolls", false, 10, 2, 3, 0, 3, 1},
+		{"tab stops on the last item without wrapping", false, 10, 9, 3, 7, 9, 7},
+		{"shift+tab steps back", true, 10, 9, 3, 7, 8, 6},
+		{"shift+tab wraps to the last from the first", true, 10, 0, 3, 0, 9, 7},
+		{"single item stays put", false, 1, 0, 3, 0, 0, 0},
+		// An empty list is left completely alone — scrollOff included, which is
+		// why the guard has to come before the scroll recompute.
+		{"empty list is untouched", false, 0, 0, 3, 5, 0, 5},
+		{"empty list is untouched under shift", true, 0, 0, 3, 5, 0, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sp := newSearchPopupModel(t, searchModeCommands, tt.n, tt.selected, "", tt.height, tt.scrollOff).searchPopup
+			sp.selectByTab(tt.shift)
+			if sp.selected != tt.wantSelected || sp.scrollOff != tt.wantScrollOff {
+				t.Errorf("selectByTab(%v) = (sel %d, off %d), want (sel %d, off %d)",
+					tt.shift, sp.selected, sp.scrollOff, tt.wantSelected, tt.wantScrollOff)
+			}
+		})
+	}
+}
+
+func TestAcceptSearchSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mode          searchMode
+		n, selected   int
+		wantText      string
+		wantPopupOpen bool
+	}{
+		{"a command gets a trailing space", searchModeCommands, 5, 0, "cmd-0 ", false},
+		{"a later command is taken by index", searchModeCommands, 5, 3, "cmd-3 ", false},
+		{"a history entry is restored verbatim", searchModeHistory, 4, 1, "cmd-1", false},
+		{"an empty list does nothing", searchModeCommands, 0, 0, "PRE", true},
+		{"a stale highlight does nothing", searchModeCommands, 3, 7, "PRE", true},
+		// A mode this function does not know leaves the prompt alone AND leaves
+		// the popup open, rather than closing on a key that did nothing.
+		{"an unknown mode does nothing", searchMode("bogus"), 3, 1, "PRE", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newSearchPopupModel(t, tt.mode, tt.n, tt.selected, "", 3, 0)
+			m.acceptSearchSelection()
+			if m.inputModel.Text != tt.wantText {
+				t.Errorf("prompt = %q, want %q", m.inputModel.Text, tt.wantText)
+			}
+			if open := m.searchPopup != nil; open != tt.wantPopupOpen {
+				t.Errorf("popup open = %v, want %v", open, tt.wantPopupOpen)
+			}
+		})
+	}
+}
+
+func TestBackspaceSearch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trims the filter and refilters", func(t *testing.T) {
+		t.Parallel()
+		m := newSearchPopupModel(t, searchModeCommands, 5, 3, "cmd", 2, 2)
+		m.backspaceSearch()
+		if m.searchPopup == nil {
+			t.Fatal("popup closed, want it still open")
+		}
+		if got := m.searchPopup.search; got != "cm" {
+			t.Errorf("search = %q, want %q", got, "cm")
+		}
+		// filterSearch resets the cursor to the top of the new result set.
+		if m.searchPopup.selected != 0 || m.searchPopup.scrollOff != 0 {
+			t.Errorf("after refilter: sel %d off %d, want 0 and 0",
+				m.searchPopup.selected, m.searchPopup.scrollOff)
+		}
+	})
+
+	t.Run("an empty filter closes the popup", func(t *testing.T) {
+		t.Parallel()
+		m := newSearchPopupModel(t, searchModeCommands, 5, 0, "", 3, 0)
+		m.backspaceSearch()
+		if m.searchPopup != nil {
+			t.Error("popup still open, want it closed")
+		}
+		if m.inputModel.Text != "PRE" {
+			t.Errorf("prompt = %q, want it untouched", m.inputModel.Text)
+		}
+	})
+}
+
+// TestTypeIntoSearch pins which keystrokes reach the filter. Declining matters
+// as much as claiming: a declined key falls through to the prompt, so widening
+// this predicate would swallow keystrokes the input still needs.
+func TestTypeIntoSearch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		key         tea.Key
+		wantHandled bool
+		wantSearch  string
+	}{
+		{"a printable rune is appended", tea.Key{Code: 'a', Text: "a"}, true, "xa"},
+		{"a space is appended", tea.Key{Code: tea.KeySpace, Text: " "}, true, "x "},
+		{"a modified rune is declined", tea.Key{Code: 'a', Text: "a", Mod: tea.ModCtrl}, false, "x"},
+		{"a key with no text is declined", tea.Key{Code: tea.KeyF1}, false, "x"},
+		{"a rune that carries no text is declined", tea.Key{Code: 'z'}, false, "x"},
+		// len() counts bytes, so any non-ASCII character is more than one byte
+		// and never reaches the filter. Pinned as found; see the report.
+		{"a multi-byte character is declined", tea.Key{Code: 'é', Text: "é"}, false, "x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newSearchPopupModel(t, searchModeCommands, 5, 0, "x", 3, 0)
+			if got := m.typeIntoSearch(tt.key); got != tt.wantHandled {
+				t.Errorf("typeIntoSearch() handled = %v, want %v", got, tt.wantHandled)
+			}
+			if got := m.searchPopup.search; got != tt.wantSearch {
+				t.Errorf("search = %q, want %q", got, tt.wantSearch)
+			}
+		})
+	}
+}
+
+// TestHandleSearchPopupKeyDispatch checks the routing itself: which keys the
+// popup claims, and that a closed popup claims nothing at all.
+func TestHandleSearchPopupKeyDispatch(t *testing.T) {
+	t.Parallel()
+
+	claimed := []struct {
+		name string
+		key  tea.Key
+	}{
+		{"up", tea.Key{Code: tea.KeyUp}},
+		{"down", tea.Key{Code: tea.KeyDown}},
+		{"tab", tea.Key{Code: tea.KeyTab}},
+		{"shift+tab", tea.Key{Code: tea.KeyTab, Mod: tea.ModShift}},
+		{"enter", tea.Key{Code: tea.KeyEnter}},
+		{"esc", tea.Key{Code: tea.KeyEsc}},
+		{"backspace", tea.Key{Code: tea.KeyBackspace}},
+		{"printable rune", tea.Key{Code: 'a', Text: "a"}},
+	}
+	for _, tt := range claimed {
+		t.Run("claims "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newSearchPopupModel(t, searchModeCommands, 5, 1, "", 3, 0)
+			if !m.handleSearchPopupKey(tt.key) {
+				t.Errorf("handleSearchPopupKey(%v) = false, want it claimed", tt.name)
+			}
+		})
+		t.Run("declines "+tt.name+" with no popup", func(t *testing.T) {
+			t.Parallel()
+			m := &model{cfg: Config{}, inputModel: NewInputModel(nil, nil, nil, ""), width: 80, height: 40}
+			if m.handleSearchPopupKey(tt.key) {
+				t.Errorf("handleSearchPopupKey(%v) = true with no popup, want declined", tt.name)
+			}
+		})
+	}
+
+	declined := []struct {
+		name string
+		key  tea.Key
+	}{
+		{"modified rune", tea.Key{Code: 'a', Text: "a", Mod: tea.ModCtrl}},
+		{"function key", tea.Key{Code: tea.KeyF1}},
+		{"multi-byte character", tea.Key{Code: 'é', Text: "é"}},
+	}
+	for _, tt := range declined {
+		t.Run("declines "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newSearchPopupModel(t, searchModeCommands, 5, 1, "", 3, 0)
+			if m.handleSearchPopupKey(tt.key) {
+				t.Errorf("handleSearchPopupKey(%v) = true, want declined", tt.name)
+			}
+			// A declined key must leave the popup exactly as it found it.
+			if m.searchPopup == nil || m.searchPopup.selected != 1 || m.searchPopup.search != "" {
+				t.Error("a declined key mutated the popup")
+			}
+		})
+	}
+
+	t.Run("esc closes the popup", func(t *testing.T) {
+		t.Parallel()
+		m := newSearchPopupModel(t, searchModeCommands, 5, 1, "", 3, 0)
+		m.handleSearchPopupKey(tea.Key{Code: tea.KeyEsc})
+		if m.searchPopup != nil {
+			t.Error("popup still open after Esc")
+		}
+	})
+}

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -84,23 +84,44 @@ func renderContextBar(pct float64, bg color.Color, p Palette) string {
 // Render renders the status bar string.
 func (s *StatusModel) Render(in StatusRenderInput) string {
 	p := paletteOrDark(in.Palette)
-
-	dim := lipgloss.NewStyle().Foreground(p.Dim)
 	bar := lipgloss.NewStyle().Width(s.Width)
+	sep := lipgloss.NewStyle().Foreground(p.Surface).Render("  │  ")
 
-	sepStyle := lipgloss.NewStyle().Foreground(p.Surface)
-	sep := sepStyle.Render("  │  ")
+	parts := []string{s.modeField(in, p)}
 
-	var parts []string
+	// Loading progress replaces the normal status content during init.
+	if in.LoadingItems != nil {
+		parts = append(parts, loadingField(in.LoadingItems, p))
+		return bar.Render(strings.Join(parts, sep))
+	}
 
-	// The bracketed field: [chat], [plan], the spinner verb while running — and a
-	// flash when there is one.
-	//
-	// A flash takes this slot over rather than adding a segment of its own. It is
-	// already the fixed-width, bracketed field the eye returns to, so a notice
-	// lands where the user is looking and the bar's geometry does not shift. The
-	// mode is not lost by borrowing it for three seconds: it has not changed, and
-	// it comes straight back.
+	// Fields render themselves out, in bar order; "" means the field has
+	// nothing to say for this input and takes no segment.
+	for _, field := range []string{
+		queueField(in.Pending, p),
+		contextField(in, p),
+		tokenField(in.TokenTracker, p),
+		locationField(in, p),
+		s.toolsField(p),
+		runCycleField(in.RunCycle, p),
+	} {
+		if field != "" {
+			parts = append(parts, field)
+		}
+	}
+
+	return bar.Render(strings.Join(parts, sep))
+}
+
+// modeField renders the bracketed field: [chat], [plan], the spinner verb while
+// running — and a flash when there is one.
+//
+// A flash takes this slot over rather than adding a segment of its own. It is
+// already the fixed-width, bracketed field the eye returns to, so a notice
+// lands where the user is looking and the bar's geometry does not shift. The
+// mode is not lost by borrowing it for three seconds: it has not changed, and
+// it comes straight back.
+func (s *StatusModel) modeField(in StatusRenderInput, p Palette) string {
 	mode := in.Mode
 	if mode == "" {
 		mode = "chat"
@@ -108,118 +129,140 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	switch {
 	case in.Flash != "":
 		flashStyle := lipgloss.NewStyle().Foreground(p.Green).Bold(true)
-		parts = append(parts, flashStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(in.Flash))))
+		return flashStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(in.Flash)))
 	case mode == "plan":
 		modeStyle := lipgloss.NewStyle().Foreground(p.Peach)
-		parts = append(parts, modeStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode))))
+		return modeStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode)))
 	case in.Running && s.ActiveTool == "":
+		// spinnerVerb picks its verb at random, so this branch alone makes the
+		// status bar — and with it View — render differently for identical model
+		// state. See matrixState.tick for the other source and for what the pair
+		// of them rules out.
 		verbStyle := lipgloss.NewStyle().Foreground(p.Blue)
-		parts = append(parts, verbStyle.Render(fmt.Sprintf(" [%s]", spinnerVerb())))
+		return verbStyle.Render(fmt.Sprintf(" [%s]", spinnerVerb()))
 	default:
 		verbStyle := lipgloss.NewStyle().Foreground(p.Blue)
-		parts = append(parts, verbStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode))))
+		return verbStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode)))
 	}
+}
 
-	// Loading progress (replaces normal status content during init).
-	if in.LoadingItems != nil {
-		var items []string
-		for _, name := range sortedKeys(in.LoadingItems) {
-			if in.LoadingItems[name] {
-				okStyle := lipgloss.NewStyle().Foreground(p.Green)
-				items = append(items, okStyle.Render(name+" \u2713"))
-			} else {
-				loadStyle := lipgloss.NewStyle().Foreground(p.Peach)
-				items = append(items, loadStyle.Render(name+"..."))
-			}
+// loadingField lists the startup subsystems, ticked as each finishes.
+func loadingField(items map[string]bool, p Palette) string {
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
+
+	var rendered []string
+	for _, name := range sortedKeys(items) {
+		if items[name] {
+			okStyle := lipgloss.NewStyle().Foreground(p.Green)
+			rendered = append(rendered, okStyle.Render(name+" ✓"))
+		} else {
+			loadStyle := lipgloss.NewStyle().Foreground(p.Peach)
+			rendered = append(rendered, loadStyle.Render(name+"..."))
 		}
-		parts = append(parts, dim.Render("load: ")+strings.Join(items, dim.Render(" ")))
-		return bar.Render(strings.Join(parts, sep))
 	}
+	return dim.Render("load: ") + strings.Join(rendered, dim.Render(" "))
+}
 
-	// Pending prompts are shown even while the active response is streaming,
-	// so the user can see that Enter was accepted without waiting for it.
-	if in.Pending > 0 {
-		queueStyle := lipgloss.NewStyle().Foreground(p.Peach)
-		parts = append(parts, queueStyle.Render(fmt.Sprintf("queued: %d", in.Pending)))
+// queueField counts the prompts waiting behind the active response. It is shown
+// even while that response is streaming, so the user can see Enter was accepted
+// without waiting for the turn to end.
+func queueField(pending int, p Palette) string {
+	if pending <= 0 {
+		return ""
 	}
+	queueStyle := lipgloss.NewStyle().Foreground(p.Peach)
+	return queueStyle.Render(fmt.Sprintf("queued: %d", pending))
+}
 
-	// Context % bar (visual bar with color coding).
-	noBg := p.Transparent
+// contextField renders the color-coded context bar, or — when no tracker has
+// reported a limit yet — the same rough estimate /context shows, so the two
+// cannot disagree about the same conversation.
+func contextField(in StatusRenderInput, p Palette) string {
 	if tt := in.TokenTracker; tt != nil && tt.Limit() > 0 {
-		pct := tt.PercentUsed()
-		parts = append(parts, renderContextBar(pct, noBg, p))
-	} else {
-		// Fallback: the same rough estimate /context shows, so the two cannot
-		// disagree about the same conversation.
-		ctxTokens := estimateContextTokenCount(in.Messages)
-		switch {
-		case ctxTokens >= 1000:
-			parts = append(parts, dim.Render(fmt.Sprintf("ctx: %.1fk", float64(ctxTokens)/1000)))
-		default:
-			parts = append(parts, dim.Render(fmt.Sprintf("ctx: %d", ctxTokens)))
+		return renderContextBar(tt.PercentUsed(), p.Transparent, p)
+	}
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
+	ctxTokens := estimateContextTokenCount(in.Messages)
+	if ctxTokens >= 1000 {
+		return dim.Render(fmt.Sprintf("ctx: %.1fk", float64(ctxTokens)/1000))
+	}
+	return dim.Render(fmt.Sprintf("ctx: %d", ctxTokens))
+}
+
+// tokenField renders the numeric token usage, colored by how close to the limit
+// it is. Without a limit it reports the running total alone.
+func tokenField(tt TokenTracker, p Palette) string {
+	if tt == nil {
+		return ""
+	}
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
+	total := tt.TotalUsed()
+	limit := tt.Limit()
+	if limit <= 0 {
+		if total <= 0 {
+			return ""
 		}
+		return dim.Render(fmt.Sprintf("tkn: %s", formatTokenCount(total)))
 	}
 
-	// Token usage (numeric).
-	if tt := in.TokenTracker; tt != nil {
-		total := tt.TotalUsed()
-		limit := tt.Limit()
-		if limit > 0 {
-			pct := tt.PercentUsed()
-			var tokenStyle lipgloss.Style
-			switch {
-			case pct >= 100:
-				tokenStyle = lipgloss.NewStyle().Foreground(p.Red)
-			case pct >= 80:
-				tokenStyle = lipgloss.NewStyle().Foreground(p.Peach)
-			default:
-				tokenStyle = dim
-			}
-			parts = append(parts, tokenStyle.Render(fmt.Sprintf("tkn: %s/%s",
-				formatTokenCount(total), formatTokenCount(limit))))
-		} else if total > 0 {
-			parts = append(parts, dim.Render(fmt.Sprintf("tkn: %s", formatTokenCount(total))))
-		}
+	tokenStyle := dim
+	switch pct := tt.PercentUsed(); {
+	case pct >= 100:
+		tokenStyle = lipgloss.NewStyle().Foreground(p.Red)
+	case pct >= 80:
+		tokenStyle = lipgloss.NewStyle().Foreground(p.Peach)
 	}
+	return tokenStyle.Render(fmt.Sprintf("tkn: %s/%s",
+		formatTokenCount(total), formatTokenCount(limit)))
+}
 
-	// Directory | host.
-	if in.FolderName != "" || in.HostName != "" {
-		dirStyle := lipgloss.NewStyle().Foreground(p.Mauve)
-		hostStyle := lipgloss.NewStyle().Foreground(p.Sky)
-
-		var locationParts []string
-		if in.FolderName != "" {
-			locationParts = append(locationParts, dirStyle.Render(in.FolderName))
-		}
-		if in.HostName != "" {
-			locationParts = append(locationParts, hostStyle.Render(in.HostName))
-		}
-		parts = append(parts, strings.Join(locationParts, dim.Render(" | ")))
+// locationField renders "directory | host", dropping whichever half is unknown.
+func locationField(in StatusRenderInput, p Palette) string {
+	if in.FolderName == "" && in.HostName == "" {
+		return ""
 	}
+	dirStyle := lipgloss.NewStyle().Foreground(p.Mauve)
+	hostStyle := lipgloss.NewStyle().Foreground(p.Sky)
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
 
-	// Active tools or thinking status.
+	var locationParts []string
+	if in.FolderName != "" {
+		locationParts = append(locationParts, dirStyle.Render(in.FolderName))
+	}
+	if in.HostName != "" {
+		locationParts = append(locationParts, hostStyle.Render(in.HostName))
+	}
+	return strings.Join(locationParts, dim.Render(" | "))
+}
+
+// toolsField names the tools currently executing: the parallel set when there
+// is more than one, otherwise the single tool with how long it has been going.
+func (s *StatusModel) toolsField(p Palette) string {
 	toolStyle := lipgloss.NewStyle().Foreground(p.Sapphire)
 	if len(s.ActiveTools) > 1 {
-		var toolNames []string
+		toolNames := make([]string, 0, len(s.ActiveTools))
 		for name := range s.ActiveTools {
 			toolNames = append(toolNames, name)
 		}
 		sort.Strings(toolNames)
-		parts = append(parts, toolStyle.Render(fmt.Sprintf("tools[%d]: %s", len(toolNames), strings.Join(toolNames, ", "))))
-	} else if s.ActiveTool != "" {
-		elapsed := time.Since(s.ToolStart).Truncate(time.Millisecond)
-		parts = append(parts, toolStyle.Render(fmt.Sprintf("tool: %s (%s)", s.ActiveTool, elapsed)))
+		return toolStyle.Render(fmt.Sprintf("tools[%d]: %s", len(toolNames), strings.Join(toolNames, ", ")))
 	}
-
-	// /run cycle indicator. The spec name is omitted: it is long enough to wrap
-	// the status bar onto a second line, and it is already shown in the sidebar.
-	if in.RunCycle != nil {
-		runStyle := lipgloss.NewStyle().Foreground(p.Peach)
-		parts = append(parts, runStyle.Render(fmt.Sprintf("cycle %d/%d",
-			in.RunCycle.Cycle, in.RunCycle.MaxRetries)))
+	if s.ActiveTool == "" {
+		return ""
 	}
+	elapsed := time.Since(s.ToolStart).Truncate(time.Millisecond)
+	return toolStyle.Render(fmt.Sprintf("tool: %s (%s)", s.ActiveTool, elapsed))
+}
 
-	return bar.Render(strings.Join(parts, sep))
+// runCycleField renders the /run cycle indicator. The spec name is omitted: it
+// is long enough to wrap the status bar onto a second line, and it is already
+// shown in the sidebar.
+func runCycleField(cycle *runCycleInfo, p Palette) string {
+	if cycle == nil {
+		return ""
+	}
+	runStyle := lipgloss.NewStyle().Foreground(p.Peach)
+	return runStyle.Render(fmt.Sprintf("cycle %d/%d", cycle.Cycle, cycle.MaxRetries))
 }
 
 // sortedKeys returns map keys in sorted order.

--- a/internal/tui/status_fields_test.go
+++ b/internal/tui/status_fields_test.go
@@ -1,0 +1,169 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStatusFieldsEmpty pins which fields decline a segment. Render skips any
+// field that returns "", so an empty string is how a field says "nothing to
+// report" — a field that returned a styled blank would add a stray separator.
+func TestStatusFieldsEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := paletteOrDark(Palette{})
+
+	tests := []struct {
+		name  string
+		field string
+	}{
+		{"no pending prompts", queueField(0, p)},
+		{"negative pending", queueField(-1, p)},
+		{"no token tracker", tokenField(nil, p)},
+		{"tracker with no limit and no usage", tokenField(&cmdMockTokenTracker{}, p)},
+		{"neither folder nor host", locationField(StatusRenderInput{}, p)},
+		{"no active tools", (&StatusModel{}).toolsField(p)},
+		{"no run cycle", runCycleField(nil, p)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.field != "" {
+				t.Errorf("field = %q, want empty", tt.field)
+			}
+		})
+	}
+}
+
+// TestStatusFieldsContent checks the text each field contributes, ignoring the
+// styling around it.
+func TestStatusFieldsContent(t *testing.T) {
+	t.Parallel()
+
+	p := paletteOrDark(Palette{})
+
+	tests := []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{"queued count", queueField(3, p), "queued: 3"},
+		{"tokens against a limit", tokenField(&cmdMockTokenTracker{limit: 100000, totalUsed: 42000, percentUsed: 42}, p), "tkn: 42.0k/100.0k"},
+		{"tokens over the limit", tokenField(&cmdMockTokenTracker{limit: 100, totalUsed: 120, percentUsed: 120}, p), "tkn: 120/100"},
+		{"tokens without a limit", tokenField(&cmdMockTokenTracker{totalUsed: 900}, p), "tkn: 900"},
+		{"context bar from a tracker", contextField(StatusRenderInput{TokenTracker: &cmdMockTokenTracker{limit: 100, totalUsed: 42, percentUsed: 42}}, p), "████░░░░░░ 42%"},
+		{"context estimate without a tracker", contextField(StatusRenderInput{}, p), "ctx: 0"},
+		{"folder only", locationField(StatusRenderInput{FolderName: "pi-go"}, p), "pi-go"},
+		{"host only", locationField(StatusRenderInput{HostName: "box"}, p), "box"},
+		{"folder and host", locationField(StatusRenderInput{FolderName: "pi-go", HostName: "box"}, p), "pi-go | box"},
+		{"run cycle", runCycleField(&runCycleInfo{Cycle: 2, MaxRetries: 5}, p), "cycle 2/5"},
+		{"loading items sort and tick", loadingField(map[string]bool{"mcp": true, "lsp": false}, p), "load: lsp... mcp ✓"},
+		{
+			"parallel tools are named in sorted order",
+			(&StatusModel{ActiveTools: map[string]time.Time{"read": {}, "bash": {}}}).toolsField(p),
+			"tools[2]: bash, read",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := stripANSI(tt.field); got != tt.want {
+				t.Errorf("field = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStatusToolsFieldSingle covers the single-tool branch, whose elapsed time
+// makes an exact comparison useless.
+func TestStatusToolsFieldSingle(t *testing.T) {
+	t.Parallel()
+
+	s := &StatusModel{ActiveTool: "bash", ToolStart: time.Now()}
+	got := stripANSI(s.toolsField(paletteOrDark(Palette{})))
+	if !strings.HasPrefix(got, "tool: bash (") || !strings.HasSuffix(got, ")") {
+		t.Errorf("toolsField() = %q, want \"tool: bash (<elapsed>)\"", got)
+	}
+}
+
+// TestStatusModeField covers the bracketed field's precedence: a flash borrows
+// the slot from everything else, plan mode outranks the spinner, and the
+// spinner only runs when no tool is active.
+func TestStatusModeField(t *testing.T) {
+	t.Parallel()
+
+	p := paletteOrDark(Palette{})
+
+	tests := []struct {
+		name  string
+		model StatusModel
+		in    StatusRenderInput
+		want  string
+	}{
+		{"empty mode defaults to chat", StatusModel{}, StatusRenderInput{}, "chat"},
+		{"plan mode", StatusModel{}, StatusRenderInput{Mode: "plan"}, "plan"},
+		{"flash outranks plan", StatusModel{}, StatusRenderInput{Mode: "plan", Flash: "Copied!"}, "Copied!"},
+		{"flash outranks the spinner", StatusModel{}, StatusRenderInput{Running: true, Flash: "Copied!"}, "Copied!"},
+		{"running with an active tool keeps the mode", StatusModel{ActiveTool: "bash"}, StatusRenderInput{Running: true}, "chat"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := strings.TrimSpace(stripANSI(tt.model.modeField(tt.in, p)))
+			got = strings.TrimSpace(strings.Trim(got, "[]"))
+			if got != tt.want {
+				t.Errorf("modeField() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStatusRenderSkipsEmptyFields checks that Render adds a separator only for
+// fields that reported something. A bar for an empty model carries the mode and
+// the context estimate and nothing else.
+func TestStatusRenderSkipsEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	s := &StatusModel{Width: 120}
+	got := stripANSI(s.Render(StatusRenderInput{}))
+	if n := strings.Count(got, "│"); n != 1 {
+		t.Errorf("Render() has %d separators, want 1; got %q", n, got)
+	}
+
+	full := stripANSI(s.Render(StatusRenderInput{
+		Pending:    2,
+		FolderName: "pi-go",
+		HostName:   "box",
+		RunCycle:   &runCycleInfo{Cycle: 1, MaxRetries: 3},
+	}))
+	for _, want := range []string{"queued: 2", "ctx: 0", "pi-go | box", "cycle 1/3"} {
+		if !strings.Contains(full, want) {
+			t.Errorf("Render() = %q, missing %q", full, want)
+		}
+	}
+	if n := strings.Count(full, "│"); n != 4 {
+		t.Errorf("Render() has %d separators, want 4; got %q", n, full)
+	}
+}
+
+// TestStatusRenderLoading checks that loading progress replaces the normal
+// content rather than joining it.
+func TestStatusRenderLoading(t *testing.T) {
+	t.Parallel()
+
+	s := &StatusModel{Width: 120}
+	got := stripANSI(s.Render(StatusRenderInput{
+		Pending:      5,
+		FolderName:   "pi-go",
+		LoadingItems: map[string]bool{"mcp": true, "lsp": false},
+	}))
+	if !strings.Contains(got, "load: lsp... mcp ✓") {
+		t.Errorf("Render() = %q, want the loading field", got)
+	}
+	for _, unwanted := range []string{"queued: 5", "pi-go", "ctx:"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("Render() = %q, should not carry %q while loading", got, unwanted)
+		}
+	}
+}

--- a/internal/tui/testdata/context_usage/breakdown_narrow.golden
+++ b/internal/tui/testdata/context_usage/breakdown_narrow.golden
@@ -1,0 +1,23 @@
+*Context usage*
+
+6% Full          ~16.4k / 256.0k Tokens
+
+───────────────────────────────────────
+
+███ System prompt                  3.5k
+███ Tool definitions               7.2k
+███ Rules                          1.1k
+███ Skills                          900
+███ MCP & dynamic tools            2.4k
+███ Subagent definitions            650
+███ Conversation                    607
+
+**Context Usage**
+
+`█░░░░░░░░░░░░░░░░░░░`  test-model · ctx ~607 tokens
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)

--- a/internal/tui/testdata/context_usage/breakdown_no_tracker.golden
+++ b/internal/tui/testdata/context_usage/breakdown_no_tracker.golden
@@ -1,0 +1,23 @@
+*Context usage*
+
+6% Full                                   ~16.4k / 256.0k Tokens
+
+────────────────────────────────────────────────────────────────
+
+███ System prompt                                           3.5k
+███ Tool definitions                                        7.2k
+███ Rules                                                   1.1k
+███ Skills                                                   900
+███ MCP & dynamic tools                                     2.4k
+███ Subagent definitions                                     650
+███ Conversation                                             607
+
+**Context Usage**
+
+`█░░░░░░░░░░░░░░░░░░░`  test-model · ctx ~607 tokens
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)

--- a/internal/tui/testdata/context_usage/breakdown_with_tracker.golden
+++ b/internal/tui/testdata/context_usage/breakdown_with_tracker.golden
@@ -1,0 +1,35 @@
+*Context usage*
+
+30% Full                                  ~60.0k / 200.0k Tokens
+
+────────────────────────────────────────────────────────────────
+
+███ System prompt                                           3.5k
+███ Tool definitions                                        7.2k
+███ Rules                                                   1.1k
+███ Skills                                                   900
+███ MCP & dynamic tools                                     2.4k
+███ Subagent definitions                                     650
+███ Conversation                                           44.2k
+
+**Context Usage**
+
+`████████░░░░░░░░░░░░`  anthropic | claude-sonnet · 40.0k/100.0k tokens (40%)
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Daily token usage*
+- **Consumed today**: 40.0k tokens
+- **Remaining**: 0 tokens
+
+*Context window*
+`██████░░░░░░░░░░░░░░`  60.0k / 200.0k (30%)
+- **Used**: 60.0k tokens
+- **Free**: 140.0k tokens (70%)
+
+*Prompt cache*
+- **Last request**: no cache hit

--- a/internal/tui/testdata/context_usage/cache_miss.golden
+++ b/internal/tui/testdata/context_usage/cache_miss.golden
@@ -1,0 +1,21 @@
+**Context Usage**
+
+`████░░░░░░░░░░░░░░░░`  test-model · 20.0k/100.0k tokens (20%)
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Daily token usage*
+- **Consumed today**: 20.0k tokens
+- **Remaining**: 0 tokens
+
+*Context window*
+`█░░░░░░░░░░░░░░░░░░░`  9.0k / 128.0k (7%)
+- **Used**: 9.0k tokens
+- **Free**: 119.0k tokens (93%)
+
+*Prompt cache*
+- **Last request**: no cache hit

--- a/internal/tui/testdata/context_usage/compact_metrics.golden
+++ b/internal/tui/testdata/context_usage/compact_metrics.golden
@@ -1,0 +1,12 @@
+**Context Usage**
+
+`█░░░░░░░░░░░░░░░░░░░`  test-model · ctx ~607 tokens
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Output compaction*
+- **Saved**: 42% of tool output

--- a/internal/tui/testdata/context_usage/compact_metrics_empty.golden
+++ b/internal/tui/testdata/context_usage/compact_metrics_empty.golden
@@ -1,0 +1,9 @@
+**Context Usage**
+
+`░░░░░░░░░░░░░░░░░░░░`  test-model · ctx ~0 tokens
+
+*Estimated usage by category*
+- **User messages**: ~0 tokens (0 msgs)
+- **Assistant messages**: ~0 tokens (0 msgs)
+- **Tool calls**: ~0 tokens (0 calls)
+- **Total context**: ~0 tokens (0 messages)

--- a/internal/tui/testdata/context_usage/ctx_window_overfull.golden
+++ b/internal/tui/testdata/context_usage/ctx_window_overfull.golden
@@ -1,0 +1,21 @@
+**Context Usage**
+
+`██████████░░░░░░░░░░`  test-model · 260.0k/500.0k tokens (52%)
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Daily token usage*
+- **Consumed today**: 260.0k tokens
+- **Remaining**: 0 tokens
+
+*Context window*
+`████████████████████`  250.0k / 200.0k (125%)
+- **Used**: 250.0k tokens
+- **Free**: 0 tokens (-25%)
+
+*Prompt cache*
+- **Last request**: no cache hit

--- a/internal/tui/testdata/context_usage/ctx_window_unknown.golden
+++ b/internal/tui/testdata/context_usage/ctx_window_unknown.golden
@@ -1,0 +1,19 @@
+**Context Usage**
+
+`████░░░░░░░░░░░░░░░░`  test-model · 10.0k/50.0k tokens (20%)
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Daily token usage*
+- **Consumed today**: 10.0k tokens
+- **Remaining**: 0 tokens
+
+*Context window*
+- **Last prompt**: 7.5k tokens (window size unknown)
+
+*Prompt cache*
+- **Last request**: no cache hit

--- a/internal/tui/testdata/context_usage/empty.golden
+++ b/internal/tui/testdata/context_usage/empty.golden
@@ -1,0 +1,9 @@
+**Context Usage**
+
+`░░░░░░░░░░░░░░░░░░░░`  test-model · ctx ~0 tokens
+
+*Estimated usage by category*
+- **User messages**: ~0 tokens (0 msgs)
+- **Assistant messages**: ~0 tokens (0 msgs)
+- **Tool calls**: ~0 tokens (0 calls)
+- **Total context**: ~0 tokens (0 messages)

--- a/internal/tui/testdata/context_usage/no_tracker_large.golden
+++ b/internal/tui/testdata/context_usage/no_tracker_large.golden
@@ -1,0 +1,9 @@
+**Context Usage**
+
+`██████░░░░░░░░░░░░░░`  openai | gpt-4 · ctx ~30.0k tokens
+
+*Estimated usage by category*
+- **User messages**: ~22.5k tokens (1 msgs)
+- **Assistant messages**: ~7.5k tokens (1 msgs)
+- **Tool calls**: ~0 tokens (0 calls)
+- **Total context**: ~30.0k tokens (2 messages)

--- a/internal/tui/testdata/context_usage/no_tracker_small.golden
+++ b/internal/tui/testdata/context_usage/no_tracker_small.golden
@@ -1,0 +1,9 @@
+**Context Usage**
+
+`█░░░░░░░░░░░░░░░░░░░`  openai | gpt-4 · ctx ~607 tokens
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)

--- a/internal/tui/testdata/context_usage/skills.golden
+++ b/internal/tui/testdata/context_usage/skills.golden
@@ -1,0 +1,14 @@
+**Context Usage**
+
+`░░░░░░░░░░░░░░░░░░░░`  test-model · ctx ~0 tokens
+
+*Estimated usage by category*
+- **User messages**: ~0 tokens (0 msgs)
+- **Assistant messages**: ~0 tokens (0 msgs)
+- **Tool calls**: ~0 tokens (0 calls)
+- **Total context**: ~0 tokens (0 messages)
+
+*Skills* (3 loaded)
+- /alpha — First skill [bundled]  body: not loaded
+- /nosource — (no description) [user]  body: not loaded
+- /zebra — Last alphabetically [project]  body: not loaded

--- a/internal/tui/testdata/context_usage/tracker_limit_full_sections.golden
+++ b/internal/tui/testdata/context_usage/tracker_limit_full_sections.golden
@@ -1,0 +1,23 @@
+**Context Usage**
+
+`███████████░░░░░░░░░`  anthropic | claude-sonnet · 56.8k/100.0k tokens (57%)
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Daily token usage*
+- **Consumed today**: 56.8k tokens
+- **Remaining**: 43.2k tokens
+
+*Context window*
+`██░░░░░░░░░░░░░░░░░░`  20.0k / 200.0k (10%)
+- **Used**: 20.0k tokens
+- **Free**: 180.0k tokens (90%)
+
+*Prompt cache*
+- **Last request**: 15.0k of 20.0k prompt tokens cached (75%)
+- **Today**: 123.5k tokens read from cache (42% of input)
+- **Stable prefix**: 15.7k tokens · **body since**: 4.3k tokens

--- a/internal/tui/testdata/context_usage/tracker_no_limit.golden
+++ b/internal/tui/testdata/context_usage/tracker_no_limit.golden
@@ -1,0 +1,12 @@
+**Context Usage**
+
+`█░░░░░░░░░░░░░░░░░░░`  local-model · ctx ~607 tokens
+
+*Estimated usage by category*
+- **User messages**: ~105 tokens (2 msgs)
+- **Assistant messages**: ~200 tokens (1 msgs)
+- **Tool calls**: ~302 tokens (1 calls)
+- **Total context**: ~607 tokens (4 messages)
+
+*Daily token usage*
+- **Consumed today**: 1.0k tokens

--- a/internal/tui/testdata/context_usage/tracker_overflow.golden
+++ b/internal/tui/testdata/context_usage/tracker_overflow.golden
@@ -1,0 +1,13 @@
+**Context Usage**
+
+`████████████████████`  test-model · 200.0k/100.0k tokens (200%)
+
+*Estimated usage by category*
+- **User messages**: ~0 tokens (0 msgs)
+- **Assistant messages**: ~0 tokens (0 msgs)
+- **Tool calls**: ~0 tokens (0 calls)
+- **Total context**: ~0 tokens (0 messages)
+
+*Daily token usage*
+- **Consumed today**: 200.0k tokens
+- **Remaining**: 0 tokens

--- a/internal/tui/testdata/run_events/error_appends_a_message_and_a_trace_entry.golden
+++ b/internal/tui/testdata/run_events/error_appends_a_message_and_a_trace_entry.golden
@@ -1,0 +1,8 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=3000332025
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+  [1] role="assistant" tool="" toolIn="" content="Agent error: connection reset by peer"
+trace:
+  [0] kind="error" summary="agent error" detail="connection reset by peer" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/matrix_falls_back_to_the_event_type_when_content_is_empty.golden
+++ b/internal/tui/testdata/run_events/matrix_falls_back_to_the_event_type_when_content_is_empty.golden
@@ -1,0 +1,6 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=2855447840829814718
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+trace:
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/matrix_is_not_fed_when_content_and_type_are_both_empty.golden
+++ b/internal/tui/testdata/run_events/matrix_is_not_fed_when_content_and_type_are_both_empty.golden
@@ -1,0 +1,6 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=false seed=0
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+trace:
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/message_end_clears_the_streaming_accumulator.golden
+++ b/internal/tui/testdata/run_events/message_end_clears_the_streaming_accumulator.golden
@@ -1,0 +1,7 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=4772730959683061956
+messages:
+  [0] role="assistant" tool="" toolIn="" content="leftover"
+trace:
+  [0] kind="llm" summary="agent response" detail="leftover" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/message_start_opens_a_fresh_assistant_placeholder.golden
+++ b/internal/tui/testdata/run_events/message_start_opens_a_fresh_assistant_placeholder.golden
@@ -1,0 +1,8 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=-6644822097849440611
+messages:
+  [0] role="assistant" tool="" toolIn="" content="leftover"
+  [1] role="assistant" tool="" toolIn="" content=""
+trace:
+  [0] kind="llm" summary="agent response" detail="leftover" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/text_delta_accumulates_into_the_last_assistant_message.golden
+++ b/internal/tui/testdata/run_events/text_delta_accumulates_into_the_last_assistant_message.golden
@@ -1,0 +1,7 @@
+streaming="Hello world" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=4029215268080288898
+messages:
+  [0] role="assistant" tool="" toolIn="" content="Hello world"
+trace:
+  [0] kind="llm" summary="agent response" detail="Hello world" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/text_delta_appends_a_new_trace_entry_after_a_tool_call.golden
+++ b/internal/tui/testdata/run_events/text_delta_appends_a_new_trace_entry_after_a_tool_call.golden
@@ -1,0 +1,10 @@
+streaming="firstsecond" scroll=0 activeTool="read" toolStartSet=true
+matrix active=true seed=8899108315356195923
+messages:
+  [0] role="assistant" tool="" toolIn="" content="firstsecond"
+  [1] role="tool" tool="read" toolIn="" content=""
+trace:
+  [0] kind="llm" summary="agent response" detail="first" timeSet=true
+  [1] kind="tool_call" summary=">>> read" detail="" timeSet=true
+  [2] kind="llm" summary="agent response" detail="second" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/text_delta_updates_the_newest_of_several_assistant_messages.golden
+++ b/internal/tui/testdata/run_events/text_delta_updates_the_newest_of_several_assistant_messages.golden
@@ -1,0 +1,9 @@
+streaming="newest" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=100629971163
+messages:
+  [0] role="assistant" tool="" toolIn="" content="older turn"
+  [1] role="tool" tool="bash" toolIn="" content="done"
+  [2] role="assistant" tool="" toolIn="" content="newest"
+trace:
+  [0] kind="llm" summary="agent response" detail="newest" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/text_delta_with_no_assistant_message_to_update.golden
+++ b/internal/tui/testdata/run_events/text_delta_with_no_assistant_message_to_update.golden
@@ -1,0 +1,7 @@
+streaming="orphan" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=101883261049
+messages:
+  [0] role="user" tool="" toolIn="" content="go"
+trace:
+  [0] kind="llm" summary="agent response" detail="orphan" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/tool_call_arg_shapes.golden
+++ b/internal/tui/testdata/run_events/tool_call_arg_shapes.golden
@@ -1,0 +1,14 @@
+streaming="" scroll=0 activeTool="edit" toolStartSet=true
+matrix active=true seed=-2677555182401033970
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+  [1] role="tool" tool="read" toolIn="internal/tui/run.go" content=""
+  [2] role="tool" tool="bash" toolIn="go test ./..." content=""
+  [3] role="tool" tool="grep" toolIn="" content=""
+  [4] role="tool" tool="edit" toolIn="" content=""
+trace:
+  [0] kind="tool_call" summary=">>> read" detail="" timeSet=true
+  [1] kind="tool_call" summary=">>> bash" detail="" timeSet=true
+  [2] kind="tool_call" summary=">>> grep" detail="" timeSet=true
+  [3] kind="tool_call" summary=">>> edit" detail="" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/tool_result_after_a_write.golden
+++ b/internal/tui/testdata/run_events/tool_result_after_a_write.golden
@@ -1,0 +1,9 @@
+streaming="" scroll=0 activeTool="" toolStartSet=true
+matrix active=true seed=-7570063676529824892
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+  [1] role="tool" tool="write" toolIn="" content="wrote 12 lines"
+trace:
+  [0] kind="tool_call" summary=">>> write" detail="" timeSet=true
+  [1] kind="tool_result" summary="<<< result" detail="wrote 12 lines" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/tool_result_after_a_write_with_no_live_run.golden
+++ b/internal/tui/testdata/run_events/tool_result_after_a_write_with_no_live_run.golden
@@ -1,0 +1,9 @@
+streaming="" scroll=0 activeTool="" toolStartSet=true
+matrix active=true seed=-7570063676529824892
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+  [1] role="tool" tool="write" toolIn="" content="wrote 12 lines"
+trace:
+  [0] kind="tool_call" summary=">>> write" detail="" timeSet=true
+  [1] kind="tool_result" summary="<<< result" detail="wrote 12 lines" timeSet=true
+run=nil

--- a/internal/tui/testdata/run_events/tool_result_fills_the_last_empty_tool_message.golden
+++ b/internal/tui/testdata/run_events/tool_result_fills_the_last_empty_tool_message.golden
@@ -1,0 +1,9 @@
+streaming="" scroll=0 activeTool="" toolStartSet=true
+matrix active=true seed=-5097548136811212583
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+  [1] role="tool" tool="bash" toolIn="" content="ok"
+trace:
+  [0] kind="tool_call" summary=">>> bash" detail="" timeSet=true
+  [1] kind="tool_result" summary="<<< result" detail="{\"exit_code\": 0, \"stdout\": \"ok\"}" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/tool_result_fills_the_newest_of_several_open_tool_cards.golden
+++ b/internal/tui/testdata/run_events/tool_result_fills_the_newest_of_several_open_tool_cards.golden
@@ -1,0 +1,8 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=-5957641618855401512
+messages:
+  [0] role="tool" tool="read" toolIn="" content=""
+  [1] role="tool" tool="bash" toolIn="" content="second result"
+trace:
+  [0] kind="tool_result" summary="<<< result" detail="second result" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/tool_result_with_no_empty_tool_message_to_fill.golden
+++ b/internal/tui/testdata/run_events/tool_result_with_no_empty_tool_message_to_fill.golden
@@ -1,0 +1,7 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=-830252635369984020
+messages:
+  [0] role="tool" tool="bash" toolIn="" content="done"
+trace:
+  [0] kind="tool_result" summary="<<< result" detail="orphan result" timeSet=true
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_events/unknown_event_type_is_inert.golden
+++ b/internal/tui/testdata/run_events/unknown_event_type_is_inert.golden
@@ -1,0 +1,6 @@
+streaming="" scroll=0 activeTool="" toolStartSet=false
+matrix active=true seed=110354948
+messages:
+  [0] role="assistant" tool="" toolIn="" content=""
+trace:
+run phase="running" checklist=0

--- a/internal/tui/testdata/run_summary/a_gate_failed_with_output.golden
+++ b/internal/tui/testdata/run_summary/a_gate_failed_with_output.golden
@@ -1,0 +1,33 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **gate_failed** |
+| Retries | 1 / 3 |
+| Slices | 2 / 3 complete |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+- **build** (`go build ./...`): **PASS**
+- **test** (`go test ./...`): **FAIL**
+  ```
+  --- FAIL: TestThing (0.01s)
+    thing_test.go:42: want 1, got 2
+FAIL
+  ```
+
+Some gates **failed**.
+
+## Unfinished Slices
+
+- Step 3: add metrics
+
+## Result
+
+Gate validation failed after 1 retries. Worktree preserved for manual inspection.

--- a/internal/tui/testdata/run_summary/all_gates_passed.golden
+++ b/internal/tui/testdata/run_summary/all_gates_passed.golden
@@ -1,0 +1,24 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **completed** |
+| Retries | 1 / 3 |
+| Slices | 3 / 3 complete |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+- **build** (`go build ./...`): **PASS**
+- **test** (`go test ./...`): **PASS**
+
+All gates **passed**.
+
+## Result
+
+All gates passed, the plan checklist was complete, and changes were merged successfully.

--- a/internal/tui/testdata/run_summary/failed_gate_with_no_output.golden
+++ b/internal/tui/testdata/run_summary/failed_gate_with_no_output.golden
@@ -1,0 +1,22 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **gate_failed** |
+| Retries | 1 / 3 |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+- **lint** (`golangci-lint run`): **FAIL**
+
+Some gates **failed**.
+
+## Result
+
+Gate validation failed after 1 retries. Worktree preserved for manual inspection.

--- a/internal/tui/testdata/run_summary/gate_output_is_truncated_past_the_cap.golden
+++ b/internal/tui/testdata/run_summary/gate_output_is_truncated_past_the_cap.golden
@@ -1,0 +1,102 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **gate_failed** |
+| Retries | 1 / 3 |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+- **test** (`go test ./...`): **FAIL**
+  ```
+  failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+failing line
+...(truncated)
+  ```
+
+Some gates **failed**.
+
+## Result
+
+Gate validation failed after 1 retries. Worktree preserved for manual inspection.

--- a/internal/tui/testdata/run_summary/gates_defined_but_never_executed.golden
+++ b/internal/tui/testdata/run_summary/gates_defined_but_never_executed.golden
@@ -1,0 +1,23 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **agent_failed** |
+| Retries | 1 / 3 |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+Gates were defined but not executed.
+
+- **build**: `go build ./...`
+- **test**: `go test ./...`
+
+## Result
+
+Subagent process exited with non-zero status (or was killed) before gates could run. Worktree preserved for manual inspection — see chat for the failing agent IDs and their worktree paths.

--- a/internal/tui/testdata/run_summary/merge_failed.golden
+++ b/internal/tui/testdata/run_summary/merge_failed.golden
@@ -1,0 +1,25 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **merge_failed** |
+| Retries | 1 / 3 |
+| Slices | 2 / 3 complete |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+No gates defined.
+
+## Unfinished Slices
+
+- Step 3: add metrics
+
+## Result
+
+Gates passed but merge into the main branch failed. Worktree preserved for manual resolution.

--- a/internal/tui/testdata/run_summary/minimal.golden
+++ b/internal/tui/testdata/run_summary/minimal.golden
@@ -1,0 +1,18 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `bare` |
+| Agent | `task-0` |
+| Outcome | **completed** |
+| Retries | 0 / 3 |
+
+## Gates
+
+No gates defined.
+
+## Result
+
+All gates passed, the plan checklist was complete, and changes were merged successfully.

--- a/internal/tui/testdata/run_summary/unfinished_slices_are_listed.golden
+++ b/internal/tui/testdata/run_summary/unfinished_slices_are_listed.golden
@@ -1,0 +1,25 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **verify_failed** |
+| Retries | 1 / 3 |
+| Slices | 2 / 3 complete |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+No gates defined.
+
+## Unfinished Slices
+
+- Step 3: add metrics
+
+## Result
+
+Gates passed but the plan was still incomplete after 1 retries — the run stopped short of the checklist. Nothing was merged; the worktree is preserved so the finished slices are not lost.

--- a/internal/tui/testdata/run_summary/unrecognized_outcome_falls_through_to_the_default.golden
+++ b/internal/tui/testdata/run_summary/unrecognized_outcome_falls_through_to_the_default.golden
@@ -1,0 +1,20 @@
+# Run Summary
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Spec | `rate-limiter` |
+| Agent | `task-42` |
+| Outcome | **interrupted_by_user** |
+| Retries | 1 / 3 |
+| Started | 2026-03-14T09:26:53Z |
+| Duration | <elapsed> |
+
+## Gates
+
+No gates defined.
+
+## Result
+
+Run ended with status: interrupted_by_user

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -557,77 +557,83 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p 
 	return b.String()
 }
 
+// toolSummaryArg maps a tool name to the single argument whose value is that
+// tool's one-line summary. Tools whose summary takes more than a lookup — ls,
+// tree and agent — are handled in toolCallSummary itself.
+var toolSummaryArg = map[string]string{
+	"read":  "file_path",
+	"write": "file_path",
+	"edit":  "file_path",
+	"bash":  "command",
+
+	"bash_wait":   "handle",
+	"bash_output": "handle",
+	"bash_kill":   "handle",
+
+	// "ripgrep" is the name the grep tool registers under when rg is installed.
+	"grep":    "pattern",
+	"ripgrep": "pattern",
+	"find":    "pattern",
+
+	// Gemini's server-side search, surfaced as a synthetic tool call so a
+	// grounded answer shows the query it searched for.
+	groundingToolName: "query",
+}
+
 // toolCallSummary returns a short one-line summary of tool arguments.
 func toolCallSummary(name string, args map[string]any) string {
 	switch name {
-	case "read":
-		if fp, ok := args["file_path"].(string); ok {
-			return fp
-		}
-	case "write":
-		if fp, ok := args["file_path"].(string); ok {
-			return fp
-		}
-	case "edit":
-		if fp, ok := args["file_path"].(string); ok {
-			return fp
-		}
-	case "bash":
-		if cmd, ok := args["command"].(string); ok {
-			return cmd
-		}
-	case "bash_wait", "bash_output", "bash_kill":
-		if h, ok := args["handle"].(string); ok {
-			return h
-		}
-	// "ripgrep" is the name the grep tool registers under when rg is installed.
-	case "grep", "ripgrep":
-		if p, ok := args["pattern"].(string); ok {
-			return p
-		}
-	// Gemini's server-side search, surfaced as a synthetic tool call so a
-	// grounded answer shows the query it searched for.
-	case groundingToolName:
-		if q, ok := args["query"].(string); ok {
-			return q
-		}
-	case "find":
-		if p, ok := args["pattern"].(string); ok {
-			return p
-		}
 	case "ls":
+		// A path that is present but empty is shown as given; only a missing
+		// path falls back to the working directory.
 		if p, ok := args["path"].(string); ok {
 			return p
 		}
 		return "."
 	case "tree":
-		p, _ := args["path"].(string)
-		if p == "" {
-			p = "."
-		}
-		if d, ok := args["depth"].(float64); ok && d > 0 {
-			return fmt.Sprintf("%s (depth %d)", p, int(d))
-		}
-		return p
+		return treeCallSummary(args)
 	case "agent":
-		typ, _ := args["type"].(string)
-		prompt, _ := args["prompt"].(string)
-		// Truncate prompt to first line, max 60 chars.
-		if idx := strings.IndexByte(prompt, '\n'); idx > 0 {
-			prompt = prompt[:idx]
-		}
-		if len(prompt) > 60 {
-			prompt = prompt[:57] + "..."
-		}
-		if typ != "" && prompt != "" {
-			return fmt.Sprintf("%s: %s", typ, prompt)
-		}
-		if typ != "" {
-			return typ
-		}
-		return prompt
+		return agentCallSummary(args)
+	}
+	if key, ok := toolSummaryArg[name]; ok {
+		s, _ := args[key].(string)
+		return s
 	}
 	return ""
+}
+
+// treeCallSummary describes a tree call as its root path, plus the depth when
+// one was asked for. Unlike ls, an empty path reads as the working directory.
+func treeCallSummary(args map[string]any) string {
+	p, _ := args["path"].(string)
+	if p == "" {
+		p = "."
+	}
+	if d, ok := args["depth"].(float64); ok && d > 0 {
+		return fmt.Sprintf("%s (depth %d)", p, int(d))
+	}
+	return p
+}
+
+// agentCallSummary describes a subagent call as "type: prompt", falling back to
+// whichever of the two the call carries. The prompt is cut to its first line
+// and 60 columns so a multi-paragraph brief cannot take over the card header.
+func agentCallSummary(args map[string]any) string {
+	typ, _ := args["type"].(string)
+	prompt, _ := args["prompt"].(string)
+	if idx := strings.IndexByte(prompt, '\n'); idx > 0 {
+		prompt = prompt[:idx]
+	}
+	if len(prompt) > 60 {
+		prompt = prompt[:57] + "..."
+	}
+	switch {
+	case typ != "" && prompt != "":
+		return fmt.Sprintf("%s: %s", typ, prompt)
+	case typ != "":
+		return typ
+	}
+	return prompt
 }
 
 // toolResultSummary returns a short one-line summary of a tool result.
@@ -638,142 +644,240 @@ func toolResultSummary(content string) string {
 		return formatToolResult(data)
 	}
 	// Collapse to single line.
-	content = strings.ReplaceAll(content, "\n", " ")
-	if len(content) > 120 {
-		return content[:117] + "..."
+	return clipSummary(strings.ReplaceAll(content, "\n", " "))
+}
+
+// summaryWidth is the column budget for a one-line tool summary. Anything
+// longer is cut to summaryWidth-3 bytes and given an ellipsis, so the rendered
+// field is never wider than summaryWidth.
+const summaryWidth = 120
+
+// clipSummary cuts s to summaryWidth, marking the cut with an ellipsis. The cut
+// is by byte, which is what these cards have always rendered.
+func clipSummary(s string) string {
+	if len(s) > summaryWidth {
+		return s[:summaryWidth-3] + "..."
 	}
-	return content
+	return s
+}
+
+// resultFormatter renders a parsed tool result, reporting whether the result
+// was one it recognizes. When ok is false the string returned is ignored and
+// the next formatter is tried.
+type resultFormatter func(data map[string]any) (_ string, ok bool)
+
+// resultFormatters are tried in order, and the first that recognizes the result
+// wins. The order is load-bearing in two places: a formatter that accepts both
+// a full payload and the bare count standing in for it has to check the payload
+// first, and bashWindowSummary has to run before bashExitSummary — see its
+// comment for what happens when it does not.
+var resultFormatters = []resultFormatter{
+	lsEntriesSummary,
+	treeCountsSummary,
+	grepMatchesSummary,
+	findFilesSummary,
+	readContentSummary,
+	writeBytesSummary,
+	editReplacementsSummary,
+	diagnosticsSummary,
+	bashWindowSummary,
+	bashExitSummary,
 }
 
 // formatToolResult extracts a readable summary from a parsed tool result.
 func formatToolResult(data map[string]any) string {
-	// ls tool: show file/dir names
-	if entries, ok := data["entries"].([]any); ok {
-		var names []string
-		for _, e := range entries {
-			if m, ok := e.(map[string]any); ok {
-				name, _ := m["name"].(string)
-				if isDir, ok := m["is_dir"].(bool); ok && isDir {
-					name += "/"
-				}
-				names = append(names, name)
-			}
+	for _, format := range resultFormatters {
+		if s, ok := format(data); ok {
+			return s
 		}
-		result := strings.Join(names, "  ")
-		if len(result) > 120 {
-			return result[:117] + "..."
+	}
+	// Fallback: compact JSON
+	b, _ := json.Marshal(data)
+	return clipSummary(string(b))
+}
+
+// lsEntriesSummary lists an ls result's names, marking directories with a
+// trailing slash.
+func lsEntriesSummary(data map[string]any) (string, bool) {
+	entries, ok := data["entries"].([]any)
+	if !ok {
+		return "", false
+	}
+	var names []string
+	for _, e := range entries {
+		m, ok := e.(map[string]any)
+		if !ok {
+			continue
 		}
-		return result
-	}
-	// tree tool: show dirs/files count
-	if _, ok := data["tree"].(string); ok {
-		d, _ := data["dirs"].(float64)
-		f, _ := data["files"].(float64)
-		return fmt.Sprintf("%d dirs, %d files", int(d), int(f))
-	}
-	// grep tool: show matches with file:line: content
-	if matchList, ok := data["matches"].([]any); ok {
-		total, _ := data["total_matches"].(float64)
-		trunc, _ := data["truncated"].(bool)
-		var sb strings.Builder
-		for _, m := range matchList {
-			if entry, ok := m.(map[string]any); ok {
-				file, _ := entry["file"].(string)
-				line, _ := entry["line"].(float64)
-				content, _ := entry["content"].(string)
-				fmt.Fprintf(&sb, "%s:%d: %s\n", file, int(line), content)
-			}
+		name, _ := m["name"].(string)
+		if isDir, ok := m["is_dir"].(bool); ok && isDir {
+			name += "/"
 		}
-		if trunc {
-			fmt.Fprintf(&sb, "... (%d total matches, truncated)", int(total))
+		names = append(names, name)
+	}
+	return clipSummary(strings.Join(names, "  ")), true
+}
+
+// treeCountsSummary reduces a tree result to the counts it reported. The tree
+// itself is far too tall for a one-line summary.
+func treeCountsSummary(data map[string]any) (string, bool) {
+	if _, ok := data["tree"].(string); !ok {
+		return "", false
+	}
+	d, _ := data["dirs"].(float64)
+	f, _ := data["files"].(float64)
+	return fmt.Sprintf("%d dirs, %d files", int(d), int(f)), true
+}
+
+// grepMatchesSummary lists a grep result as one "file:line: content" per match,
+// falling back to the match count when the result carried only the count.
+func grepMatchesSummary(data map[string]any) (string, bool) {
+	matchList, hasList := data["matches"].([]any)
+	if !hasList {
+		total, hasTotal := data["total_matches"].(float64)
+		if !hasTotal {
+			return "", false
 		}
-		return strings.TrimRight(sb.String(), "\n")
+		return fmt.Sprintf("%d matches", int(total)), true
 	}
-	if matches, ok := data["total_matches"].(float64); ok {
-		return fmt.Sprintf("%d matches", int(matches))
-	}
-	// find tool: show file list
-	if fileList, ok := data["files"].([]any); ok {
-		total, _ := data["total_files"].(float64)
-		trunc, _ := data["truncated"].(bool)
-		var sb strings.Builder
-		for _, f := range fileList {
-			if name, ok := f.(string); ok {
-				sb.WriteString(name)
-				sb.WriteByte('\n')
-			}
+	total, _ := data["total_matches"].(float64)
+	trunc, _ := data["truncated"].(bool)
+	var sb strings.Builder
+	for _, m := range matchList {
+		entry, ok := m.(map[string]any)
+		if !ok {
+			continue
 		}
-		if trunc {
-			fmt.Fprintf(&sb, "... (%d total files, truncated)", int(total))
+		file, _ := entry["file"].(string)
+		line, _ := entry["line"].(float64)
+		content, _ := entry["content"].(string)
+		fmt.Fprintf(&sb, "%s:%d: %s\n", file, int(line), content)
+	}
+	if trunc {
+		fmt.Fprintf(&sb, "... (%d total matches, truncated)", int(total))
+	}
+	return strings.TrimRight(sb.String(), "\n"), true
+}
+
+// findFilesSummary lists a find result's paths one per line, falling back to
+// the file count when the result carried only the count.
+func findFilesSummary(data map[string]any) (string, bool) {
+	fileList, hasList := data["files"].([]any)
+	if !hasList {
+		total, hasTotal := data["total_files"].(float64)
+		if !hasTotal {
+			return "", false
 		}
-		return strings.TrimRight(sb.String(), "\n")
+		return fmt.Sprintf("%d files", int(total)), true
 	}
-	if total, ok := data["total_files"].(float64); ok {
-		return fmt.Sprintf("%d files", int(total))
-	}
-	// read tool: show actual content with line numbers
-	if content, ok := data["content"].(string); ok {
-		total, _ := data["total_lines"].(float64)
-		trunc, _ := data["truncated"].(bool)
-		if trunc {
-			content += fmt.Sprintf("\n... (%d total lines, truncated)", int(total))
+	total, _ := data["total_files"].(float64)
+	trunc, _ := data["truncated"].(bool)
+	var sb strings.Builder
+	for _, f := range fileList {
+		if name, ok := f.(string); ok {
+			sb.WriteString(name)
+			sb.WriteByte('\n')
 		}
-		return content
 	}
-	if total, ok := data["total_lines"].(float64); ok {
+	if trunc {
+		fmt.Fprintf(&sb, "... (%d total files, truncated)", int(total))
+	}
+	return strings.TrimRight(sb.String(), "\n"), true
+}
+
+// readContentSummary hands a read result's content through untouched — the card
+// numbers and highlights it — or reports the line count when the result carried
+// only that.
+func readContentSummary(data map[string]any) (string, bool) {
+	content, hasContent := data["content"].(string)
+	if !hasContent {
+		total, hasTotal := data["total_lines"].(float64)
+		if !hasTotal {
+			return "", false
+		}
 		trunc := ""
 		if t, ok := data["truncated"].(bool); ok && t {
 			trunc = " (truncated)"
 		}
-		return fmt.Sprintf("%d lines%s", int(total), trunc)
+		return fmt.Sprintf("%d lines%s", int(total), trunc), true
 	}
-	// write tool: show bytes written
-	if bw, ok := data["bytes_written"].(float64); ok {
-		if p, ok := data["path"].(string); ok {
-			return fmt.Sprintf("%s (%d bytes)", p, int(bw))
-		}
+	total, _ := data["total_lines"].(float64)
+	if trunc, _ := data["truncated"].(bool); trunc {
+		content += fmt.Sprintf("\n... (%d total lines, truncated)", int(total))
 	}
-	// edit tool: show replacements
-	if r, ok := data["replacements"].(float64); ok {
-		return fmt.Sprintf("%d replacements", int(r))
+	return content, true
+}
+
+// writeBytesSummary reports what a write landed. A result carrying the byte
+// count but no path is deliberately not claimed: the count on its own names no
+// file, and a later formatter may still recognize the result.
+func writeBytesSummary(data map[string]any) (string, bool) {
+	bw, hasBytes := data["bytes_written"].(float64)
+	if !hasBytes {
+		return "", false
 	}
-	// lsp_diagnostics: show diagnostics (already prefixed with ⚠ by formatDiagnosticsForDisplay)
-	if diag, ok := data["lsp_diagnostics"].(string); ok && diag != "" {
-		return diag
+	p, hasPath := data["path"].(string)
+	if !hasPath {
+		return "", false
 	}
-	// A backgrounded command, either at the moment of handoff (the bash tool) or
-	// on any later poll of it (bash_wait, bash_kill). Both carry a handle, and
-	// both have to be taken before the exit-code branch below.
-	//
-	// While such a command is still running it has no exit status: the bash tool
-	// reports the -1 placeholder, which the exit-code branch renders as
-	// "exit -1: <first line of output>" — a live lint run reading as a crashed
-	// one. A poll is worse: BashStatus omits exit_code entirely while running, so
-	// it missed the branch altogether and fell through to the raw-JSON fallback,
-	// printing &-escaped argument soup instead of the command's output.
-	if handle, ok := data["handle"].(string); ok && handle != "" {
-		return formatBashWindow(handle, data)
+	return fmt.Sprintf("%s (%d bytes)", p, int(bw)), true
+}
+
+// editReplacementsSummary reports how many edits an edit result applied.
+func editReplacementsSummary(data map[string]any) (string, bool) {
+	r, ok := data["replacements"].(float64)
+	if !ok {
+		return "", false
 	}
-	// bash tool: show exit code + first 2 and last 2 output lines (preserve newlines for better visibility)
-	if code, ok := data["exit_code"].(float64); ok {
-		stdout, _ := data["stdout"].(string)
-		stderr, _ := data["stderr"].(string)
-		result := bashOutputPreview(stdout, stderr)
-		if result == "" {
-			result = "(No output)"
-		}
-		if int(code) != 0 {
-			return fmt.Sprintf("exit %d: %s", int(code), result)
-		}
-		return result
+	return fmt.Sprintf("%d replacements", int(r)), true
+}
+
+// diagnosticsSummary passes lsp_diagnostics through, already prefixed with ⚠ by
+// formatDiagnosticsForDisplay. An empty diagnostics string is not claimed, so a
+// clean run falls through to whatever else the result carries.
+func diagnosticsSummary(data map[string]any) (string, bool) {
+	diag, ok := data["lsp_diagnostics"].(string)
+	if !ok || diag == "" {
+		return "", false
 	}
-	// Fallback: compact JSON
-	b, _ := json.Marshal(data)
-	s := string(b)
-	if len(s) > 120 {
-		return s[:117] + "..."
+	return diag, true
+}
+
+// bashWindowSummary renders a backgrounded command, either at the moment of
+// handoff (the bash tool) or on any later poll of it (bash_wait, bash_kill).
+// Both carry a handle, and both have to be taken before bashExitSummary.
+//
+// While such a command is still running it has no exit status: the bash tool
+// reports the -1 placeholder, which bashExitSummary renders as
+// "exit -1: <first line of output>" — a live lint run reading as a crashed one.
+// A poll is worse: BashStatus omits exit_code entirely while running, so it
+// missed bashExitSummary altogether and fell through to the raw-JSON fallback,
+// printing &-escaped argument soup instead of the command's output.
+func bashWindowSummary(data map[string]any) (string, bool) {
+	handle, ok := data["handle"].(string)
+	if !ok || handle == "" {
+		return "", false
 	}
-	return s
+	return formatBashWindow(handle, data), true
+}
+
+// bashExitSummary renders a foreground bash result: its exit code, and the
+// first and last two lines of what it printed.
+func bashExitSummary(data map[string]any) (string, bool) {
+	code, ok := data["exit_code"].(float64)
+	if !ok {
+		return "", false
+	}
+	stdout, _ := data["stdout"].(string)
+	stderr, _ := data["stderr"].(string)
+	result := bashOutputPreview(stdout, stderr)
+	if result == "" {
+		result = "(No output)"
+	}
+	if int(code) != 0 {
+		return fmt.Sprintf("exit %d: %s", int(code), result), true
+	}
+	return result, true
 }
 
 // formatBashWindow renders the card for a backgrounded command: what state it

--- a/internal/tui/tool_display_seams_test.go
+++ b/internal/tui/tool_display_seams_test.go
@@ -1,0 +1,267 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClipSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"short passes through", "hello", "hello"},
+		{"exactly at budget is untouched", strings.Repeat("a", summaryWidth), strings.Repeat("a", summaryWidth)},
+		{"one over is clipped with ellipsis", strings.Repeat("a", summaryWidth+1), strings.Repeat("a", summaryWidth-3) + "..."},
+		{"long is clipped to the budget", strings.Repeat("a", 500), strings.Repeat("a", summaryWidth-3) + "..."},
+		{"empty stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := clipSummary(tt.in)
+			if got != tt.want {
+				t.Errorf("clipSummary() = %q, want %q", got, tt.want)
+			}
+			if len(got) > summaryWidth {
+				t.Errorf("clipSummary() len = %d, over budget %d", len(got), summaryWidth)
+			}
+		})
+	}
+}
+
+// TestToolCallSummaryDispatch covers the argument-lookup table and the three
+// tools that need more than a lookup.
+func TestToolCallSummaryDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+		want string
+	}{
+		{"read takes file_path", "read", map[string]any{"file_path": "/a/b.go"}, "/a/b.go"},
+		{"write takes file_path", "write", map[string]any{"file_path": "/w.go"}, "/w.go"},
+		{"edit takes file_path", "edit", map[string]any{"file_path": "/e.go"}, "/e.go"},
+		{"bash takes command", "bash", map[string]any{"command": "ls -la"}, "ls -la"},
+		{"bash_wait takes handle", "bash_wait", map[string]any{"handle": "bg_1"}, "bg_1"},
+		{"bash_output takes handle", "bash_output", map[string]any{"handle": "bg_2"}, "bg_2"},
+		{"bash_kill takes handle", "bash_kill", map[string]any{"handle": "bg_3"}, "bg_3"},
+		{"grep takes pattern", "grep", map[string]any{"pattern": "foo"}, "foo"},
+		{"ripgrep alias takes pattern", "ripgrep", map[string]any{"pattern": "bar"}, "bar"},
+		{"find takes pattern", "find", map[string]any{"pattern": "*.go"}, "*.go"},
+		{"grounding takes query", groundingToolName, map[string]any{"query": "weather"}, "weather"},
+		{"missing arg yields empty", "read", map[string]any{}, ""},
+		{"non-string arg yields empty", "read", map[string]any{"file_path": 12}, ""},
+		{"unknown tool yields empty", "no_such_tool", map[string]any{"file_path": "/z"}, ""},
+
+		{"ls uses path", "ls", map[string]any{"path": "/tmp"}, "/tmp"},
+		{"ls without path defaults to dot", "ls", map[string]any{}, "."},
+		{"ls keeps an explicitly empty path", "ls", map[string]any{"path": ""}, ""},
+		{"ls with non-string path defaults to dot", "ls", map[string]any{"path": 3}, "."},
+
+		{"tree with depth", "tree", map[string]any{"path": "/x", "depth": float64(2)}, "/x (depth 2)"},
+		{"tree without depth", "tree", map[string]any{"path": "/x"}, "/x"},
+		{"tree empty path reads as dot", "tree", map[string]any{"path": "", "depth": float64(3)}, ". (depth 3)"},
+		{"tree zero depth is omitted", "tree", map[string]any{"depth": float64(0)}, "."},
+		{"tree non-numeric depth is omitted", "tree", map[string]any{"depth": "2"}, "."},
+
+		{"agent joins type and prompt", "agent", map[string]any{"type": "explore", "prompt": "find the bug"}, "explore: find the bug"},
+		{"agent with type only", "agent", map[string]any{"type": "explore"}, "explore"},
+		{"agent with prompt only", "agent", map[string]any{"prompt": "just a prompt"}, "just a prompt"},
+		{"agent cuts prompt at first line", "agent", map[string]any{"prompt": "first line\nsecond"}, "first line"},
+		{"agent keeps a leading newline", "agent", map[string]any{"prompt": "\nlead"}, "\nlead"},
+		{"agent clips a long prompt to 60", "agent", map[string]any{"type": "x", "prompt": strings.Repeat("y", 80)}, "x: " + strings.Repeat("y", 57) + "..."},
+		{"agent with neither yields empty", "agent", map[string]any{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := toolCallSummary(tt.tool, tt.args); got != tt.want {
+				t.Errorf("toolCallSummary(%q) = %q, want %q", tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResultFormattersClaim checks that each formatter recognizes the result
+// shape it owns and produces the expected line.
+func TestResultFormattersClaim(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format resultFormatter
+		data   map[string]any
+		want   string
+	}{
+		{
+			"ls marks directories",
+			lsEntriesSummary,
+			map[string]any{"entries": []any{map[string]any{"name": "dir", "is_dir": true}, map[string]any{"name": "f.go"}}},
+			"dir/  f.go",
+		},
+		{"ls skips non-map entries", lsEntriesSummary, map[string]any{"entries": []any{"junk"}}, ""},
+		{"ls with no entries", lsEntriesSummary, map[string]any{"entries": []any{}}, ""},
+		{"tree reports counts", treeCountsSummary, map[string]any{"tree": "x", "dirs": float64(3), "files": float64(9)}, "3 dirs, 9 files"},
+		{"tree without counts", treeCountsSummary, map[string]any{"tree": "x"}, "0 dirs, 0 files"},
+		{
+			"grep lists matches and truncation",
+			grepMatchesSummary,
+			map[string]any{
+				"matches":       []any{map[string]any{"file": "a.go", "line": float64(3), "content": "hit"}},
+				"total_matches": float64(9), "truncated": true,
+			},
+			"a.go:3: hit\n... (9 total matches, truncated)",
+		},
+		{
+			"grep without truncation",
+			grepMatchesSummary,
+			map[string]any{"matches": []any{map[string]any{"file": "a.go", "line": float64(3), "content": "hit"}}},
+			"a.go:3: hit",
+		},
+		{"grep count only", grepMatchesSummary, map[string]any{"total_matches": float64(5)}, "5 matches"},
+		{
+			"find lists files and truncation",
+			findFilesSummary,
+			map[string]any{"files": []any{"a.go", "b.go"}, "total_files": float64(4), "truncated": true},
+			"a.go\nb.go\n... (4 total files, truncated)",
+		},
+		{"find count only", findFilesSummary, map[string]any{"total_files": float64(2)}, "2 files"},
+		{
+			"read appends the truncation marker",
+			readContentSummary,
+			map[string]any{"content": "one\ntwo", "total_lines": float64(10), "truncated": true},
+			"one\ntwo\n... (10 total lines, truncated)",
+		},
+		{"read passes content through", readContentSummary, map[string]any{"content": "one"}, "one"},
+		{"read count only", readContentSummary, map[string]any{"total_lines": float64(42)}, "42 lines"},
+		{"read count only truncated", readContentSummary, map[string]any{"total_lines": float64(42), "truncated": true}, "42 lines (truncated)"},
+		{"write names path and size", writeBytesSummary, map[string]any{"bytes_written": float64(120), "path": "/out.txt"}, "/out.txt (120 bytes)"},
+		{"edit counts replacements", editReplacementsSummary, map[string]any{"replacements": float64(3)}, "3 replacements"},
+		{"diagnostics pass through", diagnosticsSummary, map[string]any{"lsp_diagnostics": "⚠ bad"}, "⚠ bad"},
+		{
+			"bash window reports a running command",
+			bashWindowSummary,
+			map[string]any{"handle": "bg_1", "running": true, "elapsed": "3s"},
+			"⏳ 3s elapsed\n(no new output)",
+		},
+		{"bash exit zero shows output", bashExitSummary, map[string]any{"exit_code": float64(0), "stdout": "done"}, "done"},
+		{"bash exit zero with no output", bashExitSummary, map[string]any{"exit_code": float64(0)}, "(No output)"},
+		{"bash non-zero exit is prefixed", bashExitSummary, map[string]any{"exit_code": float64(2), "stderr": "boom"}, "exit 2: boom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := tt.format(tt.data)
+			if !ok {
+				t.Fatalf("formatter declined %v, want it claimed", tt.data)
+			}
+			if got != tt.want {
+				t.Errorf("formatter = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResultFormattersDecline pins the fall-through cases. A formatter that
+// wrongly claims a result stops the chain, so declining matters as much as
+// claiming — the empty lsp_diagnostics and empty handle cases in particular
+// have to keep falling through to the formatters behind them.
+func TestResultFormattersDecline(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format resultFormatter
+		data   map[string]any
+	}{
+		{"ls without entries", lsEntriesSummary, map[string]any{"tree": "x"}},
+		{"tree with a non-string tree", treeCountsSummary, map[string]any{"tree": 7}},
+		{"grep with a non-numeric count", grepMatchesSummary, map[string]any{"total_matches": "5"}},
+		{"find with neither field", findFilesSummary, map[string]any{"content": "x"}},
+		{"read with neither field", readContentSummary, map[string]any{"replacements": float64(1)}},
+		{"write without a path", writeBytesSummary, map[string]any{"bytes_written": float64(120)}},
+		{"write with a non-string path", writeBytesSummary, map[string]any{"bytes_written": float64(1), "path": 2}},
+		{"edit without replacements", editReplacementsSummary, map[string]any{"exit_code": float64(0)}},
+		{"empty diagnostics", diagnosticsSummary, map[string]any{"lsp_diagnostics": ""}},
+		{"missing diagnostics", diagnosticsSummary, map[string]any{}},
+		{"empty handle", bashWindowSummary, map[string]any{"handle": "", "exit_code": float64(1)}},
+		{"missing handle", bashWindowSummary, map[string]any{"exit_code": float64(1)}},
+		{"bash without an exit code", bashExitSummary, map[string]any{"stdout": "x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got, ok := tt.format(tt.data); ok {
+				t.Errorf("formatter claimed %v as %q, want declined", tt.data, got)
+			}
+		})
+	}
+}
+
+// TestFormatToolResultOrder pins the two orderings the chain depends on: a
+// full payload beats the bare count that stands in for it, and a handle beats
+// an exit code so a still-running command is never rendered as "exit -1".
+func TestFormatToolResultOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data map[string]any
+		want string
+	}{
+		{
+			"match list beats match count",
+			map[string]any{"matches": []any{map[string]any{"file": "a.go", "line": float64(1), "content": "x"}}, "total_matches": float64(7)},
+			"a.go:1: x",
+		},
+		{
+			"file list beats file count",
+			map[string]any{"files": []any{"a.go"}, "total_files": float64(7)},
+			"a.go",
+		},
+		{
+			"content beats line count",
+			map[string]any{"content": "body", "total_lines": float64(7)},
+			"body",
+		},
+		{
+			"handle beats the -1 exit placeholder",
+			map[string]any{"handle": "bg_1", "running": true, "exit_code": float64(-1), "stdout": "building"},
+			"⏳\nbuilding",
+		},
+		{
+			"a write with no path falls through to the edit count",
+			map[string]any{"bytes_written": float64(9), "replacements": float64(3)},
+			"3 replacements",
+		},
+		{
+			"empty diagnostics fall through to the exit code",
+			map[string]any{"lsp_diagnostics": "", "exit_code": float64(0), "stdout": "out"},
+			"out",
+		},
+		{
+			"an unrecognized result falls back to compact JSON",
+			map[string]any{"mystery": "shape"},
+			`{"mystery":"shape"}`,
+		},
+		{
+			"the JSON fallback is clipped",
+			map[string]any{"mystery": strings.Repeat("q", 300)},
+			`{"mystery":"` + strings.Repeat("q", summaryWidth-3-len(`{"mystery":"`)) + "...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatToolResult(tt.data); got != tt.want {
+				t.Errorf("formatToolResult() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -663,15 +663,7 @@ func (m *model) updateTerminal(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return model, cmd, true
 
 	case InputSubmitMsg:
-		if strings.HasPrefix(msg.Text, "/") {
-			if m.running {
-				return m, nil, true
-			}
-			model, cmd := m.handleSlashCommand(msg.Text)
-			return model, cmd, true
-		}
-		model, cmd := m.enqueuePrompt(msg.Text, msg.Mentions)
-		return model, cmd, true
+		return m.handleInputSubmit(msg)
 
 	case resetCtrlCCountMsg:
 		model, cmd := m.handleResetCtrlCCount()
@@ -691,35 +683,10 @@ func (m *model) updateTerminal(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return m, nil, true
 
 	case loadingTickMsg:
-		// The loading-dots ticker was the engine behind TODO §30/§42: every
-		// 300 ms fire it mutated m.loadingDots and re-armed unconditionally,
-		// producing a 3.3 Hz full-history re-render for the life of the
-		// process. The dots only animate the deferred-init splash
-		// (m.loading is set at tui.go:455 and cleared at :1963/:1985), so
-		// the re-arm belongs to that lifecycle, not to process uptime.
-		// Re-arming only while m.loading is true stops the chain at init
-		// completion and removes the idle 3.3 Hz floor.
-		if !m.loading {
-			return m, nil, true
-		}
-		m.loadingDots = (m.loadingDots + 1) % 4
-		return m, tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg { return loadingTickMsg{} }), true
+		return m.handleLoadingTick()
 
 	case matrixTickMsg:
-		if m.running {
-			m.matrix.tick(m.mainWidth())
-			// The pending-tool bullet blinks on a ~1s cycle. The phase advances
-			// here, in Update, so View stays a pure function of model state —
-			// the matrix tick (150ms while running) re-renders often enough to
-			// animate it.
-			now := time.Now()
-			m.chatModel.ToolDisplay.BlinkOn = now.UnixMilli()/500%2 == 0
-			// Same idea one level out: the tab title's prefix symbol rotates so
-			// a backgrounded session still shows it is working.
-			m.titleSpin = terminalTitleSpinIndex(now)
-			return m, matrixTickCmd(), true
-		}
-		return m, nil, true
+		return m.handleMatrixTick()
 	}
 	return nil, nil, false
 }
@@ -736,6 +703,55 @@ func (m *model) handleWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd, boo
 		return m, tea.Batch(cmd, waitForAgent(m.agentCh)), true
 	}
 	return m, cmd, true
+}
+
+// handleInputSubmit routes a submitted line: a slash command runs as one,
+// anything else joins the prompt queue. A slash command is dropped outright
+// while a turn is running, because the commands mutate state that turn is using.
+func (m *model) handleInputSubmit(msg InputSubmitMsg) (tea.Model, tea.Cmd, bool) {
+	if !strings.HasPrefix(msg.Text, "/") {
+		model, cmd := m.enqueuePrompt(msg.Text, msg.Mentions)
+		return model, cmd, true
+	}
+	if m.running {
+		return m, nil, true
+	}
+	model, cmd := m.handleSlashCommand(msg.Text)
+	return model, cmd, true
+}
+
+// handleLoadingTick advances the splash dots and re-arms the ticker only while
+// the deferred-init splash is still up.
+//
+// The re-arm used to be unconditional (TODO §30/§42): every 300 ms fire mutated
+// m.loadingDots and re-armed regardless, producing a 3.3 Hz full-history
+// re-render for the life of the process. The dots only animate the splash
+// (m.loading is set at tui.go:455 and cleared at :1963/:1985), so the re-arm
+// belongs to that lifecycle, not to process uptime. Stopping the chain when
+// m.loading clears is what removes the idle 3.3 Hz floor.
+func (m *model) handleLoadingTick() (tea.Model, tea.Cmd, bool) {
+	if !m.loading {
+		return m, nil, true
+	}
+	m.loadingDots = (m.loadingDots + 1) % 4
+	return m, tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg { return loadingTickMsg{} }), true
+}
+
+// handleMatrixTick advances everything that animates while a turn runs: the
+// matrix rain, the pending-tool bullet blink on its ~1s cycle, and the tab
+// title's rotating prefix, which keeps a backgrounded session showing progress.
+//
+// All three phases advance here, in Update, so View stays a pure function of
+// model state — the 150ms tick re-renders often enough to animate them.
+func (m *model) handleMatrixTick() (tea.Model, tea.Cmd, bool) {
+	if !m.running {
+		return m, nil, true
+	}
+	m.matrix.tick(m.mainWidth())
+	now := time.Now()
+	m.chatModel.ToolDisplay.BlinkOn = now.UnixMilli()/500%2 == 0
+	m.titleSpin = terminalTitleSpinIndex(now)
+	return m, matrixTickCmd(), true
 }
 
 // handlePaste inserts pasted text into the prompt, ignoring pastes that arrive
@@ -1314,87 +1330,220 @@ func (m *model) handleInputKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// handleSearchPopupKey routes a key press to the open search popup, reporting
+// whether the popup consumed it. Every key the popup understands is claimed;
+// anything else falls through to the handler behind it, which is how a modified
+// key still reaches the prompt while the popup is open.
 func (m *model) handleSearchPopupKey(key tea.Key) bool {
 	if m.searchPopup == nil {
 		return false
 	}
-
 	sp := m.searchPopup
 
 	switch key.Code {
 	case tea.KeyUp:
-		if sp.selected > 0 {
-			sp.selected--
-		} else if len(sp.filtered) > 1 {
-			// Wrap to last item on Up from first.
-			sp.selected = len(sp.filtered) - 1
-		}
-		sp.scrollOff = max(0, sp.selected-sp.height+1)
+		sp.selectPrev()
 		return true
 	case tea.KeyDown:
-		if sp.selected < len(sp.filtered)-1 {
-			sp.selected++
-		} else if len(sp.filtered) > 1 {
-			// Wrap to first item on Down from last.
-			sp.selected = 0
-		}
-		if sp.selected >= sp.scrollOff+sp.height {
-			sp.scrollOff = sp.selected - sp.height + 1
-		}
+		sp.selectNext()
 		return true
 	case tea.KeyTab:
-		if len(sp.filtered) == 0 {
-			return true
-		}
-		if key.Mod == tea.ModShift {
-			if sp.selected > 0 {
-				sp.selected--
-			} else {
-				// Wrap to last item on Shift+Tab from first.
-				sp.selected = len(sp.filtered) - 1
-			}
-		} else {
-			// Tab advances; stays at last item (no wrap).
-			if sp.selected < len(sp.filtered)-1 {
-				sp.selected++
-			}
-		}
-		sp.scrollOff = max(0, sp.selected-sp.height+1)
+		sp.selectByTab(key.Mod == tea.ModShift)
 		return true
 	case tea.KeyEnter:
-		if len(sp.filtered) > 0 && sp.selected < len(sp.filtered) {
-			item := sp.filtered[sp.selected]
-			switch sp.mode {
-			case searchModeCommands:
-				m.inputModel.SetText(item.Text + " ")
-				m.searchPopup = nil
-			case searchModeHistory:
-				m.inputModel.SetText(item.Text)
-				m.searchPopup = nil
-			}
-		}
+		m.acceptSearchSelection()
 		return true
 	case tea.KeyEsc:
 		m.searchPopup = nil
 		return true
 	case tea.KeyBackspace:
-		if len(sp.search) > 0 {
-			sp.search = sp.search[:len(sp.search)-1]
-			sp.filterSearch()
-		} else {
-			// If search is empty, close popup on backspace
-			m.searchPopup = nil
-		}
+		m.backspaceSearch()
 		return true
-	default:
-		// Type to search (only for printable single characters).
-		if key.Text != "" && len(key.Text) == 1 && key.Mod == 0 {
-			sp.search += key.Text
-			sp.filterSearch()
-			return true
-		}
+	}
+	return m.typeIntoSearch(key)
+}
+
+// selectPrev moves the highlight one row up, wrapping to the last item from the
+// first, and scrolls the window so the highlight stays visible.
+func (sp *searchPopupState) selectPrev() {
+	if sp.selected > 0 {
+		sp.selected--
+	} else if len(sp.filtered) > 1 {
+		// Wrap to last item on Up from first.
+		sp.selected = len(sp.filtered) - 1
+	}
+	sp.scrollOff = max(0, sp.selected-sp.height+1)
+}
+
+// selectNext moves the highlight one row down, wrapping to the first item from
+// the last.
+//
+// Note the asymmetry with selectPrev: this scrolls only when the highlight has
+// run off the bottom, rather than recomputing scrollOff unconditionally. That
+// is the existing behavior and is preserved deliberately — see the wrap note in
+// TestSearchPopupNavigation.
+func (sp *searchPopupState) selectNext() {
+	if sp.selected < len(sp.filtered)-1 {
+		sp.selected++
+	} else if len(sp.filtered) > 1 {
+		// Wrap to first item on Down from last.
+		sp.selected = 0
+	}
+	if sp.selected >= sp.scrollOff+sp.height {
+		sp.scrollOff = sp.selected - sp.height + 1
+	}
+}
+
+// selectByTab moves the highlight for Tab and Shift+Tab. Shift+Tab wraps to the
+// last item from the first; plain Tab deliberately does not wrap — it stops on
+// the last item, so holding Tab settles on a choice instead of cycling forever.
+// An empty list is left completely untouched, scrollOff included.
+func (sp *searchPopupState) selectByTab(shift bool) {
+	if len(sp.filtered) == 0 {
+		return
+	}
+	switch {
+	case shift && sp.selected > 0:
+		sp.selected--
+	case shift:
+		// Wrap to last item on Shift+Tab from first.
+		sp.selected = len(sp.filtered) - 1
+	case sp.selected < len(sp.filtered)-1:
+		sp.selected++
+	}
+	sp.scrollOff = max(0, sp.selected-sp.height+1)
+}
+
+// acceptSearchSelection puts the highlighted entry into the prompt and closes
+// the popup. A command gets a trailing space so arguments can be typed straight
+// on; a history entry is restored verbatim.
+//
+// Nothing at all happens when the highlight does not point at a real entry, or
+// when the mode is one this function does not know — the popup stays open
+// rather than closing on a key that did nothing.
+func (m *model) acceptSearchSelection() {
+	sp := m.searchPopup
+	if len(sp.filtered) == 0 || sp.selected >= len(sp.filtered) {
+		return
+	}
+	item := sp.filtered[sp.selected]
+	switch sp.mode {
+	case searchModeCommands:
+		m.inputModel.SetText(item.Text + " ")
+		m.searchPopup = nil
+	case searchModeHistory:
+		m.inputModel.SetText(item.Text)
+		m.searchPopup = nil
+	}
+}
+
+// backspaceSearch removes the last character of the filter, or closes the popup
+// when there is nothing left to remove — so Backspace walks all the way out
+// instead of dead-ending on an empty filter.
+func (m *model) backspaceSearch() {
+	sp := m.searchPopup
+	if len(sp.search) == 0 {
+		m.searchPopup = nil
+		return
+	}
+	sp.search = sp.search[:len(sp.search)-1]
+	sp.filterSearch()
+}
+
+// typeIntoSearch appends a printable keystroke to the popup's filter, reporting
+// whether it took the key. A modified key, a bare modifier, or a character that
+// is not a single byte is declined so it falls through to the prompt.
+func (m *model) typeIntoSearch(key tea.Key) bool {
+	// Type to search (only for printable single characters).
+	if key.Text == "" || len(key.Text) != 1 || key.Mod != 0 {
 		return false
 	}
+	m.searchPopup.search += key.Text
+	m.searchPopup.filterSearch()
+	return true
+}
+
+// renderStartupView is the splash shown before the first terminal size arrives.
+// With no width there is no layout to compute, so this lists the deferred-init
+// subsystems and ticks each as it finishes; before any are registered it is the
+// matrix line alone.
+func (m *model) renderStartupView() tea.View {
+	// Show matrix-style startup text before the first terminal size arrives.
+	matrixLine := renderStartupMatrixLine(m.loadingDots, m.cfg.AppVersion, m.loadingItems, m.loadingTotal, m.palette)
+	if m.loadingItems == nil {
+		return tea.NewView(matrixLine + "\n")
+	}
+	lines := []string{matrixLine}
+	for _, item := range sortedKeys(m.loadingItems) {
+		mark := " "
+		if m.loadingItems[item] {
+			mark = "✓"
+		}
+		lines = append(lines, "  "+mark+" "+item)
+	}
+	return tea.NewView(strings.Join(lines, "\n") + "\n")
+}
+
+// visibleMessageWindow picks the rows the message viewport shows: the last
+// availableHeight rows of the buffer, walked back by the scroll offset and
+// clamped to both ends. The range is half-open, [start, end).
+//
+// The window is also what the minimap is drawn from, so the same clamp decides
+// the scrollbar's extent — an off-by-one here moves the thumb, not just the text.
+func visibleMessageWindow(totalLines, availableHeight, scroll int) (int, int) {
+	start := totalLines - availableHeight - scroll
+	if start < 0 {
+		start = 0
+	}
+	end := start + availableHeight
+	if end > totalLines {
+		end = totalLines
+	}
+	return start, end
+}
+
+// sidebarInputFor gathers everything the sidebar renders for this frame.
+//
+// Height is the panel's row count, not the terminal's. Sized to the terminal
+// the sidebar outran the panel: JoinHorizontal padded the panel with blank
+// rows, leaving a gap below the prompt while the sidebar's filler dots carried
+// on past it.
+func (m *model) sidebarInputFor(width, panelRows int) SidebarRenderInput {
+	hostName := cachedHostname()
+	in := SidebarRenderInput{
+		Width:        width,
+		Height:       panelRows,
+		Mascot:       m.mascot(),
+		Mode:         m.mode,
+		ProviderName: m.providerDisplayName(),
+		ModelName:    m.cfg.ModelName,
+		GitBranch:    m.statusModel.GitBranch,
+		DiffAdded:    m.diffAdded,
+		DiffRemoved:  m.diffRemoved,
+		Running:      m.running,
+		TokenTracker: m.cfg.TokenTracker,
+		AppVersion:   m.cfg.AppVersion,
+		HostName:     hostName,
+		FolderName:   sidebarFolderName(m.cwd()),
+		Messages:     m.chatModel.Messages,
+		ActiveTool:   m.statusModel.ActiveTool,
+		LoadingItems: m.loadingItems,
+		MatrixLines:  "",
+		StatusLine:   "",
+		Orchestrator: m.cfg.Orchestrator,
+		MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
+		MemoryStatus: m.memoryStatus,
+		Artifacts:    m.artifactList(),
+		Palette:      m.palette,
+	}
+	if m.run != nil && m.run.phase != "" {
+		in.RunChecklist = m.run.checklist
+		in.RunPhase = m.run.phase
+		in.RunSpec = m.run.specName
+		in.RunCycle = m.run.retries + 1
+		in.RunMaxCycle = m.run.maxRetries
+	}
+	return in
 }
 
 func (m *model) View() tea.View {
@@ -1405,22 +1554,7 @@ func (m *model) View() tea.View {
 	m.syncPalette()
 
 	if m.width == 0 {
-		// Show matrix-style startup text before the first terminal size arrives.
-		matrixLine := renderStartupMatrixLine(m.loadingDots, m.cfg.AppVersion, m.loadingItems, m.loadingTotal, m.palette)
-		if m.loadingItems != nil {
-			var lines []string
-			lines = append(lines, matrixLine)
-			for _, item := range sortedKeys(m.loadingItems) {
-				done := m.loadingItems[item]
-				mark := " "
-				if done {
-					mark = "✓"
-				}
-				lines = append(lines, "  "+mark+" "+item)
-			}
-			return tea.NewView(strings.Join(lines, "\n") + "\n")
-		}
-		return tea.NewView(matrixLine + "\n")
+		return m.renderStartupView()
 	}
 
 	// Layout: messages + sidebar on top, status bar + input spanning the full
@@ -1450,17 +1584,7 @@ func (m *model) View() tea.View {
 
 	// Truncate messages to fit viewport.
 	msgLines := strings.Split(messagesView, "\n")
-	totalLines := len(msgLines)
-
-	startLine := totalLines - availableHeight - m.chatModel.Scroll
-	if startLine < 0 {
-		startLine = 0
-	}
-	endLine := startLine + availableHeight
-	if endLine > totalLines {
-		endLine = totalLines
-	}
-
+	startLine, endLine := visibleMessageWindow(len(msgLines), availableHeight, m.chatModel.Scroll)
 	visibleMessages := strings.Join(msgLines[startLine:endLine], "\n")
 
 	// Pad to fill the viewport. availableHeight is message rows only — the blank
@@ -1542,45 +1666,7 @@ func (m *model) View() tea.View {
 
 	var topSection string
 	if showSidebar {
-		hostName := cachedHostname()
-		sidebarInput := SidebarRenderInput{
-			Width: sidebarWidth,
-			// Exactly as tall as the panel beside it. Sized to the terminal
-			// instead, the sidebar outran the panel — JoinHorizontal padded the
-			// panel with blank rows, leaving a gap below the prompt while the
-			// sidebar's filler dots carried on past it.
-			Height:       panelRows,
-			Mascot:       m.mascot(),
-			Mode:         m.mode,
-			ProviderName: m.providerDisplayName(),
-			ModelName:    m.cfg.ModelName,
-			GitBranch:    m.statusModel.GitBranch,
-			DiffAdded:    m.diffAdded,
-			DiffRemoved:  m.diffRemoved,
-			Running:      m.running,
-			TokenTracker: m.cfg.TokenTracker,
-			AppVersion:   m.cfg.AppVersion,
-			HostName:     hostName,
-			FolderName:   sidebarFolderName(m.cwd()),
-			Messages:     m.chatModel.Messages,
-			ActiveTool:   m.statusModel.ActiveTool,
-			LoadingItems: m.loadingItems,
-			MatrixLines:  "",
-			StatusLine:   "",
-			Orchestrator: m.cfg.Orchestrator,
-			MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
-			MemoryStatus: m.memoryStatus,
-			Artifacts:    m.artifactList(),
-			Palette:      m.palette,
-		}
-		if m.run != nil && m.run.phase != "" {
-			sidebarInput.RunChecklist = m.run.checklist
-			sidebarInput.RunPhase = m.run.phase
-			sidebarInput.RunSpec = m.run.specName
-			sidebarInput.RunCycle = m.run.retries + 1
-			sidebarInput.RunMaxCycle = m.run.maxRetries
-		}
-		sidebar := RenderSidebar(sidebarInput)
+		sidebar := RenderSidebar(m.sidebarInputFor(sidebarWidth, panelRows))
 		topSection = joinPanelSidebar(leftPanel, sidebar, mainWidth, sidebarWidth)
 	} else {
 		topSection = padLinesTo(leftPanel, m.width)

--- a/internal/tui/update_terminal_seams_test.go
+++ b/internal/tui/update_terminal_seams_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"testing"
+)
+
+// TestHandleLoadingTick pins the re-arm lifecycle. The ticker used to re-arm
+// unconditionally, which held a 3.3 Hz full-history re-render for the life of
+// the process (TODO §30/§42); the chain must stop the moment the splash clears.
+func TestHandleLoadingTick(t *testing.T) {
+	t.Parallel()
+
+	t.Run("advances the dots and re-arms while loading", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.loading = true
+		m.loadingDots = 2
+		_, cmd, handled := m.handleLoadingTick()
+		if !handled {
+			t.Error("handled = false, want true")
+		}
+		if m.loadingDots != 3 {
+			t.Errorf("loadingDots = %d, want 3", m.loadingDots)
+		}
+		if cmd == nil {
+			t.Error("cmd = nil, want the ticker re-armed while loading")
+		}
+	})
+
+	t.Run("dots wrap at four", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.loading = true
+		m.loadingDots = 3
+		m.handleLoadingTick()
+		if m.loadingDots != 0 {
+			t.Errorf("loadingDots = %d, want it wrapped to 0", m.loadingDots)
+		}
+	})
+
+	t.Run("stops re-arming once the splash is gone", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.loading = false
+		m.loadingDots = 2
+		_, cmd, handled := m.handleLoadingTick()
+		if !handled {
+			t.Error("handled = false, want the message still consumed")
+		}
+		if cmd != nil {
+			t.Error("cmd != nil — the ticker re-armed after loading finished")
+		}
+		if m.loadingDots != 2 {
+			t.Errorf("loadingDots = %d, want it left alone", m.loadingDots)
+		}
+	})
+}
+
+// TestHandleMatrixTick checks that the running-state animations advance only
+// while a turn is running, and that the tick stops re-arming when it is not.
+func TestHandleMatrixTick(t *testing.T) {
+	t.Parallel()
+
+	t.Run("advances the animations and re-arms while running", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.running = true
+		m.titleSpin = 0
+		_, cmd, handled := m.handleMatrixTick()
+		if !handled {
+			t.Error("handled = false, want true")
+		}
+		if cmd == nil {
+			t.Error("cmd = nil, want the tick re-armed while running")
+		}
+	})
+
+	t.Run("idle does not re-arm or animate", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.running = false
+		m.titleSpin = 2
+		m.chatModel.ToolDisplay.BlinkOn = true
+		_, cmd, handled := m.handleMatrixTick()
+		if !handled {
+			t.Error("handled = false, want the message still consumed")
+		}
+		if cmd != nil {
+			t.Error("cmd != nil — the matrix tick re-armed while idle")
+		}
+		if m.titleSpin != 2 || !m.chatModel.ToolDisplay.BlinkOn {
+			t.Error("idle tick mutated the animation phases")
+		}
+	})
+}
+
+// TestHandleInputSubmit pins the routing: slash commands and prompts go to
+// different places, and a slash command is dropped outright mid-turn.
+func TestHandleInputSubmit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a slash command mid-turn is dropped", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.running = true
+		before := len(m.chatModel.Messages)
+		_, cmd, handled := m.handleInputSubmit(InputSubmitMsg{Text: "/clear"})
+		if !handled {
+			t.Error("handled = false, want the message consumed")
+		}
+		if cmd != nil {
+			t.Error("cmd != nil — a slash command ran while a turn was in flight")
+		}
+		if len(m.chatModel.Messages) != before {
+			t.Error("the dropped command still touched the conversation")
+		}
+	})
+
+	t.Run("a slash command outside a turn is executed", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.running = false
+		before := len(m.chatModel.Messages)
+		_, _, handled := m.handleInputSubmit(InputSubmitMsg{Text: "/help"})
+		if !handled {
+			t.Error("handled = false, want true")
+		}
+		if len(m.chatModel.Messages) == before {
+			t.Error("/help produced no output, so it was not executed")
+		}
+	})
+
+	t.Run("plain text is queued as a prompt, not run as a command", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.running = true // queued behind the running turn rather than dropped
+		_, _, handled := m.handleInputSubmit(InputSubmitMsg{Text: "hello there"})
+		if !handled {
+			t.Error("handled = false, want true")
+		}
+		if len(m.pendingPrompts) == 0 {
+			t.Error("prompt was not queued")
+		}
+	})
+}

--- a/internal/tui/view_seams_test.go
+++ b/internal/tui/view_seams_test.go
@@ -1,0 +1,141 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestVisibleMessageWindow pins the viewport clamp. The window it returns also
+// drives the minimap, so an off-by-one here moves the scrollbar thumb as well
+// as the text — which is why every boundary gets a case.
+func TestVisibleMessageWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                           string
+		total, availableHeight, scroll int
+		wantStart, wantEnd             int
+	}{
+		{"buffer taller than viewport, unscrolled", 100, 10, 0, 90, 100},
+		{"scrolled back by five", 100, 10, 5, 85, 95},
+		{"scrolled to the very top", 100, 10, 90, 0, 10},
+		{"scroll past the top clamps to zero", 100, 10, 500, 0, 10},
+		{"buffer shorter than viewport starts at zero", 5, 10, 0, 0, 5},
+		{"buffer exactly fills the viewport", 10, 10, 0, 0, 10},
+		{"empty buffer", 0, 10, 0, 0, 0},
+		{"zero-height viewport", 100, 0, 0, 100, 100},
+		{"single row buffer", 1, 10, 0, 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			start, end := visibleMessageWindow(tt.total, tt.availableHeight, tt.scroll)
+			if start != tt.wantStart || end != tt.wantEnd {
+				t.Errorf("visibleMessageWindow(%d,%d,%d) = (%d,%d), want (%d,%d)",
+					tt.total, tt.availableHeight, tt.scroll, start, end, tt.wantStart, tt.wantEnd)
+			}
+			// The range must always be a valid slice of the buffer.
+			if start < 0 || end < start || end > tt.total {
+				t.Errorf("range [%d,%d) is not a valid slice of %d rows", start, end, tt.total)
+			}
+		})
+	}
+}
+
+func TestRenderStartupView(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no loading items shows the matrix line alone", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.width = 0
+		got := ansi.Strip(m.renderStartupView().Content)
+		if strings.Contains(got, "✓") {
+			t.Errorf("unexpected tick in %q", got)
+		}
+		if !strings.HasSuffix(got, "\n") {
+			t.Errorf("startup view = %q, want a trailing newline", got)
+		}
+	})
+
+	t.Run("items are listed in sorted order and ticked when done", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.width = 0
+		m.loadingItems = map[string]bool{"mcp": true, "lsp": false, "agent": true}
+		m.loadingTotal = 3
+		lines := strings.Split(strings.TrimRight(ansi.Strip(m.renderStartupView().Content), "\n"), "\n")
+		if len(lines) != 4 {
+			t.Fatalf("want the matrix line plus 3 items, got %d lines: %q", len(lines), lines)
+		}
+		want := []string{"  ✓ agent", "    lsp", "  ✓ mcp"}
+		for i, w := range want {
+			if lines[i+1] != w {
+				t.Errorf("line %d = %q, want %q", i+1, lines[i+1], w)
+			}
+		}
+	})
+
+	t.Run("an empty but non-nil map still renders the list form", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.width = 0
+		m.loadingItems = map[string]bool{}
+		got := ansi.Strip(m.renderStartupView().Content)
+		if strings.Count(strings.TrimRight(got, "\n"), "\n") != 0 {
+			t.Errorf("want just the matrix line, got %q", got)
+		}
+	})
+}
+
+func TestSidebarInputFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("height is the panel row count, not the terminal height", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.height = 60
+		in := m.sidebarInputFor(30, 17)
+		if in.Height != 17 {
+			t.Errorf("Height = %d, want the panel's 17 rows", in.Height)
+		}
+		if in.Width != 30 {
+			t.Errorf("Width = %d, want 30", in.Width)
+		}
+	})
+
+	t.Run("no run state leaves the run fields zero", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		in := m.sidebarInputFor(30, 10)
+		if in.RunPhase != "" || in.RunSpec != "" || in.RunCycle != 0 || in.RunMaxCycle != 0 {
+			t.Errorf("run fields set without a run: %+v", in)
+		}
+	})
+
+	t.Run("a run with no phase is not shown", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.run = &runState{specName: "spec-a", retries: 1, maxRetries: 3}
+		in := m.sidebarInputFor(30, 10)
+		if in.RunPhase != "" || in.RunSpec != "" {
+			t.Errorf("a phaseless run leaked into the sidebar: %+v", in)
+		}
+	})
+
+	t.Run("an active run fills the checklist block", func(t *testing.T) {
+		t.Parallel()
+		m := newTestModelFull(t)
+		m.run = &runState{phase: "implement", specName: "spec-a", retries: 1, maxRetries: 3}
+		in := m.sidebarInputFor(30, 10)
+		if in.RunPhase != "implement" || in.RunSpec != "spec-a" {
+			t.Errorf("phase/spec = %q/%q, want implement/spec-a", in.RunPhase, in.RunSpec)
+		}
+		// Cycle is 1-based for display: the first attempt is cycle 1, not 0.
+		if in.RunCycle != 2 || in.RunMaxCycle != 3 {
+			t.Errorf("cycle = %d/%d, want 2/3", in.RunCycle, in.RunMaxCycle)
+		}
+	})
+}


### PR DESCRIPTION
A seven-agent pass over every function `gocyclo` scored above 25, following `.claude/skills/go-cyclomatic-complexity`.

| Metric | Before | After |
|---|---|---|
| Worst function | 37 | 29 (fenced) / 28 (deliberate keep) |
| Functions over 25 | 19 | **2** |
| Functions over 20 | 38 | **10** |
| Average | 4.04 | 3.98 |
| Coverage | 88.3% | **89.1%** |

Gates: `gofmt` clean · `go build ./...` · 38 packages pass · `golangci-lint run ./...` **0 issues** · `-race` clean.

## Worst offenders

| Function | Before | After | Pattern |
|---|---|---|---|
| `formatContextUsage` | 37 | **2** | section builders |
| `formatToolResult` | 34 | **3** | handler chain |
| `renderMessages` | 33 | **8** | role dispatch + sections |
| `ollamaContentsToMessages` | 31 | **8** | pure extraction + sections |
| `antContentsToMessages` | 31 | **8** | pure extraction + sections |
| `oaiContentsToMessages` | 30 | **7** | pure extraction + sections |
| `analyzeSessionFile` | 30 | **3** | named phases |
| `Orchestrator.Spawn` | 29 | **13** | setup + cleanup closure |
| `toolCallSummary` | 29 | **6** | lookup table |
| `deferredInit` | 28 | **10** | setup + cleanup closure |
| `Spawner.Spawn` | 28 | **4** | setup + cleanup, named phases |
| `smartTruncate` | 27 | **2** | pure classifier + sections |
| `modelPing` | 27 | **5** | named phases |
| `extractTriples` | 26 | **1** | section builders + pure helpers |
| `DrawerService.Search` | 25 | **7** | named phases + pure scorers |
| `aggregateTestOutput` | 22 | **4** | scan then render |

## How behavior preservation was verified

Not "the tests pass" — the tests were often the problem.

- **Characterization first.** Tests were written and run **green against the unmodified code** before any restructuring, so expectations describe observed behavior rather than the new implementation.
- **Byte-identical golden dumps of raw ANSI output** for every rendering function, captured before the refactor and diffed after — 66 frames for `View` across widths/scroll/matrix/loading states, 30 for `renderMessages` (each rendered twice to exercise the render cache), 39 tool-call and 45 result shapes.
- **20,000-input differential run** for `smartTruncate`, holding the original implementation beside the new one.
- **Mutation-tested the safety net itself.** One agent found its own goldens couldn't catch a forward/backward scan inversion (every case had a single candidate), so it checked the pre-refactor code back out of HEAD, regenerated all goldens from it, and re-ran. The mutation now fails 3 goldens + 2 unit tests.

## Deliberately not split

- **`handleSlashCommand` (28)** — 25 one-line command cases. A handler map needs an adapter closure per entry (three different signatures), turning `case "/compact": m.handleCompactCommand()` into table → closure → method. That hides the dispatch table.
- **`slashCommandDesc` (25)** — flat lookup, one string literal per command.
- **`View` (20 → 13)** — only the three separable pieces were extracted; the composition core interlocks `msgStart`/`msgRows`/`panelRows`/`inputCursorY` and feeds five memoized fields. Splitting means threading six values through helpers.
- **`buildRootRuntime` (29)** — fenced off; #188 rewrites that block.

## One intentional behavior change

`pumpACPSession` read `proc.err.Error()` **after** releasing the lock — an unsynchronized read of a field written under it. The string is now captured under the lock. Same output, one fewer data race.

## Thirteen pre-existing defects found — pinned, not fixed

Each is pinned by a test so a deliberate fix shows as a visible test change:

1. **`SpawnWithRetry` can never retry** — `awaitOutcome` reads agent status before `forwardEvents` writes it, so a crashed subagent always reads `"running"`. No production callers today, so latent rather than live.
2. **`retryStream` swallows a failing Ollama stream** — a 500 on `/api/chat` is retried ~7s then yields no error and no chunks, so `pi ping` reports a live model on an empty reply.
3. **`coerceValueAtKey` passes the parent's key into the child map** — nested objects inside array elements are never coerced.
4. `keywordSimilarity` returns scores >1 against a field documented 0–1.
5. `sqlite_store.go:369` truncates a float bm25 rank with `int(rank)` — why #4 rarely surfaces.
6. Search popup Down-wrap leaves the highlight off-screen (`selectNext` doesn't recompute scroll on wrap; `selectPrev` does).
7. Type-to-search drops all non-ASCII — `len(key.Text) == 1` counts bytes.
8. `smartTruncate` reports `applied=false` after dropping lines, so the caller discards the truncation.
9. `clipSummary` cuts by byte at 117, halving a straddling rune.
10. Failed-gate fence indents only the first line of multi-line output.
11. Ollama tool-call argument key order is map-iteration random — defeats byte-exact request caching.
12. Double coercion: the `.$` pass runs second and overwrites from the stale original.
13. `View` is not reproducible run-to-run (`matrixState.tick` seeds from `time.Now()`, plus a random spinner verb) — now documented, since it makes golden-frame tests of `View` impossible without pinning both.

**Two existing tests are named for paths they never exercise**: `TestSearch_SemanticPath` never calls `DrawerService.Search`, and `TestOllamaPingFullStreamingError` passes only because its mock also breaks the non-streaming call.