### PR TITLE
fix(config): auto-detect openrouter/ prefix to openrouter provider

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,10 @@ func autoDetectProvider(modelName string) string {
 	if strings.HasPrefix(lower, "opencode/") {
 		return "opencode"
 	}
+	// openrouter/ prefix → OpenRouter provider.
+	if strings.HasPrefix(lower, "openrouter/") {
+		return "openrouter"
+	}
 	// :cloud suffix → native Ollama provider.
 	if strings.HasSuffix(modelName, ":cloud") || strings.HasSuffix(modelName, "-cloud") {
 		return "ollama"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -102,6 +102,8 @@ func TestResolveRole_AutoDetectProvider(t *testing.T) {
 		{"opencode/kimi-k3", "opencode"},
 		{"opencode/minimax-m3", "opencode"},
 		{"opencode/gpt-5.6-luna", "opencode"},
+		{"openrouter/google/gemini-3.7-flash", "openrouter"},
+		{"openrouter/auto", "openrouter"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
ResolveRole falls back to defaultProvider ("openai") when a model's
provider can't be auto-detected, because config.autoDetectProvider has no
openrouter/ case. --model openrouter/google/gemini-3.7-flash was therefore
routed to the openai provider and rejected by model validation.

Mirror the opencode/ handling already present so openrouter/ models resolve
to the openrouter provider, bypassing validation (no KnownModels entry).

Signed-off-by: dimetron <dimetron@me.com>
