### PR TITLE
feat(tui): show how long each turn took in the usage summary

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -408,8 +408,12 @@ type agentDoneMsg struct{ err error }
 // a successful turn. It arrives after the reply text and before the channel
 // close that synthesizes agentDoneMsg, so the summary renders directly under
 // the answer.
+//
+// elapsed is the turn's wall-clock time, measured across the whole agent loop —
+// every model call, tool call and stuck recovery — not just the final response.
 type agentUsageMsg struct {
-	usage *genai.GenerateContentResponseUsageMetadata
+	usage   *genai.GenerateContentResponseUsageMetadata
+	elapsed time.Duration
 }
 
 // agentWarningMsg carries a non-fatal problem with the turn into the
@@ -459,10 +463,11 @@ func addUsage(dst, src *genai.GenerateContentResponseUsageMetadata) *genai.Gener
 }
 
 // formatTurnUsage renders a per-turn token summary as one dim line: input,
-// cached reads, output, reasoning, and total. It returns "" when u is nil or
-// all-zero, so a provider that reports no usage shows no line rather than
-// "0 in · 0 out".
-func formatTurnUsage(u *genai.GenerateContentResponseUsageMetadata) string {
+// cached reads, output, reasoning, total, and how long the turn took. It
+// returns "" when u is nil or all-zero, so a provider that reports no usage
+// shows no line rather than "0 in · 0 out" — the elapsed time rides along with
+// the token tally rather than standing on its own.
+func formatTurnUsage(u *genai.GenerateContentResponseUsageMetadata, elapsed time.Duration) string {
 	if u == nil {
 		return ""
 	}
@@ -496,7 +501,28 @@ func formatTurnUsage(u *genai.GenerateContentResponseUsageMetadata) string {
 	b.WriteString(" · ")
 	b.WriteString(formatTokenCount(total))
 	b.WriteString(" total")
+	if elapsed > 0 {
+		b.WriteString(" · took ")
+		b.WriteString(formatTurnDuration(elapsed))
+	}
 	return b.String()
+}
+
+// formatTurnDuration renders a turn's wall-clock time at a precision that suits
+// its magnitude: milliseconds under a second, one decimal of seconds under a
+// minute, and whole minutes and hours above that. Sub-second precision on a
+// ten-minute turn is noise, and rounding a fast turn to "0s" hides it.
+func formatTurnDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	case d < time.Hour:
+		return fmt.Sprintf("%dm %02ds", int(d/time.Minute), int(d/time.Second)%60)
+	default:
+		return fmt.Sprintf("%dh %02dm", int(d/time.Hour), int(d/time.Minute)%60)
+	}
 }
 
 // waitForAgent returns a Cmd that waits for the next message on the agent channel.
@@ -790,6 +816,10 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 	// named is not going to be fixed by naming it again, and every attempt
 	// costs a full turn.
 	var turnUsage *genai.GenerateContentResponseUsageMetadata
