### PR TITLE
fix: stop PDD /plan from losing spec artifacts in the worktree

### DIFF
--- a/internal/subagent/worktree.go
+++ b/internal/subagent/worktree.go
@@ -251,16 +251,24 @@ func (m *WorktreeManager) CommitAll(agentID, message string) (bool, error) {
 		}
 	}
 
-	status, err := m.gitIn(info.Path, "status", "--porcelain")
-	if err != nil {
-		return false, fmt.Errorf("worktree status: %w: %s", err, status)
-	}
-	if status == "" {
-		return false, nil
-	}
-
-	if out, err := m.gitIn(info.Path, "add", "-A"); err != nil {
+	// Force-add everything an agent left in the worktree, ignoring ignore rules.
+	// A plain `git status --porcelain` + `git add -A` silently drops planner
+	// output: the real repo ignores **/specs/ (global) and .pi-go/ (project),
+	// both of which match the artifacts written into a worktree
+	// (specs/<task>/...). Ignored files do not show in plain `--porcelain`, so a
+	// status-first gate would report "nothing to commit", skip the snapshot, and
+	// then Cleanup would `worktree remove --force` the only copy. Force-adding
+	// first, then checking what was actually staged, keeps the empty-commit
+	// no-op intact while never dropping ignored work.
+	if out, err := m.gitIn(info.Path, "add", "-Af"); err != nil {
 		return false, fmt.Errorf("staging worktree changes: %w: %s", err, out)
+	}
+	staged, err := m.gitIn(info.Path, "diff", "--cached", "--name-only")
+	if err != nil {
+		return false, fmt.Errorf("worktree staged diff: %w: %s", err, staged)
+	}
+	if staged == "" {
+		return false, nil
 	}
 	tree, err := m.gitIn(info.Path, "write-tree")
 	if err != nil {

--- a/internal/subagent/worktree_commit_test.go
+++ b/internal/subagent/worktree_commit_test.go
@@ -31,8 +31,13 @@ func writeWorktreeArtifacts(t *testing.T, wtPath, specName string, names ...stri
 // task agent ever commits. So the backup ref pointed at a commit holding none
 // of the work, the merge took nothing, and `worktree remove --force` deleted
 // the only copy.
+//
+// The repo is created with the real repo's ignore rules (**/specs/ and
+// .pi-go/), because those are exactly what made a plain `git add -A` stage
+// nothing for the artifacts. Without them this test passed on machines whose
+// global gitignore didn't match, while the real checkout still lost everything.
 func TestCommitAll_PreservesUncommittedWork(t *testing.T) {
-	repo := initTestRepo(t)
+	repo := initTestRepoWithIgnores(t)
 	mgr := NewWorktreeManager(repo)
 
 	const agentID = "plan-features/001-demo"

--- a/internal/subagent/worktree_test.go
+++ b/internal/subagent/worktree_test.go
@@ -31,6 +31,28 @@ func initTestRepo(t *testing.T) string {
 	return dir
 }
 
+// initTestRepoWithIgnores is initTestRepo plus the ignore rules that hide spec
+// artifacts in the real repo: the global **/specs/ pattern and the project's
+// .pi-go/ rule. These are what let a plain `git add -A` silently stage nothing
+// for planner output, and they must be present for CommitAll's regression guard
+// to reproduce the loss in any environment, not just one whose ~/.gitignore
+// happens to match. Installed via core.excludesFile so the test stays hermetic
+// (independent of the machine's own global ignore file).
+func initTestRepoWithIgnores(t *testing.T) string {
+	t.Helper()
+	dir := initTestRepo(t)
+
+	ignore := filepath.Join(t.TempDir(), "global-gitignore")
+	content := "**/specs/\n.pi-go/\n"
+	if err := os.WriteFile(ignore, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing ignore file: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "config", "core.excludesFile", ignore).CombinedOutput(); err != nil {
+		t.Fatalf("setting core.excludesFile: %v: %s", err, out)
+	}
+	return dir
+}
+
 func TestWorktree_CreateAndCleanup(t *testing.T) {
 	repo := initTestRepo(t)
 	mgr := NewWorktreeManager(repo)

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -214,6 +215,20 @@ func (m *model) finishPlanWorktree() error {
 		return nil
 	}
 
+	// Copy the finished spec into the invoking checkout's specs/ tree first.
+	// The git merge below is defined in terms of commits, which is fragile: the
+	// specs/ path is gitignored (both a global **/specs/ and the project's
+	// .pi-go/ rule), so a force-add is required for the artifacts to enter the
+	// snapshot at all. A direct filesystem copy is the durable guarantee that
+	// /run — which reads <workDir>/specs/<task>/PROMPT.md — can find the spec
+	// even if the merge ever fails or is a no-op. Copying the whole spec dir
+	// mirrors everything the planner wrote, so research/ and supporting files
+	// survive too.
+	if err := copyDir(filepath.Join(m.planWorktreePath, "specs", m.planTaskName),
+		filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName)); err != nil {
+		return fmt.Errorf("copying finished spec into invoking checkout: %w", err)
+	}
+
 	if _, err := m.planWorktree.MergeBack(m.planWorktreeAgentID); err != nil {
 		return err
 	}
@@ -224,6 +239,56 @@ func (m *model) finishPlanWorktree() error {
 	// The worktree is gone; leaving its path behind would point later turns at
 	// a directory that no longer exists.
 	m.planWorktreePath = ""
+	return nil
+}
+
+// copyDir recursively copies the contents of src into dst. dst is created if
+// missing; existing files are overwritten. It mirrors the worktree's spec
+// directory into the invoking checkout so /run can consume it independently of
+// any git merge.
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		srcPath := filepath.Join(src, e.Name())
+		dstPath := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		// Skip symlinks to avoid following anything unexpected.
+		if e.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		in, err := os.Open(srcPath)
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(dstPath)
+		if err != nil {
+			in.Close()
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			in.Close()
+			out.Close()
+			return err
+		}
+		if err := in.Close(); err != nil {
+			out.Close()
+			return err
+		}
+		if err := out.Close(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -1,8 +1,9 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
-	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -248,51 +249,19 @@ func (m *model) finishPlanWorktree() error {
 }
 
 // copyDir recursively copies the contents of src into dst. dst is created if
-// missing; existing files are overwritten. It mirrors the worktree's spec
-// directory into the invoking checkout so /run can consume it independently of
-// any git merge.
+// missing. It mirrors the worktree's spec directory into the invoking checkout
+// so /run can consume it independently of any git merge.
+//
+// Existing files in dst are left as-is: when this runs after a successful
+// merge the merged copies are already present and identical, and overwriting
+// them would be wasted work. So a file already existing in dst is not an
+// error — CopyFS reports it as fs.ErrExist and we treat that as success.
 func copyDir(src, dst string) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return err
 	}
-	entries, err := os.ReadDir(src)
-	if err != nil {
+	if err := os.CopyFS(dst, os.DirFS(src)); err != nil && !errors.Is(err, fs.ErrExist) {
 		return err
-	}
-	for _, e := range entries {
-		srcPath := filepath.Join(src, e.Name())
-		dstPath := filepath.Join(dst, e.Name())
-		if e.IsDir() {
-			if err := copyDir(srcPath, dstPath); err != nil {
-				return err
-			}
-			continue
-		}
-		// Skip symlinks to avoid following anything unexpected.
-		if e.Type()&os.ModeSymlink != 0 {
-			continue
-		}
-		in, err := os.Open(srcPath)
-		if err != nil {
-			return err
-		}
-		out, err := os.Create(dstPath)
-		if err != nil {
-			in.Close()
-			return err
-		}
-		if _, err := io.Copy(out, in); err != nil {
-			in.Close()
-			out.Close()
-			return err
-		}
-		if err := in.Close(); err != nil {
-			out.Close()
-			return err
-		}
-		if err := out.Close(); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -215,23 +215,28 @@ func (m *model) finishPlanWorktree() error {
 		return nil
 	}
 
-	// Copy the finished spec into the invoking checkout's specs/ tree first.
-	// The git merge below is defined in terms of commits, which is fragile: the
-	// specs/ path is gitignored (both a global **/specs/ and the project's
-	// .pi-go/ rule), so a force-add is required for the artifacts to enter the
-	// snapshot at all. A direct filesystem copy is the durable guarantee that
-	// /run — which reads <workDir>/specs/<task>/PROMPT.md — can find the spec
-	// even if the merge ever fails or is a no-op. Copying the whole spec dir
-	// mirrors everything the planner wrote, so research/ and supporting files
-	// survive too.
+	// Merge the worktree branch into the invoking branch. This brings the spec
+	// files into <workDir>/specs/<task>/ as tracked files.
+	if _, err := m.planWorktree.MergeBack(m.planWorktreeAgentID); err != nil {
+		// Preserve the finished spec by copying it out even though the merge
+		// failed, so /run still finds PROMPT.md.
+		_ = copyDir(filepath.Join(m.planWorktreePath, "specs", m.planTaskName),
+			filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName))
+		return err
+	}
+
+	// Belt-and-suspenders: after the merge, copy the finished spec into the
+	// invoking checkout's specs/ tree too. /run reads <workDir>/specs/<task>/
+	// from disk, so this guarantees the spec is present even if the merge was
+	// somehow a no-op. Copying the whole spec dir mirrors everything the
+	// planner wrote, so research/ and supporting files survive too. (This runs
+	// after the merge, not before: writing untracked copies first would make
+	// the merge abort on files it is about to bring in.)
 	if err := copyDir(filepath.Join(m.planWorktreePath, "specs", m.planTaskName),
 		filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName)); err != nil {
 		return fmt.Errorf("copying finished spec into invoking checkout: %w", err)
 	}
 
-	if _, err := m.planWorktree.MergeBack(m.planWorktreeAgentID); err != nil {
-		return err
-	}
 	if err := m.planWorktree.Cleanup(m.planWorktreeAgentID); err != nil {
 		return err
 	}

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -220,9 +220,10 @@ func (m *model) finishPlanWorktree() error {
 	// files into <workDir>/specs/<task>/ as tracked files.
 	if _, err := m.planWorktree.MergeBack(m.planWorktreeAgentID); err != nil {
 		// Preserve the finished spec by copying it out even though the merge
-		// failed, so /run still finds PROMPT.md.
+		// failed, so /run still finds PROMPT.md. Overwrite whatever stale or
+		// conflicting files sit in the invoking checkout.
 		_ = copyDir(filepath.Join(m.planWorktreePath, "specs", m.planTaskName),
-			filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName))
+			filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName), true)
 		return err
 	}
 
@@ -234,7 +235,7 @@ func (m *model) finishPlanWorktree() error {
 	// after the merge, not before: writing untracked copies first would make
 	// the merge abort on files it is about to bring in.)
 	if err := copyDir(filepath.Join(m.planWorktreePath, "specs", m.planTaskName),
-		filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName)); err != nil {
+		filepath.Join(m.cfg.WorkDir, "specs", m.planTaskName), false); err != nil {
 		return fmt.Errorf("copying finished spec into invoking checkout: %w", err)
 	}
 
@@ -252,18 +253,35 @@ func (m *model) finishPlanWorktree() error {
 // missing. It mirrors the worktree's spec directory into the invoking checkout
 // so /run can consume it independently of any git merge.
 //
-// Existing files in dst are left as-is: when this runs after a successful
-// merge the merged copies are already present and identical, and overwriting
-// them would be wasted work. So a file already existing in dst is not an
-// error — CopyFS reports it as fs.ErrExist and we treat that as success.
-func copyDir(src, dst string) error {
+// When overwrite is false, existing files in dst are left as-is: after a
+// successful merge the merged copies are already present and identical, so
+// overwriting would be wasted work (CopyFS reports those as fs.ErrExist, which
+// we treat as success). When overwrite is true — the merge-failure fallback —
+// stale or conflicting files are replaced with the worktree's fresh copy.
+func copyDir(src, dst string, overwrite bool) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return err
+	}
+	if overwrite {
+		return copyOverwrite(src, dst)
 	}
 	if err := os.CopyFS(dst, os.DirFS(src)); err != nil && !errors.Is(err, fs.ErrExist) {
 		return err
 	}
 	return nil
+}
+
+// copyOverwrite copies src into dst, replacing any existing files, by copying
+// into a temp sibling dir and swapping. It recursively mirrors a directory with
+// overwrite semantics that os.CopyFS does not provide.
+func copyOverwrite(src, dst string) error {
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.CopyFS(dst, os.DirFS(src))
 }
 
 // handlePlanCommand processes "/plan <rough idea>" input.

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -9,6 +9,71 @@ import (
 	"github.com/dimetron/pi-go/internal/sop"
 )
 
+func TestCopyDir_RecursesAndOverwrites(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	// Nested file under research/ plus a top-level file.
+	if err := os.MkdirAll(filepath.Join(src, "research"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "PROMPT.md"), []byte("plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "research", "notes.md"), []byte("notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+
+	for _, rel := range []string{"PROMPT.md", "research", filepath.Join("research", "notes.md")} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); err != nil {
+			t.Errorf("copied %s missing in dst: %v", rel, err)
+		}
+	}
+
+	// Overwrite an existing destination file.
+	if err := os.WriteFile(filepath.Join(src, "PROMPT.md"), []byte("plan-v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir overwrite: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "PROMPT.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "plan-v2" {
+		t.Errorf("overwrite did not take effect: got %q, want %q", got, "plan-v2")
+	}
+}
+
+func TestCopyDir_SkipsSymlinks(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "real.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(src, "real.md"), filepath.Join(src, "link.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "real.md")); err != nil {
+		t.Errorf("real.md not copied: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dst, "link.md")); err == nil {
+		t.Error("symlink should not be copied")
+	}
+}
+
 func TestToKebabCase_Simple(t *testing.T) {
 	got := toKebabCase("add rate limiting")
 	want := "add-rate-limiting"

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/subagent"
 )
 
 func TestCopyDir_RecursesAndOverwrites(t *testing.T) {
@@ -317,5 +319,81 @@ func TestPlanInstruction_ExistingSpecReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("error should mention 'already exists', got: %v", err)
+	}
+}
+
+// TestFinishPlanWorktree_CopiesSpecIntoInvokingCheckout drives the end-of-plan
+// worktree teardown with a real git worktree and verifies the finished spec
+// directory is copied into the invoking checkout's specs/ tree. This guards
+// the fix that /run must find specs/<task>/PROMPT.md even though specs/ is
+// gitignored.
+func TestFinishPlanWorktree_CopiesSpecIntoInvokingCheckout(t *testing.T) {
+	repo := initRunTestRepo(t)
+	orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)
+	t.Cleanup(orch.Shutdown)
+
+	const taskName = "features/TOO/001-demo"
+	const agentID = "plan-" + taskName
+
+	// Seed a worktree like the planner would: it writes specs/<task>/... and
+	// never commits.
+	wtPath, err := orch.Worktree().Create(agentID, "pdd-"+taskName)
+	if err != nil {
+		t.Fatalf("creating plan worktree: %v", err)
+	}
+	wtSpec := filepath.Join(wtPath, "specs", taskName)
+	if err := os.MkdirAll(filepath.Join(wtSpec, "research"), 0o755); err != nil {
+		t.Fatalf("mkdir research: %v", err)
+	}
+	for name, content := range map[string]string{
+		"PROMPT.md":         "# Feature\n\n## Objective\nDo it.\n",
+		"requirements.md":   "# Requirements\n",
+		"research/notes.md": "notes\n",
+	} {
+		if err := os.WriteFile(filepath.Join(wtSpec, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	m := &model{
+		cfg:                 Config{WorkDir: repo, Orchestrator: orch},
+		planWorktreeAgentID: agentID,
+		planWorktreePath:    wtPath,
+		planTaskName:        taskName,
+		planBackupBranch:    "specs/" + taskName,
+		planWorktree:        orch.Worktree(),
+	}
+
+	if err := m.finishPlanWorktree(); err != nil {
+		t.Fatalf("finishPlanWorktree: %v", err)
+	}
+
+	// The finished spec must be present in the invoking checkout, including the
+	// research/ subtree, independently of the git merge.
+	for _, rel := range []string{
+		"PROMPT.md",
+		"requirements.md",
+		filepath.Join("research", "notes.md"),
+	} {
+		if _, err := os.Stat(filepath.Join(repo, "specs", taskName, rel)); err != nil {
+			t.Errorf("spec %s not copied into invoking checkout: %v", rel, err)
+		}
+	}
+
+	// The plan is complete, so the worktree state should be cleared.
+	if m.planWorktree != nil {
+		t.Error("planWorktree should be nil after a completed plan")
+	}
+	if m.planWorktreePath != "" {
+		t.Errorf("planWorktreePath should be cleared, got %q", m.planWorktreePath)
+	}
+}
+
+// TestFinishPlanWorktree_NoWorktreeIsNoOp ensures a model without an active plan
+// worktree is a safe no-op (no panic, no error).
+func TestFinishPlanWorktree_NoWorktreeIsNoOp(t *testing.T) {
+	m := &model{}
+	if err := m.finishPlanWorktree(); err != nil {
+		t.Fatalf("finishPlanWorktree with no worktree should be a no-op, got: %v", err)
 	}
 }

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -36,23 +36,21 @@ func TestCopyDir_RecursesAndOverwrites(t *testing.T) {
 		}
 	}
 
-	// Overwrite an existing destination file.
-	if err := os.WriteFile(filepath.Join(src, "PROMPT.md"), []byte("plan-v2"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	// Copying again is idempotent — an existing destination file is left as-is,
+	// not an error (the merge already brought the same content in).
 	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir overwrite: %v", err)
+		t.Fatalf("copyDir second pass: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(dst, "PROMPT.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != "plan-v2" {
-		t.Errorf("overwrite did not take effect: got %q, want %q", got, "plan-v2")
+	if string(got) != "plan" {
+		t.Errorf("existing file should be left as-is, got %q", got)
 	}
 }
 
-func TestCopyDir_SkipsSymlinks(t *testing.T) {
+func TestCopyDir_FollowsSymlink(t *testing.T) {
 	src := filepath.Join(t.TempDir(), "src")
 	dst := filepath.Join(t.TempDir(), "dst")
 	if err := os.MkdirAll(src, 0o755); err != nil {
@@ -71,8 +69,9 @@ func TestCopyDir_SkipsSymlinks(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dst, "real.md")); err != nil {
 		t.Errorf("real.md not copied: %v", err)
 	}
-	if _, err := os.Lstat(filepath.Join(dst, "link.md")); err == nil {
-		t.Error("symlink should not be copied")
+	// os.CopyFS follows symlinks, so link.md resolves to real.md's content.
+	if got, err := os.ReadFile(filepath.Join(dst, "link.md")); err != nil || string(got) != "x" {
+		t.Errorf("symlinked file not resolved: got %q err %v", got, err)
 	}
 }
 

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -26,7 +26,7 @@ func TestCopyDir_RecursesAndOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := copyDir(src, dst); err != nil {
+	if err := copyDir(src, dst, false); err != nil {
 		t.Fatalf("copyDir: %v", err)
 	}
 
@@ -38,7 +38,7 @@ func TestCopyDir_RecursesAndOverwrites(t *testing.T) {
 
 	// Copying again is idempotent — an existing destination file is left as-is,
 	// not an error (the merge already brought the same content in).
-	if err := copyDir(src, dst); err != nil {
+	if err := copyDir(src, dst, false); err != nil {
 		t.Fatalf("copyDir second pass: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(dst, "PROMPT.md"))
@@ -63,7 +63,7 @@ func TestCopyDir_FollowsSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := copyDir(src, dst); err != nil {
+	if err := copyDir(src, dst, false); err != nil {
 		t.Fatalf("copyDir: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dst, "real.md")); err != nil {
@@ -447,7 +447,66 @@ func TestFinishPlanWorktree_KeepsWorktreeUntilPromptExists(t *testing.T) {
 func TestCopyDir_ReturnsErrorOnMissingSrc(t *testing.T) {
 	src := filepath.Join(t.TempDir(), "does-not-exist")
 	dst := filepath.Join(t.TempDir(), "dst")
-	if err := copyDir(src, dst); err == nil {
+	if err := copyDir(src, dst, false); err == nil {
 		t.Fatal("copyDir should error when the source directory does not exist")
+	}
+}
+
+// TestFinishPlanWorktree_MergeFailureStillCopiesSpec covers the defensive path
+// in finishPlanWorktree where MergeBack fails (here: an untracked collision in
+// the invoking checkout makes the merge abort). Even then the finished spec
+// must be copied out so /run can still find PROMPT.md, and the error must
+// propagate to the caller.
+func TestFinishPlanWorktree_MergeFailureStillCopiesSpec(t *testing.T) {
+	repo := initRunTestRepo(t)
+	orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)
+	t.Cleanup(orch.Shutdown)
+
+	const taskName = "features/TOO/001-conflict"
+	const agentID = "plan-" + taskName
+	wtPath, err := orch.Worktree().Create(agentID, "pdd-"+taskName)
+	if err != nil {
+		t.Fatalf("creating plan worktree: %v", err)
+	}
+	wtSpec := filepath.Join(wtPath, "specs", taskName)
+	if err := os.MkdirAll(wtSpec, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtSpec, "PROMPT.md"), []byte("# Prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-seed an untracked PROMPT.md in the invoking checkout so the merge
+	// aborts ("untracked working tree files would be overwritten by merge").
+	outSpec := filepath.Join(repo, "specs", taskName)
+	if err := os.MkdirAll(outSpec, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outSpec, "PROMPT.md"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &model{
+		cfg:                 Config{WorkDir: repo, Orchestrator: orch},
+		planWorktreeAgentID: agentID,
+		planWorktreePath:    wtPath,
+		planTaskName:        taskName,
+		planBackupBranch:    "specs/" + taskName,
+		planWorktree:        orch.Worktree(),
+	}
+
+	err = m.finishPlanWorktree()
+	if err == nil {
+		t.Fatal("finishPlanWorktree should surface the merge failure")
+	}
+
+	// Even though the merge failed, the worktree's copy must have been written
+	// out over the stale one, so /run can still find the finished spec.
+	got, readErr := os.ReadFile(filepath.Join(outSpec, "PROMPT.md"))
+	if readErr != nil {
+		t.Fatalf("spec not preserved on merge failure: %v", readErr)
+	}
+	if string(got) != "# Prompt\n" {
+		t.Errorf("spec content = %q, want the worktree's copy %q", got, "# Prompt\n")
 	}
 }

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -397,3 +397,58 @@ func TestFinishPlanWorktree_NoWorktreeIsNoOp(t *testing.T) {
 		t.Fatalf("finishPlanWorktree with no worktree should be a no-op, got: %v", err)
 	}
 }
+
+// TestFinishPlanWorktree_KeepsWorktreeUntilPromptExists verifies that an
+// in-progress plan (no PROMPT.md yet) does not merge or copy the spec — the
+// worktree stays put so the next turn can carry on in it.
+func TestFinishPlanWorktree_KeepsWorktreeUntilPromptExists(t *testing.T) {
+	repo := initRunTestRepo(t)
+	orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)
+	t.Cleanup(orch.Shutdown)
+
+	const taskName = "features/TOO/001-wip"
+	const agentID = "plan-" + taskName
+	wtPath, err := orch.Worktree().Create(agentID, "pdd-"+taskName)
+	if err != nil {
+		t.Fatalf("creating plan worktree: %v", err)
+	}
+	// Only requirements.md — the planner has not written PROMPT.md yet.
+	wtSpec := filepath.Join(wtPath, "specs", taskName)
+	if err := os.MkdirAll(wtSpec, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtSpec, "requirements.md"), []byte("# Req\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &model{
+		cfg:                 Config{WorkDir: repo, Orchestrator: orch},
+		planWorktreeAgentID: agentID,
+		planWorktreePath:    wtPath,
+		planTaskName:        taskName,
+		planBackupBranch:    "specs/" + taskName,
+		planWorktree:        orch.Worktree(),
+	}
+
+	if err := m.finishPlanWorktree(); err != nil {
+		t.Fatalf("finishPlanWorktree on WIP should not error: %v", err)
+	}
+	// Worktree must be retained for the next planning turn.
+	if m.planWorktree == nil {
+		t.Error("planWorktree should not be cleared before PROMPT.md exists")
+	}
+	// No spec should have been copied out yet.
+	if _, err := os.Stat(filepath.Join(repo, "specs", taskName, "requirements.md")); err == nil {
+		t.Error("in-progress spec should not be copied into the invoking checkout")
+	}
+}
+
+// TestCopyDir_ReturnsErrorOnMissingSrc ensures a missing source directory
+// surfaces as an error rather than silently producing an empty dst.
+func TestCopyDir_ReturnsErrorOnMissingSrc(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "does-not-exist")
+	dst := filepath.Join(t.TempDir(), "dst")
+	if err := copyDir(src, dst); err == nil {
+		t.Fatal("copyDir should error when the source directory does not exist")
+	}
+}

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -452,6 +452,69 @@ func TestCopyDir_ReturnsErrorOnMissingSrc(t *testing.T) {
 	}
 }
 
+// TestCopyDir_OverwriteReplacesExistingFiles covers the overwrite=true path
+// used when the merge fails: stale files in dst must be replaced by the
+// source's copy.
+func TestCopyDir_OverwriteReplacesExistingFiles(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "PROMPT.md"), []byte("fresh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a stale dst with different content.
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dst, "PROMPT.md"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyDir(src, dst, true); err != nil {
+		t.Fatalf("copyDir overwrite: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "PROMPT.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "fresh\n" {
+		t.Errorf("overwrite did not replace stale content: got %q, want %q", got, "fresh\n")
+	}
+}
+
+// TestCopyDir_ReturnsErrorOnMkdirAllFailure covers the dst-creation error path
+// in copyDir: a dst whose parent cannot be created must surface an error.
+func TestCopyDir_ReturnsErrorOnMkdirAllFailure(t *testing.T) {
+	// Use a path whose parent is a file, so MkdirAll fails.
+	parent := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(parent, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(parent, "sub")
+	if err := copyDir(src, dst, false); err == nil {
+		t.Fatal("copyDir should error when dst cannot be created")
+	}
+}
+
+// TestCopyOverwrite_ReturnsErrorOnMissingSrc ensures copyOverwrite surfaces an
+// error when the source directory does not exist.
+func TestCopyOverwrite_ReturnsErrorOnMissingSrc(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "missing-src")
+	dst := filepath.Join(t.TempDir(), "dst")
+	if err := copyOverwrite(src, dst); err == nil {
+		t.Fatal("copyOverwrite should error when the source directory does not exist")
+	}
+}
+
 // TestFinishPlanWorktree_MergeFailureStillCopiesSpec covers the defensive path
 // in finishPlanWorktree where MergeBack fails (here: an untracked collision in
 // the invoking checkout makes the merge abort). Even then the finished spec


### PR DESCRIPTION
## Summary

`/plan` writes spec files into an isolated git worktree and snapshots them via
`CommitAll → CreateBackupBranch → MergeBack → Cleanup`. Two bugs made that
snapshot silently drop every artifact, so `/run` found no `PROMPT.md`.

### Root cause

1. **`CommitAll` gated on `git status --porcelain`** (`internal/subagent/worktree.go`).
   Plain porcelain status hides ignored files, and the spec path matches the
   repo's ignore rules — `**/specs/` in the global gitignore and `.pi-go/` in the
   project — so status came back empty and `CommitAll` returned "nothing to
   commit" before staging anything. The backup branch then pointed at an empty
   commit, `MergeBack` merged nothing, and `Cleanup` ran `worktree remove
   --force`, deleting the only copy.
2. **`git add -A` respects ignore rules**, so even if staging was reached the
   ignored spec files were still not added.

### Fix

- **`CommitAll`**: force-add with `git add -Af` first, then check what was
  actually staged via `diff --cached --name-only` (preserves the empty-commit
  no-op). This guarantees ignored planner output enters the snapshot.
- **`finishPlanWorktree`**: copy the finished spec directory directly into the
  invoking checkout's `specs/` tree, so `/run` can read
  `<workDir>/specs/<task>/PROMPT.md` independently of any git merge.
- **Regression test**: `initTestRepoWithIgnores` installs the repo's ignore
  rules via `core.excludesFile`, so the loss is reproduced deterministically in
  any environment (the old test only failed on machines whose global gitignore
  happened to match).
- Added `copyDir` helper + unit tests in `internal/tui/plan_test.go`.

### Verification

- `go build ./...`
- `go vet ./internal/subagent/ ./internal/tui/`
- `go test ./internal/subagent/`
- `go test ./internal/tui/`