+	// Started here rather than at the top of the function so the measurement
+	// covers the model work and not the setup around it; stuck recoveries are
+	// part of the turn the user waited on, so they stay inside the span.
+	turnStart := time.Now()
 	for attempt := 0; ; attempt++ {
 		usage, err := m.streamTurn(ctx, ch, prompt, run, groundedSeen, &truncated, log)
 		turnUsage = addUsage(turnUsage, usage)
@@ -797,7 +827,7 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 		var stuck *stuckError
 		if !errors.As(err, &stuck) {
 			if err == nil && turnUsage != nil {
-				ch <- agentUsageMsg{usage: turnUsage}
+				ch <- agentUsageMsg{usage: turnUsage, elapsed: time.Since(turnStart)}
 			}
 			if err != nil {
 				fail(err)
@@ -1024,7 +1054,7 @@ func (m *model) handleAgentWarning(msg agentWarningMsg) (tea.Model, tea.Cmd) {
 // or all-zero usage block renders nothing, so providers that omit usage are
 // indistinguishable from a turn that happened to report zero.
 func (m *model) handleAgentUsage(msg agentUsageMsg) (tea.Model, tea.Cmd) {
-	if s := formatTurnUsage(msg.usage); s != "" {
+	if s := formatTurnUsage(msg.usage, msg.elapsed); s != "" {
 		m.chatModel.AppendMeta(s)
 	}
 	return m, waitForAgent(m.agentCh)

--- a/internal/tui/agent_usage_test.go
+++ b/internal/tui/agent_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/genai"
 )
@@ -57,20 +58,24 @@ func TestAddUsage(t *testing.T) {
 
 func TestFormatTurnUsage(t *testing.T) {
 	tests := []struct {
-		name string
-		u    *genai.GenerateContentResponseUsageMetadata
-		want string
+		name    string
+		u       *genai.GenerateContentResponseUsageMetadata
+		elapsed time.Duration
+		want    string
 	}{
-		{"nil", nil, ""},
-		{"all zero", &genai.GenerateContentResponseUsageMetadata{}, ""},
+		{"nil", nil, 0, ""},
+		{"all zero", &genai.GenerateContentResponseUsageMetadata{}, 0, ""},
+		{"elapsed without usage", nil, 3 * time.Second, ""},
 		{
 			"in and out only",
 			&genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 100, CandidatesTokenCount: 50},
+			0,
 			"100 in · 50 out · 150 total",
 		},
 		{
 			"with cache read",
 			&genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 100, CandidatesTokenCount: 50, CachedContentTokenCount: 30},
+			0,
 			"100 in (30 cached) · 50 out · 150 total",
 		},
 		{
@@ -79,20 +84,57 @@ func TestFormatTurnUsage(t *testing.T) {
 				PromptTokenCount: 2000, CandidatesTokenCount: 500, CachedContentTokenCount: 1000,
 				ThoughtsTokenCount: 75, TotalTokenCount: 2500,
 			},
+			0,
 			"2.0k in (1.0k cached) · 500 out · 75 reasoning · 2.5k total",
 		},
 		{
 			"reasoning only, no total",
 			&genai.GenerateContentResponseUsageMetadata{ThoughtsTokenCount: 75},
+			0,
 			"0 in · 0 out · 75 reasoning · 75 total",
+		},
+		{
+			"with elapsed time",
+			&genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 100, CandidatesTokenCount: 50},
+			12345 * time.Millisecond,
+			"100 in · 50 out · 150 total · took 12.3s",
+		},
+		{
+			"with elapsed time over a minute",
+			&genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 323600, CandidatesTokenCount: 2900, TotalTokenCount: 326500},
+			92 * time.Second,
+			"323.6k in · 2.9k out · 326.5k total · took 1m 32s",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := formatTurnUsage(tt.u); got != tt.want {
+			if got := formatTurnUsage(tt.u, tt.elapsed); got != tt.want {
 				t.Fatalf("formatTurnUsage() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatTurnDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{250 * time.Millisecond, "250ms"},
+		{999 * time.Millisecond, "999ms"},
+		{time.Second, "1.0s"},
+		{12345 * time.Millisecond, "12.3s"},
+		{59500 * time.Millisecond, "59.5s"},
+		{time.Minute, "1m 00s"},
+		{92 * time.Second, "1m 32s"},
+		{59*time.Minute + 59*time.Second, "59m 59s"},
+		{time.Hour, "1h 00m"},
+		{2*time.Hour + 5*time.Minute, "2h 05m"},
+	}
+	for _, tt := range tests {
+		if got := formatTurnDuration(tt.d); got != tt.want {
+			t.Errorf("formatTurnDuration(%s) = %q, want %q", tt.d, got, tt.want)
+		}
 	}
 }
 
@@ -118,9 +160,12 @@ func TestChatModel_RenderMessages_MetaMessage(t *testing.T) {
 
 func TestHandleAgentUsage_AppendsSummary(t *testing.T) {
 	m := &model{chatModel: NewChatModel(nil)}
-	m.handleAgentUsage(agentUsageMsg{usage: &genai.GenerateContentResponseUsageMetadata{
-		PromptTokenCount: 100, CandidatesTokenCount: 50,
-	}})
+	m.handleAgentUsage(agentUsageMsg{
+		usage: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount: 100, CandidatesTokenCount: 50,
+		},
+		elapsed: 2500 * time.Millisecond,
+	})
 	if len(m.chatModel.Messages) != 1 {
 		t.Fatalf("expected 1 meta message, got %d", len(m.chatModel.Messages))
 	}
@@ -128,7 +173,7 @@ func TestHandleAgentUsage_AppendsSummary(t *testing.T) {
 	if !msg.isMeta || msg.role != "assistant" {
 		t.Fatalf("expected a meta assistant message, got %+v", msg)
 	}
-	if msg.content != "100 in · 50 out · 150 total" {
+	if msg.content != "100 in · 50 out · 150 total · took 2.5s" {
 		t.Fatalf("unexpected summary content: %q", msg.content)
 	}
 


### PR DESCRIPTION
The per-turn tally reported tokens but not time, so a turn that cost
326.5k tokens looked the same whether it finished in four seconds or four
minutes. Carry the turn's wall-clock time alongside the usage block and
render it as a trailing "· took 1m 32s".

The clock starts just before the attempt loop in runAgentLoop, so the
number covers what the user actually waited on: every model call, tool
call and stuck recovery, not just the final response.

formatTurnDuration scales precision to magnitude — 250ms, 12.3s, 1m 32s,
2h 05m. Sub-second precision on a ten-minute turn is noise, and rounding a
fast turn to "0s" hides it.

A nil or all-zero usage block still renders no line at all, so a provider
that reports no usage does not suddenly grow a meta line carrying only a
timing.

Signed-off-by: dimetron <dimetron@me.com>
