### PR TITLE
refactor: eliminate every function above cyclomatic complexity 15

### DIFF
--- a/docs/complexity-refactor.md
+++ b/docs/complexity-refactor.md
@@ -1,0 +1,252 @@
+# Cyclomatic complexity refactor — evidence
+
+Branch point: `15e29c3`. Scope: every function in `cmd/`, `internal/`, `piagent/`
+and `pimodels/` measuring above cyclomatic complexity 15 — 81 functions across
+18 packages. Tests excluded from measurement.
+
+Tools: `gocyclo` (cyclomatic, CC) and `gocognit` (cognitive, COG). Both metrics
+are reported because they disagree in useful ways: a flat `switch` scores high CC
+and near-zero COG, while a deeply nested block scores the reverse. Chasing CC
+alone would have rewritten harmless dispatch tables and left the genuinely
+unreadable code alone.
+
+## Result
+
+| Metric | before | after |
+|---|---|---|
+| Functions | 2553 | 2858 |
+| Total CC | 11525 | 11667 |
+| **Decision points** (total CC − functions) | **8972** | **8809** |
+| Average CC | 4.514 | 4.082 |
+| **Max CC** | **37** | **15** |
+| CC > 10 | 216 | 150 |
+| **CC > 15** | **81** | **0** |
+| CC > 20 | 38 | 0 |
+| CC > 30 | 5 | 0 |
+| Total COG | 12039 | 11188 |
+| Max COG | 89 | 41 |
+| COG > 20 | 106 | 40 |
+
+Total CC rises by 142 while function count rises by 305. That is expected and is
+not complexity moving sideways: every function carries a baseline CC of 1, so
+305 new functions add 305 to the total by existing. The metric that ignores that
+baseline — decision points — falls by 163. Cognitive complexity, which has no
+such baseline, falls by 851.
+
+**No function anywhere in the repo got more complex.** Verified by joining the
+before and after measurements on package+function+file: the set of functions
+with a higher CC after than before is empty.
+
+## Verification
+
+All run at the final tree state, from the worktree:
+
+| Check | Command | Result |
+|---|---|---|
+| Build | `go build ./...` | clean |
+| Vet | `go vet ./...` | clean |
+| Tests | `go test ./... -count=1` | **45 packages, 0 failures** |
+| Lint | `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` | **0 issues** |
+
+The lint run disables golangci-lint's default truncation (`max-issues-per-linter: 50`,
+`max-same-issues: 5` in `.golangci.yml`). A default run hides a systematic problem
+behind a count of 5.
+
+Tests were run with `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`,
+`GEMINI_API_KEY` and `GOOGLE_API_KEY` stripped from the environment, so no test can
+pass here by reaching a real endpoint and then fail in CI. Baseline coverage was
+measured the same way, in a pristine detached worktree at `15e29c3`, using the
+identical command — the before and after numbers are two runs of one command, not
+one measurement and one recollection.
+
+## Coverage
+
+Every package touched by this change gained coverage. No package regressed.
+Mean across all 45 packages: **89.64% → 90.29%**.
+
+| Package | before | after | delta |
+|---|---|---|---|
+| `internal/tui/refs` | 87.0% | 90.7% | +3.7 |
+| `internal/palace` | 83.7% | 87.1% | +3.4 |
+| `internal/subagent` | 88.5% | 91.8% | +3.3 |
+| `internal/webserver` | 87.5% | 90.4% | +2.9 |
+| `internal/tools` | 87.5% | 89.8% | +2.3 |
+| `internal/codex` | 83.7% | 86.0% | +2.3 |
+| `internal/cli` | 80.5% | 82.8% | +2.3 |
+| `internal/tui` | 90.5% | 92.2% | +1.7 |
+| `internal/extension` | 85.9% | 87.5% | +1.6 |
+| `internal/config` | 90.7% | 92.3% | +1.6 |
+| `internal/provider` | 92.5% | 93.5% | +1.0 |
+| `internal/auth` | 89.6% | 90.5% | +0.9 |
+| `internal/pirpc` | 96.6% | 97.4% | +0.8 |
+| `internal/acp/server/adapter` | 99.5% | 100.0% | +0.5 |
+| `piagent` | 91.4% | 91.7% | +0.3 |
+| `internal/acp/server` | 88.8% | 89.0% | +0.2 |
+| `internal/session` | 88.4% | 88.6% | +0.2 |
+| `internal/audit` | 95.3% | 95.4% | +0.1 |
+
+Roughly 1,400 new test cases across 18 new `complexity_*_test.go` files.
+
+## Largest reductions
+
+| Function | CC before | CC after |
+|---|---|---|
+| `tui.(*ChatModel).renderMessages` | 33 | 7 |
+| `provider.ollamaContentsToMessages` | 31 | 8 |
+| `provider.antContentsToMessages` | 31 | 8 |
+| `subagent.(*Orchestrator).Spawn` | 29 | 11 |
+| `tui.(*model).handleSlashCommand` | 28 | 5 |
+| `extension.LoadSkillsWithOptions` | 27 | 4 |
+| `palace.(*DrawerService).Search` | 25 | 8 |
+| `webserver.(*ServerV2).handleGeminiVoiceWS` | 24 | 8 |
+| `palace.MineConversations` | 23 | 4 |
+| `cli.runModelList` | 22 | 7 |
+| `config.parseMCPServers` | 21 | 4 |
+| `provider.(*openaiModel).generateResponses` | 21 | 3 |
+| `cli.resolvePingTarget` | 20 | 4 |
+| `codex.(*Session).handleItem` | 20 | 5 |
+
+`tui.(*model).formatContextUsage` (CC 37 → 3, COG 67 → 3) and
+`tools.analyzeSessionFile` (CC 30 → 4, COG 71 → 4) were the two worst functions in
+the repo on both metrics.
+
+## How behaviour preservation was established
+
+Not by "the tests still pass" — the pre-existing tests did not reach many of these
+branches, which is why the functions were able to grow this large. Three stronger
+techniques were used, in descending order of strength:
+
+1. **Byte-identical golden corpora captured from pre-refactor code.**
+   `internal/tui`'s rendering path has a 350-case, 86KB corpus dumped from a
+   read-only `git archive HEAD` export *before* any source edit, covering
+   `renderMessages` across 4 message sets × 3 widths × streaming on/off, every
+   tool-card kind × 3 widths × compact × blink, 20 status-bar configurations, 38
+   `toolCallSummary` arg shapes, 29 `formatToolResult` payloads and 23 `blankFast`
+   inputs. `cmp` before/after reports identical. The dump harness remains behind
+   `PI_RENDER_GOLDEN_OUT` so the next person refactoring this code gets the same
+   diff for free. `internal/provider` did the same for wire-format translation and
+   additionally **mutation-checked** the goldens: changing the tool-result
+   placeholder string in the pre-refactor source makes the golden fail, proving the
+   assertions are not vacuous.
+
+2. **Exhaustive equivalence proof** where the domain is finite. `audit.isEmoji`
+   became a range table; the original `||` chain was transcribed verbatim as
+   `isEmojiOriginal` and every code point from 0 to 0x10FFFF is asserted to agree.
+   An off-by-one has nowhere to hide.
+
+3. **Mechanical diff against `main`** for table conversions. The slash-command
+   table was verified by extracting the case labels from both original functions
+   out of `git show main:`, confirming both covered the same 25 commands, and
+   diffing the reconstructed command→description mapping byte for byte. The
+   autocomplete list was diffed *in order*, because `completeSlashCommand` returns
+   the first prefix match — order is behaviour, not presentation.
+
+## Judgment calls worth reviewing
+
+Some targets were **deliberately not fully reduced**, because the metric was the
+wrong master:
+
+- `tui.blankFast` stopped at CC 9 / COG 16. It is the documented hot path. Going
+  lower means splitting the per-byte scan loop, which would not inline.
+  `skipFastCSI` was confirmed inlined via `-gcflags=-m`, and benchmarked at
+  308µs → 302µs with allocations unchanged, so the extraction that *was* done
+  costs nothing.
+- `tui.(*model).updateTerminal` stopped at CC 14. Its ~12-case type switch is the
+  floor; the case *bodies* were extracted (COG 17 → 5) rather than shredding arms
+  to move CC elsewhere.
+- `tui.toolCallSummary`'s table conversion is partial. `ls`, `tree` and `agent`
+  stayed in the switch because for `ls` a *present but empty* `path` returns `""`
+  while an *absent* one returns `"."`.
+- `tui`'s title-sync carve-out (`/clear`, `/exit`, `/quit` skip `setSessionTitle`)
+  stayed a separate switch rather than becoming a per-command flag with two states.
+- `pirpc.(*Server).dispatch` (CC 14) and several other flat dispatch switches were
+  left alone. A flat switch is not a defect.
+
+**Ordering and structure that is load-bearing**, now explicit and pinned:
+
+- `tools.readWindow` checks for the file's phantom trailing line on the **raw**
+  line, before BOM/CR normalization. Normalizing first would turn a final line of
+  exactly `"\r"` — or a lone BOM on line 1 — into `""` and silently drop a real line.
+- `tools.coerceAtPath` takes the value as an explicit parameter rather than
+  re-reading `obj[key]`. The original passed the originally-ranged value to both
+  the `parent.key` and `parent.$.key` checks, not the value the first may have just
+  written back.
+- `provider.sendResponses` takes `*responses.ResponseNewParams`. The original
+  closed over `params` by reference, so clearing `PreviousResponseID` on one
+  attempt persisted into the next retry. Passing by value would have silently
+  restored the stale pointer.
+- `tools.formatToolResult`'s 13 probes became an ordered slice; the shapes overlap
+  (a backgrounded bash poll carries both `handle` and `exit_code`). A test fails the
+  build if the slice and the test's shape map desync.
+- `cli.runMemoryRecent` still validates `--type` *after* opening the DB, so a run
+  with both a missing DB and a bad type still reports "memory database not found"
+  first.
+- `codex.(*Session).handleItem` keeps explicit tool cases with no `default` arm, so
+  an item type codex adds later stays silent.
+- `session.rangeHasPartID` compares `id(part) == want` where `id` returns `""` for
+  a wrong-kind part. This is equivalent to the original skip-then-compare **only
+  because both callers guarantee `want != ""`**. The invariant is documented on the
+  function and pinned from the caller side.
+- `provider`'s four content converters share only the genai-*reading* half. The
+  wire-*emitting* half is deliberately per-provider: Anthropic substitutes
+  `"No response available for this function call."` for an unmatched call, Ollama
+  substitutes `""`, and OpenAI Chat Completions uniquely *filters* calls with empty
+  IDs. A shared abstraction would have silently picked one.
+
+**Pre-existing quirks preserved and now documented rather than silently fixed:**
+`webserver.csiNum` treats an explicit `0` literally where a real terminal treats it
+as 1; `webserver.eraseDisplay` mode 1 blanks the cursor line's head as well as the
+lines above; `palace.maxFTSRank` carries a provably dead branch, kept so the
+collapse of two byte-identical copies stays mechanically checkable.
+
+## Known issues found but NOT fixed here
+
+These are pre-existing on `main` and are deliberately out of scope for a
+behaviour-preserving refactor. Each is recorded so it cannot be lost.
+
+1. **`subagent.(*WorktreeManager).Create` destroys uncommitted work on failure.**
+   The failure path is commented "Restore stashed changes on failure" but runs
+   `git stash drop`, which deletes the entry *without applying it* — and
+   `stash push -u` has already reverted the working tree. Verified empirically in a
+   throwaway repo: the changes do not come back and the stash list is empty. They
+   survive only as a dangling commit until gc. `MergeBack` in the same file gets it
+   right via `popStashByMessage` (apply, then drop). The one-line fix is to use
+   `popStashByMessage(stashMsg)` here too, but that is a behaviour change and
+   belongs in its own reviewable commit.
+   Current behaviour is pinned by `TestCreate_DropsStashWhenWorktreeAddFails`,
+   which asserts the dirty file does **not** return and carries a comment saying
+   this is the bug, why it was preserved, and that a fixer should expect the test
+   to fail and flip its assertions.
+
+2. **`spawner_timeout_test.go` has pre-existing timing flakes.**
+   `TestSpawn_AbsoluteCapStillApplies` and
+   `TestSpawn_SteadyOutputSurvivesInactivityWindow` fail roughly 1 run in 5 under
+   full-package load, racing a 700ms absolute cap against a 500ms inactivity window.
+   Confirmed not caused by this change: a scratch build of the package with all five
+   source files restored from `HEAD` flakes identically.
+
+3. **Coverage in `internal/codex` is nondeterministic** (85.5–86.7% across runs).
+   The variance is in pre-existing app-server subprocess tests.
+
+4. **Uncovered paths that remain**, stated rather than hidden: `cli.ollamaPingFull`'s
+   `provider.NewOllama` construction error and its stream-failure fallback (the
+   function builds its own LLM with no injection point, and a stream failure pays
+   real `retryStream` backoff); `piagent.buildRuntime`'s tool-construction error
+   branches. All were uncovered on `main` too.
+
+5. **`piagent.buildRuntime` takes `cfg *config.Config` deliberately** —
+   `subagent.NewOrchestrator` retains the pointer, so passing a copy would detach
+   the orchestrator's config from the one handed to `buildCallbacks`. `Orchestrator`
+   exposes no accessor for its config, so this is the one behaviour-preservation
+   claim in the change that rests on inspection rather than a test.
+
+## Follow-up work identified
+
+- Fix the `Create` stash-drop data loss (item 1 above). One line, own commit.
+- Widen the margins in `spawner_timeout_test.go` (item 2).
+- Remaining `gocognit` hotspots outside this scope: `palace/graph.go` `Traverse`
+  (25), `session/compaction.go` `LLMSummarizer` (22) and `filesTouched` (21),
+  `session/compaction_shed.go` `ShedSupersededToolResultsWithDedup` (22),
+  `provider.ollamaGenaiToolsToOllama` (36).
+- `tui.renderLiveOutput` still hand-rolls the gutter loop `writeGutterLines` owns.
+- `refs.expandFolder` duplicates path resolution now living in `readRefFile`.

--- a/internal/acp/server/adapter/complexity_stream_test.go
+++ b/internal/acp/server/adapter/complexity_stream_test.go
@@ -1,0 +1,243 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
+	"google.golang.org/adk/v2/model"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// partialTextEvent builds the delta form of a model event: ADK marks streamed
+// chunks Partial and then re-yields the turn once more as a non-partial
+// aggregate, which the dedup drops.
+func partialTextEvent(role string, parts ...*genai.Part) *adksession.Event {
+	return &adksession.Event{
+		LLMResponse: model.LLMResponse{
+			Content: &genai.Content{Role: role, Parts: parts},
+			Partial: true,
+		},
+	}
+}
+
+// chunkForPart is the part-classification chain OnEvent used to inline. The
+// table pins one row per branch the original loop had.
+func TestChunkForPart(t *testing.T) {
+	callPart := &genai.Part{FunctionCall: &genai.FunctionCall{Name: "read"}}
+	respPart := &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: "read"}}
+
+	tests := []struct {
+		name          string
+		part          *genai.Part
+		wantOK        bool
+		wantThought   bool
+		wantText      string
+		wantFinalText string
+	}{
+		{name: "nil part is dropped", part: nil},
+		{name: "function call is dropped", part: callPart},
+		{name: "function response is dropped", part: respPart},
+		{name: "empty thought is dropped", part: thoughtPart("")},
+		{name: "thought is emitted but not accumulated", part: thoughtPart("thinking"), wantOK: true, wantThought: true, wantText: "thinking"},
+		{name: "empty text is dropped", part: textPart("")},
+		{name: "text is emitted and accumulated", part: textPart("hi"), wantOK: true, wantText: "hi", wantFinalText: "hi"},
+		{
+			name:          "a part carrying both a call and text is dropped as plumbing",
+			part:          &genai.Part{Text: "ignored", FunctionCall: &genai.FunctionCall{Name: "read"}},
+			wantOK:        false,
+			wantFinalText: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(nil)
+			ev := textEvent("model", tt.part)
+
+			chunk, ok := s.chunkForPart(ev, tt.part)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if chunk.thought != tt.wantThought || chunk.text != tt.wantText {
+				t.Fatalf("chunk = %+v, want {thought:%v text:%q}", chunk, tt.wantThought, tt.wantText)
+			}
+			if got := s.Final(); got != tt.wantFinalText {
+				t.Fatalf("Final() = %q, want %q", got, tt.wantFinalText)
+			}
+		})
+	}
+}
+
+// The aggregate re-send arrives as a non-partial event repeating text already
+// delivered as deltas; chunkForPart must drop it so the reply is not doubled.
+func TestChunkForPart_DropsAggregateAfterDeltas(t *testing.T) {
+	up := &fakeUpdater{}
+	s := New(up)
+
+	delta := partialTextEvent("model", textPart("hel"))
+	if err := s.OnEvent(context.Background(), delta); err != nil {
+		t.Fatalf("OnEvent(delta): %v", err)
+	}
+	aggregate := textEvent("model", textPart("hello"))
+	if err := s.OnEvent(context.Background(), aggregate); err != nil {
+		t.Fatalf("OnEvent(aggregate): %v", err)
+	}
+
+	if got, want := len(up.updates), 1; got != want {
+		t.Fatalf("updates = %d, want %d (aggregate must be dropped)", got, want)
+	}
+	if got, want := s.Final(), "hel"; got != want {
+		t.Fatalf("Final() = %q, want %q", got, want)
+	}
+}
+
+// A user event between turns resets the dedup, so the next model aggregate
+// passes through even though the previous turn streamed deltas.
+func TestChunkForPart_UserEventResetsDedup(t *testing.T) {
+	up := &fakeUpdater{}
+	s := New(up)
+
+	if err := s.OnEvent(context.Background(), partialTextEvent("model", textPart("first"))); err != nil {
+		t.Fatalf("OnEvent(delta): %v", err)
+	}
+	// OnEvent returns early on user events, so feed the reset straight to the
+	// collector; the event carries no parts, only the role that resets dedup.
+	s.collectChunks(textEvent("user"))
+	if err := s.OnEvent(context.Background(), textEvent("model", textPart("second"))); err != nil {
+		t.Fatalf("OnEvent(aggregate): %v", err)
+	}
+
+	if got, want := len(up.updates), 2; got != want {
+		t.Fatalf("updates = %d, want %d", got, want)
+	}
+	if got, want := s.Final(), "firstsecond"; got != want {
+		t.Fatalf("Final() = %q, want %q", got, want)
+	}
+}
+
+// collectChunks returns the batch in part order and the updater read under the
+// same lock that guarded the accumulation.
+func TestCollectChunks_OrdersBatchAndReturnsUpdater(t *testing.T) {
+	up := &fakeUpdater{}
+	s := New(up)
+
+	ev := textEvent("model",
+		nil,
+		thoughtPart("why"),
+		&genai.Part{FunctionCall: &genai.FunctionCall{Name: "read"}},
+		textPart("because"),
+		textPart(""),
+	)
+	batch, updater := s.collectChunks(ev)
+
+	if updater != SessionUpdater(up) {
+		t.Fatalf("updater = %v, want the stream's updater", updater)
+	}
+	want := []pendingChunk{{thought: true, text: "why"}, {text: "because"}}
+	if len(batch) != len(want) {
+		t.Fatalf("batch = %+v, want %+v", batch, want)
+	}
+	for i := range want {
+		if batch[i] != want[i] {
+			t.Fatalf("batch[%d] = %+v, want %+v", i, batch[i], want[i])
+		}
+	}
+	if got, want := s.Final(), "because"; got != want {
+		t.Fatalf("Final() = %q, want %q", got, want)
+	}
+}
+
+func TestCollectChunks_NilUpdaterIsReturnedAsNil(t *testing.T) {
+	s := New(nil)
+	batch, updater := s.collectChunks(textEvent("model", textPart("x")))
+	if updater != nil {
+		t.Fatalf("updater = %v, want nil", updater)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("batch = %+v, want one chunk", batch)
+	}
+}
+
+func TestEmitChunks_SendsBothChunkKindsInOrder(t *testing.T) {
+	up := &fakeUpdater{}
+	s := New(up)
+
+	batch := []pendingChunk{{thought: true, text: "why"}, {text: "because"}}
+	if err := s.emitChunks(context.Background(), up, batch); err != nil {
+		t.Fatalf("emitChunks: %v", err)
+	}
+
+	if got, want := len(up.updates), 2; got != want {
+		t.Fatalf("updates = %d, want %d", got, want)
+	}
+	if th := up.updates[0].AgentThoughtChunk; th == nil || th.Content.Text == nil || th.Content.Text.Text != "why" {
+		t.Fatalf("updates[0] = %+v, want thought chunk %q", up.updates[0], "why")
+	}
+	if msg := up.updates[1].AgentMessageChunk; msg == nil || msg.Content.Text == nil || msg.Content.Text.Text != "because" {
+		t.Fatalf("updates[1] = %+v, want message chunk %q", up.updates[1], "because")
+	}
+}
+
+func TestEmitChunks_EmptyBatchIsNoOp(t *testing.T) {
+	up := &fakeUpdater{}
+	s := New(up)
+	if err := s.emitChunks(context.Background(), up, nil); err != nil {
+		t.Fatalf("emitChunks(nil): %v", err)
+	}
+	if len(up.updates) != 0 {
+		t.Fatalf("unexpected updates: %+v", up.updates)
+	}
+}
+
+// A nil updater discards message chunks rather than panicking, matching what
+// New(nil) promises.
+func TestEmitChunks_NilUpdaterDiscardsMessageChunks(t *testing.T) {
+	s := New(nil)
+	if err := s.emitChunks(context.Background(), nil, []pendingChunk{{text: "dropped"}}); err != nil {
+		t.Fatalf("emitChunks: %v", err)
+	}
+}
+
+// The first failing update aborts the batch: the chunk after it must not be
+// sent, whichever kind failed.
+func TestEmitChunks_StopsAtFirstError(t *testing.T) {
+	sentinel := errors.New("boom")
+
+	for _, tt := range []struct {
+		name  string
+		batch []pendingChunk
+	}{
+		{"thought fails first", []pendingChunk{{thought: true, text: "why"}, {text: "because"}}},
+		{"message fails first", []pendingChunk{{text: "because"}, {thought: true, text: "why"}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			up := &failOnceUpdater{err: sentinel}
+			s := New(up)
+			err := s.emitChunks(context.Background(), up, tt.batch)
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("err = %v, want to wrap %v", err, sentinel)
+			}
+			if got, want := up.calls, 1; got != want {
+				t.Fatalf("Update calls = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// failOnceUpdater fails on its first call and counts how many it received, so
+// a test can prove the batch stopped rather than merely reported an error.
+type failOnceUpdater struct {
+	calls int
+	err   error
+}
+
+func (f *failOnceUpdater) Update(_ context.Context, _ acp.SessionUpdate) error {
+	f.calls++
+	if f.calls == 1 {
+		return f.err
+	}
+	return nil
+}

--- a/internal/acp/server/adapter/stream.go
+++ b/internal/acp/server/adapter/stream.go
@@ -16,6 +16,7 @@ import (
 
 	acp "github.com/coder/acp-go-sdk"
 	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/agent"
 )
@@ -76,39 +77,67 @@ func (s *Stream) OnEvent(ctx context.Context, ev *adksession.Event) error {
 		return nil
 	}
 
-	type pending struct {
-		thought bool
-		text    string
-	}
-	var batch []pending
+	batch, updater := s.collectChunks(ev)
+	return s.emitChunks(ctx, updater, batch)
+}
 
+// pendingChunk is one text fragment collected under mu and emitted once the
+// lock is released: either a thought chunk or an assistant message chunk.
+type pendingChunk struct {
+	thought bool
+	text    string
+}
+
+// collectChunks walks ev's parts under mu, accumulating assistant text into
+// finalText, and returns the chunks to emit together with the updater to emit
+// them through — read under the same lock so emission needs none.
+func (s *Stream) collectChunks(ev *adksession.Event) ([]pendingChunk, SessionUpdater) {
 	s.mu.Lock()
-	s.dedup.BeginEvent(ev)
-	for _, part := range ev.Content.Parts {
-		if part == nil {
-			continue
-		}
-		if part.FunctionCall != nil || part.FunctionResponse != nil {
-			continue
-		}
-		if part.Thought {
-			if part.Text != "" {
-				batch = append(batch, pending{thought: true, text: part.Text})
-			}
-			continue
-		}
-		if part.Text == "" {
-			continue
-		}
-		if s.dedup.SkipText(ev) {
-			continue
-		}
-		s.finalText.WriteString(part.Text)
-		batch = append(batch, pending{text: part.Text})
-	}
-	updater := s.updater
-	s.mu.Unlock()
+	defer s.mu.Unlock()
 
+	s.dedup.BeginEvent(ev)
+	var batch []pendingChunk
+	for _, part := range ev.Content.Parts {
+		chunk, ok := s.chunkForPart(ev, part)
+		if !ok {
+			continue
+		}
+		batch = append(batch, chunk)
+	}
+	return batch, s.updater
+}
+
+// chunkForPart classifies one part of ev, reporting false for everything
+// OnEvent drops: nil parts, tool-call plumbing, empty text, and the aggregate
+// re-send of text already streamed as deltas. Assistant text is accumulated
+// into finalText here. The caller must hold mu.
+func (s *Stream) chunkForPart(ev *adksession.Event, part *genai.Part) (pendingChunk, bool) {
+	if part == nil {
+		return pendingChunk{}, false
+	}
+	if part.FunctionCall != nil || part.FunctionResponse != nil {
+		return pendingChunk{}, false
+	}
+	if part.Thought {
+		if part.Text == "" {
+			return pendingChunk{}, false
+		}
+		return pendingChunk{thought: true, text: part.Text}, true
+	}
+	if part.Text == "" {
+		return pendingChunk{}, false
+	}
+	if s.dedup.SkipText(ev) {
+		return pendingChunk{}, false
+	}
+	s.finalText.WriteString(part.Text)
+	return pendingChunk{text: part.Text}, true
+}
+
+// emitChunks forwards the collected chunks to the peer in order, stopping at
+// the first update error. A nil updater discards message chunks; thought
+// chunks go through emitThought, which handles nil itself.
+func (s *Stream) emitChunks(ctx context.Context, updater SessionUpdater, batch []pendingChunk) error {
 	for _, p := range batch {
 		if p.thought {
 			if err := s.emitThought(ctx, p.text); err != nil {

--- a/internal/acp/server/complexity_runtime_test.go
+++ b/internal/acp/server/complexity_runtime_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/provider"
+)
+
+// checkProviderCredentials is the "may this provider start without an API key"
+// rule buildSessionLLM used to inline. One row per escape hatch the original
+// condition listed, so a dropped clause shows up as a failure here.
+func TestCheckProviderCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		info    provider.Info
+		apiKey  string
+		baseURL string
+		wantErr bool
+	}{
+		{
+			name:   "key present",
+			info:   provider.Info{Provider: "anthropic"},
+			apiKey: "sk-test",
+		},
+		{
+			name:    "no key and no base URL is rejected",
+			info:    provider.Info{Provider: "anthropic"},
+			wantErr: true,
+		},
+		{
+			name:    "openai without a key is rejected too",
+			info:    provider.Info{Provider: "openai"},
+			wantErr: true,
+		},
+		{
+			name:    "a custom base URL stands in for the key",
+			info:    provider.Info{Provider: "anthropic"},
+			baseURL: "http://localhost:8080/v1",
+		},
+		{
+			name: "an Ollama-served model needs no key",
+			info: provider.Info{Provider: "anthropic", Ollama: true},
+		},
+		{
+			name: "gemini authenticates through ADC",
+			info: provider.Info{Provider: "gemini"},
+		},
+		{
+			name: "ollama provider",
+			info: provider.Info{Provider: "ollama"},
+		},
+		{
+			name: "azure authenticates through the deployment URL",
+			info: provider.Info{Provider: "azure"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkProviderCredentials(tt.info, tt.apiKey, tt.baseURL)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("checkProviderCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			// The message has to tell the user which key to set.
+			if !strings.Contains(err.Error(), tt.info.Provider) {
+				t.Errorf("err = %v, want it to name provider %q", err, tt.info.Provider)
+			}
+			if envVar := providerEnvVar(tt.info.Provider); !strings.Contains(err.Error(), envVar) {
+				t.Errorf("err = %v, want it to name %s", err, envVar)
+			}
+		})
+	}
+}
+
+// resolveOllamaBaseURL both settles the endpoint and decides whether the local
+// daemon has to answer. Non-Ollama providers must pass through untouched.
+func TestResolveOllamaBaseURL_NonOllamaPassesThrough(t *testing.T) {
+	for _, baseURL := range []string{"", "https://api.anthropic.com"} {
+		got, err := resolveOllamaBaseURL(provider.Info{Provider: "anthropic", Model: "claude-sonnet-4"}, "", baseURL)
+		if err != nil {
+			t.Fatalf("resolveOllamaBaseURL(%q): %v", baseURL, err)
+		}
+		if got != baseURL {
+			t.Errorf("resolveOllamaBaseURL(%q) = %q, want it unchanged", baseURL, got)
+		}
+	}
+}
+
+// A cloud-tagged model with no explicit endpoint resolves to ollama.com, and
+// the local-daemon health check must not run against it.
+func TestResolveOllamaBaseURL_CloudModelSkipsHealthCheck(t *testing.T) {
+	info := provider.Info{Provider: "ollama", Model: "deepseek-v4-flash:0731-cloud", Ollama: true}
+	got, err := resolveOllamaBaseURL(info, "", "")
+	if err != nil {
+		t.Fatalf("resolveOllamaBaseURL: %v", err)
+	}
+	if !strings.Contains(got, "api.ollama.com") {
+		t.Fatalf("baseURL = %q, want the ollama cloud endpoint", got)
+	}
+}
+
+// An explicit endpoint wins over the tag-based default, and a key means the
+// caller is authenticating rather than reaching a local daemon.
+func TestResolveOllamaBaseURL_APIKeySkipsHealthCheck(t *testing.T) {
+	info := provider.Info{Provider: "ollama", Model: "qwen3:8b", Ollama: true}
+	// Port 1 has nothing listening: if the health check ran, this would fail.
+	got, err := resolveOllamaBaseURL(info, "sk-ollama-test", "http://127.0.0.1:1")
+	if err != nil {
+		t.Fatalf("resolveOllamaBaseURL: %v", err)
+	}
+	if got != "http://127.0.0.1:1" {
+		t.Fatalf("baseURL = %q, want the explicit endpoint", got)
+	}
+}
+
+// With no key and a local endpoint the daemon has to answer. Pointing at a
+// closed port makes the failure deterministic rather than depending on whether
+// a daemon happens to be running on the test machine.
+func TestResolveOllamaBaseURL_LocalHealthCheckFailureIsReported(t *testing.T) {
+	info := provider.Info{Provider: "ollama", Model: "qwen3:8b", Ollama: true}
+	got, err := resolveOllamaBaseURL(info, "", "http://127.0.0.1:1")
+	if err == nil {
+		t.Fatalf("resolveOllamaBaseURL = %q, want an error when the daemon is unreachable", got)
+	}
+	if !strings.Contains(err.Error(), "ollama health check") {
+		t.Errorf("err = %v, want it to name the health check", err)
+	}
+	if got != "" {
+		t.Errorf("baseURL = %q, want empty alongside an error", got)
+	}
+}
+
+// A model with no key pointed at the cloud endpoint by hand is a credential
+// problem, not a reachability one, so the health check stays off.
+func TestResolveOllamaBaseURL_ExplicitCloudEndpointSkipsHealthCheck(t *testing.T) {
+	info := provider.Info{Provider: "ollama", Model: "qwen3:8b", Ollama: true}
+	got, err := resolveOllamaBaseURL(info, "", "https://api.ollama.com")
+	if err != nil {
+		t.Fatalf("resolveOllamaBaseURL: %v", err)
+	}
+	if !strings.Contains(got, "api.ollama.com") {
+		t.Fatalf("baseURL = %q, want the cloud endpoint preserved", got)
+	}
+}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -240,20 +240,13 @@ func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (
 	}
 
 	apiKey := config.APIKeys()[info.Provider]
-	// Providers that authenticate some other way — a local Ollama, an Azure
-	// deployment URL, gemini's ADC — are allowed through without a key.
-	if apiKey == "" && baseURL == "" && !info.Ollama &&
-		info.Provider != "gemini" && info.Provider != "ollama" && info.Provider != "azure" {
-		return nil, fmt.Errorf("no API key found for provider %q (set %s)", info.Provider, providerEnvVar(info.Provider))
+	if err := checkProviderCredentials(info, apiKey, baseURL); err != nil {
+		return nil, err
 	}
 
-	if info.Ollama {
-		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
-	}
-	if info.Ollama && apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
-		if err := provider.CheckOllama(baseURL); err != nil {
-			return nil, fmt.Errorf("ollama health check: %w", err)
-		}
+	baseURL, err = resolveOllamaBaseURL(info, apiKey, baseURL)
+	if err != nil {
+		return nil, err
 	}
 
 	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, &provider.LLMOptions{
@@ -270,6 +263,32 @@ func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (
 	tokenTracker := guardrail.New(cfg.MaxDailyTokens)
 	tokenTracker.SetContextWindowSize(sessionContextWindow(ctx, info, baseURL))
 	return guardrail.WrapModel(llm, tokenTracker), nil
+}
+
+// checkProviderCredentials rejects a provider that needs an API key and has
+// none. Providers that authenticate some other way — a local Ollama, an Azure
+// deployment URL, gemini's ADC — are allowed through without a key.
+func checkProviderCredentials(info provider.Info, apiKey, baseURL string) error {
+	if apiKey == "" && baseURL == "" && !info.Ollama &&
+		info.Provider != "gemini" && info.Provider != "ollama" && info.Provider != "azure" {
+		return fmt.Errorf("no API key found for provider %q (set %s)", info.Provider, providerEnvVar(info.Provider))
+	}
+	return nil
+}
+
+// resolveOllamaBaseURL settles an Ollama model's endpoint and health-checks a
+// local one. Non-Ollama providers keep the base URL they came with.
+func resolveOllamaBaseURL(info provider.Info, apiKey, baseURL string) (string, error) {
+	if !info.Ollama {
+		return baseURL, nil
+	}
+	baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+	if apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
+		if err := provider.CheckOllama(baseURL); err != nil {
+			return "", fmt.Errorf("ollama health check: %w", err)
+		}
+	}
+	return baseURL, nil
 }
 
 // resolveSessionProvider resolves the model to a provider, and settles on the

--- a/internal/audit/complexity_audit_test.go
+++ b/internal/audit/complexity_audit_test.go
@@ -1,0 +1,134 @@
+package audit
+
+import "testing"
+
+// TestIsEmojiRangeBoundaries pins every range in emojiRanges at both ends and
+// one code point outside each end. Converting the original || chain into a
+// table is only safe if no bound moved, so each range contributes four cases.
+func TestIsEmojiRangeBoundaries(t *testing.T) {
+	// The ranges as the original || chain spelled them, restated literally so
+	// the test does not read its expectations out of the table it is checking.
+	ranges := []struct {
+		name   string
+		lo, hi rune
+	}{
+		{"Emoticons", 0x1F600, 0x1F64F},
+		{"MiscSymbolsAndPictographs", 0x1F300, 0x1F5FF},
+		{"TransportAndMap", 0x1F680, 0x1F6FF},
+		{"Flags", 0x1F1E0, 0x1F1FF},
+		{"MiscSymbols", 0x2600, 0x26FF},
+		{"Dingbats", 0x2700, 0x27BF},
+		{"SupplementalSymbols", 0x1F900, 0x1F9FF},
+		{"ChessSymbols", 0x1FA00, 0x1FA6F},
+		{"ExtendedA", 0x1FA70, 0x1FAFF},
+	}
+
+	// Bounds that abut a neighboring range: one past the edge is still an
+	// emoji, so "just outside" cannot be asserted there.
+	inRange := func(r rune) bool {
+		for _, rg := range ranges {
+			if r >= rg.lo && r <= rg.hi {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, rg := range ranges {
+		t.Run(rg.name, func(t *testing.T) {
+			if !isEmoji(rg.lo) {
+				t.Errorf("isEmoji(%#x) = false, want true (low bound)", rg.lo)
+			}
+			if !isEmoji(rg.hi) {
+				t.Errorf("isEmoji(%#x) = false, want true (high bound)", rg.hi)
+			}
+			if below := rg.lo - 1; !inRange(below) && isEmoji(below) {
+				t.Errorf("isEmoji(%#x) = true, want false (below low bound)", below)
+			}
+			if above := rg.hi + 1; !inRange(above) && isEmoji(above) {
+				t.Errorf("isEmoji(%#x) = true, want false (above high bound)", above)
+			}
+		})
+	}
+}
+
+// TestIsEmojiNonEmoji covers code points far from any range, including the
+// ASCII and Latin planes the scanner sees on every ordinary file.
+func TestIsEmojiNonEmoji(t *testing.T) {
+	for _, r := range []rune{
+		0x0000, 'a', 'Z', '9', ' ', '\n',
+		0x00E9,           // é
+		0x0400,           // Cyrillic
+		0x200B,           // zero-width space — hidden, but not an emoji
+		0x2500,           // box drawing, just below Misc symbols
+		0x2800,           // Braille, just above Dingbats
+		0x1F000, 0x1F2FF, // below Misc Symbols and Pictographs
+		0x1F700, 0x1F8FF, // between Transport and Supplemental
+		0x1FB00, 0x10FFFF, // above every range
+	} {
+		if isEmoji(r) {
+			t.Errorf("isEmoji(%#x) = true, want false", r)
+		}
+	}
+}
+
+// TestIsEmojiTableMatchesRanges asserts the table is contiguous with what the
+// original expression encoded: nine ranges, each non-empty and correctly
+// ordered. A transposed pair would make every member of that range fail.
+func TestIsEmojiTableWellFormed(t *testing.T) {
+	if got, want := len(emojiRanges), 9; got != want {
+		t.Fatalf("len(emojiRanges) = %d, want %d", got, want)
+	}
+	for i, rg := range emojiRanges {
+		if rg.lo > rg.hi {
+			t.Errorf("emojiRanges[%d] = {%#x, %#x}: lo > hi", i, rg.lo, rg.hi)
+		}
+	}
+}
+
+// TestIsEmojiViaScanText checks the refactor through the caller that uses it,
+// so the table is exercised on the real scanning path and not only directly.
+func TestIsEmojiViaScanText(t *testing.T) {
+	// A lone emoji is not itself a finding; the point is that scanning text
+	// containing one still terminates and reports the same shape as before.
+	res := ScanText("hello \U0001F600 world", "emoji.md")
+	if res == nil {
+		t.Fatal("ScanText returned nil")
+	}
+	if len(res.Files) != 1 || res.Files[0] != "emoji.md" {
+		t.Errorf("Files = %v, want [emoji.md]", res.Files)
+	}
+}
+
+// isEmojiOriginal is the expression isEmoji held before it became a table,
+// transcribed unchanged. It exists only so the table can be proved equivalent.
+func isEmojiOriginal(r rune) bool {
+	return (r >= 0x1F600 && r <= 0x1F64F) || // Emoticons
+		(r >= 0x1F300 && r <= 0x1F5FF) || // Misc Symbols and Pictographs
+		(r >= 0x1F680 && r <= 0x1F6FF) || // Transport and Map
+		(r >= 0x1F1E0 && r <= 0x1F1FF) || // Flags
+		(r >= 0x2600 && r <= 0x26FF) || // Misc symbols
+		(r >= 0x2700 && r <= 0x27BF) || // Dingbats
+		(r >= 0x1F900 && r <= 0x1F9FF) || // Supplemental Symbols
+		(r >= 0x1FA00 && r <= 0x1FA6F) || // Chess Symbols
+		(r >= 0x1FA70 && r <= 0x1FAFF) // Symbols and Pictographs Extended-A
+}
+
+// TestIsEmojiExhaustivelyMatchesOriginal walks every code point in Unicode and
+// asserts the table agrees with the original || chain. Sampling boundaries
+// leaves an off-by-one invisible until a user pastes the one character that
+// moved; over 1.1M code points there is nowhere for one to hide.
+func TestIsEmojiExhaustivelyMatchesOriginal(t *testing.T) {
+	mismatches := 0
+	for r := rune(0); r <= 0x10FFFF; r++ {
+		if got, want := isEmoji(r), isEmojiOriginal(r); got != want {
+			mismatches++
+			if mismatches <= 10 {
+				t.Errorf("isEmoji(%#x) = %v, original = %v", r, got, want)
+			}
+		}
+	}
+	if mismatches > 10 {
+		t.Errorf("%d code points disagree in total", mismatches)
+	}
+}

--- a/internal/audit/scanner.go
+++ b/internal/audit/scanner.go
@@ -69,18 +69,27 @@ func isASCII(s string) bool {
 	return true
 }
 
+// emojiRanges lists the common emoji code point blocks, each bound inclusive.
+var emojiRanges = [...]struct{ lo, hi rune }{
+	{0x1F600, 0x1F64F}, // Emoticons
+	{0x1F300, 0x1F5FF}, // Misc Symbols and Pictographs
+	{0x1F680, 0x1F6FF}, // Transport and Map
+	{0x1F1E0, 0x1F1FF}, // Flags
+	{0x2600, 0x26FF},   // Misc symbols
+	{0x2700, 0x27BF},   // Dingbats
+	{0x1F900, 0x1F9FF}, // Supplemental Symbols
+	{0x1FA00, 0x1FA6F}, // Chess Symbols
+	{0x1FA70, 0x1FAFF}, // Symbols and Pictographs Extended-A
+}
+
 // isEmoji returns true if the rune is likely an emoji base character.
 func isEmoji(r rune) bool {
-	// Common emoji ranges.
-	return (r >= 0x1F600 && r <= 0x1F64F) || // Emoticons
-		(r >= 0x1F300 && r <= 0x1F5FF) || // Misc Symbols and Pictographs
-		(r >= 0x1F680 && r <= 0x1F6FF) || // Transport and Map
-		(r >= 0x1F1E0 && r <= 0x1F1FF) || // Flags
-		(r >= 0x2600 && r <= 0x26FF) || // Misc symbols
-		(r >= 0x2700 && r <= 0x27BF) || // Dingbats
-		(r >= 0x1F900 && r <= 0x1F9FF) || // Supplemental Symbols
-		(r >= 0x1FA00 && r <= 0x1FA6F) || // Chess Symbols
-		(r >= 0x1FA70 && r <= 0x1FAFF) // Symbols and Pictographs Extended-A
+	for _, rg := range emojiRanges {
+		if r >= rg.lo && r <= rg.hi {
+			return true
+		}
+	}
+	return false
 }
 
 // ScanText scans content for hidden Unicode characters.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -491,38 +491,9 @@ func DeviceFlow(ctx context.Context, prov Provider) (*DeviceCodeResponse, error)
 		return nil, fmt.Errorf("provider %s does not support device code flow", prov.Name)
 	}
 
-	var resp *http.Response
-	var err error
-	if prov.DeviceJSONBody {
-		payload := map[string]string{"client_id": prov.ClientID}
-		if scope := strings.Join(prov.Scopes, " "); scope != "" {
-			payload["scope"] = scope
-		}
-		for k, v := range prov.ExtraParams {
-			payload[k] = v
-		}
-		body, merr := json.Marshal(payload)
-		if merr != nil {
-			return nil, fmt.Errorf("device code request: %w", merr)
-		}
-		req, rerr := http.NewRequestWithContext(ctx, http.MethodPost, prov.DeviceURL, bytes.NewReader(body))
-		if rerr != nil {
-			return nil, fmt.Errorf("device code request: %w", rerr)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		resp, err = http.DefaultClient.Do(req)
-	} else {
-		data := url.Values{
-			"client_id": {prov.ClientID},
-			"scope":     {strings.Join(prov.Scopes, " ")},
-		}
-		for k, v := range prov.ExtraParams {
-			data.Set(k, v)
-		}
-		resp, err = http.PostForm(prov.DeviceURL, data)
-	}
+	resp, err := postDeviceCodeRequest(ctx, prov)
 	if err != nil {
-		return nil, fmt.Errorf("device code request: %w", err)
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -538,17 +509,73 @@ func DeviceFlow(ctx context.Context, prov Provider) (*DeviceCodeResponse, error)
 	if dcr.Interval == 0 {
 		dcr.Interval = 5
 	}
-	// opencode's console returns verification_uri_complete as a path relative
-	// to the console origin; resolve it against the device endpoint so callers
-	// can open the one-click URL directly.
-	if dcr.VerificationURIComplete != "" &&
-		!strings.HasPrefix(dcr.VerificationURIComplete, "http://") &&
-		!strings.HasPrefix(dcr.VerificationURIComplete, "https://") {
-		if u, perr := url.Parse(prov.DeviceURL); perr == nil && u.Scheme != "" && u.Host != "" {
-			dcr.VerificationURIComplete = u.Scheme + "://" + u.Host + dcr.VerificationURIComplete
-		}
-	}
+	dcr.VerificationURIComplete = absoluteVerificationURI(prov.DeviceURL, dcr.VerificationURIComplete)
 	return &dcr, nil
+}
+
+// postDeviceCodeRequest issues the device authorization request, as a JSON
+// body or as form encoding depending on the provider, and wraps every failure
+// on the way with the same "device code request" context.
+func postDeviceCodeRequest(ctx context.Context, prov Provider) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	if prov.DeviceJSONBody {
+		resp, err = postDeviceCodeJSON(ctx, prov)
+	} else {
+		data := url.Values{
+			"client_id": {prov.ClientID},
+			"scope":     {strings.Join(prov.Scopes, " ")},
+		}
+		for k, v := range prov.ExtraParams {
+			data.Set(k, v)
+		}
+		resp, err = http.PostForm(prov.DeviceURL, data)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("device code request: %w", err)
+	}
+	return resp, nil
+}
+
+// postDeviceCodeJSON sends the device authorization request with a JSON body,
+// which some providers require in place of form encoding. Errors are returned
+// unwrapped; postDeviceCodeRequest adds the shared context.
+func postDeviceCodeJSON(ctx context.Context, prov Provider) (*http.Response, error) {
+	payload := map[string]string{"client_id": prov.ClientID}
+	if scope := strings.Join(prov.Scopes, " "); scope != "" {
+		payload["scope"] = scope
+	}
+	for k, v := range prov.ExtraParams {
+		payload[k] = v
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, prov.DeviceURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}
+
+// absoluteVerificationURI resolves a relative verification_uri_complete
+// against the device endpoint's origin. opencode's console returns it as a
+// path relative to the console origin; resolving it lets callers open the
+// one-click URL directly. Already-absolute, empty, or unresolvable values are
+// returned unchanged.
+func absoluteVerificationURI(deviceURL, uri string) string {
+	if uri == "" ||
+		strings.HasPrefix(uri, "http://") ||
+		strings.HasPrefix(uri, "https://") {
+		return uri
+	}
+	u, err := url.Parse(deviceURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return uri
+	}
+	return u.Scheme + "://" + u.Host + uri
 }
 
 // PollDeviceToken polls for the device code token until authorized or expired.

--- a/internal/auth/complexity_auth_test.go
+++ b/internal/auth/complexity_auth_test.go
@@ -1,0 +1,334 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestAbsoluteVerificationURI pins every branch the inline conditional in
+// DeviceFlow used to hold: empty, already-absolute (both schemes), relative
+// against a good origin, and the three ways resolution can fail.
+func TestAbsoluteVerificationURI(t *testing.T) {
+	tests := []struct {
+		name      string
+		deviceURL string
+		uri       string
+		want      string
+	}{
+		{"empty is untouched", "https://console.example/device", "", ""},
+		{"https absolute is untouched", "https://console.example/device", "https://elsewhere/x", "https://elsewhere/x"},
+		{"http absolute is untouched", "https://console.example/device", "http://elsewhere/x", "http://elsewhere/x"},
+		{"relative resolves against origin", "https://console.example/device/code", "/auth?code=ABCD", "https://console.example/auth?code=ABCD"},
+		{"relative keeps http scheme", "http://console.example:8080/device", "/auth", "http://console.example:8080/auth"},
+		{"unparseable device URL leaves uri alone", "://nonsense", "/auth", "/auth"},
+		{"device URL without scheme leaves uri alone", "console.example/device", "/auth", "/auth"},
+		{"device URL without host leaves uri alone", "file:///tmp/device", "/auth", "/auth"},
+		// A scheme-relative URI is not "http://"-prefixed, so the original
+		// treated it as relative too. Keep that.
+		{"scheme-relative is treated as relative", "https://console.example/device", "//other/auth", "https://console.example//other/auth"},
+		// Case matters: the original compared prefixes case-sensitively.
+		{"uppercase scheme is treated as relative", "https://console.example/device", "HTTPS://elsewhere/x", "https://console.exampleHTTPS://elsewhere/x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := absoluteVerificationURI(tt.deviceURL, tt.uri); got != tt.want {
+				t.Errorf("absoluteVerificationURI(%q, %q) = %q, want %q", tt.deviceURL, tt.uri, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPostDeviceCodeJSONBody checks the JSON branch sends the right content
+// type and payload: client_id always, scope only when non-empty, and every
+// extra param merged in.
+func TestPostDeviceCodeJSONBody(t *testing.T) {
+	tests := []struct {
+		name        string
+		scopes      []string
+		extra       map[string]string
+		wantPayload map[string]string
+	}{
+		{
+			name:        "client id only",
+			wantPayload: map[string]string{"client_id": "cid"},
+		},
+		{
+			name:        "scopes are space joined",
+			scopes:      []string{"read", "write"},
+			wantPayload: map[string]string{"client_id": "cid", "scope": "read write"},
+		},
+		{
+			name:        "empty scope key is omitted",
+			scopes:      []string{},
+			wantPayload: map[string]string{"client_id": "cid"},
+		},
+		{
+			name:        "extra params are merged",
+			scopes:      []string{"read"},
+			extra:       map[string]string{"audience": "api"},
+			wantPayload: map[string]string{"client_id": "cid", "scope": "read", "audience": "api"},
+		},
+		{
+			name:        "extra params can override scope",
+			scopes:      []string{"read"},
+			extra:       map[string]string{"scope": "overridden"},
+			wantPayload: map[string]string{"client_id": "cid", "scope": "overridden"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPayload map[string]string
+			var gotContentType string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotContentType = r.Header.Get("Content-Type")
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &gotPayload)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			prov := Provider{
+				Name:           "test",
+				ClientID:       "cid",
+				DeviceURL:      srv.URL,
+				DeviceJSONBody: true,
+				Scopes:         tt.scopes,
+				ExtraParams:    tt.extra,
+			}
+			resp, err := postDeviceCodeRequest(context.Background(), prov)
+			if err != nil {
+				t.Fatalf("postDeviceCodeRequest: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			if gotContentType != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", gotContentType)
+			}
+			if len(gotPayload) != len(tt.wantPayload) {
+				t.Fatalf("payload = %v, want %v", gotPayload, tt.wantPayload)
+			}
+			for k, want := range tt.wantPayload {
+				if gotPayload[k] != want {
+					t.Errorf("payload[%q] = %q, want %q", k, gotPayload[k], want)
+				}
+			}
+		})
+	}
+}
+
+// TestPostDeviceCodeFormBody checks the form branch, which always sets scope
+// (even empty) — unlike the JSON branch, which omits it. That asymmetry was in
+// the original and must survive.
+func TestPostDeviceCodeFormBody(t *testing.T) {
+	var gotForm url.Values
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	prov := Provider{
+		Name:        "test",
+		ClientID:    "cid",
+		DeviceURL:   srv.URL,
+		ExtraParams: map[string]string{"audience": "api"},
+	}
+	resp, err := postDeviceCodeRequest(context.Background(), prov)
+	if err != nil {
+		t.Fatalf("postDeviceCodeRequest: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if !strings.HasPrefix(gotContentType, "application/x-www-form-urlencoded") {
+		t.Errorf("Content-Type = %q, want form encoding", gotContentType)
+	}
+	if got := gotForm.Get("client_id"); got != "cid" {
+		t.Errorf("client_id = %q, want cid", got)
+	}
+	if _, ok := gotForm["scope"]; !ok {
+		t.Error("form has no scope key; the form branch always sets one, even empty")
+	}
+	if got := gotForm.Get("audience"); got != "api" {
+		t.Errorf("audience = %q, want api", got)
+	}
+}
+
+// TestPostDeviceCodeRequestErrors covers the failure paths of both branches.
+// Every one must carry the same "device code request: " prefix the original
+// wrapped them with, whichever branch produced it.
+func TestPostDeviceCodeRequestErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		prov Provider
+	}{
+		{
+			name: "json branch: unparseable device URL fails at NewRequest",
+			prov: Provider{Name: "t", ClientID: "c", DeviceURL: "://nonsense", DeviceJSONBody: true},
+		},
+		{
+			name: "json branch: unsupported scheme fails at Do",
+			prov: Provider{Name: "t", ClientID: "c", DeviceURL: "ftp://example.invalid/device", DeviceJSONBody: true},
+		},
+		{
+			name: "form branch: unparseable device URL fails at PostForm",
+			prov: Provider{Name: "t", ClientID: "c", DeviceURL: "://nonsense"},
+		},
+		{
+			name: "form branch: unsupported scheme fails at PostForm",
+			prov: Provider{Name: "t", ClientID: "c", DeviceURL: "ftp://example.invalid/device"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := postDeviceCodeRequest(context.Background(), tt.prov)
+			if err == nil {
+				_ = resp.Body.Close()
+				t.Fatal("expected an error, got nil")
+			}
+			if resp != nil {
+				t.Error("expected a nil response alongside the error")
+			}
+			if !strings.HasPrefix(err.Error(), "device code request: ") {
+				t.Errorf("error = %q, want the shared %q prefix", err, "device code request: ")
+			}
+		})
+	}
+}
+
+// TestDeviceFlowNoDeviceURL is the one guard DeviceFlow keeps inline.
+func TestDeviceFlowNoDeviceURL(t *testing.T) {
+	_, err := DeviceFlow(context.Background(), Provider{Name: "acme"})
+	if err == nil {
+		t.Fatal("expected an error for a provider without a device endpoint")
+	}
+	if want := "provider acme does not support device code flow"; err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+}
+
+// TestDeviceFlowResponseHandling walks the response-side branches: HTTP
+// failure, malformed JSON, the interval default, and URI resolution.
+func TestDeviceFlowResponseHandling(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		jsonBody   bool
+		wantErr    string // substring; empty means success expected
+		wantIntvl  int
+		wantExpiry int
+		// wantComplete is checked with the server URL's origin substituted for
+		// the literal "ORIGIN", since httptest picks the port.
+		wantComplete string
+	}{
+		{
+			name:    "non-200 reports status and body",
+			status:  http.StatusBadRequest,
+			body:    `{"error":"invalid_client"}`,
+			wantErr: "device code request failed (400)",
+		},
+		{
+			name:    "500 also reports",
+			status:  http.StatusInternalServerError,
+			body:    "boom",
+			wantErr: "device code request failed (500)",
+		},
+		{
+			name:    "malformed JSON is reported as a parse failure",
+			status:  http.StatusOK,
+			body:    "not json",
+			wantErr: "parsing device code response",
+		},
+		{
+			name:      "absent interval defaults to 5",
+			status:    http.StatusOK,
+			body:      `{"device_code":"dc","user_code":"UC","verification_uri":"https://v/","expires_in":600}`,
+			wantIntvl: 5, wantExpiry: 600,
+		},
+		{
+			name:      "explicit interval is kept",
+			status:    http.StatusOK,
+			body:      `{"device_code":"dc","user_code":"UC","interval":9,"expires_in":600}`,
+			wantIntvl: 9, wantExpiry: 600,
+		},
+		{
+			name:      "relative verification_uri_complete is resolved",
+			status:    http.StatusOK,
+			body:      `{"device_code":"dc","interval":3,"verification_uri_complete":"/auth?code=UC"}`,
+			wantIntvl: 3, wantComplete: "ORIGIN/auth?code=UC",
+		},
+		{
+			name:      "absolute verification_uri_complete is left alone",
+			status:    http.StatusOK,
+			body:      `{"device_code":"dc","interval":3,"verification_uri_complete":"https://one.click/x"}`,
+			wantIntvl: 3, wantComplete: "https://one.click/x",
+		},
+		{
+			name:      "json body branch reaches the same response handling",
+			status:    http.StatusOK,
+			body:      `{"device_code":"dc","interval":7}`,
+			jsonBody:  true,
+			wantIntvl: 7,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = io.WriteString(w, tt.body)
+			}))
+			defer srv.Close()
+
+			prov := Provider{Name: "t", ClientID: "c", DeviceURL: srv.URL, DeviceJSONBody: tt.jsonBody}
+			dcr, err := DeviceFlow(context.Background(), prov)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected an error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DeviceFlow: %v", err)
+			}
+			if dcr.Interval != tt.wantIntvl {
+				t.Errorf("Interval = %d, want %d", dcr.Interval, tt.wantIntvl)
+			}
+			if dcr.ExpiresIn != tt.wantExpiry {
+				t.Errorf("ExpiresIn = %d, want %d", dcr.ExpiresIn, tt.wantExpiry)
+			}
+			want := strings.ReplaceAll(tt.wantComplete, "ORIGIN", srv.URL)
+			if dcr.VerificationURIComplete != want {
+				t.Errorf("VerificationURIComplete = %q, want %q", dcr.VerificationURIComplete, want)
+			}
+		})
+	}
+}
+
+// TestDeviceFlowRequestErrorIsWrapped checks that a transport failure reaches
+// the caller through DeviceFlow with the same wrapping as before the split.
+func TestDeviceFlowRequestErrorIsWrapped(t *testing.T) {
+	_, err := DeviceFlow(context.Background(), Provider{
+		Name:      "t",
+		ClientID:  "c",
+		DeviceURL: "ftp://example.invalid/device",
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.HasPrefix(err.Error(), "device code request: ") {
+		t.Errorf("error = %q, want the %q prefix", err, "device code request: ")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -276,6 +276,89 @@ func loadRootConfig() (config.Config, error) {
 	return cfg, nil
 }
 
+// resolveRuntimeModel turns the role's model and provider names into a
+// validated provider.Info plus the base URL actually used to reach it. An
+// explicit --url wins; otherwise the config's per-provider base URL is
+// consulted, first under the role's provider name and then under the provider
+// the model itself resolved to.
+func resolveRuntimeModel(cfg config.Config, modelName, providerName string) (provider.Info, string, error) {
+	baseURL := flagURL
+	if baseURL == "" && providerName != "" {
+		baseURLs := cfg.ResolveBaseURLs()
+		baseURL = baseURLs[providerName]
+	}
+	info, err := provider.ResolveWithBaseURL(modelName, baseURL)
+	if err != nil {
+		return provider.Info{}, "", fmt.Errorf("resolving model: %w", err)
+	}
+	if providerName != "" {
+		info.Provider = providerName
+		info.Custom = baseURL != ""
+	}
+	if baseURL == "" {
+		baseURLs := cfg.ResolveBaseURLs()
+		baseURL = baseURLs[info.Provider]
+		if baseURL != "" {
+			info.Custom = true
+		}
+	}
+	if err := provider.ValidateModel(info); err != nil {
+		return provider.Info{}, "", fmt.Errorf("model validation: %w", err)
+	}
+	return info, baseURL, nil
+}
+
+// requireRuntimeAPIKey rejects a provider that needs a key when none is
+// available. A custom base URL, or a provider that authenticates some other
+// way, is exempt.
+func requireRuntimeAPIKey(info provider.Info, apiKey, baseURL string) error {
+	if apiKey == "" && baseURL == "" && info.Provider != "gemini" && info.Provider != "ollama" && info.Provider != "azure" && !info.Ollama {
+		envVar := providerEnvVar(info.Provider)
+		return fmt.Errorf("no API key found for provider %q (set %s)", info.Provider, envVar)
+	}
+	return nil
+}
+
+// applyRuntimeOllamaEndpoint picks the Ollama daemon for the model, records it
+// on info, and health-checks a local daemon before anything depends on it. It
+// returns the base URL to use; non-Ollama models pass through untouched.
+func applyRuntimeOllamaEndpoint(info *provider.Info, apiKey, baseURL string) (string, error) {
+	if info.Ollama {
+		// The model's tag decides the daemon, not whether OLLAMA_API_KEY
+		// happens to be exported: a key set for some :cloud model used to send
+		// locally pulled names like qwen3.8:27b-mlx to api.ollama.com, which
+		// answers 404 for a model only this machine has.
+		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+		// Record the endpoint actually chosen so session metadata names the
+		// backend instead of leaving the model name to be interpreted.
+		info.BaseURL = baseURL
+	}
+	if info.Ollama && apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
+		if err := provider.CheckOllama(baseURL); err != nil {
+			return "", fmt.Errorf("ollama health check: %w", err)
+		}
+	}
+	return baseURL, nil
+}
+
+// resolveRuntimeContextWindow picks the context window to budget against: the
+// catalog size, overridden by what a live Ollama daemon reports, overridden in
+// turn by an explicit config value.
+func resolveRuntimeContextWindow(ctx context.Context, cfg config.Config, info provider.Info, baseURL string) int64 {
+	ctxWindowSize := provider.ContextWindowSizeFor(info.Provider, info.Model)
+	if info.Ollama {
+		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
+			ctxWindowSize = n
+		}
+	}
+	// An explicit config value wins: the embedded catalog does not cover every
+	// provider's models, and auto-compaction needs a real window to work from.
+	if cfg.ContextWindow > 0 {
+		ctxWindowSize = cfg.ContextWindow
+	}
+	return ctxWindowSize
+}
+
 func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 	cfg, err := loadRootConfig()
 	if err != nil {
@@ -298,51 +381,20 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 	}
 
 	mode := resolveMode()
-	baseURL := flagURL
-	if baseURL == "" && providerName != "" {
-		baseURLs := cfg.ResolveBaseURLs()
-		baseURL = baseURLs[providerName]
-	}
-	info, err := provider.ResolveWithBaseURL(modelName, baseURL)
+	info, baseURL, err := resolveRuntimeModel(cfg, modelName, providerName)
 	if err != nil {
-		return rootRuntime{}, fmt.Errorf("resolving model: %w", err)
-	}
-	if providerName != "" {
-		info.Provider = providerName
-		info.Custom = baseURL != ""
-	}
-	if baseURL == "" {
-		baseURLs := cfg.ResolveBaseURLs()
-		baseURL = baseURLs[info.Provider]
-		if baseURL != "" {
-			info.Custom = true
-		}
-	}
-	if err := provider.ValidateModel(info); err != nil {
-		return rootRuntime{}, fmt.Errorf("model validation: %w", err)
+		return rootRuntime{}, err
 	}
 
 	keys := config.APIKeys()
 	apiKey := keys[info.Provider]
-	if apiKey == "" && baseURL == "" && info.Provider != "gemini" && info.Provider != "ollama" && info.Provider != "azure" && !info.Ollama {
-		envVar := providerEnvVar(info.Provider)
-		return rootRuntime{}, fmt.Errorf("no API key found for provider %q (set %s)", info.Provider, envVar)
+	if err := requireRuntimeAPIKey(info, apiKey, baseURL); err != nil {
+		return rootRuntime{}, err
 	}
 
-	if info.Ollama {
-		// The model's tag decides the daemon, not whether OLLAMA_API_KEY
-		// happens to be exported: a key set for some :cloud model used to send
-		// locally pulled names like qwen3.8:27b-mlx to api.ollama.com, which
-		// answers 404 for a model only this machine has.
-		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
-		// Record the endpoint actually chosen so session metadata names the
-		// backend instead of leaving the model name to be interpreted.
-		info.BaseURL = baseURL
-	}
-	if info.Ollama && apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
-		if err := provider.CheckOllama(baseURL); err != nil {
-			return rootRuntime{}, fmt.Errorf("ollama health check: %w", err)
-		}
+	baseURL, err = applyRuntimeOllamaEndpoint(&info, apiKey, baseURL)
+	if err != nil {
+		return rootRuntime{}, err
 	}
 
 	llmOpts := &provider.LLMOptions{
@@ -358,18 +410,7 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 	}
 
 	tokenTracker := guardrail.New(cfg.MaxDailyTokens)
-	ctxWindowSize := provider.ContextWindowSizeFor(info.Provider, info.Model)
-	if info.Ollama {
-		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
-			ctxWindowSize = n
-		}
-	}
-	// An explicit config value wins: the embedded catalog does not cover every
-	// provider's models, and auto-compaction needs a real window to work from.
-	if cfg.ContextWindow > 0 {
-		ctxWindowSize = cfg.ContextWindow
-	}
-	tokenTracker.SetContextWindowSize(ctxWindowSize)
+	tokenTracker.SetContextWindowSize(resolveRuntimeContextWindow(ctx, cfg, info, baseURL))
 	llm = guardrail.WrapModel(llm, tokenTracker)
 
 	cwd, err := os.Getwd()
@@ -584,26 +625,13 @@ func runNonInteractive(
 	memStore, memWorker, closeMemory := setupMemory(parentCtx, cfg, orch)
 	defer closeMemory()
 
-	if memStore != nil {
-		memTools, memErr := tools.MemoryTools(memStore)
-		if memErr != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: warning: memory tools disabled: %v\n", memErr)
-		} else if memTools != nil {
-			coreTools = append(coreTools, memTools...)
-		}
-	}
+	coreTools = appendNonInteractiveMemoryTools(coreTools, memStore)
 
 	palaceTools, palaceContext, closePalace := setupPalace(cfg, memWorker)
 	defer closePalace()
 	coreTools = append(coreTools, palaceTools...)
 
-	instruction := agent.LoadInstruction(agent.SystemInstruction)
-	if flagSystem != "" {
-		instruction = flagSystem
-	}
-	if palaceContext != "" {
-		instruction += "\n\n## Palace Memory Context\n\n" + palaceContext
-	}
+	instruction := buildNonInteractiveInstruction(palaceContext)
 
 	hooks := convertHooks(cfg.Hooks)
 	beforeCBs := extension.BuildBeforeToolCallbacks(hooks)
@@ -637,12 +665,9 @@ func runNonInteractive(
 	// capability it cannot use. Gate on a server existing, then advertise only
 	// as much surface as the mode asks for. The after-tool callback stays wired
 	// either way; it is free when no server starts.
-	if lspMgr.AnyAvailable() {
-		lspTools, lspErr := tools.LSPToolsFor(lspMgr, resolveLSPMode())
-		if lspErr != nil {
-			return fmt.Errorf("creating LSP tools: %w", lspErr)
-		}
-		coreTools = append(coreTools, lspTools...)
+	coreTools, err = appendNonInteractiveLSPTools(coreTools, lspMgr)
+	if err != nil {
+		return err
 	}
 
 	allToolsets := buildToolsets(cfg)
@@ -650,13 +675,9 @@ func runNonInteractive(
 	loadNonInteractiveSkills(mode)
 	instruction += memoryInstructionContext(parentCtx, memStore, cfg, cwd)
 
-	sessionsPath, err := sessionsDir()
+	sessionsPath, sessionSvc, err := openSessionService()
 	if err != nil {
 		return err
-	}
-	sessionSvc, err := pisession.NewFileService(sessionsPath)
-	if err != nil {
-		return fmt.Errorf("creating session service: %w", err)
 	}
 
 	// Gemini search grounding. Always on for the Gemini provider; kill
@@ -730,19 +751,90 @@ func runNonInteractive(
 	// Capture ACP subagent events (claude, gemini) under the session dir.
 	orch.SetACPLogPath(filepath.Join(sessionsPath, sessionID, "acp.jsonl"))
 
-	if memStore != nil {
-		// Arms the observation callback wired above.
-		memSessionID = sessionID
-		_ = memStore.CreateSession(ctx, &memory.Session{
-			SessionID: sessionID,
-			Project:   cwd,
-			StartedAt: time.Now(),
-			Status:    "active",
-		})
-	}
+	armMemoryObservationSession(ctx, memStore, sessionID, cwd, &memSessionID)
 
 	sessionLog.SessionStart(sessionID, llm.Name(), mode)
 	return dispatchMode(ctx, mode, prompt, ag, sessionID, sessionLog, llm.Name(), cfg, tokenTracker)
+}
+
+// appendNonInteractiveMemoryTools adds the memory tools when a store is
+// configured. Memory is optional: a tool-construction failure is a warning and
+// the run continues without them.
+func appendNonInteractiveMemoryTools(coreTools []adktool.Tool, memStore memory.Store) []adktool.Tool {
+	if memStore == nil {
+		return coreTools
+	}
+	memTools, memErr := tools.MemoryTools(memStore)
+	if memErr != nil {
+		fmt.Fprintf(os.Stderr, "pi-go: warning: memory tools disabled: %v\n", memErr)
+		return coreTools
+	}
+	if memTools != nil {
+		coreTools = append(coreTools, memTools...)
+	}
+	return coreTools
+}
+
+// buildNonInteractiveInstruction assembles the system instruction: the built-in
+// one unless --system replaces it, with the palace memory context appended.
+func buildNonInteractiveInstruction(palaceContext string) string {
+	instruction := agent.LoadInstruction(agent.SystemInstruction)
+	if flagSystem != "" {
+		instruction = flagSystem
+	}
+	if palaceContext != "" {
+		instruction += "\n\n## Palace Memory Context\n\n" + palaceContext
+	}
+	return instruction
+}
+
+// appendNonInteractiveLSPTools adds LSP tools only when a language server is
+// actually installed.
+//
+// LSP tool declarations are billed on every request, and with no server
+// installed every call they enable fails — so the model pays tokens for
+// capability it cannot use. Gate on a server existing, then advertise only
+// as much surface as the mode asks for. The after-tool callback stays wired
+// either way; it is free when no server starts.
+func appendNonInteractiveLSPTools(coreTools []adktool.Tool, lspMgr *lsp.Manager) ([]adktool.Tool, error) {
+	if !lspMgr.AnyAvailable() {
+		return coreTools, nil
+	}
+	lspTools, lspErr := tools.LSPToolsFor(lspMgr, resolveLSPMode())
+	if lspErr != nil {
+		return nil, fmt.Errorf("creating LSP tools: %w", lspErr)
+	}
+	return append(coreTools, lspTools...), nil
+}
+
+// openSessionService opens the on-disk session store, returning both the
+// directory it lives in and the service over it.
+func openSessionService() (string, *pisession.FileService, error) {
+	sessionsPath, err := sessionsDir()
+	if err != nil {
+		return "", nil, err
+	}
+	sessionSvc, err := pisession.NewFileService(sessionsPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating session service: %w", err)
+	}
+	return sessionsPath, sessionSvc, nil
+}
+
+// armMemoryObservationSession opens the memory session row and publishes the
+// session ID the observation callback records under. Until memSessionID is set
+// the callback is inert, so this is what arms it.
+func armMemoryObservationSession(ctx context.Context, memStore memory.Store, sessionID, project string, memSessionID *string) {
+	if memStore == nil {
+		return
+	}
+	*memSessionID = sessionID
+	_ = memStore.CreateSession(ctx, &memory.Session{
+		SessionID: sessionID,
+		Project:   project,
+		StartedAt: time.Now(),
+		Status:    "active",
+	})
 }
 
 // loadNonInteractiveSkills loads the skill set and reports what it found.
@@ -1252,43 +1344,64 @@ func lastLoggedError() (path, msg string, err error) {
 		}
 		return "", "", err
 	}
+	// Log directories sort ascending by date, so walking backwards reaches the
+	// most recent one first.
 	for i := len(dateDirs) - 1; i >= 0; i-- {
 		d := dateDirs[i]
 		if !d.IsDir() {
 			continue
 		}
-		datePath := filepath.Join(logRoot, d.Name())
-		files, listErr := os.ReadDir(datePath)
-		if listErr != nil {
-			continue
-		}
-		for j := len(files) - 1; j >= 0; j-- {
-			f := files[j]
-			if f.IsDir() || !strings.HasPrefix(f.Name(), "session-") || !strings.HasSuffix(f.Name(), ".log") {
-				continue
-			}
-			p := filepath.Join(datePath, f.Name())
-			blob, readErr := os.ReadFile(p)
-			if readErr != nil {
-				continue
-			}
-			lines := strings.Split(string(blob), "\n")
-			for k := len(lines) - 1; k >= 0; k-- {
-				line := strings.TrimSpace(lines[k])
-				if line == "" {
-					continue
-				}
-				var entry logger.Entry
-				if err := json.Unmarshal([]byte(line), &entry); err != nil {
-					continue
-				}
-				if entry.Type == "error" && entry.Content != "" {
-					return p, entry.Content, nil
-				}
-			}
+		if p, m := lastLoggedErrorInDateDir(filepath.Join(logRoot, d.Name())); m != "" {
+			return p, m, nil
 		}
 	}
 	return "", "", nil
+}
+
+// lastLoggedErrorInDateDir scans one date directory's session logs newest-first
+// and returns the path and message of the first error entry found. A directory
+// that cannot be listed yields no result rather than an error: this whole path
+// is a best-effort diagnostic hint.
+func lastLoggedErrorInDateDir(datePath string) (path, msg string) {
+	files, listErr := os.ReadDir(datePath)
+	if listErr != nil {
+		return "", ""
+	}
+	for j := len(files) - 1; j >= 0; j-- {
+		f := files[j]
+		if f.IsDir() || !strings.HasPrefix(f.Name(), "session-") || !strings.HasSuffix(f.Name(), ".log") {
+			continue
+		}
+		p := filepath.Join(datePath, f.Name())
+		if m := lastLoggedErrorInLogFile(p); m != "" {
+			return p, m
+		}
+	}
+	return "", ""
+}
+
+// lastLoggedErrorInLogFile returns the content of the last non-empty "error"
+// entry in one session log, or "" when it holds none or cannot be read.
+func lastLoggedErrorInLogFile(logPath string) string {
+	blob, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		return ""
+	}
+	lines := strings.Split(string(blob), "\n")
+	for k := len(lines) - 1; k >= 0; k-- {
+		line := strings.TrimSpace(lines[k])
+		if line == "" {
+			continue
+		}
+		var entry logger.Entry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.Type == "error" && entry.Content != "" {
+			return entry.Content
+		}
+	}
+	return ""
 }
 
 func toolArgsPreview(args map[string]any) string {
@@ -1387,22 +1500,7 @@ func runPrint(ctx context.Context, ag *agent.Agent, sessionID, prompt string, lo
 		if ev == nil {
 			continue
 		}
-		// Gemini grounding runs server-side and emits no FunctionCall, so it
-		// would otherwise be invisible. Report it like any other tool call.
-		if gm := ev.GroundingMetadata; gm != nil && len(gm.WebSearchQueries) > 0 {
-			key := agent.GroundingQueryKey(gm.WebSearchQueries)
-			if !groundedSeen[key] {
-				groundedSeen[key] = true
-				args := map[string]any{"query": agent.GroundingQuery(gm)}
-				fmt.Fprint(os.Stderr, formatPrintToolCall(agent.GroundingToolName, args))
-				log.ToolCall("grounding", agent.GroundingToolName, args)
-				for _, src := range strings.Split(agent.GroundingSummary(gm), "\n") {
-					fmt.Fprintf(os.Stderr, "%s   %s%s\n", printToolDimColor, src, printToolReset)
-				}
-				fmt.Fprint(os.Stderr, formatPrintToolDone(agent.GroundingToolName))
-				log.ToolResult("grounding", agent.GroundingToolName, agent.GroundingSources(gm))
-			}
-		}
+		printGroundingEvent(ev, groundedSeen, log)
 		// Without this, a provider failure exits 0 having printed nothing.
 		// See agent.EventError.
 		if evErr := agent.EventError(ev); evErr != nil {
@@ -1413,31 +1511,62 @@ func runPrint(ctx context.Context, ag *agent.Agent, sessionID, prompt string, lo
 			continue
 		}
 		dedup.BeginEvent(ev)
-		for _, part := range ev.Content.Parts {
-			if part.Text != "" && ev.Content.Role == "thinking" {
-				fmt.Fprintf(os.Stderr, "\033[2m%s\033[0m", part.Text)
-				log.Thinking(ev.Author, part.Text)
-				continue
-			}
-			if part.Text != "" {
-				if dedup.SkipText(ev) {
-					continue
-				}
-				fmt.Print(part.Text)
-				log.LLMText(ev.Author, part.Text)
-			}
-			if part.FunctionCall != nil {
-				fmt.Fprint(os.Stderr, formatPrintToolCall(part.FunctionCall.Name, part.FunctionCall.Args))
-				log.ToolCall(ev.Author, part.FunctionCall.Name, part.FunctionCall.Args)
-			}
-			if part.FunctionResponse != nil {
-				fmt.Fprint(os.Stderr, formatPrintToolDone(part.FunctionResponse.Name))
-				log.ToolResult(ev.Author, part.FunctionResponse.Name, fmt.Sprintf("%v", part.FunctionResponse.Response))
-			}
-		}
+		printEventParts(ev, &dedup, log)
 	}
 	fmt.Println()
 	return nil
+}
+
+// printGroundingEvent reports a server-side Gemini search as a tool call.
+//
+// Gemini grounding runs server-side and emits no FunctionCall, so it would
+// otherwise be invisible. GroundingMetadata repeats on every chunk of the
+// response it grounds, so groundedSeen keeps each search to one report.
+func printGroundingEvent(ev *session.Event, groundedSeen map[string]bool, log *logger.Logger) {
+	gm := ev.GroundingMetadata
+	if gm == nil || len(gm.WebSearchQueries) == 0 {
+		return
+	}
+	key := agent.GroundingQueryKey(gm.WebSearchQueries)
+	if groundedSeen[key] {
+		return
+	}
+	groundedSeen[key] = true
+	args := map[string]any{"query": agent.GroundingQuery(gm)}
+	fmt.Fprint(os.Stderr, formatPrintToolCall(agent.GroundingToolName, args))
+	log.ToolCall("grounding", agent.GroundingToolName, args)
+	for _, src := range strings.Split(agent.GroundingSummary(gm), "\n") {
+		fmt.Fprintf(os.Stderr, "%s   %s%s\n", printToolDimColor, src, printToolReset)
+	}
+	fmt.Fprint(os.Stderr, formatPrintToolDone(agent.GroundingToolName))
+	log.ToolResult("grounding", agent.GroundingToolName, agent.GroundingSources(gm))
+}
+
+// printEventParts writes one event's parts: reply text to stdout, thinking and
+// tool activity to stderr. The caller must have called dedup.BeginEvent for ev.
+func printEventParts(ev *session.Event, dedup *agent.StreamDedup, log *logger.Logger) {
+	for _, part := range ev.Content.Parts {
+		if part.Text != "" && ev.Content.Role == "thinking" {
+			fmt.Fprintf(os.Stderr, "\033[2m%s\033[0m", part.Text)
+			log.Thinking(ev.Author, part.Text)
+			continue
+		}
+		if part.Text != "" {
+			if dedup.SkipText(ev) {
+				continue
+			}
+			fmt.Print(part.Text)
+			log.LLMText(ev.Author, part.Text)
+		}
+		if part.FunctionCall != nil {
+			fmt.Fprint(os.Stderr, formatPrintToolCall(part.FunctionCall.Name, part.FunctionCall.Args))
+			log.ToolCall(ev.Author, part.FunctionCall.Name, part.FunctionCall.Args)
+		}
+		if part.FunctionResponse != nil {
+			fmt.Fprint(os.Stderr, formatPrintToolDone(part.FunctionResponse.Name))
+			log.ToolResult(ev.Author, part.FunctionResponse.Name, fmt.Sprintf("%v", part.FunctionResponse.Response))
+		}
+	}
 }
 
 // jsonEvent represents a JSONL event for JSON output mode.
@@ -1508,50 +1637,7 @@ func runJSON(ctx context.Context, ag *agent.Agent, sessionID, prompt string, log
 		}
 
 		dedup.BeginEvent(ev)
-		for _, part := range ev.Content.Parts {
-			if part.Text != "" && ev.Content.Role == "thinking" {
-				_ = enc.Encode(jsonEvent{
-					Type:  "thinking_delta",
-					Agent: ev.Author,
-					Delta: part.Text,
-				})
-				log.Thinking(ev.Author, part.Text)
-				continue
-			}
-			if part.Text != "" {
-				if dedup.SkipText(ev) {
-					continue
-				}
-				_ = enc.Encode(jsonEvent{
-					Type:  "text_delta",
-					Agent: ev.Author,
-					Delta: part.Text,
-				})
-				log.LLMText(ev.Author, part.Text)
-			}
-			if part.FunctionCall != nil {
-				_ = enc.Encode(jsonEvent{
-					Type:      "tool_call",
-					Agent:     ev.Author,
-					ToolName:  part.FunctionCall.Name,
-					ToolInput: part.FunctionCall.Args,
-				})
-				log.ToolCall(ev.Author, part.FunctionCall.Name, part.FunctionCall.Args)
-			}
-			if part.FunctionResponse != nil {
-				respJSON, err := json.Marshal(part.FunctionResponse.Response)
-				if err != nil {
-					respJSON = []byte(fmt.Sprintf("%v", part.FunctionResponse.Response))
-				}
-				_ = enc.Encode(jsonEvent{
-					Type:     "tool_result",
-					Agent:    ev.Author,
-					ToolName: part.FunctionResponse.Name,
-					Content:  string(respJSON),
-				})
-				log.ToolResult(ev.Author, part.FunctionResponse.Name, string(respJSON))
-			}
-		}
+		encodeEventParts(enc, ev, &dedup, log)
 	}
 	if !started {
 		const warn = "pi-go: warning: no assistant events received before message_end"
@@ -1560,6 +1646,56 @@ func runJSON(ctx context.Context, ag *agent.Agent, sessionID, prompt string, log
 	}
 	_ = enc.Encode(jsonEvent{Type: "message_end"})
 	return nil
+}
+
+// encodeEventParts emits one event's parts as JSONL: thinking_delta,
+// text_delta, tool_call and tool_result. The caller must have called
+// dedup.BeginEvent for ev.
+func encodeEventParts(enc *json.Encoder, ev *session.Event, dedup *agent.StreamDedup, log *logger.Logger) {
+	for _, part := range ev.Content.Parts {
+		if part.Text != "" && ev.Content.Role == "thinking" {
+			_ = enc.Encode(jsonEvent{
+				Type:  "thinking_delta",
+				Agent: ev.Author,
+				Delta: part.Text,
+			})
+			log.Thinking(ev.Author, part.Text)
+			continue
+		}
+		if part.Text != "" {
+			if dedup.SkipText(ev) {
+				continue
+			}
+			_ = enc.Encode(jsonEvent{
+				Type:  "text_delta",
+				Agent: ev.Author,
+				Delta: part.Text,
+			})
+			log.LLMText(ev.Author, part.Text)
+		}
+		if part.FunctionCall != nil {
+			_ = enc.Encode(jsonEvent{
+				Type:      "tool_call",
+				Agent:     ev.Author,
+				ToolName:  part.FunctionCall.Name,
+				ToolInput: part.FunctionCall.Args,
+			})
+			log.ToolCall(ev.Author, part.FunctionCall.Name, part.FunctionCall.Args)
+		}
+		if part.FunctionResponse != nil {
+			respJSON, err := json.Marshal(part.FunctionResponse.Response)
+			if err != nil {
+				respJSON = []byte(fmt.Sprintf("%v", part.FunctionResponse.Response))
+			}
+			_ = enc.Encode(jsonEvent{
+				Type:     "tool_result",
+				Agent:    ev.Author,
+				ToolName: part.FunctionResponse.Name,
+				Content:  string(respJSON),
+			})
+			log.ToolResult(ev.Author, part.FunctionResponse.Name, string(respJSON))
+		}
+	}
 }
 
 // buildCommitMsgFunc creates the GenerateCommitMsg callback for /commit.

--- a/internal/cli/complexity_core_test.go
+++ b/internal/cli/complexity_core_test.go
@@ -1,0 +1,1102 @@
+// Tests for the helpers extracted while reducing cyclomatic complexity in
+// cli.go, interactive.go and serve.go. Each table pins the behavior the
+// original branch structure encoded, so a regression in the extraction shows up
+// as a failing case rather than a silent change.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+	adktool "google.golang.org/adk/v2/tool"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/lsp"
+	"github.com/dimetron/pi-go/internal/memory"
+	"github.com/dimetron/pi-go/internal/provider"
+	pisession "github.com/dimetron/pi-go/internal/session"
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+// clearBaseURLEnv unsets every base-URL variable config.BaseURLs consults, so a
+// developer's exported endpoint cannot leak into a table's expectations.
+func clearBaseURLEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"ANTHROPIC_BASE_URL", "OPENAI_BASE_URL", "GEMINI_BASE_URL",
+		"MISTRAL_BASE_URL", "XAI_BASE_URL", "OPENROUTER_BASE_URL",
+		"OLLAMA_HOST", "OPENCODE_BASE_URL",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+// --- cli.go: buildRootRuntime helpers -------------------------------------
+
+func TestResolveRuntimeModel(t *testing.T) {
+	tests := []struct {
+		name         string
+		flagURL      string
+		cfgBaseURLs  map[string]string
+		modelName    string
+		providerName string
+		wantProvider string
+		wantModel    string
+		wantBaseURL  string
+		wantCustom   bool
+		wantErr      bool
+	}{
+		{
+			name:         "plain model, no base url anywhere",
+			modelName:    "claude-sonnet-4-6",
+			wantProvider: "anthropic",
+			wantModel:    "claude-sonnet-4-6",
+		},
+		{
+			name:         "explicit --url marks the model custom",
+			flagURL:      "http://gateway.invalid/v1",
+			modelName:    "claude-sonnet-4-6",
+			wantProvider: "anthropic",
+			wantModel:    "claude-sonnet-4-6",
+			wantBaseURL:  "http://gateway.invalid/v1",
+			wantCustom:   true,
+		},
+		{
+			name:         "role provider name overrides the resolved provider",
+			modelName:    "claude-sonnet-4-6",
+			providerName: "openrouter",
+			wantProvider: "openrouter",
+			wantModel:    "claude-sonnet-4-6",
+		},
+		{
+			name:         "config base url for the role provider is used for resolution",
+			cfgBaseURLs:  map[string]string{"openrouter": "http://router.invalid/v1"},
+			modelName:    "some-unknown-model",
+			providerName: "openrouter",
+			wantProvider: "openrouter",
+			wantModel:    "some-unknown-model",
+			wantBaseURL:  "http://router.invalid/v1",
+			wantCustom:   true,
+		},
+		{
+			name:         "config base url for the resolved provider is picked up second",
+			cfgBaseURLs:  map[string]string{"anthropic": "http://proxy.invalid/v1"},
+			modelName:    "claude-sonnet-4-6",
+			wantProvider: "anthropic",
+			wantModel:    "claude-sonnet-4-6",
+			wantBaseURL:  "http://proxy.invalid/v1",
+			wantCustom:   true,
+		},
+		{
+			name:      "unresolvable model is an error",
+			modelName: "no-such-model-prefix",
+			wantErr:   true,
+		},
+		{
+			name:      "empty model is an error",
+			modelName: "",
+			wantErr:   true,
+		},
+		{
+			name:      "known provider rejects an unknown model",
+			modelName: "gpt-not-a-real-openai-model",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobalFlags(t)
+			clearBaseURLEnv(t)
+			flagURL = tt.flagURL
+
+			cfg := config.Config{BaseURLs: tt.cfgBaseURLs}
+			info, baseURL, err := resolveRuntimeModel(cfg, tt.modelName, tt.providerName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveRuntimeModel(%q, %q) = %+v, want error", tt.modelName, tt.providerName, info)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveRuntimeModel: %v", err)
+			}
+			if info.Provider != tt.wantProvider {
+				t.Errorf("provider = %q, want %q", info.Provider, tt.wantProvider)
+			}
+			if info.Model != tt.wantModel {
+				t.Errorf("model = %q, want %q", info.Model, tt.wantModel)
+			}
+			if baseURL != tt.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", baseURL, tt.wantBaseURL)
+			}
+			if info.Custom != tt.wantCustom {
+				t.Errorf("custom = %v, want %v", info.Custom, tt.wantCustom)
+			}
+		})
+	}
+}
+
+func TestRequireRuntimeAPIKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		info    provider.Info
+		apiKey  string
+		baseURL string
+		wantErr bool
+	}{
+		{
+			name:    "no key and no base url for a key-requiring provider fails",
+			info:    provider.Info{Provider: "anthropic"},
+			wantErr: true,
+		},
+		{
+			name:   "a key satisfies the requirement",
+			info:   provider.Info{Provider: "anthropic"},
+			apiKey: "sk-test",
+		},
+		{
+			name:    "a custom base url stands in for a key",
+			info:    provider.Info{Provider: "anthropic"},
+			baseURL: "http://gateway.invalid/v1",
+		},
+		{name: "gemini is exempt", info: provider.Info{Provider: "gemini"}},
+		{name: "ollama is exempt", info: provider.Info{Provider: "ollama"}},
+		{name: "azure is exempt", info: provider.Info{Provider: "azure"}},
+		{
+			name: "an ollama-served model is exempt whatever the provider name",
+			info: provider.Info{Provider: "openai", Ollama: true},
+		},
+		{
+			name:    "openai without a key fails",
+			info:    provider.Info{Provider: "openai"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireRuntimeAPIKey(tt.info, tt.apiKey, tt.baseURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requireRuntimeAPIKey(%+v, %q, %q) error = %v, wantErr %v",
+					tt.info, tt.apiKey, tt.baseURL, err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "no API key found") {
+				t.Errorf("error = %q, want it to mention the missing key", err)
+			}
+		})
+	}
+}
+
+func TestApplyRuntimeOllamaEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-ollama model passes through untouched", func(t *testing.T) {
+		t.Parallel()
+		info := provider.Info{Provider: "anthropic", Model: "claude-sonnet-4-6"}
+		got, err := applyRuntimeOllamaEndpoint(&info, "", "http://gateway.invalid/v1")
+		if err != nil {
+			t.Fatalf("applyRuntimeOllamaEndpoint: %v", err)
+		}
+		if got != "http://gateway.invalid/v1" {
+			t.Errorf("baseURL = %q, want it unchanged", got)
+		}
+		if info.BaseURL != "" {
+			t.Errorf("info.BaseURL = %q, want it left alone for a non-ollama model", info.BaseURL)
+		}
+	})
+
+	t.Run("ollama model records the resolved endpoint on info", func(t *testing.T) {
+		t.Parallel()
+		info := provider.Info{Provider: "ollama", Model: "qwen3:8b", Ollama: true}
+		// A key is supplied so the local health check is skipped: the branch
+		// under test is the endpoint resolution, not the daemon probe.
+		got, err := applyRuntimeOllamaEndpoint(&info, "key", "http://ollama.invalid:11434")
+		if err != nil {
+			t.Fatalf("applyRuntimeOllamaEndpoint: %v", err)
+		}
+		if got == "" {
+			t.Fatal("baseURL = \"\", want a resolved endpoint")
+		}
+		if info.BaseURL != got {
+			t.Errorf("info.BaseURL = %q, want it to match the returned %q", info.BaseURL, got)
+		}
+	})
+
+	t.Run("cloud endpoint skips the local health check", func(t *testing.T) {
+		t.Parallel()
+		info := provider.Info{Provider: "ollama", Model: "gpt-oss:120b-cloud", Ollama: true}
+		got, err := applyRuntimeOllamaEndpoint(&info, "", "")
+		if err != nil {
+			t.Fatalf("applyRuntimeOllamaEndpoint: %v", err)
+		}
+		if !provider.IsOllamaCloudEndpoint(got) {
+			t.Fatalf("baseURL = %q, want a cloud endpoint for a :cloud model", got)
+		}
+	})
+}
+
+func TestResolveRuntimeContextWindow(t *testing.T) {
+	t.Parallel()
+
+	info := provider.Info{Provider: "anthropic", Model: "claude-sonnet-4-6"}
+	catalog := provider.ContextWindowSizeFor(info.Provider, info.Model)
+
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want int64
+	}{
+		{name: "catalog size when config says nothing", cfg: config.Config{}, want: catalog},
+		{name: "explicit config value wins", cfg: config.Config{ContextWindow: 4242}, want: 4242},
+		{name: "zero config value does not override", cfg: config.Config{ContextWindow: 0}, want: catalog},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveRuntimeContextWindow(context.Background(), tt.cfg, info, "")
+			if got != tt.want {
+				t.Errorf("resolveRuntimeContextWindow = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- cli.go: runNonInteractive helpers ------------------------------------
+
+func TestAppendNonInteractiveMemoryTools(t *testing.T) {
+	t.Parallel()
+
+	base := make([]adktool.Tool, 3)
+	got := appendNonInteractiveMemoryTools(base, nil)
+	if len(got) != len(base) {
+		t.Errorf("nil store changed the tool count: %d, want %d", len(got), len(base))
+	}
+}
+
+func TestBuildNonInteractiveInstruction(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagSystem    string
+		palaceContext string
+		want          string // "" means "compare against the built-in instruction"
+	}{
+		{
+			name:       "--system replaces the built-in instruction",
+			flagSystem: "be terse",
+			want:       "be terse",
+		},
+		{
+			name:          "palace context is appended under its own heading",
+			flagSystem:    "be terse",
+			palaceContext: "remembered things",
+			want:          "be terse\n\n## Palace Memory Context\n\nremembered things",
+		},
+		{
+			name:          "empty palace context adds no heading",
+			flagSystem:    "be terse",
+			palaceContext: "",
+			want:          "be terse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobalFlags(t)
+			flagSystem = tt.flagSystem
+			if got := buildNonInteractiveInstruction(tt.palaceContext); got != tt.want {
+				t.Errorf("buildNonInteractiveInstruction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	// The built-in instruction interpolates live environment and project state,
+	// so it is pinned structurally rather than by an exact snapshot.
+	t.Run("built-in instruction is used when --system is unset", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagSystem = ""
+		got := buildNonInteractiveInstruction("")
+		if got == "" {
+			t.Fatal("instruction is empty, want the built-in one")
+		}
+		if !strings.Contains(got, "You are pi-go") {
+			t.Errorf("instruction does not look like the built-in one:\n%q", got[:min(200, len(got))])
+		}
+		if strings.Contains(got, "## Palace Memory Context") {
+			t.Error("instruction has a palace heading with no palace context")
+		}
+	})
+
+	t.Run("palace context is appended to the built-in instruction too", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagSystem = ""
+		got := buildNonInteractiveInstruction("remembered things")
+		if !strings.HasSuffix(got, "\n\n## Palace Memory Context\n\nremembered things") {
+			t.Errorf("instruction does not end with the palace block:\n%q", got[max(0, len(got)-120):])
+		}
+	})
+}
+
+func TestAppendNonInteractiveLSPTools(t *testing.T) {
+	t.Parallel()
+
+	mgr := lsp.NewManager(nil)
+	t.Cleanup(mgr.Shutdown)
+
+	base := make([]adktool.Tool, 2)
+	got, err := appendNonInteractiveLSPTools(base, mgr)
+	if err != nil {
+		t.Fatalf("appendNonInteractiveLSPTools: %v", err)
+	}
+	if len(got) < len(base) {
+		t.Errorf("tool count shrank: %d, want at least %d", len(got), len(base))
+	}
+	// With no language server installed the slice must come back untouched;
+	// with one installed it only ever grows.
+	if !mgr.AnyAvailable() && len(got) != len(base) {
+		t.Errorf("no server available but tool count changed: %d, want %d", len(got), len(base))
+	}
+}
+
+func TestOpenSessionService(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, svc, err := openSessionService()
+	if err != nil {
+		t.Fatalf("openSessionService: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("session service is nil")
+	}
+	want := filepath.Join(home, ".pi-go", "sessions")
+	if path != want {
+		t.Errorf("sessions path = %q, want %q", path, want)
+	}
+}
+
+// recordingStore is a memory.Store that only remembers the sessions created on
+// it; every other method is an unused stub.
+type recordingStore struct {
+	memory.Store
+	created []*memory.Session
+}
+
+func (s *recordingStore) CreateSession(_ context.Context, sess *memory.Session) error {
+	s.created = append(s.created, sess)
+	return nil
+}
+
+func TestArmMemoryObservationSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil store leaves the callback disarmed", func(t *testing.T) {
+		t.Parallel()
+		memSessionID := ""
+		armMemoryObservationSession(context.Background(), nil, "sess-1", "/proj", &memSessionID)
+		if memSessionID != "" {
+			t.Errorf("memSessionID = %q, want it left empty", memSessionID)
+		}
+	})
+
+	t.Run("store arms the callback and opens the session", func(t *testing.T) {
+		t.Parallel()
+		store := &recordingStore{}
+		memSessionID := ""
+		armMemoryObservationSession(context.Background(), store, "sess-1", "/proj", &memSessionID)
+		if memSessionID != "sess-1" {
+			t.Errorf("memSessionID = %q, want %q", memSessionID, "sess-1")
+		}
+		if len(store.created) != 1 {
+			t.Fatalf("created %d sessions, want 1", len(store.created))
+		}
+		got := store.created[0]
+		if got.SessionID != "sess-1" || got.Project != "/proj" || got.Status != "active" {
+			t.Errorf("created session = %+v, want sess-1 / /proj / active", got)
+		}
+	})
+}
+
+// --- cli.go: lastLoggedError helpers --------------------------------------
+
+func TestLastLoggedErrorInLogFile(t *testing.T) {
+	t.Parallel()
+
+	entry := func(typ, content string) string {
+		blob, err := json.Marshal(map[string]string{"type": typ, "content": content})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return string(blob)
+	}
+
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{name: "empty file has no error", lines: nil, want: ""},
+		{name: "only non-error entries", lines: []string{entry("user", "hi"), entry("llm", "yo")}, want: ""},
+		{name: "single error is found", lines: []string{entry("error", "boom")}, want: "boom"},
+		{
+			name:  "last error wins over an earlier one",
+			lines: []string{entry("error", "first"), entry("user", "hi"), entry("error", "second")},
+			want:  "second",
+		},
+		{
+			name:  "an error with empty content is skipped",
+			lines: []string{entry("error", "real"), entry("error", "")},
+			want:  "real",
+		},
+		{
+			name:  "blank lines and malformed json are skipped",
+			lines: []string{entry("error", "real"), "", "   ", "{not json"},
+			want:  "real",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := filepath.Join(t.TempDir(), "session-x.log")
+			if err := os.WriteFile(p, []byte(strings.Join(tt.lines, "\n")), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if got := lastLoggedErrorInLogFile(p); got != tt.want {
+				t.Errorf("lastLoggedErrorInLogFile = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("unreadable file yields no error message", func(t *testing.T) {
+		t.Parallel()
+		if got := lastLoggedErrorInLogFile(filepath.Join(t.TempDir(), "missing.log")); got != "" {
+			t.Errorf("lastLoggedErrorInLogFile = %q, want \"\"", got)
+		}
+	})
+}
+
+func TestLastLoggedErrorInDateDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing directory yields nothing", func(t *testing.T) {
+		t.Parallel()
+		p, m := lastLoggedErrorInDateDir(filepath.Join(t.TempDir(), "nope"))
+		if p != "" || m != "" {
+			t.Errorf("= (%q, %q), want empty", p, m)
+		}
+	})
+
+	t.Run("only session-*.log files are read, newest first", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		write := func(name, content string) {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+				t.Fatalf("write %s: %v", name, err)
+			}
+		}
+		// Names sort ascending, so session-02 is the newer of the two.
+		write("session-01.log", errorLogLine("old"))
+		write("session-02.log", errorLogLine("new"))
+		// Neither of these matches the session-*.log shape.
+		write("other.log", errorLogLine("ignored-prefix"))
+		write("session-03.txt", errorLogLine("ignored-suffix"))
+		if err := os.Mkdir(filepath.Join(dir, "session-dir.log"), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		p, m := lastLoggedErrorInDateDir(dir)
+		if m != "new" {
+			t.Errorf("message = %q, want %q", m, "new")
+		}
+		if filepath.Base(p) != "session-02.log" {
+			t.Errorf("path = %q, want it to be session-02.log", p)
+		}
+	})
+
+	t.Run("falls back to an older file when the newest holds no error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "session-01.log"), []byte(errorLogLine("old")), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "session-02.log"), []byte(`{"type":"user","content":"hi"}`), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		p, m := lastLoggedErrorInDateDir(dir)
+		if m != "old" || filepath.Base(p) != "session-01.log" {
+			t.Errorf("= (%q, %q), want session-01.log / old", p, m)
+		}
+	})
+}
+
+// errorLogLine renders one JSONL session-log line carrying an error entry.
+func errorLogLine(content string) string {
+	blob, err := json.Marshal(map[string]string{"type": "error", "content": content})
+	if err != nil {
+		panic(err)
+	}
+	return string(blob) + "\n"
+}
+
+func TestLastLoggedError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	t.Run("absent log root is not an error", func(t *testing.T) {
+		path, msg, err := lastLoggedError()
+		if err != nil {
+			t.Fatalf("lastLoggedError: %v", err)
+		}
+		if path != "" || msg != "" {
+			t.Errorf("= (%q, %q), want empty", path, msg)
+		}
+	})
+
+	t.Run("newest date directory wins", func(t *testing.T) {
+		logRoot := filepath.Join(home, ".pi-go", "log")
+		for _, d := range []struct{ dir, msg string }{
+			{"2026-08-20", "older"},
+			{"2026-08-21", "newer"},
+		} {
+			full := filepath.Join(logRoot, d.dir)
+			if err := os.MkdirAll(full, 0o750); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(full, "session-1.log"), []byte(errorLogLine(d.msg)), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+		// A stray file at the log root must not be mistaken for a date dir.
+		if err := os.WriteFile(filepath.Join(logRoot, "stray.log"), []byte("junk"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		path, msg, err := lastLoggedError()
+		if err != nil {
+			t.Fatalf("lastLoggedError: %v", err)
+		}
+		if msg != "newer" {
+			t.Errorf("message = %q, want %q", msg, "newer")
+		}
+		if !strings.Contains(path, "2026-08-21") {
+			t.Errorf("path = %q, want it under 2026-08-21", path)
+		}
+	})
+}
+
+// --- cli.go: runPrint / runJSON part rendering ----------------------------
+
+func modelEvent(parts ...*genai.Part) *session.Event {
+	ev := &session.Event{Author: "assistant"}
+	ev.Content = &genai.Content{Role: genai.RoleModel, Parts: parts}
+	return ev
+}
+
+func TestPrintEventParts(t *testing.T) {
+	ev := modelEvent(
+		&genai.Part{Text: "hello"},
+		&genai.Part{FunctionCall: &genai.FunctionCall{Name: "bash", Args: map[string]any{"cmd": "ls"}}},
+		&genai.Part{FunctionResponse: &genai.FunctionResponse{Name: "bash", Response: map[string]any{"out": "ok"}}},
+	)
+
+	var dedup agent.StreamDedup
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			dedup.BeginEvent(ev)
+			printEventParts(ev, &dedup, nil)
+		})
+	})
+
+	if stdout != "hello" {
+		t.Errorf("stdout = %q, want %q", stdout, "hello")
+	}
+	if !strings.Contains(stderr, "tool: bash") {
+		t.Errorf("stderr = %q, want it to name the tool call", stderr)
+	}
+	if !strings.Contains(stderr, "done") {
+		t.Errorf("stderr = %q, want it to report the tool result", stderr)
+	}
+}
+
+func TestPrintEventPartsThinkingGoesToStderr(t *testing.T) {
+	ev := &session.Event{Author: "assistant"}
+	ev.Content = &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: "pondering"}}}
+
+	var dedup agent.StreamDedup
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			dedup.BeginEvent(ev)
+			printEventParts(ev, &dedup, nil)
+		})
+	})
+
+	if stdout != "" {
+		t.Errorf("stdout = %q, want thinking kept off stdout", stdout)
+	}
+	if !strings.Contains(stderr, "pondering") {
+		t.Errorf("stderr = %q, want the thinking text", stderr)
+	}
+}
+
+func TestPrintEventPartsSkipsAggregateResend(t *testing.T) {
+	delta := modelEvent(&genai.Part{Text: "hi"})
+	delta.Partial = true
+	aggregate := modelEvent(&genai.Part{Text: "hi"})
+
+	var dedup agent.StreamDedup
+	stdout := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			for _, ev := range []*session.Event{delta, aggregate} {
+				dedup.BeginEvent(ev)
+				printEventParts(ev, &dedup, nil)
+			}
+		})
+	})
+
+	if stdout != "hi" {
+		t.Errorf("stdout = %q, want the aggregate re-send suppressed", stdout)
+	}
+}
+
+func TestPrintGroundingEvent(t *testing.T) {
+	newEvent := func(queries []string) *session.Event {
+		ev := &session.Event{Author: "assistant"}
+		if queries != nil {
+			ev.GroundingMetadata = &genai.GroundingMetadata{WebSearchQueries: queries}
+		}
+		return ev
+	}
+
+	t.Run("no grounding metadata prints nothing", func(t *testing.T) {
+		got := captureStderr(t, func() {
+			printGroundingEvent(newEvent(nil), map[string]bool{}, nil)
+		})
+		if got != "" {
+			t.Errorf("stderr = %q, want nothing", got)
+		}
+	})
+
+	t.Run("empty query list prints nothing", func(t *testing.T) {
+		got := captureStderr(t, func() {
+			printGroundingEvent(newEvent([]string{}), map[string]bool{}, nil)
+		})
+		if got != "" {
+			t.Errorf("stderr = %q, want nothing", got)
+		}
+	})
+
+	t.Run("a search is reported once and then suppressed", func(t *testing.T) {
+		seen := map[string]bool{}
+		ev := newEvent([]string{"go generics"})
+
+		first := captureStderr(t, func() { printGroundingEvent(ev, seen, nil) })
+		if !strings.Contains(first, agent.GroundingToolName) {
+			t.Errorf("stderr = %q, want it to name %q", first, agent.GroundingToolName)
+		}
+
+		second := captureStderr(t, func() { printGroundingEvent(ev, seen, nil) })
+		if second != "" {
+			t.Errorf("repeat stderr = %q, want the second report suppressed", second)
+		}
+	})
+}
+
+func TestEncodeEventParts(t *testing.T) {
+	ev := modelEvent(
+		&genai.Part{Text: "hello"},
+		&genai.Part{FunctionCall: &genai.FunctionCall{Name: "bash", Args: map[string]any{"cmd": "ls"}}},
+		&genai.Part{FunctionResponse: &genai.FunctionResponse{Name: "bash", Response: map[string]any{"out": "ok"}}},
+	)
+
+	var buf bytes.Buffer
+	var dedup agent.StreamDedup
+	dedup.BeginEvent(ev)
+	encodeEventParts(json.NewEncoder(&buf), ev, &dedup, nil)
+
+	var gotTypes []string
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var e jsonEvent
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		gotTypes = append(gotTypes, e.Type)
+	}
+
+	want := []string{"text_delta", "tool_call", "tool_result"}
+	if strings.Join(gotTypes, ",") != strings.Join(want, ",") {
+		t.Errorf("event types = %v, want %v", gotTypes, want)
+	}
+}
+
+func TestEncodeEventPartsThinkingAndDedup(t *testing.T) {
+	thinking := &session.Event{Author: "assistant"}
+	thinking.Content = &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: "pondering"}}}
+
+	var buf bytes.Buffer
+	var dedup agent.StreamDedup
+	dedup.BeginEvent(thinking)
+	encodeEventParts(json.NewEncoder(&buf), thinking, &dedup, nil)
+	if !strings.Contains(buf.String(), `"thinking_delta"`) {
+		t.Errorf("output = %q, want a thinking_delta event", buf.String())
+	}
+
+	delta := modelEvent(&genai.Part{Text: "hi"})
+	delta.Partial = true
+	aggregate := modelEvent(&genai.Part{Text: "hi"})
+
+	buf.Reset()
+	enc := json.NewEncoder(&buf)
+	var d2 agent.StreamDedup
+	for _, ev := range []*session.Event{delta, aggregate} {
+		d2.BeginEvent(ev)
+		encodeEventParts(enc, ev, &d2, nil)
+	}
+	if n := strings.Count(buf.String(), `"text_delta"`); n != 1 {
+		t.Errorf("text_delta count = %d, want 1 (aggregate re-send suppressed)", n)
+	}
+}
+
+// --- interactive.go: deferredInit helpers ---------------------------------
+
+func TestDeferredInitCoreTools(t *testing.T) {
+	root := t.TempDir()
+	var res initResources
+
+	coreTools, err := deferredInitCoreTools(root, "", &res)
+	if err != nil {
+		t.Fatalf("deferredInitCoreTools: %v", err)
+	}
+	t.Cleanup(func() {
+		if res.bashSup != nil {
+			res.bashSup.KillAll()
+		}
+		if res.sandbox != nil {
+			_ = res.sandbox.Close()
+		}
+	})
+
+	if len(coreTools) == 0 {
+		t.Error("no core tools returned")
+	}
+	// Both must be recorded on res, otherwise a later init failure leaks them.
+	if res.sandbox == nil {
+		t.Error("res.sandbox not recorded")
+	}
+	if res.bashSup == nil {
+		t.Error("res.bashSup not recorded")
+	}
+}
+
+func TestRunDeferredInitPhase2(t *testing.T) {
+	resetGlobalFlags(t)
+
+	var mu struct {
+		items []string
+	}
+	done := make(chan struct{})
+	events := make(chan string, 64)
+	go func() {
+		defer close(done)
+		for item := range events {
+			mu.items = append(mu.items, item)
+		}
+	}()
+
+	// cfg.MCP is nil, so the MCP goroutine returns before sending anything —
+	// which is exactly the branch the "mcp" absence below pins.
+	ps := runDeferredInitPhase2(context.Background(), config.Config{}, t.TempDir(),
+		func(item string, done bool) {
+			if done {
+				events <- item
+			}
+		})
+	close(events)
+	<-done
+	t.Cleanup(func() {
+		if ps.lspMgr != nil {
+			ps.lspMgr.Shutdown()
+		}
+	})
+
+	if ps == nil {
+		t.Fatal("runDeferredInitPhase2 returned nil")
+	}
+	if ps.lspMgr == nil {
+		t.Error("lsp manager not set")
+	}
+	if ps.skillDirs == nil {
+		t.Error("skill dirs not set")
+	}
+	joined := strings.Join(mu.items, ",")
+	for _, want := range []string{"git", "lsp", "skills"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("progress items = %q, want %q reported done", joined, want)
+		}
+	}
+	if strings.Contains(joined, "mcp") {
+		t.Errorf("progress items = %q, want no mcp step when no servers are configured", joined)
+	}
+}
+
+func TestAppendDeferredMemoryTools(t *testing.T) {
+	t.Run("memory off returns nil store and recorder", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagMemoryOff = true
+
+		base := make([]adktool.Tool, 2)
+		got, store, rec := appendDeferredMemoryTools(config.Config{}, t.TempDir(), base)
+		if len(got) != len(base) {
+			t.Errorf("tool count = %d, want %d", len(got), len(base))
+		}
+		if store != nil || rec != nil {
+			t.Errorf("store = %v, recorder = %v, want both nil", store, rec)
+		}
+	})
+
+	t.Run("memory on returns a store and recorder", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagMemoryOff = false
+
+		base := make([]adktool.Tool, 2)
+		got, store, rec := appendDeferredMemoryTools(config.Config{}, t.TempDir(), base)
+		if store == nil {
+			t.Fatal("store is nil, want a lazy store")
+		}
+		if rec == nil {
+			t.Fatal("recorder is nil")
+		}
+		if len(got) <= len(base) {
+			t.Errorf("tool count = %d, want the memory tools appended to %d", len(got), len(base))
+		}
+	})
+}
+
+func TestBuildDeferredInstructionParts(t *testing.T) {
+	t.Run("built-in parts by default", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagSystem = ""
+		got := buildDeferredInstructionParts()
+		if got.String() == "" {
+			t.Error("instruction is empty, want the built-in set")
+		}
+	})
+
+	t.Run("--system replaces the base outright", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagSystem = "be terse"
+		got := buildDeferredInstructionParts()
+		if got.Base != "be terse" {
+			t.Errorf("Base = %q, want %q", got.Base, "be terse")
+		}
+		if got.String() != "be terse" {
+			t.Errorf("String() = %q, want %q", got.String(), "be terse")
+		}
+	})
+}
+
+func TestBuildDeferredCallbacks(t *testing.T) {
+	resetGlobalFlags(t)
+
+	sandbox, err := tools.NewSandbox(t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("NewSandbox: %v", err)
+	}
+	t.Cleanup(func() { _ = sandbox.Close() })
+
+	mgr := lsp.NewManager(nil)
+	t.Cleanup(mgr.Shutdown)
+
+	base := buildDeferredCallbacks(config.Config{}, "anthropic", sandbox, nil, nil)
+	if base.deduper == nil {
+		t.Error("deduper is nil")
+	}
+	if base.compactMetrics == nil {
+		t.Error("compactMetrics is nil")
+	}
+	if len(base.beforeModel) == 0 {
+		t.Error("no before-model callbacks; the read-image callback is always added")
+	}
+	// The compactor and dedup callbacks are unconditional.
+	if len(base.afterTool) < 2 {
+		t.Errorf("after-tool callbacks = %d, want at least the compactor and deduper", len(base.afterTool))
+	}
+
+	withLSP := buildDeferredCallbacks(config.Config{}, "anthropic", sandbox, mgr, nil)
+	if len(withLSP.afterTool) != len(base.afterTool)+1 {
+		t.Errorf("after-tool callbacks with an LSP manager = %d, want %d",
+			len(withLSP.afterTool), len(base.afterTool)+1)
+	}
+
+	rec := newDeferredMemoryRecorder(config.Config{}, t.TempDir())
+	withMem := buildDeferredCallbacks(config.Config{}, "anthropic", sandbox, nil, rec)
+	if len(withMem.afterTool) != len(base.afterTool)+1 {
+		t.Errorf("after-tool callbacks with a memory recorder = %d, want %d",
+			len(withMem.afterTool), len(base.afterTool)+1)
+	}
+}
+
+func TestResolveDeferredSessionResumed(t *testing.T) {
+	resetGlobalFlags(t)
+	flagSession = "existing-session"
+
+	svc, err := pisession.NewFileService(t.TempDir())
+	if err != nil {
+		t.Fatalf("session service: %v", err)
+	}
+
+	// ag is never touched on the resume path: the session ID is already known,
+	// so CreateSession is not reached. Passing nil pins that.
+	sessionID, title, resumed, err := resolveDeferredSession(
+		context.Background(), nil, svc, &cliMockLLM{name: "test-model"}, "anthropic", "http://x.invalid")
+	if err != nil {
+		t.Fatalf("resolveDeferredSession: %v", err)
+	}
+	if sessionID != "existing-session" {
+		t.Errorf("sessionID = %q, want %q", sessionID, "existing-session")
+	}
+	if !resumed {
+		t.Error("resumed = false, want true when --session names one")
+	}
+	if title != "" {
+		t.Errorf("defaultTitle = %q, want empty for a resumed session", title)
+	}
+}
+
+// --- serve.go -------------------------------------------------------------
+
+func TestValidateServeHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		wantErr bool
+	}{
+		{name: "no headers", headers: nil},
+		{name: "one valid header", headers: []string{"X-Key=value"}},
+		{name: "several valid headers", headers: []string{"a=1", "b=2"}},
+		{name: "empty value still has the separator", headers: []string{"a="}},
+		{name: "missing separator", headers: []string{"nope"}, wantErr: true},
+		{name: "one bad header among good ones", headers: []string{"a=1", "nope"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobalFlags(t)
+			flagServeHeaders = tt.headers
+			err := validateServeHeaders()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateServeHeaders(%v) error = %v, wantErr %v", tt.headers, err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "expected key=value") {
+				t.Errorf("error = %q, want it to explain the expected form", err)
+			}
+		})
+	}
+}
+
+func TestResolveServeProject(t *testing.T) {
+	t.Run("--project wins", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagServeProject = "/some/project"
+		got, err := resolveServeProject()
+		if err != nil {
+			t.Fatalf("resolveServeProject: %v", err)
+		}
+		if got != "/some/project" {
+			t.Errorf("project = %q, want %q", got, "/some/project")
+		}
+	})
+
+	t.Run("falls back to the working directory", func(t *testing.T) {
+		resetGlobalFlags(t)
+		flagServeProject = ""
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		got, err := resolveServeProject()
+		if err != nil {
+			t.Fatalf("resolveServeProject: %v", err)
+		}
+		if got != cwd {
+			t.Errorf("project = %q, want %q", got, cwd)
+		}
+	})
+}
+
+func TestPrintServeBanner(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		url        string
+		headers    []string
+		insecure   bool
+		wantLines  []string
+		absentText []string
+	}{
+		{
+			name:       "minimal run prints only the required lines",
+			wantLines:  []string{"http://localhost:8765", "Project: /proj", "Pair code: ABC123", "Pairing timeout:"},
+			absentText: []string{"Model:", "URL:", "Header:", "TLS verification", "Voice:"},
+		},
+		{
+			name:      "model is printed when set",
+			model:     "claude-sonnet-4-6",
+			wantLines: []string{"Model: claude-sonnet-4-6"},
+		},
+		{
+			name:      "url is printed when set",
+			url:       "http://gateway.invalid/v1",
+			wantLines: []string{"URL: http://gateway.invalid/v1"},
+		},
+		{
+			name:      "every header gets its own line",
+			headers:   []string{"a=1", "b=2"},
+			wantLines: []string{"Header: a=1", "Header: b=2"},
+		},
+		{
+			name:      "insecure is called out",
+			insecure:  true,
+			wantLines: []string{"TLS verification: disabled (--insecure)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetGlobalFlags(t)
+			flagServeModel = tt.model
+			flagServeURL = tt.url
+			flagServeHeaders = tt.headers
+			flagServeInsecure = tt.insecure
+
+			var buf bytes.Buffer
+			printServeBanner(&buf, ":8765", "/proj", "ABC123")
+			got := buf.String()
+
+			for _, want := range tt.wantLines {
+				if !strings.Contains(got, want) {
+					t.Errorf("banner missing %q:\n%s", want, got)
+				}
+			}
+			for _, absent := range tt.absentText {
+				if strings.Contains(got, absent) {
+					t.Errorf("banner unexpectedly contains %q:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/complexity_ping_test.go
+++ b/internal/cli/complexity_ping_test.go
@@ -1,0 +1,1453 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/memory"
+	"github.com/dimetron/pi-go/internal/palace"
+	"github.com/dimetron/pi-go/internal/provider"
+)
+
+// These tests pin the branch structure that the complexity refactor extracted
+// out of modelPing, ollamaPingFull, resolvePingTarget, reportHTTPVerdict,
+// runModelList, runMemoryRecent, scanFiles and runMemoryMine. Each extracted
+// helper is exercised at the boundaries its original branch encoded, so a
+// behavior change shows up as a failing case rather than as a diff nobody can
+// verify by eye.
+
+// ---------------------------------------------------------------------------
+// ping request construction
+// ---------------------------------------------------------------------------
+
+func TestPingSystemMessage(t *testing.T) {
+	t.Parallel()
+	pingPong := pingSystemMessage(true)
+	if !strings.Contains(pingPong, `reply with exactly "prompt-prompt"`) {
+		t.Errorf("ping-pong system message lost its exact-reply instruction: %q", pingPong)
+	}
+	custom := pingSystemMessage(false)
+	if custom != "You are a connectivity test. Reply briefly and concisely." {
+		t.Errorf("custom-prompt system message = %q", custom)
+	}
+	if pingPong == custom {
+		t.Error("the two modes must not share a system message")
+	}
+}
+
+func TestNewPingRequest(t *testing.T) {
+	t.Parallel()
+	req := newPingRequest("2+2", false)
+	if len(req.Contents) != 1 || req.Contents[0].Role != genai.RoleUser {
+		t.Fatalf("expected a single user turn, got %#v", req.Contents)
+	}
+	if got := req.Contents[0].Parts[0].Text; got != "2+2" {
+		t.Errorf("prompt = %q, want %q", got, "2+2")
+	}
+	sys := req.Config.SystemInstruction.Parts[0].Text
+	if sys != pingSystemMessage(false) {
+		t.Errorf("system instruction = %q, want the custom-prompt message", sys)
+	}
+	if got := newPingRequest("x", true).Config.SystemInstruction.Parts[0].Text; got != pingSystemMessage(true) {
+		t.Errorf("ping-pong request did not carry the ping-pong system message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// modelPing: the non-streaming half
+// ---------------------------------------------------------------------------
+
+func TestModelPingNonStreamCollectsAndCounts(t *testing.T) {
+	t.Parallel()
+	llm := &pingMockLLM{
+		name: "mock",
+		responses: []*model.LLMResponse{
+			{Content: genai.NewContentFromText("hel", genai.RoleModel)},
+			{Content: genai.NewContentFromText("lo", genai.RoleModel)},
+		},
+	}
+	w, read := captureWriter(t)
+	text, events, err := modelPingNonStream(context.Background(), llm, newPingRequest("hi", false), w)
+	if err != nil {
+		t.Fatalf("modelPingNonStream: %v", err)
+	}
+	if text != "hello" {
+		t.Errorf("text = %q, want %q", text, "hello")
+	}
+	if events != 2 {
+		t.Errorf("events = %d, want 2", events)
+	}
+	if out := read(); !strings.Contains(out, "[non-stream]") {
+		t.Errorf("expected traced events, got:\n%s", out)
+	}
+}
+
+// A non-stream error keeps whatever text already arrived: the Azure soft-failure
+// path in modelPing depends on that partial result surviving.
+func TestModelPingNonStreamErrorKeepsPartialText(t *testing.T) {
+	t.Parallel()
+	llm := &pingMockLLM{name: "mock", err: errors.New("boom")}
+	w, _ := captureWriter(t)
+	text, events, err := modelPingNonStream(context.Background(), llm, newPingRequest("hi", false), w)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "non-streaming LLM error") {
+		t.Errorf("error = %v, want it wrapped as a non-streaming LLM error", err)
+	}
+	if text != "" || events != 1 {
+		t.Errorf("got (text=%q, events=%d), want (\"\", 1)", text, events)
+	}
+}
+
+func TestLogPingNonStreamEvent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		resp    *model.LLMResponse
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "bare event",
+			resp:    &model.LLMResponse{Partial: true},
+			want:    []string{"event 7: partial=true"},
+			notWant: []string{"errorCode", "tokens("},
+		},
+		{
+			name: "error code is shown",
+			resp: &model.LLMResponse{ErrorCode: "429", ErrorMessage: "slow down"},
+			want: []string{"errorCode=429", "errorMsg=slow down"},
+		},
+		{
+			name: "usage is shown",
+			resp: &model.LLMResponse{UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount: 11, CandidatesTokenCount: 22,
+			}},
+			want: []string{"tokens(in=11 out=22)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w, read := captureWriter(t)
+			logPingNonStreamEvent(w, tt.resp, 7)
+			out := read()
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in:\n%s", want, out)
+				}
+			}
+			for _, no := range tt.notWant {
+				if strings.Contains(out, no) {
+					t.Errorf("did not expect %q in:\n%s", no, out)
+				}
+			}
+		})
+	}
+}
+
+func TestLogPingNonStreamContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil content writes nothing", func(t *testing.T) {
+		t.Parallel()
+		w, read := captureWriter(t)
+		var sb strings.Builder
+		logPingNonStreamContent(w, &model.LLMResponse{}, &sb)
+		if out := read(); out != "" {
+			t.Errorf("expected no output for a content-less event, got:\n%s", out)
+		}
+		if sb.Len() != 0 {
+			t.Errorf("expected no accumulated text, got %q", sb.String())
+		}
+	})
+
+	t.Run("parts are traced and text accumulated", func(t *testing.T) {
+		t.Parallel()
+		resp := &model.LLMResponse{Content: &genai.Content{
+			Role: genai.RoleModel,
+			Parts: []*genai.Part{
+				{Text: "answer"},
+				{FunctionCall: &genai.FunctionCall{Name: "search"}},
+				{Text: "thought text", Thought: true},
+			},
+		}}
+		w, read := captureWriter(t)
+		var sb strings.Builder
+		logPingNonStreamContent(w, resp, &sb)
+		out := read()
+		for _, want := range []string{"role=model parts=3", "part[0] text(6 chars): answer", "part[1] tool_call: search", "part[2] thought=true"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in:\n%s", want, out)
+			}
+		}
+		// Every text part is accumulated, thought parts included — that is what
+		// the original loop did.
+		if sb.String() != "answerthought text" {
+			t.Errorf("accumulated %q", sb.String())
+		}
+	})
+
+	t.Run("long text is previewed at 120 chars", func(t *testing.T) {
+		t.Parallel()
+		long := strings.Repeat("x", 200)
+		resp := &model.LLMResponse{Content: &genai.Content{
+			Role:  genai.RoleModel,
+			Parts: []*genai.Part{{Text: long}},
+		}}
+		w, read := captureWriter(t)
+		var sb strings.Builder
+		logPingNonStreamContent(w, resp, &sb)
+		if out := read(); !strings.Contains(out, strings.Repeat("x", 120)+"...") {
+			t.Errorf("expected a 120-char preview with an ellipsis, got:\n%s", out)
+		}
+		if sb.String() != long {
+			t.Error("the accumulated text must not be truncated, only the preview")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// modelPing: the streaming half
+// ---------------------------------------------------------------------------
+
+func TestAccumulatePingStreamParts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		resp         *model.LLMResponse
+		wantThinking int
+		wantText     int
+		wantOut      string
+	}{
+		{name: "nil content", resp: &model.LLMResponse{}},
+		{
+			name: "model text counts as text",
+			resp: &model.LLMResponse{Content: &genai.Content{
+				Role: genai.RoleModel, Parts: []*genai.Part{{Text: "a"}, {Text: "b"}},
+			}},
+			wantText: 2, wantOut: "ab",
+		},
+		{
+			name: "thinking role is counted but never joins the reply",
+			resp: &model.LLMResponse{Content: &genai.Content{
+				Role: "thinking", Parts: []*genai.Part{{Text: "hmm"}},
+			}},
+			wantThinking: 1,
+		},
+		{
+			name: "empty text parts are ignored entirely",
+			resp: &model.LLMResponse{Content: &genai.Content{
+				Role: genai.RoleModel, Parts: []*genai.Part{{Text: ""}, {FunctionCall: &genai.FunctionCall{Name: "f"}}},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var sb strings.Builder
+			thinking, text := accumulatePingStreamParts(tt.resp, &sb)
+			if thinking != tt.wantThinking || text != tt.wantText {
+				t.Errorf("got (thinking=%d, text=%d), want (%d, %d)", thinking, text, tt.wantThinking, tt.wantText)
+			}
+			if sb.String() != tt.wantOut {
+				t.Errorf("accumulated %q, want %q", sb.String(), tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestLogPingStreamFinalEvent(t *testing.T) {
+	t.Parallel()
+	w, read := captureWriter(t)
+	logPingStreamFinalEvent(w, &model.LLMResponse{TurnComplete: true}, 3)
+	out := read()
+	if !strings.Contains(out, "final event 3: turnComplete=true") {
+		t.Errorf("unexpected final-event line:\n%s", out)
+	}
+	if strings.Contains(out, "tokens(") {
+		t.Errorf("no usage metadata means no token line:\n%s", out)
+	}
+
+	w2, read2 := captureWriter(t)
+	logPingStreamFinalEvent(w2, &model.LLMResponse{UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount: 5, CandidatesTokenCount: 6,
+	}}, 4)
+	if out := read2(); !strings.Contains(out, "tokens(in=5 out=6)") {
+		t.Errorf("expected token counts, got:\n%s", out)
+	}
+}
+
+func TestModelPingStream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects text and reports chunk counts", func(t *testing.T) {
+		t.Parallel()
+		llm := &cliThinkingLLM{name: "mock", thoughtText: "hmm", responseText: "done"}
+		w, read := captureWriter(t)
+		text, err := modelPingStream(context.Background(), llm, newPingRequest("hi", false), w)
+		if err != nil {
+			t.Fatalf("modelPingStream: %v", err)
+		}
+		if text != "done" {
+			t.Errorf("text = %q, want %q — thinking output must not join the reply", text, "done")
+		}
+		if out := read(); !strings.Contains(out, "(1 thinking, 1 text chunks)") {
+			t.Errorf("expected the chunk tally, got:\n%s", out)
+		}
+	})
+
+	t.Run("an error-code event is reported and skipped", func(t *testing.T) {
+		t.Parallel()
+		llm := &pingMockLLM{name: "mock", responses: []*model.LLMResponse{
+			{ErrorCode: "overloaded", ErrorMessage: "try later"},
+			{Content: genai.NewContentFromText("recovered", genai.RoleModel)},
+		}}
+		w, read := captureWriter(t)
+		text, err := modelPingStream(context.Background(), llm, newPingRequest("hi", false), w)
+		if err != nil {
+			t.Fatalf("an error-code event must not fail the stream: %v", err)
+		}
+		if text != "recovered" {
+			t.Errorf("text = %q, want %q", text, "recovered")
+		}
+		out := read()
+		if !strings.Contains(out, "errorCode=overloaded") {
+			t.Errorf("expected the error code to be traced, got:\n%s", out)
+		}
+		// The skipped event must not also print a final-event summary line.
+		if strings.Count(out, "final event") != 1 {
+			t.Errorf("expected exactly one final-event line, got:\n%s", out)
+		}
+	})
+
+	t.Run("a transport error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		llm := &pingMockLLM{name: "mock", err: errors.New("reset")}
+		w, _ := captureWriter(t)
+		_, err := modelPingStream(context.Background(), llm, newPingRequest("hi", false), w)
+		if err == nil || !strings.Contains(err.Error(), "streaming LLM error") {
+			t.Fatalf("err = %v, want it wrapped as a streaming LLM error", err)
+		}
+	})
+
+	t.Run("long replies are previewed at 200 chars", func(t *testing.T) {
+		t.Parallel()
+		long := strings.Repeat("y", 300)
+		llm := &pingMockLLM{name: "mock", responses: []*model.LLMResponse{
+			{Content: genai.NewContentFromText(long, genai.RoleModel)},
+		}}
+		w, read := captureWriter(t)
+		text, err := modelPingStream(context.Background(), llm, newPingRequest("hi", false), w)
+		if err != nil {
+			t.Fatalf("modelPingStream: %v", err)
+		}
+		if text != long {
+			t.Error("the returned reply must not be truncated")
+		}
+		if out := read(); !strings.Contains(out, "Reply: "+strings.Repeat("y", 200)+"...") {
+			t.Errorf("expected a 200-char preview, got:\n%s", out)
+		}
+	})
+
+	t.Run("an empty reply prints no preview line", func(t *testing.T) {
+		t.Parallel()
+		llm := &pingMockLLM{name: "mock", responses: []*model.LLMResponse{{TurnComplete: true}}}
+		w, read := captureWriter(t)
+		text, err := modelPingStream(context.Background(), llm, newPingRequest("hi", false), w)
+		if err != nil || text != "" {
+			t.Fatalf("got (%q, %v), want (\"\", nil)", text, err)
+		}
+		if out := read(); strings.Contains(out, "Reply:") {
+			t.Errorf("expected no Reply line for empty output, got:\n%s", out)
+		}
+	})
+}
+
+// streamAwareLLM answers differently depending on the stream flag, which is the
+// only way to reach modelPing's "the stream failed but the non-stream did not"
+// branch — a mock that fails both calls stops at the non-stream check first.
+type streamAwareLLM struct {
+	name        string
+	nonStream   []*model.LLMResponse
+	streamErr   error
+	streamTexts []string
+}
+
+func (m *streamAwareLLM) Name() string { return m.name }
+
+func (m *streamAwareLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		if !stream {
+			for _, r := range m.nonStream {
+				if !yield(r, nil) {
+					return
+				}
+			}
+			return
+		}
+		if m.streamErr != nil {
+			yield(nil, m.streamErr)
+			return
+		}
+		for _, text := range m.streamTexts {
+			if !yield(&model.LLMResponse{Content: genai.NewContentFromText(text, genai.RoleModel)}, nil) {
+				return
+			}
+		}
+	}
+}
+
+// A stream failure returns the text the non-streaming call already produced,
+// not the streaming accumulator — a caller that reported the empty streaming
+// result would throw away a reply that proves the model is alive.
+func TestModelPingStreamFailureReturnsNonStreamText(t *testing.T) {
+	t.Parallel()
+	llm := &streamAwareLLM{
+		name:      "mock",
+		nonStream: []*model.LLMResponse{{Content: genai.NewContentFromText("ns reply", genai.RoleModel)}},
+		streamErr: errors.New("stream died"),
+	}
+	reply, err := modelPing(context.Background(), llm, "hi", false, "openai")
+	if err == nil || !strings.Contains(err.Error(), "streaming LLM error") {
+		t.Fatalf("err = %v, want a streaming LLM error", err)
+	}
+	if reply != "ns reply" {
+		t.Errorf("reply = %q, want the non-streaming text %q", reply, "ns reply")
+	}
+}
+
+// When the non-streaming call comes back empty the streaming text is the reply.
+func TestModelPingEmptyNonStreamFallsBackToStream(t *testing.T) {
+	t.Parallel()
+	llm := &streamAwareLLM{
+		name:        "mock",
+		nonStream:   []*model.LLMResponse{{TurnComplete: true}},
+		streamTexts: []string{"stream only"},
+	}
+	reply, err := modelPing(context.Background(), llm, "hi", false, "openai")
+	if err != nil {
+		t.Fatalf("modelPing: %v", err)
+	}
+	if reply != "stream only" {
+		t.Errorf("reply = %q, want %q", reply, "stream only")
+	}
+}
+
+// Both modes silent is the one case that is a hard failure.
+func TestModelPingBothModesEmpty(t *testing.T) {
+	t.Parallel()
+	llm := &streamAwareLLM{name: "mock", nonStream: []*model.LLMResponse{{TurnComplete: true}}}
+	if _, err := modelPing(context.Background(), llm, "hi", false, "openai"); err == nil ||
+		!strings.Contains(err.Error(), "empty response in both streaming and non-streaming modes") {
+		t.Fatalf("err = %v, want the both-modes-empty error", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ollamaPingFull helpers
+// ---------------------------------------------------------------------------
+
+// ollamaStreamAwareServer answers /api/chat differently for the streaming and
+// non-streaming calls, which mockOllamaPingServer cannot do. The non-streaming
+// request is the one that carries "stream":false.
+func ollamaStreamAwareServer(t *testing.T, models []string, nonStreamText, streamText string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			resp := struct {
+				Models []struct{ Name string } `json:"models"`
+			}{}
+			for _, m := range models {
+				resp.Models = append(resp.Models, struct{ Name string }{Name: m})
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/api/chat":
+			body, _ := io.ReadAll(r.Body)
+			text := streamText
+			if strings.Contains(string(body), `"stream":false`) {
+				text = nonStreamText
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]string{"role": "assistant", "content": text},
+				"done":    true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Which of the two probes the reply comes from is the branch under test. The
+// assertions name the source rather than the exact string, because the mock
+// server's single JSON object is read as more than one streaming event and the
+// resulting chunk count is an artifact of the mock, not of ollamaPingFull.
+func TestOllamaPingFullReplySelection(t *testing.T) {
+	const nsMarker, sMarker = "NONSTREAM", "STREAMED"
+
+	tests := []struct {
+		name                      string
+		nonStreamText, streamText string
+		wantFrom                  string
+		notFrom                   string
+		wantErr                   string
+	}{
+		{
+			name:          "non-stream wins when both answer",
+			nonStreamText: nsMarker, streamText: sMarker,
+			wantFrom: nsMarker, notFrom: sMarker,
+		},
+		{
+			name:       "empty non-stream falls back to the stream",
+			streamText: sMarker,
+			wantFrom:   sMarker,
+		},
+		{name: "both silent is an error", wantErr: "empty response in both modes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := ollamaStreamAwareServer(t, []string{"test-model"}, tt.nonStreamText, tt.streamText)
+			w, _ := captureWriter(t)
+			reply, err := ollamaPingFull(context.Background(), srv.URL, "test-model", "hello", false, w)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want it to mention %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ollamaPingFull: %v", err)
+			}
+			if !strings.Contains(reply, tt.wantFrom) {
+				t.Errorf("reply = %q, want it to come from %s", reply, tt.wantFrom)
+			}
+			if tt.notFrom != "" && strings.Contains(reply, tt.notFrom) {
+				t.Errorf("reply = %q, must not include the %s probe's text", reply, tt.notFrom)
+			}
+		})
+	}
+}
+
+func TestOllamaEnsureModel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		available []string
+		want      string
+		wantErr   string
+	}{
+		{name: "exact match", available: []string{"llama3:8b"}, want: "llama3:8b"},
+		{name: "tag-less prefix match", available: []string{"llama3:8b"}, want: "llama3"},
+		{name: "not served", available: []string{"mistral"}, want: "llama3", wantErr: "not found in available models"},
+		{name: "empty daemon", available: nil, want: "llama3", wantErr: "not found in available models"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := mockOllamaPingServer(t, tt.available, "")
+			defer srv.Close()
+			w, read := captureWriter(t)
+			err := ollamaEnsureModel(context.Background(), srv.URL, tt.want, w)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want it to mention %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ollamaEnsureModel: %v", err)
+			}
+			if out := read(); !strings.Contains(out, "found ✓") {
+				t.Errorf("expected a found line, got:\n%s", out)
+			}
+		})
+	}
+}
+
+// A daemon that cannot be reached at all is a different failure from a model
+// that is not served, and the wrapping says which.
+func TestOllamaEnsureModelListFailure(t *testing.T) {
+	t.Parallel()
+	w, _ := captureWriter(t)
+	err := ollamaEnsureModel(context.Background(), "http://127.0.0.1:1", "llama3", w)
+	if err == nil || !strings.Contains(err.Error(), "list models") {
+		t.Fatalf("err = %v, want it wrapped as a list-models failure", err)
+	}
+}
+
+func TestAppendOllamaPingText(t *testing.T) {
+	t.Parallel()
+	thinkingResp := func() *model.LLMResponse {
+		return &model.LLMResponse{Content: &genai.Content{
+			Role: "thinking", Parts: []*genai.Part{{Text: "hmm"}},
+		}}
+	}
+	tests := []struct {
+		name         string
+		resp         *model.LLMResponse
+		skipThinking bool
+		wantChunks   int
+		wantOut      string
+	}{
+		{name: "nil content", resp: &model.LLMResponse{}},
+		{
+			name: "model text is taken either way",
+			resp: &model.LLMResponse{Content: &genai.Content{
+				Role: genai.RoleModel, Parts: []*genai.Part{{Text: "a"}, {Text: "b"}},
+			}},
+			skipThinking: true, wantChunks: 2, wantOut: "ab",
+		},
+		{
+			// The streaming probe drops thinking output...
+			name: "thinking dropped when skipping",
+			resp: thinkingResp(), skipThinking: true,
+		},
+		{
+			// ...while the non-streaming probe has always kept every text part.
+			name: "thinking kept when not skipping",
+			resp: thinkingResp(), skipThinking: false, wantChunks: 1, wantOut: "hmm",
+		},
+		{
+			name: "empty text is never a chunk",
+			resp: &model.LLMResponse{Content: &genai.Content{
+				Role: genai.RoleModel, Parts: []*genai.Part{{Text: ""}},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var sb strings.Builder
+			got := appendOllamaPingText(tt.resp, &sb, tt.skipThinking)
+			if got != tt.wantChunks {
+				t.Errorf("chunks = %d, want %d", got, tt.wantChunks)
+			}
+			if sb.String() != tt.wantOut {
+				t.Errorf("accumulated %q, want %q", sb.String(), tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestLogOllamaPingUsage(t *testing.T) {
+	t.Parallel()
+	w, read := captureWriter(t)
+	logOllamaPingUsage(w, "non-stream", &model.LLMResponse{})
+	if out := read(); out != "" {
+		t.Errorf("expected nothing without usage metadata, got:\n%s", out)
+	}
+
+	w2, read2 := captureWriter(t)
+	logOllamaPingUsage(w2, "stream", &model.LLMResponse{UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount: 3, CandidatesTokenCount: 4,
+	}})
+	out := read2()
+	if !strings.Contains(out, "[stream]") || !strings.Contains(out, "tokens(in=3 out=4)") {
+		t.Errorf("unexpected usage line:\n%s", out)
+	}
+}
+
+func TestOllamaPingNonStreamAndStream(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-stream keeps thinking text", func(t *testing.T) {
+		t.Parallel()
+		llm := &cliThinkingLLM{name: "mock", thoughtText: "hmm", responseText: "hi"}
+		w, read := captureWriter(t)
+		text, err := ollamaPingNonStream(context.Background(), llm, newPingRequest("p", false), w)
+		if err != nil {
+			t.Fatalf("ollamaPingNonStream: %v", err)
+		}
+		if text != "hmmhi" {
+			t.Errorf("text = %q, want %q", text, "hmmhi")
+		}
+		if out := read(); !strings.Contains(out, "[non-stream] Done") && !strings.Contains(out, "Done") {
+			t.Errorf("expected a Done line, got:\n%s", out)
+		}
+	})
+
+	t.Run("stream drops thinking text and counts chunks", func(t *testing.T) {
+		t.Parallel()
+		llm := &cliThinkingLLM{name: "mock", thoughtText: "hmm", responseText: "hi"}
+		w, read := captureWriter(t)
+		text, err := ollamaPingStream(context.Background(), llm, newPingRequest("p", false), w)
+		if err != nil {
+			t.Fatalf("ollamaPingStream: %v", err)
+		}
+		if text != "hi" {
+			t.Errorf("text = %q, want %q", text, "hi")
+		}
+		if out := read(); !strings.Contains(out, "1 chunks") {
+			t.Errorf("expected one counted chunk, got:\n%s", out)
+		}
+	})
+
+	t.Run("errors are wrapped per phase", func(t *testing.T) {
+		t.Parallel()
+		llm := &pingMockLLM{name: "mock", err: errors.New("down")}
+		w, _ := captureWriter(t)
+		if _, err := ollamaPingNonStream(context.Background(), llm, newPingRequest("p", false), w); err == nil ||
+			!strings.Contains(err.Error(), "non-streaming:") {
+			t.Errorf("non-stream err = %v, want a \"non-streaming:\" prefix", err)
+		}
+		if _, err := ollamaPingStream(context.Background(), llm, newPingRequest("p", false), w); err == nil ||
+			!strings.Contains(err.Error(), "streaming:") {
+			t.Errorf("stream err = %v, want a \"streaming:\" prefix", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// resolvePingTarget helpers
+// ---------------------------------------------------------------------------
+
+func TestPingRoleFromFlags(t *testing.T) {
+	origSmol, origSlow, origPlan := flagSmol, flagSlow, flagPlan
+	t.Cleanup(func() { flagSmol, flagSlow, flagPlan = origSmol, origSlow, origPlan })
+
+	tests := []struct {
+		name             string
+		smol, slow, plan bool
+		want             string
+	}{
+		{name: "no flag", want: "default"},
+		{name: "smol", smol: true, want: "smol"},
+		{name: "slow", slow: true, want: "slow"},
+		{name: "plan", plan: true, want: "plan"},
+		// The switch is ordered, so smol wins when several are set.
+		{name: "smol wins over slow and plan", smol: true, slow: true, plan: true, want: "smol"},
+		{name: "slow wins over plan", slow: true, plan: true, want: "slow"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagSmol, flagSlow, flagPlan = tt.smol, tt.slow, tt.plan
+			if got := pingRoleFromFlags(); got != tt.want {
+				t.Errorf("pingRoleFromFlags() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvePingCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		info        provider.Info
+		baseURL     string
+		explicit    bool
+		env         map[string]string
+		wantBaseURL string
+		wantCodex   bool
+	}{
+		{
+			name:        "default base URL fills in for a bare provider",
+			info:        provider.Info{Provider: "anthropic", Model: "claude-x"},
+			wantBaseURL: "https://api.anthropic.com",
+		},
+		{
+			name:        "a configured base URL survives",
+			info:        provider.Info{Provider: "openai", Model: "gpt-x"},
+			baseURL:     "https://proxy.example",
+			explicit:    true,
+			wantBaseURL: "https://proxy.example",
+		},
+		{
+			name:        "an unknown provider gets no default",
+			info:        provider.Info{Provider: "who", Model: "m"},
+			wantBaseURL: "",
+		},
+		{
+			name:        "ollama routes through the tag resolver",
+			info:        provider.Info{Provider: "ollama", Model: "qwen3:8b", Ollama: true},
+			wantBaseURL: "http://localhost:11434",
+		},
+		{
+			name:        "azure reads its endpoint env var",
+			info:        provider.Info{Provider: "azure", Model: "gpt-4o"},
+			env:         map[string]string{"AZURE_OPENAI_ENDPOINT": "https://unit.openai.azure.com"},
+			wantBaseURL: "https://unit.openai.azure.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("OLLAMA_HOST", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			gotURL, _, gotCodex := resolvePingCredentials(tt.info, tt.baseURL, tt.explicit)
+			if gotURL != tt.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", gotURL, tt.wantBaseURL)
+			}
+			if gotCodex != tt.wantCodex {
+				t.Errorf("codexBackend = %v, want %v", gotCodex, tt.wantCodex)
+			}
+		})
+	}
+}
+
+func TestPingProbePaths(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		info          provider.Info
+		baseURL       string
+		codex         bool
+		wantEndpoint  string
+		wantFallbacks bool
+	}{
+		{
+			name: "codex overrides everything with POST /responses",
+			// The provider is openai, which would otherwise probe /v1/models.
+			info: provider.Info{Provider: "openai", Model: "gpt-5"}, baseURL: codexPingBaseURL,
+			codex: true, wantEndpoint: "/responses",
+		},
+		{
+			name: "openai probes the model list",
+			info: provider.Info{Provider: "openai", Model: "gpt-5"}, baseURL: "https://api.openai.com",
+			wantEndpoint: "/v1/models",
+		},
+		{
+			name: "a /v1 base URL is not doubled up",
+			info: provider.Info{Provider: "openai", Model: "gpt-5"}, baseURL: "https://proxy.example/v1",
+			wantEndpoint: "/models",
+		},
+		{
+			name: "anthropic probes messages",
+			info: provider.Info{Provider: "anthropic", Model: "claude-x"}, baseURL: "https://api.anthropic.com",
+			wantEndpoint: "/v1/messages",
+		},
+		{
+			name: "azure supplies fallbacks",
+			info: provider.Info{Provider: "azure", Model: "gpt-4o"}, baseURL: "https://unit.openai.azure.com",
+			wantFallbacks: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			endpoint, fallbacks := pingProbePaths(tt.info, tt.baseURL, tt.codex)
+			if tt.wantEndpoint != "" && endpoint != tt.wantEndpoint {
+				t.Errorf("endpoint = %q, want %q", endpoint, tt.wantEndpoint)
+			}
+			if tt.wantFallbacks {
+				if endpoint == "" {
+					t.Error("azure must still name a first probe path")
+				}
+				if len(fallbacks) == 0 {
+					t.Error("azure must supply at least one fallback path")
+				}
+				return
+			}
+			if len(fallbacks) != 0 {
+				t.Errorf("fallbacks = %v, want none — only azure has them", fallbacks)
+			}
+		})
+	}
+}
+
+func TestResolvePingModelInfo(t *testing.T) {
+	origURL, origModel := flagURL, flagModel
+	t.Cleanup(func() { flagURL, flagModel = origURL, origModel })
+	flagURL, flagModel = "", ""
+	t.Setenv("HOME", t.TempDir())
+
+	t.Run("a configured provider wins over inference", func(t *testing.T) {
+		cfg := config.Config{Roles: map[string]config.RoleConfig{
+			"default": {Model: "claude-sonnet-4-5", Provider: "anthropic"},
+		}}
+		info, _, explicit, err := resolvePingModelInfo(cfg, "default")
+		if err != nil {
+			t.Fatalf("resolvePingModelInfo: %v", err)
+		}
+		if info.Provider != "anthropic" {
+			t.Errorf("provider = %q, want anthropic", info.Provider)
+		}
+		if explicit {
+			t.Error("no --url and no configured base URL means the base URL is not explicit")
+		}
+	})
+
+	t.Run("--url marks the base URL explicit", func(t *testing.T) {
+		flagURL = "https://proxy.example"
+		t.Cleanup(func() { flagURL = "" })
+		cfg := config.Config{Roles: map[string]config.RoleConfig{
+			"default": {Model: "gpt-5", Provider: "openai"},
+		}}
+		_, baseURL, explicit, err := resolvePingModelInfo(cfg, "default")
+		if err != nil {
+			t.Fatalf("resolvePingModelInfo: %v", err)
+		}
+		if baseURL != "https://proxy.example" || !explicit {
+			t.Errorf("got (%q, %v), want (\"https://proxy.example\", true)", baseURL, explicit)
+		}
+	})
+
+	t.Run("an unresolvable role is an error", func(t *testing.T) {
+		cfg := config.Config{Roles: map[string]config.RoleConfig{}}
+		if _, _, _, err := resolvePingModelInfo(cfg, "nope"); err == nil {
+			t.Fatal("expected an error for a role with no model")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// reportHTTPVerdict's per-status helpers
+// ---------------------------------------------------------------------------
+
+func TestPingVerdictHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reachable resolves an openai alias", func(t *testing.T) {
+		t.Parallel()
+		target := pingVerdictTarget("openai")
+		target.info.Model = "gpt-5"
+		resp := &http.Response{
+			Status: "200 OK",
+			Body:   io.NopCloser(strings.NewReader(`{"data":[{"id":"gpt-5.1"}]}`)),
+		}
+		w, read := captureWriter(t)
+		if !target.verdictReachable(w, resp) {
+			t.Fatal("a 2xx must count as reachable")
+		}
+		if target.info.Model != "gpt-5.1" {
+			t.Errorf("model = %q, want the resolved alias gpt-5.1", target.info.Model)
+		}
+		if out := read(); !strings.Contains(out, "Endpoint reachable") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+	})
+
+	t.Run("reachable leaves non-openai models alone", func(t *testing.T) {
+		t.Parallel()
+		target := pingVerdictTarget("anthropic")
+		w, _ := captureWriter(t)
+		resp := &http.Response{Status: "200 OK", Body: io.NopCloser(strings.NewReader(`{"data":[{"id":"x"}]}`))}
+		if !target.verdictReachable(w, resp) {
+			t.Fatal("a 2xx must count as reachable")
+		}
+		if target.info.Model != "test-model" {
+			t.Errorf("model = %q, want it untouched", target.info.Model)
+		}
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		t.Parallel()
+		target := pingVerdictTarget("openai")
+		w, read := captureWriter(t)
+		if target.verdictUnauthorized(w, 401, false) {
+			t.Error("401 without a custom azure endpoint must stop the run")
+		}
+		if out := read(); !strings.Contains(out, "Authentication failed") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+
+		w2, read2 := captureWriter(t)
+		if !target.verdictUnauthorized(w2, 403, true) {
+			t.Error("a custom azure endpoint is allowed to reject the probe")
+		}
+		if out := read2(); !strings.Contains(out, "continuing with model ping") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		w, read := captureWriter(t)
+		if pingVerdictTarget("openai").verdictNotFound(w, 404) {
+			t.Error("404 stops a non-azure run")
+		}
+		if out := read(); !strings.Contains(out, "Endpoint not found") || !strings.Contains(out, "https://example.com") {
+			t.Errorf("expected the base URL to be named, got:\n%s", out)
+		}
+
+		w2, read2 := captureWriter(t)
+		if !pingVerdictTarget("azure").verdictNotFound(w2, 404) {
+			t.Error("404 continues for azure")
+		}
+		if out := read2(); !strings.Contains(out, "continuing with model ping") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+	})
+
+	t.Run("unprocessable", func(t *testing.T) {
+		t.Parallel()
+		target := pingVerdictTarget("azure")
+		resp := &http.Response{Status: "422 Unprocessable Entity"}
+		w, read := captureWriter(t)
+		if target.verdictUnprocessable(w, resp, false) {
+			t.Error("422 without a custom endpoint is a dead end")
+		}
+		if out := read(); !strings.Contains(out, "Unexpected status") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+
+		w2, read2 := captureWriter(t)
+		if !target.verdictUnprocessable(w2, resp, true) {
+			t.Error("422 on a custom proxy continues to the model ping")
+		}
+		if out := read2(); !strings.Contains(out, "structured POST") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// model list helpers
+// ---------------------------------------------------------------------------
+
+func TestSelectModelListProviders(t *testing.T) {
+	origURL := flagURL
+	t.Cleanup(func() { flagURL = origURL })
+
+	tests := []struct {
+		name        string
+		args        []string
+		keys        map[string]string
+		baseURLs    map[string]string
+		flagURL     string
+		azureEnv    string
+		want        []string
+		wantErr     string
+		wantPrinted string
+	}{
+		{
+			name: "a named provider is queried alone",
+			args: []string{"anthropic"}, want: []string{"anthropic"},
+		},
+		{
+			name: "the name is case-insensitive",
+			args: []string{"OpenAI"}, want: []string{"openai"},
+		},
+		{
+			name: "azure prints its catalog and queries nothing",
+			args: []string{"azure"}, want: nil, wantPrinted: "azure (",
+		},
+		{
+			name: "an unknown name is an error",
+			args: []string{"nope"}, wantErr: `unknown provider "nope"`,
+		},
+		{
+			name: "ollama is always queried, keys or not",
+			keys: map[string]string{}, want: []string{"ollama"},
+		},
+		{
+			name: "a key opts a provider in",
+			keys: map[string]string{"anthropic": "sk-a"},
+			want: []string{"anthropic", "ollama"},
+		},
+		{
+			name:     "a base URL opts a provider in without a key",
+			baseURLs: map[string]string{"mistral": "https://m.example"},
+			want:     []string{"mistral", "ollama"},
+		},
+		{
+			name:    "--url opts every provider in",
+			flagURL: "https://proxy.example",
+			want:    []string{"anthropic", "openai", "gemini", "mistral", "xai", "ollama", "openrouter"},
+		},
+		{
+			name: "a configured azure prints alongside the queried providers",
+			keys: map[string]string{"azure": "sk-az"}, want: []string{"ollama"},
+			wantPrinted: "azure (",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagURL = tt.flagURL
+			t.Setenv("AZURE_OPENAI_ENDPOINT", tt.azureEnv)
+			keys, baseURLs := tt.keys, tt.baseURLs
+			if keys == nil {
+				keys = map[string]string{}
+			}
+			if baseURLs == nil {
+				baseURLs = map[string]string{}
+			}
+
+			var out strings.Builder
+			got, err := selectModelListProviders(&out, tt.args, keys, baseURLs)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want it to mention %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("selectModelListProviders: %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("providers = %v, want %v", got, tt.want)
+			}
+			if tt.wantPrinted != "" && !strings.Contains(out.String(), tt.wantPrinted) {
+				t.Errorf("expected %q in the printed output, got:\n%s", tt.wantPrinted, out.String())
+			}
+			if tt.wantPrinted == "" && out.String() != "" {
+				t.Errorf("expected nothing printed, got:\n%s", out.String())
+			}
+		})
+	}
+}
+
+// With nothing configured at all the command has to say so rather than exit
+// quietly — but a lone Azure setup is a configuration, so it does not error.
+func TestSelectModelListProvidersNothingConfigured(t *testing.T) {
+	origURL := flagURL
+	t.Cleanup(func() { flagURL = origURL })
+	flagURL = ""
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "")
+
+	// allProviders always contributes ollama, so the empty case is reached by
+	// asking about a provider set that excludes it.
+	origAll := allProviders
+	t.Cleanup(func() { allProviders = origAll })
+	allProviders = []string{"anthropic"}
+
+	var out strings.Builder
+	if _, err := selectModelListProviders(&out, nil, map[string]string{}, map[string]string{}); err == nil ||
+		!strings.Contains(err.Error(), "no providers configured") {
+		t.Fatalf("err = %v, want a no-providers-configured error", err)
+	}
+
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "https://unit.openai.azure.com")
+	var out2 strings.Builder
+	got, err := selectModelListProviders(&out2, nil, map[string]string{}, map[string]string{})
+	if err != nil {
+		t.Fatalf("a configured azure must not be an error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("providers = %v, want none to query", got)
+	}
+	if !strings.Contains(out2.String(), "azure (") {
+		t.Errorf("expected the azure catalog, got:\n%s", out2.String())
+	}
+}
+
+func TestModelListBaseURL(t *testing.T) {
+	origURL := flagURL
+	t.Cleanup(func() { flagURL = origURL })
+
+	tests := []struct {
+		name     string
+		provider string
+		flagURL  string
+		baseURLs map[string]string
+		want     string
+	}{
+		{name: "--url wins", provider: "openai", flagURL: "https://flag.example",
+			baseURLs: map[string]string{"openai": "https://cfg.example"}, want: "https://flag.example"},
+		{name: "config is next", provider: "openai",
+			baseURLs: map[string]string{"openai": "https://cfg.example"}, want: "https://cfg.example"},
+		{name: "ollama falls back to localhost", provider: "ollama", want: "http://localhost:11434"},
+		{name: "--url beats the ollama default", provider: "ollama", flagURL: "https://flag.example",
+			want: "https://flag.example"},
+		{name: "everyone else gets nothing", provider: "anthropic", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagURL = tt.flagURL
+			baseURLs := tt.baseURLs
+			if baseURLs == nil {
+				baseURLs = map[string]string{}
+			}
+			if got := modelListBaseURL(tt.provider, baseURLs); got != tt.want {
+				t.Errorf("modelListBaseURL(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintProviderModels(t *testing.T) {
+	out := captureStdout(t, func() {
+		printProviderModels("openai", []provider.ModelInfo{
+			{ID: "gpt-z"},
+			{ID: "gpt-a", OwnedBy: "openai"},
+		})
+	})
+	if !strings.Contains(out, "openai (2 models):") {
+		t.Errorf("expected the count header, got:\n%s", out)
+	}
+	// Sorted by ID, so gpt-a comes first, and only it shows an owner.
+	if strings.Index(out, "gpt-a") > strings.Index(out, "gpt-z") {
+		t.Errorf("models are not sorted by ID:\n%s", out)
+	}
+	if !strings.Contains(out, "gpt-a") || !strings.Contains(out, "openai\n") {
+		t.Errorf("expected the owner column for gpt-a, got:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// memory recent helpers
+// ---------------------------------------------------------------------------
+
+func obsOfType(typ string) *memory.Observation {
+	return &memory.Observation{Type: memory.ObservationType(typ), Title: "t " + typ, CreatedAt: time.Now()}
+}
+
+func TestLimitRecentObservations(t *testing.T) {
+	t.Parallel()
+	mixed := []*memory.Observation{
+		obsOfType("bugfix"), obsOfType("decision"), obsOfType("bugfix"), obsOfType("feature"),
+	}
+	tests := []struct {
+		name     string
+		in       []*memory.Observation
+		obsType  string
+		limit    int
+		wantLen  int
+		wantType string
+	}{
+		{name: "no filter truncates to the limit", in: mixed, limit: 2, wantLen: 2},
+		{name: "no filter keeps a short list whole", in: mixed, limit: 10, wantLen: 4},
+		{name: "no filter at the exact limit", in: mixed, limit: 4, wantLen: 4},
+		{name: "filter keeps only the type", in: mixed, obsType: "bugfix", limit: 10, wantLen: 2, wantType: "bugfix"},
+		{name: "filter stops at the limit", in: mixed, obsType: "bugfix", limit: 1, wantLen: 1, wantType: "bugfix"},
+		{name: "filter with no hits yields nothing", in: mixed, obsType: "refactor", limit: 10, wantLen: 0},
+		{name: "empty input", in: nil, limit: 5, wantLen: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := limitRecentObservations(tt.in, tt.obsType, tt.limit)
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			for _, obs := range got {
+				if tt.wantType != "" && string(obs.Type) != tt.wantType {
+					t.Errorf("type = %q, want %q", obs.Type, tt.wantType)
+				}
+			}
+		})
+	}
+}
+
+func TestPrintRecentReport(t *testing.T) {
+	t.Run("empty names the project", func(t *testing.T) {
+		out := captureStdout(t, func() { printRecentReport("/tmp/proj", nil, nil) })
+		if !strings.Contains(out, "No observations found.") || !strings.Contains(out, "Project: /tmp/proj") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+	})
+
+	t.Run("observations only", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printRecentReport("/tmp/proj", []*memory.Observation{obsOfType("bugfix")}, nil)
+		})
+		if !strings.Contains(out, "Observations (1)") || !strings.Contains(out, "t bugfix") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+		if strings.Contains(out, "Session Summaries") {
+			t.Errorf("no summaries means no summary section:\n%s", out)
+		}
+	})
+
+	t.Run("summaries only, with a long request truncated", func(t *testing.T) {
+		long := strings.Repeat("q", 200)
+		out := captureStdout(t, func() {
+			printRecentReport("/tmp/proj", nil, []*memory.SessionSummary{
+				{Request: long, CreatedAt: time.Now()},
+			})
+		})
+		if !strings.Contains(out, "Session Summaries (1)") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+		if !strings.Contains(out, strings.Repeat("q", 80)+"...") {
+			t.Errorf("expected the request truncated at 80 chars, got:\n%s", out)
+		}
+		if strings.Contains(out, "Observations (") {
+			t.Errorf("no observations means no observation section:\n%s", out)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// memory mine helpers
+// ---------------------------------------------------------------------------
+
+func TestSkipMineDir(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"node_modules", true},
+		{"vendor", true},
+		{".git", true},
+		{".hidden", true},
+		{".", false},
+		{"internal", false},
+		{"src", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := skipMineDir(tt.name); got != tt.want {
+				t.Errorf("skipMineDir(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMineFileEligible(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return p
+	}
+	entryFor := func(path string) os.DirEntry {
+		t.Helper()
+		entries, err := os.ReadDir(filepath.Dir(path))
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		for _, e := range entries {
+			if e.Name() == filepath.Base(path) {
+				return e
+			}
+		}
+		t.Fatalf("no dir entry for %s", path)
+		return nil
+	}
+
+	goFile := write("a.go", "package main\n")
+	blank := write("blank.go", "   \n\t\n")
+	binary := write("x.bin", "data")
+	jsonl := write("chat.jsonl", "{}\n")
+	big := write("big.go", strings.Repeat("x", 512*1024+1))
+
+	tests := []struct {
+		name   string
+		path   string
+		convos bool
+		want   bool
+	}{
+		{name: "supported source file", path: goFile, want: true},
+		{name: "unsupported extension", path: binary, want: false},
+		{name: "blank file is skipped", path: blank, want: false},
+		{name: "oversized file is skipped", path: big, want: false},
+		{name: "convos takes jsonl", path: jsonl, convos: true, want: true},
+		{name: "convos ignores source files", path: goFile, convos: true, want: false},
+		// A convos run applies none of the size or content checks.
+		{name: "convos does not check size", path: write("big.md", strings.Repeat("y", 512*1024+1)), convos: true, want: true},
+		{name: "convos does not check for content", path: write("empty.txt", ""), convos: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mineFileEligible(tt.path, entryFor(tt.path), tt.convos); got != tt.want {
+				t.Errorf("mineFileEligible(%q, convos=%v) = %v, want %v",
+					filepath.Base(tt.path), tt.convos, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintMineFileList(t *testing.T) {
+	out := captureStdout(t, func() { printMineFileList([]string{"a.go", "b.go"}) })
+	if !strings.Contains(out, "Files (2 total):") {
+		t.Errorf("expected the total, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[ 1] a.go") || !strings.Contains(out, "[ 2] b.go") {
+		t.Errorf("expected a 1-based numbered list, got:\n%s", out)
+	}
+}
+
+func TestMinePalaceConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := minePalaceConfig("/tmp/db.sqlite", "/tmp/model")
+	if cfg.DBPath != "/tmp/db.sqlite" || cfg.ModelPath != "/tmp/model" {
+		t.Errorf("paths not carried through: %+v", cfg)
+	}
+	// With no user config on disk the palace defaults have to survive intact.
+	def := palace.DefaultConfig()
+	if cfg.UseOllama != def.UseOllama || cfg.OllamaURL != def.OllamaURL || cfg.OllamaModel != def.OllamaModel {
+		t.Errorf("embedder defaults were altered: %+v", cfg)
+	}
+}
+
+func TestPrintMineBanner(t *testing.T) {
+	t.Run("ollama embedder names the daemon", func(t *testing.T) {
+		cfg := palace.PalaceConfig{UseOllama: true, OllamaModel: "embed-m", OllamaURL: "http://d:1"}
+		out := captureStdout(t, func() { printMineBanner(cfg, "/db", "/model", "wing-x") })
+		for _, want := range []string{"Palace DB: /db", "ollama embed-m (http://d:1)", "Wing:      wing-x"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("local embedder names the model path", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printMineBanner(palace.PalaceConfig{UseOllama: false}, "/db", "/model", "wing-x")
+		})
+		if !strings.Contains(out, "in-process /model") {
+			t.Errorf("expected the in-process line, got:\n%s", out)
+		}
+	})
+}
+
+func TestMinePalaceOptions(t *testing.T) {
+	t.Parallel()
+	// Both variants add exactly one embedder option to the two path options.
+	if got := len(minePalaceOptions(palace.PalaceConfig{UseOllama: true}, "/db", "/model")); got != 3 {
+		t.Errorf("ollama options = %d, want 3", got)
+	}
+	if got := len(minePalaceOptions(palace.PalaceConfig{UseOllama: false}, "/db", "/model")); got != 3 {
+		t.Errorf("local options = %d, want 3", got)
+	}
+
+	// The options have to actually configure the embedder they name.
+	ollamaCfg := palace.DefaultConfig()
+	for _, opt := range minePalaceOptions(palace.PalaceConfig{
+		UseOllama: true, OllamaURL: "http://d:1", OllamaModel: "embed-m",
+	}, "/db", "/model") {
+		opt(&ollamaCfg)
+	}
+	if !ollamaCfg.UseOllama || ollamaCfg.OllamaURL != "http://d:1" || ollamaCfg.OllamaModel != "embed-m" {
+		t.Errorf("ollama options did not apply: %+v", ollamaCfg)
+	}
+
+	localCfg := palace.DefaultConfig()
+	for _, opt := range minePalaceOptions(palace.PalaceConfig{UseOllama: false}, "/db", "/model") {
+		opt(&localCfg)
+	}
+	if localCfg.UseOllama {
+		t.Error("local options must turn the ollama embedder off")
+	}
+}
+
+// The auto-init step has to fail loudly when it cannot create the directories
+// it needs — a silent failure here leaves the run indexing into nothing.
+func TestEnsureMineModelDirectoryFailure(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := ensureMineModel(filepath.Join(blocker, "sub", "palace.db"), filepath.Join(dir, "model", "m.onnx"))
+	if err == nil || !strings.Contains(err.Error(), "creating palace directory") {
+		t.Fatalf("err = %v, want a palace-directory failure", err)
+	}
+}

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
 	adkmodel "google.golang.org/adk/v2/model"
 	adktool "google.golang.org/adk/v2/tool"
 
@@ -151,10 +152,200 @@ func deferredInit(
 	// --- Phase 1: Core tools (fast, needed by everything) ---
 	send("tools", false)
 
+	coreTools, err := deferredInitCoreTools(sandboxRoot, worktreeDir, res)
+	if err != nil {
+		fail(err)
+		return
+	}
+	sandbox, bashSup := res.sandbox, res.bashSup
+
+	send("tools", true)
+
+	// --- Phase 2: Parallel subsystems ---
+	ps := runDeferredInitPhase2(ctx, cfg, cwd, send)
+
+	// --- Phase 3: Sequential finalization ---
+	send("agent", false)
+
+	// Store cleanup resources.
+	res.lspMgr = ps.lspMgr
+
+	// Build orchestrator (needs git results).
+	orch := subagent.NewOrchestrator(&cfg, ps.repoRoot, ps.agentConfigs)
+	orch.SetProviderOptions(flagURL, flagInsecure, flagHeaders)
+	res.orch = orch
+
+	// Build agent event channel and tools.
+	agentEventCh := make(chan tui.AgentSubEvent, 128)
+	agentEventCB := func(agentID, eventType, content string) {
+		select {
+		case agentEventCh <- tui.AgentSubEvent{AgentID: agentID, Kind: eventType, Content: content}:
+		default:
+		}
+	}
+	agentTools, _ := tools.AgentTools(orch, agentEventCB)
+	coreTools = append(coreTools, agentTools...)
+
+	// Stream live shell output to the same channel the subagent cards use. The
+	// prefix keeps the two streams apart; the non-blocking send in agentEventCB
+	// is what keeps a slow UI from stalling a running command.
+	bashSup.SetSink(func(execID, kind, content string) {
+		agentEventCB(execID, tui.BashEventKind(kind), content)
+	})
+
+	// Append LSP tools.
+	if ps.lspTools != nil {
+		coreTools = append(coreTools, ps.lspTools...)
+	}
+
+	coreTools, memStore, memRecorder := appendDeferredMemoryTools(cfg, cwd, coreTools)
+
+	// Build system instruction. The parts are kept so the context gauge can
+	// attribute overhead to each section; composing them here is what keeps the
+	// breakdown honest — instruction is literally parts.String().
+	instructionParts := buildDeferredInstructionParts()
+	instruction := instructionParts.String()
+
+	cbs := buildDeferredCallbacks(cfg, providerName, sandbox, ps.lspMgr, memRecorder)
+
+	// Session service.
+	sessionsPath, sessionSvc, err := openSessionService()
+	if err != nil {
+		fail(err)
+		return
+	}
+
+	mcpToolsets := ps.mcpToolsets
+	// Gemini search grounding (see agent.GeminiGroundingTool doc).
+	//
+	// APPEND — never replace. Assigning coreTools = []adktool.Tool{gTool} here
+	// leaves the agent with *no* tools at all: bash, read, write, edit, grep,
+	// ls, subagent, LSP and memory all vanish, and the model, given no function
+	// declarations, invents names like "execute_command" and gets back
+	// "tool not found. Available tools: " with an empty list.
+	//
+	// The built-in search coexists with function declarations: geminitool's
+	// ProcessRequest appends to req.Config.Tools rather than overwriting it, and
+	// a single Gemini turn will happily call `read` and `google_search` both.
+	if gTool, ok := agent.GeminiGroundingTool(providerName); ok {
+		coreTools = append(coreTools, gTool)
+	}
+
+	// Session logger. Created before the agent so it can capture the agent's
+	// non-fatal diagnostics (e.g. unresolved instruction placeholders) in the
+	// session log instead of leaking them to stderr and corrupting the TUI.
+	// SessionStart is deferred until the session ID is resolved below.
+	sessionLog, logErr := logger.New()
+	if logErr == nil {
+		res.sessionLog = sessionLog
+		// --trace-http entries are dropped until the log file exists; the
+		// transport is built before this point. See the matching note in
+		// cli.go. Detached on shutdown where sessionLog is closed.
+		httplog.SetSink(logger.HTTPSink(sessionLog))
+	}
+
+	// Create agent.
+	ag, err := agent.New(agent.Config{
+		Model:                llm,
+		Tools:                coreTools,
+		Toolsets:             mcpToolsets,
+		Instruction:          instruction,
+		SessionService:       sessionSvc,
+		BeforeToolCallbacks:  cbs.beforeTool,
+		AfterToolCallbacks:   cbs.afterTool,
+		BeforeModelCallbacks: cbs.beforeModel,
+		AfterModelCallbacks:  cbs.afterModel,
+		Logger:               sessionLog,
+	})
+	if err != nil {
+		fail(fmt.Errorf("creating agent: %w", err))
+		return
+	}
+
+	sessionID, defaultTitle, resumed, err := resolveDeferredSession(ctx, ag, sessionSvc, llm, providerName, baseURL)
+	if err != nil {
+		fail(err)
+		return
+	}
+
+	// Store session ID for resume hint on exit.
+	res.sessionID = sessionID
+
+	// Two-stage auto-compaction, installed as a pre-turn hook so history is
+	// only ever rewritten between turns. Buffered so a compaction notice never
+	// blocks the turn if the TUI is momentarily busy.
+	noticeCh := make(chan string, 8)
+	if hook := buildAutoCompactHook(autoCompactDeps{
+		SessionSvc:    sessionSvc,
+		Tracker:       tokenTracker,
+		Deduper:       cbs.deduper,
+		Cfg:           autoCompactConfigFrom(cfg),
+		Log:           sessionLog,
+		SummarizerLLM: llm,
+		Notify: func(msg string) {
+			select {
+			case noticeCh <- msg:
+			default:
+			}
+		},
+	}); hook != nil {
+		ag.SetPreTurnHook(hook)
+	}
+
+	// Capture ACP subagent events (claude, gemini) under the session dir.
+	res.orch.SetACPLogPath(filepath.Join(sessionsPath, sessionID, "acp.jsonl"))
+
+	// Session logger was created above; record the session start now that the
+	// session ID is known.
+	if logErr == nil {
+		sessionLog.SessionStart(sessionID, llm.Name(), "interactive")
+	}
+
+	// Commit message function.
+	commitMsgFn := buildCommitMsgFunc(ctx, cfg)
+
+	send("agent", true)
+
+	// Send final result.
+	ch <- tui.InitEvent{
+		Done: true,
+		Result: &tui.InitResult{
+			Agent:             ag,
+			SessionID:         sessionID,
+			SessionTitle:      defaultTitle,
+			Resumed:           resumed,
+			SessionService:    sessionSvc,
+			Orchestrator:      orch,
+			Logger:            sessionLog,
+			Skills:            ps.skills,
+			SkillDirs:         ps.skillDirs,
+			GenerateCommitMsg: commitMsgFn,
+			AgentEventCh:      agentEventCh,
+			SystemNoticeCh:    noticeCh,
+			ContextBreakdown: buildContextBreakdown(
+				instructionParts, coreTools, mcpToolsets, ps.skills, ps.agentConfigs),
+			TokenTracker:   tokenTracker,
+			CompactMetrics: cbs.compactMetrics,
+			GitBranch:      ps.gitBranch,
+			DiffAdded:      ps.diffAdded,
+			DiffRemoved:    ps.diffRemoved,
+			MCPToolsets:    ps.mcpToolsets,
+			MCPServers:     buildMCPServerConfigs(cfg),
+		},
+	}
+
+	if memStore != nil {
+		initMemoryAfterUI(ctx, cfg, cwd, sessionID, orch, memStore, memRecorder, res)
+	}
+}
+
+// deferredInitCoreTools builds the sandbox, the bash supervisor and the core
+// tool set. Both the sandbox and the supervisor are recorded on res as soon as
+// they exist, so a later failure here still leaves them for cleanup to close.
+func deferredInitCoreTools(sandboxRoot, worktreeDir string, res *initResources) ([]adktool.Tool, error) {
 	sandbox, err := tools.NewSandbox(sandboxRoot, worktreeDir)
 	if err != nil {
-		fail(fmt.Errorf("creating sandbox: %w", err))
-		return
+		return nil, fmt.Errorf("creating sandbox: %w", err)
 	}
 	res.sandbox = sandbox
 
@@ -171,41 +362,43 @@ func deferredInit(
 
 	coreTools, err := tools.CoreTools(sandbox, tools.WithBashSupervisor(bashSup))
 	if err != nil {
-		fail(fmt.Errorf("creating core tools: %w", err))
-		return
+		return nil, fmt.Errorf("creating core tools: %w", err)
 	}
 	bashCtlTools, err := tools.BashControlTools(bashSup)
 	if err != nil {
-		fail(fmt.Errorf("creating bash control tools: %w", err))
-		return
+		return nil, fmt.Errorf("creating bash control tools: %w", err)
 	}
-	coreTools = append(coreTools, bashCtlTools...)
+	return append(coreTools, bashCtlTools...), nil
+}
 
-	send("tools", true)
+// deferredParallelState collects what the phase-2 goroutines discover. Fields
+// written by more than one goroutine are guarded by mu.
+type deferredParallelState struct {
+	mu sync.Mutex
 
-	// --- Phase 2: Parallel subsystems ---
-	type parallelState struct {
-		mu sync.Mutex
+	// Git + subagents
+	repoRoot     string
+	agentConfigs []subagent.AgentConfig
+	gitBranch    string
+	diffAdded    int
+	diffRemoved  int
 
-		// Git + subagents
-		repoRoot     string
-		agentConfigs []subagent.AgentConfig
-		gitBranch    string
-		diffAdded    int
-		diffRemoved  int
+	// LSP
+	lspMgr   *lsp.Manager
+	lspTools []adktool.Tool
 
-		// LSP
-		lspMgr   *lsp.Manager
-		lspTools []adktool.Tool
+	// MCP
+	mcpToolsets []adktool.Toolset
 
-		// MCP
-		mcpToolsets []adktool.Toolset
+	// Skills
+	skills    []extension.Skill
+	skillDirs []string
+}
 
-		// Skills
-		skills    []extension.Skill
-		skillDirs []string
-	}
-	var ps parallelState
+// runDeferredInitPhase2 discovers git state, LSP servers, MCP toolsets and
+// skills concurrently and returns once all four are done.
+func runDeferredInitPhase2(ctx context.Context, cfg config.Config, cwd string, send func(item string, done bool)) *deferredParallelState {
+	var ps deferredParallelState
 	var wg sync.WaitGroup
 
 	// Git + subagent discovery
@@ -273,67 +466,53 @@ func deferredInit(
 	}()
 
 	wg.Wait()
+	return &ps
+}
 
-	// --- Phase 3: Sequential finalization ---
-	send("agent", false)
-
-	// Store cleanup resources.
-	res.lspMgr = ps.lspMgr
-
-	// Build orchestrator (needs git results).
-	orch := subagent.NewOrchestrator(&cfg, ps.repoRoot, ps.agentConfigs)
-	orch.SetProviderOptions(flagURL, flagInsecure, flagHeaders)
-	res.orch = orch
-
-	// Build agent event channel and tools.
-	agentEventCh := make(chan tui.AgentSubEvent, 128)
-	agentEventCB := func(agentID, eventType, content string) {
-		select {
-		case agentEventCh <- tui.AgentSubEvent{AgentID: agentID, Kind: eventType, Content: content}:
-		default:
-		}
+// appendDeferredMemoryTools adds the memory tools when memory is enabled and
+// returns the lazy store and observation recorder they run against. Both are
+// nil when memory is off, which is what gates the post-UI memory init.
+func appendDeferredMemoryTools(cfg config.Config, cwd string, coreTools []adktool.Tool) ([]adktool.Tool, *lazyMemoryStore, *deferredMemoryRecorder) {
+	if !deferredMemoryEnabled(cfg) {
+		return coreTools, nil, nil
 	}
-	agentTools, _ := tools.AgentTools(orch, agentEventCB)
-	coreTools = append(coreTools, agentTools...)
-
-	// Stream live shell output to the same channel the subagent cards use. The
-	// prefix keeps the two streams apart; the non-blocking send in agentEventCB
-	// is what keeps a slow UI from stalling a running command.
-	bashSup.SetSink(func(execID, kind, content string) {
-		agentEventCB(execID, tui.BashEventKind(kind), content)
-	})
-
-	// Append LSP tools.
-	if ps.lspTools != nil {
-		coreTools = append(coreTools, ps.lspTools...)
+	memStore := newLazyMemoryStore()
+	if memTools, memErr := tools.MemoryTools(memStore); memErr == nil {
+		coreTools = append(coreTools, memTools...)
 	}
+	return coreTools, memStore, newDeferredMemoryRecorder(cfg, cwd)
+}
 
-	memEnabled := deferredMemoryEnabled(cfg)
-	var memStore *lazyMemoryStore
-	var memRecorder *deferredMemoryRecorder
-	if memEnabled {
-		memStore = newLazyMemoryStore()
-		if memTools, memErr := tools.MemoryTools(memStore); memErr == nil {
-			coreTools = append(coreTools, memTools...)
-		}
-		memRecorder = newDeferredMemoryRecorder(cfg, cwd)
-	}
-
-	// Build system instruction. The parts are kept so the context gauge can
-	// attribute overhead to each section; composing them here is what keeps the
-	// breakdown honest — instruction is literally parts.String().
-	var (
-		instruction      string
-		instructionParts agent.InstructionParts
-	)
+// buildDeferredInstructionParts returns the system instruction as its parts:
+// --system replaces the base outright, otherwise the built-in set is loaded.
+func buildDeferredInstructionParts() agent.InstructionParts {
 	if flagSystem != "" {
-		instructionParts = agent.InstructionParts{Base: flagSystem}
-	} else {
-		instructionParts = agent.LoadInstructionParts(agent.SystemInstruction)
+		return agent.InstructionParts{Base: flagSystem}
 	}
-	instruction = instructionParts.String()
+	return agent.LoadInstructionParts(agent.SystemInstruction)
+}
 
-	// Build callbacks.
+// deferredCallbacks is the callback wiring for the interactive agent, plus the
+// two objects the caller still needs a handle on: the deduper the auto-compact
+// hook shares, and the metrics the context gauge reads.
+type deferredCallbacks struct {
+	beforeTool     []llmagent.BeforeToolCallback
+	afterTool      []llmagent.AfterToolCallback
+	beforeModel    []llmagent.BeforeModelCallback
+	afterModel     []llmagent.AfterModelCallback
+	deduper        *tools.ResultDeduper
+	compactMetrics *tools.CompactMetrics
+}
+
+// buildDeferredCallbacks assembles the tool and model callback chains in the
+// order they must run.
+func buildDeferredCallbacks(
+	cfg config.Config,
+	providerName string,
+	sandbox *tools.Sandbox,
+	lspMgr *lsp.Manager,
+	memRecorder *deferredMemoryRecorder,
+) deferredCallbacks {
 	compactorCfg := compactorConfigFrom(cfg)
 	compactMetrics := tools.NewCompactMetrics()
 	compactorCB := tools.BuildCompactorCallback(compactorCfg, compactMetrics)
@@ -347,8 +526,8 @@ func deferredInit(
 	tracingBefore, tracingAfter := extension.BuildTracingCallbacks()
 	beforeCBs = append(beforeCBs, tracingBefore...)
 	afterCBs = append(afterCBs, tracingAfter...)
-	if ps.lspMgr != nil {
-		afterCBs = append(afterCBs, lsp.BuildLSPAfterToolCallback(ps.lspMgr))
+	if lspMgr != nil {
+		afterCBs = append(afterCBs, lsp.BuildLSPAfterToolCallback(lspMgr))
 	}
 	// Dedup runs after the compactor so both calls are compared in their final,
 	// post-compaction form.
@@ -364,74 +543,33 @@ func deferredInit(
 		afterCBs = append(afterCBs, memRecorder.afterTool)
 	}
 
-	// Session service.
-	sessionsPath, err := sessionsDir()
-	if err != nil {
-		fail(err)
-		return
+	return deferredCallbacks{
+		beforeTool:     beforeCBs,
+		afterTool:      afterCBs,
+		beforeModel:    llmBefore,
+		afterModel:     llmAfter,
+		deduper:        resultDeduper,
+		compactMetrics: compactMetrics,
 	}
-	sessionSvc, err := pisession.NewFileService(sessionsPath)
-	if err != nil {
-		fail(fmt.Errorf("creating session service: %w", err))
-		return
-	}
+}
 
-	mcpToolsets := ps.mcpToolsets
-	// Gemini search grounding (see agent.GeminiGroundingTool doc).
-	//
-	// APPEND — never replace. Assigning coreTools = []adktool.Tool{gTool} here
-	// leaves the agent with *no* tools at all: bash, read, write, edit, grep,
-	// ls, subagent, LSP and memory all vanish, and the model, given no function
-	// declarations, invents names like "execute_command" and gets back
-	// "tool not found. Available tools: " with an empty list.
-	//
-	// The built-in search coexists with function declarations: geminitool's
-	// ProcessRequest appends to req.Config.Tools rather than overwriting it, and
-	// a single Gemini turn will happily call `read` and `google_search` both.
-	if gTool, ok := agent.GeminiGroundingTool(providerName); ok {
-		coreTools = append(coreTools, gTool)
-	}
-
-	// Session logger. Created before the agent so it can capture the agent's
-	// non-fatal diagnostics (e.g. unresolved instruction placeholders) in the
-	// session log instead of leaking them to stderr and corrupting the TUI.
-	// SessionStart is deferred until the session ID is resolved below.
-	sessionLog, logErr := logger.New()
-	if logErr == nil {
-		res.sessionLog = sessionLog
-		// --trace-http entries are dropped until the log file exists; the
-		// transport is built before this point. See the matching note in
-		// cli.go. Detached on shutdown where sessionLog is closed.
-		httplog.SetSink(logger.HTTPSink(sessionLog))
-	}
-
-	// Create agent.
-	ag, err := agent.New(agent.Config{
-		Model:                llm,
-		Tools:                coreTools,
-		Toolsets:             mcpToolsets,
-		Instruction:          instruction,
-		SessionService:       sessionSvc,
-		BeforeToolCallbacks:  beforeCBs,
-		AfterToolCallbacks:   afterCBs,
-		BeforeModelCallbacks: llmBefore,
-		AfterModelCallbacks:  llmAfter,
-		Logger:               sessionLog,
-	})
-	if err != nil {
-		fail(fmt.Errorf("creating agent: %w", err))
-		return
-	}
-
-	// Resolve session (--continue is resolved in fast path, flagSession is set).
-	sessionID := flagSession
-	resumed := sessionID != ""
-	var defaultTitle string
+// resolveDeferredSession returns the session to run in — the one named by
+// --continue/--session if there is one, otherwise a fresh one — and records the
+// model and backend it is running under.
+func resolveDeferredSession(
+	ctx context.Context,
+	ag *agent.Agent,
+	sessionSvc *pisession.FileService,
+	llm adkmodel.LLM,
+	providerName, baseURL string,
+) (sessionID, defaultTitle string, resumed bool, err error) {
+	// --continue is resolved in the fast path, which sets flagSession.
+	sessionID = flagSession
+	resumed = sessionID != ""
 	if sessionID == "" {
 		sessionID, defaultTitle, err = ag.CreateSession(ctx)
 		if err != nil {
-			fail(fmt.Errorf("creating session: %w", err))
-			return
+			return "", "", false, fmt.Errorf("creating session: %w", err)
 		}
 	}
 
@@ -447,75 +585,7 @@ func deferredInit(
 	// first thing anyone needs when reading a transcript back.
 	_ = sessionSvc.SetSessionProvider(sessionID, providerName, baseURL) // best-effort metadata
 
-	// Store session ID for resume hint on exit.
-	res.sessionID = sessionID
-
-	// Two-stage auto-compaction, installed as a pre-turn hook so history is
-	// only ever rewritten between turns. Buffered so a compaction notice never
-	// blocks the turn if the TUI is momentarily busy.
-	noticeCh := make(chan string, 8)
-	if hook := buildAutoCompactHook(autoCompactDeps{
-		SessionSvc:    sessionSvc,
-		Tracker:       tokenTracker,
-		Deduper:       resultDeduper,
-		Cfg:           autoCompactConfigFrom(cfg),
-		Log:           sessionLog,
-		SummarizerLLM: llm,
-		Notify: func(msg string) {
-			select {
-			case noticeCh <- msg:
-			default:
-			}
-		},
-	}); hook != nil {
-		ag.SetPreTurnHook(hook)
-	}
-
-	// Capture ACP subagent events (claude, gemini) under the session dir.
-	res.orch.SetACPLogPath(filepath.Join(sessionsPath, sessionID, "acp.jsonl"))
-
-	// Session logger was created above; record the session start now that the
-	// session ID is known.
-	if logErr == nil {
-		sessionLog.SessionStart(sessionID, llm.Name(), "interactive")
-	}
-
-	// Commit message function.
-	commitMsgFn := buildCommitMsgFunc(ctx, cfg)
-
-	send("agent", true)
-
-	// Send final result.
-	ch <- tui.InitEvent{
-		Done: true,
-		Result: &tui.InitResult{
-			Agent:             ag,
-			SessionID:         sessionID,
-			SessionTitle:      defaultTitle,
-			Resumed:           resumed,
-			SessionService:    sessionSvc,
-			Orchestrator:      orch,
-			Logger:            sessionLog,
-			Skills:            ps.skills,
-			SkillDirs:         ps.skillDirs,
-			GenerateCommitMsg: commitMsgFn,
-			AgentEventCh:      agentEventCh,
-			SystemNoticeCh:    noticeCh,
-			ContextBreakdown: buildContextBreakdown(
-				instructionParts, coreTools, mcpToolsets, ps.skills, ps.agentConfigs),
-			TokenTracker:   tokenTracker,
-			CompactMetrics: compactMetrics,
-			GitBranch:      ps.gitBranch,
-			DiffAdded:      ps.diffAdded,
-			DiffRemoved:    ps.diffRemoved,
-			MCPToolsets:    ps.mcpToolsets,
-			MCPServers:     buildMCPServerConfigs(cfg),
-		},
-	}
-
-	if memEnabled {
-		initMemoryAfterUI(ctx, cfg, cwd, sessionID, orch, memStore, memRecorder, res)
-	}
+	return sessionID, defaultTitle, resumed, nil
 }
 
 type lazyMemoryStore struct {

--- a/internal/cli/memory_mine.go
+++ b/internal/cli/memory_mine.go
@@ -38,8 +38,7 @@ func scanFiles(dir string, convos bool) ([]string, error) {
 		}
 
 		if d.IsDir() {
-			name := d.Name()
-			if (name[0] == '.' && name != ".") || skipDirNames[name] {
+			if skipMineDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -54,36 +53,50 @@ func scanFiles(dir string, convos bool) ([]string, error) {
 			return nil
 		}
 
-		if convos {
-			ext := strings.ToLower(filepath.Ext(path))
-			if ext == ".jsonl" || ext == ".txt" || ext == ".md" {
-				files = append(files, relPath)
-			}
-		} else {
-			ext := strings.ToLower(filepath.Ext(path))
-			if !supportedExtensions[ext] {
-				return nil
-			}
-
-			info, err := d.Info()
-			if err != nil {
-				return nil
-			}
-			if info.Size() > 512*1024 {
-				return nil
-			}
-
-			data, err := os.ReadFile(path)
-			if err != nil || strings.TrimSpace(string(data)) == "" {
-				return nil
-			}
-
+		if mineFileEligible(path, d, convos) {
 			files = append(files, relPath)
 		}
 		return nil
 	})
 
 	return files, err
+}
+
+// skipMineDir reports whether a directory is excluded from the walk: any dotted
+// directory, plus the well-known dependency and build trees.
+func skipMineDir(name string) bool {
+	return (name[0] == '.' && name != ".") || skipDirNames[name]
+}
+
+// mineFileEligible reports whether a walked file should be mined.
+//
+// A --convos run takes any transcript extension as-is. A project run is
+// stricter: the extension has to be a supported source type, the file has to be
+// small enough to embed usefully, and it has to have content — an unreadable or
+// blank file yields a drawer with nothing in it.
+func mineFileEligible(path string, d os.DirEntry, convos bool) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	if convos {
+		return ext == ".jsonl" || ext == ".txt" || ext == ".md"
+	}
+
+	if !supportedExtensions[ext] {
+		return false
+	}
+
+	info, err := d.Info()
+	if err != nil {
+		return false
+	}
+	if info.Size() > 512*1024 {
+		return false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil || strings.TrimSpace(string(data)) == "" {
+		return false
+	}
+	return true
 }
 
 // loadGitignore loads .gitignore patterns from the given directory.
@@ -222,12 +235,7 @@ func runMemoryMine(dir, wing string, convos bool) error {
 		return nil
 	}
 
-	// Print file list.
-	fmt.Printf("\nFiles (%d total):\n", len(files))
-	for i, f := range files {
-		fmt.Printf("  [%2d] %s\n", i+1, f)
-	}
-	fmt.Println()
+	printMineFileList(files)
 
 	// Phase 2: Mine files with live visual progress.
 	totalFiles := len(files)
@@ -283,20 +291,7 @@ func runMemoryMine(dir, wing string, convos bool) error {
 	dbPath := filepath.Join(absDir, ".pi-go", "palace.db")
 	modelPath := defaultPalaceModelPath()
 
-	palaceCfg := palace.DefaultConfig()
-	palaceCfg.DBPath = dbPath
-	palaceCfg.ModelPath = modelPath
-	if userCfg, err := config.Load(); err == nil && userCfg.Palace != nil {
-		if userCfg.Palace.OllamaURL != "" {
-			palaceCfg.OllamaURL = userCfg.Palace.OllamaURL
-		}
-		if userCfg.Palace.OllamaModel != "" {
-			palaceCfg.OllamaModel = userCfg.Palace.OllamaModel
-		}
-		if userCfg.Palace.LocalEmbedder {
-			palaceCfg.UseOllama = false
-		}
-	}
+	palaceCfg := minePalaceConfig(dbPath, modelPath)
 
 	// Mining without an embedder produces drawers with no vectors, which look
 	// fine until every semantic search silently returns nothing. Refuse up front
@@ -305,52 +300,13 @@ func runMemoryMine(dir, wing string, convos bool) error {
 		return ollamaSetupError(palaceCfg, err)
 	}
 
-	// Name the database and model up front. Mining writes to a per-project DB and
-	// loads a model from a shared cache, and neither location is obvious from the
-	// command line — so a run that appeared to do nothing (or that re-embedded
-	// everything) gave no clue which store it had actually touched.
-	fmt.Printf("Palace DB: %s\n", dbPath)
-	if palaceCfg.UseOllama {
-		fmt.Printf("Embedder:  ollama %s (%s)\n", palaceCfg.OllamaModel, palaceCfg.OllamaURL)
-	} else {
-		fmt.Printf("Embedder:  in-process %s\n", modelPath)
-	}
-	fmt.Printf("Wing:      %s\n\n", wing)
+	printMineBanner(palaceCfg, dbPath, modelPath, wing)
 
-	// Auto-init: create the palace directory and fetch the model if needed, so
-	// `pi memory mine` works on a fresh checkout without a separate `memory init`
-	// / `memory model download` step.
-	//
-	// ModelReady checks for the fp32 weights specifically, not just for the
-	// directory. That matters for repair as much as for first use: installs made
-	// before the fp32 switch hold only model_qint8_arm64.onnx, which loads fine
-	// but runs ~3x slower on the pure-Go backend, so a directory-exists check
-	// would leave them on the slow model indefinitely.
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
-		return fmt.Errorf("creating palace directory: %w", err)
-	}
-	if !palace.ModelReady(modelPath) {
-		fmt.Printf("Embedding model not found (or is the older quantized build) — downloading %s ...\n",
-			palace.DetectPlatformOnnxFile())
-		dest := filepath.Dir(modelPath)
-		if err := os.MkdirAll(dest, 0o755); err != nil {
-			return fmt.Errorf("creating model directory: %w", err)
-		}
-		if _, err := palace.DownloadModel(dest, palace.DetectPlatformOnnxFile()); err != nil {
-			return fmt.Errorf("downloading embedding model: %w", err)
-		}
-		fmt.Printf("Model ready: %s\n\n", modelPath)
+	if err := ensureMineModel(dbPath, modelPath); err != nil {
+		return err
 	}
 
-	palaceOpts := []palace.Option{
-		palace.WithDBPath(dbPath),
-		palace.WithModelPath(modelPath),
-	}
-	if palaceCfg.UseOllama {
-		palaceOpts = append(palaceOpts, palace.WithOllamaEmbedder(palaceCfg.OllamaURL, palaceCfg.OllamaModel))
-	} else {
-		palaceOpts = append(palaceOpts, palace.WithLocalEmbedder())
-	}
+	palaceOpts := minePalaceOptions(palaceCfg, dbPath, modelPath)
 	// Opening the palace loads the embedding model and runs any schema
 	// migrations, which on a cold start is seconds of silence right after the
 	// banner — the exact point the run looked wedged.
@@ -400,6 +356,93 @@ func runMemoryMine(dir, wing string, convos bool) error {
 	}
 
 	return nil
+}
+
+// printMineFileList shows every file the run is about to mine, numbered.
+func printMineFileList(files []string) {
+	fmt.Printf("\nFiles (%d total):\n", len(files))
+	for i, f := range files {
+		fmt.Printf("  [%2d] %s\n", i+1, f)
+	}
+	fmt.Println()
+}
+
+// minePalaceConfig builds the palace config for a mining run, letting the user
+// config override the embedder defaults. A broken config is not fatal here: the
+// defaults are the same ones mining used before the config existed.
+func minePalaceConfig(dbPath, modelPath string) palace.PalaceConfig {
+	palaceCfg := palace.DefaultConfig()
+	palaceCfg.DBPath = dbPath
+	palaceCfg.ModelPath = modelPath
+	userCfg, err := config.Load()
+	if err != nil || userCfg.Palace == nil {
+		return palaceCfg
+	}
+	if userCfg.Palace.OllamaURL != "" {
+		palaceCfg.OllamaURL = userCfg.Palace.OllamaURL
+	}
+	if userCfg.Palace.OllamaModel != "" {
+		palaceCfg.OllamaModel = userCfg.Palace.OllamaModel
+	}
+	if userCfg.Palace.LocalEmbedder {
+		palaceCfg.UseOllama = false
+	}
+	return palaceCfg
+}
+
+// printMineBanner names the database and model up front. Mining writes to a
+// per-project DB and loads a model from a shared cache, and neither location is
+// obvious from the command line — so a run that appeared to do nothing (or that
+// re-embedded everything) gave no clue which store it had actually touched.
+func printMineBanner(palaceCfg palace.PalaceConfig, dbPath, modelPath, wing string) {
+	fmt.Printf("Palace DB: %s\n", dbPath)
+	if palaceCfg.UseOllama {
+		fmt.Printf("Embedder:  ollama %s (%s)\n", palaceCfg.OllamaModel, palaceCfg.OllamaURL)
+	} else {
+		fmt.Printf("Embedder:  in-process %s\n", modelPath)
+	}
+	fmt.Printf("Wing:      %s\n\n", wing)
+}
+
+// ensureMineModel auto-inits: it creates the palace directory and fetches the
+// model if needed, so `pi memory mine` works on a fresh checkout without a
+// separate `memory init` / `memory model download` step.
+//
+// ModelReady checks for the fp32 weights specifically, not just for the
+// directory. That matters for repair as much as for first use: installs made
+// before the fp32 switch hold only model_qint8_arm64.onnx, which loads fine
+// but runs ~3x slower on the pure-Go backend, so a directory-exists check
+// would leave them on the slow model indefinitely.
+func ensureMineModel(dbPath, modelPath string) error {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return fmt.Errorf("creating palace directory: %w", err)
+	}
+	if palace.ModelReady(modelPath) {
+		return nil
+	}
+	fmt.Printf("Embedding model not found (or is the older quantized build) — downloading %s ...\n",
+		palace.DetectPlatformOnnxFile())
+	dest := filepath.Dir(modelPath)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("creating model directory: %w", err)
+	}
+	if _, err := palace.DownloadModel(dest, palace.DetectPlatformOnnxFile()); err != nil {
+		return fmt.Errorf("downloading embedding model: %w", err)
+	}
+	fmt.Printf("Model ready: %s\n\n", modelPath)
+	return nil
+}
+
+// minePalaceOptions turns the resolved config into the options palace.New takes.
+func minePalaceOptions(palaceCfg palace.PalaceConfig, dbPath, modelPath string) []palace.Option {
+	palaceOpts := []palace.Option{
+		palace.WithDBPath(dbPath),
+		palace.WithModelPath(modelPath),
+	}
+	if palaceCfg.UseOllama {
+		return append(palaceOpts, palace.WithOllamaEmbedder(palaceCfg.OllamaURL, palaceCfg.OllamaModel))
+	}
+	return append(palaceOpts, palace.WithLocalEmbedder())
 }
 
 // ollamaSetupError turns an embedder-availability failure into instructions.

--- a/internal/cli/memory_recent.go
+++ b/internal/cli/memory_recent.go
@@ -77,10 +77,8 @@ func runMemoryRecent(project string, limit int, obsType string, asJSON bool) err
 	ctx := context.Background()
 
 	// Validate type filter if provided.
-	if obsType != "" {
-		if !memory.ValidObservationTypes[memory.ObservationType(obsType)] {
-			return fmt.Errorf("invalid type %q, valid types: decision, bugfix, feature, refactor, discovery, change", obsType)
-		}
+	if obsType != "" && !memory.ValidObservationTypes[memory.ObservationType(obsType)] {
+		return fmt.Errorf("invalid type %q, valid types: decision, bugfix, feature, refactor, discovery, change", obsType)
 	}
 
 	// Fetch recent observations.
@@ -88,22 +86,7 @@ func runMemoryRecent(project string, limit int, obsType string, asJSON bool) err
 	if err != nil {
 		return fmt.Errorf("fetching recent observations: %w", err)
 	}
-
-	// Filter by type if specified.
-	if obsType != "" {
-		filtered := make([]*memory.Observation, 0, len(observations))
-		for _, obs := range observations {
-			if string(obs.Type) == obsType {
-				filtered = append(filtered, obs)
-				if len(filtered) >= limit {
-					break
-				}
-			}
-		}
-		observations = filtered
-	} else if len(observations) > limit {
-		observations = observations[:limit]
-	}
+	observations = limitRecentObservations(observations, obsType, limit)
 
 	// Also fetch session summaries.
 	summaries, err := store.RecentSummaries(ctx, project, limit)
@@ -114,11 +97,39 @@ func runMemoryRecent(project string, limit int, obsType string, asJSON bool) err
 	if asJSON {
 		return printRecentJSON(observations, summaries, limit)
 	}
+	printRecentReport(project, observations, summaries)
+	return nil
+}
 
+// limitRecentObservations applies the --type filter and caps the result at
+// limit. The caller over-fetches so that filtering still has enough rows left.
+func limitRecentObservations(observations []*memory.Observation, obsType string, limit int) []*memory.Observation {
+	if obsType == "" {
+		if len(observations) > limit {
+			return observations[:limit]
+		}
+		return observations
+	}
+
+	filtered := make([]*memory.Observation, 0, len(observations))
+	for _, obs := range observations {
+		if string(obs.Type) != obsType {
+			continue
+		}
+		filtered = append(filtered, obs)
+		if len(filtered) >= limit {
+			break
+		}
+	}
+	return filtered
+}
+
+// printRecentReport renders the human-readable listing.
+func printRecentReport(project string, observations []*memory.Observation, summaries []*memory.SessionSummary) {
 	if len(observations) == 0 && len(summaries) == 0 {
 		fmt.Println("No observations found.")
 		fmt.Printf("Project: %s\n", project)
-		return nil
+		return
 	}
 
 	fmt.Printf("Recent Memory — %s\n", project)
@@ -148,8 +159,6 @@ func runMemoryRecent(project string, limit int, obsType string, asJSON bool) err
 			fmt.Printf("[%s] %s\n", age, request)
 		}
 	}
-
-	return nil
 }
 
 // findMemoryDB locates the memory database, checking project-specific and global locations.

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -71,48 +71,14 @@ func runModelList(cmd *cobra.Command, args []string) error {
 	}
 	baseURLs := cfg.ResolveBaseURLs()
 
-	// Determine which providers to query.
-	var providers []string
-	if len(args) == 1 {
-		p := strings.ToLower(args[0])
-		switch p {
-		case "anthropic", "openai", "gemini", "mistral", "xai", "ollama", "openrouter":
-			providers = []string{p}
-		case "azure":
-			// Not a live query: enumerating deployments needs ARM credentials
-			// and the resource ID, not the inference API key, so there is
-			// nothing to call. This used to list OpenAI's catalog instead,
-			// which showed models the subscription does not serve, omitted the
-			// deployments it does, and failed outright without OPENAI_API_KEY.
-			printAzureDeployments(cmd.OutOrStdout())
-			return nil
-		default:
-			return fmt.Errorf("unknown provider %q; valid: anthropic, openai, azure, gemini, mistral, xai, ollama, openrouter", args[0])
-		}
-	} else {
-		// Query all providers that have credentials or a base URL configured.
-		for _, p := range allProviders {
-			if p == "ollama" {
-				providers = append(providers, p)
-				continue
-			}
-			if keys[p] != "" || baseURLs[p] != "" || flagURL != "" {
-				providers = append(providers, p)
-			}
-		}
-		// Azure is not in allProviders because it has nothing to query, but a
-		// configured Azure user asking for "every provider" should still see
-		// their deployments rather than have them silently omitted.
-		azureConfigured := keys["azure"] != "" || os.Getenv("AZURE_OPENAI_ENDPOINT") != ""
-		if azureConfigured {
-			printAzureDeployments(cmd.OutOrStdout())
-		}
-		if len(providers) == 0 {
-			if azureConfigured {
-				return nil
-			}
-			return fmt.Errorf("no providers configured; set an API key (e.g. OPENAI_API_KEY) or specify a provider: pi model list <provider>")
-		}
+	providers, err := selectModelListProviders(cmd.OutOrStdout(), args, keys, baseURLs)
+	if err != nil {
+		return err
+	}
+	// An empty list with no error means the command already produced its output
+	// — the Azure catalog is printed, not queried.
+	if len(providers) == 0 {
+		return nil
 	}
 
 	exitCode := 0
@@ -120,16 +86,8 @@ func runModelList(cmd *cobra.Command, args []string) error {
 		opts := provider.ListModelsOptions{
 			APIKey:   keys[p],
 			Insecure: flagInsecure,
+			BaseURL:  modelListBaseURL(p, baseURLs),
 		}
-		// Resolve base URL: --url flag > env var > default.
-		baseURL := flagURL
-		if baseURL == "" {
-			baseURL = baseURLs[p]
-		}
-		if baseURL == "" && p == "ollama" {
-			baseURL = "http://localhost:11434"
-		}
-		opts.BaseURL = baseURL
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 		models, err := provider.ListModels(ctx, p, opts)
@@ -141,26 +99,92 @@ func runModelList(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Sort model IDs alphabetically.
-		sort.Slice(models, func(i, j int) bool {
-			return models[i].ID < models[j].ID
-		})
-
-		fmt.Printf("%s (%d models):\n", p, len(models))
-		for _, m := range models {
-			if m.OwnedBy != "" {
-				fmt.Printf("  %-45s  %s\n", m.ID, m.OwnedBy)
-			} else {
-				fmt.Printf("  %s\n", m.ID)
-			}
-		}
-		fmt.Println()
+		printProviderModels(p, models)
 	}
 
 	if exitCode != 0 {
 		return fmt.Errorf("one or more providers failed")
 	}
 	return nil
+}
+
+// selectModelListProviders decides which providers `model list` queries: the
+// one named as an argument, or every configured one. An empty result with a nil
+// error means there is nothing left to query because the command has already
+// printed all it had to say.
+func selectModelListProviders(out io.Writer, args []string, keys, baseURLs map[string]string) ([]string, error) {
+	if len(args) == 1 {
+		p := strings.ToLower(args[0])
+		switch p {
+		case "anthropic", "openai", "gemini", "mistral", "xai", "ollama", "openrouter":
+			return []string{p}, nil
+		case "azure":
+			// Not a live query: enumerating deployments needs ARM credentials
+			// and the resource ID, not the inference API key, so there is
+			// nothing to call. This used to list OpenAI's catalog instead,
+			// which showed models the subscription does not serve, omitted the
+			// deployments it does, and failed outright without OPENAI_API_KEY.
+			printAzureDeployments(out)
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unknown provider %q; valid: anthropic, openai, azure, gemini, mistral, xai, ollama, openrouter", args[0])
+		}
+	}
+
+	// Query all providers that have credentials or a base URL configured.
+	var providers []string
+	for _, p := range allProviders {
+		if p == "ollama" {
+			providers = append(providers, p)
+			continue
+		}
+		if keys[p] != "" || baseURLs[p] != "" || flagURL != "" {
+			providers = append(providers, p)
+		}
+	}
+	// Azure is not in allProviders because it has nothing to query, but a
+	// configured Azure user asking for "every provider" should still see
+	// their deployments rather than have them silently omitted.
+	azureConfigured := keys["azure"] != "" || os.Getenv("AZURE_OPENAI_ENDPOINT") != ""
+	if azureConfigured {
+		printAzureDeployments(out)
+	}
+	if len(providers) == 0 && !azureConfigured {
+		return nil, fmt.Errorf("no providers configured; set an API key (e.g. OPENAI_API_KEY) or specify a provider: pi model list <provider>")
+	}
+	return providers, nil
+}
+
+// modelListBaseURL resolves the endpoint to query: --url flag > env var >
+// default. Only Ollama has a default, because only Ollama is expected to be
+// running somewhere unconfigured.
+func modelListBaseURL(providerName string, baseURLs map[string]string) string {
+	baseURL := flagURL
+	if baseURL == "" {
+		baseURL = baseURLs[providerName]
+	}
+	if baseURL == "" && providerName == "ollama" {
+		baseURL = "http://localhost:11434"
+	}
+	return baseURL
+}
+
+// printProviderModels renders one provider's catalog, sorted by model ID.
+func printProviderModels(providerName string, models []provider.ModelInfo) {
+	// Sort model IDs alphabetically.
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].ID < models[j].ID
+	})
+
+	fmt.Printf("%s (%d models):\n", providerName, len(models))
+	for _, m := range models {
+		if m.OwnedBy != "" {
+			fmt.Printf("  %-45s  %s\n", m.ID, m.OwnedBy)
+		} else {
+			fmt.Printf("  %s\n", m.ID)
+		}
+	}
+	fmt.Println()
 }
 
 // printAzureDeployments renders the embedded Azure deployment catalog.

--- a/internal/cli/ping.go
+++ b/internal/cli/ping.go
@@ -213,19 +213,56 @@ func resolvePingTarget(cfg config.Config) (*pingTarget, error) {
 		cfg.Roles["default"] = config.RoleConfig{Model: flagModel}
 	}
 
-	activeRole := "default"
-	switch {
-	case flagSmol:
-		activeRole = "smol"
-	case flagSlow:
-		activeRole = "slow"
-	case flagPlan:
-		activeRole = "plan"
+	info, baseURL, explicitBaseURL, err := resolvePingModelInfo(cfg, pingRoleFromFlags())
+	if err != nil {
+		return nil, err
 	}
 
+	baseURL, apiKey, codexBackend := resolvePingCredentials(info, baseURL, explicitBaseURL)
+	endpoint, fallbacks := pingProbePaths(info, baseURL, codexBackend)
+
+	opts := &provider.LLMOptions{
+		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),
+	}
+	applyTransportOptions(opts, cfg)
+
+	trimmed := strings.TrimRight(baseURL, "/")
+	fallbackURLs := make([]string, 0, len(fallbacks))
+	for _, p := range fallbacks {
+		fallbackURLs = append(fallbackURLs, trimmed+p)
+	}
+	return &pingTarget{
+		info:         info,
+		apiKey:       apiKey,
+		baseURL:      baseURL,
+		targetURL:    trimmed + endpoint,
+		fallbackURLs: fallbackURLs,
+		codexBackend: codexBackend,
+		opts:         opts,
+	}, nil
+}
+
+// pingRoleFromFlags returns the role the --smol/--slow/--plan flags select.
+func pingRoleFromFlags() string {
+	switch {
+	case flagSmol:
+		return "smol"
+	case flagSlow:
+		return "slow"
+	case flagPlan:
+		return "plan"
+	default:
+		return "default"
+	}
+}
+
+// resolvePingModelInfo resolves the role's model into provider info. It also
+// returns the base URL the resolution used and whether that URL was configured
+// rather than defaulted — the codex-token check needs to tell those apart.
+func resolvePingModelInfo(cfg config.Config, activeRole string) (provider.Info, string, bool, error) {
 	modelName, providerName, _, _, _, err := cfg.ResolveRole(activeRole)
 	if err != nil {
-		return nil, fmt.Errorf("resolving model role: %w", err)
+		return provider.Info{}, "", false, fmt.Errorf("resolving model role: %w", err)
 	}
 
 	baseURL := flagURL
@@ -237,16 +274,21 @@ func resolvePingTarget(cfg config.Config) (*pingTarget, error) {
 
 	info, err := provider.ResolveWithBaseURL(modelName, baseURL)
 	if err != nil {
-		return nil, fmt.Errorf("resolving model: %w", err)
+		return provider.Info{}, "", false, fmt.Errorf("resolving model: %w", err)
 	}
 	if providerName != "" {
 		info.Provider = providerName
 		info.Custom = baseURL != ""
 	}
 	if err := provider.ValidateModel(info); err != nil {
-		return nil, fmt.Errorf("model validation: %w", err)
+		return provider.Info{}, "", false, fmt.Errorf("model validation: %w", err)
 	}
+	return info, baseURL, explicitBaseURL, nil
+}
 
+// resolvePingCredentials settles the base URL and API key the probe uses, and
+// reports whether the run has to go through the ChatGPT codex backend.
+func resolvePingCredentials(info provider.Info, baseURL string, explicitBaseURL bool) (string, string, bool) {
 	apiKey := config.APIKeys()[info.Provider]
 	if info.Ollama {
 		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
@@ -274,44 +316,26 @@ func resolvePingTarget(cfg config.Config) (*pingTarget, error) {
 	if codexBackend {
 		baseURL = codexPingBaseURL
 	}
+	return baseURL, apiKey, codexBackend
+}
 
-	var endpoint string
-	var fallbacks []string
+// pingProbePaths returns the health-check path to probe, plus any paths to try
+// when the first one does not answer 2xx.
+func pingProbePaths(info provider.Info, baseURL string, codexBackend bool) (string, []string) {
+	if codexBackend {
+		// The codex backend only exposes POST /responses — use it as a
+		// reachability target (it will 405 for GET, which we treat as
+		// "server alive, endpoint requires POST").
+		return "/responses", nil
+	}
 	if info.Provider == "azure" {
 		// Same rules NewAzureOpenAI applies to real traffic: api-version on a
 		// native resource, /models on a compat gateway. The first candidate is
 		// the probe; the rest are tried only if it does not answer 2xx.
 		paths := provider.AzureProbePaths(info.Model, "", baseURL)
-		endpoint, fallbacks = paths[0], paths[1:]
-	} else {
-		endpoint = pingEndpointForBaseURL(info.Provider, baseURL)
+		return paths[0], paths[1:]
 	}
-	if codexBackend {
-		// The codex backend only exposes POST /responses — use it as a
-		// reachability target (it will 405 for GET, which we treat as
-		// "server alive, endpoint requires POST").
-		endpoint = "/responses"
-	}
-
-	opts := &provider.LLMOptions{
-		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),
-	}
-	applyTransportOptions(opts, cfg)
-
-	trimmed := strings.TrimRight(baseURL, "/")
-	fallbackURLs := make([]string, 0, len(fallbacks))
-	for _, p := range fallbacks {
-		fallbackURLs = append(fallbackURLs, trimmed+p)
-	}
-	return &pingTarget{
-		info:         info,
-		apiKey:       apiKey,
-		baseURL:      baseURL,
-		targetURL:    trimmed + endpoint,
-		fallbackURLs: fallbackURLs,
-		codexBackend: codexBackend,
-		opts:         opts,
-	}, nil
+	return pingEndpointForBaseURL(info.Provider, baseURL), nil
 }
 
 // printHeader summarizes the resolved target before the phases begin.
@@ -610,34 +634,13 @@ func (t *pingTarget) reportHTTPVerdict(w pingWriter, resp *http.Response) bool {
 
 	switch code := resp.StatusCode; {
 	case code >= 200 && code < 300:
-		w("* %s✓ Endpoint reachable via %s%s\n", colorGreen, t.info.Provider, colorReset)
-		w("* Status: %s\n", resp.Status)
-		if t.info.Provider == "openai" {
-			if resolved, ok := resolveOpenAIModelFromList(resp, t.info.Model, w); ok {
-				t.info.Model = resolved
-			}
-		}
-		return true
+		return t.verdictReachable(w, resp)
 
 	case code == 401 || code == 403:
-		if customAzure {
-			w("* %s⚠ Received HTTP %d on health check, continuing with model ping (custom Azure/proxy setups may reject GET checks)%s\n", colorYellow, code, colorReset)
-			return true
-		}
-		w("* %s✗ Authentication failed (HTTP %d)%s\n", colorYellow, code, colorReset)
-		w("* The API endpoint is reachable but the API key is invalid or missing.\n")
-		w("* Check %s\n", providerEnvVar(t.info.Provider))
-		return false
+		return t.verdictUnauthorized(w, code, customAzure)
 
 	case code == 404:
-		if t.info.Provider == "azure" {
-			w("* %s⚠ Endpoint returned 404 for health path, continuing with model ping (Azure/proxy endpoints often disable GET health routes)%s\n", colorYellow, colorReset)
-			return true
-		}
-		w("* %s✗ Endpoint not found (HTTP %d)%s\n", colorYellow, code, colorReset)
-		w("* The server is reachable but the model endpoint was not found.\n")
-		w("* Base URL: %s\n", t.baseURL)
-		return false
+		return t.verdictNotFound(w, code)
 
 	case code == 405:
 		// Method Not Allowed is fine for POST-only endpoints — server is alive.
@@ -646,12 +649,7 @@ func (t *pingTarget) reportHTTPVerdict(w pingWriter, resp *http.Response) bool {
 		return true
 
 	case code == 422:
-		if customAzure {
-			w("* %s⚠ Received HTTP 422 on health check, continuing with model ping (proxy endpoint expects structured POST requests)%s\n", colorYellow, colorReset)
-			return true
-		}
-		w("* %s? Unexpected status: %s%s\n", colorYellow, resp.Status, colorReset)
-		return false
+		return t.verdictUnprocessable(w, resp, customAzure)
 
 	case code == 429:
 		w("* %s⚠ Rate limited (HTTP %d) — endpoint reachable but throttled%s\n", colorYellow, code, colorReset)
@@ -665,6 +663,56 @@ func (t *pingTarget) reportHTTPVerdict(w pingWriter, resp *http.Response) bool {
 		w("* %s? Unexpected status: %s%s\n", colorYellow, resp.Status, colorReset)
 		return false
 	}
+}
+
+// verdictReachable reports a 2xx health check. For OpenAI the body is the model
+// list, so it doubles as the place a model alias gets resolved to a real ID.
+func (t *pingTarget) verdictReachable(w pingWriter, resp *http.Response) bool {
+	w("* %s✓ Endpoint reachable via %s%s\n", colorGreen, t.info.Provider, colorReset)
+	w("* Status: %s\n", resp.Status)
+	if t.info.Provider == "openai" {
+		if resolved, ok := resolveOpenAIModelFromList(resp, t.info.Model, w); ok {
+			t.info.Model = resolved
+		}
+	}
+	return true
+}
+
+// verdictUnauthorized reports a 401/403. A custom Azure or proxy endpoint is
+// allowed to reject the GET probe and still be worth pinging.
+func (t *pingTarget) verdictUnauthorized(w pingWriter, code int, customAzure bool) bool {
+	if customAzure {
+		w("* %s⚠ Received HTTP %d on health check, continuing with model ping (custom Azure/proxy setups may reject GET checks)%s\n", colorYellow, code, colorReset)
+		return true
+	}
+	w("* %s✗ Authentication failed (HTTP %d)%s\n", colorYellow, code, colorReset)
+	w("* The API endpoint is reachable but the API key is invalid or missing.\n")
+	w("* Check %s\n", providerEnvVar(t.info.Provider))
+	return false
+}
+
+// verdictNotFound reports a 404. Azure deployments routinely serve no GET
+// health route at all, which says nothing about whether the model answers.
+func (t *pingTarget) verdictNotFound(w pingWriter, code int) bool {
+	if t.info.Provider == "azure" {
+		w("* %s⚠ Endpoint returned 404 for health path, continuing with model ping (Azure/proxy endpoints often disable GET health routes)%s\n", colorYellow, colorReset)
+		return true
+	}
+	w("* %s✗ Endpoint not found (HTTP %d)%s\n", colorYellow, code, colorReset)
+	w("* The server is reachable but the model endpoint was not found.\n")
+	w("* Base URL: %s\n", t.baseURL)
+	return false
+}
+
+// verdictUnprocessable reports a 422, which on a proxy means the route exists
+// but wants a structured POST rather than the bare GET probe.
+func (t *pingTarget) verdictUnprocessable(w pingWriter, resp *http.Response, customAzure bool) bool {
+	if customAzure {
+		w("* %s⚠ Received HTTP 422 on health check, continuing with model ping (proxy endpoint expects structured POST requests)%s\n", colorYellow, colorReset)
+		return true
+	}
+	w("* %s? Unexpected status: %s%s\n", colorYellow, resp.Status, colorReset)
+	return false
 }
 
 // pingModel sends the prompt to the model and reports the reply. With no
@@ -799,64 +847,14 @@ func allowSoftNonStreamFailure(provider string) bool {
 // For Azure, a non-stream failure is soft: ping continues with stream=true,
 // matching the path interactive chat actually exercises.
 func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong bool, provider string) (string, error) {
-	w := func(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) }
+	w := pingWriter(func(format string, a ...any) { fmt.Fprintf(os.Stderr, format, a...) })
 
-	systemMsg := "You are a connectivity test. Reply briefly and concisely."
-	if isPingPong {
-		systemMsg = `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`
-	}
-
-	req := &llmmodel.LLMRequest{
-		Contents: []*genai.Content{
-			genai.NewContentFromText(prompt, genai.RoleUser),
-		},
-		Config: &genai.GenerateContentConfig{
-			SystemInstruction: genai.NewContentFromText(systemMsg, genai.RoleUser),
-		},
-	}
+	req := newPingRequest(prompt, isPingPong)
 
 	// --- Non-streaming test ---
 	w("*   %s[non-stream]%s Calling GenerateContent(stream=false)...\n", colorGray, colorReset)
 	nsStart := time.Now()
-	var nsResult strings.Builder
-	nsEvents := 0
-	var nsErr error
-	for resp, err := range llm.GenerateContent(ctx, req, false) {
-		nsEvents++
-		if err != nil {
-			w("*   %s[non-stream]%s ERROR at event %d: %v\n", colorGray, colorReset, nsEvents, err)
-			nsErr = fmt.Errorf("non-streaming LLM error: %w", err)
-			break
-		}
-		w("*   %s[non-stream]%s event %d: partial=%v turnComplete=%v finish=%v",
-			colorGray, colorReset, nsEvents, resp.Partial, resp.TurnComplete, resp.FinishReason)
-		if resp.ErrorCode != "" {
-			w(" errorCode=%s errorMsg=%s", resp.ErrorCode, resp.ErrorMessage)
-		}
-		if resp.UsageMetadata != nil {
-			w(" tokens(in=%d out=%d)", resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
-		}
-		w("\n")
-		if resp.Content != nil {
-			w("*   %s[non-stream]%s   role=%s parts=%d\n", colorGray, colorReset, resp.Content.Role, len(resp.Content.Parts))
-			for i, part := range resp.Content.Parts {
-				if part.Text != "" {
-					preview := part.Text
-					if len(preview) > 120 {
-						preview = preview[:120] + "..."
-					}
-					w("*   %s[non-stream]%s   part[%d] text(%d chars): %s\n", colorGray, colorReset, i, len(part.Text), preview)
-					nsResult.WriteString(part.Text)
-				}
-				if part.FunctionCall != nil {
-					w("*   %s[non-stream]%s   part[%d] tool_call: %s\n", colorGray, colorReset, i, part.FunctionCall.Name)
-				}
-				if part.Thought {
-					w("*   %s[non-stream]%s   part[%d] thought=true\n", colorGray, colorReset, i)
-				}
-			}
-		}
-	}
+	nsText, nsEvents, nsErr := modelPingNonStream(ctx, llm, req, w)
 	if nsErr != nil {
 		if !allowSoftNonStreamFailure(provider) {
 			return "", nsErr
@@ -870,59 +868,15 @@ func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong 
 
 	// --- Streaming test ---
 	w("*   %s[stream]%s Calling GenerateContent(stream=true)...\n", colorGray, colorReset)
-	sStart := time.Now()
-	var sResult strings.Builder
-	sEvents := 0
-	sThinkingChunks := 0
-	sTextChunks := 0
-	for resp, err := range llm.GenerateContent(ctx, req, true) {
-		sEvents++
-		if err != nil {
-			w("*   %s[stream]%s ERROR at event %d: %v\n", colorGray, colorReset, sEvents, err)
-			return nsResult.String(), fmt.Errorf("streaming LLM error: %w", err)
-		}
-		if resp.ErrorCode != "" {
-			w("*   %s[stream]%s event %d: errorCode=%s errorMsg=%s\n", colorGray, colorReset, sEvents, resp.ErrorCode, resp.ErrorMessage)
-			continue
-		}
-		if resp.Content != nil {
-			role := resp.Content.Role
-			for _, part := range resp.Content.Parts {
-				if part.Text != "" {
-					if role == "thinking" {
-						sThinkingChunks++
-					} else {
-						sTextChunks++
-						sResult.WriteString(part.Text)
-					}
-				}
-			}
-		}
-		// Print summary for non-partial final event.
-		if !resp.Partial {
-			w("*   %s[stream]%s final event %d: turnComplete=%v finish=%v", colorGray, colorReset, sEvents, resp.TurnComplete, resp.FinishReason)
-			if resp.UsageMetadata != nil {
-				w(" tokens(in=%d out=%d)", resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
-			}
-			w("\n")
-		}
-	}
-	sDur := time.Since(sStart)
-	w("*   %s[stream]%s Done: %d events (%d thinking, %d text chunks), %s%s%s\n",
-		colorGray, colorReset, sEvents, sThinkingChunks, sTextChunks, colorGray, sDur.Round(time.Millisecond), colorReset)
-
-	if sResult.Len() > 0 {
-		preview := sResult.String()
-		if len(preview) > 200 {
-			preview = preview[:200] + "..."
-		}
-		w("*   %s[stream]%s Reply: %s\n", colorGray, colorReset, preview)
+	sText, sErr := modelPingStream(ctx, llm, req, w)
+	if sErr != nil {
+		return nsText, sErr
 	}
 
 	// Return non-streaming result (or streaming if non-streaming was empty).
-	reply := strings.TrimSpace(nsResult.String())
+	reply := strings.TrimSpace(nsText)
 	if reply == "" {
-		reply = strings.TrimSpace(sResult.String())
+		reply = strings.TrimSpace(sText)
 	}
 	if reply == "" {
 		return "", fmt.Errorf("model returned empty response in both streaming and non-streaming modes")
@@ -930,30 +884,154 @@ func modelPing(ctx context.Context, llm llmmodel.LLM, prompt string, isPingPong 
 	return reply, nil
 }
 
+// pingSystemMessage is the system instruction a connectivity probe sends. The
+// Prompt:Prompt variant pins the expected reply so the check can be exact.
+func pingSystemMessage(isPingPong bool) string {
+	if isPingPong {
+		return `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`
+	}
+	return "You are a connectivity test. Reply briefly and concisely."
+}
+
+// newPingRequest builds the single-turn request both the cloud and the Ollama
+// ping paths send.
+func newPingRequest(prompt string, isPingPong bool) *llmmodel.LLMRequest {
+	return &llmmodel.LLMRequest{
+		Contents: []*genai.Content{
+			genai.NewContentFromText(prompt, genai.RoleUser),
+		},
+		Config: &genai.GenerateContentConfig{
+			SystemInstruction: genai.NewContentFromText(pingSystemMessage(isPingPong), genai.RoleUser),
+		},
+	}
+}
+
+// modelPingNonStream runs the stream=false probe, tracing every event, and
+// returns the text collected so far plus the number of events seen. The text is
+// meaningful even when err is non-nil: a soft failure keeps what arrived before
+// the error.
+func modelPingNonStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, int, error) {
+	var result strings.Builder
+	events := 0
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		events++
+		if err != nil {
+			w("*   %s[non-stream]%s ERROR at event %d: %v\n", colorGray, colorReset, events, err)
+			return result.String(), events, fmt.Errorf("non-streaming LLM error: %w", err)
+		}
+		logPingNonStreamEvent(w, resp, events)
+		logPingNonStreamContent(w, resp, &result)
+	}
+	return result.String(), events, nil
+}
+
+// logPingNonStreamEvent prints the one-line header for a non-streamed event.
+func logPingNonStreamEvent(w pingWriter, resp *llmmodel.LLMResponse, event int) {
+	w("*   %s[non-stream]%s event %d: partial=%v turnComplete=%v finish=%v",
+		colorGray, colorReset, event, resp.Partial, resp.TurnComplete, resp.FinishReason)
+	if resp.ErrorCode != "" {
+		w(" errorCode=%s errorMsg=%s", resp.ErrorCode, resp.ErrorMessage)
+	}
+	if resp.UsageMetadata != nil {
+		w(" tokens(in=%d out=%d)", resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
+	}
+	w("\n")
+}
+
+// logPingNonStreamContent prints each part of a non-streamed event and appends
+// its text to out.
+func logPingNonStreamContent(w pingWriter, resp *llmmodel.LLMResponse, out *strings.Builder) {
+	if resp.Content == nil {
+		return
+	}
+	w("*   %s[non-stream]%s   role=%s parts=%d\n", colorGray, colorReset, resp.Content.Role, len(resp.Content.Parts))
+	for i, part := range resp.Content.Parts {
+		if part.Text != "" {
+			w("*   %s[non-stream]%s   part[%d] text(%d chars): %s\n", colorGray, colorReset, i, len(part.Text), truncate(part.Text, 120))
+			out.WriteString(part.Text)
+		}
+		if part.FunctionCall != nil {
+			w("*   %s[non-stream]%s   part[%d] tool_call: %s\n", colorGray, colorReset, i, part.FunctionCall.Name)
+		}
+		if part.Thought {
+			w("*   %s[non-stream]%s   part[%d] thought=true\n", colorGray, colorReset, i)
+		}
+	}
+}
+
+// modelPingStream runs the stream=true probe and returns the model text it
+// accumulated. Thinking chunks are counted but never join the reply.
+func modelPingStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
+	sStart := time.Now()
+	var result strings.Builder
+	events, thinkingChunks, textChunks := 0, 0, 0
+	for resp, err := range llm.GenerateContent(ctx, req, true) {
+		events++
+		if err != nil {
+			w("*   %s[stream]%s ERROR at event %d: %v\n", colorGray, colorReset, events, err)
+			return result.String(), fmt.Errorf("streaming LLM error: %w", err)
+		}
+		if resp.ErrorCode != "" {
+			w("*   %s[stream]%s event %d: errorCode=%s errorMsg=%s\n", colorGray, colorReset, events, resp.ErrorCode, resp.ErrorMessage)
+			continue
+		}
+		thinking, text := accumulatePingStreamParts(resp, &result)
+		thinkingChunks += thinking
+		textChunks += text
+		// Print summary for non-partial final event.
+		if !resp.Partial {
+			logPingStreamFinalEvent(w, resp, events)
+		}
+	}
+	sDur := time.Since(sStart)
+	w("*   %s[stream]%s Done: %d events (%d thinking, %d text chunks), %s%s%s\n",
+		colorGray, colorReset, events, thinkingChunks, textChunks, colorGray, sDur.Round(time.Millisecond), colorReset)
+
+	reply := result.String()
+	if reply != "" {
+		w("*   %s[stream]%s Reply: %s\n", colorGray, colorReset, truncate(reply, 200))
+	}
+	return reply, nil
+}
+
+// accumulatePingStreamParts appends the model text of one streamed event to out
+// and reports how many thinking and text chunks the event carried.
+func accumulatePingStreamParts(resp *llmmodel.LLMResponse, out *strings.Builder) (thinking, text int) {
+	if resp.Content == nil {
+		return 0, 0
+	}
+	role := resp.Content.Role
+	for _, part := range resp.Content.Parts {
+		if part.Text == "" {
+			continue
+		}
+		if role == "thinking" {
+			thinking++
+			continue
+		}
+		text++
+		out.WriteString(part.Text)
+	}
+	return thinking, text
+}
+
+// logPingStreamFinalEvent prints the summary line for a non-partial event.
+func logPingStreamFinalEvent(w pingWriter, resp *llmmodel.LLMResponse, event int) {
+	w("*   %s[stream]%s final event %d: turnComplete=%v finish=%v", colorGray, colorReset, event, resp.TurnComplete, resp.FinishReason)
+	if resp.UsageMetadata != nil {
+		w(" tokens(in=%d out=%d)", resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
+	}
+	w("\n")
+}
+
 // ollamaPingFull performs a complete Ollama ping: lists models, checks availability,
 // then runs non-streaming and streaming tests using the native Ollama provider.
 // No artificial timeout — local models can be slow (thinking, model loading).
 func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPingPong bool, w func(string, ...any)) (string, error) {
-	// Step 1: List available models.
-	models, err := provider.OllamaListModels(ctx, baseURL)
-	if err != nil {
-		return "", fmt.Errorf("list models: %w", err)
+	// Step 1: List available models and confirm ours is one of them.
+	if err := ollamaEnsureModel(ctx, baseURL, modelName, w); err != nil {
+		return "", err
 	}
-	w("*   Available models: %s\n", strings.Join(models, ", "))
-
-	// Check if our model is available.
-	modelBase := strings.Split(modelName, ":")[0]
-	found := false
-	for _, m := range models {
-		if m == modelName || strings.HasPrefix(m, modelBase) {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return "", fmt.Errorf("model %q not found in available models", modelName)
-	}
-	w("*   Model %s: %sfound ✓%s\n", modelName, colorGreen, colorReset)
 
 	// Step 2: Create native Ollama LLM.
 	llm, err := provider.NewOllama(ctx, modelName, "", baseURL, "none", nil)
@@ -961,75 +1039,25 @@ func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPi
 		return "", fmt.Errorf("create client: %w", err)
 	}
 
-	systemMsg := "You are a connectivity test. Reply briefly and concisely."
-	if isPingPong {
-		systemMsg = `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`
-	}
-
-	req := &llmmodel.LLMRequest{
-		Contents: []*genai.Content{
-			genai.NewContentFromText(prompt, genai.RoleUser),
-		},
-		Config: &genai.GenerateContentConfig{
-			SystemInstruction: genai.NewContentFromText(systemMsg, genai.RoleUser),
-		},
-	}
+	req := newPingRequest(prompt, isPingPong)
 
 	// Step 3: Non-streaming test.
-	w("*   %s[non-stream]%s Calling Ollama chat (stream=false)...\n", colorGray, colorReset)
-	nsStart := time.Now()
-	var nsResult strings.Builder
-	for resp, err := range llm.GenerateContent(ctx, req, false) {
-		if err != nil {
-			w("*   %s[non-stream]%s ERROR: %v\n", colorGray, colorReset, err)
-			return "", fmt.Errorf("non-streaming: %w", err)
-		}
-		if resp.Content != nil {
-			for _, part := range resp.Content.Parts {
-				if part.Text != "" {
-					nsResult.WriteString(part.Text)
-				}
-			}
-		}
-		if resp.UsageMetadata != nil {
-			w("*   %s[non-stream]%s tokens(in=%d out=%d)\n",
-				colorGray, colorReset, resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
-		}
+	nsText, err := ollamaPingNonStream(ctx, llm, req, w)
+	if err != nil {
+		return "", err
 	}
-	nsDur := time.Since(nsStart)
-	nsText := strings.TrimSpace(nsResult.String())
-	w("*   %s[non-stream]%s Done %s(%s)%s: %s\n", colorGray, colorReset, colorGray, nsDur.Round(time.Millisecond), colorReset, truncate(nsText, 120))
 
 	// Step 4: Streaming test.
-	w("*   %s[stream]%s Calling Ollama chat (stream=true)...\n", colorGray, colorReset)
-	sStart := time.Now()
-	var sResult strings.Builder
-	sChunks := 0
-	for resp, err := range llm.GenerateContent(ctx, req, true) {
-		if err != nil {
-			w("*   %s[stream]%s ERROR: %v\n", colorGray, colorReset, err)
-			if nsText != "" {
-				w("*   %s[stream]%s Falling back to non-streaming result\n", colorGray, colorReset)
-				return nsText, nil
-			}
-			return "", fmt.Errorf("streaming: %w", err)
+	sText, err := ollamaPingStream(ctx, llm, req, w)
+	if err != nil {
+		// A stream failure after a usable non-streaming reply still proves the
+		// model answered, so report that rather than the transport error.
+		if nsText != "" {
+			w("*   %s[stream]%s Falling back to non-streaming result\n", colorGray, colorReset)
+			return nsText, nil
 		}
-		if resp.Content != nil {
-			for _, part := range resp.Content.Parts {
-				if part.Text != "" && resp.Content.Role != "thinking" {
-					sResult.WriteString(part.Text)
-					sChunks++
-				}
-			}
-		}
-		if resp.UsageMetadata != nil {
-			w("*   %s[stream]%s tokens(in=%d out=%d)\n",
-				colorGray, colorReset, resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
-		}
+		return "", err
 	}
-	sDur := time.Since(sStart)
-	sText := strings.TrimSpace(sResult.String())
-	w("*   %s[stream]%s Done %s(%s)%s, %d chunks: %s\n", colorGray, colorReset, colorGray, sDur.Round(time.Millisecond), colorReset, sChunks, truncate(sText, 120))
 
 	// Return non-streaming result (preferred) or streaming fallback.
 	reply := nsText
@@ -1040,6 +1068,98 @@ func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPi
 		return "", fmt.Errorf("model returned empty response in both modes")
 	}
 	return reply, nil
+}
+
+// ollamaEnsureModel reports the daemon's model list and fails when modelName is
+// not served by it. A tag-less prefix match counts as a hit, because a model
+// pulled as "llama3:8b" is routinely asked for as "llama3".
+func ollamaEnsureModel(ctx context.Context, baseURL, modelName string, w pingWriter) error {
+	models, err := provider.OllamaListModels(ctx, baseURL)
+	if err != nil {
+		return fmt.Errorf("list models: %w", err)
+	}
+	w("*   Available models: %s\n", strings.Join(models, ", "))
+
+	modelBase := strings.Split(modelName, ":")[0]
+	for _, m := range models {
+		if m == modelName || strings.HasPrefix(m, modelBase) {
+			w("*   Model %s: %sfound ✓%s\n", modelName, colorGreen, colorReset)
+			return nil
+		}
+	}
+	return fmt.Errorf("model %q not found in available models", modelName)
+}
+
+// ollamaPingNonStream runs the stream=false Ollama probe and returns the
+// trimmed reply.
+func ollamaPingNonStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
+	w("*   %s[non-stream]%s Calling Ollama chat (stream=false)...\n", colorGray, colorReset)
+	nsStart := time.Now()
+	var nsResult strings.Builder
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			w("*   %s[non-stream]%s ERROR: %v\n", colorGray, colorReset, err)
+			return "", fmt.Errorf("non-streaming: %w", err)
+		}
+		appendOllamaPingText(resp, &nsResult, false)
+		logOllamaPingUsage(w, "non-stream", resp)
+	}
+	nsDur := time.Since(nsStart)
+	nsText := strings.TrimSpace(nsResult.String())
+	w("*   %s[non-stream]%s Done %s(%s)%s: %s\n", colorGray, colorReset, colorGray, nsDur.Round(time.Millisecond), colorReset, truncate(nsText, 120))
+	return nsText, nil
+}
+
+// ollamaPingStream runs the stream=true Ollama probe and returns the trimmed
+// reply, excluding thinking chunks.
+func ollamaPingStream(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest, w pingWriter) (string, error) {
+	w("*   %s[stream]%s Calling Ollama chat (stream=true)...\n", colorGray, colorReset)
+	sStart := time.Now()
+	var sResult strings.Builder
+	sChunks := 0
+	for resp, err := range llm.GenerateContent(ctx, req, true) {
+		if err != nil {
+			w("*   %s[stream]%s ERROR: %v\n", colorGray, colorReset, err)
+			return "", fmt.Errorf("streaming: %w", err)
+		}
+		sChunks += appendOllamaPingText(resp, &sResult, true)
+		logOllamaPingUsage(w, "stream", resp)
+	}
+	sDur := time.Since(sStart)
+	sText := strings.TrimSpace(sResult.String())
+	w("*   %s[stream]%s Done %s(%s)%s, %d chunks: %s\n", colorGray, colorReset, colorGray, sDur.Round(time.Millisecond), colorReset, sChunks, truncate(sText, 120))
+	return sText, nil
+}
+
+// appendOllamaPingText appends the text parts of one event to out and returns
+// how many chunks it contributed.
+//
+// skipThinking drops thinking-role output. Only the streaming probe sets it:
+// the non-streaming call returns one assembled message and has always taken
+// every text part it carries, so filtering there would change what a reasoning
+// model reports as its reply.
+func appendOllamaPingText(resp *llmmodel.LLMResponse, out *strings.Builder, skipThinking bool) int {
+	if resp.Content == nil {
+		return 0
+	}
+	chunks := 0
+	for _, part := range resp.Content.Parts {
+		if part.Text == "" || (skipThinking && resp.Content.Role == "thinking") {
+			continue
+		}
+		out.WriteString(part.Text)
+		chunks++
+	}
+	return chunks
+}
+
+// logOllamaPingUsage prints the token counts an event carried, if any.
+func logOllamaPingUsage(w pingWriter, label string, resp *llmmodel.LLMResponse) {
+	if resp.UsageMetadata == nil {
+		return
+	}
+	w("*   %s[%s]%s tokens(in=%d out=%d)\n",
+		colorGray, label, colorReset, resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
 }
 
 func truncate(s string, n int) string {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -55,19 +55,13 @@ Each browser tab gets its own isolated agent session.`,
 }
 
 func runServe(cmd *cobra.Command, args []string) error {
-	for _, h := range flagServeHeaders {
-		if !strings.Contains(h, "=") {
-			return fmt.Errorf("invalid --header %q: expected key=value", h)
-		}
+	if err := validateServeHeaders(); err != nil {
+		return err
 	}
 
-	project := flagServeProject
-	if project == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("getting current directory: %w", err)
-		}
-		project = cwd
+	project, err := resolveServeProject()
+	if err != nil {
+		return err
 	}
 
 	// Open serve.log for streaming structured logs.
@@ -117,27 +111,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating initial pair code: %w", err)
 	}
 
-	fmt.Printf("Pi-Go web server started at http://%s\n", browsableAddr(server.Addr()))
-	fmt.Printf("Project: %s\n", project)
-	if flagServeModel != "" {
-		fmt.Printf("Model: %s\n", flagServeModel)
-	}
-	if flagServeURL != "" {
-		fmt.Printf("URL: %s\n", flagServeURL)
-	}
-	for _, h := range flagServeHeaders {
-		fmt.Printf("Header: %s\n", h)
-	}
-	if flagServeInsecure {
-		fmt.Println("TLS verification: disabled (--insecure)")
-	}
-	if flagServeVoice {
-		fmt.Printf("Voice: enabled (%s) — speech drives the pi session in this project\n", serveVoiceModel())
-	}
-	fmt.Printf("Pairing timeout: %s\n", flagServePairingTimeout)
-	fmt.Printf("Pair code: %s\n", code)
-	fmt.Println("Open /pair in your browser, then enter this pair code in mobile app.")
-	fmt.Println("\nPress Ctrl+C to stop the server")
+	printServeBanner(os.Stdout, server.Addr(), project, code)
 
 	// Wait for shutdown signal
 	<-sigChan
@@ -152,6 +126,57 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Server stopped")
 	return nil
+}
+
+// validateServeHeaders rejects a --header that is not key=value, before the
+// listener opens.
+func validateServeHeaders() error {
+	for _, h := range flagServeHeaders {
+		if !strings.Contains(h, "=") {
+			return fmt.Errorf("invalid --header %q: expected key=value", h)
+		}
+	}
+	return nil
+}
+
+// resolveServeProject is the project directory to serve: --project, or the
+// current directory when the flag is unset.
+func resolveServeProject() (string, error) {
+	if flagServeProject != "" {
+		return flagServeProject, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting current directory: %w", err)
+	}
+	return cwd, nil
+}
+
+// printServeBanner writes the startup summary: where to reach the server, what
+// it is serving, and the pair code needed to get in. Optional lines are printed
+// only for the options actually in effect.
+func printServeBanner(w io.Writer, addr, project, code string) {
+	fmt.Fprintf(w, "Pi-Go web server started at http://%s\n", browsableAddr(addr))
+	fmt.Fprintf(w, "Project: %s\n", project)
+	if flagServeModel != "" {
+		fmt.Fprintf(w, "Model: %s\n", flagServeModel)
+	}
+	if flagServeURL != "" {
+		fmt.Fprintf(w, "URL: %s\n", flagServeURL)
+	}
+	for _, h := range flagServeHeaders {
+		fmt.Fprintf(w, "Header: %s\n", h)
+	}
+	if flagServeInsecure {
+		fmt.Fprintln(w, "TLS verification: disabled (--insecure)")
+	}
+	if flagServeVoice {
+		fmt.Fprintf(w, "Voice: enabled (%s) — speech drives the pi session in this project\n", serveVoiceModel())
+	}
+	fmt.Fprintf(w, "Pairing timeout: %s\n", flagServePairingTimeout)
+	fmt.Fprintf(w, "Pair code: %s\n", code)
+	fmt.Fprintln(w, "Open /pair in your browser, then enter this pair code in mobile app.")
+	fmt.Fprintln(w, "\nPress Ctrl+C to stop the server")
 }
 
 // browsableAddr turns a listen address into one a browser can open. Wildcard

--- a/internal/codex/complexity_codex_test.go
+++ b/internal/codex/complexity_codex_test.go
@@ -1,0 +1,309 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file pins the behavior that (*Session).handleItem encoded as one large
+// switch before it was split into emitMessageItem, emitReasoningItem and
+// emitToolItem. Every row is a branch the original switch had, so a change in
+// which event a given item shape produces shows up here.
+
+// itemSession returns a Session whose emit() lands in a buffered channel, plus
+// a drain that reports the events one handleItem call produced. emit is a
+// non-blocking send, so the buffer has to be larger than any single call needs.
+func itemSession() (*Session, func() []Event) {
+	s := &Session{threadID: "thread-1", events: make(chan Event, 8)}
+	return s, func() []Event {
+		var got []Event
+		for {
+			select {
+			case ev := <-s.events:
+				got = append(got, ev)
+			default:
+				return got
+			}
+		}
+	}
+}
+
+func exitCode(n int) *int { return &n }
+
+func TestHandleItemEmitsPerItemShape(t *testing.T) {
+	tests := []struct {
+		name      string
+		item      Item
+		completed bool
+		wantEvent []Event // the full sequence, in order
+		wantText  string  // what was accumulated into the run result
+	}{
+		// agentMessage: emitted on both started and completed, accumulated only
+		// on completed — counting both would duplicate the answer.
+		{
+			name:      "agent message started emits but does not accumulate",
+			item:      Item{Type: ItemAgentMessage, Text: "hello"},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeMessage, Content: "hello", SessionID: "thread-1"}},
+			wantText:  "",
+		},
+		{
+			name:      "agent message completed emits and accumulates",
+			item:      Item{Type: ItemAgentMessage, Text: "hello"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeMessage, Content: "hello", SessionID: "thread-1"}},
+			wantText:  "hello",
+		},
+		{
+			name:      "blank agent message is dropped entirely",
+			item:      Item{Type: ItemAgentMessage, Text: "   \n\t "},
+			completed: true,
+			wantEvent: nil,
+			wantText:  "",
+		},
+		{
+			name:      "agent message keeps its surrounding whitespace when emitted",
+			item:      Item{Type: ItemAgentMessage, Text: "  padded  "},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeMessage, Content: "  padded  ", SessionID: "thread-1"}},
+			wantText:  "  padded  ",
+		},
+
+		// exitedReviewMode: the same shape, reading Review rather than Text.
+		{
+			name:      "review text is emitted and accumulated on completion",
+			item:      Item{Type: ItemExitedReviewMode, Review: "looks fine"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeMessage, Content: "looks fine", SessionID: "thread-1"}},
+			wantText:  "looks fine",
+		},
+		{
+			name:      "review text started does not accumulate",
+			item:      Item{Type: ItemExitedReviewMode, Review: "looks fine"},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeMessage, Content: "looks fine", SessionID: "thread-1"}},
+			wantText:  "",
+		},
+		{
+			name:      "blank review is dropped",
+			item:      Item{Type: ItemExitedReviewMode, Review: " "},
+			completed: true,
+			wantEvent: nil,
+			wantText:  "",
+		},
+		{
+			// exitedReviewMode reads Review, never Text — a stray Text field
+			// must not leak into the transcript.
+			name:      "review ignores the Text field",
+			item:      Item{Type: ItemExitedReviewMode, Text: "not this", Review: "this"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeMessage, Content: "this", SessionID: "thread-1"}},
+			wantText:  "this",
+		},
+
+		// reasoning: progress, completed only, and never accumulated.
+		{
+			name:      "reasoning summary is joined and emitted as progress",
+			item:      Item{Type: ItemReasoning, Summary: []string{"first", "second"}},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeProgress, Content: "first\nsecond", SessionID: "thread-1"}},
+			wantText:  "",
+		},
+		{
+			name:      "reasoning started emits nothing",
+			item:      Item{Type: ItemReasoning, Summary: []string{"first"}},
+			completed: false,
+			wantEvent: nil,
+			wantText:  "",
+		},
+		{
+			name:      "all-blank reasoning summary is dropped",
+			item:      Item{Type: ItemReasoning, Summary: []string{"", "  ", "\n"}},
+			completed: true,
+			wantEvent: nil,
+			wantText:  "",
+		},
+		{
+			name:      "empty reasoning summary is dropped",
+			item:      Item{Type: ItemReasoning},
+			completed: true,
+			wantEvent: nil,
+			wantText:  "",
+		},
+
+		// commandExecution: three distinct completed phrasings.
+		{
+			name:      "command started names the command",
+			item:      Item{Type: ItemCommandExecution, Command: "go test ./..."},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Running: go test ./...", SessionID: "thread-1"}},
+		},
+		{
+			name:      "command completed with an exit code reports it",
+			item:      Item{Type: ItemCommandExecution, Command: "go test", ExitCode: exitCode(2)},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Command completed (exit 2)", SessionID: "thread-1"}},
+		},
+		{
+			name:      "command completed with exit zero still reports the code",
+			item:      Item{Type: ItemCommandExecution, Command: "go test", ExitCode: exitCode(0)},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Command completed (exit 0)", SessionID: "thread-1"}},
+		},
+		{
+			name:      "command completed without an exit code omits it",
+			item:      Item{Type: ItemCommandExecution, Command: "go test"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Command completed", SessionID: "thread-1"}},
+		},
+
+		// fileChange: the started line counts the changes.
+		{
+			name:      "file change started counts the paths",
+			item:      Item{Type: ItemFileChange, Changes: []FileChange{{Path: "a.go"}, {Path: "b.go"}}},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Applying 2 file changes", SessionID: "thread-1"}},
+		},
+		{
+			name:      "file change started with no paths still reports a count",
+			item:      Item{Type: ItemFileChange},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Applying 0 file changes", SessionID: "thread-1"}},
+		},
+		{
+			name:      "file change completed drops the count",
+			item:      Item{Type: ItemFileChange, Changes: []FileChange{{Path: "a.go"}}},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "File changes completed", SessionID: "thread-1"}},
+		},
+
+		// mcpToolCall / dynamicToolCall share one case: the server prefix is
+		// added only when the item carries one.
+		{
+			name:      "mcp tool call started is prefixed by its server",
+			item:      Item{Type: ItemMCPToolCall, Server: "fs", Tool: "read"},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Calling fs/read", SessionID: "thread-1"}},
+		},
+		{
+			name:      "mcp tool call completed is prefixed by its server",
+			item:      Item{Type: ItemMCPToolCall, Server: "fs", Tool: "read"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Called fs/read", SessionID: "thread-1"}},
+		},
+		{
+			name:      "mcp tool call without a server is unprefixed",
+			item:      Item{Type: ItemMCPToolCall, Tool: "read"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Called read", SessionID: "thread-1"}},
+		},
+		{
+			name:      "dynamic tool call takes the same path",
+			item:      Item{Type: ItemDynamicToolCall, Tool: "shell"},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Calling shell", SessionID: "thread-1"}},
+		},
+		{
+			name:      "dynamic tool call honors a server prefix too",
+			item:      Item{Type: ItemDynamicToolCall, Server: "local", Tool: "shell"},
+			completed: true,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Called local/shell", SessionID: "thread-1"}},
+		},
+
+		// webSearch is the one tool item with no completion line at all.
+		{
+			name:      "web search started names the query",
+			item:      Item{Type: ItemWebSearch, Query: "golang cyclomatic"},
+			completed: false,
+			wantEvent: []Event{{Type: EventTypeTool, Content: "Web search: golang cyclomatic", SessionID: "thread-1"}},
+		},
+		{
+			name:      "web search completed emits nothing",
+			item:      Item{Type: ItemWebSearch, Query: "golang cyclomatic"},
+			completed: true,
+			wantEvent: nil,
+		},
+
+		// An item type pi-go does not render must stay silent, not fall through
+		// into the tool phrasing.
+		{
+			name:      "unknown item type is ignored",
+			item:      Item{Type: "somethingCodexAddedLater", Text: "x", Command: "y"},
+			completed: true,
+			wantEvent: nil,
+		},
+		{
+			name:      "empty item type is ignored",
+			item:      Item{},
+			completed: false,
+			wantEvent: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, drain := itemSession()
+			var text strings.Builder
+
+			s.handleItem(tt.item, tt.completed, &text)
+
+			got := drain()
+			if len(got) != len(tt.wantEvent) {
+				t.Fatalf("emitted %d events %+v, want %d %+v", len(got), got, len(tt.wantEvent), tt.wantEvent)
+			}
+			for i := range got {
+				if got[i] != tt.wantEvent[i] {
+					t.Errorf("event %d = %+v, want %+v", i, got[i], tt.wantEvent[i])
+				}
+			}
+			if text.String() != tt.wantText {
+				t.Errorf("accumulated text = %q, want %q", text.String(), tt.wantText)
+			}
+		})
+	}
+}
+
+// The session id rides on every event handleItem emits; a helper that dropped
+// it would leave the caller unable to attribute the event.
+func TestHandleItemStampsTheThreadID(t *testing.T) {
+	s := &Session{threadID: "thread-xyz", events: make(chan Event, 4)}
+	var text strings.Builder
+
+	s.handleItem(Item{Type: ItemAgentMessage, Text: "a"}, true, &text)
+	s.handleItem(Item{Type: ItemReasoning, Summary: []string{"b"}}, true, &text)
+	s.handleItem(Item{Type: ItemWebSearch, Query: "c"}, false, &text)
+	close(s.events)
+
+	n := 0
+	for ev := range s.events {
+		n++
+		if ev.SessionID != "thread-xyz" {
+			t.Errorf("event %+v carries SessionID %q, want thread-xyz", ev, ev.SessionID)
+		}
+	}
+	if n != 3 {
+		t.Errorf("got %d events, want 3", n)
+	}
+}
+
+// Accumulation is additive across the items of one turn: the builder handleItem
+// is handed is the turn's answer, not a per-item scratch buffer.
+func TestHandleItemAccumulatesAcrossItems(t *testing.T) {
+	s, drain := itemSession()
+	var text strings.Builder
+
+	s.handleItem(Item{Type: ItemAgentMessage, Text: "part one. "}, true, &text)
+	// Not completed, so this one is shown but not counted.
+	s.handleItem(Item{Type: ItemAgentMessage, Text: "draft"}, false, &text)
+	s.handleItem(Item{Type: ItemExitedReviewMode, Review: "part two."}, true, &text)
+	// Tool and reasoning items never contribute to the answer.
+	s.handleItem(Item{Type: ItemCommandExecution, Command: "ls"}, true, &text)
+	s.handleItem(Item{Type: ItemReasoning, Summary: []string{"thinking"}}, true, &text)
+
+	if got, want := text.String(), "part one. part two."; got != want {
+		t.Errorf("accumulated text = %q, want %q", got, want)
+	}
+	if got := len(drain()); got != 5 {
+		t.Errorf("emitted %d events, want 5", got)
+	}
+}

--- a/internal/codex/session.go
+++ b/internal/codex/session.go
@@ -413,31 +413,46 @@ func (s *Session) handleNotification(notif JSONRPCNotification, text *strings.Bu
 func (s *Session) handleItem(item Item, completed bool, text *strings.Builder) {
 	switch item.Type {
 	case ItemAgentMessage:
-		if strings.TrimSpace(item.Text) == "" {
-			return
-		}
-		s.emit(Event{Type: EventTypeMessage, Content: item.Text, SessionID: s.threadID})
-		if completed {
-			text.WriteString(item.Text)
-		}
+		s.emitMessageItem(item.Text, completed, text)
 
 	case ItemExitedReviewMode:
-		if strings.TrimSpace(item.Review) == "" {
-			return
-		}
-		s.emit(Event{Type: EventTypeMessage, Content: item.Review, SessionID: s.threadID})
-		if completed {
-			text.WriteString(item.Review)
-		}
+		s.emitMessageItem(item.Review, completed, text)
 
 	case ItemReasoning:
-		if !completed {
-			return
-		}
-		if summary := strings.TrimSpace(strings.Join(item.Summary, "\n")); summary != "" {
-			s.emit(Event{Type: EventTypeProgress, Content: summary, SessionID: s.threadID})
-		}
+		s.emitReasoningItem(item, completed)
 
+	case ItemCommandExecution, ItemFileChange, ItemMCPToolCall, ItemDynamicToolCall, ItemWebSearch:
+		s.emitToolItem(item, completed)
+	}
+}
+
+// emitMessageItem emits one text-bearing item and, on completion, accumulates
+// it into the run result. Blank content is dropped rather than emitted.
+func (s *Session) emitMessageItem(content string, completed bool, text *strings.Builder) {
+	if strings.TrimSpace(content) == "" {
+		return
+	}
+	s.emit(Event{Type: EventTypeMessage, Content: content, SessionID: s.threadID})
+	if completed {
+		text.WriteString(content)
+	}
+}
+
+// emitReasoningItem emits a reasoning summary. Only the completed item carries
+// one worth showing, and an all-blank summary is dropped.
+func (s *Session) emitReasoningItem(item Item, completed bool) {
+	if !completed {
+		return
+	}
+	if summary := strings.TrimSpace(strings.Join(item.Summary, "\n")); summary != "" {
+		s.emit(Event{Type: EventTypeProgress, Content: summary, SessionID: s.threadID})
+	}
+}
+
+// emitToolItem emits the progress line for one tool-shaped item, phrased for
+// whether the item has started or finished.
+func (s *Session) emitToolItem(item Item, completed bool) {
+	switch item.Type {
 	case ItemCommandExecution:
 		if !completed {
 			s.emitTool("Running: " + item.Command)

--- a/internal/config/complexity_config_test.go
+++ b/internal/config/complexity_config_test.go
@@ -1,0 +1,286 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// This file pins the behavior parseMCPServers encoded before it was split into
+// parseMCPServerObject, parseMCPServerArray and applyMCPTransport. It parses
+// user-authored config, so the malformed-input paths matter as much as the
+// happy ones: every wrong-typed field below used to be swallowed by a failing
+// type assertion, and must still be.
+
+// sortServers gives the object format a deterministic order to compare against.
+// Go map iteration is unordered, so parseMCPServerObject's output order is not
+// part of the contract — its contents are.
+func sortServers(s []MCPServer) []MCPServer {
+	sort.Slice(s, func(i, j int) bool { return s[i].Name < s[j].Name })
+	return s
+}
+
+// mustJSON parses a config fragment the way LoadFrom would, so the tests feed
+// parseMCPServers exactly the `any` shapes encoding/json produces rather than
+// hand-built maps that could differ.
+func mustJSON(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		t.Fatalf("bad test fixture %q: %v", s, err)
+	}
+	return v
+}
+
+func TestParseMCPServersFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string // JSON, as it appears under "mcpServers"
+		want []MCPServer
+	}{
+		// ---- Claude Desktop object format ----
+		{
+			name: "object format takes the name from the key",
+			in:   `{"fs": {"command": "npx", "args": ["-y", "server-fs"]}}`,
+			want: []MCPServer{{Name: "fs", Command: "npx", Args: []string{"-y", "server-fs"}}},
+		},
+		{
+			name: "object format url transport with headers",
+			in:   `{"api": {"url": "https://example.test/mcp", "headers": {"Authorization": "Bearer t"}}}`,
+			want: []MCPServer{{Name: "api", URL: "https://example.test/mcp", Headers: map[string]string{"Authorization": "Bearer t"}}},
+		},
+		{
+			name: "object format keeps every well-formed entry",
+			in:   `{"a": {"command": "a"}, "b": {"url": "https://b.test"}}`,
+			want: []MCPServer{{Name: "a", Command: "a"}, {Name: "b", URL: "https://b.test"}},
+		},
+		{
+			// The comment in the source calls these "disabled servers": an entry
+			// with neither a command nor a URL has no transport to dial.
+			name: "object format skips an entry with neither command nor url",
+			in:   `{"off": {"args": ["--x"]}, "on": {"command": "run"}}`,
+			want: []MCPServer{{Name: "on", Command: "run"}},
+		},
+		{
+			name: "object format skips an entry whose value is not an object",
+			in:   `{"bogus": "just a string", "ok": {"command": "run"}}`,
+			want: []MCPServer{{Name: "ok", Command: "run"}},
+		},
+		{
+			name: "object format skips a null entry",
+			in:   `{"bogus": null, "ok": {"command": "run"}}`,
+			want: []MCPServer{{Name: "ok", Command: "run"}},
+		},
+		{
+			name: "object format skips an entry that is an array",
+			in:   `{"bogus": ["command", "run"], "ok": {"command": "run"}}`,
+			want: []MCPServer{{Name: "ok", Command: "run"}},
+		},
+		{
+			name: "empty object yields an empty, non-nil slice",
+			in:   `{}`,
+			want: []MCPServer{},
+		},
+
+		// ---- legacy array format ----
+		{
+			name: "array format takes the name from the element",
+			in:   `[{"name": "fs", "command": "npx", "args": ["-y"]}]`,
+			want: []MCPServer{{Name: "fs", Command: "npx", Args: []string{"-y"}}},
+		},
+		{
+			name: "array format url transport with headers",
+			in:   `[{"name": "api", "url": "https://example.test", "headers": {"X-K": "v"}}]`,
+			want: []MCPServer{{Name: "api", URL: "https://example.test", Headers: map[string]string{"X-K": "v"}}},
+		},
+		{
+			name: "array format preserves element order",
+			in:   `[{"name": "b", "command": "b"}, {"name": "a", "command": "a"}]`,
+			want: []MCPServer{{Name: "b", Command: "b"}, {Name: "a", Command: "a"}},
+		},
+		{
+			name: "array format skips an element with neither command nor url",
+			in:   `[{"name": "off"}, {"name": "on", "command": "run"}]`,
+			want: []MCPServer{{Name: "on", Command: "run"}},
+		},
+		{
+			// This is the branch parseMCPServerArray turned from a wrapping
+			// `if ok { … }` into a guard `continue`; a non-object element is
+			// dropped and must not stop the rest being read.
+			name: "array format skips non-object elements and keeps going",
+			in:   `["nope", 42, null, {"name": "on", "command": "run"}, true]`,
+			want: []MCPServer{{Name: "on", Command: "run"}},
+		},
+		{
+			// A nameless entry with a real transport is still usable, so it
+			// survives with an empty Name rather than being dropped.
+			name: "array format keeps an entry with no name but a command",
+			in:   `[{"command": "run"}]`,
+			want: []MCPServer{{Name: "", Command: "run"}},
+		},
+		{
+			name: "empty array yields an empty, non-nil slice",
+			in:   `[]`,
+			want: []MCPServer{},
+		},
+
+		// ---- wrong-typed fields, in both formats ----
+		{
+			name: "non-string command is ignored, dropping the entry",
+			in:   `{"x": {"command": 5}}`,
+			want: []MCPServer{},
+		},
+		{
+			name: "non-string url is ignored, dropping the entry",
+			in:   `{"x": {"url": ["https://a"]}}`,
+			want: []MCPServer{},
+		},
+		{
+			name: "non-array args is ignored but the entry survives on its command",
+			in:   `{"x": {"command": "run", "args": "not-a-list"}}`,
+			want: []MCPServer{{Name: "x", Command: "run"}},
+		},
+		{
+			name: "non-object headers is ignored but the entry survives",
+			in:   `{"x": {"url": "https://a", "headers": "nope"}}`,
+			want: []MCPServer{{Name: "x", URL: "https://a"}},
+		},
+		{
+			name: "non-string name in the array format is ignored",
+			in:   `[{"name": 7, "command": "run"}]`,
+			want: []MCPServer{{Name: "", Command: "run"}},
+		},
+		{
+			// toStringSlice keeps the slot but leaves a non-string element
+			// empty, so the positional args line up with what was configured.
+			name: "non-string args elements become empty strings",
+			in:   `{"x": {"command": "run", "args": ["-y", 5, null]}}`,
+			want: []MCPServer{{Name: "x", Command: "run", Args: []string{"-y", "", ""}}},
+		},
+		{
+			// toStringMap drops non-string values, and an all-non-string map
+			// collapses to nil rather than an empty map.
+			name: "headers with no string values collapse to nil",
+			in:   `{"x": {"url": "https://a", "headers": {"n": 1}}}`,
+			want: []MCPServer{{Name: "x", URL: "https://a"}},
+		},
+		{
+			name: "headers keep only the string values",
+			in:   `{"x": {"url": "https://a", "headers": {"n": 1, "s": "keep"}}}`,
+			want: []MCPServer{{Name: "x", URL: "https://a", Headers: map[string]string{"s": "keep"}}},
+		},
+		{
+			name: "empty headers object collapses to nil",
+			in:   `{"x": {"url": "https://a", "headers": {}}}`,
+			want: []MCPServer{{Name: "x", URL: "https://a"}},
+		},
+		{
+			name: "empty args array yields an empty, non-nil slice",
+			in:   `{"x": {"command": "run", "args": []}}`,
+			want: []MCPServer{{Name: "x", Command: "run", Args: []string{}}},
+		},
+		{
+			// An empty-string command is indistinguishable from an absent one,
+			// so the entry is skipped as having no transport.
+			name: "empty string command does not count as a transport",
+			in:   `{"x": {"command": ""}}`,
+			want: []MCPServer{},
+		},
+		{
+			name: "both command and url are kept when both are present",
+			in:   `{"x": {"command": "run", "url": "https://a"}}`,
+			want: []MCPServer{{Name: "x", Command: "run", URL: "https://a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMCPServers(mustJSON(t, tt.in))
+			if !reflect.DeepEqual(sortServers(got), sortServers(tt.want)) {
+				t.Errorf("parseMCPServers(%s) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The two formats above are the only ones parseMCPServers recognizes; anything
+// else — including a config file that set mcpServers to a scalar — yields nil
+// rather than a panic or an empty slice.
+func TestParseMCPServersUnsupportedShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+	}{
+		{"nil", nil},
+		{"string", "servers.json"},
+		{"number", float64(3)},
+		{"bool", true},
+		{"typed nil map", map[string]any(nil)},
+		{"typed nil slice", []any(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMCPServers(tt.in)
+			// A nil map or slice still takes its format branch and returns the
+			// empty slice that branch builds; only the unsupported types are
+			// nil. Either way the caller sees no servers.
+			if len(got) != 0 {
+				t.Errorf("parseMCPServers(%v) = %+v, want no servers", tt.in, got)
+			}
+		})
+	}
+	if got := parseMCPServers(nil); got != nil {
+		t.Errorf("parseMCPServers(nil) = %+v, want nil", got)
+	}
+	if got := parseMCPServers("nope"); got != nil {
+		t.Errorf("parseMCPServers(string) = %+v, want nil", got)
+	}
+}
+
+// applyMCPTransport is shared by both formats, so it is worth pinning on its
+// own: it must only ever set the four transport fields, and must leave a field
+// untouched — not zero it — when the key is absent or wrongly typed.
+func TestApplyMCPTransportLeavesUnsetFieldsAlone(t *testing.T) {
+	// Start from a fully populated server, then apply an object that names
+	// nothing. Every field must survive.
+	srv := MCPServer{
+		Name:    "keep-me",
+		Command: "keep-cmd",
+		Args:    []string{"keep-arg"},
+		URL:     "keep-url",
+		Headers: map[string]string{"keep": "header"},
+	}
+	before := srv
+
+	applyMCPTransport(&srv, map[string]any{"unrelated": "value"})
+	if !reflect.DeepEqual(srv, before) {
+		t.Errorf("applyMCPTransport with no known keys changed %+v to %+v", before, srv)
+	}
+
+	applyMCPTransport(&srv, map[string]any{
+		"command": 1, "args": "x", "url": false, "headers": []any{"y"},
+	})
+	if !reflect.DeepEqual(srv, before) {
+		t.Errorf("applyMCPTransport with wrongly typed keys changed %+v to %+v", before, srv)
+	}
+
+	// Name is never read from the object, even when the object has one.
+	applyMCPTransport(&srv, map[string]any{"name": "other", "command": "new-cmd"})
+	if srv.Name != "keep-me" {
+		t.Errorf("applyMCPTransport overwrote Name with %q", srv.Name)
+	}
+	if srv.Command != "new-cmd" {
+		t.Errorf("applyMCPTransport did not set Command, got %q", srv.Command)
+	}
+}
+
+// The two format helpers must agree on everything except where the name comes
+// from — that equivalence is what let the shared applyMCPTransport be extracted.
+func TestMCPServerFormatsAgreeOnTransport(t *testing.T) {
+	object := parseMCPServers(mustJSON(t, `{"fs": {"command": "npx", "args": ["-y", "s"], "url": "https://u", "headers": {"H": "v"}}}`))
+	array := parseMCPServers(mustJSON(t, `[{"name": "fs", "command": "npx", "args": ["-y", "s"], "url": "https://u", "headers": {"H": "v"}}]`))
+	if !reflect.DeepEqual(object, array) {
+		t.Errorf("object format %+v and array format %+v disagree", object, array)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -430,63 +430,72 @@ func parseMCPServers(v any) []MCPServer {
 	}
 	switch x := v.(type) {
 	case map[string]any:
-		// Claude Desktop object format: mcpServers is a map keyed by server name.
-		// Each value is { "command": "...", "args": [...] } or { "url": "..." }.
-		servers := make([]MCPServer, 0, len(x))
-		for name, val := range x {
-			srv := MCPServer{Name: name}
-			if m, ok := val.(map[string]any); ok {
-				if cmd, ok := m["command"].(string); ok {
-					srv.Command = cmd
-				}
-				if args, ok := m["args"].([]any); ok {
-					srv.Args = toStringSlice(args)
-				}
-				if url, ok := m["url"].(string); ok {
-					srv.URL = url
-				}
-				if headers, ok := m["headers"].(map[string]any); ok {
-					srv.Headers = toStringMap(headers)
-				}
-			}
-			// Skip servers that have neither command nor URL (e.g., disabled servers).
-			if srv.Command == "" && srv.URL == "" {
-				continue
-			}
-			servers = append(servers, srv)
-		}
-		return servers
+		return parseMCPServerObject(x)
 	case []any:
-		// Legacy array format.
-		servers := make([]MCPServer, 0, len(x))
-		for _, item := range x {
-			if m, ok := item.(map[string]any); ok {
-				srv := MCPServer{}
-				if n, ok := m["name"].(string); ok {
-					srv.Name = n
-				}
-				if cmd, ok := m["command"].(string); ok {
-					srv.Command = cmd
-				}
-				if args, ok := m["args"].([]any); ok {
-					srv.Args = toStringSlice(args)
-				}
-				if url, ok := m["url"].(string); ok {
-					srv.URL = url
-				}
-				if headers, ok := m["headers"].(map[string]any); ok {
-					srv.Headers = toStringMap(headers)
-				}
-				// Skip servers that have neither command nor URL.
-				if srv.Command == "" && srv.URL == "" {
-					continue
-				}
-				servers = append(servers, srv)
-			}
-		}
-		return servers
+		return parseMCPServerArray(x)
 	default:
 		return nil
+	}
+}
+
+// parseMCPServerObject reads the Claude Desktop object format: mcpServers is a
+// map keyed by server name, and each value is { "command": "...", "args": [...] }
+// or { "url": "..." }.
+func parseMCPServerObject(x map[string]any) []MCPServer {
+	servers := make([]MCPServer, 0, len(x))
+	for name, val := range x {
+		srv := MCPServer{Name: name}
+		if m, ok := val.(map[string]any); ok {
+			applyMCPTransport(&srv, m)
+		}
+		// Skip servers that have neither command nor URL (e.g., disabled servers).
+		if srv.Command == "" && srv.URL == "" {
+			continue
+		}
+		servers = append(servers, srv)
+	}
+	return servers
+}
+
+// parseMCPServerArray reads the legacy array format, where the server name is a
+// field of each element rather than the key it is stored under.
+func parseMCPServerArray(x []any) []MCPServer {
+	servers := make([]MCPServer, 0, len(x))
+	for _, item := range x {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		srv := MCPServer{}
+		if n, ok := m["name"].(string); ok {
+			srv.Name = n
+		}
+		applyMCPTransport(&srv, m)
+		// Skip servers that have neither command nor URL.
+		if srv.Command == "" && srv.URL == "" {
+			continue
+		}
+		servers = append(servers, srv)
+	}
+	return servers
+}
+
+// applyMCPTransport fills the transport fields of srv — command, args, url and
+// headers — from one server object. Entries that are absent or hold the wrong
+// JSON type are left at their zero value, which is what makes a malformed entry
+// fall out as "neither command nor URL" and be skipped by the callers.
+func applyMCPTransport(srv *MCPServer, m map[string]any) {
+	if cmd, ok := m["command"].(string); ok {
+		srv.Command = cmd
+	}
+	if args, ok := m["args"].([]any); ok {
+		srv.Args = toStringSlice(args)
+	}
+	if url, ok := m["url"].(string); ok {
+		srv.URL = url
+	}
+	if headers, ok := m["headers"].(map[string]any); ok {
+		srv.Headers = toStringMap(headers)
 	}
 }
 

--- a/internal/extension/complexity_extension_test.go
+++ b/internal/extension/complexity_extension_test.go
@@ -1,0 +1,520 @@
+package extension
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- bundledMainFile ---
+
+// TestBundledMainFile pins the fallback rule the original inline block used:
+// the conventional SKILL.md wins, but an *empty* one still falls through to
+// the first file. Collapsing those two conditions would be the easy mistake.
+func TestBundledMainFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		skillName string
+		files     []BundledSkillFile
+		want      string
+	}{
+		{
+			name:      "no files yields nothing",
+			skillName: "alpha",
+			files:     nil,
+			want:      "",
+		},
+		{
+			name:      "conventional path wins",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/alpha/other.md", Content: []byte("other")},
+				{RelPath: "bundled_skills/alpha/SKILL.md", Content: []byte("main")},
+			},
+			want: "main",
+		},
+		{
+			name:      "conventional path wins even when it is first",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/alpha/SKILL.md", Content: []byte("main")},
+				{RelPath: "bundled_skills/alpha/other.md", Content: []byte("other")},
+			},
+			want: "main",
+		},
+		{
+			name:      "no conventional path falls back to the first file",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/alpha/other.md", Content: []byte("first")},
+				{RelPath: "bundled_skills/alpha/more.md", Content: []byte("second")},
+			},
+			want: "first",
+		},
+		{
+			// The original tested len(mainFile) == 0 *after* the loop, so an
+			// empty SKILL.md does not suppress the fallback — and the fallback
+			// is files[0], not "the next file".
+			name:      "empty conventional file falls back to files[0]",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/alpha/other.md", Content: []byte("fallback")},
+				{RelPath: "bundled_skills/alpha/SKILL.md", Content: []byte("")},
+			},
+			want: "fallback",
+		},
+		{
+			// Same rule, and here files[0] *is* the empty SKILL.md, so the
+			// fallback reproduces the empty result rather than skipping ahead.
+			name:      "empty conventional file at index 0 stays empty",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/alpha/SKILL.md", Content: []byte("")},
+				{RelPath: "bundled_skills/alpha/other.md", Content: []byte("not reached")},
+			},
+			want: "",
+		},
+		{
+			name:      "everything empty yields nothing",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/alpha/SKILL.md", Content: []byte("")},
+			},
+			want: "",
+		},
+		{
+			name:      "another skill's SKILL.md does not match",
+			skillName: "alpha",
+			files: []BundledSkillFile{
+				{RelPath: "bundled_skills/beta/SKILL.md", Content: []byte("beta")},
+			},
+			want: "beta", // matched only by the first-file fallback
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(bundledMainFile(tt.files, tt.skillName)); got != tt.want {
+				t.Errorf("bundledMainFile = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- skillCandidates ---
+
+// TestSkillCandidates pins the discovery order and the two skip rules: plain
+// files are not skills, and a subdirectory without a SKILL.md is not one
+// either. The directory's own SKILL.md is always candidate zero, listed
+// whether or not it exists — appendDirSkills stats it again.
+func TestSkillCandidates(t *testing.T) {
+	dir := t.TempDir()
+	setupSkillWithContent(t, dir, "beta", "---\nname: beta\n---\nB")
+	setupSkillWithContent(t, dir, "alpha", "---\nname: alpha\n---\nA")
+	// A subdirectory with no SKILL.md.
+	if err := os.MkdirAll(filepath.Join(dir, "empty-sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A plain file, not a directory.
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := skillCandidates(dir, readDir(t, dir))
+
+	if len(got) != 3 {
+		t.Fatalf("got %d candidates, want 3: %+v", len(got), got)
+	}
+	if got[0].path != filepath.Join(dir, "SKILL.md") {
+		t.Errorf("candidate[0].path = %q, want the directory's own SKILL.md", got[0].path)
+	}
+	if got[0].defaultName != filepath.Base(dir) {
+		t.Errorf("candidate[0].defaultName = %q, want %q", got[0].defaultName, filepath.Base(dir))
+	}
+	// os.ReadDir sorts by name, so alpha precedes beta.
+	for i, want := range []string{"alpha", "beta"} {
+		c := got[i+1]
+		if c.defaultName != want {
+			t.Errorf("candidate[%d].defaultName = %q, want %q", i+1, c.defaultName, want)
+		}
+		if c.path != filepath.Join(dir, want, "SKILL.md") {
+			t.Errorf("candidate[%d].path = %q, want %q", i+1, c.path, filepath.Join(dir, want, "SKILL.md"))
+		}
+	}
+}
+
+// TestSkillCandidatesOwnSkillFile covers a directory that is itself a skill.
+func TestSkillCandidatesOwnSkillFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: self\n---\nS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := skillCandidates(dir, readDir(t, dir))
+	if len(got) != 1 {
+		t.Fatalf("got %d candidates, want 1: %+v", len(got), got)
+	}
+}
+
+// --- auditRejects ---
+
+const (
+	bidiOverride = "\u202E" // critical
+	tagChar      = "\U000E0001"
+	zeroWidth    = "\u200B" // warning only
+)
+
+// TestAuditRejects walks all five outcomes the inline audit block encoded.
+func TestAuditRejects(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        AuditMode
+		body        string
+		path        string // overrides the written file when non-empty
+		wantReject  bool
+		wantBlocked int
+	}{
+		{
+			name: "skip mode never scans and never rejects",
+			mode: AuditSkip, body: "Bad " + bidiOverride + " char.",
+			wantReject: false, wantBlocked: 0,
+		},
+		{
+			name: "clean file is not rejected",
+			mode: AuditBlock, body: "Perfectly ordinary text.",
+			wantReject: false, wantBlocked: 0,
+		},
+		{
+			name: "warning-only finding is not rejected",
+			mode: AuditBlock, body: "Zero" + zeroWidth + "width.",
+			wantReject: false, wantBlocked: 0,
+		},
+		{
+			name: "critical finding under block is rejected and recorded",
+			mode: AuditBlock, body: "Hidden " + bidiOverride + " text.",
+			wantReject: true, wantBlocked: 1,
+		},
+		{
+			name: "critical tag char under block is rejected",
+			mode: AuditBlock, body: "Tag " + tagChar + " text.",
+			wantReject: true, wantBlocked: 1,
+		},
+		{
+			name: "critical finding under warn is not rejected",
+			mode: AuditWarn, body: "Hidden " + bidiOverride + " text.",
+			wantReject: false, wantBlocked: 0,
+		},
+		{
+			name: "a scan failure warns and loads",
+			mode: AuditBlock, path: filepath.Join(t.TempDir(), "does-not-exist", "SKILL.md"),
+			wantReject: false, wantBlocked: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.path
+			if path == "" {
+				dir := t.TempDir()
+				path = filepath.Join(dir, "SKILL.md")
+				if err := os.WriteFile(path, []byte("---\nname: s\n---\n"+tt.body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var blocked []string
+			got := auditRejects(LoadOptions{AuditMode: tt.mode}, skillCandidate{path: path, defaultName: "s"}, &blocked)
+			if got != tt.wantReject {
+				t.Errorf("auditRejects = %v, want %v", got, tt.wantReject)
+			}
+			if len(blocked) != tt.wantBlocked {
+				t.Errorf("blocked = %v, want %d entries", blocked, tt.wantBlocked)
+			}
+			if tt.wantBlocked > 0 && blocked[0] != path {
+				t.Errorf("blocked[0] = %q, want %q", blocked[0], path)
+			}
+		})
+	}
+}
+
+// TestAuditRejectsAppendsAcrossCalls checks blocked accumulates rather than
+// being replaced — it is threaded through by pointer now, not closed over.
+func TestAuditRejectsAppendsAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	var blocked []string
+	for _, name := range []string{"one", "two"} {
+		setupSkillWithContent(t, dir, name, "---\nname: "+name+"\n---\nBad "+bidiOverride+" char.")
+		path := filepath.Join(dir, name, "SKILL.md")
+		if !auditRejects(LoadOptions{AuditMode: AuditBlock}, skillCandidate{path: path, defaultName: name}, &blocked) {
+			t.Fatalf("%s: expected rejection", name)
+		}
+	}
+	if len(blocked) != 2 {
+		t.Errorf("blocked = %v, want 2 entries", blocked)
+	}
+}
+
+// --- appendDirSkills ---
+
+// TestAppendDirSkillsMissingDir keeps the "not an error" rule for a directory
+// that does not exist, and returns the accumulator untouched.
+func TestAppendDirSkillsMissingDir(t *testing.T) {
+	seen := map[string]int{}
+	in := []Skill{{Name: "kept"}}
+	got, err := appendDirSkills(in, seen, nil, LoadOptions{AuditMode: AuditSkip}, filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "kept" {
+		t.Errorf("skills = %+v, want the input unchanged", got)
+	}
+}
+
+// TestAppendDirSkillsUnreadableDir keeps the other half of that rule: a read
+// failure that is not "not exist" is fatal, and carries the directory name.
+func TestAppendDirSkillsUnreadableDir(t *testing.T) {
+	// A regular file where a directory was expected: ReadDir fails with
+	// ENOTDIR, which is not os.IsNotExist.
+	notADir := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var blocked []string
+	got, err := appendDirSkills(nil, map[string]int{}, &blocked, LoadOptions{AuditMode: AuditSkip}, notADir)
+	if err == nil {
+		t.Fatal("expected an error for a non-directory")
+	}
+	if !strings.Contains(err.Error(), "reading skills dir "+notADir) {
+		t.Errorf("error = %q, want it to name the directory", err)
+	}
+	if got != nil {
+		t.Errorf("skills = %+v, want nil on error", got)
+	}
+}
+
+// TestAppendDirSkillsParseFailureIsFatal covers the other error return. A
+// SKILL.md that is a directory passes the Stat guard but cannot be read.
+func TestAppendDirSkillsParseFailureIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "broken", "SKILL.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var blocked []string
+	_, err := appendDirSkills(nil, map[string]int{}, &blocked, LoadOptions{AuditMode: AuditSkip}, dir)
+	if err == nil {
+		t.Fatal("expected an error for an unreadable SKILL.md")
+	}
+	if !strings.Contains(err.Error(), "parsing ") {
+		t.Errorf("error = %q, want a parsing failure", err)
+	}
+}
+
+// TestAppendDirSkillsDefaultNameAndSource pins the two per-skill fixups the
+// loop applies: the directory name fills in for a missing frontmatter name,
+// and Source is decided by whether the search dir is absolute.
+func TestAppendDirSkillsDefaultNameAndSource(t *testing.T) {
+	t.Run("absolute dir is a user skill and names default from the dir", func(t *testing.T) {
+		dir := t.TempDir()
+		// No name: in the frontmatter, so the directory name is used.
+		setupSkillWithContent(t, dir, "unnamed", "---\ndescription: no name here\n---\nBody.")
+		var blocked []string
+		got, err := appendDirSkills(nil, map[string]int{}, &blocked, LoadOptions{AuditMode: AuditSkip}, dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d skills, want 1", len(got))
+		}
+		if got[0].Name != "unnamed" {
+			t.Errorf("Name = %q, want the directory name %q", got[0].Name, "unnamed")
+		}
+		if got[0].Source != "user" {
+			t.Errorf("Source = %q, want user for an absolute dir", got[0].Source)
+		}
+	})
+
+	t.Run("relative dir is a project skill", func(t *testing.T) {
+		base := t.TempDir()
+		t.Chdir(base)
+		setupSkillWithContent(t, "skills", "local", "---\nname: local\ndescription: d\n---\nBody.")
+		var blocked []string
+		got, err := appendDirSkills(nil, map[string]int{}, &blocked, LoadOptions{AuditMode: AuditSkip}, "skills")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d skills, want 1", len(got))
+		}
+		if got[0].Source != "project" {
+			t.Errorf("Source = %q, want project for a relative dir", got[0].Source)
+		}
+	})
+}
+
+// TestAppendDirSkillsOverrideByIndex is the reason seen carries an index
+// rather than a bool: a later directory must replace the earlier skill in
+// place, not append a duplicate.
+func TestAppendDirSkillsOverrideByIndex(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	setupSkillWithContent(t, first, "dup", "---\nname: dup\ndescription: first\n---\nA")
+	setupSkillWithContent(t, second, "other", "---\nname: other\ndescription: other\n---\nO")
+	setupSkillWithContent(t, second, "dup", "---\nname: dup\ndescription: second\n---\nB")
+
+	seen := map[string]int{}
+	var blocked []string
+	opts := LoadOptions{AuditMode: AuditSkip}
+
+	skills, err := appendDirSkills(nil, seen, &blocked, opts, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 || skills[0].Description != "first" {
+		t.Fatalf("after first dir: %+v", skills)
+	}
+
+	skills, err = appendDirSkills(skills, seen, &blocked, opts, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2 (dup overridden in place, other appended)", len(skills))
+	}
+	got, ok := FindSkill(skills, "dup")
+	if !ok {
+		t.Fatal("dup missing after override")
+	}
+	if got.Description != "second" {
+		t.Errorf("dup.Description = %q, want the later directory to win", got.Description)
+	}
+	if seen["dup"] != 0 {
+		t.Errorf("seen[dup] = %d, want the original index 0", seen["dup"])
+	}
+}
+
+// --- appendBundledSkills / LoadSkillsWithOptions ---
+
+// TestAppendBundledSkillsIndexesSeen checks the bundled pass records an index
+// for every skill it appends, which is what lets a user skill override one.
+func TestAppendBundledSkillsIndexesSeen(t *testing.T) {
+	seen := map[string]int{}
+	skills := appendBundledSkills(nil, seen)
+	if len(skills) == 0 {
+		t.Skip("no bundled skills embedded in this build")
+	}
+	if len(seen) != len(skills) {
+		t.Fatalf("seen has %d entries for %d skills", len(seen), len(skills))
+	}
+	for name, idx := range seen {
+		if idx < 0 || idx >= len(skills) {
+			t.Fatalf("seen[%q] = %d, out of range", name, idx)
+		}
+		if skills[idx].Name != name {
+			t.Errorf("seen[%q] points at %q", name, skills[idx].Name)
+		}
+		if skills[idx].Source != "bundled" {
+			t.Errorf("%q has Source %q, want bundled", name, skills[idx].Source)
+		}
+	}
+}
+
+// TestAppendBundledSkillsAppendsToExisting checks the accumulator form: the
+// helper appends to what it is given rather than starting fresh.
+func TestAppendBundledSkillsAppendsToExisting(t *testing.T) {
+	seen := map[string]int{}
+	base := []Skill{{Name: "pre-existing"}}
+	got := appendBundledSkills(base, seen)
+	if len(got) < 1 || got[0].Name != "pre-existing" {
+		t.Fatalf("skills = %+v, want the input preserved at index 0", got)
+	}
+	for name, idx := range seen {
+		if got[idx].Name != name {
+			t.Errorf("seen[%q] = %d points at %q; indices must account for the prefix", name, idx, got[idx].Name)
+		}
+	}
+}
+
+// TestLoadSkillsWithOptionsUserOverridesBundled is the end-to-end check that
+// the two extracted passes still share one index map: a user skill named after
+// a bundled one replaces it instead of duplicating it.
+func TestLoadSkillsWithOptionsUserOverridesBundled(t *testing.T) {
+	bundled := appendBundledSkills(nil, map[string]int{})
+	if len(bundled) == 0 {
+		t.Skip("no bundled skills embedded in this build")
+	}
+	target := bundled[0].Name
+
+	dir := t.TempDir()
+	setupSkillWithContent(t, dir, target, "---\nname: "+target+"\ndescription: overridden by user\n---\nUser body.")
+
+	skills, err := LoadSkillsWithOptions(LoadOptions{AuditMode: AuditSkip}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != len(bundled) {
+		t.Fatalf("got %d skills, want %d — the override should not add one", len(skills), len(bundled))
+	}
+	got, ok := FindSkill(skills, target)
+	if !ok {
+		t.Fatalf("%q missing after override", target)
+	}
+	if got.Source != "user" {
+		t.Errorf("Source = %q, want user", got.Source)
+	}
+	if got.Description != "overridden by user" {
+		t.Errorf("Description = %q, want the user skill's", got.Description)
+	}
+}
+
+// TestLoadSkillsWithOptionsMultipleDirsStopAtFirstError checks the error from
+// a later directory still aborts the whole load, as the inline loop did.
+func TestLoadSkillsWithOptionsMultipleDirsStopAtFirstError(t *testing.T) {
+	good := t.TempDir()
+	setupSkillWithContent(t, good, "fine", "---\nname: fine\ndescription: d\n---\nB")
+
+	notADir := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skills, err := LoadSkillsWithOptions(LoadOptions{AuditMode: AuditSkip}, good, notADir)
+	if err == nil {
+		t.Fatal("expected an error from the second directory")
+	}
+	if skills != nil {
+		t.Errorf("skills = %+v, want nil on error", skills)
+	}
+}
+
+// TestLoadSkillsWithOptionsBlockedSummary checks the blocked list still
+// reaches the trailing summary now that it is threaded through by pointer.
+func TestLoadSkillsWithOptionsBlockedSummary(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	setupSkillWithContent(t, dirA, "bad-a", "---\nname: bad-a\ndescription: d\n---\nX"+bidiOverride+"Y")
+	setupSkillWithContent(t, dirB, "bad-b", "---\nname: bad-b\ndescription: d\n---\nX"+tagChar+"Y")
+	setupSkillWithContent(t, dirB, "good", "---\nname: good\ndescription: d\n---\nfine")
+
+	skills, err := LoadSkillsWithOptions(LoadOptions{AuditMode: AuditBlock}, dirA, dirB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := FindSkill(skills, "bad-a"); ok {
+		t.Error("bad-a should have been blocked")
+	}
+	if _, ok := FindSkill(skills, "bad-b"); ok {
+		t.Error("bad-b should have been blocked")
+	}
+	if _, ok := FindSkill(skills, "good"); !ok {
+		t.Error("good should have loaded")
+	}
+	if want := 1 + bundledSkillCount(t); len(skills) != want {
+		t.Errorf("got %d skills, want %d", len(skills), want)
+	}
+}
+
+func readDir(t *testing.T, dir string) []os.DirEntry {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}

--- a/internal/extension/skills.go
+++ b/internal/extension/skills.go
@@ -60,113 +60,16 @@ func LoadSkills(dirs ...string) ([]Skill, error) {
 // by user or project skills.
 func LoadSkillsWithOptions(opts LoadOptions, dirs ...string) ([]Skill, error) {
 	seen := make(map[string]int) // name → index in result
-	var skills []Skill
 	var blocked []string
 
 	// Load bundled skills first (lowest priority).
-	bundledMap, err := LoadBundledSkills()
-	if err == nil {
-		for skillName, files := range bundledMap {
-			var mainFile []byte
-			for _, f := range files {
-				if f.RelPath == "bundled_skills/"+skillName+"/SKILL.md" {
-					mainFile = f.Content
-					break
-				}
-			}
-			if len(mainFile) == 0 && len(files) > 0 {
-				mainFile = files[0].Content
-			}
-			if len(mainFile) == 0 {
-				continue
-			}
-			skill, body, err := parseSkillContent(string(mainFile), skillName)
-			if err != nil {
-				continue
-			}
-			skill.Source = "bundled"
-			skillName := skill.Name
-			seen[skillName] = len(skills)
-			// Body is already in memory for bundled skills — cache it so
-			// LoadSkillBody doesn't need to re-read the embed fs.
-			if body != "" {
-				bundledBodyCache.Store(skillName, body)
-			}
-			skills = append(skills, skill)
-		}
-	}
+	skills := appendBundledSkills(nil, seen)
 
 	for _, dir := range dirs {
-		entries, err := os.ReadDir(dir)
+		var err error
+		skills, err = appendDirSkills(skills, seen, &blocked, opts, dir)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("reading skills dir %s: %w", dir, err)
-		}
-
-		skillFiles := []struct {
-			path        string
-			defaultName string
-		}{
-			{path: filepath.Join(dir, "SKILL.md"), defaultName: filepath.Base(dir)},
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			skillFile := filepath.Join(dir, entry.Name(), "SKILL.md")
-			if _, err := os.Stat(skillFile); err != nil {
-				continue
-			}
-			skillFiles = append(skillFiles, struct {
-				path        string
-				defaultName string
-			}{path: skillFile, defaultName: entry.Name()})
-		}
-
-		for _, skillInfo := range skillFiles {
-			if _, err := os.Stat(skillInfo.path); err != nil {
-				continue
-			}
-
-			// Audit the skill file before loading.
-			if opts.AuditMode != AuditSkip {
-				scanResult, scanErr := audit.ScanFile(skillInfo.path)
-				if scanErr != nil {
-					fmt.Fprintf(os.Stderr, "pi-go: warning: audit scan failed for %s: %v\n", skillInfo.path, scanErr)
-				} else if scanResult.HasCritical() {
-					if opts.AuditMode == AuditBlock {
-						blocked = append(blocked, skillInfo.path)
-						fmt.Fprintf(os.Stderr, "pi-go: BLOCKED skill %s — critical hidden characters detected\n", skillInfo.defaultName)
-						continue
-					}
-					// AuditWarn: log but continue loading.
-					fmt.Fprintf(os.Stderr, "pi-go: WARNING: skill %s has critical hidden characters\n", skillInfo.defaultName)
-				}
-			}
-
-			skill, err := parseSkillFile(skillInfo.path)
-			if err != nil {
-				return nil, fmt.Errorf("parsing %s: %w", skillInfo.path, err)
-			}
-			// Default name from directory if not set in frontmatter
-			if skill.Name == "" {
-				skill.Name = skillInfo.defaultName
-			}
-			// Determine source based on whether the path is absolute.
-			source := "user"
-			if !filepath.IsAbs(dir) {
-				source = "project"
-			}
-			skill.Source = source
-			if idx, ok := seen[skill.Name]; ok {
-				// Override with project/user-level skill.
-				skills[idx] = skill
-			} else {
-				seen[skill.Name] = len(skills)
-				skills = append(skills, skill)
-			}
+			return nil, err
 		}
 	}
 
@@ -175,6 +78,149 @@ func LoadSkillsWithOptions(opts LoadOptions, dirs ...string) ([]Skill, error) {
 	}
 
 	return skills, nil
+}
+
+// skillCandidate pairs a SKILL.md path with the name to fall back to when the
+// file's frontmatter carries no name of its own.
+type skillCandidate struct {
+	path        string
+	defaultName string
+}
+
+// appendBundledSkills appends the skills embedded in the binary, recording
+// each one's index in seen so a later user or project skill can override it.
+// An unreadable embed fs yields no skills rather than an error.
+func appendBundledSkills(skills []Skill, seen map[string]int) []Skill {
+	bundledMap, err := LoadBundledSkills()
+	if err != nil {
+		return skills
+	}
+	for skillName, files := range bundledMap {
+		mainFile := bundledMainFile(files, skillName)
+		if len(mainFile) == 0 {
+			continue
+		}
+		skill, body, err := parseSkillContent(string(mainFile), skillName)
+		if err != nil {
+			continue
+		}
+		skill.Source = "bundled"
+		seen[skill.Name] = len(skills)
+		// Body is already in memory for bundled skills — cache it so
+		// LoadSkillBody doesn't need to re-read the embed fs.
+		if body != "" {
+			bundledBodyCache.Store(skill.Name, body)
+		}
+		skills = append(skills, skill)
+	}
+	return skills
+}
+
+// bundledMainFile picks a bundled skill's SKILL.md out of its file set,
+// falling back to the first file when that path is absent or empty.
+func bundledMainFile(files []BundledSkillFile, skillName string) []byte {
+	var mainFile []byte
+	for _, f := range files {
+		if f.RelPath == "bundled_skills/"+skillName+"/SKILL.md" {
+			mainFile = f.Content
+			break
+		}
+	}
+	if len(mainFile) == 0 && len(files) > 0 {
+		mainFile = files[0].Content
+	}
+	return mainFile
+}
+
+// appendDirSkills loads every SKILL.md under dir, overriding any same-named
+// skill loaded earlier. A directory that does not exist is skipped; any other
+// read failure, and any parse failure, is fatal.
+func appendDirSkills(skills []Skill, seen map[string]int, blocked *[]string, opts LoadOptions, dir string) ([]Skill, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return skills, nil
+		}
+		return nil, fmt.Errorf("reading skills dir %s: %w", dir, err)
+	}
+
+	for _, skillInfo := range skillCandidates(dir, entries) {
+		if _, err := os.Stat(skillInfo.path); err != nil {
+			continue
+		}
+
+		// Audit the skill file before loading.
+		if auditRejects(opts, skillInfo, blocked) {
+			continue
+		}
+
+		skill, err := parseSkillFile(skillInfo.path)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", skillInfo.path, err)
+		}
+		// Default name from directory if not set in frontmatter
+		if skill.Name == "" {
+			skill.Name = skillInfo.defaultName
+		}
+		// Determine source based on whether the path is absolute.
+		source := "user"
+		if !filepath.IsAbs(dir) {
+			source = "project"
+		}
+		skill.Source = source
+		if idx, ok := seen[skill.Name]; ok {
+			// Override with project/user-level skill.
+			skills[idx] = skill
+		} else {
+			seen[skill.Name] = len(skills)
+			skills = append(skills, skill)
+		}
+	}
+	return skills, nil
+}
+
+// skillCandidates lists the SKILL.md files to consider under dir: the
+// directory's own SKILL.md first, then one per subdirectory that has one.
+func skillCandidates(dir string, entries []os.DirEntry) []skillCandidate {
+	candidates := []skillCandidate{
+		{path: filepath.Join(dir, "SKILL.md"), defaultName: filepath.Base(dir)},
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(dir, entry.Name(), "SKILL.md")
+		if _, err := os.Stat(skillFile); err != nil {
+			continue
+		}
+		candidates = append(candidates, skillCandidate{path: skillFile, defaultName: entry.Name()})
+	}
+	return candidates
+}
+
+// auditRejects scans a skill file and reports whether it must not be loaded.
+// Only a critical finding under AuditBlock rejects — and records the path in
+// blocked; AuditWarn warns and loads, and a scan failure warns and loads.
+func auditRejects(opts LoadOptions, skillInfo skillCandidate, blocked *[]string) bool {
+	if opts.AuditMode == AuditSkip {
+		return false
+	}
+	scanResult, scanErr := audit.ScanFile(skillInfo.path)
+	if scanErr != nil {
+		fmt.Fprintf(os.Stderr, "pi-go: warning: audit scan failed for %s: %v\n", skillInfo.path, scanErr)
+		return false
+	}
+	if !scanResult.HasCritical() {
+		return false
+	}
+	if opts.AuditMode == AuditBlock {
+		*blocked = append(*blocked, skillInfo.path)
+		fmt.Fprintf(os.Stderr, "pi-go: BLOCKED skill %s — critical hidden characters detected\n", skillInfo.defaultName)
+		return true
+	}
+	// AuditWarn: log but continue loading.
+	fmt.Fprintf(os.Stderr, "pi-go: WARNING: skill %s has critical hidden characters\n", skillInfo.defaultName)
+	return false
 }
 
 // parseSkillFile reads a SKILL.md file and returns its metadata. The body is

--- a/internal/palace/complexity_palace_test.go
+++ b/internal/palace/complexity_palace_test.go
@@ -1,0 +1,873 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests pin the behavior of the helpers extracted out of
+// (*DrawerService).Search, MineConversations and extractTriples. Each case
+// corresponds to a branch that used to live inline in those functions, so a
+// regression in the extraction shows up here rather than in an integration
+// test that happens to exercise the same path.
+
+// --- drawer_service: FTS5 scoring ------------------------------------------
+
+func TestMaxFTSRank(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []SearchResult
+		want    int
+	}{
+		{"no results floors at 1", nil, 1},
+		{"empty slice floors at 1", []SearchResult{}, 1},
+		{"negative ranks never lower the floor", []SearchResult{{Rank: -8}, {Rank: -1}}, 1},
+		{"zero rank never lowers the floor", []SearchResult{{Rank: 0}}, 1},
+		{"largest positive rank wins", []SearchResult{{Rank: 2}, {Rank: 9}, {Rank: 5}}, 9},
+		{"mixed signs take the maximum", []SearchResult{{Rank: -4}, {Rank: 3}}, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maxFTSRank(tc.results); got != tc.want {
+				t.Errorf("maxFTSRank = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFTSRelevance(t *testing.T) {
+	tests := []struct {
+		name          string
+		rank, maxRank int
+		want          float64
+	}{
+		{"zero maxRank falls back to the midpoint", 0, 0, 0.5},
+		{"negative maxRank falls back to the midpoint", -3, -1, 0.5},
+		{"rank equal to maxRank scores the midpoint", 4, 4, 0.5},
+		{"rank of zero against maxRank 1 scores the top", 0, 1, 1.0},
+		{"more negative rank scores higher", -1, 1, 1.5},
+		{"halfway between", 2, 4, 0.75},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ftsRelevance(tc.rank, tc.maxRank); got != tc.want {
+				t.Errorf("ftsRelevance(%d, %d) = %v, want %v", tc.rank, tc.maxRank, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKeywordOnlyResults(t *testing.T) {
+	t.Run("rank zero keeps its similarity untouched", func(t *testing.T) {
+		in := []SearchResult{{Drawer: Drawer{ID: "a"}, Rank: 0, Similarity: 0.25}}
+		got := keywordOnlyResults(in, 5)
+		if got[0].Similarity != 0.25 {
+			t.Errorf("Similarity = %v, want the original 0.25 — rank 0 means semantic-only", got[0].Similarity)
+		}
+	})
+
+	t.Run("ranked rows are rescored", func(t *testing.T) {
+		in := []SearchResult{{Drawer: Drawer{ID: "a"}, Rank: -2}, {Drawer: Drawer{ID: "b"}, Rank: -1}}
+		got := keywordOnlyResults(in, 5)
+		if got[0].Similarity <= got[1].Similarity {
+			t.Errorf("rank -2 scored %v, rank -1 scored %v — more negative rank must score higher",
+				got[0].Similarity, got[1].Similarity)
+		}
+		if got[0].Similarity < 0.5 {
+			t.Errorf("Similarity = %v, want >= 0.5 — the scale starts at the midpoint", got[0].Similarity)
+		}
+	})
+
+	t.Run("trims to the limit", func(t *testing.T) {
+		in := []SearchResult{{Rank: -3}, {Rank: -2}, {Rank: -1}}
+		if got := keywordOnlyResults(in, 2); len(got) != 2 {
+			t.Errorf("len = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("fewer results than the limit are returned whole", func(t *testing.T) {
+		in := []SearchResult{{Rank: -1}}
+		if got := keywordOnlyResults(in, 10); len(got) != 1 {
+			t.Errorf("len = %d, want 1", len(got))
+		}
+	})
+}
+
+// --- drawer_service: semantic/keyword merge --------------------------------
+
+func TestResolveRanked(t *testing.T) {
+	ds := NewDrawerService(newTestStore(t), nil, DefaultConfig())
+	ctx := context.Background()
+	kept := addDrawer(t, ds, "w", "r", "a drawer that exists in the store")
+
+	got := ds.resolveRanked(ctx, []ScoredResult{
+		{DrawerID: kept.ID, Similarity: 0.9},
+		{DrawerID: "not-in-the-store", Similarity: 0.8},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 — a ranked ID with no drawer must be dropped, not fail the search", len(got))
+	}
+	res, ok := got[kept.ID]
+	if !ok {
+		t.Fatalf("resolved map is missing %q", kept.ID)
+	}
+	if res.Similarity != 0.9 {
+		t.Errorf("Similarity = %v, want the ranked score 0.9", res.Similarity)
+	}
+	if res.Drawer.ID != kept.ID {
+		t.Errorf("Drawer.ID = %q, want %q", res.Drawer.ID, kept.ID)
+	}
+}
+
+func TestMergeSearchResults(t *testing.T) {
+	semantic := map[string]SearchResult{
+		"s1": {Drawer: Drawer{ID: "s1"}, Similarity: 0.9},
+		"s2": {Drawer: Drawer{ID: "s2"}, Similarity: 0.7},
+	}
+
+	t.Run("semantic results come first in ranked order", func(t *testing.T) {
+		ranked := []ScoredResult{{DrawerID: "s1"}, {DrawerID: "s2"}}
+		got := mergeSearchResults(ranked, semantic, nil, 10)
+		if len(got) != 2 || got[0].Drawer.ID != "s1" || got[1].Drawer.ID != "s2" {
+			t.Fatalf("got %v, want [s1 s2] in ranked order", ids(got))
+		}
+	})
+
+	t.Run("ranked IDs missing from the semantic map are dropped", func(t *testing.T) {
+		ranked := []ScoredResult{{DrawerID: "s1"}, {DrawerID: "gone"}, {DrawerID: "s2"}}
+		got := mergeSearchResults(ranked, semantic, nil, 10)
+		if len(got) != 2 {
+			t.Fatalf("got %v, want only the two resolvable IDs", ids(got))
+		}
+	})
+
+	t.Run("FTS5 hits already in the semantic set are not duplicated", func(t *testing.T) {
+		ranked := []ScoredResult{{DrawerID: "s1"}}
+		fts := []SearchResult{{Drawer: Drawer{ID: "s1"}, Rank: -1}}
+		got := mergeSearchResults(ranked, semantic, fts, 10)
+		if len(got) != 1 {
+			t.Fatalf("got %v, want a single s1 — the FTS5 hit duplicates the semantic one", ids(got))
+		}
+		if got[0].Similarity != 0.9 {
+			t.Errorf("Similarity = %v, want the semantic 0.9 to win over the FTS5 score", got[0].Similarity)
+		}
+	})
+
+	t.Run("FTS5-only hits are appended with a normalized score", func(t *testing.T) {
+		ranked := []ScoredResult{{DrawerID: "s1"}}
+		fts := []SearchResult{{Drawer: Drawer{ID: "k1"}, Rank: -4}}
+		got := mergeSearchResults(ranked, semantic, fts, 10)
+		if len(got) != 2 || got[1].Drawer.ID != "k1" {
+			t.Fatalf("got %v, want [s1 k1]", ids(got))
+		}
+		if got[1].Similarity < 0.5 {
+			t.Errorf("Similarity = %v, want >= 0.5", got[1].Similarity)
+		}
+		if got[1].Rank != -4 {
+			t.Errorf("Rank = %d, want the original -4 preserved", got[1].Rank)
+		}
+	})
+
+	t.Run("duplicate FTS5 IDs are added once", func(t *testing.T) {
+		fts := []SearchResult{
+			{Drawer: Drawer{ID: "k1"}, Rank: -2},
+			{Drawer: Drawer{ID: "k1"}, Rank: -1},
+		}
+		got := mergeSearchResults(nil, semantic, fts, 10)
+		if len(got) != 1 {
+			t.Fatalf("got %v, want a single k1", ids(got))
+		}
+	})
+
+	t.Run("trims to the limit", func(t *testing.T) {
+		ranked := []ScoredResult{{DrawerID: "s1"}, {DrawerID: "s2"}}
+		fts := []SearchResult{{Drawer: Drawer{ID: "k1"}, Rank: -1}}
+		got := mergeSearchResults(ranked, semantic, fts, 2)
+		if len(got) != 2 {
+			t.Fatalf("got %v, want 2 after trimming", ids(got))
+		}
+	})
+}
+
+func ids(results []SearchResult) []string {
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		out = append(out, r.Drawer.ID)
+	}
+	return out
+}
+
+// --- miner_convo -----------------------------------------------------------
+
+func TestResolveMineConfig(t *testing.T) {
+	t.Run("nil config with no yaml defaults the wing to the directory name", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "my-project")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		got := resolveMineConfig(dir, nil)
+		if got.Wing != "my-project" {
+			t.Errorf("Wing = %q, want %q", got.Wing, "my-project")
+		}
+	})
+
+	t.Run("nil config loads mempalace.yaml when present", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestFile(t, filepath.Join(dir, "mempalace.yaml"), "wing: from-yaml\n")
+		got := resolveMineConfig(dir, nil)
+		if got.Wing != "from-yaml" {
+			t.Errorf("Wing = %q, want %q", got.Wing, "from-yaml")
+		}
+	})
+
+	t.Run("an empty wing in a loaded config still defaults", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "fallback-dir")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		writeTestFile(t, filepath.Join(dir, "mempalace.yaml"), "rooms: []\n")
+		got := resolveMineConfig(dir, nil)
+		if got.Wing != "fallback-dir" {
+			t.Errorf("Wing = %q, want %q", got.Wing, "fallback-dir")
+		}
+	})
+
+	t.Run("an explicit wing is preserved", func(t *testing.T) {
+		got := resolveMineConfig(t.TempDir(), &MineConfig{Wing: "explicit"})
+		if got.Wing != "explicit" {
+			t.Errorf("Wing = %q, want %q", got.Wing, "explicit")
+		}
+	})
+
+	t.Run("an explicit config with an empty wing takes the directory name", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "named")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		got := resolveMineConfig(dir, &MineConfig{})
+		if got.Wing != "named" {
+			t.Errorf("Wing = %q, want %q", got.Wing, "named")
+		}
+	})
+}
+
+// fakeDirEntry is the minimum os.DirEntry needed to drive visitMineDir.
+type fakeDirEntry struct{ name string }
+
+func (f fakeDirEntry) Name() string             { return f.name }
+func (fakeDirEntry) IsDir() bool                { return true }
+func (fakeDirEntry) Type() fs.FileMode          { return fs.ModeDir }
+func (fakeDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+
+func TestVisitMineDir(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		skip bool
+	}{
+		{"dotfile directory is skipped", ".git", true},
+		{"a bare dot is the walk root, not a dotfile", ".", false},
+		{"named skip directory", "node_modules", true},
+		{"ordinary directory is descended", "internal", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := visitMineDir(fakeDirEntry{name: tc.dir})
+			if tc.skip && !errors.Is(got, filepath.SkipDir) {
+				t.Errorf("visitMineDir(%q) = %v, want SkipDir", tc.dir, got)
+			}
+			if !tc.skip && got != nil {
+				t.Errorf("visitMineDir(%q) = %v, want nil", tc.dir, got)
+			}
+		})
+	}
+}
+
+func TestConvoMinerParseFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "ok.jsonl"), `{"role":"user","content":"hi"}
+{"role":"assistant","content":"hello"}
+`)
+	writeTestFile(t, filepath.Join(dir, "ok.txt"), "> question\nAssistant: answer\n")
+	writeTestFile(t, filepath.Join(dir, "ok.md"), "> question\nAssistant: answer\n")
+	writeTestFile(t, filepath.Join(dir, "skip.go"), "package main\n")
+	writeTestFile(t, filepath.Join(dir, "empty.txt"), "no markers here\n")
+	// A directory named like a conversation file: opening it succeeds but
+	// reading it fails, which is the parse-error branch.
+	for _, bad := range []string{"bad.jsonl", "bad.txt"} {
+		if err := os.MkdirAll(filepath.Join(dir, bad), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		file          string
+		wantParsed    bool
+		wantExchanges int
+		wantErrors    int
+	}{
+		{"jsonl parses", "ok.jsonl", true, 1, 0},
+		{"txt parses", "ok.txt", true, 1, 0},
+		{"md parses", "ok.md", true, 1, 0},
+		{"text with no markers parses to zero exchanges", "empty.txt", true, 0, 0},
+		{"unsupported extension is skipped without an error", "skip.go", false, 0, 0},
+		{"unreadable jsonl counts an error", "bad.jsonl", false, 0, 1},
+		{"unreadable text counts an error", "bad.txt", false, 0, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &convoMiner{result: &MineResult{}}
+			got, parsed := m.parseFile(filepath.Join(dir, tc.file), tc.file)
+			if parsed != tc.wantParsed {
+				t.Fatalf("parsed = %v, want %v", parsed, tc.wantParsed)
+			}
+			if len(got) != tc.wantExchanges {
+				t.Errorf("exchanges = %d, want %d", len(got), tc.wantExchanges)
+			}
+			if m.result.Errors != tc.wantErrors {
+				t.Errorf("result.Errors = %d, want %d", m.result.Errors, tc.wantErrors)
+			}
+		})
+	}
+}
+
+func TestConvoMinerAddExchanges(t *testing.T) {
+	newMiner := func(t *testing.T, cfg *MineConfig) *convoMiner {
+		t.Helper()
+		return &convoMiner{
+			ctx:    context.Background(),
+			palace: newTestPalace(t),
+			cfg:    cfg,
+			result: &MineResult{},
+		}
+	}
+
+	t.Run("counts additions and reports progress", func(t *testing.T) {
+		var gotFile string
+		var gotAdded, gotSkipped, gotErrors int
+		m := newMiner(t, &MineConfig{
+			Wing: "w",
+			Progress: func(file string, added, skipped, errors int) {
+				gotFile, gotAdded, gotSkipped, gotErrors = file, added, skipped, errors
+			},
+		})
+
+		m.addExchanges("chat.txt", []exchange{{content: "first"}, {content: "second"}})
+
+		if m.result.Added != 2 || m.result.Processed != 2 {
+			t.Errorf("Added=%d Processed=%d, want 2 and 2", m.result.Added, m.result.Processed)
+		}
+		if gotFile != "chat.txt" || gotAdded != 2 || gotSkipped != 0 || gotErrors != 0 {
+			t.Errorf("progress = (%q, %d, %d, %d), want (chat.txt, 2, 0, 0)",
+				gotFile, gotAdded, gotSkipped, gotErrors)
+		}
+	})
+
+	t.Run("duplicate content is skipped, not counted as an error", func(t *testing.T) {
+		var gotAdded, gotSkipped int
+		m := newMiner(t, &MineConfig{
+			Wing: "w",
+			Progress: func(_ string, added, skipped, _ int) {
+				gotAdded, gotSkipped = added, skipped
+			},
+		})
+
+		// Identical content in two different chunk slots of the same file:
+		// the ids differ, so the content-hash dedup fires on the second.
+		m.addExchanges("chat.txt", []exchange{{content: "same text"}, {content: "same text"}})
+
+		if m.result.Added != 1 || m.result.Skipped != 1 {
+			t.Errorf("Added=%d Skipped=%d, want 1 and 1", m.result.Added, m.result.Skipped)
+		}
+		if m.result.Errors != 0 {
+			t.Errorf("Errors = %d, want 0 — a duplicate is not an error", m.result.Errors)
+		}
+		if gotAdded != 1 || gotSkipped != 1 {
+			t.Errorf("progress added=%d skipped=%d, want 1 and 1", gotAdded, gotSkipped)
+		}
+	})
+
+	t.Run("a non-duplicate failure is counted as an error", func(t *testing.T) {
+		var gotErrors int
+		m := newMiner(t, &MineConfig{
+			Wing: "w",
+			Progress: func(_ string, _, _, errors int) {
+				gotErrors = errors
+			},
+		})
+
+		// Empty content is rejected by AddDrawer for a reason that is not a
+		// duplicate, which is the other side of the error branch.
+		m.addExchanges("chat.txt", []exchange{{content: ""}})
+
+		if m.result.Errors != 1 || m.result.Skipped != 0 || m.result.Added != 0 {
+			t.Errorf("Errors=%d Skipped=%d Added=%d, want 1, 0, 0",
+				m.result.Errors, m.result.Skipped, m.result.Added)
+		}
+		if gotErrors != 1 {
+			t.Errorf("progress errors = %d, want 1", gotErrors)
+		}
+	})
+
+	t.Run("a nil progress callback is not invoked", func(t *testing.T) {
+		m := newMiner(t, &MineConfig{Wing: "w"})
+		m.addExchanges("chat.txt", []exchange{{content: "only one"}})
+		if m.result.Added != 1 {
+			t.Errorf("Added = %d, want 1", m.result.Added)
+		}
+	})
+
+	t.Run("room detection uses the configured keywords", func(t *testing.T) {
+		m := newMiner(t, &MineConfig{
+			Wing:  "w",
+			Rooms: []RoomDef{{Name: "auth", Keywords: []string{"token"}}},
+		})
+		m.addExchanges("chat.txt", []exchange{{content: "refresh token handling"}})
+
+		drawers, err := m.palace.ListDrawers(m.ctx, DrawerFilter{Wing: "w"})
+		if err != nil {
+			t.Fatalf("ListDrawers: %v", err)
+		}
+		if len(drawers) != 1 || drawers[0].Room != "auth" {
+			t.Fatalf("got %d drawers, first room %v, want 1 drawer in room auth", len(drawers), roomOf(drawers))
+		}
+	})
+}
+
+func roomOf(drawers []*Drawer) string {
+	if len(drawers) == 0 {
+		return ""
+	}
+	return drawers[0].Room
+}
+
+// TestMineConversations_ReportsProgressForEmptyParse pins the distinction the
+// (exchanges, parsed) return carries: a file that parses to zero exchanges
+// still reports progress, while an unsupported extension does not.
+func TestMineConversations_ReportsProgressForEmptyParse(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "nomarkers.txt"), "just prose with no turn markers\n")
+	writeTestFile(t, filepath.Join(dir, "code.go"), "package main\n")
+
+	var reported []string
+	cfg := &MineConfig{
+		Wing: "w",
+		Progress: func(file string, _, _, _ int) {
+			reported = append(reported, file)
+		},
+	}
+
+	if _, err := MineConversations(context.Background(), newTestPalace(t), dir, cfg); err != nil {
+		t.Fatalf("MineConversations: %v", err)
+	}
+
+	if len(reported) != 1 || reported[0] != "nomarkers.txt" {
+		t.Errorf("progress reported for %v, want only [nomarkers.txt]", reported)
+	}
+}
+
+// TestMineConversations_CountsWalkErrors pins the walkErr branch of visit: an
+// unreadable subdirectory is tallied and the walk continues, rather than
+// abandoning the rest of the tree.
+func TestMineConversations_CountsWalkErrors(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: permission bits do not make a directory unreadable")
+	}
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "chat.txt"), "> question\nAssistant: answer\n")
+
+	locked := filepath.Join(dir, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0o755) })
+
+	result, err := MineConversations(context.Background(), newTestPalace(t), dir, &MineConfig{Wing: "w"})
+	if err != nil {
+		t.Fatalf("MineConversations: %v", err)
+	}
+	if result.Errors == 0 {
+		t.Error("Errors = 0, want the unreadable directory to be counted")
+	}
+	if result.Added != 1 {
+		t.Errorf("Added = %d, want 1 — the readable file must still be mined", result.Added)
+	}
+}
+
+// --- tool_kg_extract -------------------------------------------------------
+
+func TestTripleSinkAdd(t *testing.T) {
+	t.Run("blank fields are dropped", func(t *testing.T) {
+		ts := newTripleSink()
+		ts.add("", "imports", "x", "r", 0.9)
+		ts.add("a", "", "x", "r", 0.9)
+		ts.add("a", "imports", "", "r", 0.9)
+		ts.add("   ", "imports", "x", "r", 0.9)
+		if len(ts.out) != 0 {
+			t.Errorf("got %d triples, want 0", len(ts.out))
+		}
+	})
+
+	t.Run("a self-referential triple is dropped case-insensitively", func(t *testing.T) {
+		ts := newTripleSink()
+		ts.add("Handler", "defined_in", "handler", "r", 0.9)
+		if len(ts.out) != 0 {
+			t.Errorf("got %d triples, want 0 — subject and object are the same entity", len(ts.out))
+		}
+	})
+
+	t.Run("duplicates are dropped case-insensitively, first reason wins", func(t *testing.T) {
+		ts := newTripleSink()
+		ts.add("A", "defined_in", "f.go", "first", 0.95)
+		ts.add("a", "DEFINED_IN", "F.GO", "second", 0.10)
+		if len(ts.out) != 1 {
+			t.Fatalf("got %d triples, want 1", len(ts.out))
+		}
+		if ts.out[0].Reason != "first" {
+			t.Errorf("Reason = %q, want %q", ts.out[0].Reason, "first")
+		}
+		if ts.out[0].Confidence != 0.95 {
+			t.Errorf("Confidence = %v, want 0.95", ts.out[0].Confidence)
+		}
+	})
+
+	t.Run("fields are trimmed and the predicate normalized", func(t *testing.T) {
+		ts := newTripleSink()
+		ts.add("  Sub  ", "  part of  ", "  Obj  ", "r", 0.7)
+		if len(ts.out) != 1 {
+			t.Fatalf("got %d triples, want 1", len(ts.out))
+		}
+		got := ts.out[0]
+		if got.Subject != "Sub" || got.Object != "Obj" {
+			t.Errorf("Subject=%q Object=%q, want Sub and Obj", got.Subject, got.Object)
+		}
+		if got.Predicate != "part_of" {
+			t.Errorf("Predicate = %q, want %q", got.Predicate, "part_of")
+		}
+	})
+}
+
+func TestImportBlockBody(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		start int
+		want  string
+	}{
+		{"terminated block stops at the closing paren", "import (\n\t\"a\"\n)\nrest", len("import ("), "\n\t\"a\""},
+		{"unterminated block runs to the end", "import (\n\t\"a\"\n\t\"b\"", len("import ("), "\n\t\"a\"\n\t\"b\""},
+		{"immediately closed block is empty", "import (\n)", len("import ("), ""},
+		{"an indented closing paren does not terminate", "import (\n\t\"a\"\n\t)", len("import ("), "\n\t\"a\"\n\t)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := importBlockBody(tc.text, tc.start); got != tc.want {
+				t.Errorf("importBlockBody = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmitImport(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		sourceFile string
+		wantSubj   string
+		wantObj    string
+		wantConf   float64
+		wantEmit   bool
+	}{
+		{name: "empty path emits nothing", path: ""},
+		{name: "stdlib path emits nothing", path: "strings"},
+		{name: "relative path emits nothing", path: "./local"},
+		{
+			name: "third-party path with a source file anchors to the file",
+			path: "github.com/x/y", sourceFile: "internal/a/b.go",
+			wantSubj: "b.go", wantObj: "github.com/x/y", wantConf: 0.95, wantEmit: true,
+		},
+		{
+			name:     "third-party path with no source file anchors to the codebase",
+			path:     "github.com/x/y",
+			wantSubj: "codebase", wantObj: "github.com/x/y", wantConf: 0.50, wantEmit: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newTripleSink()
+			emitImport("", tc.path, tc.sourceFile, ts.add)
+			if !tc.wantEmit {
+				if len(ts.out) != 0 {
+					t.Fatalf("got %d triples, want 0", len(ts.out))
+				}
+				return
+			}
+			if len(ts.out) != 1 {
+				t.Fatalf("got %d triples, want 1", len(ts.out))
+			}
+			got := ts.out[0]
+			if got.Subject != tc.wantSubj || got.Object != tc.wantObj || got.Predicate != "imports" {
+				t.Errorf("triple = (%q, %q, %q), want (%q, imports, %q)",
+					got.Subject, got.Predicate, got.Object, tc.wantSubj, tc.wantObj)
+			}
+			if got.Confidence != tc.wantConf {
+				t.Errorf("Confidence = %v, want %v", got.Confidence, tc.wantConf)
+			}
+		})
+	}
+}
+
+func TestExtractImportTriples(t *testing.T) {
+	t.Run("single-line forms", func(t *testing.T) {
+		text := `import "github.com/a/one"
+from "github.com/b/two"
+require("github.com/c/three")
+import alias "github.com/d/four"
+`
+		ts := newTripleSink()
+		extractImportTriples(text, "", ts.add)
+		want := []string{"github.com/a/one", "github.com/b/two", "github.com/c/three", "github.com/d/four"}
+		assertObjects(t, ts.out, want)
+	})
+
+	t.Run("parenthesized Go block", func(t *testing.T) {
+		text := "package x\n\nimport (\n\t\"fmt\"\n\t\"github.com/a/one\"\n\t\"github.com/b/two\"\n)\n\nfunc noop() {}\n"
+		ts := newTripleSink()
+		extractImportTriples(text, "", ts.add)
+		// "fmt" is stdlib and filtered out.
+		assertObjects(t, ts.out, []string{"github.com/a/one", "github.com/b/two"})
+	})
+
+	t.Run("a path seen on a single line is not re-emitted from the block", func(t *testing.T) {
+		text := "import \"github.com/a/one\"\n\nimport (\n\t\"github.com/a/one\"\n\t\"github.com/b/two\"\n)\n"
+		ts := newTripleSink()
+		extractImportTriples(text, "", ts.add)
+		assertObjects(t, ts.out, []string{"github.com/a/one", "github.com/b/two"})
+	})
+
+	t.Run("quoted strings outside an import block are ignored", func(t *testing.T) {
+		text := "func f() { log(\"github.com/not/an/import\") }\n"
+		ts := newTripleSink()
+		extractImportTriples(text, "", ts.add)
+		assertObjects(t, ts.out, nil)
+	})
+}
+
+func TestExtractDeclarationTriples(t *testing.T) {
+	const decls = "func Handler() {}\n" +
+		"func (s *Server) Serve() {}\n" +
+		"type Config struct {\n}\n" +
+		"type Store interface {\n}\n" +
+		"def python_thing():\n" +
+		"class JSThing:\n" +
+		"const result = 1\n"
+
+	t.Run("nothing is emitted without a source file", func(t *testing.T) {
+		ts := newTripleSink()
+		extractDeclarationTriples(decls, "", ts.add)
+		if len(ts.out) != 0 {
+			t.Errorf("got %d triples, want 0 — there is no file to anchor them to", len(ts.out))
+		}
+	})
+
+	t.Run("every declaration kind is anchored to the source file", func(t *testing.T) {
+		ts := newTripleSink()
+		extractDeclarationTriples(decls, "internal/x/y.go", ts.add)
+
+		subjects := map[string]ExtractedTriple{}
+		for _, tr := range ts.out {
+			subjects[tr.Subject] = tr
+		}
+		for _, want := range []string{"Handler", "Serve", "Config", "Store", "python_thing", "JSThing"} {
+			tr, ok := subjects[want]
+			if !ok {
+				t.Errorf("missing a triple for %q; got %v", want, subjectsOf(ts.out))
+				continue
+			}
+			if tr.Predicate != "defined_in" || tr.Object != "internal/x/y.go" || tr.Confidence != 0.95 {
+				t.Errorf("%q = (%q, %q, %v), want (defined_in, internal/x/y.go, 0.95)",
+					want, tr.Predicate, tr.Object, tr.Confidence)
+			}
+		}
+		if _, ok := subjects["result"]; ok {
+			t.Error("`const result` produced a triple; common words must be filtered from the generic pattern")
+		}
+	})
+
+	t.Run("the Go pattern is not subject to the common-word filter", func(t *testing.T) {
+		// `func Result` is capitalized, so goFuncDeclRe matches it. The
+		// common-word filter applies only to the generic pattern, so this
+		// must survive even though "result" is a common word.
+		ts := newTripleSink()
+		extractDeclarationTriples("func Result() {}\n", "f.go", ts.add)
+		assertSubjects(t, ts.out, []string{"Result"})
+	})
+
+	t.Run("lowercase Go declarations are not matched", func(t *testing.T) {
+		ts := newTripleSink()
+		extractDeclarationTriples("func unexported() {}\ntype hidden struct {\n}\n", "f.go", ts.add)
+		assertSubjects(t, ts.out, nil)
+	})
+
+	t.Run("heuristic order decides the reason on a collision", func(t *testing.T) {
+		// A single name reachable by both the Go func pattern and the
+		// generic one: the sink dedupes, so the earlier heuristic's reason
+		// is the one recorded.
+		ts := newTripleSink()
+		extractDeclarationTriples("func Thing() {}\nclass Thing:\n", "f.go", ts.add)
+		if len(ts.out) != 1 {
+			t.Fatalf("got %d triples, want 1", len(ts.out))
+		}
+		if ts.out[0].Reason != "Go func declaration in source file" {
+			t.Errorf("Reason = %q, want the Go func reason to win", ts.out[0].Reason)
+		}
+	})
+}
+
+func TestExtractPathTriples(t *testing.T) {
+	const text = "see internal/x/sibling.go and internal/other/far.go and internal/x/self.go\n"
+
+	t.Run("nothing is emitted without a source file", func(t *testing.T) {
+		ts := newTripleSink()
+		extractPathTriples(text, "", ts.add)
+		if len(ts.out) != 0 {
+			t.Errorf("got %d triples, want 0", len(ts.out))
+		}
+	})
+
+	t.Run("only same-directory paths become part_of", func(t *testing.T) {
+		ts := newTripleSink()
+		extractPathTriples(text, "internal/x/self.go", ts.add)
+		assertSubjects(t, ts.out, []string{"internal/x/sibling.go"})
+		if len(ts.out) == 1 {
+			got := ts.out[0]
+			if got.Predicate != "part_of" || got.Object != "self.go" || got.Confidence != 0.70 {
+				t.Errorf("triple = (%q, %q, %v), want (part_of, self.go, 0.7)",
+					got.Predicate, got.Object, got.Confidence)
+			}
+		}
+	})
+
+	t.Run("a source file at the repo root has no directory to share", func(t *testing.T) {
+		ts := newTripleSink()
+		extractPathTriples("see internal/x/a.go\n", "main.go", ts.add)
+		assertSubjects(t, ts.out, nil)
+	})
+}
+
+// TestExtractTriples_EndToEnd runs the three extraction steps together over
+// one chunk, which is what extractTriples did inline before the split.
+func TestExtractTriples_EndToEnd(t *testing.T) {
+	text := "package handler\n\n" +
+		"import (\n\t\"fmt\"\n\t\"github.com/dimetron/pi-go/internal/palace\"\n)\n\n" +
+		"type Handler struct {\n}\n\n" +
+		"func Serve() {}\n\n" +
+		"// see internal/api/routes.go for the table\n"
+
+	t.Run("with a source file", func(t *testing.T) {
+		got := extractTriples(text, "internal/api/handler.go")
+		want := map[string]string{
+			"github.com/dimetron/pi-go/internal/palace": "imports",
+			"Handler":                "defined_in",
+			"Serve":                  "defined_in",
+			"internal/api/routes.go": "part_of",
+		}
+		byKey := map[string]ExtractedTriple{}
+		for _, tr := range got {
+			// Imports are keyed by object, declarations and paths by subject.
+			if tr.Predicate == "imports" {
+				byKey[tr.Object] = tr
+			} else {
+				byKey[tr.Subject] = tr
+			}
+		}
+		for key, pred := range want {
+			tr, ok := byKey[key]
+			if !ok {
+				t.Errorf("missing a triple for %q", key)
+				continue
+			}
+			if tr.Predicate != pred {
+				t.Errorf("%q predicate = %q, want %q", key, tr.Predicate, pred)
+			}
+		}
+		for _, tr := range got {
+			if tr.Object == "fmt" {
+				t.Error("stdlib import fmt leaked into the candidates")
+			}
+		}
+	})
+
+	t.Run("without a source file only imports survive", func(t *testing.T) {
+		got := extractTriples(text, "")
+		for _, tr := range got {
+			if tr.Predicate != "imports" {
+				t.Errorf("unexpected %q triple with no source file: %+v", tr.Predicate, tr)
+			}
+			if tr.Subject != "codebase" {
+				t.Errorf("Subject = %q, want %q when there is no file to anchor to", tr.Subject, "codebase")
+			}
+		}
+		if len(got) == 0 {
+			t.Error("expected at least the third-party import to be extracted")
+		}
+	})
+
+	t.Run("prose yields nothing", func(t *testing.T) {
+		if got := extractTriples("Just a sentence about nothing in particular.", "notes.md"); len(got) != 0 {
+			t.Errorf("got %d triples from prose, want 0: %v", len(got), got)
+		}
+	})
+}
+
+func subjectsOf(triples []ExtractedTriple) []string {
+	out := make([]string, 0, len(triples))
+	for _, tr := range triples {
+		out = append(out, tr.Subject)
+	}
+	return out
+}
+
+func objectsOf(triples []ExtractedTriple) []string {
+	out := make([]string, 0, len(triples))
+	for _, tr := range triples {
+		out = append(out, tr.Object)
+	}
+	return out
+}
+
+func assertSubjects(t *testing.T, triples []ExtractedTriple, want []string) {
+	t.Helper()
+	assertSetEqual(t, "subjects", subjectsOf(triples), want)
+}
+
+func assertObjects(t *testing.T, triples []ExtractedTriple, want []string) {
+	t.Helper()
+	assertSetEqual(t, "objects", objectsOf(triples), want)
+}
+
+func assertSetEqual(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = [%s], want [%s]", label, strings.Join(got, " "), strings.Join(want, " "))
+	}
+	gotSet := make(map[string]bool, len(got))
+	for _, g := range got {
+		gotSet[g] = true
+	}
+	for _, w := range want {
+		if !gotSet[w] {
+			t.Fatalf("%s = [%s], want [%s]", label, strings.Join(got, " "), strings.Join(want, " "))
+		}
+	}
+}

--- a/internal/palace/drawer_service.go
+++ b/internal/palace/drawer_service.go
@@ -141,25 +141,7 @@ func (ds *DrawerService) Search(ctx context.Context, q SearchQuery) ([]SearchRes
 
 	// If no embedder, return FTS5 results only.
 	if ds.embedder == nil {
-		// Ensure FTS5 results have proper similarity scores.
-		maxRank := 1
-		for _, r := range ftsResults {
-			if r.Rank > maxRank {
-				maxRank = r.Rank
-			}
-		}
-		if maxRank == 0 {
-			maxRank = 1
-		}
-		for i := range ftsResults {
-			if ftsResults[i].Rank != 0 {
-				ftsResults[i].Similarity = float32(0.5 + (0.5 * float64(maxRank-ftsResults[i].Rank) / float64(maxRank)))
-			}
-		}
-		if len(ftsResults) > q.Limit {
-			ftsResults = ftsResults[:q.Limit]
-		}
-		return ftsResults, nil
+		return keywordOnlyResults(ftsResults, q.Limit), nil
 	}
 
 	// Semantic search.
@@ -178,8 +160,57 @@ func (ds *DrawerService) Search(ctx context.Context, q SearchQuery) ([]SearchRes
 	}
 
 	ranked := RankBySimilarity(vecs[0], candidates, q.Limit*3)
+	semanticMap := ds.resolveRanked(ctx, ranked)
 
-	// Build a map of semantic results keyed by drawer ID.
+	return mergeSearchResults(ranked, semanticMap, ftsResults, q.Limit), nil
+}
+
+// maxFTSRank returns the largest FTS5 rank in results, floored at 1 so it is
+// always a safe divisor for the score normalization.
+func maxFTSRank(results []SearchResult) int {
+	maxRank := 1
+	for _, r := range results {
+		if r.Rank > maxRank {
+			maxRank = r.Rank
+		}
+	}
+	if maxRank == 0 {
+		maxRank = 1
+	}
+	return maxRank
+}
+
+// ftsRelevance converts an FTS5 rank to a relevance score (higher = better).
+// FTS5 rank is negative (more negative = more relevant), so we normalize:
+// 0.5 + (0.5 * normalizedRank), which keeps exact keyword matches high while
+// leaving room above them for true semantic similarity.
+func ftsRelevance(rank, maxRank int) float64 {
+	if maxRank <= 0 {
+		return 0.5
+	}
+	return 0.5 + (0.5 * float64(maxRank-rank) / float64(maxRank))
+}
+
+// keywordOnlyResults scores and trims FTS5 results for the no-embedder path,
+// where there is nothing to merge them with.
+func keywordOnlyResults(ftsResults []SearchResult, limit int) []SearchResult {
+	// Ensure FTS5 results have proper similarity scores.
+	maxRank := maxFTSRank(ftsResults)
+	for i := range ftsResults {
+		if ftsResults[i].Rank != 0 {
+			ftsResults[i].Similarity = float32(ftsRelevance(ftsResults[i].Rank, maxRank))
+		}
+	}
+	if len(ftsResults) > limit {
+		ftsResults = ftsResults[:limit]
+	}
+	return ftsResults
+}
+
+// resolveRanked loads the drawer behind each ranked embedding, keyed by drawer
+// ID. Rows whose drawer can no longer be loaded are dropped silently: a stale
+// embedding is not a reason to fail the whole search.
+func (ds *DrawerService) resolveRanked(ctx context.Context, ranked []ScoredResult) map[string]SearchResult {
 	semanticMap := make(map[string]SearchResult)
 	for _, sr := range ranked {
 		drawer, err := ds.store.GetDrawer(ctx, sr.DrawerID)
@@ -191,19 +222,20 @@ func (ds *DrawerService) Search(ctx context.Context, q SearchQuery) ([]SearchRes
 			Similarity: sr.Similarity,
 		}
 	}
+	return semanticMap
+}
 
-	// Merge FTS5 results into semantic map.
-	// FTS5 results get a boosted score: 0.5 + (0.5 * normalizedRank)
-	// This ensures exact keyword matches rank high but semantic still matters.
-	maxRank := 1
-	for _, r := range ftsResults {
-		if r.Rank > maxRank {
-			maxRank = r.Rank
-		}
-	}
-	if maxRank == 0 {
-		maxRank = 1
-	}
+// mergeSearchResults merges FTS5 results into the semantic ranking. Semantic
+// results come first (they have true similarity scores); FTS5 results not
+// already present are appended with a normalized relevance score. The result
+// is trimmed to limit.
+func mergeSearchResults(
+	ranked []ScoredResult,
+	semanticMap map[string]SearchResult,
+	ftsResults []SearchResult,
+	limit int,
+) []SearchResult {
+	maxRank := maxFTSRank(ftsResults)
 
 	merged := make([]SearchResult, 0, len(semanticMap)+len(ftsResults))
 	seen := make(map[string]bool)
@@ -221,29 +253,20 @@ func (ds *DrawerService) Search(ctx context.Context, q SearchQuery) ([]SearchRes
 		if seen[fts.Drawer.ID] {
 			continue
 		}
-		// Convert FTS5 rank to a relevance score (higher = better).
-		// FTS5 rank is negative (more negative = more relevant), so we normalize.
-		var ftsScore float64
-		if maxRank > 0 {
-			// Normalize: most negative = highest score
-			ftsScore = 0.5 + (0.5 * float64(maxRank-fts.Rank) / float64(maxRank))
-		} else {
-			ftsScore = 0.5
-		}
 		merged = append(merged, SearchResult{
 			Drawer:     fts.Drawer,
-			Similarity: float32(ftsScore),
+			Similarity: float32(ftsRelevance(fts.Rank, maxRank)),
 			Rank:       fts.Rank,
 		})
 		seen[fts.Drawer.ID] = true
 	}
 
 	// Trim to requested limit.
-	if len(merged) > q.Limit {
-		merged = merged[:q.Limit]
+	if len(merged) > limit {
+		merged = merged[:limit]
 	}
 
-	return merged, nil
+	return merged
 }
 
 // DeleteDrawer removes a drawer by ID.

--- a/internal/palace/miner_convo.go
+++ b/internal/palace/miner_convo.go
@@ -21,6 +21,37 @@ func MineConversations(ctx context.Context, palace *Palace, dir string, cfg *Min
 		return nil, fmt.Errorf("mine-convo: resolve dir: %w", err)
 	}
 
+	cfg = resolveMineConfig(absDir, cfg)
+
+	// Try git first for accurate .gitignore handling (nested files, ** globs,
+	// negation, parent .gitignore). Fall back to manual parsing if not a repo.
+	ignoredSet := gitIgnoredSet(absDir)
+	var gitignorePatterns []string
+	if ignoredSet == nil {
+		gitignorePatterns = loadGitignore(absDir)
+	}
+
+	m := &convoMiner{
+		ctx:               ctx,
+		palace:            palace,
+		cfg:               cfg,
+		absDir:            absDir,
+		ignoredSet:        ignoredSet,
+		gitignorePatterns: gitignorePatterns,
+		result:            &MineResult{},
+	}
+
+	if err := filepath.WalkDir(absDir, m.visit); err != nil {
+		return m.result, fmt.Errorf("mine-convo: walk: %w", err)
+	}
+
+	return m.result, nil
+}
+
+// resolveMineConfig fills in the config for a mining run: a nil config is
+// loaded from .mempalace.yaml, falling back to a wing named after the
+// directory, and an unset wing gets the same default.
+func resolveMineConfig(absDir string, cfg *MineConfig) *MineConfig {
 	if cfg == nil {
 		loaded, loadErr := readMempalaceYAML(absDir)
 		if loadErr != nil {
@@ -33,99 +64,124 @@ func MineConversations(ctx context.Context, palace *Palace, dir string, cfg *Min
 	if cfg.Wing == "" {
 		cfg.Wing = filepath.Base(absDir)
 	}
+	return cfg
+}
 
-	// Try git first for accurate .gitignore handling (nested files, ** globs,
-	// negation, parent .gitignore). Fall back to manual parsing if not a repo.
-	ignoredSet := gitIgnoredSet(absDir)
-	var gitignorePatterns []string
-	if ignoredSet == nil {
-		gitignorePatterns = loadGitignore(absDir)
-	}
+// convoMiner carries the state shared by every step of a MineConversations
+// directory walk, so the per-entry work can be split into named steps instead
+// of one large closure.
+type convoMiner struct {
+	ctx               context.Context
+	palace            *Palace
+	cfg               *MineConfig
+	absDir            string
+	ignoredSet        map[string]bool
+	gitignorePatterns []string
+	result            *MineResult
+}
 
-	result := &MineResult{}
-
-	err = filepath.WalkDir(absDir, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			result.Errors++
-			return nil
-		}
-		if d.IsDir() {
-			name := d.Name()
-			if name[0] == '.' && name != "." || skipDirNames[name] {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		ext := strings.ToLower(filepath.Ext(path))
-		relPath, _ := filepath.Rel(absDir, path)
-
-		if isGitIgnoredSet(relPath, ignoredSet) || (ignoredSet == nil && isGitignored(relPath, gitignorePatterns)) {
-			return nil
-		}
-
-		var exchanges []exchange
-
-		switch ext {
-		case ".jsonl":
-			exchanges, err = parseJSONL(path)
-			if err != nil {
-				result.Errors++
-				slog.Warn("mine-convo: parse jsonl", "path", relPath, "error", err)
-				return nil
-			}
-		case ".txt", ".md":
-			exchanges, err = parsePlainText(path)
-			if err != nil {
-				result.Errors++
-				slog.Warn("mine-convo: parse text", "path", relPath, "error", err)
-				return nil
-			}
-		default:
-			return nil
-		}
-
-		fileAdded, fileSkipped, fileErrors := 0, 0, 0
-		for i, ex := range exchanges {
-			result.Processed++
-
-			room := detectRoomFromContent(ex.content, cfg.Rooms)
-
-			_, addErr := palace.AddDrawer(ctx, DrawerInput{
-				Wing:       cfg.Wing,
-				Room:       room,
-				Content:    ex.content,
-				SourceFile: relPath,
-				ChunkIndex: i,
-				AddedBy:    "miner:convo",
-				Importance: 4,
-			})
-			if addErr != nil {
-				if _, ok := errors.AsType[*DuplicateError](addErr); ok {
-					result.Skipped++
-					fileSkipped++
-				} else {
-					result.Errors++
-					fileErrors++
-					slog.Warn("mine-convo: add drawer", "file", relPath, "exchange", i, "error", addErr)
-				}
-				continue
-			}
-			result.Added++
-			fileAdded++
-		}
-
-		if cfg.Progress != nil {
-			cfg.Progress(relPath, fileAdded, fileSkipped, fileErrors)
-		}
+// visit is the filepath.WalkDir callback. Errors are counted, never returned:
+// one unreadable file must not abandon the rest of the tree.
+func (m *convoMiner) visit(path string, d os.DirEntry, walkErr error) error {
+	if walkErr != nil {
+		m.result.Errors++
 		return nil
-	})
-
-	if err != nil {
-		return result, fmt.Errorf("mine-convo: walk: %w", err)
+	}
+	if d.IsDir() {
+		return visitMineDir(d)
 	}
 
-	return result, nil
+	relPath, _ := filepath.Rel(m.absDir, path)
+	if m.isIgnored(relPath) {
+		return nil
+	}
+
+	exchanges, parsed := m.parseFile(path, relPath)
+	if !parsed {
+		return nil
+	}
+	m.addExchanges(relPath, exchanges)
+	return nil
+}
+
+// visitMineDir reports whether a directory should be descended into.
+func visitMineDir(d os.DirEntry) error {
+	name := d.Name()
+	if name[0] == '.' && name != "." || skipDirNames[name] {
+		return filepath.SkipDir
+	}
+	return nil
+}
+
+// isIgnored applies the git-derived ignore set, falling back to manually
+// parsed .gitignore patterns when the directory is not a repo.
+func (m *convoMiner) isIgnored(relPath string) bool {
+	return isGitIgnoredSet(relPath, m.ignoredSet) ||
+		(m.ignoredSet == nil && isGitignored(relPath, m.gitignorePatterns))
+}
+
+// parseFile dispatches on extension. The second return distinguishes "parsed,
+// possibly to zero exchanges" from "skipped or failed" — only the former
+// reports progress for the file.
+func (m *convoMiner) parseFile(path, relPath string) ([]exchange, bool) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jsonl":
+		exchanges, err := parseJSONL(path)
+		if err != nil {
+			m.result.Errors++
+			slog.Warn("mine-convo: parse jsonl", "path", relPath, "error", err)
+			return nil, false
+		}
+		return exchanges, true
+	case ".txt", ".md":
+		exchanges, err := parsePlainText(path)
+		if err != nil {
+			m.result.Errors++
+			slog.Warn("mine-convo: parse text", "path", relPath, "error", err)
+			return nil, false
+		}
+		return exchanges, true
+	default:
+		return nil, false
+	}
+}
+
+// addExchanges inserts one file's exchanges as drawers, tallying per-file
+// counts for the progress callback alongside the run totals.
+func (m *convoMiner) addExchanges(relPath string, exchanges []exchange) {
+	fileAdded, fileSkipped, fileErrors := 0, 0, 0
+	for i, ex := range exchanges {
+		m.result.Processed++
+
+		room := detectRoomFromContent(ex.content, m.cfg.Rooms)
+
+		_, addErr := m.palace.AddDrawer(m.ctx, DrawerInput{
+			Wing:       m.cfg.Wing,
+			Room:       room,
+			Content:    ex.content,
+			SourceFile: relPath,
+			ChunkIndex: i,
+			AddedBy:    "miner:convo",
+			Importance: 4,
+		})
+		if addErr != nil {
+			if _, ok := errors.AsType[*DuplicateError](addErr); ok {
+				m.result.Skipped++
+				fileSkipped++
+			} else {
+				m.result.Errors++
+				fileErrors++
+				slog.Warn("mine-convo: add drawer", "file", relPath, "exchange", i, "error", addErr)
+			}
+			continue
+		}
+		m.result.Added++
+		fileAdded++
+	}
+
+	if m.cfg.Progress != nil {
+		m.cfg.Progress(relPath, fileAdded, fileSkipped, fileErrors)
+	}
 }
 
 // exchange represents a user-assistant exchange pair.

--- a/internal/palace/tool_kg_extract.go
+++ b/internal/palace/tool_kg_extract.go
@@ -111,7 +111,7 @@ func palaceKGExtractHandler(_ context.Context, _ *Palace, input KGExtractToolInp
 // appropriate confidence based on whether the chunk has a source file.
 // Stdlib paths are filtered out: they are noise in a project knowledge
 // graph.
-func emitImport(text, path, sourceFile string, add func(subj, pred, obj, reason string, conf float64)) {
+func emitImport(text, path, sourceFile string, add tripleAdder) {
 	if path == "" || isStdlibImport(path) {
 		return
 	}
@@ -166,6 +166,59 @@ var (
 	filePathRe = regexp.MustCompile(`(?:^|[\s"'(\[])([a-zA-Z0-9_./-]+/[a-zA-Z0-9_.-]+\.[a-z]{1,8})(?:\b|["')])`)
 )
 
+// declHeuristics are the declaration patterns that yield a "defined_in"
+// triple, in the order they are applied. Order is significant: the sink
+// dedupes by (subject, predicate, object), so the first pattern to match an
+// identifier is the one whose reason is recorded.
+var declHeuristics = []struct {
+	re *regexp.Regexp
+	// reason is the note attached to triples this pattern produces.
+	reason string
+	// skipCommonWords drops English noise words that look like identifiers.
+	// Only the generic (Python/JS) pattern needs it: its identifiers are not
+	// required to start with a capital, so `const result = ...` matches.
+	skipCommonWords bool
+}{
+	{goFuncDeclRe, "Go func declaration in source file", false},
+	{goTypeDeclRe, "Go type declaration in source file", false},
+	{genericDeclRe, "declaration in source file", true},
+}
+
+// tripleAdder records one candidate triple. Implemented by tripleSink.add.
+type tripleAdder func(subj, pred, obj, reason string, conf float64)
+
+// tripleSink accumulates candidate triples, dropping blanks, self-referential
+// pairs (subject equal to object), and case-insensitive duplicates.
+type tripleSink struct {
+	out  []ExtractedTriple
+	seen map[string]bool // dedupe by (subj|pred|obj)
+}
+
+func newTripleSink() *tripleSink {
+	return &tripleSink{seen: make(map[string]bool)}
+}
+
+func (ts *tripleSink) add(subj, pred, obj, reason string, conf float64) {
+	s := strings.TrimSpace(subj)
+	p := strings.TrimSpace(pred)
+	o := strings.TrimSpace(obj)
+	if s == "" || p == "" || o == "" || strings.EqualFold(s, o) {
+		return
+	}
+	key := strings.ToLower(s) + "|" + strings.ToLower(p) + "|" + strings.ToLower(o)
+	if ts.seen[key] {
+		return
+	}
+	ts.seen[key] = true
+	ts.out = append(ts.out, ExtractedTriple{
+		Subject:    s,
+		Predicate:  normalizePredicate(p),
+		Object:     o,
+		Confidence: conf,
+		Reason:     reason,
+	})
+}
+
 // extractTriples runs the heuristic pass over text and returns candidate
 // triples. The result is unsorted; the caller sorts and truncates.
 //
@@ -176,42 +229,26 @@ var (
 //	0.50 — heuristic pair from free-form identifiers
 //	0.30 — bare identifier pair with no anchor
 func extractTriples(text, sourceFile string) []ExtractedTriple {
-	var out []ExtractedTriple
-	seen := make(map[string]bool) // dedupe by (subj|pred|obj)
+	sink := newTripleSink()
+	extractImportTriples(text, sourceFile, sink.add)
+	extractDeclarationTriples(text, sourceFile, sink.add)
+	extractPathTriples(text, sourceFile, sink.add)
+	return sink.out
+}
 
-	add := func(subj, pred, obj, reason string, conf float64) {
-		s := strings.TrimSpace(subj)
-		p := strings.TrimSpace(pred)
-		o := strings.TrimSpace(obj)
-		if s == "" || p == "" || o == "" || strings.EqualFold(s, o) {
-			return
-		}
-		key := strings.ToLower(s) + "|" + strings.ToLower(p) + "|" + strings.ToLower(o)
-		if seen[key] {
-			return
-		}
-		seen[key] = true
-		out = append(out, ExtractedTriple{
-			Subject:    s,
-			Predicate:  normalizePredicate(p),
-			Object:     o,
-			Confidence: conf,
-			Reason:     reason,
-		})
-	}
-
-	// Code-level extraction: imports.
-	//
-	// Two passes. The first catches imports written on a single line —
-	// `import "path"`, `from "path"`, `require("path")`, with the keyword
-	// and the literal on the same line. The second catches Go's
-	// parenthesized form: `import ( ... "path" ... )` where the keyword
-	// is on one line and the literal is on a later line. The single-line
-	// regex cannot match that form because the quote is not on the same
-	// line as the `import` keyword, and tightening the alternation to
-	// allow a `( )` block just shifts the problem: the `import (` would
-	// then have to be followed by a quote on the same line, which it
-	// never is.
+// extractImportTriples emits an "imports" triple for each import path in text.
+//
+// Two passes. The first catches imports written on a single line —
+// `import "path"`, `from "path"`, `require("path")`, with the keyword
+// and the literal on the same line. The second catches Go's
+// parenthesized form: `import ( ... "path" ... )` where the keyword
+// is on one line and the literal is on a later line. The single-line
+// regex cannot match that form because the quote is not on the same
+// line as the `import` keyword, and tightening the alternation to
+// allow a `( )` block just shifts the problem: the `import (` would
+// then have to be followed by a quote on the same line, which it
+// never is.
+func extractImportTriples(text, sourceFile string, add tripleAdder) {
 	seenInImport := make(map[string]bool)
 	for _, m := range importPathRe.FindAllStringSubmatch(text, -1) {
 		seenInImport[m[1]] = true
@@ -223,16 +260,7 @@ func extractTriples(text, sourceFile string) []ExtractedTriple {
 	// paren is found by line — Go does not allow nested parens in an
 	// import block, so the first `)` at column 0 is reliable.
 	for _, openIdx := range importBlockOpenRe.FindAllStringIndex(text, -1) {
-		blockStart := openIdx[1] // just after the `(`
-		rest := text[blockStart:]
-		closeRel := strings.Index(rest, "\n)")
-		var blockEnd int
-		if closeRel < 0 {
-			blockEnd = len(rest)
-		} else {
-			blockEnd = closeRel
-		}
-		block := text[blockStart : blockStart+blockEnd]
+		block := importBlockBody(text, openIdx[1]) // openIdx[1] is just after the `(`
 		for _, m := range quotedStringRe.FindAllStringSubmatch(block, -1) {
 			if seenInImport[m[1]] {
 				continue
@@ -241,56 +269,55 @@ func extractTriples(text, sourceFile string) []ExtractedTriple {
 			emitImport(text, m[1], sourceFile, add)
 		}
 	}
+}
 
-	// Code-level extraction: Go function declarations.
-	for _, m := range goFuncDeclRe.FindAllStringSubmatch(text, -1) {
-		name := m[1]
-		if name == "" {
-			continue
-		}
-		if sourceFile != "" {
-			add(name, "defined_in", sourceFile, "Go func declaration in source file", 0.95)
-		}
+// importBlockBody returns the text of a parenthesized import block starting at
+// blockStart, up to the first `)` at column 0. An unterminated block runs to
+// the end of the chunk rather than being dropped: chunked input routinely cuts
+// a file mid-block, and the paths before the cut are still real imports.
+func importBlockBody(text string, blockStart int) string {
+	rest := text[blockStart:]
+	closeRel := strings.Index(rest, "\n)")
+	if closeRel < 0 {
+		return rest
 	}
+	return rest[:closeRel]
+}
 
-	// Code-level extraction: Go type declarations.
-	for _, m := range goTypeDeclRe.FindAllStringSubmatch(text, -1) {
-		name := m[1]
-		if name == "" {
-			continue
-		}
-		if sourceFile != "" {
-			add(name, "defined_in", sourceFile, "Go type declaration in source file", 0.95)
-		}
+// extractDeclarationTriples emits a "defined_in" triple for each declaration
+// in text. Nothing is emitted without a source file: a declaration with no
+// file to anchor it to has no object to point at.
+func extractDeclarationTriples(text, sourceFile string, add tripleAdder) {
+	if sourceFile == "" {
+		return
 	}
-
-	// Code-level extraction: generic declarations (Python, JS, etc).
-	for _, m := range genericDeclRe.FindAllStringSubmatch(text, -1) {
-		name := m[1]
-		if name == "" || isCommonWord(name) {
-			continue
-		}
-		if sourceFile != "" {
-			add(name, "defined_in", sourceFile, "declaration in source file", 0.95)
-		}
-	}
-
-	// Path-aware: every path mentioned alongside a source file gets a
-	// "part_of" candidate if it shares a directory.
-	if sourceFile != "" {
-		srcDir := pathDir(sourceFile)
-		for _, m := range filePathRe.FindAllStringSubmatch(text, -1) {
-			p := m[1]
-			if p == "" || p == sourceFile {
+	for _, h := range declHeuristics {
+		for _, m := range h.re.FindAllStringSubmatch(text, -1) {
+			name := m[1]
+			if name == "" || (h.skipCommonWords && isCommonWord(name)) {
 				continue
 			}
-			if pathDir(p) == srcDir {
-				add(p, "part_of", fileBase(sourceFile), "shares directory with source file", 0.70)
-			}
+			add(name, "defined_in", sourceFile, h.reason, 0.95)
 		}
 	}
+}
 
-	return out
+// extractPathTriples emits a "part_of" triple for every path mentioned
+// alongside the source file that shares its directory.
+func extractPathTriples(text, sourceFile string, add tripleAdder) {
+	if sourceFile == "" {
+		return
+	}
+	srcDir := pathDir(sourceFile)
+	for _, m := range filePathRe.FindAllStringSubmatch(text, -1) {
+		p := m[1]
+		if p == "" || p == sourceFile {
+			continue
+		}
+		if pathDir(p) == srcDir {
+			add(p, "part_of", fileBase(sourceFile), "shares directory with source file", 0.70)
+		}
+	}
 }
 
 // formatExtractedTriples renders the candidates as a markdown block the agent

--- a/internal/pirpc/complexity_pirpc_test.go
+++ b/internal/pirpc/complexity_pirpc_test.go
@@ -1,0 +1,366 @@
+package pirpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/logger"
+)
+
+// emitCapture builds a Server that writes NDJSON into a buffer, which is all
+// the part-emitting helpers need — no agent, no stdin.
+func emitCapture(t *testing.T) (*Server, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	return NewServer(Config{Out: &buf}), &buf
+}
+
+// decodeEmitted parses the buffer's NDJSON lines into maps.
+func decodeEmitted(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("emitted line is not JSON: %q: %v", line, err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func modelEvent(author string, parts ...*genai.Part) *session.Event {
+	ev := &session.Event{}
+	ev.Author = author
+	ev.Content = &genai.Content{Role: string(genai.RoleModel), Parts: parts}
+	return ev
+}
+
+// TestEmitPartTextRouting pins the switch that decides which delta kind a
+// text part becomes. The thinking case is selected by role, so a "thinking"
+// role with empty text must fall through to neither case.
+func TestEmitPartTextRouting(t *testing.T) {
+	tests := []struct {
+		name      string
+		role      string
+		text      string
+		wantKind  string // "" means nothing emitted
+		wantDelta string
+	}{
+		{"model text becomes a text delta", string(genai.RoleModel), "hello", "text_delta", "hello"},
+		{"thinking role becomes a thinking delta", "thinking", "pondering", "thinking_delta", "pondering"},
+		{"empty text emits nothing", string(genai.RoleModel), "", "", ""},
+		{"empty text on a thinking event emits nothing", "thinking", "", "", ""},
+		{"an unknown role still emits text", "tool", "from a tool", "text_delta", "from a tool"},
+		{"whitespace is text, not emptiness", string(genai.RoleModel), " ", "text_delta", " "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, buf := emitCapture(t)
+			ev := &session.Event{}
+			ev.Author = "assistant"
+			ev.Content = &genai.Content{Role: tt.role, Parts: []*genai.Part{{Text: tt.text}}}
+
+			var dedup agent.StreamDedup
+			dedup.BeginEvent(ev)
+			s.emitPart(ev, ev.Content.Parts[0], &dedup)
+
+			got := decodeEmitted(t, buf)
+			if tt.wantKind == "" {
+				if len(got) != 0 {
+					t.Fatalf("emitted %v, want nothing", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("emitted %d events, want 1: %v", len(got), got)
+			}
+			ame, ok := got[0]["assistantMessageEvent"].(map[string]any)
+			if !ok {
+				t.Fatalf("event has no assistantMessageEvent: %v", got[0])
+			}
+			if ame["type"] != tt.wantKind {
+				t.Errorf("delta kind = %v, want %v", ame["type"], tt.wantKind)
+			}
+			if ame["delta"] != tt.wantDelta {
+				t.Errorf("delta = %q, want %q", ame["delta"], tt.wantDelta)
+			}
+		})
+	}
+}
+
+// TestEmitPartDedupSkipDropsWholePart is the branch most at risk from the
+// extraction: inside the loop the dedup skip was a `continue`, which also
+// skipped the tool-call and tool-result blocks below it. As an extracted
+// function that has to be a `return`, not a fallthrough.
+func TestEmitPartDedupSkipDropsWholePart(t *testing.T) {
+	s, buf := emitCapture(t)
+	var dedup agent.StreamDedup
+
+	// A partial event marks the stream as having streamed deltas.
+	partial := modelEvent("assistant", &genai.Part{Text: "hel"})
+	partial.Partial = true
+	dedup.BeginEvent(partial)
+	s.emitPart(partial, partial.Content.Parts[0], &dedup)
+
+	// The aggregate re-send carries the same text *and* a function call on the
+	// same part. The text is a duplicate; the call must be dropped with it.
+	aggregate := modelEvent("assistant", &genai.Part{
+		Text:         "hel",
+		FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read"},
+	})
+	dedup.BeginEvent(aggregate)
+	s.emitPart(aggregate, aggregate.Content.Parts[0], &dedup)
+
+	got := decodeEmitted(t, buf)
+	if len(got) != 1 {
+		t.Fatalf("emitted %d events, want only the first delta: %v", len(got), got)
+	}
+	for _, ev := range got {
+		if ev["type"] == "tool_execution_start" {
+			t.Error("a skipped text part still emitted its tool call; the `continue` became a fallthrough")
+		}
+	}
+}
+
+// TestEmitPartTextAndToolCallTogether is the control for the test above: when
+// the text is *not* a duplicate, both the delta and the tool call go out.
+func TestEmitPartTextAndToolCallTogether(t *testing.T) {
+	s, buf := emitCapture(t)
+	var dedup agent.StreamDedup
+
+	ev := modelEvent("assistant", &genai.Part{
+		Text:         "calling a tool",
+		FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"path": "a.go"}},
+	})
+	dedup.BeginEvent(ev)
+	s.emitPart(ev, ev.Content.Parts[0], &dedup)
+
+	got := decodeEmitted(t, buf)
+	if len(got) != 2 {
+		t.Fatalf("emitted %d events, want 2 (delta + tool call): %v", len(got), got)
+	}
+	if got[0]["type"] != "message_update" {
+		t.Errorf("first event = %v, want message_update", got[0]["type"])
+	}
+	if got[1]["type"] != "tool_execution_start" {
+		t.Errorf("second event = %v, want tool_execution_start", got[1]["type"])
+	}
+}
+
+// TestEmitPartCallAndResponseTogether covers a part carrying both halves,
+// which the original emitted in order: start then end.
+func TestEmitPartCallAndResponseTogether(t *testing.T) {
+	s, buf := emitCapture(t)
+	var dedup agent.StreamDedup
+
+	ev := modelEvent("assistant", &genai.Part{
+		FunctionCall:     &genai.FunctionCall{ID: "c1", Name: "read"},
+		FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"ok": true}},
+	})
+	dedup.BeginEvent(ev)
+	s.emitPart(ev, ev.Content.Parts[0], &dedup)
+
+	got := decodeEmitted(t, buf)
+	if len(got) != 2 {
+		t.Fatalf("emitted %d events, want 2: %v", len(got), got)
+	}
+	if got[0]["type"] != "tool_execution_start" || got[1]["type"] != "tool_execution_end" {
+		t.Errorf("order = %v then %v, want start then end", got[0]["type"], got[1]["type"])
+	}
+}
+
+// TestEmitToolCallShape pins the tool_execution_start payload, including that
+// a provider-assigned ID is used verbatim and an absent one is synthesized.
+func TestEmitToolCallShape(t *testing.T) {
+	tests := []struct {
+		name   string
+		fc     *genai.FunctionCall
+		wantID string
+	}{
+		{"provider id is used verbatim", &genai.FunctionCall{ID: "call_abc", Name: "grep"}, "call_abc"},
+		{"missing id is synthesized from the name", &genai.FunctionCall{Name: "grep"}, "grep-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, buf := emitCapture(t)
+			s.emitToolCall("assistant", tt.fc)
+
+			got := decodeEmitted(t, buf)
+			if len(got) != 1 {
+				t.Fatalf("emitted %d events, want 1", len(got))
+			}
+			if got[0]["type"] != "tool_execution_start" {
+				t.Errorf("type = %v, want tool_execution_start", got[0]["type"])
+			}
+			if got[0]["toolCallId"] != tt.wantID {
+				t.Errorf("toolCallId = %v, want %v", got[0]["toolCallId"], tt.wantID)
+			}
+			if got[0]["toolName"] != tt.fc.Name {
+				t.Errorf("toolName = %v, want %v", got[0]["toolName"], tt.fc.Name)
+			}
+		})
+	}
+}
+
+// TestEmitToolResultShape pins the tool_execution_end payload. isError is
+// hard-coded false; pi-acp uses it to pick the card style, so a change there
+// would be user-visible.
+func TestEmitToolResultShape(t *testing.T) {
+	s, buf := emitCapture(t)
+	s.emitToolResult("assistant", &genai.FunctionResponse{
+		ID: "call_abc", Name: "grep", Response: map[string]any{"hits": float64(3)},
+	})
+
+	got := decodeEmitted(t, buf)
+	if len(got) != 1 {
+		t.Fatalf("emitted %d events, want 1", len(got))
+	}
+	if got[0]["type"] != "tool_execution_end" {
+		t.Errorf("type = %v, want tool_execution_end", got[0]["type"])
+	}
+	if got[0]["toolCallId"] != "call_abc" {
+		t.Errorf("toolCallId = %v, want call_abc", got[0]["toolCallId"])
+	}
+	if got[0]["isError"] != false {
+		t.Errorf("isError = %v, want false", got[0]["isError"])
+	}
+	res, ok := got[0]["result"].(map[string]any)
+	if !ok || res["hits"] != float64(3) {
+		t.Errorf("result = %v, want the response passed through", got[0]["result"])
+	}
+}
+
+// TestEmitToolIDsPairAcrossCallAndResult is the invariant the synthesized-ID
+// path exists for: start and end must agree, or pi-acp cannot pair them into
+// one card. Two unidentified calls must not collide either.
+func TestEmitToolIDsPairAcrossCallAndResult(t *testing.T) {
+	s, buf := emitCapture(t)
+	s.emitToolCall("assistant", &genai.FunctionCall{Name: "read"})
+	s.emitToolCall("assistant", &genai.FunctionCall{Name: "read"})
+
+	got := decodeEmitted(t, buf)
+	if len(got) != 2 {
+		t.Fatalf("emitted %d events, want 2", len(got))
+	}
+	if got[0]["toolCallId"] == got[1]["toolCallId"] {
+		t.Errorf("two unidentified calls share the id %v", got[0]["toolCallId"])
+	}
+	if got[0]["toolCallId"] != "read-1" || got[1]["toolCallId"] != "read-2" {
+		t.Errorf("ids = %v, %v; want read-1, read-2", got[0]["toolCallId"], got[1]["toolCallId"])
+	}
+}
+
+// TestEmitPartLogging checks the session-log side of each branch, which the
+// extraction moved along with the emit calls. A nil log must stay harmless.
+func TestEmitPartLogging(t *testing.T) {
+	t.Run("nil log is tolerated on every branch", func(t *testing.T) {
+		s, _ := emitCapture(t)
+		if s.log != nil {
+			t.Fatal("expected a nil log on a Config without one")
+		}
+		var dedup agent.StreamDedup
+		for _, part := range []*genai.Part{
+			{Text: "text"},
+			{FunctionCall: &genai.FunctionCall{ID: "c", Name: "n"}},
+			{FunctionResponse: &genai.FunctionResponse{ID: "c", Name: "n", Response: map[string]any{}}},
+		} {
+			ev := modelEvent("assistant", part)
+			dedup.BeginEvent(ev)
+			s.emitPart(ev, part, &dedup) // must not panic
+		}
+		thinking := &session.Event{}
+		thinking.Author = "assistant"
+		thinking.Content = &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: "hmm"}}}
+		s.emitPart(thinking, thinking.Content.Parts[0], &dedup)
+	})
+
+	t.Run("every branch reaches the session log", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		log, err := logger.New()
+		if err != nil {
+			t.Fatalf("logger.New() error = %v", err)
+		}
+		s, _ := emitCapture(t)
+		s.log = log
+
+		var dedup agent.StreamDedup
+
+		thinking := &session.Event{}
+		thinking.Author = "assistant"
+		thinking.Content = &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: "weighing options"}}}
+		dedup.BeginEvent(thinking)
+		s.emitPart(thinking, thinking.Content.Parts[0], &dedup)
+
+		text := modelEvent("assistant", &genai.Part{Text: "the answer"})
+		dedup.BeginEvent(text)
+		s.emitPart(text, text.Content.Parts[0], &dedup)
+
+		call := modelEvent("assistant", &genai.Part{
+			FunctionCall: &genai.FunctionCall{ID: "c1", Name: "grepper"},
+		})
+		dedup.BeginEvent(call)
+		s.emitPart(call, call.Content.Parts[0], &dedup)
+
+		result := modelEvent("assistant", &genai.Part{
+			FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "grepper", Response: map[string]any{"hits": 3}},
+		})
+		dedup.BeginEvent(result)
+		s.emitPart(result, result.Content.Parts[0], &dedup)
+
+		if err := log.Close(); err != nil {
+			t.Fatalf("closing log: %v", err)
+		}
+		contents, err := os.ReadFile(log.Path())
+		if err != nil {
+			t.Fatalf("reading log: %v", err)
+		}
+		for _, want := range []string{"weighing options", "the answer", "grepper"} {
+			if !bytes.Contains(contents, []byte(want)) {
+				t.Errorf("session log is missing %q:\n%s", want, contents)
+			}
+		}
+	})
+}
+
+// TestEmitToolResultUnmarshalableResponseStillEmits pins the inner guard on
+// the log write: a response that cannot be marshaled skips the log line but
+// must not stop the tool_execution_end event.
+func TestEmitToolResultUnmarshalableResponseStillEmits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	log, err := logger.New()
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+	s, buf := emitCapture(t)
+	s.log = log
+
+	// A channel value is not JSON-marshalable.
+	s.emitToolResult("assistant", &genai.FunctionResponse{
+		ID: "c1", Name: "weird", Response: map[string]any{"ch": make(chan int)},
+	})
+
+	// emit itself drops the unmarshalable event, so nothing lands on the wire
+	// — but the call must return rather than panic, and the log must be clean.
+	if err := log.Close(); err != nil {
+		t.Fatalf("closing log: %v", err)
+	}
+	contents, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatalf("reading log: %v", err)
+	}
+	if bytes.Contains(contents, []byte("chan")) {
+		t.Errorf("unmarshalable response reached the log:\n%s", contents)
+	}
+	_ = buf
+}

--- a/internal/pirpc/rpc.go
+++ b/internal/pirpc/rpc.go
@@ -50,6 +50,7 @@ import (
 
 	adkmodel "google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/agent"
 	"github.com/dimetron/pi-go/internal/logger"
@@ -294,47 +295,64 @@ func (s *Server) runTurn(ctx context.Context, message string) {
 
 		dedup.BeginEvent(ev)
 		for _, part := range ev.Content.Parts {
-			switch {
-			case part.Text != "" && ev.Content.Role == "thinking":
-				s.emitDelta("thinking_delta", part.Text)
-				if s.log != nil {
-					s.log.Thinking(ev.Author, part.Text)
-				}
-			case part.Text != "":
-				if dedup.SkipText(ev) {
-					continue
-				}
-				s.emitDelta("text_delta", part.Text)
-				if s.log != nil {
-					s.log.LLMText(ev.Author, part.Text)
-				}
-			}
+			s.emitPart(ev, part, &dedup)
+		}
+	}
+}
 
-			if fc := part.FunctionCall; fc != nil {
-				s.emit(map[string]any{
-					"type":       "tool_execution_start",
-					"toolCallId": s.toolCallID(fc.ID, fc.Name),
-					"toolName":   fc.Name,
-					"args":       fc.Args,
-				})
-				if s.log != nil {
-					s.log.ToolCall(ev.Author, fc.Name, fc.Args)
-				}
-			}
+// emitPart streams one content part: thinking or assistant text, a tool call,
+// and a tool result. A part the dedup filter rejects is dropped whole, which
+// is what the inline `continue` did before.
+func (s *Server) emitPart(ev *session.Event, part *genai.Part, dedup *agent.StreamDedup) {
+	switch {
+	case part.Text != "" && ev.Content.Role == "thinking":
+		s.emitDelta("thinking_delta", part.Text)
+		if s.log != nil {
+			s.log.Thinking(ev.Author, part.Text)
+		}
+	case part.Text != "":
+		if dedup.SkipText(ev) {
+			return
+		}
+		s.emitDelta("text_delta", part.Text)
+		if s.log != nil {
+			s.log.LLMText(ev.Author, part.Text)
+		}
+	}
 
-			if fr := part.FunctionResponse; fr != nil {
-				s.emit(map[string]any{
-					"type":       "tool_execution_end",
-					"toolCallId": s.toolCallID(fr.ID, fr.Name),
-					"result":     fr.Response,
-					"isError":    false,
-				})
-				if s.log != nil {
-					if b, mErr := json.Marshal(fr.Response); mErr == nil {
-						s.log.ToolResult(ev.Author, fr.Name, string(b))
-					}
-				}
-			}
+	if fc := part.FunctionCall; fc != nil {
+		s.emitToolCall(ev.Author, fc)
+	}
+
+	if fr := part.FunctionResponse; fr != nil {
+		s.emitToolResult(ev.Author, fr)
+	}
+}
+
+// emitToolCall opens a tool card on the adapter side.
+func (s *Server) emitToolCall(author string, fc *genai.FunctionCall) {
+	s.emit(map[string]any{
+		"type":       "tool_execution_start",
+		"toolCallId": s.toolCallID(fc.ID, fc.Name),
+		"toolName":   fc.Name,
+		"args":       fc.Args,
+	})
+	if s.log != nil {
+		s.log.ToolCall(author, fc.Name, fc.Args)
+	}
+}
+
+// emitToolResult closes the tool card opened by emitToolCall.
+func (s *Server) emitToolResult(author string, fr *genai.FunctionResponse) {
+	s.emit(map[string]any{
+		"type":       "tool_execution_end",
+		"toolCallId": s.toolCallID(fr.ID, fr.Name),
+		"result":     fr.Response,
+		"isError":    false,
+	})
+	if s.log != nil {
+		if b, mErr := json.Marshal(fr.Response); mErr == nil {
+			s.log.ToolResult(author, fr.Name, string(b))
 		}
 	}
 }

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -309,29 +309,8 @@ func antStopReasonToGenai(reason anthropic.StopReason) genai.FinishReason {
 }
 
 func antContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]anthropic.MessageParam, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemPrompt := strings.TrimSpace(systemBuilder.String())
-
-	// Collect function responses for matching
-	functionResponses := make(map[string]*genai.FunctionResponse)
-	for _, c := range contents {
-		if c == nil || c.Parts == nil {
-			continue
-		}
-		for _, p := range c.Parts {
-			if p != nil && p.FunctionResponse != nil {
-				functionResponses[p.FunctionResponse.ID] = p.FunctionResponse
-			}
-		}
-	}
+	systemPrompt := genaiSystemInstruction(config)
+	functionResponses := genaiFunctionResponses(contents)
 
 	var messages []anthropic.MessageParam
 	for _, content := range contents {
@@ -343,64 +322,13 @@ func antContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 			continue
 		}
 
-		var textParts []string
-		var functionCalls []*genai.FunctionCall
+		textParts, functionCalls := genaiSplitParts(content.Parts)
 
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.Text != "" {
-				textParts = append(textParts, part.Text)
-			} else if part.FunctionCall != nil {
-				functionCalls = append(functionCalls, part.FunctionCall)
-			}
-		}
-
-		if len(functionCalls) > 0 && (role == "model" || role == "assistant") {
-			// Assistant message with tool use blocks
-			var contentBlocks []anthropic.ContentBlockParamUnion
-			if len(textParts) > 0 {
-				contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
-			}
-			for _, fc := range functionCalls {
-				argsJSON, _ := json.Marshal(fc.Args)
-				var inputMap map[string]any
-				_ = json.Unmarshal(argsJSON, &inputMap)
-				if inputMap == nil {
-					inputMap = make(map[string]any)
-				}
-				contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(fc.ID, inputMap, fc.Name))
-			}
-			messages = append(messages, anthropic.MessageParam{
-				Role:    anthropic.MessageParamRoleAssistant,
-				Content: contentBlocks,
-			})
-
-			// Tool results as user message
-			var toolResultBlocks []anthropic.ContentBlockParamUnion
-			for _, fc := range functionCalls {
-				contentStr := "No response available for this function call."
-				if fr := functionResponses[fc.ID]; fr != nil {
-					contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
-				}
-				toolResultBlocks = append(toolResultBlocks, anthropic.NewToolResultBlock(fc.ID, contentStr, false))
-			}
-			messages = append(messages, anthropic.MessageParam{
-				Role:    anthropic.MessageParamRoleUser,
-				Content: toolResultBlocks,
-			})
-		} else if len(textParts) > 0 {
-			msgRole := anthropic.MessageParamRoleUser
-			if role == "model" || role == "assistant" {
-				msgRole = anthropic.MessageParamRoleAssistant
-			}
-			var contentBlocks []anthropic.ContentBlockParamUnion
-			contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
-			messages = append(messages, anthropic.MessageParam{
-				Role:    msgRole,
-				Content: contentBlocks,
-			})
+		switch {
+		case len(functionCalls) > 0 && genaiIsAssistantRole(role):
+			messages = append(messages, antToolUseMessages(textParts, functionCalls, functionResponses)...)
+		case len(textParts) > 0:
+			messages = append(messages, antTextMessage(role, strings.Join(textParts, "\n")))
 		}
 	}
 
@@ -415,6 +343,58 @@ func antContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 	}
 
 	return messages, systemPrompt
+}
+
+// antToolUseMessages renders one assistant turn that called tools as the pair
+// Anthropic expects: an assistant message of tool_use blocks, then a user
+// message of the matching tool_result blocks.
+func antToolUseMessages(
+	textParts []string,
+	functionCalls []*genai.FunctionCall,
+	functionResponses map[string]*genai.FunctionResponse,
+) []anthropic.MessageParam {
+	// Assistant message with tool use blocks
+	var contentBlocks []anthropic.ContentBlockParamUnion
+	if len(textParts) > 0 {
+		contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
+	}
+	for _, fc := range functionCalls {
+		argsJSON, _ := json.Marshal(fc.Args)
+		var inputMap map[string]any
+		_ = json.Unmarshal(argsJSON, &inputMap)
+		if inputMap == nil {
+			inputMap = make(map[string]any)
+		}
+		contentBlocks = append(contentBlocks, anthropic.NewToolUseBlock(fc.ID, inputMap, fc.Name))
+	}
+
+	// Tool results as user message
+	var toolResultBlocks []anthropic.ContentBlockParamUnion
+	for _, fc := range functionCalls {
+		contentStr := "No response available for this function call."
+		if fr := functionResponses[fc.ID]; fr != nil {
+			contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
+		}
+		toolResultBlocks = append(toolResultBlocks, anthropic.NewToolResultBlock(fc.ID, contentStr, false))
+	}
+
+	return []anthropic.MessageParam{
+		{Role: anthropic.MessageParamRoleAssistant, Content: contentBlocks},
+		{Role: anthropic.MessageParamRoleUser, Content: toolResultBlocks},
+	}
+}
+
+// antTextMessage renders a text-only turn as a single-block message under the
+// Anthropic role its genai role maps to.
+func antTextMessage(role, text string) anthropic.MessageParam {
+	msgRole := anthropic.MessageParamRoleUser
+	if genaiIsAssistantRole(role) {
+		msgRole = anthropic.MessageParamRoleAssistant
+	}
+	return anthropic.MessageParam{
+		Role:    msgRole,
+		Content: []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock(text)},
+	}
 }
 
 func antGenaiToolsToAnthropic(tools []*genai.Tool) []anthropic.ToolUnionParam {
@@ -568,54 +548,76 @@ func antRunStreaming(ctx context.Context, client *anthropic.Client, params anthr
 				}
 			}
 		case anthropic.ContentBlockDeltaEvent:
-			idx := int(e.Index)
-			delta := e.Delta
-			switch delta.Type {
-			case "text_delta":
-				if textDelta, ok := delta.AsAny().(anthropic.TextDelta); ok {
-					state.text += textDelta.Text
-					if !yield(&model.LLMResponse{
-						Partial:      true,
-						TurnComplete: false,
-						Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
-					}, nil) {
-						return
-					}
-				}
-			case "thinking_delta":
-				if thinkingDelta, ok := delta.AsAny().(anthropic.ThinkingDelta); ok {
-					if !yield(&model.LLMResponse{
-						Partial:      true,
-						TurnComplete: false,
-						Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
-					}, nil) {
-						return
-					}
-				}
-			case "input_json_delta":
-				if jsonDelta, ok := delta.AsAny().(anthropic.InputJSONDelta); ok {
-					if block, exists := state.toolUse[idx]; exists {
-						block.inputJSON += jsonDelta.PartialJSON
-						state.toolUse[idx] = block
-					}
-				}
+			if !antHandleContentBlockDelta(e, state, yield) {
+				return
 			}
 		case anthropic.MessageDeltaEvent:
-			state.stopReason = e.Delta.StopReason
-			state.outputTokens = e.Usage.OutputTokens
-			// Anthropic may also surface cache deltas in message_delta;
-			// take the last reported value (it's monotonically increasing
-			// across a single response).
-			if v := e.Usage.CacheReadInputTokens; v > state.cacheReadTokens {
-				state.cacheReadTokens = v
-			}
-			if v := e.Usage.CacheCreationInputTokens; v > state.cacheCreationTokens {
-				state.cacheCreationTokens = v
-			}
+			antApplyMessageDelta(e, state)
 		}
 	}
 
-	if err := stream.Err(); err != nil {
+	antFinishStream(ctx, stream.Err(), state, yield)
+}
+
+// antHandleContentBlockDelta folds one content_block_delta event into state,
+// yielding the partial response it carries. It reports whether streaming should
+// continue — false once the consumer has stopped reading.
+func antHandleContentBlockDelta(e anthropic.ContentBlockDeltaEvent, state *antStreamState, yield func(*model.LLMResponse, error) bool) bool {
+	idx := int(e.Index)
+	delta := e.Delta
+	switch delta.Type {
+	case "text_delta":
+		if textDelta, ok := delta.AsAny().(anthropic.TextDelta); ok {
+			state.text += textDelta.Text
+			if !yield(&model.LLMResponse{
+				Partial:      true,
+				TurnComplete: false,
+				Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
+			}, nil) {
+				return false
+			}
+		}
+	case "thinking_delta":
+		if thinkingDelta, ok := delta.AsAny().(anthropic.ThinkingDelta); ok {
+			if !yield(&model.LLMResponse{
+				Partial:      true,
+				TurnComplete: false,
+				Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
+			}, nil) {
+				return false
+			}
+		}
+	case "input_json_delta":
+		if jsonDelta, ok := delta.AsAny().(anthropic.InputJSONDelta); ok {
+			if block, exists := state.toolUse[idx]; exists {
+				block.inputJSON += jsonDelta.PartialJSON
+				state.toolUse[idx] = block
+			}
+		}
+	}
+	return true
+}
+
+// antApplyMessageDelta records the stop reason and usage a message_delta event
+// reports.
+func antApplyMessageDelta(e anthropic.MessageDeltaEvent, state *antStreamState) {
+	state.stopReason = e.Delta.StopReason
+	state.outputTokens = e.Usage.OutputTokens
+	// Anthropic may also surface cache deltas in message_delta;
+	// take the last reported value (it's monotonically increasing
+	// across a single response).
+	if v := e.Usage.CacheReadInputTokens; v > state.cacheReadTokens {
+		state.cacheReadTokens = v
+	}
+	if v := e.Usage.CacheCreationInputTokens; v > state.cacheCreationTokens {
+		state.cacheCreationTokens = v
+	}
+}
+
+// antFinishStream emits the terminal response for a finished Anthropic stream:
+// the cancellation marker, a stream error, or the accumulated final message.
+func antFinishStream(ctx context.Context, err error, state *antStreamState, yield func(*model.LLMResponse, error) bool) {
+	if err != nil {
 		if ctx.Err() == context.Canceled {
 			_ = yield(canceledResponse(), nil)
 			return
@@ -692,58 +694,12 @@ func antRunStreamingBeta(ctx context.Context, client *anthropic.BetaService, par
 		case anthropic.BetaRawMessageStartEvent:
 			state.inputTokens = e.Message.Usage.InputTokens
 		case anthropic.BetaRawContentBlockStartEvent:
-			idx := int(e.Index)
-			switch e.ContentBlock.Type {
-			case "tool_use":
-				if toolUse, ok := e.ContentBlock.AsAny().(anthropic.BetaToolUseBlock); ok {
-					state.toolUse[idx] = antToolUseAcc{id: toolUse.ID, name: toolUse.Name}
-				}
-			case "advisor_tool_result":
-				// Advisor result arrives fully formed in a single event.
-				// Yield it as a text part so the executor sees the advice.
-				if advResult, ok := e.ContentBlock.AsAny().(anthropic.BetaAdvisorToolResultBlock); ok {
-					advText := extractAdvisorResultText(advResult)
-					if advText != "" {
-						// Yield as a special "advisor" role to distinguish from regular text.
-						if !yield(&model.LLMResponse{
-							Partial:      true,
-							TurnComplete: false,
-							Content:      &genai.Content{Role: "advisor", Parts: []*genai.Part{{Text: advText}}},
-						}, nil) {
-							return
-						}
-					}
-				}
+			if !antHandleBetaContentBlockStart(e, state, yield) {
+				return
 			}
 		case anthropic.BetaRawContentBlockDeltaEvent:
-			idx := int(e.Index)
-			delta := e.Delta
-			switch delta.Type {
-			case "text_delta":
-				textDelta := delta.AsTextDelta()
-				state.text += textDelta.Text
-				if !yield(&model.LLMResponse{
-					Partial:      true,
-					TurnComplete: false,
-					Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
-				}, nil) {
-					return
-				}
-			case "thinking_delta":
-				thinkingDelta := delta.AsThinkingDelta()
-				if !yield(&model.LLMResponse{
-					Partial:      true,
-					TurnComplete: false,
-					Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
-				}, nil) {
-					return
-				}
-			case "input_json_delta":
-				jsonDelta := delta.AsInputJSONDelta()
-				if block, exists := state.toolUse[idx]; exists {
-					block.inputJSON += jsonDelta.PartialJSON
-					state.toolUse[idx] = block
-				}
+			if !antHandleBetaContentBlockDelta(e, state, yield) {
+				return
 			}
 		case anthropic.BetaRawMessageDeltaEvent:
 			state.stopReason = anthropic.StopReason(e.Delta.StopReason)
@@ -751,16 +707,73 @@ func antRunStreamingBeta(ctx context.Context, client *anthropic.BetaService, par
 		}
 	}
 
-	if err := stream.Err(); err != nil {
-		if ctx.Err() == context.Canceled {
-			_ = yield(canceledResponse(), nil)
-			return
-		}
-		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
-		return
-	}
+	antFinishStream(ctx, stream.Err(), state, yield)
+}
 
-	_ = yield(buildAntFinalResponse(state), nil)
+// antHandleBetaContentBlockStart opens a streamed beta content block: it records
+// a tool_use header, or yields an advisor result that arrives complete. It
+// reports whether streaming should continue.
+func antHandleBetaContentBlockStart(e anthropic.BetaRawContentBlockStartEvent, state *antStreamState, yield func(*model.LLMResponse, error) bool) bool {
+	idx := int(e.Index)
+	switch e.ContentBlock.Type {
+	case "tool_use":
+		if toolUse, ok := e.ContentBlock.AsAny().(anthropic.BetaToolUseBlock); ok {
+			state.toolUse[idx] = antToolUseAcc{id: toolUse.ID, name: toolUse.Name}
+		}
+	case "advisor_tool_result":
+		// Advisor result arrives fully formed in a single event.
+		// Yield it as a text part so the executor sees the advice.
+		if advResult, ok := e.ContentBlock.AsAny().(anthropic.BetaAdvisorToolResultBlock); ok {
+			advText := extractAdvisorResultText(advResult)
+			if advText != "" {
+				// Yield as a special "advisor" role to distinguish from regular text.
+				if !yield(&model.LLMResponse{
+					Partial:      true,
+					TurnComplete: false,
+					Content:      &genai.Content{Role: "advisor", Parts: []*genai.Part{{Text: advText}}},
+				}, nil) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// antHandleBetaContentBlockDelta folds one beta content_block_delta event into
+// state, yielding the partial response it carries. It reports whether streaming
+// should continue.
+func antHandleBetaContentBlockDelta(e anthropic.BetaRawContentBlockDeltaEvent, state *antStreamState, yield func(*model.LLMResponse, error) bool) bool {
+	idx := int(e.Index)
+	delta := e.Delta
+	switch delta.Type {
+	case "text_delta":
+		textDelta := delta.AsTextDelta()
+		state.text += textDelta.Text
+		if !yield(&model.LLMResponse{
+			Partial:      true,
+			TurnComplete: false,
+			Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
+		}, nil) {
+			return false
+		}
+	case "thinking_delta":
+		thinkingDelta := delta.AsThinkingDelta()
+		if !yield(&model.LLMResponse{
+			Partial:      true,
+			TurnComplete: false,
+			Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
+		}, nil) {
+			return false
+		}
+	case "input_json_delta":
+		jsonDelta := delta.AsInputJSONDelta()
+		if block, exists := state.toolUse[idx]; exists {
+			block.inputJSON += jsonDelta.PartialJSON
+			state.toolUse[idx] = block
+		}
+	}
+	return true
 }
 
 // antRunNonStreamingBeta handles non-streaming with the beta API (advisor tool support).

--- a/internal/provider/complexity_provider_test.go
+++ b/internal/provider/complexity_provider_test.go
@@ -1,0 +1,1852 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	ollamaapi "github.com/ollama/ollama/api"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// This file pins the behavior of the genai.Content -> wire-format translation
+// layer and of the streaming event dispatchers, so the complexity refactor of
+// antContentsToMessages / ollamaContentsToMessages / oaiContentsToMessages /
+// oaiContentsToResponsesInput and the *RunStreaming* loops is demonstrably
+// behavior-preserving.
+
+// -----------------------------------------------------------------------------
+// Shared genai-side helpers
+// -----------------------------------------------------------------------------
+
+func TestGenaiSystemInstruction(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *genai.GenerateContentConfig
+		want   string
+	}{
+		{name: "nil config", config: nil, want: ""},
+		{
+			name:   "nil system instruction",
+			config: &genai.GenerateContentConfig{},
+			want:   "",
+		},
+		{
+			name:   "no parts",
+			config: &genai.GenerateContentConfig{SystemInstruction: &genai.Content{}},
+			want:   "",
+		},
+		{
+			name: "single part",
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "be terse"}}},
+			},
+			want: "be terse",
+		},
+		{
+			name: "joins parts and skips nil and empty",
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{Parts: []*genai.Part{
+					{Text: "one"},
+					nil,
+					{Text: ""},
+					{Text: "two"},
+				}},
+			},
+			want: "one\ntwo",
+		},
+		{
+			name: "surrounding whitespace trimmed",
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "  padded  "}}},
+			},
+			want: "padded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := genaiSystemInstruction(tt.config); got != tt.want {
+				t.Errorf("genaiSystemInstruction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenaiFunctionResponses(t *testing.T) {
+	contents := []*genai.Content{
+		nil,
+		{Role: "user", Parts: nil},
+		{Role: "user", Parts: []*genai.Part{
+			nil,
+			{Text: "not a response"},
+			{FunctionResponse: &genai.FunctionResponse{ID: "a", Response: map[string]any{"result": "ra"}}},
+		}},
+		{Role: "user", Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{ID: "b", Response: map[string]any{"result": "rb"}}},
+		}},
+	}
+
+	got := genaiFunctionResponses(contents)
+	if len(got) != 2 {
+		t.Fatalf("got %d responses, want 2: %v", len(got), got)
+	}
+	for _, id := range []string{"a", "b"} {
+		if got[id] == nil {
+			t.Errorf("missing function response %q", id)
+		}
+	}
+}
+
+func TestGenaiFunctionResponses_LastWins(t *testing.T) {
+	// Two responses share an ID; the later one must win, as the original
+	// map-assignment loop did.
+	contents := []*genai.Content{
+		{Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: "dup", Response: map[string]any{"result": "first"}}}}},
+		{Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: "dup", Response: map[string]any{"result": "second"}}}}},
+	}
+	got := genaiFunctionResponses(contents)
+	if len(got) != 1 {
+		t.Fatalf("got %d responses, want 1", len(got))
+	}
+	if payload := oaiFunctionResponseContent(got["dup"].Response); payload != "second" {
+		t.Errorf("Response = %v, want %q", payload, "second")
+	}
+}
+
+func TestGenaiSplitParts(t *testing.T) {
+	call := &genai.FunctionCall{ID: "c1", Name: "fn"}
+	tests := []struct {
+		name      string
+		parts     []*genai.Part
+		wantText  []string
+		wantCalls int
+	}{
+		{name: "nil parts", parts: nil, wantText: nil, wantCalls: 0},
+		{name: "only nils", parts: []*genai.Part{nil, nil}, wantText: nil, wantCalls: 0},
+		{
+			name:      "text only",
+			parts:     []*genai.Part{{Text: "a"}, {Text: "b"}},
+			wantText:  []string{"a", "b"},
+			wantCalls: 0,
+		},
+		{
+			name:      "calls only",
+			parts:     []*genai.Part{{FunctionCall: call}},
+			wantText:  nil,
+			wantCalls: 1,
+		},
+		{
+			name:      "mixed, nils skipped",
+			parts:     []*genai.Part{nil, {Text: "a"}, {FunctionCall: call}, {Text: "b"}},
+			wantText:  []string{"a", "b"},
+			wantCalls: 1,
+		},
+		{
+			// A part carrying text is never also read as a function call:
+			// the original used if/else-if, not two ifs.
+			name:      "text wins over call on same part",
+			parts:     []*genai.Part{{Text: "a", FunctionCall: call}},
+			wantText:  []string{"a"},
+			wantCalls: 0,
+		},
+		{
+			name:      "function response part is neither",
+			parts:     []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: "c1"}}},
+			wantText:  nil,
+			wantCalls: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, calls := genaiSplitParts(tt.parts)
+			if len(text) != len(tt.wantText) {
+				t.Fatalf("text = %v, want %v", text, tt.wantText)
+			}
+			for i := range text {
+				if text[i] != tt.wantText[i] {
+					t.Errorf("text[%d] = %q, want %q", i, text[i], tt.wantText[i])
+				}
+			}
+			if len(calls) != tt.wantCalls {
+				t.Errorf("calls = %d, want %d", len(calls), tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestGenaiIsAssistantRole(t *testing.T) {
+	tests := []struct {
+		role string
+		want bool
+	}{
+		{"model", true},
+		{"assistant", true},
+		{"user", false},
+		{"system", false},
+		{"", false},
+		{"Model", false},      // the original compared exactly, no folding
+		{"assistant ", false}, // callers trim before calling
+	}
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			if got := genaiIsAssistantRole(tt.role); got != tt.want {
+				t.Errorf("genaiIsAssistantRole(%q) = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Golden wire payloads: one fixture, four providers
+// -----------------------------------------------------------------------------
+
+// conversionFixture is the shared input for the golden tests below. It covers
+// every content-block kind the converters branch on: a skipped nil content, a
+// skipped system turn, a multi-part user text turn containing a nil part, an
+// assistant turn mixing text with a function call, the matching function
+// response turn, and a trailing assistant text turn.
+func conversionFixture() []*genai.Content {
+	return []*genai.Content{
+		nil,
+		{Role: "system", Parts: []*genai.Part{{Text: "skipped"}}},
+		{Role: "user", Parts: []*genai.Part{nil, {Text: "first"}, {Text: "second"}}},
+		{Role: "model", Parts: []*genai.Part{
+			{Text: "let me check"},
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "call_1",
+				Name: "lookup",
+				Args: map[string]any{"q": "x"},
+			}},
+		}},
+		{Role: "user", Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_1",
+				Response: map[string]any{"result": "ok"},
+			}},
+		}},
+		{Role: "assistant", Parts: []*genai.Part{{Text: "done"}}},
+	}
+}
+
+func fixtureConfig() *genai.GenerateContentConfig {
+	return &genai.GenerateContentConfig{
+		SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "sys one"}, {Text: "sys two"}}},
+	}
+}
+
+// marshalGolden renders v as indented JSON for comparison against a pinned
+// payload.
+func marshalGolden(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	pretty, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal indent: %v", err)
+	}
+	return string(pretty)
+}
+
+func TestAntContentsToMessages_Golden(t *testing.T) {
+	messages, system := antContentsToMessages(conversionFixture(), fixtureConfig())
+
+	if system != "sys one\nsys two" {
+		t.Errorf("system = %q, want %q", system, "sys one\nsys two")
+	}
+	// user text, assistant tool_use, user tool_result, assistant text.
+	if len(messages) != 4 {
+		t.Fatalf("got %d messages, want 4:\n%s", len(messages), marshalGolden(t, messages))
+	}
+
+	roles := []anthropic.MessageParamRole{
+		anthropic.MessageParamRoleUser,
+		anthropic.MessageParamRoleAssistant,
+		anthropic.MessageParamRoleUser,
+		anthropic.MessageParamRoleAssistant,
+	}
+	for i, want := range roles {
+		if messages[i].Role != want {
+			t.Errorf("messages[%d].Role = %q, want %q", i, messages[i].Role, want)
+		}
+	}
+
+	got := marshalGolden(t, messages)
+	want := `[
+  {
+    "content": [
+      {
+        "text": "first\nsecond",
+        "type": "text"
+      }
+    ],
+    "role": "user"
+  },
+  {
+    "content": [
+      {
+        "text": "let me check",
+        "type": "text"
+      },
+      {
+        "id": "call_1",
+        "input": {
+          "q": "x"
+        },
+        "name": "lookup",
+        "type": "tool_use"
+      }
+    ],
+    "role": "assistant"
+  },
+  {
+    "content": [
+      {
+        "content": [
+          {
+            "text": "ok",
+            "type": "text"
+          }
+        ],
+        "is_error": false,
+        "tool_use_id": "call_1",
+        "type": "tool_result"
+      }
+    ],
+    "role": "user"
+  },
+  {
+    "content": [
+      {
+        "text": "done",
+        "type": "text"
+      }
+    ],
+    "role": "assistant"
+  }
+]`
+	if got != want {
+		t.Errorf("anthropic wire payload mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+func TestOllamaContentsToMessages_Golden(t *testing.T) {
+	messages, system := ollamaContentsToMessages(conversionFixture(), fixtureConfig())
+
+	if system != "sys one\nsys two" {
+		t.Errorf("system = %q, want %q", system, "sys one\nsys two")
+	}
+	// user text, assistant with tool_calls, tool result, assistant text.
+	if len(messages) != 4 {
+		t.Fatalf("got %d messages, want 4:\n%s", len(messages), marshalGolden(t, messages))
+	}
+
+	wantRoles := []string{"user", "assistant", "tool", "assistant"}
+	for i, want := range wantRoles {
+		if messages[i].Role != want {
+			t.Errorf("messages[%d].Role = %q, want %q", i, messages[i].Role, want)
+		}
+	}
+	if messages[0].Content != "first\nsecond" {
+		t.Errorf("user content = %q, want %q", messages[0].Content, "first\nsecond")
+	}
+	if messages[1].Content != "let me check" {
+		t.Errorf("assistant content = %q, want %q", messages[1].Content, "let me check")
+	}
+	if len(messages[1].ToolCalls) != 1 {
+		t.Fatalf("got %d tool calls, want 1", len(messages[1].ToolCalls))
+	}
+	tc := messages[1].ToolCalls[0]
+	if tc.ID != "call_1" || tc.Function.Name != "lookup" {
+		t.Errorf("tool call = {%q %q}, want {call_1 lookup}", tc.ID, tc.Function.Name)
+	}
+	if got := tc.Function.Arguments.ToMap()["q"]; got != "x" {
+		t.Errorf("tool call arg q = %v, want %q", got, "x")
+	}
+	if messages[2].Content != "ok" || messages[2].ToolCallID != "call_1" {
+		t.Errorf("tool result = {%q %q}, want {ok call_1}", messages[2].Content, messages[2].ToolCallID)
+	}
+	if messages[3].Content != "done" {
+		t.Errorf("final assistant content = %q, want %q", messages[3].Content, "done")
+	}
+}
+
+func TestOaiContentsToMessages_Golden(t *testing.T) {
+	messages, system := oaiContentsToMessages(conversionFixture(), fixtureConfig())
+
+	if system != "sys one\nsys two" {
+		t.Errorf("system = %q, want %q", system, "sys one\nsys two")
+	}
+	// user text, assistant with tool_calls, tool message, assistant text.
+	if len(messages) != 4 {
+		t.Fatalf("got %d messages, want 4:\n%s", len(messages), marshalGolden(t, messages))
+	}
+
+	got := marshalGolden(t, messages)
+	want := `[
+  {
+    "content": "first\nsecond",
+    "role": "user"
+  },
+  {
+    "content": "let me check",
+    "role": "assistant",
+    "tool_calls": [
+      {
+        "function": {
+          "arguments": "{\"q\":\"x\"}",
+          "name": "lookup"
+        },
+        "id": "call_1",
+        "type": "function"
+      }
+    ]
+  },
+  {
+    "content": "ok",
+    "role": "tool",
+    "tool_call_id": "call_1"
+  },
+  {
+    "content": "done",
+    "role": "assistant"
+  }
+]`
+	if got != want {
+		t.Errorf("openai chat completions wire payload mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+func TestOaiContentsToResponsesInput_Golden(t *testing.T) {
+	input, instructions, err := oaiContentsToResponsesInput(conversionFixture(), fixtureConfig())
+	if err != nil {
+		t.Fatalf("oaiContentsToResponsesInput: %v", err)
+	}
+	if instructions != "sys one\nsys two" {
+		t.Errorf("instructions = %q, want %q", instructions, "sys one\nsys two")
+	}
+
+	items := input.OfInputItemList
+	// user message, assistant message, function_call, function_call_output,
+	// assistant message.
+	if len(items) != 5 {
+		t.Fatalf("got %d items, want 5:\n%s", len(items), marshalGolden(t, items))
+	}
+
+	got := marshalGolden(t, items)
+	want := `[
+  {
+    "content": "first\nsecond",
+    "role": "user"
+  },
+  {
+    "content": "let me check",
+    "role": "assistant"
+  },
+  {
+    "arguments": "{\"q\":\"x\"}",
+    "call_id": "call_1",
+    "name": "lookup",
+    "type": "function_call"
+  },
+  {
+    "call_id": "call_1",
+    "output": "ok",
+    "type": "function_call_output"
+  },
+  {
+    "content": "done",
+    "role": "assistant"
+  }
+]`
+	if got != want {
+		t.Errorf("openai responses wire payload mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Per-provider branch behavior
+// -----------------------------------------------------------------------------
+
+func TestContentsToMessages_EmptyConversationGetsPlaceholder(t *testing.T) {
+	// Anthropic and Ollama both inject a minimal user message when the
+	// conversation yields none, so the endpoint does not reject the request.
+	config := fixtureConfig()
+	onlySystem := []*genai.Content{
+		{Role: "system", Parts: []*genai.Part{{Text: "skipped"}}},
+	}
+
+	antMessages, _ := antContentsToMessages(onlySystem, config)
+	if len(antMessages) != 1 || antMessages[0].Role != anthropic.MessageParamRoleUser {
+		t.Fatalf("anthropic placeholder = %s", marshalGolden(t, antMessages))
+	}
+	if got := marshalGolden(t, antMessages); got != `[
+  {
+    "content": [
+      {
+        "text": "Hello",
+        "type": "text"
+      }
+    ],
+    "role": "user"
+  }
+]` {
+		t.Errorf("anthropic placeholder payload:\n%s", got)
+	}
+
+	ollamaMessages, _ := ollamaContentsToMessages(onlySystem, config)
+	if len(ollamaMessages) != 1 {
+		t.Fatalf("got %d ollama messages, want 1", len(ollamaMessages))
+	}
+	if ollamaMessages[0].Role != "user" || ollamaMessages[0].Content != "Hello" {
+		t.Errorf("ollama placeholder = {%q %q}, want {user Hello}",
+			ollamaMessages[0].Role, ollamaMessages[0].Content)
+	}
+
+	// The OpenAI Chat Completions path does NOT inject a placeholder.
+	oaiMessages, _ := oaiContentsToMessages(onlySystem, config)
+	if len(oaiMessages) != 0 {
+		t.Errorf("openai messages = %d, want 0", len(oaiMessages))
+	}
+}
+
+func TestContentsToMessages_ToolCallOnUserRoleFallsThroughToText(t *testing.T) {
+	// A function call on a non-assistant role does not take the tool branch.
+	// With text alongside it, the turn renders as a plain user message.
+	contents := []*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{Text: "hi"},
+			{FunctionCall: &genai.FunctionCall{ID: "c1", Name: "fn"}},
+		},
+	}}
+
+	antMessages, _ := antContentsToMessages(contents, nil)
+	if len(antMessages) != 1 || antMessages[0].Role != anthropic.MessageParamRoleUser {
+		t.Fatalf("anthropic = %s", marshalGolden(t, antMessages))
+	}
+
+	ollamaMessages, _ := ollamaContentsToMessages(contents, nil)
+	if len(ollamaMessages) != 1 || ollamaMessages[0].Role != "user" || ollamaMessages[0].Content != "hi" {
+		t.Fatalf("ollama = %s", marshalGolden(t, ollamaMessages))
+	}
+
+	oaiMessages, _ := oaiContentsToMessages(contents, nil)
+	if len(oaiMessages) != 1 || oaiMessages[0].OfUser == nil {
+		t.Fatalf("openai = %s", marshalGolden(t, oaiMessages))
+	}
+}
+
+func TestContentsToMessages_ToolCallWithNoTextEmitsNoAssistantText(t *testing.T) {
+	contents := []*genai.Content{
+		{Role: "model", Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{ID: "c1", Name: "fn", Args: map[string]any{}}},
+		}},
+		{Role: "user", Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{ID: "c1", Response: map[string]any{"result": "raw text"}}},
+		}},
+	}
+
+	antMessages, _ := antContentsToMessages(contents, nil)
+	if len(antMessages) != 2 {
+		t.Fatalf("anthropic messages = %d, want 2", len(antMessages))
+	}
+	if len(antMessages[0].Content) != 1 {
+		t.Errorf("anthropic assistant blocks = %d, want 1 (tool_use only)", len(antMessages[0].Content))
+	}
+
+	ollamaMessages, _ := ollamaContentsToMessages(contents, nil)
+	if len(ollamaMessages) != 2 {
+		t.Fatalf("ollama messages = %d, want 2", len(ollamaMessages))
+	}
+	if ollamaMessages[0].Content != "" {
+		t.Errorf("ollama assistant content = %q, want empty", ollamaMessages[0].Content)
+	}
+	if ollamaMessages[1].Content != "raw text" {
+		t.Errorf("ollama tool content = %q, want %q", ollamaMessages[1].Content, "raw text")
+	}
+}
+
+func TestAntToolUseMessages_UnmatchedCallGetsPlaceholderResult(t *testing.T) {
+	calls := []*genai.FunctionCall{{ID: "missing", Name: "fn", Args: map[string]any{"a": 1}}}
+	messages := antToolUseMessages(nil, calls, map[string]*genai.FunctionResponse{})
+
+	if len(messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(messages))
+	}
+	got := marshalGolden(t, messages[1])
+	want := `{
+  "content": [
+    {
+      "content": [
+        {
+          "text": "No response available for this function call.",
+          "type": "text"
+        }
+      ],
+      "is_error": false,
+      "tool_use_id": "missing",
+      "type": "tool_result"
+    }
+  ],
+  "role": "user"
+}`
+	if got != want {
+		t.Errorf("placeholder tool_result mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+func TestAntToolUseMessages_NilArgsBecomeEmptyObject(t *testing.T) {
+	// json.Unmarshal of "null" leaves inputMap nil, which the original
+	// replaced with an empty map so the wire payload is `{}` not `null`.
+	calls := []*genai.FunctionCall{{ID: "c1", Name: "fn", Args: nil}}
+	messages := antToolUseMessages(nil, calls, nil)
+
+	got := marshalGolden(t, messages[0])
+	want := `{
+  "content": [
+    {
+      "id": "c1",
+      "input": {},
+      "name": "fn",
+      "type": "tool_use"
+    }
+  ],
+  "role": "assistant"
+}`
+	if got != want {
+		t.Errorf("nil-args tool_use mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+func TestOllamaToolCallMessages_UnmatchedCallGetsEmptyResult(t *testing.T) {
+	// Unlike Anthropic, Ollama leaves an unmatched result empty.
+	calls := []*genai.FunctionCall{{ID: "missing", Name: "fn"}}
+	messages := ollamaToolCallMessages(nil, calls, map[string]*genai.FunctionResponse{})
+
+	if len(messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(messages))
+	}
+	if messages[1].Role != "tool" || messages[1].Content != "" {
+		t.Errorf("tool message = {%q %q}, want {tool \"\"}", messages[1].Role, messages[1].Content)
+	}
+}
+
+func TestOaiToolCallMessages_SkipsCallsWithoutID(t *testing.T) {
+	calls := []*genai.FunctionCall{
+		nil,
+		{ID: "  ", Name: "blank"},
+		{ID: "keep", Name: "fn", Args: map[string]any{"a": 1}},
+	}
+	messages := oaiToolCallMessages([]string{"text"}, calls, map[string]*genai.FunctionResponse{})
+
+	// assistant + exactly one tool message.
+	if len(messages) != 2 {
+		t.Fatalf("got %d messages, want 2:\n%s", len(messages), marshalGolden(t, messages))
+	}
+	if messages[0].OfAssistant == nil {
+		t.Fatal("first message is not an assistant message")
+	}
+	if n := len(messages[0].OfAssistant.ToolCalls); n != 1 {
+		t.Errorf("tool calls = %d, want 1", n)
+	}
+	if messages[0].OfAssistant.Content.OfString.Value != "text" {
+		t.Errorf("assistant content = %q, want %q",
+			messages[0].OfAssistant.Content.OfString.Value, "text")
+	}
+}
+
+func TestTextMessageRoleMapping(t *testing.T) {
+	tests := []struct {
+		role          string
+		wantAssistant bool
+	}{
+		{"model", true},
+		{"assistant", true},
+		{"user", false},
+		{"", false},
+		{"tool", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			antMsg := antTextMessage(tt.role, "hello")
+			wantAnt := anthropic.MessageParamRoleUser
+			if tt.wantAssistant {
+				wantAnt = anthropic.MessageParamRoleAssistant
+			}
+			if antMsg.Role != wantAnt {
+				t.Errorf("antTextMessage role = %q, want %q", antMsg.Role, wantAnt)
+			}
+			if len(antMsg.Content) != 1 {
+				t.Errorf("antTextMessage blocks = %d, want 1", len(antMsg.Content))
+			}
+
+			ollamaMsg := ollamaTextMessage(tt.role, "hello")
+			wantOllama := "user"
+			if tt.wantAssistant {
+				wantOllama = "assistant"
+			}
+			if ollamaMsg.Role != wantOllama {
+				t.Errorf("ollamaTextMessage role = %q, want %q", ollamaMsg.Role, wantOllama)
+			}
+			if ollamaMsg.Content != "hello" {
+				t.Errorf("ollamaTextMessage content = %q, want %q", ollamaMsg.Content, "hello")
+			}
+
+			oaiMsg := oaiTextMessage(tt.role, "hello")
+			if tt.wantAssistant {
+				if oaiMsg.OfAssistant == nil {
+					t.Errorf("oaiTextMessage(%q) is not an assistant message", tt.role)
+				} else if oaiMsg.OfAssistant.Content.OfString.Value != "hello" {
+					t.Errorf("oaiTextMessage content = %q, want %q",
+						oaiMsg.OfAssistant.Content.OfString.Value, "hello")
+				}
+			} else if oaiMsg.OfUser == nil {
+				t.Errorf("oaiTextMessage(%q) is not a user message", tt.role)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Responses input assembly
+// -----------------------------------------------------------------------------
+
+func TestAddTrimmedID(t *testing.T) {
+	set := map[string]struct{}{}
+	addTrimmedID(set, "")
+	addTrimmedID(set, "   ")
+	addTrimmedID(set, "  padded  ")
+	addTrimmedID(set, "plain")
+
+	if len(set) != 2 {
+		t.Fatalf("set = %v, want 2 entries", set)
+	}
+	for _, id := range []string{"padded", "plain"} {
+		if _, ok := set[id]; !ok {
+			t.Errorf("missing %q in %v", id, set)
+		}
+	}
+}
+
+func TestOaiResponsesPairedIDs(t *testing.T) {
+	contents := []*genai.Content{
+		nil,
+		{Parts: []*genai.Part{
+			nil,
+			{Text: "text only"},
+			{FunctionCall: &genai.FunctionCall{ID: " paired "}},
+			{FunctionCall: &genai.FunctionCall{ID: ""}},
+			{FunctionCall: &genai.FunctionCall{ID: "orphan_call"}},
+		}},
+		{Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{ID: "paired"}},
+			{FunctionResponse: &genai.FunctionResponse{ID: "   "}},
+			{FunctionResponse: &genai.FunctionResponse{ID: "orphan_output"}},
+		}},
+	}
+
+	callIDs, responseIDs := oaiResponsesPairedIDs(contents)
+
+	wantCalls := map[string]bool{"paired": true, "orphan_call": true}
+	if len(callIDs) != len(wantCalls) {
+		t.Errorf("callIDs = %v, want %v", callIDs, wantCalls)
+	}
+	for id := range wantCalls {
+		if _, ok := callIDs[id]; !ok {
+			t.Errorf("callIDs missing %q", id)
+		}
+	}
+
+	wantResponses := map[string]bool{"paired": true, "orphan_output": true}
+	if len(responseIDs) != len(wantResponses) {
+		t.Errorf("responseIDs = %v, want %v", responseIDs, wantResponses)
+	}
+	for id := range wantResponses {
+		if _, ok := responseIDs[id]; !ok {
+			t.Errorf("responseIDs missing %q", id)
+		}
+	}
+}
+
+func TestOaiContentsToResponsesInput_DropsUnpairedHalves(t *testing.T) {
+	// A canceled turn leaves a function call with no output, and an output
+	// with no call. Both halves must be dropped, but the surrounding text
+	// must survive.
+	contents := []*genai.Content{
+		{Role: "model", Parts: []*genai.Part{
+			{Text: "before"},
+			{FunctionCall: &genai.FunctionCall{ID: "orphan_call", Name: "fn"}},
+			{Text: "after"},
+		}},
+		{Role: "user", Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{ID: "orphan_output", Response: map[string]any{"result": "x"}}},
+		}},
+	}
+
+	input, _, err := oaiContentsToResponsesInput(contents, nil)
+	if err != nil {
+		t.Fatalf("oaiContentsToResponsesInput: %v", err)
+	}
+
+	got := marshalGolden(t, input.OfInputItemList)
+	want := `[
+  {
+    "content": "before",
+    "role": "assistant"
+  },
+  {
+    "content": "after",
+    "role": "assistant"
+  }
+]`
+	if got != want {
+		t.Errorf("unpaired-halves payload mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+func TestOaiAppendResponsesItems_FlushesTextBeforeCalls(t *testing.T) {
+	// Text accumulated before a function call must be flushed as its own
+	// message so the items keep their original order.
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{Text: "a"},
+			{Text: "b"},
+			{FunctionCall: &genai.FunctionCall{ID: "c1", Name: "fn", Args: map[string]any{}}},
+			{Text: "c"},
+		},
+	}
+	callIDs := map[string]struct{}{"c1": {}}
+	responseIDs := map[string]struct{}{"c1": {}}
+
+	items := oaiAppendResponsesItems(responses.ResponseInputParam{}, content, callIDs, responseIDs)
+
+	got := marshalGolden(t, items)
+	want := `[
+  {
+    "content": "a\nb",
+    "role": "assistant"
+  },
+  {
+    "arguments": "{}",
+    "call_id": "c1",
+    "name": "fn",
+    "type": "function_call"
+  },
+  {
+    "content": "c",
+    "role": "assistant"
+  }
+]`
+	if got != want {
+		t.Errorf("flush ordering mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+func TestOaiResponsesReasoning(t *testing.T) {
+	budget := func(v int32) *genai.GenerateContentConfig {
+		return &genai.GenerateContentConfig{
+			ThinkingConfig: &genai.ThinkingConfig{ThinkingBudget: &v},
+		}
+	}
+	tests := []struct {
+		name       string
+		config     *genai.GenerateContentConfig
+		wantOK     bool
+		wantEffort shared.ReasoningEffort
+	}{
+		{name: "nil config", config: nil},
+		{name: "nil thinking config", config: &genai.GenerateContentConfig{}},
+		{
+			name:   "nil budget",
+			config: &genai.GenerateContentConfig{ThinkingConfig: &genai.ThinkingConfig{}},
+		},
+		{name: "zero budget", config: budget(0)},
+		{name: "negative budget", config: budget(-1)},
+		{name: "low", config: budget(1), wantOK: true, wantEffort: shared.ReasoningEffortLow},
+		{name: "low upper bound", config: budget(1999), wantOK: true, wantEffort: shared.ReasoningEffortLow},
+		{name: "medium lower bound", config: budget(2000), wantOK: true, wantEffort: shared.ReasoningEffortMedium},
+		{name: "medium upper bound", config: budget(7999), wantOK: true, wantEffort: shared.ReasoningEffortMedium},
+		{name: "high lower bound", config: budget(8000), wantOK: true, wantEffort: shared.ReasoningEffortHigh},
+		{name: "high", config: budget(100000), wantOK: true, wantEffort: shared.ReasoningEffortHigh},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := oaiResponsesReasoning(tt.config)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got.Effort != tt.wantEffort {
+				t.Errorf("effort = %q, want %q", got.Effort, tt.wantEffort)
+			}
+			if !ok && got.Effort != "" {
+				t.Errorf("effort = %q, want empty when not configured", got.Effort)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Anthropic streaming event handlers
+// -----------------------------------------------------------------------------
+
+// decodeAntEvent decodes a raw SSE event payload into T. The SDK's As*Delta
+// accessors read from the raw JSON, so events must be built by unmarshalling
+// rather than by setting struct fields.
+func decodeAntEvent[T any](t *testing.T, raw string) T {
+	t.Helper()
+	var v T
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("unmarshal %s: %v", raw, err)
+	}
+	return v
+}
+
+// collectYield returns a yield func that records every response it is handed
+// and reports stop after the given number of calls (0 means never stop).
+func collectYield(got *[]*model.LLMResponse, stopAfter int) func(*model.LLMResponse, error) bool {
+	return func(r *model.LLMResponse, _ error) bool {
+		*got = append(*got, r)
+		return stopAfter == 0 || len(*got) < stopAfter
+	}
+}
+
+func TestAntHandleContentBlockDelta(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		wantContinue bool
+		wantYields   int
+		wantRole     string
+		wantText     string
+		wantAccText  string
+		wantToolJSON string
+	}{
+		{
+			name:         "text delta accumulates and yields",
+			raw:          `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+			wantContinue: true,
+			wantYields:   1,
+			wantRole:     string(genai.RoleModel),
+			wantText:     "hello",
+			wantAccText:  "hello",
+		},
+		{
+			name:         "thinking delta yields but does not accumulate text",
+			raw:          `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"pondering"}}`,
+			wantContinue: true,
+			wantYields:   1,
+			wantRole:     "thinking",
+			wantText:     "pondering",
+			wantAccText:  "",
+		},
+		{
+			name:         "input json delta appends to known tool block",
+			raw:          `{"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"{\"a\":"}}`,
+			wantContinue: true,
+			wantYields:   0,
+			wantToolJSON: `{"a":`,
+		},
+		{
+			name:         "unknown delta type is ignored",
+			raw:          `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}`,
+			wantContinue: true,
+			wantYields:   0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &antStreamState{toolUse: map[int]antToolUseAcc{7: {id: "t7", name: "fn"}}}
+			var got []*model.LLMResponse
+
+			e := decodeAntEvent[anthropic.ContentBlockDeltaEvent](t, tt.raw)
+			cont := antHandleContentBlockDelta(e, state, collectYield(&got, 0))
+
+			if cont != tt.wantContinue {
+				t.Errorf("continue = %v, want %v", cont, tt.wantContinue)
+			}
+			if len(got) != tt.wantYields {
+				t.Fatalf("yields = %d, want %d", len(got), tt.wantYields)
+			}
+			if tt.wantYields > 0 {
+				r := got[0]
+				if !r.Partial || r.TurnComplete {
+					t.Errorf("Partial=%v TurnComplete=%v, want true/false", r.Partial, r.TurnComplete)
+				}
+				if r.Content.Role != tt.wantRole {
+					t.Errorf("role = %q, want %q", r.Content.Role, tt.wantRole)
+				}
+				if r.Content.Parts[0].Text != tt.wantText {
+					t.Errorf("text = %q, want %q", r.Content.Parts[0].Text, tt.wantText)
+				}
+			}
+			if state.text != tt.wantAccText {
+				t.Errorf("state.text = %q, want %q", state.text, tt.wantAccText)
+			}
+			if state.toolUse[7].inputJSON != tt.wantToolJSON {
+				t.Errorf("state.toolUse[7].inputJSON = %q, want %q",
+					state.toolUse[7].inputJSON, tt.wantToolJSON)
+			}
+		})
+	}
+}
+
+func TestAntHandleContentBlockDelta_UnknownToolIndexIgnored(t *testing.T) {
+	state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+	var got []*model.LLMResponse
+
+	e := decodeAntEvent[anthropic.ContentBlockDeltaEvent](t,
+		`{"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"x"}}`)
+	if !antHandleContentBlockDelta(e, state, collectYield(&got, 0)) {
+		t.Error("continue = false, want true")
+	}
+	if len(state.toolUse) != 0 {
+		t.Errorf("toolUse = %v, want no entry created", state.toolUse)
+	}
+}
+
+func TestAntHandleContentBlockDelta_StopsWhenConsumerStops(t *testing.T) {
+	for _, tt := range []struct{ name, raw string }{
+		{"text", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`},
+		{"thinking", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hm"}}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+			stop := func(*model.LLMResponse, error) bool { return false }
+
+			e := decodeAntEvent[anthropic.ContentBlockDeltaEvent](t, tt.raw)
+			if antHandleContentBlockDelta(e, state, stop) {
+				t.Error("continue = true, want false when the consumer stops")
+			}
+		})
+	}
+}
+
+func TestAntApplyMessageDelta(t *testing.T) {
+	state := &antStreamState{cacheReadTokens: 10, cacheCreationTokens: 20}
+
+	var e anthropic.MessageDeltaEvent
+	e.Delta.StopReason = anthropic.StopReasonMaxTokens
+	e.Usage.OutputTokens = 42
+	e.Usage.CacheReadInputTokens = 5      // lower: must not overwrite
+	e.Usage.CacheCreationInputTokens = 30 // higher: must overwrite
+	antApplyMessageDelta(e, state)
+
+	if state.stopReason != anthropic.StopReasonMaxTokens {
+		t.Errorf("stopReason = %q, want %q", state.stopReason, anthropic.StopReasonMaxTokens)
+	}
+	if state.outputTokens != 42 {
+		t.Errorf("outputTokens = %d, want 42", state.outputTokens)
+	}
+	if state.cacheReadTokens != 10 {
+		t.Errorf("cacheReadTokens = %d, want 10 (lower value must not overwrite)", state.cacheReadTokens)
+	}
+	if state.cacheCreationTokens != 30 {
+		t.Errorf("cacheCreationTokens = %d, want 30", state.cacheCreationTokens)
+	}
+}
+
+func TestAntFinishStream(t *testing.T) {
+	t.Run("success yields final response", func(t *testing.T) {
+		state := &antStreamState{
+			text:         "answer",
+			toolUse:      map[int]antToolUseAcc{},
+			stopReason:   anthropic.StopReasonEndTurn,
+			inputTokens:  3,
+			outputTokens: 4,
+		}
+		var got []*model.LLMResponse
+		antFinishStream(context.Background(), nil, state, collectYield(&got, 0))
+
+		if len(got) != 1 {
+			t.Fatalf("yields = %d, want 1", len(got))
+		}
+		if !got[0].TurnComplete || got[0].Partial {
+			t.Errorf("TurnComplete=%v Partial=%v, want true/false", got[0].TurnComplete, got[0].Partial)
+		}
+		if got[0].Content.Parts[0].Text != "answer" {
+			t.Errorf("text = %q, want %q", got[0].Content.Parts[0].Text, "answer")
+		}
+	})
+
+	t.Run("error yields STREAM_ERROR", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+		antFinishStream(context.Background(), errors.New("boom"), state, collectYield(&got, 0))
+
+		if len(got) != 1 {
+			t.Fatalf("yields = %d, want 1", len(got))
+		}
+		if got[0].ErrorCode != "STREAM_ERROR" || got[0].ErrorMessage != "boom" {
+			t.Errorf("got {%q %q}, want {STREAM_ERROR boom}", got[0].ErrorCode, got[0].ErrorMessage)
+		}
+	})
+
+	t.Run("canceled context yields cancellation marker", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+		antFinishStream(ctx, errors.New("boom"), state, collectYield(&got, 0))
+
+		if len(got) != 1 {
+			t.Fatalf("yields = %d, want 1", len(got))
+		}
+		want := canceledResponse()
+		if got[0].ErrorCode != want.ErrorCode {
+			t.Errorf("ErrorCode = %q, want %q", got[0].ErrorCode, want.ErrorCode)
+		}
+		if got[0].ErrorCode == "STREAM_ERROR" {
+			t.Error("cancellation must not surface as STREAM_ERROR")
+		}
+	})
+}
+
+func TestAntHandleBetaContentBlockStart(t *testing.T) {
+	t.Run("tool use records id and name", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockStartEvent](t,
+			`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"tu_1","name":"fn","input":{}}}`)
+		if !antHandleBetaContentBlockStart(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if state.toolUse[2].id != "tu_1" || state.toolUse[2].name != "fn" {
+			t.Errorf("toolUse[2] = %+v, want {tu_1 fn}", state.toolUse[2])
+		}
+		if len(got) != 0 {
+			t.Errorf("yields = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("advisor result yields advisor role", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockStartEvent](t,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"advisor_tool_result","tool_use_id":"adv_1","content":{"type":"advisor_result","text":"use option B"}}}`)
+		if !antHandleBetaContentBlockStart(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if len(got) != 1 {
+			t.Fatalf("yields = %d, want 1", len(got))
+		}
+		if got[0].Content.Role != "advisor" {
+			t.Errorf("role = %q, want %q", got[0].Content.Role, "advisor")
+		}
+		if got[0].Content.Parts[0].Text != "use option B" {
+			t.Errorf("text = %q, want %q", got[0].Content.Parts[0].Text, "use option B")
+		}
+	})
+
+	t.Run("advisor result stops when consumer stops", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		stop := func(*model.LLMResponse, error) bool { return false }
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockStartEvent](t,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"advisor_tool_result","tool_use_id":"adv_1","content":{"type":"advisor_result","text":"advice"}}}`)
+		if antHandleBetaContentBlockStart(e, state, stop) {
+			t.Error("continue = true, want false")
+		}
+	})
+
+	t.Run("empty advisor text yields nothing", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockStartEvent](t,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"advisor_tool_result","tool_use_id":"adv_1","content":{"type":"advisor_result","text":""}}}`)
+		if !antHandleBetaContentBlockStart(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if len(got) != 0 {
+			t.Errorf("yields = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("text block is ignored", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockStartEvent](t,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		if !antHandleBetaContentBlockStart(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if len(state.toolUse) != 0 || len(got) != 0 {
+			t.Errorf("toolUse=%v yields=%d, want empty/0", state.toolUse, len(got))
+		}
+	})
+}
+
+func TestAntHandleBetaContentBlockDelta(t *testing.T) {
+	t.Run("text delta accumulates and yields", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockDeltaEvent](t,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`)
+		if !antHandleBetaContentBlockDelta(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if state.text != "hi" {
+			t.Errorf("state.text = %q, want %q", state.text, "hi")
+		}
+		if len(got) != 1 || got[0].Content.Role != string(genai.RoleModel) {
+			t.Fatalf("yields = %d, want 1 with model role", len(got))
+		}
+	})
+
+	t.Run("thinking delta yields without accumulating", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockDeltaEvent](t,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hm"}}`)
+		if !antHandleBetaContentBlockDelta(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if state.text != "" {
+			t.Errorf("state.text = %q, want empty", state.text)
+		}
+		if len(got) != 1 || got[0].Content.Role != "thinking" {
+			t.Fatalf("yields = %d, want 1 with thinking role", len(got))
+		}
+	})
+
+	t.Run("input json delta appends to known block", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{4: {id: "t", inputJSON: `{"a"`}}}
+		var got []*model.LLMResponse
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockDeltaEvent](t,
+			`{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":":1}"}}`)
+		if !antHandleBetaContentBlockDelta(e, state, collectYield(&got, 0)) {
+			t.Error("continue = false, want true")
+		}
+		if state.toolUse[4].inputJSON != `{"a":1}` {
+			t.Errorf("inputJSON = %q, want %q", state.toolUse[4].inputJSON, `{"a":1}`)
+		}
+	})
+
+	t.Run("stops when consumer stops", func(t *testing.T) {
+		state := &antStreamState{toolUse: map[int]antToolUseAcc{}}
+		stop := func(*model.LLMResponse, error) bool { return false }
+
+		e := decodeAntEvent[anthropic.BetaRawContentBlockDeltaEvent](t,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`)
+		if antHandleBetaContentBlockDelta(e, state, stop) {
+			t.Error("continue = true, want false")
+		}
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Ollama streaming accumulator
+// -----------------------------------------------------------------------------
+
+func TestOllamaStreamState_HandleChunk(t *testing.T) {
+	var got []*model.LLMResponse
+	state := &ollamaStreamState{yield: collectYield(&got, 0)}
+
+	// Out-of-band reasoning, then inline reasoning, then the answer.
+	chunks := []ollamaapi.ChatResponse{
+		{Message: ollamaapi.Message{Thinking: "out of band"}},
+		{Message: ollamaapi.Message{Content: "<think>inline</think>answer"}},
+		{
+			Message:    ollamaapi.Message{ToolCalls: []ollamaapi.ToolCall{{ID: "tc1", Function: ollamaapi.ToolCallFunction{Name: "fn"}}}},
+			Done:       true,
+			DoneReason: "stop",
+			Metrics:    ollamaapi.Metrics{PromptEvalCount: 11, EvalCount: 22},
+		},
+	}
+	for i, c := range chunks {
+		if err := state.handleChunk(c); err != nil {
+			t.Fatalf("chunk %d: %v", i, err)
+		}
+	}
+
+	if state.aggregatedThinking != "out of bandinline" {
+		t.Errorf("thinking = %q, want %q", state.aggregatedThinking, "out of bandinline")
+	}
+	if state.aggregatedText != "answer" {
+		t.Errorf("text = %q, want %q", state.aggregatedText, "answer")
+	}
+	if len(state.toolCalls) != 1 {
+		t.Errorf("toolCalls = %d, want 1", len(state.toolCalls))
+	}
+	if state.doneReason != "stop" || state.promptTokens != 11 || state.evalTokens != 22 {
+		t.Errorf("metrics = {%q %d %d}, want {stop 11 22}",
+			state.doneReason, state.promptTokens, state.evalTokens)
+	}
+
+	// Three partials: out-of-band thinking, inline thinking, answer text.
+	if len(got) != 3 {
+		t.Fatalf("yields = %d, want 3", len(got))
+	}
+	wantRoles := []string{"thinking", "thinking", string(genai.RoleModel)}
+	for i, want := range wantRoles {
+		if got[i].Content.Role != want {
+			t.Errorf("yield %d role = %q, want %q", i, got[i].Content.Role, want)
+		}
+	}
+}
+
+func TestOllamaStreamState_EmitSkipsEmptyText(t *testing.T) {
+	var got []*model.LLMResponse
+	state := &ollamaStreamState{yield: collectYield(&got, 0)}
+
+	if err := state.emitThinking(""); err != nil {
+		t.Fatalf("emitThinking: %v", err)
+	}
+	if err := state.emitText(""); err != nil {
+		t.Fatalf("emitText: %v", err)
+	}
+	if err := state.emitSplit("", ""); err != nil {
+		t.Fatalf("emitSplit: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("yields = %d, want 0 for empty text", len(got))
+	}
+}
+
+func TestOllamaStreamState_EmitPropagatesCancel(t *testing.T) {
+	stop := func(*model.LLMResponse, error) bool { return false }
+
+	t.Run("thinking", func(t *testing.T) {
+		state := &ollamaStreamState{yield: stop}
+		if err := state.emitThinking("x"); err == nil {
+			t.Error("emitThinking err = nil, want cancellation error")
+		}
+	})
+	t.Run("text", func(t *testing.T) {
+		state := &ollamaStreamState{yield: stop}
+		if err := state.emitText("x"); err == nil {
+			t.Error("emitText err = nil, want cancellation error")
+		}
+	})
+	t.Run("split stops on thinking half", func(t *testing.T) {
+		state := &ollamaStreamState{yield: stop}
+		if err := state.emitSplit("thinking", "text"); err == nil {
+			t.Error("emitSplit err = nil, want cancellation error")
+		}
+		if state.aggregatedText != "" {
+			t.Errorf("text = %q, want empty (the text half must not run)", state.aggregatedText)
+		}
+	})
+	t.Run("handleChunk propagates", func(t *testing.T) {
+		state := &ollamaStreamState{yield: stop}
+		if err := state.handleChunk(ollamaapi.ChatResponse{
+			Message: ollamaapi.Message{Thinking: "x"},
+		}); err == nil {
+			t.Error("handleChunk err = nil, want cancellation error")
+		}
+	})
+	t.Run("handleChunk propagates from content", func(t *testing.T) {
+		state := &ollamaStreamState{yield: stop}
+		if err := state.handleChunk(ollamaapi.ChatResponse{
+			Message: ollamaapi.Message{Content: "plain"},
+		}); err == nil {
+			t.Error("handleChunk err = nil, want cancellation error")
+		}
+	})
+	t.Run("handleChunk propagates from flush", func(t *testing.T) {
+		state := &ollamaStreamState{yield: stop}
+		// A trailing partial tag is held back in the splitter's carry, so the
+		// final Done chunk flushes it and emits.
+		if _, text := state.splitter.split("hello<thi"); text != "hello" {
+			t.Fatalf("split text = %q, want %q", text, "hello")
+		}
+		if err := state.handleChunk(ollamaapi.ChatResponse{Done: true}); err == nil {
+			t.Error("handleChunk err = nil, want cancellation error")
+		}
+	})
+}
+
+func TestOllamaStreamState_FinalParts(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     *ollamaStreamState
+		wantTexts []string
+		wantCalls int
+	}{
+		{
+			name:      "text wins over thinking",
+			state:     &ollamaStreamState{aggregatedText: "answer", aggregatedThinking: "reasoning"},
+			wantTexts: []string{"answer"},
+		},
+		{
+			name:      "thinking fallback when no text and no tool calls",
+			state:     &ollamaStreamState{aggregatedThinking: "reasoning"},
+			wantTexts: []string{"reasoning"},
+		},
+		{
+			name: "no thinking fallback when a tool was called",
+			state: &ollamaStreamState{
+				aggregatedThinking: "reasoning",
+				toolCalls:          []ollamaapi.ToolCall{{ID: "tc1"}},
+			},
+			wantTexts: nil,
+			wantCalls: 1,
+		},
+		{
+			name:      "empty state yields no parts",
+			state:     &ollamaStreamState{},
+			wantTexts: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts := tt.state.finalParts()
+			if len(parts) != len(tt.wantTexts)+tt.wantCalls {
+				t.Fatalf("parts = %d, want %d", len(parts), len(tt.wantTexts)+tt.wantCalls)
+			}
+			for i, want := range tt.wantTexts {
+				if parts[i].Text != want {
+					t.Errorf("parts[%d].Text = %q, want %q", i, parts[i].Text, want)
+				}
+			}
+		})
+	}
+}
+
+func TestOllamaStreamState_FinalResponse(t *testing.T) {
+	t.Run("usage present", func(t *testing.T) {
+		state := &ollamaStreamState{
+			aggregatedText: "answer",
+			doneReason:     "length",
+			promptTokens:   7,
+			evalTokens:     9,
+		}
+		resp := state.finalResponse()
+
+		if resp.Partial || !resp.TurnComplete {
+			t.Errorf("Partial=%v TurnComplete=%v, want false/true", resp.Partial, resp.TurnComplete)
+		}
+		if resp.FinishReason != genai.FinishReasonMaxTokens {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, genai.FinishReasonMaxTokens)
+		}
+		if resp.UsageMetadata == nil {
+			t.Fatal("UsageMetadata = nil, want populated")
+		}
+		if resp.UsageMetadata.PromptTokenCount != 7 || resp.UsageMetadata.CandidatesTokenCount != 9 {
+			t.Errorf("usage = {%d %d}, want {7 9}",
+				resp.UsageMetadata.PromptTokenCount, resp.UsageMetadata.CandidatesTokenCount)
+		}
+	})
+
+	t.Run("no usage when both counts are zero", func(t *testing.T) {
+		resp := (&ollamaStreamState{aggregatedText: "x"}).finalResponse()
+		if resp.UsageMetadata != nil {
+			t.Errorf("UsageMetadata = %+v, want nil", resp.UsageMetadata)
+		}
+		if resp.FinishReason != genai.FinishReasonStop {
+			t.Errorf("FinishReason = %q, want %q", resp.FinishReason, genai.FinishReasonStop)
+		}
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Gemini client configuration
+// -----------------------------------------------------------------------------
+
+func TestGeminiAPIKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		gemini string
+		google string
+		want   string
+	}{
+		{name: "neither set", want: ""},
+		{name: "gemini only", gemini: "g1", want: "g1"},
+		{name: "google only", google: "g2", want: "g2"},
+		{name: "gemini wins", gemini: "g1", google: "g2", want: "g1"},
+		{name: "empty gemini falls through", gemini: "", google: "g2", want: "g2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GEMINI_API_KEY", tt.gemini)
+			t.Setenv("GOOGLE_API_KEY", tt.google)
+			if got := geminiAPIKey(); got != tt.want {
+				t.Errorf("geminiAPIKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiHTTPOptions(t *testing.T) {
+	t.Run("no overrides", func(t *testing.T) {
+		opts, overridden := geminiHTTPOptions("", nil)
+		if overridden {
+			t.Error("overridden = true, want false")
+		}
+		if opts.BaseURL != "" || opts.Headers != nil {
+			t.Errorf("opts = %+v, want zero value", opts)
+		}
+	})
+
+	t.Run("empty extra headers is not an override", func(t *testing.T) {
+		_, overridden := geminiHTTPOptions("", &LLMOptions{ExtraHeaders: map[string]string{}})
+		if overridden {
+			t.Error("overridden = true, want false for an empty header map")
+		}
+	})
+
+	t.Run("base url only", func(t *testing.T) {
+		opts, overridden := geminiHTTPOptions("https://example.test", nil)
+		if !overridden {
+			t.Error("overridden = false, want true")
+		}
+		if opts.BaseURL != "https://example.test" {
+			t.Errorf("BaseURL = %q, want %q", opts.BaseURL, "https://example.test")
+		}
+		if opts.Headers != nil {
+			t.Errorf("Headers = %v, want nil", opts.Headers)
+		}
+	})
+
+	t.Run("headers only", func(t *testing.T) {
+		opts, overridden := geminiHTTPOptions("", &LLMOptions{
+			ExtraHeaders: map[string]string{"X-Token": "abc"},
+		})
+		if !overridden {
+			t.Error("overridden = false, want true")
+		}
+		if opts.BaseURL != "" {
+			t.Errorf("BaseURL = %q, want empty", opts.BaseURL)
+		}
+		if got := opts.Headers.Get("X-Token"); got != "abc" {
+			t.Errorf("X-Token = %q, want %q", got, "abc")
+		}
+	})
+
+	t.Run("both", func(t *testing.T) {
+		opts, overridden := geminiHTTPOptions("https://example.test", &LLMOptions{
+			ExtraHeaders: map[string]string{"X-Token": "abc"},
+		})
+		if !overridden {
+			t.Error("overridden = false, want true")
+		}
+		if opts.BaseURL != "https://example.test" || opts.Headers.Get("X-Token") != "abc" {
+			t.Errorf("opts = %+v, want both set", opts)
+		}
+		if _, ok := opts.Headers[http.CanonicalHeaderKey("X-Token")]; !ok {
+			t.Error("header key was not canonicalized via Header.Set")
+		}
+	})
+}
+
+func TestGeminiNeedsHTTPClient(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *LLMOptions
+		want bool
+	}{
+		{name: "nil opts", opts: nil, want: false},
+		{name: "empty opts", opts: &LLMOptions{}, want: false},
+		{name: "insecure skip tls", opts: &LLMOptions{InsecureSkipTLS: true}, want: true},
+		{name: "ca cert path", opts: &LLMOptions{CACertPath: "/tmp/ca.pem"}, want: true},
+		{name: "connect timeout", opts: &LLMOptions{ConnectTimeout: 1}, want: true},
+		{name: "negative connect timeout", opts: &LLMOptions{ConnectTimeout: -1}, want: false},
+		{name: "extra headers alone do not need a client", opts: &LLMOptions{
+			ExtraHeaders: map[string]string{"X": "y"},
+		}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := geminiNeedsHTTPClient(tt.opts); got != tt.want {
+				t.Errorf("geminiNeedsHTTPClient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Responses streaming event handlers
+// -----------------------------------------------------------------------------
+
+func TestApplyResponsesCompleted(t *testing.T) {
+	t.Run("populates state", func(t *testing.T) {
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+		resp := &responses.Response{ID: "resp_1", Status: responses.ResponseStatusCompleted}
+		resp.Usage.InputTokens = 11
+		resp.Usage.OutputTokens = 22
+		resp.Usage.InputTokensDetails.CachedTokens = 3
+
+		applyResponsesCompleted(state, resp)
+
+		if state.responseID != "resp_1" {
+			t.Errorf("responseID = %q, want %q", state.responseID, "resp_1")
+		}
+		if state.promptTokens != 11 || state.completionTokens != 22 || state.cachedTokens != 3 {
+			t.Errorf("usage = {%d %d %d}, want {11 22 3}",
+				state.promptTokens, state.completionTokens, state.cachedTokens)
+		}
+		if state.finishReason != string(responses.ResponseStatusCompleted) {
+			t.Errorf("finishReason = %q, want %q", state.finishReason, responses.ResponseStatusCompleted)
+		}
+	})
+
+	t.Run("zero values leave prior state intact", func(t *testing.T) {
+		state := &responsesStreamState{
+			toolCalls:        map[int64]toolCallAcc{},
+			responseID:       "old",
+			promptTokens:     5,
+			completionTokens: 6,
+			cachedTokens:     7,
+		}
+		applyResponsesCompleted(state, &responses.Response{})
+
+		if state.responseID != "old" {
+			t.Errorf("responseID = %q, want %q", state.responseID, "old")
+		}
+		if state.promptTokens != 5 || state.completionTokens != 6 || state.cachedTokens != 7 {
+			t.Errorf("usage = {%d %d %d}, want {5 6 7}",
+				state.promptTokens, state.completionTokens, state.cachedTokens)
+		}
+		if state.finishReason != "" {
+			t.Errorf("finishReason = %q, want empty", state.finishReason)
+		}
+	})
+}
+
+func TestApplyResponsesToolCallEvent(t *testing.T) {
+	t.Run("argument deltas append", func(t *testing.T) {
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+
+		applyResponsesToolCallEvent(state, responses.ResponseStreamEventUnion{
+			Type: "response.function_call_arguments.delta", OutputIndex: 0, Delta: `{"a"`,
+		})
+		applyResponsesToolCallEvent(state, responses.ResponseStreamEventUnion{
+			Type: "response.function_call_arguments.delta", OutputIndex: 0, Delta: `:1}`,
+		})
+
+		if got := state.toolCalls[0].arguments; got != `{"a":1}` {
+			t.Errorf("arguments = %q, want %q", got, `{"a":1}`)
+		}
+	})
+
+	t.Run("done overwrites accumulated arguments", func(t *testing.T) {
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{0: {arguments: "partial"}}}
+
+		applyResponsesToolCallEvent(state, responses.ResponseStreamEventUnion{
+			Type: "response.function_call_arguments.done", OutputIndex: 0,
+			Name: "fn", Arguments: `{"full":true}`,
+		})
+
+		acc := state.toolCalls[0]
+		if acc.arguments != `{"full":true}` {
+			t.Errorf("arguments = %q, want %q", acc.arguments, `{"full":true}`)
+		}
+		if acc.name != "fn" {
+			t.Errorf("name = %q, want %q", acc.name, "fn")
+		}
+	})
+
+	t.Run("output item added records header", func(t *testing.T) {
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+		evt := decodeAntEvent[responses.ResponseStreamEventUnion](t, `{
+			"type": "response.output_item.added",
+			"output_index": 2,
+			"item": {"type": "function_call", "call_id": "call_9", "name": "lookup", "arguments": "{}"}
+		}`)
+
+		applyResponsesToolCallEvent(state, evt)
+
+		acc := state.toolCalls[2]
+		if acc.id != "call_9" || acc.name != "lookup" {
+			t.Errorf("acc = %+v, want {call_9 lookup}", acc)
+		}
+		if acc.arguments != "" {
+			t.Errorf("arguments = %q, want empty (added must not carry args)", acc.arguments)
+		}
+	})
+
+	t.Run("output item done carries fallback arguments", func(t *testing.T) {
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+		evt := decodeAntEvent[responses.ResponseStreamEventUnion](t, `{
+			"type": "response.output_item.done",
+			"output_index": 1,
+			"item": {"type": "function_call", "call_id": "call_3", "name": "fn", "arguments": "{\"z\":9}"}
+		}`)
+
+		applyResponsesToolCallEvent(state, evt)
+
+		acc := state.toolCalls[1]
+		if acc.id != "call_3" || acc.name != "fn" || acc.arguments != `{"z":9}` {
+			t.Errorf("acc = %+v, want {call_3 fn {\"z\":9}}", acc)
+		}
+	})
+
+	t.Run("unrelated events are ignored", func(t *testing.T) {
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+		for _, typ := range []string{
+			"response.output_text.delta",
+			"response.reasoning_text.delta",
+			"response.completed",
+			"error",
+		} {
+			applyResponsesToolCallEvent(state, responses.ResponseStreamEventUnion{
+				Type: typ, OutputIndex: 0, Delta: "ignored",
+			})
+		}
+		if len(state.toolCalls) != 0 {
+			t.Errorf("toolCalls = %v, want empty", state.toolCalls)
+		}
+	})
+}
+
+func TestFinishResponsesStream(t *testing.T) {
+	t.Run("stores response id and yields final", func(t *testing.T) {
+		m := &openaiModel{}
+		state := &responsesStreamState{
+			toolCalls:        map[int64]toolCallAcc{},
+			text:             "answer",
+			finishReason:     "completed",
+			promptTokens:     4,
+			completionTokens: 5,
+			cachedTokens:     1,
+		}
+		var got []*model.LLMResponse
+
+		m.finishResponsesStream(state, &responses.Response{ID: "resp_x"}, collectYield(&got, 0))
+
+		if len(got) != 1 {
+			t.Fatalf("yields = %d, want 1", len(got))
+		}
+		if !got[0].TurnComplete || got[0].Partial {
+			t.Errorf("TurnComplete=%v Partial=%v, want true/false", got[0].TurnComplete, got[0].Partial)
+		}
+		if got[0].Content.Parts[0].Text != "answer" {
+			t.Errorf("text = %q, want %q", got[0].Content.Parts[0].Text, "answer")
+		}
+		if got[0].UsageMetadata == nil || got[0].UsageMetadata.CachedContentTokenCount != 1 {
+			t.Errorf("usage = %+v, want cached=1", got[0].UsageMetadata)
+		}
+		if m.responseState == nil || m.responseState.previousResponseID != "resp_x" {
+			t.Errorf("responseState = %+v, want previousResponseID resp_x", m.responseState)
+		}
+	})
+
+	t.Run("nil final response leaves state untouched", func(t *testing.T) {
+		m := &openaiModel{}
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+		var got []*model.LLMResponse
+
+		m.finishResponsesStream(state, nil, collectYield(&got, 0))
+
+		if len(got) != 1 {
+			t.Fatalf("yields = %d, want 1", len(got))
+		}
+		if got[0].UsageMetadata != nil {
+			t.Errorf("UsageMetadata = %+v, want nil when no tokens were reported", got[0].UsageMetadata)
+		}
+		if m.responseState != nil {
+			t.Errorf("responseState = %+v, want nil", m.responseState)
+		}
+	})
+
+	t.Run("blank response id is not stored", func(t *testing.T) {
+		m := &openaiModel{}
+		state := &responsesStreamState{toolCalls: map[int64]toolCallAcc{}}
+		var got []*model.LLMResponse
+
+		m.finishResponsesStream(state, &responses.Response{ID: ""}, collectYield(&got, 0))
+
+		if m.responseState != nil {
+			t.Errorf("responseState = %+v, want nil", m.responseState)
+		}
+	})
+}
+
+func TestBuildResponsesParams(t *testing.T) {
+	budget := int32(9000)
+	req := &model.LLMRequest{
+		Contents: conversionFixture(),
+		Config: &genai.GenerateContentConfig{
+			SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "sys"}}},
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{Name: "fn", Description: "d"}},
+			}},
+			ThinkingConfig: &genai.ThinkingConfig{ThinkingBudget: &budget},
+		},
+	}
+
+	t.Run("platform backend", func(t *testing.T) {
+		m := &openaiModel{}
+		params, sentPrev, err := m.buildResponsesParams(req, "gpt-5.1")
+		if err != nil {
+			t.Fatalf("buildResponsesParams: %v", err)
+		}
+		if params.Model != "gpt-5.1" {
+			t.Errorf("Model = %q, want %q", params.Model, "gpt-5.1")
+		}
+		if params.Store.Value {
+			t.Error("Store = true, want false (responses are never persisted by default)")
+		}
+		if params.Instructions.Value != "sys" {
+			t.Errorf("Instructions = %q, want %q", params.Instructions.Value, "sys")
+		}
+		if len(params.Tools) != 1 {
+			t.Errorf("Tools = %d, want 1", len(params.Tools))
+		}
+		if params.Reasoning.Effort != shared.ReasoningEffortHigh {
+			t.Errorf("Reasoning.Effort = %q, want %q", params.Reasoning.Effort, shared.ReasoningEffortHigh)
+		}
+		if len(params.Include) != 0 {
+			t.Errorf("Include = %v, want empty for the platform backend", params.Include)
+		}
+		// store=false, so the retained pointer is never threaded through.
+		if sentPrev {
+			t.Error("sentPreviousResponseID = true, want false when store is false")
+		}
+		if params.PreviousResponseID.Valid() {
+			t.Error("PreviousResponseID set, want unset")
+		}
+	})
+
+	t.Run("codex backend opts into encrypted reasoning", func(t *testing.T) {
+		m := &openaiModel{codexBackend: true}
+		params, _, err := m.buildResponsesParams(req, "gpt-5.1-codex")
+		if err != nil {
+			t.Fatalf("buildResponsesParams: %v", err)
+		}
+		if len(params.Include) != 1 ||
+			params.Include[0] != responses.ResponseIncludableReasoningEncryptedContent {
+			t.Errorf("Include = %v, want reasoning.encrypted_content", params.Include)
+		}
+	})
+
+	t.Run("no instructions, tools or reasoning", func(t *testing.T) {
+		m := &openaiModel{}
+		bare := &model.LLMRequest{Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+		}}
+		params, _, err := m.buildResponsesParams(bare, "gpt-5.1")
+		if err != nil {
+			t.Fatalf("buildResponsesParams: %v", err)
+		}
+		if params.Instructions.Valid() {
+			t.Error("Instructions set, want unset")
+		}
+		if len(params.Tools) != 0 {
+			t.Errorf("Tools = %d, want 0", len(params.Tools))
+		}
+		if params.Reasoning.Effort != "" {
+			t.Errorf("Reasoning.Effort = %q, want empty", params.Reasoning.Effort)
+		}
+	})
+}

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -21,28 +21,14 @@ func NewGemini(ctx context.Context, modelName, baseURL string, opts *LLMOptions)
 	}
 
 	// Check for API key in env vars
-	apiKey := os.Getenv("GEMINI_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("GOOGLE_API_KEY")
-	}
-	if apiKey != "" {
+	if apiKey := geminiAPIKey(); apiKey != "" {
 		cfg.APIKey = apiKey
 	}
 
-	httpOpts := genai.HTTPOptions{}
-	if baseURL != "" {
-		httpOpts.BaseURL = baseURL
-	}
-	if opts != nil && len(opts.ExtraHeaders) > 0 {
-		httpOpts.Headers = make(http.Header)
-		for k, v := range opts.ExtraHeaders {
-			httpOpts.Headers.Set(k, v)
-		}
-	}
-	if baseURL != "" || (opts != nil && len(opts.ExtraHeaders) > 0) {
+	if httpOpts, overridden := geminiHTTPOptions(baseURL, opts); overridden {
 		cfg.HTTPOptions = httpOpts
 	}
-	if opts != nil && (opts.InsecureSkipTLS || opts.CACertPath != "" || opts.ConnectTimeout > 0) {
+	if geminiNeedsHTTPClient(opts) {
 		httpClient, err := BuildHTTPClient(opts, 0)
 		if err != nil {
 			return nil, err
@@ -56,4 +42,40 @@ func NewGemini(ctx context.Context, modelName, baseURL string, opts *LLMOptions)
 	}
 
 	return llm, nil
+}
+
+// geminiAPIKey reads the Gemini API key from the environment, preferring
+// GEMINI_API_KEY over GOOGLE_API_KEY. It returns "" when neither is set, in
+// which case the client falls back to Application Default Credentials.
+func geminiAPIKey() string {
+	if apiKey := os.Getenv("GEMINI_API_KEY"); apiKey != "" {
+		return apiKey
+	}
+	return os.Getenv("GOOGLE_API_KEY")
+}
+
+// geminiHTTPOptions builds the endpoint and header overrides for the Gemini
+// client. The second result reports whether any override was requested — when
+// false the options are left at the SDK default rather than being overwritten
+// with an empty struct.
+func geminiHTTPOptions(baseURL string, opts *LLMOptions) (genai.HTTPOptions, bool) {
+	hasExtraHeaders := opts != nil && len(opts.ExtraHeaders) > 0
+
+	httpOpts := genai.HTTPOptions{}
+	if baseURL != "" {
+		httpOpts.BaseURL = baseURL
+	}
+	if hasExtraHeaders {
+		httpOpts.Headers = make(http.Header)
+		for k, v := range opts.ExtraHeaders {
+			httpOpts.Headers.Set(k, v)
+		}
+	}
+	return httpOpts, baseURL != "" || hasExtraHeaders
+}
+
+// geminiNeedsHTTPClient reports whether opts asks for transport settings that
+// only a custom *http.Client can carry.
+func geminiNeedsHTTPClient(opts *LLMOptions) bool {
+	return opts != nil && (opts.InsecureSkipTLS || opts.CACertPath != "" || opts.ConnectTimeout > 0)
 }

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -316,29 +316,8 @@ func ollamaFinishReasonToGenai(reason string) genai.FinishReason {
 
 // ollamaContentsToMessages converts genai.Content to Ollama messages.
 func ollamaContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]ollamaapi.Message, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemPrompt := strings.TrimSpace(systemBuilder.String())
-
-	// Collect function responses for matching.
-	functionResponses := make(map[string]*genai.FunctionResponse)
-	for _, c := range contents {
-		if c == nil || c.Parts == nil {
-			continue
-		}
-		for _, p := range c.Parts {
-			if p != nil && p.FunctionResponse != nil {
-				functionResponses[p.FunctionResponse.ID] = p.FunctionResponse
-			}
-		}
-	}
+	systemPrompt := genaiSystemInstruction(config)
+	functionResponses := genaiFunctionResponses(contents)
 
 	var messages []ollamaapi.Message
 	for _, content := range contents {
@@ -350,67 +329,13 @@ func ollamaContentsToMessages(contents []*genai.Content, config *genai.GenerateC
 			continue
 		}
 
-		var textParts []string
-		var functionCalls []*genai.FunctionCall
+		textParts, functionCalls := genaiSplitParts(content.Parts)
 
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.Text != "" {
-				textParts = append(textParts, part.Text)
-			} else if part.FunctionCall != nil {
-				functionCalls = append(functionCalls, part.FunctionCall)
-			}
-		}
-
-		if len(functionCalls) > 0 && (role == "model" || role == "assistant") {
-			// Assistant message with tool calls.
-			toolCalls := make([]ollamaapi.ToolCall, 0, len(functionCalls))
-			for _, fc := range functionCalls {
-				args := ollamaapi.NewToolCallFunctionArguments()
-				for k, v := range fc.Args {
-					args.Set(k, v)
-				}
-				toolCalls = append(toolCalls, ollamaapi.ToolCall{
-					ID: fc.ID,
-					Function: ollamaapi.ToolCallFunction{
-						Name:      fc.Name,
-						Arguments: args,
-					},
-				})
-			}
-
-			msg := ollamaapi.Message{
-				Role:      "assistant",
-				ToolCalls: toolCalls,
-			}
-			if len(textParts) > 0 {
-				msg.Content = strings.Join(textParts, "\n")
-			}
-			messages = append(messages, msg)
-
-			// Tool results as separate messages.
-			for _, fc := range functionCalls {
-				contentStr := ""
-				if fr := functionResponses[fc.ID]; fr != nil {
-					contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
-				}
-				messages = append(messages, ollamaapi.Message{
-					Role:       "tool",
-					Content:    contentStr,
-					ToolCallID: fc.ID,
-				})
-			}
-		} else if len(textParts) > 0 {
-			msgRole := "user"
-			if role == "model" || role == "assistant" {
-				msgRole = "assistant"
-			}
-			messages = append(messages, ollamaapi.Message{
-				Role:    msgRole,
-				Content: strings.Join(textParts, "\n"),
-			})
+		switch {
+		case len(functionCalls) > 0 && genaiIsAssistantRole(role):
+			messages = append(messages, ollamaToolCallMessages(textParts, functionCalls, functionResponses)...)
+		case len(textParts) > 0:
+			messages = append(messages, ollamaTextMessage(role, strings.Join(textParts, "\n")))
 		}
 	}
 
@@ -423,6 +348,68 @@ func ollamaContentsToMessages(contents []*genai.Content, config *genai.GenerateC
 	}
 
 	return messages, systemPrompt
+}
+
+// ollamaToolCallMessages renders one assistant turn that called tools: the
+// assistant message carrying the tool calls, then one "tool" message per call
+// holding its result.
+func ollamaToolCallMessages(
+	textParts []string,
+	functionCalls []*genai.FunctionCall,
+	functionResponses map[string]*genai.FunctionResponse,
+) []ollamaapi.Message {
+	// Assistant message with tool calls.
+	toolCalls := make([]ollamaapi.ToolCall, 0, len(functionCalls))
+	for _, fc := range functionCalls {
+		args := ollamaapi.NewToolCallFunctionArguments()
+		for k, v := range fc.Args {
+			args.Set(k, v)
+		}
+		toolCalls = append(toolCalls, ollamaapi.ToolCall{
+			ID: fc.ID,
+			Function: ollamaapi.ToolCallFunction{
+				Name:      fc.Name,
+				Arguments: args,
+			},
+		})
+	}
+
+	msg := ollamaapi.Message{
+		Role:      "assistant",
+		ToolCalls: toolCalls,
+	}
+	if len(textParts) > 0 {
+		msg.Content = strings.Join(textParts, "\n")
+	}
+	messages := make([]ollamaapi.Message, 0, 1+len(functionCalls))
+	messages = append(messages, msg)
+
+	// Tool results as separate messages.
+	for _, fc := range functionCalls {
+		contentStr := ""
+		if fr := functionResponses[fc.ID]; fr != nil {
+			contentStr = oaiFunctionResponseContent(fr.Response) // reuse helper
+		}
+		messages = append(messages, ollamaapi.Message{
+			Role:       "tool",
+			Content:    contentStr,
+			ToolCallID: fc.ID,
+		})
+	}
+	return messages
+}
+
+// ollamaTextMessage renders a text-only turn under the Ollama role its genai
+// role maps to.
+func ollamaTextMessage(role, text string) ollamaapi.Message {
+	msgRole := "user"
+	if genaiIsAssistantRole(role) {
+		msgRole = "assistant"
+	}
+	return ollamaapi.Message{
+		Role:    msgRole,
+		Content: text,
+	}
 }
 
 // ollamaGenaiToolsToOllama converts genai tools to Ollama native tool format.
@@ -515,103 +502,109 @@ func convertToToolProperty(raw any) ollamaapi.ToolProperty {
 	return prop
 }
 
-func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *ollamaapi.ChatRequest, yield func(*model.LLMResponse, error) bool) {
-	var aggregatedText string
-	var aggregatedThinking string
-	var toolCalls []ollamaapi.ToolCall
-	var doneReason string
-	var promptTokens, evalTokens int
-	var splitter thinkSplitter
+// ollamaStreamState accumulates the chunks of an Ollama chat stream while
+// yielding each one as a partial response, and builds the final response from
+// what it accumulated.
+type ollamaStreamState struct {
+	yield func(*model.LLMResponse, error) bool
 
-	emitThinking := func(text string) error {
-		if text == "" {
-			return nil
-		}
-		aggregatedThinking += text
-		if !yield(&model.LLMResponse{
-			Partial:      true,
-			TurnComplete: false,
-			Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: text}}},
-		}, nil) {
-			return fmt.Errorf("yield canceled")
-		}
+	aggregatedText     string
+	aggregatedThinking string
+	toolCalls          []ollamaapi.ToolCall
+	doneReason         string
+	promptTokens       int
+	evalTokens         int
+	splitter           thinkSplitter
+}
+
+// emitThinking yields reasoning text on the thinking stream.
+func (s *ollamaStreamState) emitThinking(text string) error {
+	if text == "" {
 		return nil
 	}
+	s.aggregatedThinking += text
+	if !s.yield(&model.LLMResponse{
+		Partial:      true,
+		TurnComplete: false,
+		Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: text}}},
+	}, nil) {
+		return fmt.Errorf("yield canceled")
+	}
+	return nil
+}
 
-	emitText := func(text string) error {
-		if text == "" {
-			return nil
-		}
-		aggregatedText += text
-		if !yield(&model.LLMResponse{
-			Partial:      true,
-			TurnComplete: false,
-			Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: text}}},
-		}, nil) {
-			return fmt.Errorf("yield canceled")
-		}
+// emitText yields answer text on the model stream.
+func (s *ollamaStreamState) emitText(text string) error {
+	if text == "" {
 		return nil
 	}
+	s.aggregatedText += text
+	if !s.yield(&model.LLMResponse{
+		Partial:      true,
+		TurnComplete: false,
+		Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: text}}},
+	}, nil) {
+		return fmt.Errorf("yield canceled")
+	}
+	return nil
+}
 
-	err := client.Chat(ctx, chatReq, func(resp ollamaapi.ChatResponse) error {
-		msg := resp.Message
+// emitSplit yields one thinkSplitter result: its reasoning half, then its
+// answer half.
+func (s *ollamaStreamState) emitSplit(thinking, text string) error {
+	if err := s.emitThinking(thinking); err != nil {
+		return err
+	}
+	return s.emitText(text)
+}
 
-		// Reasoning that Ollama already separated out.
-		if err := emitThinking(msg.Thinking); err != nil {
+// handleChunk folds one streamed chat response into the state.
+func (s *ollamaStreamState) handleChunk(resp ollamaapi.ChatResponse) error {
+	msg := resp.Message
+
+	// Reasoning that Ollama already separated out.
+	if err := s.emitThinking(msg.Thinking); err != nil {
+		return err
+	}
+
+	// Reasoning the model left inline as <think>...</think> is routed to
+	// the thinking stream instead of surfacing as the answer.
+	if msg.Content != "" {
+		inlineThinking, text := s.splitter.split(msg.Content)
+		if err := s.emitSplit(inlineThinking, text); err != nil {
 			return err
 		}
-
-		// Reasoning the model left inline as <think>...</think> is routed to
-		// the thinking stream instead of surfacing as the answer.
-		if msg.Content != "" {
-			inlineThinking, text := splitter.split(msg.Content)
-			if err := emitThinking(inlineThinking); err != nil {
-				return err
-			}
-			if err := emitText(text); err != nil {
-				return err
-			}
-		}
-
-		if resp.Done {
-			inlineThinking, text := splitter.flush()
-			if err := emitThinking(inlineThinking); err != nil {
-				return err
-			}
-			if err := emitText(text); err != nil {
-				return err
-			}
-		}
-
-		// Accumulate tool calls.
-		if len(msg.ToolCalls) > 0 {
-			toolCalls = append(toolCalls, msg.ToolCalls...)
-		}
-
-		// Capture metrics from final response.
-		if resp.Done {
-			doneReason = resp.DoneReason
-			promptTokens = resp.PromptEvalCount
-			evalTokens = resp.EvalCount
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		if ctx.Err() == context.Canceled {
-			_ = yield(canceledResponse(), nil)
-			return
-		}
-		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
-		return
 	}
 
-	// Build final response.
-	finalParts := make([]*genai.Part, 0, 1+len(toolCalls))
-	if aggregatedText != "" {
-		finalParts = append(finalParts, &genai.Part{Text: aggregatedText})
-	} else if aggregatedThinking != "" && len(toolCalls) == 0 {
+	if resp.Done {
+		inlineThinking, text := s.splitter.flush()
+		if err := s.emitSplit(inlineThinking, text); err != nil {
+			return err
+		}
+	}
+
+	// Accumulate tool calls.
+	if len(msg.ToolCalls) > 0 {
+		s.toolCalls = append(s.toolCalls, msg.ToolCalls...)
+	}
+
+	// Capture metrics from final response.
+	if resp.Done {
+		s.doneReason = resp.DoneReason
+		s.promptTokens = resp.PromptEvalCount
+		s.evalTokens = resp.EvalCount
+	}
+
+	return nil
+}
+
+// finalParts assembles the parts of the completed turn: the answer text (or the
+// thinking fallback), then one part per tool call.
+func (s *ollamaStreamState) finalParts() []*genai.Part {
+	finalParts := make([]*genai.Part, 0, 1+len(s.toolCalls))
+	if s.aggregatedText != "" {
+		finalParts = append(finalParts, &genai.Part{Text: s.aggregatedText})
+	} else if s.aggregatedThinking != "" && len(s.toolCalls) == 0 {
 		// Fallback: model responded entirely via thinking tokens (e.g. thinking forced
 		// on a nothink model). Surface the thinking content rather than returning nothing.
 		//
@@ -620,29 +613,50 @@ func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *
 		// — and firing it there restates the reasoning as if it were the answer
 		// (seen with minimax-m3:cloud: "The user wants me to run a bash
 		// command..." printed above the real reply).
-		finalParts = append(finalParts, &genai.Part{Text: aggregatedThinking})
+		finalParts = append(finalParts, &genai.Part{Text: s.aggregatedThinking})
 	}
-	for _, tc := range toolCalls {
+	for _, tc := range s.toolCalls {
 		args := tc.Function.Arguments.ToMap()
 		p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
 		p.FunctionCall.ID = tc.ID
 		finalParts = append(finalParts, p)
 	}
+	return finalParts
+}
+
+// finalResponse builds the terminal response for the completed turn.
+func (s *ollamaStreamState) finalResponse() *model.LLMResponse {
+	finalParts := s.finalParts()
 
 	var usage *genai.GenerateContentResponseUsageMetadata
-	if promptTokens > 0 || evalTokens > 0 {
+	if s.promptTokens > 0 || s.evalTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(promptTokens),
-			CandidatesTokenCount: int32(evalTokens),
+			PromptTokenCount:     int32(s.promptTokens),
+			CandidatesTokenCount: int32(s.evalTokens),
 		}
 	}
-	_ = yield(&model.LLMResponse{
+	return &model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
-		FinishReason:  ollamaFinishReasonToGenai(doneReason),
+		FinishReason:  ollamaFinishReasonToGenai(s.doneReason),
 		UsageMetadata: usage,
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
-	}, nil)
+	}
+}
+
+func ollamaRunStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *ollamaapi.ChatRequest, yield func(*model.LLMResponse, error) bool) {
+	state := &ollamaStreamState{yield: yield}
+
+	if err := client.Chat(ctx, chatReq, state.handleChunk); err != nil {
+		if ctx.Err() == context.Canceled {
+			_ = yield(canceledResponse(), nil)
+			return
+		}
+		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+		return
+	}
+
+	_ = yield(state.finalResponse(), nil)
 }
 
 func ollamaRunNonStreaming(ctx context.Context, client *ollamaapi.Client, chatReq *ollamaapi.ChatRequest, yield func(*model.LLMResponse, error) bool) {

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -48,8 +48,14 @@ func (m *openaiModel) generateChat(ctx context.Context, req *model.LLMRequest, m
 	}
 }
 
-// oaiContentsToMessages converts genai.Content to OpenAI messages (Chat Completions path).
-func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]openai.ChatCompletionMessageParamUnion, string) {
+// The genai* helpers below are the parts of the genai.Content -> wire-format
+// conversion that every provider does identically (Anthropic, Ollama, OpenAI
+// Chat Completions and OpenAI Responses). Only the wire types they feed differ,
+// so they live here alongside oaiFunctionResponseContent's other callers.
+
+// genaiSystemInstruction flattens config.SystemInstruction into the single
+// system prompt string the providers send out of band.
+func genaiSystemInstruction(config *genai.GenerateContentConfig) string {
 	var systemBuilder strings.Builder
 	if config != nil && config.SystemInstruction != nil {
 		for _, p := range config.SystemInstruction.Parts {
@@ -59,9 +65,12 @@ func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 			}
 		}
 	}
-	systemInstruction := strings.TrimSpace(systemBuilder.String())
+	return strings.TrimSpace(systemBuilder.String())
+}
 
-	// Collect function responses for matching with function calls.
+// genaiFunctionResponses indexes every function response in the conversation by
+// its call ID, so a function call can be paired with its result.
+func genaiFunctionResponses(contents []*genai.Content) map[string]*genai.FunctionResponse {
 	functionResponses := make(map[string]*genai.FunctionResponse)
 	for _, c := range contents {
 		if c == nil || c.Parts == nil {
@@ -73,6 +82,36 @@ func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 			}
 		}
 	}
+	return functionResponses
+}
+
+// genaiSplitParts splits one content's parts into its text fragments and its
+// function calls. A part with text is never also read as a function call.
+func genaiSplitParts(parts []*genai.Part) ([]string, []*genai.FunctionCall) {
+	var textParts []string
+	var functionCalls []*genai.FunctionCall
+	for _, part := range parts {
+		if part == nil {
+			continue
+		}
+		if part.Text != "" {
+			textParts = append(textParts, part.Text)
+		} else if part.FunctionCall != nil {
+			functionCalls = append(functionCalls, part.FunctionCall)
+		}
+	}
+	return textParts, functionCalls
+}
+
+// genaiIsAssistantRole reports whether a genai role denotes the model's turn.
+func genaiIsAssistantRole(role string) bool {
+	return role == "model" || role == "assistant"
+}
+
+// oaiContentsToMessages converts genai.Content to OpenAI messages (Chat Completions path).
+func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]openai.ChatCompletionMessageParamUnion, string) {
+	systemInstruction := genaiSystemInstruction(config)
+	functionResponses := genaiFunctionResponses(contents)
 
 	var messages []openai.ChatCompletionMessageParamUnion
 	for _, content := range contents {
@@ -80,67 +119,72 @@ func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 			continue
 		}
 		role := strings.TrimSpace(content.Role)
-		var textParts []string
-		var functionCalls []*genai.FunctionCall
+		textParts, functionCalls := genaiSplitParts(content.Parts)
 
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.Text != "" {
-				textParts = append(textParts, part.Text)
-			} else if part.FunctionCall != nil {
-				functionCalls = append(functionCalls, part.FunctionCall)
-			}
-		}
-
-		if len(functionCalls) > 0 && (role == "model" || role == "assistant") {
-			toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(functionCalls))
-			var toolResponseMessages []openai.ChatCompletionMessageParamUnion
-			for _, fc := range functionCalls {
-				if fc == nil || strings.TrimSpace(fc.ID) == "" {
-					continue
-				}
-				argsJSON, _ := json.Marshal(fc.Args)
-				toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
-					OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-						ID:   fc.ID,
-						Type: constant.Function("function"),
-						Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-							Name:      fc.Name,
-							Arguments: string(argsJSON),
-						},
-					},
-				})
-				contentStr := "No response available for this function call."
-				if fr := functionResponses[fc.ID]; fr != nil {
-					contentStr = oaiFunctionResponseContent(fr.Response)
-				}
-				toolResponseMessages = append(toolResponseMessages, openai.ToolMessage(contentStr, fc.ID))
-			}
-			asst := openai.ChatCompletionAssistantMessageParam{
-				Role:      constant.Assistant("assistant"),
-				ToolCalls: toolCalls,
-			}
-			if len(textParts) > 0 {
-				asst.Content.OfString = param.NewOpt(strings.Join(textParts, "\n"))
-			}
-			messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
-			messages = append(messages, toolResponseMessages...)
-		} else if len(textParts) > 0 {
-			text := strings.Join(textParts, "\n")
-			if role == "model" || role == "assistant" {
-				asst := openai.ChatCompletionAssistantMessageParam{
-					Role: constant.Assistant("assistant"),
-				}
-				asst.Content.OfString = param.NewOpt(text)
-				messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
-			} else {
-				messages = append(messages, openai.UserMessage(text))
-			}
+		switch {
+		case len(functionCalls) > 0 && genaiIsAssistantRole(role):
+			messages = append(messages, oaiToolCallMessages(textParts, functionCalls, functionResponses)...)
+		case len(textParts) > 0:
+			messages = append(messages, oaiTextMessage(role, strings.Join(textParts, "\n")))
 		}
 	}
 	return messages, systemInstruction
+}
+
+// oaiToolCallMessages renders one assistant turn that called tools: the
+// assistant message carrying the tool calls, followed by one tool message per
+// call holding its result.
+func oaiToolCallMessages(
+	textParts []string,
+	functionCalls []*genai.FunctionCall,
+	functionResponses map[string]*genai.FunctionResponse,
+) []openai.ChatCompletionMessageParamUnion {
+	toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(functionCalls))
+	var toolResponseMessages []openai.ChatCompletionMessageParamUnion
+	for _, fc := range functionCalls {
+		if fc == nil || strings.TrimSpace(fc.ID) == "" {
+			continue
+		}
+		argsJSON, _ := json.Marshal(fc.Args)
+		toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+			OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+				ID:   fc.ID,
+				Type: constant.Function("function"),
+				Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+					Name:      fc.Name,
+					Arguments: string(argsJSON),
+				},
+			},
+		})
+		contentStr := "No response available for this function call."
+		if fr := functionResponses[fc.ID]; fr != nil {
+			contentStr = oaiFunctionResponseContent(fr.Response)
+		}
+		toolResponseMessages = append(toolResponseMessages, openai.ToolMessage(contentStr, fc.ID))
+	}
+	asst := openai.ChatCompletionAssistantMessageParam{
+		Role:      constant.Assistant("assistant"),
+		ToolCalls: toolCalls,
+	}
+	if len(textParts) > 0 {
+		asst.Content.OfString = param.NewOpt(strings.Join(textParts, "\n"))
+	}
+	messages := make([]openai.ChatCompletionMessageParamUnion, 0, 1+len(toolResponseMessages))
+	messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
+	return append(messages, toolResponseMessages...)
+}
+
+// oaiTextMessage renders a text-only turn as the assistant or user message its
+// genai role calls for.
+func oaiTextMessage(role, text string) openai.ChatCompletionMessageParamUnion {
+	if !genaiIsAssistantRole(role) {
+		return openai.UserMessage(text)
+	}
+	asst := openai.ChatCompletionAssistantMessageParam{
+		Role: constant.Assistant("assistant"),
+	}
+	asst.Content.OfString = param.NewOpt(text)
+	return openai.ChatCompletionMessageParamUnion{OfAssistant: &asst}
 }
 
 func oaiGenaiToolsToOpenAI(tools []*genai.Tool) []openai.ChatCompletionToolUnionParam {

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -38,101 +38,18 @@ func modelNeedsResponses(modelName string) bool {
 // supports reasoning effort, stateful multi-turn via previous_response_id).
 func (m *openaiModel) generateResponses(ctx context.Context, req *model.LLMRequest, modelName string, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		m.mu.Lock()
-		state := m.responseState
-		m.mu.Unlock()
-
-		input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
+		params, sentPreviousResponseID, err := m.buildResponsesParams(req, modelName)
 		if err != nil {
 			_ = yield(nil, fmt.Errorf("responses input: %w", err))
 			return
 		}
 
-		params := responses.ResponseNewParams{
-			Model: modelName,
-			Input: input,
-			// Default to store=false so we never persist LLM responses
-			// server-side without an explicit opt-in. Multi-turn continues
-			// to work on the platform Responses API via full conversation
-			// replay (params.Input carries the whole thread).
-			Store: param.NewOpt(false),
-		}
-		if instructions != "" {
-			params.Instructions = param.NewOpt(instructions)
-		}
-
-		// The ChatGPT codex backend is stateless — it rejects requests that
-		// expect server-side persistence and requires clients to opt in to
-		// encrypted reasoning echo so multi-turn context can round-trip on
-		// the client side. Matches pi-mono's openai-codex-responses body.
-		if m.codexBackend {
-			params.Include = []responses.ResponseIncludable{
-				responses.ResponseIncludableReasoningEncryptedContent,
-			}
-		}
-
-		// previous_response_id requires OpenAI to retain responses
-		// server-side, which conflicts with store=false. Skip threading
-		// the pointer; the full conversation in params.Input is sufficient.
-		sentPreviousResponseID := shouldSendPreviousResponseID(params.Store.Value, m.codexBackend, state)
-		if sentPreviousResponseID {
-			params.PreviousResponseID = param.NewOpt(state.previousResponseID)
-		}
-
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = oaiGenaiToolsToResponses(req.Config.Tools)
-		}
-
-		// Apply reasoning effort if configured via ThinkingConfig.BudgetTokens.
-		// Low tokens (100-500) → low effort; medium (2000-4000) → medium; high (8000+) → high.
-		if req.Config != nil && req.Config.ThinkingConfig != nil && req.Config.ThinkingConfig.ThinkingBudget != nil {
-			bt := *req.Config.ThinkingConfig.ThinkingBudget
-			switch {
-			case bt >= 8000:
-				params.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffortHigh}
-			case bt >= 2000:
-				params.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffortMedium}
-			case bt > 0:
-				params.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffortLow}
-			}
-		}
-
 		// send performs the request once, including the previous_response_id
-		// recovery below. It takes its own yield so retryStream can re-run it.
+		// recovery in sendResponses. It takes its own yield so retryStream can
+		// re-run it; params is shared across attempts, as before, so a pointer
+		// cleared on one attempt stays cleared on the next.
 		send := func(y func(*model.LLMResponse, error) bool) {
-			runOnce := func(p responses.ResponseNewParams) (bool, error) {
-				if stream {
-					return m.runResponsesStreaming(ctx, p, y)
-				}
-				return m.runResponsesNonStreaming(ctx, p, y)
-			}
-
-			emitted, err := runOnce(params)
-
-			// A stored previous_response_id can stop resolving upstream at any
-			// point: a proxy or load balancer routing the next turn to a different
-			// deployment, `store=false` (zero-data-retention accounts), expiry, or
-			// a model switch. The full conversation is already in params.Input —
-			// previous_response_id is only an optimisation here — so retrying
-			// without it is lossless. Only retry when nothing was streamed yet,
-			// otherwise the caller would see the turn's text twice.
-			if err != nil && sentPreviousResponseID && !emitted && isPreviousResponseNotFound(err) {
-				m.clearPreviousResponseID()
-				params.PreviousResponseID = param.Opt[string]{}
-				// The retry is the last attempt, so its emitted flag is moot.
-				_, err = runOnce(params)
-			}
-
-			if err != nil {
-				// Clear the stale pointer so the next turn starts fresh rather
-				// than replaying the same rejected id.
-				m.clearPreviousResponseID()
-				if stream {
-					_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
-					return
-				}
-				_ = y(nil, fmt.Errorf("OpenAI Responses API failed: %w", err))
-			}
+			m.sendResponses(ctx, params, sentPreviousResponseID, stream, y)
 		}
 
 		if stream {
@@ -140,6 +57,124 @@ func (m *openaiModel) generateResponses(ctx context.Context, req *model.LLMReque
 		} else {
 			send(yield)
 		}
+	}
+}
+
+// buildResponsesParams assembles the Responses request for one turn. It also
+// reports whether the request carries a previous_response_id, which decides
+// whether a failure is worth retrying without it.
+func (m *openaiModel) buildResponsesParams(req *model.LLMRequest, modelName string) (*responses.ResponseNewParams, bool, error) {
+	m.mu.Lock()
+	state := m.responseState
+	m.mu.Unlock()
+
+	input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
+	if err != nil {
+		return nil, false, err
+	}
+
+	params := &responses.ResponseNewParams{
+		Model: modelName,
+		Input: input,
+		// Default to store=false so we never persist LLM responses
+		// server-side without an explicit opt-in. Multi-turn continues
+		// to work on the platform Responses API via full conversation
+		// replay (params.Input carries the whole thread).
+		Store: param.NewOpt(false),
+	}
+	if instructions != "" {
+		params.Instructions = param.NewOpt(instructions)
+	}
+
+	// The ChatGPT codex backend is stateless — it rejects requests that
+	// expect server-side persistence and requires clients to opt in to
+	// encrypted reasoning echo so multi-turn context can round-trip on
+	// the client side. Matches pi-mono's openai-codex-responses body.
+	if m.codexBackend {
+		params.Include = []responses.ResponseIncludable{
+			responses.ResponseIncludableReasoningEncryptedContent,
+		}
+	}
+
+	// previous_response_id requires OpenAI to retain responses
+	// server-side, which conflicts with store=false. Skip threading
+	// the pointer; the full conversation in params.Input is sufficient.
+	sentPreviousResponseID := shouldSendPreviousResponseID(params.Store.Value, m.codexBackend, state)
+	if sentPreviousResponseID {
+		params.PreviousResponseID = param.NewOpt(state.previousResponseID)
+	}
+
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		params.Tools = oaiGenaiToolsToResponses(req.Config.Tools)
+	}
+
+	if reasoning, ok := oaiResponsesReasoning(req.Config); ok {
+		params.Reasoning = reasoning
+	}
+
+	return params, sentPreviousResponseID, nil
+}
+
+// oaiResponsesReasoning maps a configured thinking budget onto a Responses
+// reasoning effort. Low tokens (100-500) → low effort; medium (2000-4000) →
+// medium; high (8000+) → high. The second result is false when no budget is
+// configured, or when the budget is not positive.
+func oaiResponsesReasoning(config *genai.GenerateContentConfig) (shared.ReasoningParam, bool) {
+	if config == nil || config.ThinkingConfig == nil || config.ThinkingConfig.ThinkingBudget == nil {
+		return shared.ReasoningParam{}, false
+	}
+	switch bt := *config.ThinkingConfig.ThinkingBudget; {
+	case bt >= 8000:
+		return shared.ReasoningParam{Effort: shared.ReasoningEffortHigh}, true
+	case bt >= 2000:
+		return shared.ReasoningParam{Effort: shared.ReasoningEffortMedium}, true
+	case bt > 0:
+		return shared.ReasoningParam{Effort: shared.ReasoningEffortLow}, true
+	}
+	return shared.ReasoningParam{}, false
+}
+
+// sendResponses performs one Responses request, recovering from a
+// previous_response_id the upstream can no longer resolve, and surfaces any
+// remaining error to the caller in the shape the streaming mode expects.
+func (m *openaiModel) sendResponses(
+	ctx context.Context,
+	params *responses.ResponseNewParams,
+	sentPreviousResponseID, stream bool,
+	y func(*model.LLMResponse, error) bool,
+) {
+	runOnce := func() (bool, error) {
+		if stream {
+			return m.runResponsesStreaming(ctx, *params, y)
+		}
+		return m.runResponsesNonStreaming(ctx, *params, y)
+	}
+
+	emitted, err := runOnce()
+
+	// A stored previous_response_id can stop resolving upstream at any
+	// point: a proxy or load balancer routing the next turn to a different
+	// deployment, `store=false` (zero-data-retention accounts), expiry, or
+	// a model switch. The full conversation is already in params.Input —
+	// previous_response_id is only an optimisation here — so retrying
+	// without it is lossless. Only retry when nothing was streamed yet,
+	// otherwise the caller would see the turn's text twice.
+	if err != nil && sentPreviousResponseID && !emitted && isPreviousResponseNotFound(err) {
+		m.clearPreviousResponseID()
+		params.PreviousResponseID = param.Opt[string]{}
+		// The retry is the last attempt, so its emitted flag is moot.
+		_, err = runOnce()
+	}
+
+	if err != nil {
+		// Clear the stale pointer so the next turn starts fresh rather
+		// than replaying the same rejected id.
+		m.clearPreviousResponseID()
+		if stream {
+			_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+			return
+		}
+		_ = y(nil, fmt.Errorf("OpenAI Responses API failed: %w", err))
 	}
 }
 
@@ -186,42 +221,9 @@ func (m *openaiModel) clearPreviousResponseID() {
 // `{"detail":"Input must be a list"}`, and the platform Responses API accepts lists too.
 func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.GenerateContentConfig) (responses.ResponseNewParamsInputUnion, string, error) {
 	// Extract system instruction.
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	instructions := strings.TrimSpace(systemBuilder.String())
+	instructions := genaiSystemInstruction(config)
 
-	// A canceled turn can persist a function call before its tool result is
-	// emitted. Responses requires calls and outputs to be paired, so omit either
-	// half of an incomplete pair when replaying conversation history.
-	callIDs := make(map[string]struct{})
-	responseIDs := make(map[string]struct{})
-	for _, content := range contents {
-		if content == nil {
-			continue
-		}
-		for _, part := range content.Parts {
-			if part == nil {
-				continue
-			}
-			if part.FunctionCall != nil {
-				if id := strings.TrimSpace(part.FunctionCall.ID); id != "" {
-					callIDs[id] = struct{}{}
-				}
-			}
-			if part.FunctionResponse != nil {
-				if id := strings.TrimSpace(part.FunctionResponse.ID); id != "" {
-					responseIDs[id] = struct{}{}
-				}
-			}
-		}
-	}
+	callIDs, responseIDs := oaiResponsesPairedIDs(contents)
 
 	// Always build a list of input items. The ChatGPT codex backend
 	// (/backend-api/codex/responses) rejects a bare string with
@@ -233,50 +235,99 @@ func oaiContentsToResponsesInput(contents []*genai.Content, config *genai.Genera
 		if content == nil || strings.TrimSpace(content.Role) == "system" {
 			continue
 		}
-		role := oaiResponsesRole(content.Role)
-		var textParts []string
-		flushText := func() {
-			if len(textParts) == 0 {
-				return
-			}
-			items = append(items, responses.ResponseInputItemParamOfMessage(strings.Join(textParts, "\n"), role))
-			textParts = nil
-		}
+		items = oaiAppendResponsesItems(items, content, callIDs, responseIDs)
+	}
 
+	return responses.ResponseNewParamsInputUnion{OfInputItemList: items}, instructions, nil
+}
+
+// oaiResponsesPairedIDs collects the function call IDs and function response IDs
+// present in the conversation.
+//
+// A canceled turn can persist a function call before its tool result is
+// emitted. Responses requires calls and outputs to be paired, so the two sets
+// let the caller omit either half of an incomplete pair when replaying
+// conversation history.
+func oaiResponsesPairedIDs(contents []*genai.Content) (callIDs, responseIDs map[string]struct{}) {
+	callIDs = make(map[string]struct{})
+	responseIDs = make(map[string]struct{})
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
 		for _, part := range content.Parts {
 			if part == nil {
 				continue
 			}
-			switch {
-			case part.Text != "":
-				textParts = append(textParts, part.Text)
-			case part.FunctionCall != nil:
-				flushText()
-				fc := part.FunctionCall
-				if strings.TrimSpace(fc.ID) == "" {
-					continue
-				}
-				if _, ok := responseIDs[fc.ID]; !ok {
-					continue
-				}
-				argsJSON, _ := json.Marshal(fc.Args)
-				items = append(items, responses.ResponseInputItemParamOfFunctionCall(string(argsJSON), fc.ID, fc.Name))
-			case part.FunctionResponse != nil:
-				flushText()
-				fr := part.FunctionResponse
-				if strings.TrimSpace(fr.ID) == "" {
-					continue
-				}
-				if _, ok := callIDs[fr.ID]; !ok {
-					continue
-				}
-				items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(fr.ID, oaiFunctionResponseContent(fr.Response)))
+			if part.FunctionCall != nil {
+				addTrimmedID(callIDs, part.FunctionCall.ID)
+			}
+			if part.FunctionResponse != nil {
+				addTrimmedID(responseIDs, part.FunctionResponse.ID)
 			}
 		}
-		flushText()
+	}
+	return callIDs, responseIDs
+}
+
+// addTrimmedID records the trimmed id in set, ignoring blank IDs.
+func addTrimmedID(set map[string]struct{}, id string) {
+	if trimmed := strings.TrimSpace(id); trimmed != "" {
+		set[trimmed] = struct{}{}
+	}
+}
+
+// oaiAppendResponsesItems appends the input items for one content to items.
+// Consecutive text parts coalesce into a single message, which is flushed
+// before each function call or output so the items keep their original order.
+// Function calls and outputs whose counterpart is missing are dropped.
+func oaiAppendResponsesItems(
+	items responses.ResponseInputParam,
+	content *genai.Content,
+	callIDs, responseIDs map[string]struct{},
+) responses.ResponseInputParam {
+	role := oaiResponsesRole(content.Role)
+	var textParts []string
+	flushText := func() {
+		if len(textParts) == 0 {
+			return
+		}
+		items = append(items, responses.ResponseInputItemParamOfMessage(strings.Join(textParts, "\n"), role))
+		textParts = nil
 	}
 
-	return responses.ResponseNewParamsInputUnion{OfInputItemList: items}, instructions, nil
+	for _, part := range content.Parts {
+		if part == nil {
+			continue
+		}
+		switch {
+		case part.Text != "":
+			textParts = append(textParts, part.Text)
+		case part.FunctionCall != nil:
+			flushText()
+			fc := part.FunctionCall
+			if strings.TrimSpace(fc.ID) == "" {
+				continue
+			}
+			if _, ok := responseIDs[fc.ID]; !ok {
+				continue
+			}
+			argsJSON, _ := json.Marshal(fc.Args)
+			items = append(items, responses.ResponseInputItemParamOfFunctionCall(string(argsJSON), fc.ID, fc.Name))
+		case part.FunctionResponse != nil:
+			flushText()
+			fr := part.FunctionResponse
+			if strings.TrimSpace(fr.ID) == "" {
+				continue
+			}
+			if _, ok := callIDs[fr.ID]; !ok {
+				continue
+			}
+			items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(fr.ID, oaiFunctionResponseContent(fr.Response)))
+		}
+	}
+	flushText()
+	return items
 }
 
 func oaiResponsesRole(role string) responses.EasyInputMessageRole {
@@ -376,19 +427,7 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 		// response.completed — capture final response with usage and status.
 		if evtType == "response.completed" {
 			finalResp = &evt.Response
-			if evt.Response.ID != "" {
-				state.responseID = evt.Response.ID
-			}
-			if evt.Response.Usage.InputTokens > 0 {
-				state.promptTokens = evt.Response.Usage.InputTokens
-			}
-			if evt.Response.Usage.OutputTokens > 0 {
-				state.completionTokens = evt.Response.Usage.OutputTokens
-			}
-			if c := evt.Response.Usage.InputTokensDetails.CachedTokens; c > 0 {
-				state.cachedTokens = c
-			}
-			state.finishReason = string(evt.Response.Status)
+			applyResponsesCompleted(state, finalResp)
 			continue
 		}
 
@@ -424,33 +463,7 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 			}
 		}
 
-		// response.function_call_arguments.delta — streaming function call args.
-		// response.output_item.* carries the function call header (id, name),
-		// and may carry the final arguments depending on backend/SDK mapping.
-		// The per-chunk argument text is in evt.Delta; evt.Arguments is only set
-		// on the `.done` event (as the full summary string).
-		if evtType == "response.function_call_arguments.delta" {
-			updateResponsesToolCall(state, evt.OutputIndex, "", "", evt.Delta, true)
-		}
-		// response.function_call_arguments.done — final full arguments string.
-		// Use it as a safety net: if deltas were missed, overwrite with the
-		// authoritative complete arguments payload.
-		if evtType == "response.function_call_arguments.done" {
-			updateResponsesToolCall(state, evt.OutputIndex, "", evt.Name, evt.Arguments, false)
-		}
-
-		// response.output_item.added — function call item header.
-		if evtType == "response.output_item.added" {
-			fc := evt.Item.AsFunctionCall()
-			updateResponsesToolCall(state, evt.OutputIndex, fc.CallID, fc.Name, "", false)
-		}
-
-		// response.output_item.done — final fallback arguments. Some Responses
-		// streams only populate arguments here.
-		if evtType == "response.output_item.done" {
-			fc := evt.Item.AsFunctionCall()
-			updateResponsesToolCall(state, evt.OutputIndex, fc.CallID, fc.Name, fc.Arguments, false)
-		}
+		applyResponsesToolCallEvent(state, evt)
 	}
 
 	if err := stream.Err(); err != nil {
@@ -463,6 +476,62 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 		return emitted, err
 	}
 
+	m.finishResponsesStream(state, finalResp, yield)
+	return true, nil
+}
+
+// applyResponsesCompleted records the usage and status the response.completed
+// event carries.
+func applyResponsesCompleted(state *responsesStreamState, resp *responses.Response) {
+	if resp.ID != "" {
+		state.responseID = resp.ID
+	}
+	if resp.Usage.InputTokens > 0 {
+		state.promptTokens = resp.Usage.InputTokens
+	}
+	if resp.Usage.OutputTokens > 0 {
+		state.completionTokens = resp.Usage.OutputTokens
+	}
+	if c := resp.Usage.InputTokensDetails.CachedTokens; c > 0 {
+		state.cachedTokens = c
+	}
+	state.finishReason = string(resp.Status)
+}
+
+// applyResponsesToolCallEvent folds the function-call events into the tool call
+// accumulator. Events of any other type are ignored.
+func applyResponsesToolCallEvent(state *responsesStreamState, evt responses.ResponseStreamEventUnion) {
+	switch evt.Type {
+	// response.function_call_arguments.delta — streaming function call args.
+	// response.output_item.* carries the function call header (id, name),
+	// and may carry the final arguments depending on backend/SDK mapping.
+	// The per-chunk argument text is in evt.Delta; evt.Arguments is only set
+	// on the `.done` event (as the full summary string).
+	case "response.function_call_arguments.delta":
+		updateResponsesToolCall(state, evt.OutputIndex, "", "", evt.Delta, true)
+
+	// response.function_call_arguments.done — final full arguments string.
+	// Use it as a safety net: if deltas were missed, overwrite with the
+	// authoritative complete arguments payload.
+	case "response.function_call_arguments.done":
+		updateResponsesToolCall(state, evt.OutputIndex, "", evt.Name, evt.Arguments, false)
+
+	// response.output_item.added — function call item header.
+	case "response.output_item.added":
+		fc := evt.Item.AsFunctionCall()
+		updateResponsesToolCall(state, evt.OutputIndex, fc.CallID, fc.Name, "", false)
+
+	// response.output_item.done — final fallback arguments. Some Responses
+	// streams only populate arguments here.
+	case "response.output_item.done":
+		fc := evt.Item.AsFunctionCall()
+		updateResponsesToolCall(state, evt.OutputIndex, fc.CallID, fc.Name, fc.Arguments, false)
+	}
+}
+
+// finishResponsesStream yields the terminal response for a stream that ran to
+// completion, and remembers the response ID for multi-turn continuation.
+func (m *openaiModel) finishResponsesStream(state *responsesStreamState, finalResp *responses.Response, yield func(*model.LLMResponse, error) bool) {
 	// Build final response parts.
 	finalParts := buildResponsesFinalParts(state)
 	var usage *genai.GenerateContentResponseUsageMetadata
@@ -491,7 +560,6 @@ func (m *openaiModel) runResponsesStreaming(ctx context.Context, params response
 		UsageMetadata: usage,
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
 	}, nil)
-	return true, nil
 }
 
 // buildResponsesFinalParts assembles the final parts from streaming state.

--- a/internal/session/autocompact.go
+++ b/internal/session/autocompact.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 )
 
 // AutoCompactOutcome reports what an auto-compaction pass did, so callers can
@@ -167,39 +168,11 @@ func callOrphansResponseOnTail(events []*session.Event, lastCompactedIdx, splitI
 	if lastCompactedIdx < 0 || lastCompactedIdx >= n {
 		return false
 	}
-	ev := events[lastCompactedIdx]
-	if ev == nil || ev.Content == nil {
-		return false
-	}
-	var callID string
-	for _, part := range ev.Content.Parts {
-		if part == nil || part.FunctionCall == nil {
-			continue
-		}
-		if part.FunctionCall.ID == "" {
-			continue
-		}
-		callID = part.FunctionCall.ID
-		break
-	}
+	callID := firstPartID(events[lastCompactedIdx], functionCallID)
 	if callID == "" {
 		return false
 	}
-	for j := splitIdx; j < n; j++ {
-		ev := events[j]
-		if ev == nil || ev.Content == nil {
-			continue
-		}
-		for _, part := range ev.Content.Parts {
-			if part == nil || part.FunctionResponse == nil {
-				continue
-			}
-			if part.FunctionResponse.ID == callID {
-				return true
-			}
-		}
-	}
-	return false
+	return rangeHasPartID(events, splitIdx, n, functionResponseID, callID)
 }
 
 // responseOrphansCallOnCompacted reports whether events[splitIdx] contains a
@@ -210,34 +183,61 @@ func responseOrphansCallOnCompacted(events []*session.Event, splitIdx int) bool 
 	if splitIdx >= len(events) {
 		return false
 	}
-	ev := events[splitIdx]
-	if ev == nil || ev.Content == nil {
-		return false
-	}
-	var respID string
-	for _, part := range ev.Content.Parts {
-		if part == nil || part.FunctionResponse == nil {
-			continue
-		}
-		if part.FunctionResponse.ID == "" {
-			continue
-		}
-		respID = part.FunctionResponse.ID
-		break
-	}
+	respID := firstPartID(events[splitIdx], functionResponseID)
 	if respID == "" {
 		return false
 	}
-	for j := 0; j < splitIdx; j++ {
+	return rangeHasPartID(events, 0, splitIdx, functionCallID, respID)
+}
+
+// partIDFunc reads the tool-pairing ID out of a single part, returning "" when
+// the part is nil, is not the kind being looked for, or carries no ID. The two
+// orphan checks above are mirror images of each other — same scan, opposite
+// direction and opposite part kind — so the kind is a parameter rather than
+// duplicated control flow.
+type partIDFunc func(part *genai.Part) string
+
+// functionCallID reads the ID of a FunctionCall part.
+func functionCallID(part *genai.Part) string {
+	if part == nil || part.FunctionCall == nil {
+		return ""
+	}
+	return part.FunctionCall.ID
+}
+
+// functionResponseID reads the ID of a FunctionResponse part.
+func functionResponseID(part *genai.Part) string {
+	if part == nil || part.FunctionResponse == nil {
+		return ""
+	}
+	return part.FunctionResponse.ID
+}
+
+// firstPartID returns the first non-empty ID that id reads out of ev's parts,
+// or "" when ev holds no part of that kind with an ID.
+func firstPartID(ev *session.Event, id partIDFunc) string {
+	if ev == nil || ev.Content == nil {
+		return ""
+	}
+	for _, part := range ev.Content.Parts {
+		if got := id(part); got != "" {
+			return got
+		}
+	}
+	return ""
+}
+
+// rangeHasPartID reports whether any event in events[lo:hi) carries a part
+// whose ID, as read by id, equals want. want must be non-empty: id returns ""
+// for parts of the wrong kind, so an empty want would match them.
+func rangeHasPartID(events []*session.Event, lo, hi int, id partIDFunc, want string) bool {
+	for j := lo; j < hi; j++ {
 		ev := events[j]
 		if ev == nil || ev.Content == nil {
 			continue
 		}
 		for _, part := range ev.Content.Parts {
-			if part == nil || part.FunctionCall == nil {
-				continue
-			}
-			if part.FunctionCall.ID == respID {
+			if id(part) == want {
 				return true
 			}
 		}

--- a/internal/session/complexity_session_test.go
+++ b/internal/session/complexity_session_test.go
@@ -1,0 +1,355 @@
+package session
+
+import (
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// These tests pin the branch structure that callOrphansResponseOnTail and
+// responseOrphansCallOnCompacted encoded before they were collapsed onto the
+// shared firstPartID/rangeHasPartID pair. Both directions matter: they are
+// what stops a tool call reaching the model with no result, or a result with
+// no call, after a compaction cut.
+
+// cxCall builds an event carrying a single FunctionCall part with the given ID.
+func cxCall(id string) *session.Event {
+	ev := &session.Event{Author: "pi"}
+	ev.Content = &genai.Content{
+		Role:  string(genai.RoleModel),
+		Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: id, Name: "read"}}},
+	}
+	return ev
+}
+
+// cxResp builds an event carrying a single FunctionResponse part with the ID.
+func cxResp(id string) *session.Event {
+	ev := &session.Event{}
+	ev.Content = &genai.Content{
+		Role:  string(genai.RoleUser),
+		Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: id, Name: "read"}}},
+	}
+	return ev
+}
+
+// cxText builds a plain text event: no call, no response.
+func cxText(s string) *session.Event {
+	ev := &session.Event{Author: "pi"}
+	ev.Content = genai.NewContentFromText(s, genai.RoleModel)
+	return ev
+}
+
+// cxParts builds an event from explicit parts, so tests can construct the
+// nil-part and empty-ID shapes the walkers have to skip.
+func cxParts(parts ...*genai.Part) *session.Event {
+	ev := &session.Event{Author: "pi"}
+	ev.Content = &genai.Content{Role: string(genai.RoleModel), Parts: parts}
+	return ev
+}
+
+func TestFunctionPartIDReaders(t *testing.T) {
+	callPart := &genai.Part{FunctionCall: &genai.FunctionCall{ID: "c1"}}
+	respPart := &genai.Part{FunctionResponse: &genai.FunctionResponse{ID: "r1"}}
+	textPart := &genai.Part{Text: "hello"}
+
+	tests := []struct {
+		name string
+		id   partIDFunc
+		part *genai.Part
+		want string
+	}{
+		{"call reader on nil part", functionCallID, nil, ""},
+		{"call reader on text part", functionCallID, textPart, ""},
+		{"call reader on response part", functionCallID, respPart, ""},
+		{"call reader on call part", functionCallID, callPart, "c1"},
+		{"call reader on empty call ID", functionCallID, &genai.Part{FunctionCall: &genai.FunctionCall{}}, ""},
+		{"response reader on nil part", functionResponseID, nil, ""},
+		{"response reader on text part", functionResponseID, textPart, ""},
+		{"response reader on call part", functionResponseID, callPart, ""},
+		{"response reader on response part", functionResponseID, respPart, "r1"},
+		{"response reader on empty response ID", functionResponseID, &genai.Part{FunctionResponse: &genai.FunctionResponse{}}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id(tc.part); got != tc.want {
+				t.Errorf("id(part) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstPartID(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *session.Event
+		id   partIDFunc
+		want string
+	}{
+		{"nil event", nil, functionCallID, ""},
+		{"nil content", &session.Event{Author: "pi"}, functionCallID, ""},
+		{"no parts", cxParts(), functionCallID, ""},
+		{"nil part is skipped", cxParts(nil, &genai.Part{FunctionCall: &genai.FunctionCall{ID: "c2"}}), functionCallID, "c2"},
+		{
+			"empty ID is skipped, next non-empty wins",
+			cxParts(
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: ""}},
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "c3"}},
+			),
+			functionCallID,
+			"c3",
+		},
+		{
+			"first non-empty wins over later parts",
+			cxParts(
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "first"}},
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "second"}},
+			),
+			functionCallID,
+			"first",
+		},
+		{"wrong kind yields nothing", cxCall("c4"), functionResponseID, ""},
+		{"response event read as response", cxResp("r4"), functionResponseID, "r4"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstPartID(tc.ev, tc.id); got != tc.want {
+				t.Errorf("firstPartID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRangeHasPartID(t *testing.T) {
+	// Index:      0        1          2                3        4
+	events := []*session.Event{cxCall("A"), cxText("x"), nil, cxResp("A"), {}}
+
+	tests := []struct {
+		name    string
+		lo, hi  int
+		id      partIDFunc
+		want    string
+		wantHit bool
+	}{
+		{"response present in range", 2, 5, functionResponseID, "A", true},
+		{"response outside range", 0, 2, functionResponseID, "A", false},
+		{"call present in range", 0, 3, functionCallID, "A", true},
+		{"call not in range", 1, 5, functionCallID, "A", false},
+		{"unknown ID never matches", 0, 5, functionCallID, "Z", false},
+		{"empty range", 3, 3, functionResponseID, "A", false},
+		{"inverted range scans nothing", 4, 1, functionResponseID, "A", false},
+		{"nil event and nil content are skipped", 2, 3, functionResponseID, "A", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rangeHasPartID(events, tc.lo, tc.hi, tc.id, tc.want); got != tc.wantHit {
+				t.Errorf("rangeHasPartID(%d, %d, %q) = %v, want %v", tc.lo, tc.hi, tc.want, got, tc.wantHit)
+			}
+		})
+	}
+}
+
+func TestCallOrphansResponseOnTail(t *testing.T) {
+	tests := []struct {
+		name     string
+		events   []*session.Event
+		splitIdx int
+		want     bool
+	}{
+		{
+			name:     "call at the edge with its response on the tail",
+			events:   []*session.Event{cxText("ask"), cxCall("A"), cxResp("A")},
+			splitIdx: 2,
+			want:     true,
+		},
+		{
+			name:     "call at the edge with its response also compacted",
+			events:   []*session.Event{cxCall("A"), cxResp("A"), cxText("done")},
+			splitIdx: 2,
+			want:     false,
+		},
+		{
+			name:     "call with no response anywhere",
+			events:   []*session.Event{cxCall("A"), cxText("done")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "tail response belongs to a different call",
+			events:   []*session.Event{cxCall("A"), cxResp("B")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "last compacted event is not a call",
+			events:   []*session.Event{cxText("ask"), cxResp("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "call with an empty ID cannot be paired",
+			events:   []*session.Event{cxCall(""), cxResp("")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "nil event at the edge",
+			events:   []*session.Event{nil, cxResp("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "nil content at the edge",
+			events:   []*session.Event{{Author: "pi"}, cxResp("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "index below zero",
+			events:   []*session.Event{cxCall("A"), cxResp("A")},
+			splitIdx: 0,
+			want:     false,
+		},
+		{
+			name:     "index at or past the end",
+			events:   []*session.Event{cxCall("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := len(tc.events)
+			got := callOrphansResponseOnTail(tc.events, tc.splitIdx-1, tc.splitIdx, n)
+			if got != tc.want {
+				t.Errorf("callOrphansResponseOnTail = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResponseOrphansCallOnCompacted(t *testing.T) {
+	tests := []struct {
+		name     string
+		events   []*session.Event
+		splitIdx int
+		want     bool
+	}{
+		{
+			name:     "response at the edge with its call compacted",
+			events:   []*session.Event{cxCall("A"), cxResp("A")},
+			splitIdx: 1,
+			want:     true,
+		},
+		{
+			name:     "response at the edge with its call also on the tail",
+			events:   []*session.Event{cxText("ask"), cxResp("A"), cxCall("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "compacted call belongs to a different response",
+			events:   []*session.Event{cxCall("B"), cxResp("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "first tail event is not a response",
+			events:   []*session.Event{cxCall("A"), cxText("done")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "response with an empty ID cannot be paired",
+			events:   []*session.Event{cxCall(""), cxResp("")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "nil event at the edge",
+			events:   []*session.Event{cxCall("A"), nil},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "nil content at the edge",
+			events:   []*session.Event{cxCall("A"), {Author: "pi"}},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "nil event on the compacted side is skipped",
+			events:   []*session.Event{nil, cxResp("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+		{
+			name:     "split index past the end",
+			events:   []*session.Event{cxCall("A")},
+			splitIdx: 1,
+			want:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := responseOrphansCallOnCompacted(tc.events, tc.splitIdx); got != tc.want {
+				t.Errorf("responseOrphansCallOnCompacted = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAdvanceToCleanBoundary_ShiftsPastBothOrphanKinds exercises the two
+// detectors through their only caller, including the case where the boundary
+// has to walk past several consecutive pairs and the case where no clean cut
+// exists at all.
+func TestAdvanceToCleanBoundary_ShiftsPastBothOrphanKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		events   []*session.Event
+		splitIdx int
+		want     int
+	}{
+		{
+			// Interleaved pairs force the loop to take several steps and to
+			// alternate between the two detectors: call(A)/call(B) each drag
+			// the edge right, then resp(B) at the edge drags it right again
+			// because its call is on the compacted side.
+			name:     "walks past interleaved pairs, alternating detectors",
+			events:   []*session.Event{cxCall("A"), cxCall("B"), cxResp("A"), cxResp("B")},
+			splitIdx: 1,
+			want:     4,
+		},
+		{
+			name:     "stops at the first clean cut between two pairs",
+			events:   []*session.Event{cxText("ask"), cxCall("A"), cxResp("A"), cxCall("B"), cxResp("B"), cxText("done")},
+			splitIdx: 2,
+			want:     3,
+		},
+		{
+			name:     "already clean",
+			events:   []*session.Event{cxText("a"), cxCall("A"), cxResp("A"), cxText("b")},
+			splitIdx: 3,
+			want:     3,
+		},
+		{
+			name:     "no clean cut runs to the end",
+			events:   []*session.Event{cxCall("A"), cxResp("A")},
+			splitIdx: 1,
+			want:     2,
+		},
+		{
+			name:     "unpaired call needs no shift",
+			events:   []*session.Event{cxCall("A"), cxText("b"), cxText("c")},
+			splitIdx: 1,
+			want:     1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := advanceToCleanBoundary(tc.events, tc.splitIdx); got != tc.want {
+				t.Errorf("advanceToCleanBoundary(%d) = %d, want %d", tc.splitIdx, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/subagent/agents.go
+++ b/internal/subagent/agents.go
@@ -105,43 +105,8 @@ func parseAgentContent(content, path string) (AgentConfig, error) {
 		}
 
 		if inFrontmatter {
-			key, value, ok := parseAgentFrontmatterLine(line)
-			if !ok {
-				continue
-			}
-			switch key {
-			case "name":
-				cfg.Name = value
-			case "description":
-				cfg.Description = value
-			case "role":
-				cfg.Role = value
-			case "worktree":
-				cfg.Worktree = strings.ToLower(value) == "true"
-			case "timeout":
-				if ms, err := strconv.Atoi(value); err == nil && ms > 0 {
-					// The unit is milliseconds, which reads as seconds at a
-					// glance — a bundled agent shipped `timeout: 30` and was
-					// SIGKILLed 30ms in, every time, unable to emit a single
-					// token. Anything under a second cannot be deliberate, so
-					// treat it as the unit mistake it is rather than honoring a
-					// value that guarantees the agent never runs.
-					if ms < minAgentTimeoutMs {
-						slog.Warn("subagent: implausibly small timeout ignored; the unit is milliseconds",
-							"agent", cfg.Name, "timeout_ms", ms, "using", "default")
-					} else {
-						cfg.Timeout = ms
-					}
-				}
-			case "lsp":
-				cfg.LSP = strings.ToLower(strings.TrimSpace(value))
-			case "tools":
-				for _, t := range strings.Split(value, ",") {
-					t = strings.TrimSpace(t)
-					if t != "" {
-						cfg.Tools = append(cfg.Tools, t)
-					}
-				}
+			if key, value, ok := parseAgentFrontmatterLine(line); ok {
+				applyAgentFrontmatterKey(&cfg, key, value)
 			}
 		} else {
 			body.WriteString(line)
@@ -155,6 +120,62 @@ func parseAgentContent(content, path string) (AgentConfig, error) {
 
 	cfg.Instruction = strings.TrimSpace(body.String())
 	return cfg, nil
+}
+
+// applyAgentFrontmatterKey sets the field of cfg named by a frontmatter key.
+// Unknown keys are ignored.
+func applyAgentFrontmatterKey(cfg *AgentConfig, key, value string) {
+	switch key {
+	case "name":
+		cfg.Name = value
+	case "description":
+		cfg.Description = value
+	case "role":
+		cfg.Role = value
+	case "worktree":
+		cfg.Worktree = strings.ToLower(value) == "true"
+	case "timeout":
+		if ms, ok := parseAgentTimeout(cfg.Name, value); ok {
+			cfg.Timeout = ms
+		}
+	case "lsp":
+		cfg.LSP = strings.ToLower(strings.TrimSpace(value))
+	case "tools":
+		cfg.Tools = append(cfg.Tools, parseAgentToolList(value)...)
+	}
+}
+
+// parseAgentTimeout reads a frontmatter `timeout:` value, reporting ok=false
+// when it is unusable and the default should stand instead.
+//
+// The unit is milliseconds, which reads as seconds at a glance — a bundled
+// agent shipped `timeout: 30` and was SIGKILLed 30ms in, every time, unable to
+// emit a single token. Anything under a second cannot be deliberate, so treat
+// it as the unit mistake it is rather than honoring a value that guarantees the
+// agent never runs.
+func parseAgentTimeout(agentName, value string) (int, bool) {
+	ms, err := strconv.Atoi(value)
+	if err != nil || ms <= 0 {
+		return 0, false
+	}
+	if ms < minAgentTimeoutMs {
+		slog.Warn("subagent: implausibly small timeout ignored; the unit is milliseconds",
+			"agent", agentName, "timeout_ms", ms, "using", "default")
+		return 0, false
+	}
+	return ms, true
+}
+
+// parseAgentToolList splits a comma-separated frontmatter `tools:` value,
+// dropping empty entries.
+func parseAgentToolList(value string) []string {
+	var tools []string
+	for _, t := range strings.Split(value, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			tools = append(tools, t)
+		}
+	}
+	return tools
 }
 
 // parseAgentFrontmatterLine parses "key: value" from a frontmatter line.
@@ -209,6 +230,34 @@ func findNearestProjectAgentsDir(cwd string) (string, error) {
 	return "", os.ErrNotExist
 }
 
+// loadAgentsWithSource loads a directory of agent files and stamps each one
+// with the source it came from ("user" or "project").
+func loadAgentsWithSource(dir, source string) ([]AgentConfig, error) {
+	agents, err := LoadAgentsFromDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for i := range agents {
+		agents[i].Source = source
+	}
+	return agents, nil
+}
+
+// mergeAgentsByName appends agents to all, replacing in place any entry already
+// present under the same name. seen maps agent name → index in all and is
+// updated as entries are appended, so successive calls override earlier ones.
+func mergeAgentsByName(all []AgentConfig, seen map[string]int, agents []AgentConfig) []AgentConfig {
+	for _, agent := range agents {
+		if idx, ok := seen[agent.Name]; ok {
+			all[idx] = agent
+			continue
+		}
+		seen[agent.Name] = len(all)
+		all = append(all, agent)
+	}
+	return all
+}
+
 // DiscoverAgents loads agents from bundled, user, and project directories.
 // Priority: project > user > bundled (later sources override earlier ones by name).
 func DiscoverAgents(cwd string, scope AgentScope) (*AgentDiscoveryResult, error) {
@@ -222,58 +271,29 @@ func DiscoverAgents(cwd string, scope AgentScope) (*AgentDiscoveryResult, error)
 	result.Bundled = bundledAgents
 
 	// Load user agents (~/.pi-go/agents/)
-	homeDir, err := os.UserHomeDir()
-	if err == nil {
-		userDir := filepath.Join(homeDir, ".pi-go", "agents")
-		userAgents, err := LoadAgentsFromDir(userDir)
+	if homeDir, homeErr := os.UserHomeDir(); homeErr == nil {
+		userAgents, err := loadAgentsWithSource(filepath.Join(homeDir, ".pi-go", "agents"), "user")
 		if err != nil {
 			return nil, fmt.Errorf("loading user agents: %w", err)
-		}
-		for i := range userAgents {
-			userAgents[i].Source = "user"
 		}
 		result.User = userAgents
 	}
 
 	// Load project agents (.pi-go/agents/ in nearest ancestor)
-	projectDir, err := findNearestProjectAgentsDir(cwd)
-	if err == nil {
-		projectAgents, err := LoadAgentsFromDir(projectDir)
+	if projectDir, findErr := findNearestProjectAgentsDir(cwd); findErr == nil {
+		projectAgents, err := loadAgentsWithSource(projectDir, "project")
 		if err != nil {
 			return nil, fmt.Errorf("loading project agents: %w", err)
-		}
-		for i := range projectAgents {
-			projectAgents[i].Source = "project"
 		}
 		result.Project = projectAgents
 	}
 
-	// Merge all agents with priority: project > user > bundled
+	// Merge all agents with priority: project > user > bundled — each pass
+	// overrides same-named entries left by the passes before it.
 	seen := make(map[string]int) // name → index in All
-	for _, agent := range result.Bundled {
-		if idx, ok := seen[agent.Name]; ok {
-			result.All[idx] = agent // bundled is lowest priority
-		} else {
-			seen[agent.Name] = len(result.All)
-			result.All = append(result.All, agent)
-		}
-	}
-	for _, agent := range result.User {
-		if idx, ok := seen[agent.Name]; ok {
-			result.All[idx] = agent // user overrides bundled
-		} else {
-			seen[agent.Name] = len(result.All)
-			result.All = append(result.All, agent)
-		}
-	}
-	for _, agent := range result.Project {
-		if idx, ok := seen[agent.Name]; ok {
-			result.All[idx] = agent // project overrides user
-		} else {
-			seen[agent.Name] = len(result.All)
-			result.All = append(result.All, agent)
-		}
-	}
+	result.All = mergeAgentsByName(result.All, seen, result.Bundled)
+	result.All = mergeAgentsByName(result.All, seen, result.User)
+	result.All = mergeAgentsByName(result.All, seen, result.Project)
 
 	// Filter based on scope
 	switch scope {

--- a/internal/subagent/complexity_subagent_test.go
+++ b/internal/subagent/complexity_subagent_test.go
@@ -1,0 +1,1293 @@
+package subagent
+
+// Tests for the helpers extracted while reducing cyclomatic complexity in
+// agents.go, orchestrator.go, spawner.go, spawner_acp.go and worktree.go.
+//
+// Each helper is exercised at the boundaries its original branch encoded, so a
+// change in branch structure shows up as a failing case here rather than as a
+// silent behavior change in a long function.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	sharedacp "github.com/dimetron/pi-go/internal/acp"
+	"github.com/dimetron/pi-go/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// agents.go
+// ---------------------------------------------------------------------------
+
+func TestApplyAgentFrontmatterKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		check func(t *testing.T, cfg AgentConfig)
+	}{
+		{"name", "name", "explore", func(t *testing.T, c AgentConfig) {
+			if c.Name != "explore" {
+				t.Errorf("Name = %q", c.Name)
+			}
+		}},
+		{"description", "description", "does things", func(t *testing.T, c AgentConfig) {
+			if c.Description != "does things" {
+				t.Errorf("Description = %q", c.Description)
+			}
+		}},
+		{"role", "role", "smol", func(t *testing.T, c AgentConfig) {
+			if c.Role != "smol" {
+				t.Errorf("Role = %q", c.Role)
+			}
+		}},
+		{"worktree true", "worktree", "TRUE", func(t *testing.T, c AgentConfig) {
+			if !c.Worktree {
+				t.Error("Worktree = false, want true")
+			}
+		}},
+		{"worktree other", "worktree", "yes", func(t *testing.T, c AgentConfig) {
+			if c.Worktree {
+				t.Error("Worktree = true, want false")
+			}
+		}},
+		{"timeout accepted", "timeout", "60000", func(t *testing.T, c AgentConfig) {
+			if c.Timeout != 60000 {
+				t.Errorf("Timeout = %d", c.Timeout)
+			}
+		}},
+		{"timeout too small leaves default", "timeout", "30", func(t *testing.T, c AgentConfig) {
+			if c.Timeout != 0 {
+				t.Errorf("Timeout = %d, want 0", c.Timeout)
+			}
+		}},
+		{"lsp lowercased", "lsp", "  FULL  ", func(t *testing.T, c AgentConfig) {
+			if c.LSP != "full" {
+				t.Errorf("LSP = %q", c.LSP)
+			}
+		}},
+		{"tools split", "tools", "read, write ,, edit", func(t *testing.T, c AgentConfig) {
+			want := []string{"read", "write", "edit"}
+			if len(c.Tools) != len(want) {
+				t.Fatalf("Tools = %v", c.Tools)
+			}
+			for i := range want {
+				if c.Tools[i] != want[i] {
+					t.Errorf("Tools[%d] = %q, want %q", i, c.Tools[i], want[i])
+				}
+			}
+		}},
+		{"unknown key ignored", "unknown-key", "blue", func(t *testing.T, c AgentConfig) {
+			if !reflect.DeepEqual(c, AgentConfig{}) {
+				t.Errorf("unknown key mutated cfg: %+v", c)
+			}
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg AgentConfig
+			applyAgentFrontmatterKey(&cfg, tt.key, tt.value)
+			tt.check(t, cfg)
+		})
+	}
+}
+
+// TestApplyAgentFrontmatterKey_ToolsAccumulate pins the append semantics: two
+// `tools:` lines add up rather than the second replacing the first.
+func TestApplyAgentFrontmatterKey_ToolsAccumulate(t *testing.T) {
+	var cfg AgentConfig
+	applyAgentFrontmatterKey(&cfg, "tools", "read")
+	applyAgentFrontmatterKey(&cfg, "tools", "write")
+	if len(cfg.Tools) != 2 || cfg.Tools[0] != "read" || cfg.Tools[1] != "write" {
+		t.Errorf("Tools = %v, want [read write]", cfg.Tools)
+	}
+}
+
+func TestParseAgentTimeout(t *testing.T) {
+	tests := []struct {
+		value   string
+		wantMs  int
+		wantOK  bool
+		comment string
+	}{
+		{"60000", 60000, true, "plausible millisecond value"},
+		{"1000", 1000, true, "exactly the minimum is honored"},
+		{"999", 0, false, "just under the minimum is a unit mistake"},
+		{"30", 0, false, "seconds-looking value ignored"},
+		{"0", 0, false, "zero means unset"},
+		{"-5", 0, false, "negative ignored"},
+		{"abc", 0, false, "non-numeric ignored"},
+		{"", 0, false, "empty ignored"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value+"/"+tt.comment, func(t *testing.T) {
+			gotMs, gotOK := parseAgentTimeout("agent", tt.value)
+			if gotMs != tt.wantMs || gotOK != tt.wantOK {
+				t.Errorf("parseAgentTimeout(%q) = (%d, %v), want (%d, %v)",
+					tt.value, gotMs, gotOK, tt.wantMs, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseAgentToolList(t *testing.T) {
+	tests := []struct {
+		value string
+		want  []string
+	}{
+		{"read, write, edit", []string{"read", "write", "edit"}},
+		{"  read  ", []string{"read"}},
+		{"read,,write", []string{"read", "write"}},
+		{",", nil},
+		{"", nil},
+		{"   ", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got := parseAgentToolList(tt.value)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseAgentToolList(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadAgentsWithSource(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("alpha.md", "---\nname: alpha\n---\nbody\n")
+	write("beta.md", "---\nname: beta\n---\nbody\n")
+	write("ignored.txt", "not markdown")
+
+	agents, err := loadAgentsWithSource(dir, "project")
+	if err != nil {
+		t.Fatalf("loadAgentsWithSource: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Fatalf("got %d agents, want 2: %+v", len(agents), agents)
+	}
+	for _, a := range agents {
+		if a.Source != "project" {
+			t.Errorf("agent %q Source = %q, want project", a.Name, a.Source)
+		}
+	}
+
+	// A missing directory is not an error, and stamps nothing.
+	missing, err := loadAgentsWithSource(filepath.Join(dir, "nope"), "user")
+	if err != nil {
+		t.Fatalf("missing dir returned error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing dir returned %d agents", len(missing))
+	}
+}
+
+func TestMergeAgentsByName(t *testing.T) {
+	bundled := []AgentConfig{{Name: "a", Source: "bundled"}, {Name: "b", Source: "bundled"}}
+	user := []AgentConfig{{Name: "b", Source: "user"}, {Name: "c", Source: "user"}}
+	project := []AgentConfig{{Name: "a", Source: "project"}}
+
+	seen := make(map[string]int)
+	var all []AgentConfig
+	all = mergeAgentsByName(all, seen, bundled)
+	all = mergeAgentsByName(all, seen, user)
+	all = mergeAgentsByName(all, seen, project)
+
+	want := []struct{ name, source string }{
+		{"a", "project"}, // project overrides bundled, in bundled's slot
+		{"b", "user"},    // user overrides bundled, in bundled's slot
+		{"c", "user"},    // appended after the bundled entries
+	}
+	if len(all) != len(want) {
+		t.Fatalf("merged = %+v, want %d entries", all, len(want))
+	}
+	for i, w := range want {
+		if all[i].Name != w.name || all[i].Source != w.source {
+			t.Errorf("[%d] = %q/%q, want %q/%q", i, all[i].Name, all[i].Source, w.name, w.source)
+		}
+	}
+}
+
+func TestMergeAgentsByName_EmptyInputIsNoOp(t *testing.T) {
+	seen := map[string]int{"a": 0}
+	all := []AgentConfig{{Name: "a"}}
+	got := mergeAgentsByName(all, seen, nil)
+	if len(got) != 1 || got[0].Name != "a" {
+		t.Errorf("merging nil changed the slice: %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// worktree.go
+// ---------------------------------------------------------------------------
+
+func TestClaimExistingWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+	wtPath := filepath.Join(repo, ".pi-go", "tasks", "x")
+
+	t.Run("branch attached at the expected path is reused", func(t *testing.T) {
+		reuse, err := mgr.claimExistingWorktree("agent-1", "br", wtPath, true, wtPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reuse {
+			t.Error("reuse = false, want true")
+		}
+	})
+
+	t.Run("branch attached elsewhere is refused", func(t *testing.T) {
+		reuse, err := mgr.claimExistingWorktree("agent-1", "br", wtPath, true, filepath.Join(repo, "other"))
+		if err == nil {
+			t.Fatal("expected an error for a branch checked out elsewhere")
+		}
+		if reuse {
+			t.Error("reuse = true on refusal")
+		}
+		if !strings.Contains(err.Error(), "already checked out") {
+			t.Errorf("error = %v, want 'already checked out'", err)
+		}
+	})
+
+	t.Run("branch exists but is unattached falls through", func(t *testing.T) {
+		reuse, err := mgr.claimExistingWorktree("agent-1", "br", wtPath, true, "")
+		if err != nil || reuse {
+			t.Errorf("got (%v, %v), want (false, nil)", reuse, err)
+		}
+	})
+
+	t.Run("stale directory is removed", func(t *testing.T) {
+		if err := os.MkdirAll(wtPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(wtPath, "leftover"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		reuse, err := mgr.claimExistingWorktree("agent-1", "br", wtPath, false, "")
+		if err != nil || reuse {
+			t.Fatalf("got (%v, %v), want (false, nil)", reuse, err)
+		}
+		if _, statErr := os.Stat(wtPath); !os.IsNotExist(statErr) {
+			t.Errorf("stale directory survived: %v", statErr)
+		}
+	})
+}
+
+func TestStashBeforeWorktreeAdd_CleanTree(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	msg, stashed, err := mgr.stashBeforeWorktreeAdd("agent-clean")
+	if err != nil {
+		t.Fatalf("stashBeforeWorktreeAdd on a clean tree: %v", err)
+	}
+	if stashed {
+		t.Error("stashed = true on a clean tree")
+	}
+	if msg == "" {
+		t.Error("message is empty; the pop would not be able to find its entry")
+	}
+	if n := stashCount(t, repo); n != 0 {
+		t.Errorf("stash list has %d entries, want 0", n)
+	}
+}
+
+func TestStashBeforeWorktreeAdd_DirtyTree(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if err := os.WriteFile(filepath.Join(repo, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, stashed, err := mgr.stashBeforeWorktreeAdd("agent-dirty")
+	if err != nil {
+		t.Fatalf("stashBeforeWorktreeAdd: %v", err)
+	}
+	if !stashed {
+		t.Fatal("stashed = false, want true for a dirty tree")
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Fatalf("stash list has %d entries, want 1", n)
+	}
+	// The message must be the one findStashByMessage can locate, which is what
+	// makes the eventual pop deterministic.
+	if _, found := mgr.findStashByMessage(msg); !found {
+		t.Errorf("stash entry for message %q not found", msg)
+	}
+}
+
+func TestStashBeforeWorktreeAdd_NotARepo(t *testing.T) {
+	mgr := NewWorktreeManager(t.TempDir())
+
+	_, stashed, err := mgr.stashBeforeWorktreeAdd("agent-norepo")
+	if err == nil {
+		t.Fatal("expected an error outside a git repo")
+	}
+	if stashed {
+		t.Error("stashed = true on failure")
+	}
+	if !strings.Contains(err.Error(), "git stash before worktree") {
+		t.Errorf("error = %v, want it to name the stash step", err)
+	}
+}
+
+func TestAddWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	fresh := filepath.Join(repo, ".pi-go", "tasks", "fresh")
+	if err := os.MkdirAll(filepath.Dir(fresh), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// branchExists=false creates the branch with -b.
+	if err := mgr.addWorktree(fresh, "wt-new", false); err != nil {
+		t.Fatalf("addWorktree(-b): %v", err)
+	}
+	if !mgr.branchExists("wt-new") {
+		t.Error("branch wt-new was not created")
+	}
+
+	// A second add on the same branch fails, and the error names the step.
+	err := mgr.addWorktree(filepath.Join(repo, ".pi-go", "tasks", "dup"), "wt-new", true)
+	if err == nil {
+		t.Fatal("expected an error re-adding an attached branch")
+	}
+	if !strings.Contains(err.Error(), "git worktree add") {
+		t.Errorf("error = %v, want it to name the add step", err)
+	}
+}
+
+func TestAddWorktree_AttachesExistingBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if out, err := exec.Command("git", "-C", repo, "branch", "detached-br").CombinedOutput(); err != nil {
+		t.Fatalf("creating branch: %v: %s", err, out)
+	}
+
+	wt := filepath.Join(repo, ".pi-go", "tasks", "attach")
+	if err := os.MkdirAll(filepath.Dir(wt), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// branchExists=true must attach without -b, which would fail on an
+	// existing branch.
+	if err := mgr.addWorktree(wt, "detached-br", true); err != nil {
+		t.Fatalf("addWorktree(attach): %v", err)
+	}
+	if got := mgr.worktreeForBranch("detached-br"); !samePath(got, wt) {
+		t.Errorf("branch attached at %q, want %q", got, wt)
+	}
+}
+
+// TestCreate_DropsStashWhenWorktreeAddFails is the safety-critical case: the
+// stash push succeeded, then `git worktree add` failed. Create must not record
+// the agent, and must not leave the entry orphaned in the stash list.
+//
+// It pins CURRENT behavior, which is not the behavior the code's own comment
+// claims. The comment says "Restore stashed changes on failure"; the code runs
+// `git stash drop`, which deletes the entry WITHOUT applying it — so the
+// uncommitted work the stash was protecting is destroyed. The assertions below
+// spell that out (the dirty file does not come back). This is pre-existing on
+// main and was preserved deliberately: this refactor is behavior-preserving, so
+// fixing it is a separate change. Compare (*WorktreeManager).MergeBack, which
+// gets it right via popStashByMessage (apply, then drop).
+//
+// Whoever fixes it should expect this test to fail and should flip these
+// assertions to "dirty.txt is restored".
+func TestCreate_DropsStashWhenWorktreeAddFails(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	// Make the tree dirty so the stash push actually creates an entry.
+	if err := os.WriteFile(filepath.Join(repo, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force `git worktree add -b` to fail after the stash has already been
+	// taken: a branch name ending in ".lock" survives sanitizeWorktreeName but
+	// is rejected by git's ref-format rules.
+	const requested = "blocked.lock"
+	if _, branch := worktreeNames("blocked-1234567890", requested); branch != requested {
+		t.Fatalf("sanitized branch = %q, want %q; the test no longer forces an add failure", branch, requested)
+	}
+
+	_, err := mgr.Create("blocked-1234567890", requested)
+	if err == nil {
+		t.Fatal("expected Create to fail when worktree add cannot run")
+	}
+	if !strings.Contains(err.Error(), "git worktree add") {
+		t.Errorf("error = %v, want it to name the add step", err)
+	}
+	if n := stashCount(t, repo); n != 0 {
+		t.Errorf("stash list has %d entries after a failed Create, want 0", n)
+	}
+	// The stash was dropped, not applied: the user's uncommitted file is gone
+	// and is no longer recoverable from the stash list. See the doc comment.
+	if _, statErr := os.Stat(filepath.Join(repo, "dirty.txt")); !os.IsNotExist(statErr) {
+		t.Errorf("dirty.txt was restored (stat err = %v); the drop-without-apply "+
+			"behavior this test pins has changed — update the test if that was intended", statErr)
+	}
+	if mgr.Active() != 0 {
+		t.Errorf("Active() = %d after a failed Create, want 0", mgr.Active())
+	}
+	if got := mgr.PathFor("blocked-1234567890"); got != "" {
+		t.Errorf("PathFor = %q after a failed Create, want empty", got)
+	}
+}
+
+// TestCreate_StashSurvivesSuccessfulAdd is the other half of the pairing: on
+// success the entry stays in the list, tagged with the message MergeBack pops.
+func TestCreate_StashSurvivesSuccessfulAdd(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if err := os.WriteFile(filepath.Join(repo, "dirty.txt"), []byte("uncommitted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := mgr.Create("keep-1234567890"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.CleanupAll() })
+
+	if n := stashCount(t, repo); n != 1 {
+		t.Fatalf("stash list has %d entries, want 1", n)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "dirty.txt")); !os.IsNotExist(err) {
+		t.Errorf("uncommitted file still present after stash: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// spawner.go
+// ---------------------------------------------------------------------------
+
+func TestChildExitError(t *testing.T) {
+	cfg := TimeoutConfig{Absolute: 2 * time.Second, Inactivity: time.Second}
+	waitErr := errors.New("exit status 1")
+
+	tests := []struct {
+		name        string
+		timedOut    bool
+		ctxErr      error
+		waitErr     error
+		stderr      string
+		wantNil     bool
+		wantSubstrs []string
+		wantTimeout bool
+	}{
+		{
+			name: "clean exit", wantNil: true,
+		},
+		{
+			name: "idle timeout wins over everything",
+			// Even with a deadline and a wait error present, the idle case is
+			// first — a limit kill is also a signal kill.
+			timedOut: true, ctxErr: context.DeadlineExceeded, waitErr: waitErr, stderr: "boom",
+			wantSubstrs: []string{"produced no output for 1s", timeoutHint},
+			wantTimeout: true,
+		},
+		{
+			name:   "absolute deadline",
+			ctxErr: context.DeadlineExceeded, waitErr: waitErr, stderr: "boom",
+			wantSubstrs: []string{"exceeded its 2s time limit", timeoutHint},
+			wantTimeout: true,
+		},
+		{
+			name:    "wait error with stderr",
+			waitErr: waitErr, stderr: "panic: nope",
+			wantSubstrs: []string{"pi process failed", "exit status 1", "panic: nope"},
+		},
+		{
+			name:        "wait error without stderr",
+			waitErr:     waitErr,
+			wantSubstrs: []string{"pi process failed", "exit status 1"},
+		},
+		{
+			name: "stderr alone is not a failure", stderr: "just chatter", wantNil: true,
+		},
+		{
+			name: "canceled context that is not a deadline", ctxErr: context.Canceled, wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := childExitError(cfg, tt.timedOut, tt.ctxErr, tt.waitErr, tt.stderr)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("childExitError = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("childExitError = nil, want an error")
+			}
+			for _, want := range tt.wantSubstrs {
+				if !strings.Contains(got.Error(), want) {
+					t.Errorf("error %q missing %q", got, want)
+				}
+			}
+			if errors.Is(got, ErrSubagentTimeout) != tt.wantTimeout {
+				t.Errorf("errors.Is(err, ErrSubagentTimeout) = %v, want %v",
+					errors.Is(got, ErrSubagentTimeout), tt.wantTimeout)
+			}
+			if !tt.wantTimeout && tt.waitErr != nil && !errors.Is(got, tt.waitErr) {
+				t.Errorf("wait error not wrapped in %v", got)
+			}
+		})
+	}
+}
+
+func TestEmitChildLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		wantEvent  Event
+		wantResult string
+	}{
+		{
+			name: "non-JSON becomes text",
+			line: "plain output",
+			// The raw line is emitted but NOT accumulated into the result.
+			wantEvent: Event{Type: "text_delta", Content: "plain output"},
+		},
+		{
+			name:       "text_delta accumulates",
+			line:       `{"type":"text_delta","delta":"hi"}`,
+			wantEvent:  Event{Type: "text_delta", Content: "hi"},
+			wantResult: "hi",
+		},
+		{
+			name:      "tool_call carries name and args",
+			line:      `{"type":"tool_call","tool_name":"read","tool_input":{"path":"x"}}`,
+			wantEvent: Event{Type: "tool_call", Content: "read"},
+		},
+		{
+			name:      "tool_result",
+			line:      `{"type":"tool_result","content":"ok"}`,
+			wantEvent: Event{Type: "tool_result", Content: "ok"},
+		},
+		{
+			name:      "message_start carries session id",
+			line:      `{"type":"message_start","session_id":"s1"}`,
+			wantEvent: Event{Type: "message_start", SessionID: "s1"},
+		},
+		{
+			name:      "message_end drops payload",
+			line:      `{"type":"message_end","content":"ignored"}`,
+			wantEvent: Event{Type: "message_end"},
+		},
+		{
+			name:      "unknown type concatenates delta and content",
+			line:      `{"type":"thinking","delta":"a","content":"b"}`,
+			wantEvent: Event{Type: "thinking", Content: "ab"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Process{events: make(chan Event, 4)}
+			var result strings.Builder
+			p.emitChildLine(tt.line, &result)
+
+			select {
+			case got := <-p.events:
+				if got.Type != tt.wantEvent.Type || got.Content != tt.wantEvent.Content ||
+					got.SessionID != tt.wantEvent.SessionID {
+					t.Errorf("event = %+v, want %+v", got, tt.wantEvent)
+				}
+			default:
+				t.Fatal("no event emitted")
+			}
+			if result.String() != tt.wantResult {
+				t.Errorf("result = %q, want %q", result.String(), tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestEmitChildLine_ToolArgsPassedThrough(t *testing.T) {
+	p := &Process{events: make(chan Event, 1)}
+	var result strings.Builder
+	p.emitChildLine(`{"type":"tool_call","tool_name":"read","tool_input":{"path":"x"}}`, &result)
+
+	ev := <-p.events
+	args, ok := ev.ToolArgs.(map[string]any)
+	if !ok {
+		t.Fatalf("ToolArgs = %#v, want a map", ev.ToolArgs)
+	}
+	if args["path"] != "x" {
+		t.Errorf("ToolArgs[path] = %v, want x", args["path"])
+	}
+}
+
+func TestReadChildLines_DrainsUntilClosed(t *testing.T) {
+	p := &Process{events: make(chan Event, 8)}
+	lines := make(chan string, 4)
+	lines <- `{"type":"text_delta","delta":"a"}`
+	lines <- "" // blank lines are skipped, not emitted
+	lines <- `{"type":"text_delta","delta":"b"}`
+	close(lines)
+
+	idle := NewInactivityTimer(10 * time.Second)
+	defer idle.Stop()
+
+	result, timedOut := p.readChildLines(lines, idle, func() { t.Error("cancel called on a clean drain") })
+	if timedOut {
+		t.Error("timedOut = true on a clean drain")
+	}
+	if result != "ab" {
+		t.Errorf("result = %q, want %q", result, "ab")
+	}
+	if len(p.events) != 2 {
+		t.Errorf("emitted %d events, want 2 (blank line must be skipped)", len(p.events))
+	}
+}
+
+func TestReadChildLines_IdleTimeoutCancelsAndDrains(t *testing.T) {
+	p := &Process{events: make(chan Event, 8)}
+	lines := make(chan string, 2)
+	lines <- `{"type":"text_delta","delta":"partial"}`
+
+	idle := NewInactivityTimer(20 * time.Millisecond)
+	defer idle.Stop()
+
+	canceled := false
+	// Feed one more line after the timer fires, so the post-cancel drain loop
+	// has something to consume before the producer closes.
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		lines <- "late"
+		close(lines)
+	}()
+
+	result, timedOut := p.readChildLines(lines, idle, func() { canceled = true })
+	if !timedOut {
+		t.Fatal("timedOut = false, want true")
+	}
+	if !canceled {
+		t.Error("cancel was not called on idle timeout")
+	}
+	// Text seen before the timeout is kept — the partial answer is not thrown away.
+	if result != "partial" {
+		t.Errorf("result = %q, want %q", result, "partial")
+	}
+}
+
+func TestStartLineScanner(t *testing.T) {
+	lines := startLineScanner(strings.NewReader("one\ntwo\nthree\n"))
+
+	var got []string
+	for l := range lines {
+		got = append(got, l)
+	}
+	want := []string{"one", "two", "three"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestStartStderrCollector(t *testing.T) {
+	c := startStderrCollector(strings.NewReader("first\nsecond\n"))
+	<-c.done
+	if got := c.Text(); got != "first\nsecond" {
+		t.Errorf("Text() = %q, want %q", got, "first\nsecond")
+	}
+}
+
+// TestStartStderrCollector_Bounded pins the cap: a chatty child must not turn
+// the diagnostic buffer into the new place the memory goes.
+func TestStartStderrCollector_Bounded(t *testing.T) {
+	line := strings.Repeat("x", 1024) + "\n"
+	c := startStderrCollector(strings.NewReader(strings.Repeat(line, 200))) // ~200KB
+	<-c.done
+
+	got := len(c.Text())
+	if got == 0 {
+		t.Fatal("captured nothing")
+	}
+	// The check is "buffer under the cap before appending", so the last line
+	// can push it one line past maxStderrCapture, but no further.
+	if got > maxStderrCapture+len(line) {
+		t.Errorf("captured %d bytes, want <= %d", got, maxStderrCapture+len(line))
+	}
+}
+
+func TestBuildCommand(t *testing.T) {
+	s := &Spawner{PiBinary: "/bin/echo"}
+	dir := t.TempDir()
+
+	cmd := s.buildCommand(t.Context(), SpawnOpts{
+		Prompt:  "do it",
+		Model:   "m1",
+		WorkDir: dir,
+		Env:     []string{"EXTRA_ONE=1"},
+	})
+
+	if cmd.Path != "/bin/echo" {
+		t.Errorf("Path = %q", cmd.Path)
+	}
+	if cmd.Dir != dir {
+		t.Errorf("Dir = %q, want %q", cmd.Dir, dir)
+	}
+	if cmd.WaitDelay != 3*time.Second {
+		t.Errorf("WaitDelay = %v, want 3s", cmd.WaitDelay)
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "--model m1") || !strings.HasSuffix(joined, "do it") {
+		t.Errorf("Args = %v", cmd.Args)
+	}
+	var found bool
+	for _, e := range cmd.Env {
+		if e == "EXTRA_ONE=1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("opts.Env not merged into cmd.Env: %v", cmd.Env)
+	}
+}
+
+func TestBuildCommand_NoExtraEnvOrWorkDir(t *testing.T) {
+	s := &Spawner{PiBinary: "/bin/echo"}
+	cmd := s.buildCommand(t.Context(), SpawnOpts{Prompt: "p"})
+
+	if cmd.Dir != "" {
+		t.Errorf("Dir = %q, want empty", cmd.Dir)
+	}
+	if len(cmd.Env) == 0 {
+		t.Error("Env is empty; the filtered base env should still be present")
+	}
+}
+
+func TestStartChildProcess(t *testing.T) {
+	cmd := exec.Command("/bin/echo", "hello")
+	stdout, stderr, err := startChildProcess(cmd)
+	if err != nil {
+		t.Fatalf("startChildProcess: %v", err)
+	}
+	if stdout == nil || stderr == nil {
+		t.Fatal("nil pipe returned on success")
+	}
+	if _, err := stdout.Read(make([]byte, 1)); err != nil {
+		t.Errorf("reading stdout: %v", err)
+	}
+	_ = cmd.Wait()
+}
+
+func TestStartChildProcess_StartFailure(t *testing.T) {
+	cmd := exec.Command(filepath.Join(t.TempDir(), "no-such-binary"))
+	_, _, err := startChildProcess(cmd)
+	if err == nil {
+		t.Fatal("expected an error starting a missing binary")
+	}
+	if !strings.Contains(err.Error(), "starting pi process") {
+		t.Errorf("error = %v, want it to name the start step", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// spawner_acp.go
+// ---------------------------------------------------------------------------
+
+func TestACPProcEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   sharedacp.Event
+		want Event
+	}{
+		{
+			"message",
+			sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "hi", SessionID: "s"},
+			Event{Type: "text_delta", Content: "hi", SessionID: "s"},
+		},
+		{
+			"progress",
+			sharedacp.Event{Type: sharedacp.EventTypeProgress, Content: "p", SessionID: "s"},
+			Event{Type: "tool_call", Content: "p", SessionID: "s"},
+		},
+		{
+			"tool",
+			sharedacp.Event{Type: sharedacp.EventTypeTool, Content: "t", SessionID: "s"},
+			Event{Type: "tool_call", Content: "t", SessionID: "s"},
+		},
+		{
+			"stderr",
+			sharedacp.Event{Type: sharedacp.EventTypeStderr, Content: "e", SessionID: "s"},
+			Event{Type: "stderr", Content: "e", SessionID: "s"},
+		},
+		{
+			"error carries Error, not Content",
+			sharedacp.Event{Type: sharedacp.EventTypeError, Error: "bad", Content: "dropped", SessionID: "s"},
+			Event{Type: "error", Error: "bad", SessionID: "s"},
+		},
+		{
+			"unknown type passes through",
+			sharedacp.Event{Type: "custom", Content: "c", SessionID: "s"},
+			Event{Type: "custom", Content: "c", SessionID: "s"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := acpProcEvent(tt.in); got != tt.want {
+				t.Errorf("acpProcEvent(%+v) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteGracefully(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"strict sentinel", "all done " + acpCompletionSentinel, "all done"},
+		{"loose sentinel", "all done " + acpCompletionMatcher, "all done"},
+		{"both forms", acpCompletionSentinel + " x " + acpCompletionMatcher, "x"},
+		{"no sentinel", "  plain  ", "plain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := completeGracefully(sharedacp.RunResult{
+				Status: sharedacp.StatusError,
+				Error:  "signal: killed",
+				Result: tt.in,
+			})
+			if got.Status != sharedacp.StatusSuccess {
+				t.Errorf("Status = %v, want success", got.Status)
+			}
+			if got.Error != "" {
+				t.Errorf("Error = %q, want empty", got.Error)
+			}
+			if got.Result != tt.want {
+				t.Errorf("Result = %q, want %q", got.Result, tt.want)
+			}
+		})
+	}
+}
+
+func TestACPErrorText(t *testing.T) {
+	tests := []struct {
+		name   string
+		result sharedacp.RunResult
+		want   string
+	}{
+		{"error only", sharedacp.RunResult{Error: " boom "}, "boom"},
+		{"stderr only", sharedacp.RunResult{Stderr: " oops "}, "stderr: oops"},
+		{"both", sharedacp.RunResult{Error: "boom", Stderr: "oops"}, "boom\nstderr: oops"},
+		{"neither", sharedacp.RunResult{}, "subprocess failed"},
+		{"whitespace-only stderr is not appended", sharedacp.RunResult{Error: "boom", Stderr: "   "}, "boom"},
+		{"whitespace-only everything", sharedacp.RunResult{Error: "  ", Stderr: "  "}, "subprocess failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := acpErrorText(tt.result); got != tt.want {
+				t.Errorf("acpErrorText = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPumpACPEvents_SendsStartOnceAndDetectsSentinel(t *testing.T) {
+	sess := newFakeACPSession()
+	proc := &Process{events: make(chan Event, 32)}
+
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "working", SessionID: "s1"}
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "done " + acpCompletionSentinel, SessionID: "s1"}
+	// Events after the sentinel must not re-trigger completion handling.
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "trailing", SessionID: "s1"}
+	close(sess.events)
+
+	sentStart, graceful := pumpACPEvents(sess, proc)
+	if !sentStart {
+		t.Error("sentStart = false, want true")
+	}
+	if !graceful {
+		t.Error("gracefulCompletion = false, want true")
+	}
+
+	close(proc.events)
+	var types []string
+	for ev := range proc.events {
+		types = append(types, ev.Type)
+	}
+	want := []string{"message_start", "text_delta", "text_delta", "text_delta"}
+	if len(types) != len(want) {
+		t.Fatalf("events = %v, want %v", types, want)
+	}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, types[i], want[i])
+		}
+	}
+}
+
+func TestPumpACPEvents_NoSessionIDMeansNoStart(t *testing.T) {
+	sess := newFakeACPSession()
+	proc := &Process{events: make(chan Event, 8)}
+
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeStderr, Content: "warn"}
+	close(sess.events)
+
+	sentStart, graceful := pumpACPEvents(sess, proc)
+	if sentStart {
+		t.Error("sentStart = true with no session id")
+	}
+	if graceful {
+		t.Error("gracefulCompletion = true without a sentinel")
+	}
+	if len(proc.events) != 1 {
+		t.Fatalf("emitted %d events, want 1", len(proc.events))
+	}
+	if ev := <-proc.events; ev.Type != "stderr" {
+		t.Errorf("event type = %q, want stderr", ev.Type)
+	}
+}
+
+// TestPumpACPEvents_SentinelSplitAcrossEvents pins the accumulate-then-match
+// behavior: the sentinel is detected across chunk boundaries.
+func TestPumpACPEvents_SentinelSplitAcrossEvents(t *testing.T) {
+	sess := newFakeACPSession()
+	proc := &Process{events: make(chan Event, 16)}
+
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "<Task ", SessionID: "s"}
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "Completed>", SessionID: "s"}
+	close(sess.events)
+
+	if _, graceful := pumpACPEvents(sess, proc); !graceful {
+		t.Error("gracefulCompletion = false for a sentinel split across events")
+	}
+}
+
+// TestPumpACPEvents_NonMessageEventsDoNotAccumulate proves the accumulator only
+// sees message text: a tool event carrying the sentinel must not end the run.
+func TestPumpACPEvents_NonMessageEventsDoNotAccumulate(t *testing.T) {
+	sess := newFakeACPSession()
+	proc := &Process{events: make(chan Event, 8)}
+
+	sess.events <- sharedacp.Event{Type: sharedacp.EventTypeTool, Content: acpCompletionSentinel, SessionID: "s"}
+	close(sess.events)
+
+	if _, graceful := pumpACPEvents(sess, proc); graceful {
+		t.Error("gracefulCompletion = true for a sentinel in a tool event")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// orchestrator.go
+// ---------------------------------------------------------------------------
+
+func TestTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil is completed", nil, "completed"},
+		{"timeout sentinel", fmt.Errorf("wrapped: %w", ErrSubagentTimeout), "timeout"},
+		// A timeout also arrives as a signal kill; the sentinel must win.
+		{"timeout wrapping a signal kill", fmt.Errorf("signal: killed: %w", ErrSubagentTimeout), "timeout"},
+		{"signal kill", errors.New("signal: killed"), "killed"},
+		{"other failure", errors.New("exit status 2"), "failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := terminalStatus(tt.err); got != tt.want {
+				t.Errorf("terminalStatus(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpawnEnv(t *testing.T) {
+	t.Run("no worktree manager leaves env untouched", func(t *testing.T) {
+		o := &Orchestrator{}
+		in := []string{"A=1"}
+		got := o.spawnEnv(in, "/some/dir")
+		if len(got) != 1 || got[0] != "A=1" {
+			t.Errorf("env = %v, want [A=1]", got)
+		}
+	})
+
+	t.Run("adds sandbox and worktree roots", func(t *testing.T) {
+		o := &Orchestrator{worktree: NewWorktreeManager("/repo")}
+		in := []string{"A=1"}
+		got := o.spawnEnv(in, "/repo/.pi-go/tasks/x")
+
+		want := []string{"A=1", "PI_SANDBOX_ROOT=/repo", "PI_WORKTREE_ROOT=/repo/.pi-go/tasks/x"}
+		if len(got) != len(want) {
+			t.Fatalf("env = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+		// The caller's slice must not be mutated — it is copied first.
+		if len(in) != 1 {
+			t.Errorf("caller env was mutated: %v", in)
+		}
+	})
+
+	t.Run("empty workDir omits the worktree root", func(t *testing.T) {
+		o := &Orchestrator{worktree: NewWorktreeManager("/repo")}
+		got := o.spawnEnv(nil, "")
+		if len(got) != 1 || got[0] != "PI_SANDBOX_ROOT=/repo" {
+			t.Errorf("env = %v, want [PI_SANDBOX_ROOT=/repo]", got)
+		}
+	})
+}
+
+func TestResolveWorkDir(t *testing.T) {
+	t.Run("explicit WorkDir wins", func(t *testing.T) {
+		o := &Orchestrator{repoRoot: "/repo", worktree: NewWorktreeManager("/repo")}
+		got, err := o.resolveWorkDir("a1", SpawnInput{WorkDir: "/explicit"}, true)
+		if err != nil || got != "/explicit" {
+			t.Errorf("got (%q, %v), want (/explicit, nil)", got, err)
+		}
+	})
+
+	t.Run("no worktree falls back to repo root", func(t *testing.T) {
+		o := &Orchestrator{repoRoot: "/repo"}
+		got, err := o.resolveWorkDir("a1", SpawnInput{}, true)
+		if err != nil || got != "/repo" {
+			t.Errorf("got (%q, %v), want (/repo, nil)", got, err)
+		}
+	})
+
+	t.Run("worktree not requested falls back to repo root", func(t *testing.T) {
+		o := &Orchestrator{repoRoot: "/repo", worktree: NewWorktreeManager("/repo")}
+		got, err := o.resolveWorkDir("a1", SpawnInput{}, false)
+		if err != nil || got != "/repo" {
+			t.Errorf("got (%q, %v), want (/repo, nil)", got, err)
+		}
+	})
+
+	t.Run("creates the worktree", func(t *testing.T) {
+		repo := initTestRepo(t)
+		mgr := NewWorktreeManager(repo)
+		o := &Orchestrator{repoRoot: repo, worktree: mgr}
+		t.Cleanup(func() { _ = mgr.CleanupAll() })
+
+		got, err := o.resolveWorkDir("wd-1234567890", SpawnInput{WorktreeName: "named"}, true)
+		if err != nil {
+			t.Fatalf("resolveWorkDir: %v", err)
+		}
+		want := filepath.Join(repo, ".pi-go", "tasks", "named")
+		if got != want {
+			t.Errorf("workDir = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("worktree failure is wrapped", func(t *testing.T) {
+		// A manager rooted outside a git repo cannot create a worktree.
+		o := &Orchestrator{repoRoot: "/repo", worktree: NewWorktreeManager(t.TempDir())}
+		_, err := o.resolveWorkDir("wd-1234567890", SpawnInput{}, true)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(err.Error(), "creating worktree") {
+			t.Errorf("error = %v, want it to name the worktree step", err)
+		}
+	})
+}
+
+func TestTrackAgent(t *testing.T) {
+	o := NewOrchestrator(&config.Config{}, "", nil)
+	state := &agentState{ID: "a1", Type: "explore", Status: "running"}
+
+	if !o.trackAgent(state) {
+		t.Fatal("trackAgent = false on an open orchestrator")
+	}
+	if len(o.List()) != 1 {
+		t.Errorf("List() = %d entries, want 1", len(o.List()))
+	}
+
+	o.mu.Lock()
+	o.closed = true
+	o.mu.Unlock()
+
+	if o.trackAgent(&agentState{ID: "a2", Status: "running"}) {
+		t.Error("trackAgent = true after shutdown")
+	}
+	if len(o.List()) != 1 {
+		t.Errorf("List() = %d entries after a rejected track, want 1", len(o.List()))
+	}
+}
+
+func TestAbandonSpawn(t *testing.T) {
+	t.Run("releases the pool slot without a worktree", func(t *testing.T) {
+		o := NewOrchestrator(&config.Config{}, "", nil)
+		if err := o.pool.Acquire(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		before := o.pool.Available()
+		o.abandonSpawn("a1", false)
+		if got := o.pool.Available(); got != before+1 {
+			t.Errorf("Available() = %d, want %d", got, before+1)
+		}
+	})
+
+	t.Run("removes the worktree it created", func(t *testing.T) {
+		repo := initTestRepo(t)
+		o := NewOrchestrator(&config.Config{}, repo, nil)
+		if err := o.pool.Acquire(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := o.worktree.Create("ab-1234567890"); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		o.abandonSpawn("ab-1234567890", true)
+
+		if o.worktree.Active() != 0 {
+			t.Errorf("Active() = %d after abandonSpawn, want 0", o.worktree.Active())
+		}
+		if got := o.pool.Available(); got != o.pool.Size() {
+			t.Errorf("Available() = %d, want %d", got, o.pool.Size())
+		}
+	})
+}
+
+func TestDispatchSpawn_DefaultRoutesToSpawner(t *testing.T) {
+	o := NewOrchestrator(&config.Config{}, "", nil)
+	// An empty prompt is rejected by (*Spawner).Spawn and by nothing else, so
+	// this error proves the default arm was taken.
+	_, err := o.dispatchSpawn(t.Context(), SpawnOpts{}, "explore")
+	if err == nil || !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("err = %v, want 'prompt is required' from the pi spawner", err)
+	}
+}
+
+func TestDispatchSpawn_ACPRoutesToACPDispatcher(t *testing.T) {
+	sess := newFakeACPSession()
+	withFakeACPRunner(t, sess)
+	o := NewOrchestrator(&config.Config{}, "", nil)
+
+	proc, err := o.dispatchSpawn(t.Context(), SpawnOpts{Prompt: "go"}, "claude")
+	if err != nil {
+		t.Fatalf("dispatchSpawn: %v", err)
+	}
+	// An ACP-dispatched Process has no *exec.Cmd; the pi spawner always sets one.
+	if proc.cmd != nil {
+		t.Error("expected an ACP Process (no exec.Cmd), got a pi child")
+	}
+	sess.finish(sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: "ok"})
+	if got, err := proc.Wait(); err != nil || got != "ok" {
+		t.Errorf("Wait() = (%q, %v), want (ok, nil)", got, err)
+	}
+}
+
+func TestForwardAgentEvents_PublishesRunDone(t *testing.T) {
+	o := NewOrchestrator(&config.Config{}, "", nil)
+	if err := o.pool.Acquire(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := &Process{events: make(chan Event, 4), done: make(chan struct{})}
+	proc.events <- Event{Type: "text_delta", Content: "hi"}
+	close(proc.events)
+	close(proc.done) // Wait returns (result="", err=nil) → status "completed"
+
+	state := &agentState{ID: "a1", Type: "explore", Status: "running", StartedAt: time.Now()}
+	if !o.trackAgent(state) {
+		t.Fatal("trackAgent failed")
+	}
+
+	out := make(chan Event, 8)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		o.forwardAgentEvents(out, proc, state, false)
+	}()
+
+	var got []Event
+	for ev := range out {
+		got = append(got, ev)
+	}
+	<-done
+
+	if len(got) != 2 {
+		t.Fatalf("events = %+v, want 2", got)
+	}
+	if got[0].Type != "text_delta" {
+		t.Errorf("[0] = %+v, want the forwarded text_delta", got[0])
+	}
+	if got[1].Type != "run_done" || got[1].Status != "completed" {
+		t.Errorf("[1] = %+v, want run_done/completed", got[1])
+	}
+	if state.FinishedAt.IsZero() {
+		t.Error("FinishedAt was not set")
+	}
+	if got := o.pool.Available(); got != o.pool.Size() {
+		t.Errorf("pool slot not released: Available() = %d, want %d", got, o.pool.Size())
+	}
+}
+
+// TestForwardAgentEvents_KeepsNonRunningStatus proves the status is only
+// derived when the agent is still marked running — a canceled agent keeps the
+// status the canceller set.
+func TestForwardAgentEvents_KeepsNonRunningStatus(t *testing.T) {
+	o := NewOrchestrator(&config.Config{}, "", nil)
+	if err := o.pool.Acquire(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := &Process{events: make(chan Event, 1), done: make(chan struct{})}
+	close(proc.events)
+	proc.err = errors.New("signal: killed")
+	close(proc.done)
+
+	state := &agentState{ID: "a1", Type: "explore", Status: "canceled", StartedAt: time.Now()}
+	if !o.trackAgent(state) {
+		t.Fatal("trackAgent failed")
+	}
+
+	out := make(chan Event, 4)
+	go o.forwardAgentEvents(out, proc, state, false)
+
+	var last Event
+	for ev := range out {
+		last = ev
+	}
+	if last.Type != "run_done" || last.Status != "canceled" {
+		t.Errorf("run_done status = %q, want canceled", last.Status)
+	}
+	if !state.FinishedAt.IsZero() {
+		t.Error("FinishedAt was set for an already-terminal agent")
+	}
+}

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -412,27 +412,10 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 	// Determine if worktree is needed.
 	useWorktree := resolveWorktreeUsage(agent.Worktree, input.Worktree, input.WorkDir)
 
-	workDir := o.repoRoot // default to project root so subagents run in the right directory
-	if input.WorkDir != "" {
-		workDir = input.WorkDir
-	} else if useWorktree && o.worktree != nil {
-		wtPath, err := o.worktree.Create(agentID, input.WorktreeName)
-		if err != nil {
-			o.pool.Release()
-			return nil, "", fmt.Errorf("creating worktree: %w", err)
-		}
-		workDir = wtPath
-	}
-
-	// Pass repo root to subagent so its sandbox covers the full repo,
-	// not just the worktree directory.
-	env := input.Env
-	if o.worktree != nil {
-		env = append(append([]string(nil), env...), "PI_SANDBOX_ROOT="+o.worktree.RepoRoot())
-		// Also pass the worktree path so subagent can normalize relative paths
-		if workDir != "" {
-			env = append(env, "PI_WORKTREE_ROOT="+workDir)
-		}
+	workDir, err := o.resolveWorkDir(agentID, input, useWorktree)
+	if err != nil {
+		o.pool.Release()
+		return nil, "", err
 	}
 
 	// An explicit spawn timeout overrides the agent definition; otherwise use
@@ -450,31 +433,16 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 		Prompt:      input.Prompt,
 		Instruction: agent.Instruction,
 		Timeout:     timeout,
-		Env:         env,
+		Env:         o.spawnEnv(input.Env, workDir),
 		BaseURL:     o.BaseURL,
 		Insecure:    o.Insecure,
 		Headers:     o.Headers,
 		LSP:         agent.LSP,
 	}
 
-	// ACP-bundled agents (claude/gemini/cursor/copilot) launch their own CLI
-	// binary via the ACP adapter; codex agents launch `codex app-server` and
-	// speak its JSON-RPC protocol directly; everyone else runs as a child
-	// pi --mode json.
-	var proc *Process
-	switch {
-	case isACPAgent(agent.Name):
-		proc, err = dispatchACP(ctx, spawnOpts, agent.Name)
-	case isCodexAgent(agent.Name):
-		proc, err = dispatchCodex(ctx, spawnOpts, agent.Name)
-	default:
-		proc, err = o.spawner.Spawn(ctx, spawnOpts)
-	}
+	proc, err := o.dispatchSpawn(ctx, spawnOpts, agent.Name)
 	if err != nil {
-		if useWorktree && o.worktree != nil {
-			_ = o.worktree.Cleanup(agentID)
-		}
-		o.pool.Release()
+		o.abandonSpawn(agentID, useWorktree)
 		return nil, "", fmt.Errorf("spawning agent: %w", err)
 	}
 
@@ -489,19 +457,12 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 		Status:      "running",
 	}
 
-	o.mu.Lock()
-	if o.closed {
-		o.mu.Unlock()
+	if !o.trackAgent(state) {
 		// Orchestrator shut down while we were setting up — clean up and bail.
 		proc.Cancel()
-		if useWorktree && o.worktree != nil {
-			_ = o.worktree.Cleanup(agentID)
-		}
-		o.pool.Release()
+		o.abandonSpawn(agentID, useWorktree)
 		return nil, "", fmt.Errorf("orchestrator is shut down")
 	}
-	o.agents[agentID] = state
-	o.mu.Unlock()
 
 	// Create a forwarding channel that handles cleanup on completion.
 	events := make(chan Event, 64)
@@ -509,55 +470,129 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 	// records external-CLI subagent event streams, and the Event shape is the
 	// same regardless of which protocol produced it.
 	logACP := isACPAgent(agent.Name) || isCodexAgent(agent.Name)
-	go func() {
-		defer close(events)
-		defer o.pool.Release()
-
-		for ev := range proc.Events() {
-			if logACP {
-				o.writeACPEvent(agentID, agent.Name, ev)
-			}
-			events <- ev
-		}
-
-		// Process done — update state.
-		_, waitErr := proc.Wait()
-
-		o.mu.Lock()
-		if state.Status == "running" {
-			// Distinguish a timeout from a crash from an exit-code failure. A
-			// timeout is reported first because it also arrives as a signal
-			// kill — the spawner SIGKILLs the group — and would otherwise be
-			// indistinguishable from an OOM.
-			switch {
-			case errors.Is(waitErr, ErrSubagentTimeout):
-				state.Status = "timeout"
-			case waitErr != nil && isKilledBySignal(waitErr):
-				state.Status = "killed"
-			case waitErr != nil:
-				state.Status = "failed"
-			default:
-				state.Status = "completed"
-			}
-			state.FinishedAt = time.Now()
-		}
-		finalStatus := state.Status
-		o.evictCompletedAgentsLocked()
-		o.mu.Unlock()
-
-		// Publish the terminal status before closing the channel. Consumers must
-		// use this snapshot rather than querying the evictable status map.
-		events <- Event{Type: "run_done", Status: finalStatus}
-
-		// Worktree cleanup is intentionally NOT done here. Deletion is
-		// deferred to the caller (e.g. the TUI /run flow calls
-		// wm.Cleanup after a successful merge) or to Shutdown via
-		// CleanupAll. Auto-cleaning on process exit raced with the
-		// merge step, causing "no worktree found" merge failures.
-		_ = state.SkipCleanup // kept for API stability; no longer gated here
-	}()
+	go o.forwardAgentEvents(events, proc, state, logACP)
 
 	return events, agentID, nil
+}
+
+// resolveWorkDir picks the directory the subagent runs in, creating its
+// worktree when one is called for.
+func (o *Orchestrator) resolveWorkDir(agentID string, input SpawnInput, useWorktree bool) (string, error) {
+	if input.WorkDir != "" {
+		return input.WorkDir, nil
+	}
+	if useWorktree && o.worktree != nil {
+		wtPath, err := o.worktree.Create(agentID, input.WorktreeName)
+		if err != nil {
+			return "", fmt.Errorf("creating worktree: %w", err)
+		}
+		return wtPath, nil
+	}
+	return o.repoRoot, nil // default to project root so subagents run in the right directory
+}
+
+// spawnEnv extends the caller's env with the roots the subagent needs: the repo
+// root so its sandbox covers the full repo and not just the worktree directory,
+// and the worktree path so it can normalize relative paths.
+func (o *Orchestrator) spawnEnv(env []string, workDir string) []string {
+	if o.worktree == nil {
+		return env
+	}
+	env = append(append([]string(nil), env...), "PI_SANDBOX_ROOT="+o.worktree.RepoRoot())
+	if workDir != "" {
+		env = append(env, "PI_WORKTREE_ROOT="+workDir)
+	}
+	return env
+}
+
+// dispatchSpawn launches the agent through the right runner. ACP-bundled agents
+// (claude/gemini/cursor/copilot) launch their own CLI binary via the ACP
+// adapter; codex agents launch `codex app-server` and speak its JSON-RPC
+// protocol directly; everyone else runs as a child pi --mode json.
+func (o *Orchestrator) dispatchSpawn(ctx context.Context, spawnOpts SpawnOpts, agentName string) (*Process, error) {
+	switch {
+	case isACPAgent(agentName):
+		return dispatchACP(ctx, spawnOpts, agentName)
+	case isCodexAgent(agentName):
+		return dispatchCodex(ctx, spawnOpts, agentName)
+	default:
+		return o.spawner.Spawn(ctx, spawnOpts)
+	}
+}
+
+// abandonSpawn gives back the resources taken for a spawn that never reached
+// the running state.
+func (o *Orchestrator) abandonSpawn(agentID string, useWorktree bool) {
+	if useWorktree && o.worktree != nil {
+		_ = o.worktree.Cleanup(agentID)
+	}
+	o.pool.Release()
+}
+
+// trackAgent registers a running agent, reporting false if the orchestrator was
+// shut down while the spawn was being set up.
+func (o *Orchestrator) trackAgent(state *agentState) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.closed {
+		return false
+	}
+	o.agents[state.ID] = state
+	return true
+}
+
+// forwardAgentEvents republishes the process's events on out, then records the
+// terminal status and publishes it as a final run_done event.
+func (o *Orchestrator) forwardAgentEvents(out chan Event, proc *Process, state *agentState, logACP bool) {
+	defer close(out)
+	defer o.pool.Release()
+
+	for ev := range proc.Events() {
+		if logACP {
+			o.writeACPEvent(state.ID, state.Type, ev)
+		}
+		out <- ev
+	}
+
+	// Process done — update state.
+	_, waitErr := proc.Wait()
+
+	o.mu.Lock()
+	if state.Status == "running" {
+		state.Status = terminalStatus(waitErr)
+		state.FinishedAt = time.Now()
+	}
+	finalStatus := state.Status
+	o.evictCompletedAgentsLocked()
+	o.mu.Unlock()
+
+	// Publish the terminal status before closing the channel. Consumers must
+	// use this snapshot rather than querying the evictable status map.
+	out <- Event{Type: "run_done", Status: finalStatus}
+
+	// Worktree cleanup is intentionally NOT done here. Deletion is
+	// deferred to the caller (e.g. the TUI /run flow calls
+	// wm.Cleanup after a successful merge) or to Shutdown via
+	// CleanupAll. Auto-cleaning on process exit raced with the
+	// merge step, causing "no worktree found" merge failures.
+	_ = state.SkipCleanup // kept for API stability; no longer gated here
+}
+
+// terminalStatus distinguishes a timeout from a crash from an exit-code
+// failure. A timeout is reported first because it also arrives as a signal
+// kill — the spawner SIGKILLs the group — and would otherwise be
+// indistinguishable from an OOM.
+func terminalStatus(waitErr error) string {
+	switch {
+	case errors.Is(waitErr, ErrSubagentTimeout):
+		return "timeout"
+	case waitErr != nil && isKilledBySignal(waitErr):
+		return "killed"
+	case waitErr != nil:
+		return "failed"
+	default:
+		return "completed"
+	}
 }
 
 // isKilledBySignal returns true if the error indicates the process was killed by a signal

--- a/internal/subagent/spawner.go
+++ b/internal/subagent/spawner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -130,19 +131,10 @@ func spawnArgs(opts SpawnOpts) []string {
 	return append(args, opts.Prompt)
 }
 
-// Spawn starts a pi subprocess in JSON mode and returns a Process handle for streaming events.
-func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
-	if opts.Prompt == "" {
-		return nil, fmt.Errorf("prompt is required")
-	}
-
-	// Resolve timeout configuration (applies defaults if not set).
-	timeoutCfg := ResolveTimeout(opts.Timeout)
-	procCtx, cancel := context.WithTimeout(ctx, timeoutCfg.Absolute)
-
-	args := spawnArgs(opts)
-
-	cmd := exec.CommandContext(procCtx, s.PiBinary, args...)
+// buildCommand assembles the child pi command: arguments, environment, kill
+// semantics and working directory.
+func (s *Spawner) buildCommand(procCtx context.Context, opts SpawnOpts) *exec.Cmd {
+	cmd := exec.CommandContext(procCtx, s.PiBinary, spawnArgs(opts)...)
 
 	// Set up environment: filtered process env + additional env vars. The
 	// child's concurrency budget is this process's share, not a copy of it —
@@ -160,22 +152,103 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 	if opts.WorkDir != "" {
 		cmd.Dir = opts.WorkDir
 	}
+	return cmd
+}
 
-	stdout, err := cmd.StdoutPipe()
+// startChildProcess opens both output pipes and starts cmd. The pipes must be
+// created before Start, so a failure at any of the three steps aborts the spawn.
+func startChildProcess(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err error) {
+	stdout, err = cmd.StdoutPipe()
 	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("creating stdout pipe: %w", err)
+		return nil, nil, fmt.Errorf("creating stdout pipe: %w", err)
 	}
 
-	stderr, err := cmd.StderrPipe()
+	stderr, err = cmd.StderrPipe()
 	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("creating stderr pipe: %w", err)
+		return nil, nil, fmt.Errorf("creating stderr pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("starting pi process: %w", err)
+	}
+	return stdout, stderr, nil
+}
+
+// stderrCollector drains a child's stderr into a bounded buffer, concurrently
+// with stdout.
+//
+// These are two independent pipes with their own kernel buffers. Reading them
+// in sequence — stdout to EOF, then stderr — deadlocks the moment the child
+// writes more than a pipe buffer (~64KB) to stderr: the child blocks in
+// write(2), so it never closes stdout, so the parent never finishes the stdout
+// scan and never reaches the stderr read. The child then sits there until a
+// timeout kills it, and because stderr was never drained the error arrives with
+// no diagnostic text attached at all.
+type stderrCollector struct {
+	mu   sync.Mutex
+	buf  strings.Builder
+	done chan struct{}
+}
+
+// startStderrCollector begins draining r in the background. done is closed at
+// EOF, which is the signal that the pipe is safe to Wait on.
+func startStderrCollector(r io.Reader) *stderrCollector {
+	c := &stderrCollector{done: make(chan struct{})}
+	go func() {
+		defer close(c.done)
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			c.mu.Lock()
+			if c.buf.Len() < maxStderrCapture {
+				c.buf.WriteString(sc.Text())
+				c.buf.WriteByte('\n')
+			}
+			c.mu.Unlock()
+		}
+	}()
+	return c
+}
+
+// Text returns the captured stderr, trimmed.
+func (c *stderrCollector) Text() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.TrimSpace(c.buf.String())
+}
+
+// startLineScanner feeds stdout lines to the reader goroutine rather than
+// having it scan inline, so the reader can wait on "a line arrived" and
+// "nothing has arrived in a while" at the same time. A bare
+// `for scanner.Scan()` can only block.
+func startLineScanner(r io.Reader) <-chan string {
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, 256*1024), 1024*1024) // up to 1MB lines
+		for sc.Scan() {
+			lines <- sc.Text()
+		}
+	}()
+	return lines
+}
+
+// Spawn starts a pi subprocess in JSON mode and returns a Process handle for streaming events.
+func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
+	if opts.Prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	// Resolve timeout configuration (applies defaults if not set).
+	timeoutCfg := ResolveTimeout(opts.Timeout)
+	procCtx, cancel := context.WithTimeout(ctx, timeoutCfg.Absolute)
+
+	cmd := s.buildCommand(procCtx, opts)
+
+	stdout, stderr, err := startChildProcess(cmd)
+	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("starting pi process: %w", err)
+		return nil, err
 	}
 
 	proc := &Process{
@@ -185,139 +258,117 @@ func (s *Spawner) Spawn(ctx context.Context, opts SpawnOpts) (*Process, error) {
 		cancel: cancel,
 	}
 
-	// Drain stderr concurrently with stdout.
-	//
-	// These are two independent pipes with their own kernel buffers. Reading
-	// them in sequence — stdout to EOF, then stderr — deadlocks the moment the
-	// child writes more than a pipe buffer (~64KB) to stderr: the child blocks
-	// in write(2), so it never closes stdout, so the parent never finishes the
-	// stdout scan and never reaches the stderr read. The child then sits there
-	// until a timeout kills it, and because stderr was never drained the error
-	// arrives with no diagnostic text attached at all.
-	var (
-		stderrMu   sync.Mutex
-		stderrBuf  strings.Builder
-		stderrDone = make(chan struct{})
-	)
-	go func() {
-		defer close(stderrDone)
-		sc := bufio.NewScanner(stderr)
-		for sc.Scan() {
-			stderrMu.Lock()
-			if stderrBuf.Len() < maxStderrCapture {
-				stderrBuf.WriteString(sc.Text())
-				stderrBuf.WriteByte('\n')
-			}
-			stderrMu.Unlock()
-		}
-	}()
-
-	// Feed stdout lines to the reader below rather than scanning inline, so the
-	// reader can wait on "a line arrived" and "nothing has arrived in a while"
-	// at the same time. A bare `for scanner.Scan()` can only block.
-	lines := make(chan string, 64)
-	go func() {
-		defer close(lines)
-		sc := bufio.NewScanner(stdout)
-		sc.Buffer(make([]byte, 0, 256*1024), 1024*1024) // up to 1MB lines
-		for sc.Scan() {
-			lines <- sc.Text()
-		}
-	}()
+	stderrC := startStderrCollector(stderr)
+	lines := startLineScanner(stdout)
 
 	// Reader goroutine: parse JSONL from stdout, send events.
-	go func() {
-		defer close(proc.done)
-		defer close(proc.events)
-
-		var resultBuilder strings.Builder
-
-		// The inactivity timer is what separates "slow" from "wedged". Without
-		// it the absolute cap is the only limit, so a long but productive agent
-		// is killed on the same rule as one that has hung — which is precisely
-		// the failure this fixes.
-		idle := NewInactivityTimer(timeoutCfg.Inactivity)
-		defer idle.Stop()
-
-		timedOutIdle := false
-
-	read:
-		for {
-			select {
-			case line, ok := <-lines:
-				if !ok {
-					break read
-				}
-				idle.Reset()
-				if line == "" {
-					continue
-				}
-
-				var ev jsonEvent
-				if err := json.Unmarshal([]byte(line), &ev); err != nil {
-					// Non-JSON output; emit as text.
-					proc.sendEvent(Event{Type: "text_delta", Content: line})
-					continue
-				}
-
-				switch ev.Type {
-				case "text_delta":
-					resultBuilder.WriteString(ev.Delta)
-					proc.sendEvent(Event{Type: "text_delta", Content: ev.Delta})
-				case "tool_call":
-					proc.sendEvent(Event{Type: "tool_call", Content: ev.ToolName, ToolArgs: ev.ToolInput})
-				case "tool_result":
-					proc.sendEvent(Event{Type: "tool_result", Content: ev.Content})
-				case "message_start":
-					proc.sendEvent(Event{Type: "message_start", SessionID: ev.SessionID})
-				case "message_end":
-					proc.sendEvent(Event{Type: "message_end"})
-				default:
-					proc.sendEvent(Event{Type: ev.Type, Content: ev.Delta + ev.Content})
-				}
-
-			case <-idle.C():
-				timedOutIdle = true
-				cancel()          // kills the process group; stdout closes, so lines drains
-				for range lines { //nolint:revive // drain so the scanner goroutine can exit
-				}
-				break read
-			}
-		}
-
-		// Both pipes must be at EOF before Wait, and stderr is wanted for the
-		// error message below.
-		<-stderrDone
-
-		// Wait for process exit.
-		waitErr := cmd.Wait()
-
-		proc.mu.Lock()
-		proc.result = resultBuilder.String()
-
-		stderrMu.Lock()
-		stderrStr := strings.TrimSpace(stderrBuf.String())
-		stderrMu.Unlock()
-
-		switch {
-		case timedOutIdle:
-			proc.err = fmt.Errorf("pi subagent produced no output for %s: %w (%s)",
-				timeoutCfg.Inactivity, ErrSubagentTimeout, timeoutHint)
-		case errors.Is(procCtx.Err(), context.DeadlineExceeded):
-			proc.err = fmt.Errorf("pi subagent exceeded its %s time limit: %w (%s)",
-				timeoutCfg.Absolute, ErrSubagentTimeout, timeoutHint)
-		case waitErr != nil && stderrStr != "":
-			proc.err = fmt.Errorf("pi process failed: %w: %s", waitErr, stderrStr)
-		case waitErr != nil:
-			proc.err = fmt.Errorf("pi process failed: %w", waitErr)
-		}
-		if proc.err != nil {
-			proc.sendEvent(Event{Type: "error", Error: proc.err.Error()})
-		}
-		proc.mu.Unlock()
-	}()
+	go proc.pumpChildOutput(procCtx, timeoutCfg, lines, stderrC, cancel)
 
 	return proc, nil
+}
+
+// pumpChildOutput is the reader goroutine: it consumes stdout lines until the
+// child is done or goes silent, waits for the process, and records the result.
+func (p *Process) pumpChildOutput(procCtx context.Context, timeoutCfg TimeoutConfig, lines <-chan string, stderrC *stderrCollector, cancel context.CancelFunc) {
+	defer close(p.done)
+	defer close(p.events)
+
+	// The inactivity timer is what separates "slow" from "wedged". Without
+	// it the absolute cap is the only limit, so a long but productive agent
+	// is killed on the same rule as one that has hung — which is precisely
+	// the failure this fixes.
+	idle := NewInactivityTimer(timeoutCfg.Inactivity)
+	defer idle.Stop()
+
+	result, timedOutIdle := p.readChildLines(lines, idle, cancel)
+
+	// Both pipes must be at EOF before Wait, and stderr is wanted for the
+	// error message below.
+	<-stderrC.done
+
+	// Wait for process exit.
+	waitErr := p.cmd.Wait()
+
+	p.mu.Lock()
+	p.result = result
+	p.err = childExitError(timeoutCfg, timedOutIdle, procCtx.Err(), waitErr, stderrC.Text())
+	if p.err != nil {
+		p.sendEvent(Event{Type: "error", Error: p.err.Error()})
+	}
+	p.mu.Unlock()
+}
+
+// readChildLines consumes stdout lines, emitting an Event for each and
+// accumulating the assistant text. It returns the accumulated result and
+// whether the inactivity timer fired.
+func (p *Process) readChildLines(lines <-chan string, idle *InactivityTimer, cancel context.CancelFunc) (string, bool) {
+	var resultBuilder strings.Builder
+
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				return resultBuilder.String(), false
+			}
+			idle.Reset()
+			if line == "" {
+				continue
+			}
+			p.emitChildLine(line, &resultBuilder)
+
+		case <-idle.C():
+			cancel()          // kills the process group; stdout closes, so lines drains
+			for range lines { //nolint:revive // drain so the scanner goroutine can exit
+			}
+			return resultBuilder.String(), true
+		}
+	}
+}
+
+// emitChildLine parses one JSONL line from the child and sends the matching
+// Event, appending assistant text to result.
+func (p *Process) emitChildLine(line string, result *strings.Builder) {
+	var ev jsonEvent
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		// Non-JSON output; emit as text.
+		p.sendEvent(Event{Type: "text_delta", Content: line})
+		return
+	}
+
+	switch ev.Type {
+	case "text_delta":
+		result.WriteString(ev.Delta)
+		p.sendEvent(Event{Type: "text_delta", Content: ev.Delta})
+	case "tool_call":
+		p.sendEvent(Event{Type: "tool_call", Content: ev.ToolName, ToolArgs: ev.ToolInput})
+	case "tool_result":
+		p.sendEvent(Event{Type: "tool_result", Content: ev.Content})
+	case "message_start":
+		p.sendEvent(Event{Type: "message_start", SessionID: ev.SessionID})
+	case "message_end":
+		p.sendEvent(Event{Type: "message_end"})
+	default:
+		p.sendEvent(Event{Type: ev.Type, Content: ev.Delta + ev.Content})
+	}
+}
+
+// childExitError classifies how a child pi process ended, returning nil for a
+// clean exit. The two timeout cases come first because a limit kill is also a
+// signal kill, and would otherwise be reported as a bare process failure.
+func childExitError(timeoutCfg TimeoutConfig, timedOutIdle bool, ctxErr, waitErr error, stderrStr string) error {
+	switch {
+	case timedOutIdle:
+		return fmt.Errorf("pi subagent produced no output for %s: %w (%s)",
+			timeoutCfg.Inactivity, ErrSubagentTimeout, timeoutHint)
+	case errors.Is(ctxErr, context.DeadlineExceeded):
+		return fmt.Errorf("pi subagent exceeded its %s time limit: %w (%s)",
+			timeoutCfg.Absolute, ErrSubagentTimeout, timeoutHint)
+	case waitErr != nil && stderrStr != "":
+		return fmt.Errorf("pi process failed: %w: %s", waitErr, stderrStr)
+	case waitErr != nil:
+		return fmt.Errorf("pi process failed: %w", waitErr)
+	}
+	return nil
 }
 
 // sendEvent sends an event to the channel without blocking.

--- a/internal/subagent/spawner_acp.go
+++ b/internal/subagent/spawner_acp.go
@@ -152,38 +152,7 @@ func pumpACPSession(sess acpSession, proc *Process, agentName string) {
 	defer close(proc.done)
 	defer close(proc.events)
 
-	sentStart := false
-	var textAcc strings.Builder
-	// gracefulCompletion is set when the agent emits the <Task Completed>!
-	// sentinel. Once flipped, sess.Cancel() is invoked to tear down the
-	// subprocess, and the resulting session error is coerced back to
-	// StatusSuccess since the agent itself signaled it was done.
-	gracefulCompletion := false
-	for ev := range sess.Events() {
-		if !sentStart && ev.SessionID != "" {
-			sendProcEvent(proc, Event{Type: "message_start", SessionID: ev.SessionID})
-			sentStart = true
-		}
-		switch ev.Type {
-		case sharedacp.EventTypeMessage:
-			sendProcEvent(proc, Event{Type: "text_delta", Content: ev.Content, SessionID: ev.SessionID})
-			if !gracefulCompletion {
-				textAcc.WriteString(ev.Content)
-				if strings.Contains(textAcc.String(), acpCompletionMatcher) {
-					gracefulCompletion = true
-					_ = sess.Cancel()
-				}
-			}
-		case sharedacp.EventTypeProgress, sharedacp.EventTypeTool:
-			sendProcEvent(proc, Event{Type: "tool_call", Content: ev.Content, SessionID: ev.SessionID})
-		case sharedacp.EventTypeStderr:
-			sendProcEvent(proc, Event{Type: "stderr", Content: ev.Content, SessionID: ev.SessionID})
-		case sharedacp.EventTypeError:
-			sendProcEvent(proc, Event{Type: "error", Error: ev.Error, SessionID: ev.SessionID})
-		default:
-			sendProcEvent(proc, Event{Type: ev.Type, Content: ev.Content, SessionID: ev.SessionID})
-		}
-	}
+	sentStart, gracefulCompletion := pumpACPEvents(sess, proc)
 
 	result := sess.Wait()
 
@@ -192,37 +161,13 @@ func pumpACPSession(sess acpSession, proc *Process, agentName string) {
 	}
 
 	if gracefulCompletion {
-		// The Cancel() above will typically make the runner surface a kill
-		// error; override so the caller sees a clean completion and strip
-		// both the strict and the loose sentinel form from the final text.
-		result.Status = sharedacp.StatusSuccess
-		result.Error = ""
-		r := result.Result
-		r = strings.ReplaceAll(r, acpCompletionSentinel, "")
-		r = strings.ReplaceAll(r, acpCompletionMatcher, "")
-		result.Result = strings.TrimSpace(r)
+		result = completeGracefully(result)
 	}
 
 	proc.mu.Lock()
 	proc.result = result.Result
 	if result.Status == sharedacp.StatusError {
-		errMsg := strings.TrimSpace(result.Error)
-		// Always append stderr for diagnostics, especially on timeout/kill.
-		// The RunResult may contain stderr content from the subprocess.
-		if result.Stderr != "" {
-			stderrMsg := strings.TrimSpace(result.Stderr)
-			if stderrMsg != "" {
-				if errMsg != "" {
-					errMsg = fmt.Sprintf("%s\nstderr: %s", errMsg, stderrMsg)
-				} else {
-					errMsg = fmt.Sprintf("stderr: %s", stderrMsg)
-				}
-			}
-		}
-		if errMsg == "" {
-			errMsg = "subprocess failed"
-		}
-		proc.err = fmt.Errorf("%s ACP %s", agentName, errMsg)
+		proc.err = fmt.Errorf("%s ACP %s", agentName, acpErrorText(result))
 		proc.mu.Unlock()
 		sendProcEvent(proc, Event{Type: "error", Error: proc.err.Error(), SessionID: result.SessionID})
 	} else {
@@ -230,6 +175,82 @@ func pumpACPSession(sess acpSession, proc *Process, agentName string) {
 	}
 
 	sendProcEvent(proc, Event{Type: "message_end", SessionID: result.SessionID, StopReason: result.StopReason})
+}
+
+// pumpACPEvents forwards the session's event stream to proc until it closes.
+//
+// sentStart reports whether a message_start was emitted, so the caller can
+// still emit one from the final result. gracefulCompletion is set when the
+// agent emits the <Task Completed>! sentinel: once flipped, sess.Cancel() is
+// invoked to tear down the subprocess, and the resulting session error is
+// coerced back to StatusSuccess since the agent itself signaled it was done.
+func pumpACPEvents(sess acpSession, proc *Process) (sentStart, gracefulCompletion bool) {
+	var textAcc strings.Builder
+	for ev := range sess.Events() {
+		if !sentStart && ev.SessionID != "" {
+			sendProcEvent(proc, Event{Type: "message_start", SessionID: ev.SessionID})
+			sentStart = true
+		}
+		sendProcEvent(proc, acpProcEvent(ev))
+
+		if ev.Type != sharedacp.EventTypeMessage || gracefulCompletion {
+			continue
+		}
+		textAcc.WriteString(ev.Content)
+		if strings.Contains(textAcc.String(), acpCompletionMatcher) {
+			gracefulCompletion = true
+			_ = sess.Cancel()
+		}
+	}
+	return sentStart, gracefulCompletion
+}
+
+// acpProcEvent maps one ACP session event onto the orchestrator's Event shape.
+func acpProcEvent(ev sharedacp.Event) Event {
+	switch ev.Type {
+	case sharedacp.EventTypeMessage:
+		return Event{Type: "text_delta", Content: ev.Content, SessionID: ev.SessionID}
+	case sharedacp.EventTypeProgress, sharedacp.EventTypeTool:
+		return Event{Type: "tool_call", Content: ev.Content, SessionID: ev.SessionID}
+	case sharedacp.EventTypeStderr:
+		return Event{Type: "stderr", Content: ev.Content, SessionID: ev.SessionID}
+	case sharedacp.EventTypeError:
+		return Event{Type: "error", Error: ev.Error, SessionID: ev.SessionID}
+	default:
+		return Event{Type: ev.Type, Content: ev.Content, SessionID: ev.SessionID}
+	}
+}
+
+// completeGracefully rewrites a run that ended on the <Task Completed>!
+// sentinel. The Cancel() that sentinel triggered will typically make the runner
+// surface a kill error; override so the caller sees a clean completion and
+// strip both the strict and the loose sentinel form from the final text.
+func completeGracefully(result sharedacp.RunResult) sharedacp.RunResult {
+	result.Status = sharedacp.StatusSuccess
+	result.Error = ""
+	r := result.Result
+	r = strings.ReplaceAll(r, acpCompletionSentinel, "")
+	r = strings.ReplaceAll(r, acpCompletionMatcher, "")
+	result.Result = strings.TrimSpace(r)
+	return result
+}
+
+// acpErrorText builds the message for a failed ACP run. Stderr is always
+// appended for diagnostics, especially on timeout/kill, where the RunResult
+// carries the subprocess's stderr and often nothing else.
+func acpErrorText(result sharedacp.RunResult) string {
+	errMsg := strings.TrimSpace(result.Error)
+	if stderrMsg := strings.TrimSpace(result.Stderr); stderrMsg != "" {
+		if errMsg != "" {
+			errMsg = fmt.Sprintf("%s\nstderr: %s", errMsg, stderrMsg)
+		} else {
+			errMsg = fmt.Sprintf("stderr: %s", stderrMsg)
+		}
+	}
+	if errMsg == "" {
+		return "subprocess failed"
+	}
+	return errMsg
 }
 
 // sendProcEvent enqueues an event without blocking; events are dropped if

--- a/internal/subagent/worktree.go
+++ b/internal/subagent/worktree.go
@@ -109,6 +109,83 @@ func (m *WorktreeManager) popStashByMessage(msg string) error {
 	return nil
 }
 
+// claimExistingWorktree decides what to do about a branch or directory that is
+// already there before `git worktree add` runs.
+//
+// Re-running /run on the same spec produces a deterministic branch name, so a
+// prior run that left the branch behind (e.g. after a failed merge) would
+// otherwise make `worktree add -b` fail with "a branch named X already exists".
+//
+// It returns reuse=true when the branch is attached to exactly the worktree we
+// would have created, and an error when it is attached somewhere else — the
+// alternative there is silently overwriting a live worktree. Otherwise it
+// prunes any stale leftovers so `worktree add` can recreate cleanly.
+func (m *WorktreeManager) claimExistingWorktree(agentID, branch, wtPath string, branchExists bool, attachedAt string) (bool, error) {
+	if branchExists && attachedAt != "" {
+		if !samePath(attachedAt, wtPath) {
+			return false, fmt.Errorf("branch %q is already checked out at %s; cannot reuse for agent %s", branch, attachedAt, agentID)
+		}
+		return true, nil
+	}
+
+	// If a stale worktree directory exists without a linked branch, prune
+	// the metadata and remove the leftover directory so `worktree add`
+	// can recreate cleanly.
+	if _, statErr := os.Stat(wtPath); statErr == nil && attachedAt == "" {
+		_, _ = m.git("worktree", "prune")
+		_ = os.RemoveAll(wtPath)
+	}
+	return false, nil
+}
+
+// stashBeforeWorktreeAdd stashes any uncommitted changes before creating the
+// worktree, because `git worktree add HEAD` fails if the working tree is dirty.
+// Use -u to also stash untracked files.
+//
+// Exit code semantics (stable across git versions and locales):
+//
+//	0   — changes stashed
+//	1   — nothing to stash (clean tree)
+//	128 — fatal (e.g. not a git repo, corrupt repo)
+//
+// We detect "did stash happen" by counting stash entries before/after rather
+// than by string-matching the (locale-dependent) output. The returned message
+// is the unique one used for the push, so the eventual pop can find exactly
+// this entry; stashed reports whether an entry was actually created.
+func (m *WorktreeManager) stashBeforeWorktreeAdd(agentID string) (msg string, stashed bool, err error) {
+	stashMsg := stashMessage(agentID)
+	beforeCount, _ := m.stashIndexAfter()
+	stashOut, stashErr := m.git("stash", "push", "-u", "-m", stashMsg)
+	if stashErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(stashErr, &exitErr) && exitErr.ExitCode() == 1 {
+			// Nothing to stash — proceed without tracking a stash entry.
+			stashErr = nil
+		} else {
+			return "", false, fmt.Errorf("git stash before worktree: %w (output: %s)", stashErr, stashOut)
+		}
+	}
+	afterCount, _ := m.stashIndexAfter()
+	return stashMsg, stashErr == nil && afterCount > beforeCount, nil
+}
+
+// addWorktree runs `git worktree add`. If the branch already exists but is not
+// checked out anywhere, attach it without `-b`; otherwise create a fresh branch
+// from HEAD.
+func (m *WorktreeManager) addWorktree(wtPath, branch string, branchExists bool) error {
+	var out string
+	var err error
+	if branchExists {
+		out, err = m.git("worktree", "add", wtPath, branch)
+	} else {
+		out, err = m.git("worktree", "add", "-b", branch, wtPath, "HEAD")
+	}
+	if err != nil {
+		return fmt.Errorf("git worktree add: %w: %s", err, out)
+	}
+	return nil
+}
+
 // Create creates a new git worktree for the given agent ID.
 // If the current branch has uncommitted changes, they are stashed before
 // creating the worktree and tracked in `pendingStash` so that MergeBack
@@ -139,76 +216,36 @@ func (m *WorktreeManager) Create(agentID string, requestedName ...string) (strin
 	}
 
 	// Verify whether the branch and/or worktree already exist before issuing
-	// `git worktree add -b`. Re-running /run on the same spec produces a
-	// deterministic branch name, so a prior run that left the branch behind
-	// (e.g. after a failed merge) would otherwise cause `worktree add -b`
-	// to fail with "a branch named X already exists".
+	// `git worktree add -b` — see claimExistingWorktree.
 	branchExists := m.branchExists(branch)
 	attachedAt := m.worktreeForBranch(branch)
 
-	// If the branch is already attached to a worktree, reuse it when the
-	// path matches what we would have chosen; otherwise refuse rather than
-	// silently overwriting a live worktree.
-	if branchExists && attachedAt != "" {
-		if !samePath(attachedAt, wtPath) {
-			return "", fmt.Errorf("branch %q is already checked out at %s; cannot reuse for agent %s", branch, attachedAt, agentID)
-		}
+	reuse, err := m.claimExistingWorktree(agentID, branch, wtPath, branchExists, attachedAt)
+	if err != nil {
+		return "", err
+	}
+	if reuse {
 		m.active[agentID] = worktreeInfo{Path: wtPath, Branch: branch}
 		return wtPath, nil
 	}
 
-	// If a stale worktree directory exists without a linked branch, prune
-	// the metadata and remove the leftover directory so `worktree add`
-	// can recreate cleanly.
-	if _, statErr := os.Stat(wtPath); statErr == nil && attachedAt == "" {
-		_, _ = m.git("worktree", "prune")
-		_ = os.RemoveAll(wtPath)
-	}
-
-	// Stash any uncommitted changes before creating the worktree.
-	// git worktree add HEAD fails if the working tree is dirty.
-	// Use -u to also stash untracked files.
-	//
-	// Exit code semantics (stable across git versions and locales):
-	//   0   — changes stashed
-	//   1   — nothing to stash (clean tree)
-	//   128 — fatal (e.g. not a git repo, corrupt repo)
-	//
-	// We detect "did stash happen" by counting stash entries before/after
-	// rather than by string-matching the (locale-dependent) output.
-	stashMsg := stashMessage(agentID)
-	beforeCount, _ := m.stashIndexAfter()
-	stashOut, stashErr := m.git("stash", "push", "-u", "-m", stashMsg)
-	if stashErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(stashErr, &exitErr) && exitErr.ExitCode() == 1 {
-			// Nothing to stash — proceed without tracking a stash entry.
-			stashErr = nil
-		} else {
-			return "", fmt.Errorf("git stash before worktree: %w (output: %s)", stashErr, stashOut)
-		}
-	}
-	afterCount, _ := m.stashIndexAfter()
-	stashedSomething := stashErr == nil && afterCount > beforeCount
-
-	// If the branch already exists but is not checked out anywhere, attach
-	// it without `-b`. Otherwise create a fresh branch from HEAD.
-	var out string
-	var err error
-	if branchExists {
-		out, err = m.git("worktree", "add", wtPath, branch)
-	} else {
-		out, err = m.git("worktree", "add", "-b", branch, wtPath, "HEAD")
-	}
+	stashMsg, stashedSomething, err := m.stashBeforeWorktreeAdd(agentID)
 	if err != nil {
+		return "", err
+	}
+
+	// Everything from here to the success path below is paired with that
+	// stash: the only exit between the two is the failure branch immediately
+	// after `worktree add`, which disposes of the stash entry explicitly.
+	if err := m.addWorktree(wtPath, branch, branchExists); err != nil {
 		// Restore stashed changes on failure. We do this regardless of
-		// whether `beforeCount` showed entries — if anything landed in
+		// what the stash list held beforehand — if anything landed in
 		// the stash list, drop it so the user isn't left with orphaned
 		// entries after a failed Create.
 		if stashedSomething {
 			_, _ = m.git("stash", "drop", "--quiet", "stash@{0}")
 		}
-		return "", fmt.Errorf("git worktree add: %w: %s", err, out)
+		return "", err
 	}
 
 	// Stash survives on success — MergeBack/Cleanup will pop it via

--- a/internal/tools/compactor_bash.go
+++ b/internal/tools/compactor_bash.go
@@ -131,28 +131,33 @@ func isLinterCommand(cmd string) bool {
 		strings.Contains(cmd, "clippy")
 }
 
-// filterBuildOutput keeps only error/warning lines from build output.
-func filterBuildOutput(s string, cfg CompactorConfig) (string, bool) {
-	lines := strings.Split(s, "\n")
-	if len(lines) < 10 {
-		return s, false // not worth filtering short output
-	}
+// buildErrorMarkers mark a build output line as an error or warning worth keeping.
+var buildErrorMarkers = []string{"error", "warning:", "fatal", "cannot", "undefined"}
 
-	var filtered []string
-	errorCount := 0
+// buildSummaryMarkers mark a build output line as a run summary worth keeping.
+var buildSummaryMarkers = []string{"build failed", "exit status"}
+
+// containsAnyOf reports whether s contains any of the given substrings.
+func containsAnyOf(s string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// selectBuildErrorLines keeps each error line up to cfg.MaxBuildErrors, a bounded
+// run of context lines after each one, and any summary line. It returns the kept
+// lines and how many errors were kept.
+func selectBuildErrorLines(lines []string, cfg CompactorConfig) (filtered []string, errorCount int) {
 	linesInError := 0
 	inError := false
 
 	for _, line := range lines {
 		lower := strings.ToLower(line)
 
-		isErrorLine := strings.Contains(lower, "error") ||
-			strings.Contains(lower, "warning:") ||
-			strings.Contains(lower, "fatal") ||
-			strings.Contains(lower, "cannot") ||
-			strings.Contains(lower, "undefined")
-
-		if isErrorLine {
+		if containsAnyOf(lower, buildErrorMarkers) {
 			if errorCount < cfg.MaxBuildErrors {
 				inError = true
 				linesInError = 0
@@ -174,11 +179,21 @@ func filterBuildOutput(s string, cfg CompactorConfig) (string, bool) {
 
 		// Keep summary lines
 		if strings.HasPrefix(line, "FAIL") || strings.HasPrefix(line, "ok ") ||
-			strings.Contains(lower, "build failed") || strings.Contains(lower, "exit status") {
+			containsAnyOf(lower, buildSummaryMarkers) {
 			filtered = append(filtered, line)
 		}
 	}
+	return filtered, errorCount
+}
 
+// filterBuildOutput keeps only error/warning lines from build output.
+func filterBuildOutput(s string, cfg CompactorConfig) (string, bool) {
+	lines := strings.Split(s, "\n")
+	if len(lines) < 10 {
+		return s, false // not worth filtering short output
+	}
+
+	filtered, errorCount := selectBuildErrorLines(lines, cfg)
 	if len(filtered) >= len(lines) {
 		return s, false
 	}
@@ -196,47 +211,55 @@ var goTestResultPattern = regexp.MustCompile(`^(ok|FAIL)\s+\S+\s+[\d.]+s`)
 // goTestFailPattern matches Go test failure output headers.
 var goTestFailPattern = regexp.MustCompile(`^--- FAIL: (\S+)`)
 
-// aggregateTestOutput compacts test output into a summary with failure details.
-func aggregateTestOutput(s string, cfg CompactorConfig) (string, bool) {
-	lines := strings.Split(s, "\n")
-	if len(lines) < 20 {
-		return s, false // too short to benefit
-	}
+// testOutputSummary is the parsed shape of a test run: the per-status counts, the
+// failure details kept, and the per-package result lines.
+type testOutputSummary struct {
+	passCount, failCount, skipCount int
+	failedTests                     []string
+	failDetails                     []string
+	resultLines                     []string
+}
 
+// appendFailDetail flushes an in-progress failure detail if there is one and
+// there is still room for it under maxFailures.
+func appendFailDetail(details, current []string, maxFailures int) []string {
+	if len(current) > 0 && len(details) < maxFailures {
+		return append(details, strings.Join(current, "\n"))
+	}
+	return details
+}
+
+// parseTestOutput scans test output into counts, failure details and result lines.
+func parseTestOutput(lines []string, cfg CompactorConfig) testOutputSummary {
 	var (
-		passCount, failCount, skipCount int
-		failedTests                     []string
-		failDetails                     []string
-		resultLines                     []string
-		inFail                          bool
-		failLines                       int
-		currentFailDetail               []string
+		sum               testOutputSummary
+		inFail            bool
+		failLines         int
+		currentFailDetail []string
 	)
 
 	for _, line := range lines {
 		// Go test result lines
 		if goTestResultPattern.MatchString(line) {
-			resultLines = append(resultLines, line)
+			sum.resultLines = append(sum.resultLines, line)
 			if strings.HasPrefix(line, "FAIL") {
-				failCount++
+				sum.failCount++
 			} else {
-				passCount++
+				sum.passCount++
 			}
 			continue
 		}
 
 		if strings.Contains(line, "--- SKIP") {
-			skipCount++
+			sum.skipCount++
 			continue
 		}
 
 		// Capture failure details
 		if m := goTestFailPattern.FindStringSubmatch(line); m != nil {
 			// Flush previous fail
-			if len(currentFailDetail) > 0 && len(failDetails) < cfg.MaxTestFailures {
-				failDetails = append(failDetails, strings.Join(currentFailDetail, "\n"))
-			}
-			failedTests = append(failedTests, m[1])
+			sum.failDetails = appendFailDetail(sum.failDetails, currentFailDetail, cfg.MaxTestFailures)
+			sum.failedTests = append(sum.failedTests, m[1])
 			currentFailDetail = []string{line}
 			inFail = true
 			failLines = 0
@@ -253,37 +276,50 @@ func aggregateTestOutput(s string, cfg CompactorConfig) (string, bool) {
 	}
 
 	// Flush last failure
-	if len(currentFailDetail) > 0 && len(failDetails) < cfg.MaxTestFailures {
-		failDetails = append(failDetails, strings.Join(currentFailDetail, "\n"))
-	}
+	sum.failDetails = appendFailDetail(sum.failDetails, currentFailDetail, cfg.MaxTestFailures)
+	return sum
+}
 
-	if passCount == 0 && failCount == 0 {
-		return s, false // couldn't parse test output
-	}
-
+// renderTestSummary formats a parsed test run as the compacted summary text.
+func renderTestSummary(sum testOutputSummary, cfg CompactorConfig) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Test Summary: PASS=%d FAIL=%d SKIP=%d\n", passCount, failCount, skipCount)
+	fmt.Fprintf(&b, "Test Summary: PASS=%d FAIL=%d SKIP=%d\n", sum.passCount, sum.failCount, sum.skipCount)
 
-	if len(failDetails) > 0 {
+	if len(sum.failDetails) > 0 {
 		fmt.Fprintf(&b, "\nFailure Details:\n")
-		for _, d := range failDetails {
+		for _, d := range sum.failDetails {
 			b.WriteString(d)
 			b.WriteString("\n\n")
 		}
-		if len(failedTests) > cfg.MaxTestFailures {
-			fmt.Fprintf(&b, "... and %d more failures\n", len(failedTests)-cfg.MaxTestFailures)
+		if len(sum.failedTests) > cfg.MaxTestFailures {
+			fmt.Fprintf(&b, "... and %d more failures\n", len(sum.failedTests)-cfg.MaxTestFailures)
 		}
 	}
 
-	if len(resultLines) > 0 {
+	if len(sum.resultLines) > 0 {
 		fmt.Fprintf(&b, "\nPackage Results:\n")
-		for _, r := range resultLines {
+		for _, r := range sum.resultLines {
 			b.WriteString(r)
 			b.WriteString("\n")
 		}
 	}
 
-	result := b.String()
+	return b.String()
+}
+
+// aggregateTestOutput compacts test output into a summary with failure details.
+func aggregateTestOutput(s string, cfg CompactorConfig) (string, bool) {
+	lines := strings.Split(s, "\n")
+	if len(lines) < 20 {
+		return s, false // too short to benefit
+	}
+
+	sum := parseTestOutput(lines, cfg)
+	if sum.passCount == 0 && sum.failCount == 0 {
+		return s, false // couldn't parse test output
+	}
+
+	result := renderTestSummary(sum, cfg)
 	if len(result) >= len(s) {
 		return s, false
 	}
@@ -378,6 +414,99 @@ func aggregateLinterOutput(s string, cfg CompactorConfig) (string, bool) {
 	return result, true
 }
 
+// scoredLine pairs an output line with its smart-truncation priority.
+type scoredLine struct {
+	line  string
+	score int
+}
+
+// truncateErrorMarkers mark the highest-priority lines for smart truncation.
+var truncateErrorMarkers = []string{"error", "fail", "panic", "fatal"}
+
+// truncateDeclPrefixes mark source declarations, ranked above ordinary content.
+var truncateDeclPrefixes = []string{"import", "package", "func ", "type "}
+
+// hasAnyPrefix reports whether s starts with any of the given prefixes.
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// lineTruncationScore ranks a line for retention: errors and failures first, then
+// warnings, then declarations, then ordinary content, with blank lines last.
+func lineTruncationScore(line string) int {
+	lower := strings.ToLower(line)
+	switch {
+	case containsAnyOf(lower, truncateErrorMarkers):
+		return 10
+	case strings.Contains(lower, "warning"):
+		return 7
+	case hasAnyPrefix(line, truncateDeclPrefixes):
+		return 5
+	case strings.TrimSpace(line) == "":
+		return 0 // blank lines are lowest priority
+	default:
+		return 1 // default priority
+	}
+}
+
+// partitionByPriority splits the middle band into high- and low-priority lines,
+// dropping blank (score 0) lines entirely.
+func partitionByPriority(middle []scoredLine) (highPri, lowPri []string) {
+	for _, sl := range middle {
+		if sl.score >= 5 {
+			highPri = append(highPri, sl.line)
+		} else if sl.score > 0 {
+			lowPri = append(lowPri, sl.line)
+		}
+	}
+	return highPri, lowPri
+}
+
+// appendUpTo appends lines from src to dst while the budget allows, returning the
+// grown slice and the budget left.
+func appendUpTo(dst, src []string, remaining int) ([]string, int) {
+	for _, l := range src {
+		if remaining <= 0 {
+			break
+		}
+		dst = append(dst, l)
+		remaining--
+	}
+	return dst, remaining
+}
+
+// selectMiddleLines keeps at most middleSize lines from the middle band,
+// preferring high-priority ones, and appends an omission marker when it dropped
+// any.
+func selectMiddleLines(middle []scoredLine, middleSize int) []string {
+	var result []string
+	if len(middle) <= middleSize {
+		for _, sl := range middle {
+			result = append(result, sl.line)
+		}
+		return result
+	}
+
+	highPri, lowPri := partitionByPriority(middle)
+	remaining := middleSize
+	result, remaining = appendUpTo(result, highPri, remaining)
+	result, remaining = appendUpTo(result, lowPri, remaining)
+
+	// The original guard read `remaining < len(middle)-len(all)+headSize`, where
+	// `all` was the whole output so far — the head lines plus what was picked
+	// here. Substituting len(all) = headSize+len(result) cancels both headSize
+	// terms, leaving this.
+	if remaining < len(middle)-len(result) {
+		result = append(result, fmt.Sprintf("... (%d lines omitted)", len(middle)-middleSize))
+	}
+	return result
+}
+
 // smartTruncate applies priority-based line selection to keep the most important content.
 func smartTruncate(s string, cfg CompactorConfig) (string, bool) {
 	lines := strings.Split(s, "\n")
@@ -386,30 +515,9 @@ func smartTruncate(s string, cfg CompactorConfig) (string, bool) {
 	}
 
 	// Priority scoring: errors/failures > imports/declarations > other content
-	type scored struct {
-		line  string
-		score int
-	}
-
-	scoredLines := make([]scored, len(lines))
+	scoredLines := make([]scoredLine, len(lines))
 	for i, line := range lines {
-		score := 1 // default priority
-		lower := strings.ToLower(line)
-
-		// High priority: errors, failures, important markers
-		if strings.Contains(lower, "error") || strings.Contains(lower, "fail") ||
-			strings.Contains(lower, "panic") || strings.Contains(lower, "fatal") {
-			score = 10
-		} else if strings.Contains(lower, "warning") {
-			score = 7
-		} else if strings.HasPrefix(line, "import") || strings.HasPrefix(line, "package") ||
-			strings.HasPrefix(line, "func ") || strings.HasPrefix(line, "type ") {
-			score = 5
-		} else if strings.TrimSpace(line) == "" {
-			score = 0 // blank lines are lowest priority
-		}
-
-		scoredLines[i] = scored{line: line, score: score}
+		scoredLines[i] = scoredLine{line: line, score: lineTruncationScore(line)}
 	}
 
 	// Keep first and last 10% unconditionally for context
@@ -426,39 +534,7 @@ func smartTruncate(s string, cfg CompactorConfig) (string, bool) {
 
 	// Middle: select by priority
 	middle := scoredLines[headSize : len(scoredLines)-tailSize]
-	if len(middle) > middleSize {
-		// Collect high-priority lines first
-		var highPri, lowPri []string
-		for _, sl := range middle {
-			if sl.score >= 5 {
-				highPri = append(highPri, sl.line)
-			} else if sl.score > 0 {
-				lowPri = append(lowPri, sl.line)
-			}
-		}
-		remaining := middleSize
-		for _, l := range highPri {
-			if remaining <= 0 {
-				break
-			}
-			result = append(result, l)
-			remaining--
-		}
-		for _, l := range lowPri {
-			if remaining <= 0 {
-				break
-			}
-			result = append(result, l)
-			remaining--
-		}
-		if remaining < len(middle)-len(result)+headSize {
-			result = append(result, fmt.Sprintf("... (%d lines omitted)", len(middle)-middleSize))
-		}
-	} else {
-		for _, sl := range middle {
-			result = append(result, sl.line)
-		}
-	}
+	result = append(result, selectMiddleLines(middle, middleSize)...)
 
 	// Tail
 	for i := len(scoredLines) - tailSize; i < len(scoredLines); i++ {

--- a/internal/tools/compactor_git.go
+++ b/internal/tools/compactor_git.go
@@ -131,6 +131,82 @@ var diffFileHeader = regexp.MustCompile(`^diff --git a/(.+) b/(.+)$`)
 // diffHunkHeader matches hunk headers like "@@ -1,5 +1,7 @@".
 var diffHunkHeader = regexp.MustCompile(`^@@.*@@`)
 
+// diffTextCompactor accumulates the compacted form of a unified diff as a caller
+// feeds it one line at a time.
+type diffTextCompactor struct {
+	cfg         CompactorConfig
+	b           strings.Builder
+	totalLines  int
+	hunkLines   int
+	inHunk      bool
+	currentFile string
+	additions   int
+	deletions   int
+}
+
+// emit passes one line through to the output and counts it against MaxDiffLines.
+func (c *diffTextCompactor) emit(line string) {
+	c.b.WriteString(line)
+	c.b.WriteString("\n")
+	c.totalLines++
+}
+
+// flushFile writes the "(+n -m)" tally for the file being read, if it changed.
+func (c *diffTextCompactor) flushFile() {
+	if c.currentFile != "" && (c.additions > 0 || c.deletions > 0) {
+		fmt.Fprintf(&c.b, "  (+%d -%d)\n", c.additions, c.deletions)
+	}
+}
+
+// startFile closes off the previous file's tally and begins a new file.
+func (c *diffTextCompactor) startFile(name, header string) {
+	c.flushFile()
+	c.currentFile = name
+	c.emit(header)
+	c.additions = 0
+	c.deletions = 0
+	c.inHunk = false
+	c.hunkLines = 0
+}
+
+// consumeHunkLine keeps the first MaxDiffHunkLines lines of a hunk while counting
+// additions and deletions across the whole hunk.
+func (c *diffTextCompactor) consumeHunkLine(line string) {
+	c.hunkLines++
+	if c.hunkLines <= c.cfg.MaxDiffHunkLines {
+		c.emit(line)
+	}
+	if strings.HasPrefix(line, "+") {
+		c.additions++
+	} else if strings.HasPrefix(line, "-") {
+		c.deletions++
+	}
+}
+
+// consume routes one diff line to the file-header, hunk-header, hunk-body or
+// passthrough case.
+func (c *diffTextCompactor) consume(line string) {
+	if m := diffFileHeader.FindStringSubmatch(line); m != nil {
+		c.startFile(m[2], line)
+		return
+	}
+
+	if diffHunkHeader.MatchString(line) {
+		c.inHunk = true
+		c.hunkLines = 0
+		c.emit(line)
+		return
+	}
+
+	if c.inHunk {
+		c.consumeHunkLine(line)
+		return
+	}
+
+	// Non-hunk content (--- +++ headers, etc.)
+	c.emit(line)
+}
+
 // compactGitDiffText summarizes a unified diff to file-level changes with limited hunks.
 func compactGitDiffText(s string, cfg CompactorConfig) (string, bool) {
 	lines := strings.Split(s, "\n")
@@ -138,75 +214,22 @@ func compactGitDiffText(s string, cfg CompactorConfig) (string, bool) {
 		return s, false
 	}
 
-	var b strings.Builder
-	totalLines := 0
-	hunkLines := 0
-	inHunk := false
-	currentFile := ""
-	additions := 0
-	deletions := 0
-
+	c := &diffTextCompactor{cfg: cfg}
 	for _, line := range lines {
-		if totalLines >= cfg.MaxDiffLines {
+		if c.totalLines >= cfg.MaxDiffLines {
 			break
 		}
-
-		if m := diffFileHeader.FindStringSubmatch(line); m != nil {
-			// Emit previous file summary if needed
-			if currentFile != "" && (additions > 0 || deletions > 0) {
-				fmt.Fprintf(&b, "  (+%d -%d)\n", additions, deletions)
-			}
-			currentFile = m[2]
-			b.WriteString(line)
-			b.WriteString("\n")
-			totalLines++
-			additions = 0
-			deletions = 0
-			inHunk = false
-			hunkLines = 0
-			continue
-		}
-
-		if diffHunkHeader.MatchString(line) {
-			inHunk = true
-			hunkLines = 0
-			b.WriteString(line)
-			b.WriteString("\n")
-			totalLines++
-			continue
-		}
-
-		if inHunk {
-			hunkLines++
-			if hunkLines <= cfg.MaxDiffHunkLines {
-				b.WriteString(line)
-				b.WriteString("\n")
-				totalLines++
-			}
-			if strings.HasPrefix(line, "+") {
-				additions++
-			} else if strings.HasPrefix(line, "-") {
-				deletions++
-			}
-			continue
-		}
-
-		// Non-hunk content (--- +++ headers, etc.)
-		b.WriteString(line)
-		b.WriteString("\n")
-		totalLines++
+		c.consume(line)
 	}
 
 	// Final file summary
-	if currentFile != "" && (additions > 0 || deletions > 0) {
-		fmt.Fprintf(&b, "  (+%d -%d)\n", additions, deletions)
+	c.flushFile()
+
+	if c.totalLines < len(lines) {
+		fmt.Fprintf(&c.b, "\n... (%d lines omitted from diff)\n", len(lines)-c.totalLines)
 	}
 
-	if totalLines < len(lines) {
-		fmt.Fprintf(&b, "\n... (%d lines omitted from diff)\n", len(lines)-totalLines)
-	}
-
-	result := b.String()
+	result := c.b.String()
 	if len(result) >= len(s) {
 		return s, false
 	}

--- a/internal/tools/complexity_compactor_test.go
+++ b/internal/tools/complexity_compactor_test.go
@@ -1,0 +1,1117 @@
+package tools
+
+// Golden tests pinning the exact output of the text-transformation functions
+// refactored for cyclomatic complexity: filterBuildOutput, aggregateTestOutput,
+// smartTruncate, compactGitDiffText, gitOverviewHandler and grepHandler.
+//
+// Every `want` string in this file was captured from the pre-refactor
+// implementation, so a passing run is the evidence that the extraction of
+// helpers preserved behavior byte for byte.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cxCfg returns the default compactor config for complexity-refactor tests.
+func cxCfg(mutate func(*CompactorConfig)) CompactorConfig {
+	cfg := DefaultCompactorConfig()
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	return cfg
+}
+
+func cxLines(ss ...string) string { return strings.Join(ss, "\n") }
+
+// --------------------------------------------------------------------------
+// filterBuildOutput
+// --------------------------------------------------------------------------
+
+func TestFilterBuildOutput_Golden(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		cfg     CompactorConfig
+		want    string
+		applied bool
+	}{
+		{
+			name: "errors with context and cap",
+			cfg: cxCfg(func(c *CompactorConfig) {
+				c.MaxBuildErrors = 2
+				c.MaxBuildErrLines = 2
+			}),
+			in: cxLines(
+				"go: downloading x",
+				"main.go:3:5: undefined: foo",
+				"  context one",
+				"  context two",
+				"  context three",
+				"main.go:9:1: error: bad thing",
+				"  detail a",
+				"main.go:12:1: warning: hmm",
+				"other.go:1:1: cannot find package",
+				"FAIL\tpkg/a\t0.1s",
+				"ok  \tpkg/b\t0.2s",
+				"build failed",
+				"exit status 2",
+				"trailing noise",
+			),
+			want: "main.go:3:5: undefined: foo\n  context one\n  context two\n" +
+				"main.go:9:1: error: bad thing\n  detail a\n" +
+				"FAIL\tpkg/a\t0.1s\nok  \tpkg/b\t0.2s\nbuild failed\nexit status 2\n" +
+				"... (2 errors shown, may have more)",
+			applied: true,
+		},
+		{
+			name: "summary lines only, no errors",
+			cfg:  cxCfg(nil),
+			in: cxLines(
+				"line one", "line two", "line three", "line four", "line five",
+				"FAIL\tpkg/a\t0.1s", "ok  \tpkg/b\t0.2s", "build failed",
+				"exit status 1", "line ten", "line eleven",
+			),
+			want:    "FAIL\tpkg/a\t0.1s\nok  \tpkg/b\t0.2s\nbuild failed\nexit status 1",
+			applied: true,
+		},
+		{
+			name: "nothing filtered out",
+			cfg:  cxCfg(func(c *CompactorConfig) { c.MaxBuildErrors = 100 }),
+			in: cxLines(
+				"error 1", "error 2", "error 3", "error 4", "error 5",
+				"error 6", "error 7", "error 8", "error 9", "error 10",
+			),
+			want: cxLines(
+				"error 1", "error 2", "error 3", "error 4", "error 5",
+				"error 6", "error 7", "error 8", "error 9", "error 10",
+			),
+			applied: false,
+		},
+		{
+			name:    "short output untouched",
+			cfg:     cxCfg(nil),
+			in:      cxLines("a", "b", "c"),
+			want:    cxLines("a", "b", "c"),
+			applied: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, applied := filterBuildOutput(tc.in, tc.cfg)
+			if applied != tc.applied {
+				t.Errorf("applied = %v, want %v", applied, tc.applied)
+			}
+			if got != tc.want {
+				t.Errorf("output mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// aggregateTestOutput
+// --------------------------------------------------------------------------
+
+func cxTestOutput() string {
+	lines := []string{
+		"=== RUN   TestOne",
+		"--- FAIL: TestOne (0.00s)",
+		"    one_test.go:10: boom",
+		"    one_test.go:11: more",
+		"    one_test.go:12: dropped",
+		"=== RUN   TestTwo",
+		"--- FAIL: TestTwo (0.00s)",
+		"    two_test.go:20: bang",
+		"=== RUN   TestThree",
+		"--- SKIP: TestThree (0.00s)",
+		"FAIL",
+		"FAIL\tpkg/a\t0.15s",
+		"ok  \tpkg/b\t0.25s",
+	}
+	for i := 0; i < 10; i++ {
+		lines = append(lines, fmt.Sprintf("noise %d", i))
+	}
+	return cxLines(lines...)
+}
+
+func cxRepeat(n int, f func(int) string) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, f(i))
+	}
+	return out
+}
+
+func TestAggregateTestOutput_Golden(t *testing.T) {
+	passOnly := append(
+		cxRepeat(22, func(i int) string { return fmt.Sprintf("=== RUN   TestP%d", i) }),
+		"ok  \tpkg/one\t0.10s", "ok  \tpkg/two\t0.20s",
+	)
+	noise := cxRepeat(25, func(i int) string { return fmt.Sprintf("just noise %d", i) })
+	blanksThenOK := append(cxRepeat(24, func(int) string { return "" }), "ok  \tx\t0.1s")
+
+	tests := []struct {
+		name    string
+		in      string
+		cfg     CompactorConfig
+		want    string
+		applied bool
+	}{
+		{
+			name: "failures capped with details truncated",
+			cfg: cxCfg(func(c *CompactorConfig) {
+				c.MaxTestFailures = 1
+				c.MaxTestFailLines = 2
+			}),
+			in: cxTestOutput(),
+			want: "Test Summary: PASS=1 FAIL=1 SKIP=1\n\nFailure Details:\n" +
+				"--- FAIL: TestOne (0.00s)\n    one_test.go:10: boom\n    one_test.go:11: more\n\n" +
+				"... and 1 more failures\n\nPackage Results:\n" +
+				"FAIL\tpkg/a\t0.15s\nok  \tpkg/b\t0.25s\n",
+			applied: true,
+		},
+		{
+			name: "passes only, no failure section",
+			cfg:  cxCfg(nil),
+			in:   cxLines(passOnly...),
+			want: "Test Summary: PASS=2 FAIL=0 SKIP=0\n\nPackage Results:\n" +
+				"ok  \tpkg/one\t0.10s\nok  \tpkg/two\t0.20s\n",
+			applied: true,
+		},
+		{
+			name:    "unparseable output untouched",
+			cfg:     cxCfg(nil),
+			in:      cxLines(noise...),
+			want:    cxLines(noise...),
+			applied: false,
+		},
+		{
+			name:    "summary longer than input",
+			cfg:     cxCfg(nil),
+			in:      cxLines(blanksThenOK...),
+			want:    cxLines(blanksThenOK...),
+			applied: false,
+		},
+		{
+			name:    "short output untouched",
+			cfg:     cxCfg(nil),
+			in:      "short output",
+			want:    "short output",
+			applied: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, applied := aggregateTestOutput(tc.in, tc.cfg)
+			if applied != tc.applied {
+				t.Errorf("applied = %v, want %v", applied, tc.applied)
+			}
+			if got != tc.want {
+				t.Errorf("output mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// smartTruncate
+// --------------------------------------------------------------------------
+
+// cxMixedScores builds 40 lines cycling through every priority band:
+// error (10), warning (7), declaration (5), blank (0) and plain (1).
+func cxMixedScores() []string {
+	return cxRepeat(40, func(i int) string {
+		switch i % 5 {
+		case 0:
+			return fmt.Sprintf("line %d error here", i)
+		case 1:
+			return fmt.Sprintf("warning at %d", i)
+		case 2:
+			return fmt.Sprintf("func f%d() {}", i)
+		case 3:
+			return ""
+		default:
+			return fmt.Sprintf("plain %d", i)
+		}
+	})
+}
+
+// cxMostlyLowPriority builds 40 lines that are almost all score-1 or blank, so
+// the low-priority fill loop runs after the high-priority one is exhausted.
+func cxMostlyLowPriority() []string {
+	return cxRepeat(40, func(i int) string {
+		switch {
+		case i == 7:
+			return "boom error at seven"
+		case i%4 == 3:
+			return ""
+		default:
+			return fmt.Sprintf("plain %d", i)
+		}
+	})
+}
+
+func TestSmartTruncate_Golden(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		cfg     CompactorConfig
+		want    string
+		applied bool
+	}{
+		{
+			name: "high priority lines fill the middle",
+			cfg:  cxCfg(func(c *CompactorConfig) { c.MaxLines = 20 }),
+			in:   cxLines(cxMixedScores()...),
+			want: "line 0 error here\nwarning at 1\nfunc f2() {}\nline 5 error here\nwarning at 6\n" +
+				"func f7() {}\nline 10 error here\nwarning at 11\nfunc f12() {}\nline 15 error here\n" +
+				"warning at 16\nfunc f17() {}\nline 20 error here\nwarning at 21\nfunc f22() {}\n" +
+				"line 25 error here\nwarning at 26\nfunc f27() {}\n... (20 lines omitted)\n\nplain 39",
+			applied: true,
+		},
+		{
+			name: "zero head and tail when MaxLines is small",
+			cfg:  cxCfg(func(c *CompactorConfig) { c.MaxLines = 5 }),
+			in:   cxLines(cxMixedScores()...),
+			want: "line 0 error here\nwarning at 1\nfunc f2() {}\nline 5 error here\nwarning at 6\n" +
+				"... (35 lines omitted)",
+			applied: true,
+		},
+		{
+			name: "low priority fill after high priority exhausted",
+			cfg:  cxCfg(func(c *CompactorConfig) { c.MaxLines = 20 }),
+			in:   cxLines(cxMostlyLowPriority()...),
+			want: "plain 0\nplain 1\nboom error at seven\nplain 2\nplain 4\nplain 5\nplain 6\n" +
+				"plain 8\nplain 9\nplain 10\nplain 12\nplain 13\nplain 14\nplain 16\nplain 17\n" +
+				"plain 18\nplain 20\nplain 21\n... (20 lines omitted)\nplain 38\n",
+			applied: true,
+		},
+		{
+			name:    "short input untouched",
+			cfg:     cxCfg(nil),
+			in:      "short",
+			want:    "short",
+			applied: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, applied := smartTruncate(tc.in, tc.cfg)
+			if applied != tc.applied {
+				t.Errorf("applied = %v, want %v", applied, tc.applied)
+			}
+			if got != tc.want {
+				t.Errorf("output mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// compactGitDiffText
+// --------------------------------------------------------------------------
+
+func TestCompactGitDiffText_Golden(t *testing.T) {
+	multiFileDiff := cxLines(
+		"diff --git a/a.go b/a.go",
+		"index 111..222 100644",
+		"--- a/a.go",
+		"+++ b/a.go",
+		"@@ -1,4 +1,6 @@",
+		" ctx",
+		"+add one",
+		"+add two",
+		"-del one",
+		"+add three",
+		"diff --git a/b.go b/b.go",
+		"--- a/b.go",
+		"+++ b/b.go",
+		"@@ -10,2 +10,3 @@",
+		"+bee one",
+		"-bee two",
+		" bee ctx",
+		"diff --git a/c.go b/c.go",
+		"@@ -1 +1 @@",
+		"+cee",
+	)
+
+	tests := []struct {
+		name    string
+		in      string
+		cfg     CompactorConfig
+		want    string
+		applied bool
+	}{
+		{
+			name: "multi file diff with hunk and line caps",
+			cfg: cxCfg(func(c *CompactorConfig) {
+				c.MaxDiffLines = 14
+				c.MaxDiffHunkLines = 3
+			}),
+			in: multiFileDiff,
+			want: "diff --git a/a.go b/a.go\nindex 111..222 100644\n--- a/a.go\n+++ b/a.go\n" +
+				"@@ -1,4 +1,6 @@\n ctx\n+add one\n+add two\n  (+3 -1)\n" +
+				"diff --git a/b.go b/b.go\n--- a/b.go\n+++ b/b.go\n@@ -10,2 +10,3 @@\n" +
+				"+bee one\n-bee two\n  (+1 -1)\n\n... (6 lines omitted from diff)\n",
+			applied: true,
+		},
+		{
+			name:    "non hunk content only, summary grows the output",
+			cfg:     cxCfg(func(c *CompactorConfig) { c.MaxDiffLines = 3 }),
+			in:      cxLines("plain one", "plain two", "plain three", "plain four", "plain five"),
+			want:    cxLines("plain one", "plain two", "plain three", "plain four", "plain five"),
+			applied: false,
+		},
+		{
+			name:    "omission marker makes result longer than input",
+			cfg:     cxCfg(func(c *CompactorConfig) { c.MaxDiffLines = 2 }),
+			in:      "ab\ncd\nef",
+			want:    "ab\ncd\nef",
+			applied: false,
+		},
+		{
+			name:    "short diff untouched",
+			cfg:     cxCfg(nil),
+			in:      "short diff",
+			want:    "short diff",
+			applied: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, applied := compactGitDiffText(tc.in, tc.cfg)
+			if applied != tc.applied {
+				t.Errorf("applied = %v, want %v", applied, tc.applied)
+			}
+			if got != tc.want {
+				t.Errorf("output mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// gitOverviewHandler
+// --------------------------------------------------------------------------
+
+// cxGitRepoWithStatus builds a repo with one commit plus a staged, an unstaged
+// and an untracked file, so every include flag has something to include.
+func cxGitRepoWithStatus(t *testing.T) *Sandbox {
+	t.Helper()
+	dir := initGitRepo(t)
+
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git := func(args ...string) {
+		t.Helper()
+		cxRunGit(t, dir, args...)
+	}
+
+	write("committed.go", "package main\n")
+	write("modified.go", "package main\n")
+	git("add", "committed.go", "modified.go")
+	git("commit", "-m", "initial commit")
+
+	write("staged.go", "package main\n")
+	git("add", "staged.go")
+	write("modified.go", "package main\n\nfunc main() {}\n")
+	write("untracked.go", "package main\n")
+
+	return testSandbox(t, dir)
+}
+
+func TestGitOverviewHandler_IncludeFlags(t *testing.T) {
+	sb := cxGitRepoWithStatus(t)
+
+	yes, no := true, false
+	tests := []struct {
+		name                                  string
+		input                                 GitOverviewInput
+		wantStaged, wantUnstaged, wantUntrack []string
+	}{
+		{
+			name:         "defaults include everything",
+			input:        GitOverviewInput{},
+			wantStaged:   []string{"A staged.go"},
+			wantUnstaged: []string{"M modified.go"},
+			wantUntrack:  []string{"untracked.go"},
+		},
+		{
+			name:         "explicit true is the same as default",
+			input:        GitOverviewInput{IncludeStaged: &yes, IncludeUnstaged: &yes, IncludeUntracked: &yes},
+			wantStaged:   []string{"A staged.go"},
+			wantUnstaged: []string{"M modified.go"},
+			wantUntrack:  []string{"untracked.go"},
+		},
+		{
+			name:         "staged excluded",
+			input:        GitOverviewInput{IncludeStaged: &no},
+			wantUnstaged: []string{"M modified.go"},
+			wantUntrack:  []string{"untracked.go"},
+		},
+		{
+			name:        "unstaged excluded",
+			input:       GitOverviewInput{IncludeUnstaged: &no},
+			wantStaged:  []string{"A staged.go"},
+			wantUntrack: []string{"untracked.go"},
+		},
+		{
+			name:         "untracked excluded",
+			input:        GitOverviewInput{IncludeUntracked: &no},
+			wantStaged:   []string{"A staged.go"},
+			wantUnstaged: []string{"M modified.go"},
+		},
+		{
+			name:  "all excluded",
+			input: GitOverviewInput{IncludeStaged: &no, IncludeUnstaged: &no, IncludeUntracked: &no},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := gitOverviewHandler(sb, nil, tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cxWantSlice(t, "staged", out.StagedFiles, tc.wantStaged)
+			cxWantSlice(t, "unstaged", out.UnstagedFiles, tc.wantUnstaged)
+			cxWantSlice(t, "untracked", out.UntrackedFiles, tc.wantUntrack)
+
+			if out.Branch == "" {
+				t.Error("branch should always be populated")
+			}
+			if len(out.RecentCommits) != 1 {
+				t.Errorf("recent commits = %d, want 1", len(out.RecentCommits))
+			}
+			if out.Upstream != "" {
+				t.Errorf("upstream = %q, want empty for a repo with no remote", out.Upstream)
+			}
+			if out.Ahead != 0 || out.Behind != 0 {
+				t.Errorf("ahead/behind = %d/%d, want 0/0", out.Ahead, out.Behind)
+			}
+		})
+	}
+}
+
+// TestGitOverviewHandler_Upstream covers the upstream / ahead-behind branch,
+// which a repo without a remote never reaches.
+func TestGitOverviewHandler_Upstream(t *testing.T) {
+	origin := initGitRepo(t)
+	if err := os.WriteFile(filepath.Join(origin, "a.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cxRunGit(t, origin, "add", "a.go")
+	cxRunGit(t, origin, "commit", "-m", "one")
+
+	clone := t.TempDir()
+	cxRunGit(t, clone, "clone", origin, ".")
+	cxRunGit(t, clone, "config", "user.email", "test@test.com")
+	cxRunGit(t, clone, "config", "user.name", "Test")
+	cxRunGit(t, clone, "config", "commit.gpgsign", "false")
+
+	// One local commit ahead of the tracked upstream.
+	if err := os.WriteFile(filepath.Join(clone, "b.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cxRunGit(t, clone, "add", "b.go")
+	cxRunGit(t, clone, "commit", "-m", "two")
+
+	out, err := gitOverviewHandler(testSandbox(t, clone), nil, GitOverviewInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Upstream == "" {
+		t.Fatal("expected a tracked upstream after clone")
+	}
+	if out.Ahead != 1 {
+		t.Errorf("ahead = %d, want 1", out.Ahead)
+	}
+	if out.Behind != 0 {
+		t.Errorf("behind = %d, want 0", out.Behind)
+	}
+}
+
+func cxWantSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s = %v, want %v", label, got, want)
+			return
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// grepHandler
+// --------------------------------------------------------------------------
+
+// cxGrepTree lays out a small tree covering directory recursion, glob
+// filtering, skipped directories and a plain file target.
+func cxGrepTree(t *testing.T) (*Sandbox, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	files := map[string]string{
+		"a.go":              "package main\nfunc Alpha() {}\nfunc beta() {}\n",
+		"b.txt":             "alpha in text\nFUNC upper\n",
+		"sub/c.go":          "package sub\nfunc Gamma() {}\n",
+		"node_modules/d.go": "func Skipped() {}\n",
+	}
+	for name, body := range files {
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return testSandbox(t, dir), dir
+}
+
+func TestGrepHandler_Table(t *testing.T) {
+	sb, _ := cxGrepTree(t)
+
+	tests := []struct {
+		name      string
+		input     GrepInput
+		wantErr   string
+		wantFiles []string // sorted set of files that must appear
+		wantTotal int
+	}{
+		{
+			name:    "empty pattern is rejected",
+			input:   GrepInput{Pattern: ""},
+			wantErr: "pattern is required",
+		},
+		{
+			name:    "missing path is rejected",
+			input:   GrepInput{Pattern: "func", Path: "nope"},
+			wantErr: "path not found",
+		},
+		{
+			name:    "invalid regex is rejected",
+			input:   GrepInput{Pattern: "[invalid"},
+			wantErr: "invalid regex pattern",
+		},
+		{
+			name:      "directory walk finds all go files",
+			input:     GrepInput{Pattern: "^func ", Path: "."},
+			wantFiles: []string{"a.go", "c.go"},
+			wantTotal: 3,
+		},
+		{
+			name:      "glob narrows to txt",
+			input:     GrepInput{Pattern: "alpha", Path: ".", Glob: "*.txt"},
+			wantFiles: []string{"b.txt"},
+			wantTotal: 1,
+		},
+		{
+			name:      "case insensitive matches both cases",
+			input:     GrepInput{Pattern: "ALPHA", Path: ".", CaseInsensitive: true},
+			wantFiles: []string{"a.go", "b.txt"},
+			wantTotal: 2,
+		},
+		{
+			name:      "case sensitive misses",
+			input:     GrepInput{Pattern: "ALPHA", Path: "."},
+			wantTotal: 0,
+		},
+		{
+			name:      "single file target",
+			input:     GrepInput{Pattern: "func", Path: "a.go"},
+			wantFiles: []string{"a.go"},
+			wantTotal: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := grepHandler(sb, tc.input)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out.TotalMatches != tc.wantTotal {
+				t.Errorf("total = %d, want %d (matches: %+v)", out.TotalMatches, tc.wantTotal, out.Matches)
+			}
+			for _, want := range tc.wantFiles {
+				found := false
+				for _, m := range out.Matches {
+					if strings.HasSuffix(m.File, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("no match in %s; got %+v", want, out.Matches)
+				}
+			}
+			if out.Truncated {
+				t.Error("did not expect truncation")
+			}
+		})
+	}
+}
+
+// TestGrepHandler_Truncates covers the maxGrepMatches cap on both the directory
+// walk and the single-file path.
+func TestGrepHandler_Truncates(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < maxGrepMatches+50; i++ {
+		fmt.Fprintf(&b, "hit %d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "many.txt"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sb := testSandbox(t, dir)
+
+	for _, path := range []string{"many.txt", "."} {
+		t.Run(path, func(t *testing.T) {
+			out, err := grepHandler(sb, GrepInput{Pattern: "^hit ", Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out.Matches) != maxGrepMatches {
+				t.Errorf("matches = %d, want %d", len(out.Matches), maxGrepMatches)
+			}
+			if out.TotalMatches != maxGrepMatches+50 {
+				t.Errorf("total = %d, want %d", out.TotalMatches, maxGrepMatches+50)
+			}
+			if !out.Truncated {
+				t.Error("expected Truncated = true")
+			}
+		})
+	}
+}
+
+// TestGrepHandler_RegexCacheReuse runs the same pattern twice so the second call
+// takes the cache-hit path rather than recompiling.
+func TestGrepHandler_RegexCacheReuse(t *testing.T) {
+	sb, _ := cxGrepTree(t)
+	in := GrepInput{Pattern: "cxCacheProbe_" + t.Name(), Path: "."}
+
+	first, err := grepHandler(sb, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := grepHandler(sb, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.TotalMatches != second.TotalMatches {
+		t.Errorf("cached run differs: %d vs %d", first.TotalMatches, second.TotalMatches)
+	}
+}
+
+// cxRunGit runs a git command in dir with a deterministic identity and fails the
+// test on error.
+func cxRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
+		"GIT_CONFIG_KEY_1=tag.gpgsign", "GIT_CONFIG_VALUE_1=false",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %s: %v", strings.Join(args, " "), out, err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Extracted helpers
+// --------------------------------------------------------------------------
+
+func TestContainsAnyOf(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		subs []string
+		want bool
+	}{
+		{name: "first marker", s: "an error here", subs: buildErrorMarkers, want: true},
+		{name: "last marker", s: "undefined: foo", subs: buildErrorMarkers, want: true},
+		{name: "middle marker", s: "fatal: nope", subs: buildErrorMarkers, want: true},
+		{name: "no marker", s: "all good", subs: buildErrorMarkers, want: false},
+		{name: "warning needs the colon", s: "warning about it", subs: buildErrorMarkers, want: false},
+		{name: "empty marker list", s: "anything", subs: nil, want: false},
+		{name: "summary marker", s: "exit status 2", subs: buildSummaryMarkers, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containsAnyOf(tc.s, tc.subs); got != tc.want {
+				t.Errorf("containsAnyOf(%q) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasAnyPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{name: "import", s: "import \"fmt\"", want: true},
+		{name: "package", s: "package tools", want: true},
+		{name: "func needs the space", s: "func main() {}", want: true},
+		{name: "funcy is not func", s: "funcy()", want: false},
+		{name: "type", s: "type T struct{}", want: true},
+		{name: "indented declaration does not count", s: "\tfunc main() {}", want: false},
+		{name: "plain", s: "hello", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasAnyPrefix(tc.s, truncateDeclPrefixes); got != tc.want {
+				t.Errorf("hasAnyPrefix(%q) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectBuildErrorLines(t *testing.T) {
+	cfg := cxCfg(func(c *CompactorConfig) {
+		c.MaxBuildErrors = 1
+		c.MaxBuildErrLines = 1
+	})
+	lines := []string{
+		"noise before",
+		"first error",
+		"context kept",
+		"context dropped",
+		"second error over the cap",
+		"ok  pkg",
+		"unrelated",
+	}
+	filtered, count := selectBuildErrorLines(lines, cfg)
+	wantFiltered := []string{"first error", "context kept", "ok  pkg"}
+	cxWantSlice(t, "filtered", filtered, wantFiltered)
+	if count != 1 {
+		t.Errorf("errorCount = %d, want 1", count)
+	}
+}
+
+func TestAppendFailDetail(t *testing.T) {
+	tests := []struct {
+		name        string
+		details     []string
+		current     []string
+		maxFailures int
+		want        []string
+	}{
+		{name: "appends joined detail", current: []string{"a", "b"}, maxFailures: 2, want: []string{"a\nb"}},
+		{name: "nothing in progress", details: []string{"x"}, maxFailures: 2, want: []string{"x"}},
+		{name: "at the cap", details: []string{"x"}, current: []string{"a"}, maxFailures: 1, want: []string{"x"}},
+		{name: "zero cap keeps nothing", current: []string{"a"}, maxFailures: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendFailDetail(tc.details, tc.current, tc.maxFailures)
+			cxWantSlice(t, "details", got, tc.want)
+		})
+	}
+}
+
+func TestLineTruncationScore(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want int
+	}{
+		{name: "error", line: "an ERROR occurred", want: 10},
+		{name: "fail", line: "test failed", want: 10},
+		{name: "panic", line: "panic: nil map", want: 10},
+		{name: "fatal", line: "Fatal: stop", want: 10},
+		{name: "warning", line: "WARNING here", want: 7},
+		{name: "import declaration", line: "import \"os\"", want: 5},
+		{name: "func declaration", line: "func f() {}", want: 5},
+		{name: "blank", line: "   ", want: 0},
+		{name: "empty", line: "", want: 0},
+		{name: "ordinary", line: "just some text", want: 1},
+		{name: "error beats warning", line: "warning: this error", want: 10},
+		{name: "warning beats declaration", line: "func warning() {}", want: 7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lineTruncationScore(tc.line); got != tc.want {
+				t.Errorf("lineTruncationScore(%q) = %d, want %d", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPartitionByPriority(t *testing.T) {
+	middle := []scoredLine{
+		{line: "err", score: 10},
+		{line: "warn", score: 7},
+		{line: "decl", score: 5},
+		{line: "plain", score: 1},
+		{line: "blank", score: 0},
+	}
+	high, low := partitionByPriority(middle)
+	cxWantSlice(t, "high", high, []string{"err", "warn", "decl"})
+	cxWantSlice(t, "low", low, []string{"plain"})
+}
+
+func TestAppendUpTo(t *testing.T) {
+	tests := []struct {
+		name          string
+		dst, src      []string
+		remaining     int
+		want          []string
+		wantRemaining int
+	}{
+		{name: "budget covers all", src: []string{"a", "b"}, remaining: 3, want: []string{"a", "b"}, wantRemaining: 1},
+		{name: "budget runs out", src: []string{"a", "b", "c"}, remaining: 2, want: []string{"a", "b"}, wantRemaining: 0},
+		{name: "no budget", src: []string{"a"}, remaining: 0, wantRemaining: 0},
+		{name: "negative budget", src: []string{"a"}, remaining: -1, wantRemaining: -1},
+		{name: "appends onto existing", dst: []string{"x"}, src: []string{"a"}, remaining: 1, want: []string{"x", "a"}, wantRemaining: 0},
+		{name: "empty source", dst: []string{"x"}, remaining: 2, want: []string{"x"}, wantRemaining: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, remaining := appendUpTo(tc.dst, tc.src, tc.remaining)
+			cxWantSlice(t, "appended", got, tc.want)
+			if remaining != tc.wantRemaining {
+				t.Errorf("remaining = %d, want %d", remaining, tc.wantRemaining)
+			}
+		})
+	}
+}
+
+// TestSelectMiddleLines_FitsWholeBand covers the branch smartTruncate itself can
+// never reach: it only calls in when the band is larger than the budget.
+func TestSelectMiddleLines_FitsWholeBand(t *testing.T) {
+	middle := []scoredLine{
+		{line: "a", score: 1},
+		{line: "", score: 0},
+		{line: "c", score: 10},
+	}
+	cxWantSlice(t, "selected", selectMiddleLines(middle, 5), []string{"a", "", "c"})
+	cxWantSlice(t, "selected exactly", selectMiddleLines(middle, 3), []string{"a", "", "c"})
+	if got := selectMiddleLines(nil, 0); got != nil {
+		t.Errorf("selectMiddleLines(nil, 0) = %v, want nil", got)
+	}
+}
+
+func TestSelectMiddleLines_DropsAndMarks(t *testing.T) {
+	middle := []scoredLine{
+		{line: "err", score: 10},
+		{line: "plain1", score: 1},
+		{line: "blank", score: 0},
+		{line: "plain2", score: 1},
+	}
+	// Budget of 2: the high-priority line first, then one low-priority line, then
+	// the omission marker for the 2 lines that did not fit.
+	cxWantSlice(t, "selected", selectMiddleLines(middle, 2),
+		[]string{"err", "plain1", "... (2 lines omitted)"})
+}
+
+// TestDiffTextCompactor_FlushFile pins the guard on the per-file tally: it is
+// written only when a file is open and something actually changed.
+func TestDiffTextCompactor_FlushFile(t *testing.T) {
+	tests := []struct {
+		name                 string
+		currentFile          string
+		additions, deletions int
+		want                 string
+	}{
+		{name: "no file open", additions: 3, want: ""},
+		{name: "file open but unchanged", currentFile: "a.go", want: ""},
+		{name: "additions only", currentFile: "a.go", additions: 2, want: "  (+2 -0)\n"},
+		{name: "deletions only", currentFile: "a.go", deletions: 4, want: "  (+0 -4)\n"},
+		{name: "both", currentFile: "a.go", additions: 1, deletions: 1, want: "  (+1 -1)\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &diffTextCompactor{
+				cfg:         cxCfg(nil),
+				currentFile: tc.currentFile,
+				additions:   tc.additions,
+				deletions:   tc.deletions,
+			}
+			c.flushFile()
+			if got := c.b.String(); got != tc.want {
+				t.Errorf("flushFile wrote %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiffTextCompactor_ConsumeRouting checks each arm of consume in isolation.
+func TestDiffTextCompactor_ConsumeRouting(t *testing.T) {
+	c := &diffTextCompactor{cfg: cxCfg(func(cfg *CompactorConfig) { cfg.MaxDiffHunkLines = 1 })}
+
+	c.consume("--- a/x.go") // passthrough, no hunk open yet
+	if c.inHunk {
+		t.Error("passthrough line should not open a hunk")
+	}
+
+	c.consume("@@ -1 +1 @@")
+	if !c.inHunk || c.hunkLines != 0 {
+		t.Errorf("hunk header: inHunk=%v hunkLines=%d, want true/0", c.inHunk, c.hunkLines)
+	}
+
+	c.consume("+one") // kept, counted as an addition
+	c.consume("-two") // over MaxDiffHunkLines: counted but not emitted
+	if c.additions != 1 || c.deletions != 1 {
+		t.Errorf("additions/deletions = %d/%d, want 1/1", c.additions, c.deletions)
+	}
+
+	c.consume("diff --git a/y.go b/y.go")
+	if c.currentFile != "y.go" {
+		t.Errorf("currentFile = %q, want y.go", c.currentFile)
+	}
+	if c.inHunk || c.additions != 0 || c.deletions != 0 {
+		t.Errorf("file header should reset hunk state, got inHunk=%v +%d -%d", c.inHunk, c.additions, c.deletions)
+	}
+
+	want := "--- a/x.go\n@@ -1 +1 @@\n+one\ndiff --git a/y.go b/y.go\n"
+	if got := c.b.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+	if c.totalLines != 4 {
+		t.Errorf("totalLines = %d, want 4", c.totalLines)
+	}
+}
+
+func TestIncludeOrDefault(t *testing.T) {
+	yes, no := true, false
+	tests := []struct {
+		name string
+		flag *bool
+		want bool
+	}{
+		{name: "unset defaults to true", want: true},
+		{name: "explicit true", flag: &yes, want: true},
+		{name: "explicit false", flag: &no, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := includeOrDefault(tc.flag); got != tc.want {
+				t.Errorf("includeOrDefault = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCollectGitHead_EmptyRepo pins the "HEAD does not resolve yet" path, where
+// both branch and commit list are left unset.
+func TestCollectGitHead_EmptyRepo(t *testing.T) {
+	dir := initGitRepo(t)
+	var out GitOverviewOutput
+	collectGitHead(nil, dir, &out)
+	if len(out.RecentCommits) != 0 {
+		t.Errorf("recent commits = %v, want none in an empty repo", out.RecentCommits)
+	}
+}
+
+// TestCollectGitStatusFiles_NotARepo pins the early return when git status fails.
+func TestCollectGitStatusFiles_NotARepo(t *testing.T) {
+	var out GitOverviewOutput
+	collectGitStatusFiles(nil, t.TempDir(), GitOverviewInput{}, &out)
+	if out.StagedFiles != nil || out.UnstagedFiles != nil || out.UntrackedFiles != nil {
+		t.Errorf("expected no file lists outside a repo, got %+v", out)
+	}
+}
+
+// TestCollectGitUpstream_NoUpstream pins the early return when the branch tracks
+// nothing.
+func TestCollectGitUpstream_NoUpstream(t *testing.T) {
+	var out GitOverviewOutput
+	collectGitUpstream(nil, initGitRepo(t), &out)
+	if out.Upstream != "" || out.Ahead != 0 || out.Behind != 0 {
+		t.Errorf("expected no upstream info, got %+v", out)
+	}
+}
+
+func TestCompileGrepPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   GrepInput
+		probe   string
+		wantHit bool
+		wantErr bool
+	}{
+		{name: "case sensitive miss", input: GrepInput{Pattern: "Needle"}, probe: "needle", wantHit: false},
+		{name: "case sensitive hit", input: GrepInput{Pattern: "Needle"}, probe: "Needle", wantHit: true},
+		{name: "case insensitive hit", input: GrepInput{Pattern: "Needle", CaseInsensitive: true}, probe: "needle", wantHit: true},
+		{name: "invalid pattern", input: GrepInput{Pattern: "[unclosed"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			re, err := compileGrepPattern(tc.input)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "invalid regex pattern") {
+					t.Fatalf("err = %v, want invalid regex pattern", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := re.MatchString(tc.probe); got != tc.wantHit {
+				t.Errorf("MatchString(%q) = %v, want %v", tc.probe, got, tc.wantHit)
+			}
+		})
+	}
+}
+
+// TestCompileGrepPattern_CacheKeyIsCaseAware guards the cache key: the same
+// pattern with and without CaseInsensitive must not share an entry.
+func TestCompileGrepPattern_CacheKeyIsCaseAware(t *testing.T) {
+	pattern := "CxCacheKeyProbe"
+
+	sensitive, err := compileGrepPattern(GrepInput{Pattern: pattern})
+	if err != nil {
+		t.Fatal(err)
+	}
+	insensitive, err := compileGrepPattern(GrepInput{Pattern: pattern, CaseInsensitive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sensitive.MatchString("cxcachekeyprobe") {
+		t.Error("case-sensitive regex should not match lower case")
+	}
+	if !insensitive.MatchString("cxcachekeyprobe") {
+		t.Error("case-insensitive regex should match lower case")
+	}
+
+	// Second call for the same key comes back from the cache.
+	cached, err := compileGrepPattern(GrepInput{Pattern: pattern})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached != sensitive {
+		t.Error("expected the cached *regexp.Regexp to be reused")
+	}
+}

--- a/internal/tools/complexity_core_test.go
+++ b/internal/tools/complexity_core_test.go
@@ -1,0 +1,1265 @@
+package tools
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/dimetron/pi-go/internal/lsp"
+)
+
+// This file pins the behavior of the helpers extracted while reducing
+// cyclomatic complexity in lsp.go, read.go, registry.go, session_stats.go and
+// session_sweep.go. Each test exercises a boundary the original branch
+// structure encoded, so a behavioral drift shows up here rather than in the
+// tool output.
+
+// --- lsp.go: symbolKindName ------------------------------------------------
+
+// TestSymbolKindNameTable checks every entry of the lookup table that replaced
+// the dispatch switch, including the fallback for unmapped kinds.
+func TestSymbolKindNameTable(t *testing.T) {
+	want := map[int]string{
+		1: "file", 2: "module", 3: "namespace", 4: "package", 5: "class",
+		6: "method", 7: "property", 8: "field", 9: "constructor", 10: "enum",
+		11: "interface", 12: "function", 13: "variable", 14: "constant",
+		23: "struct",
+	}
+	for kind, name := range want {
+		if got := symbolKindName(kind); got != name {
+			t.Errorf("symbolKindName(%d) = %q, want %q", kind, got, name)
+		}
+	}
+	if len(symbolKindNames) != len(want) {
+		t.Errorf("symbolKindNames has %d entries, want %d", len(symbolKindNames), len(want))
+	}
+	// Kinds the table does not carry fall through to the numeric form, both
+	// inside the recognized range (15-22 are unmapped) and outside it.
+	for _, kind := range []int{0, 15, 22, 24, 999, -1} {
+		if got, want := symbolKindName(kind), fmt.Sprintf("kind(%d)", kind); got != want {
+			t.Errorf("symbolKindName(%d) = %q, want %q", kind, got, want)
+		}
+	}
+	// The constants and the table must not have drifted apart.
+	if symbolKindName(lsp.SymbolKindStruct) != "struct" {
+		t.Error("lsp.SymbolKindStruct is no longer mapped to \"struct\"")
+	}
+}
+
+// --- read.go: readNonText --------------------------------------------------
+
+func TestReadNonText(t *testing.T) {
+	dir := t.TempDir()
+	sb := testSandbox(t, dir)
+
+	t.Run("plain text is not handled", func(t *testing.T) {
+		path := writeFile(t, dir, "plain.txt", "hello\nworld\n")
+		out, handled, err := readNonText(sb, path, 12)
+		if err != nil {
+			t.Fatalf("readNonText: %v", err)
+		}
+		if handled {
+			t.Fatalf("plain text should be left to the caller, got %+v", out)
+		}
+	})
+
+	t.Run("binary is handled without returning its bytes", func(t *testing.T) {
+		path := writeFile(t, dir, "blob.bin", "MZ\x00\x01\x02binary")
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, handled, err := readNonText(sb, path, info.Size())
+		if err != nil {
+			t.Fatalf("readNonText: %v", err)
+		}
+		if !handled {
+			t.Fatal("binary file should be handled")
+		}
+		if strings.Contains(out.Content, "\x00") {
+			t.Error("binary bytes leaked into the output")
+		}
+	})
+
+	t.Run("notebook is rendered", func(t *testing.T) {
+		nb := `{"cells":[{"cell_type":"code","source":["print(1)\n"]}]}`
+		path := writeFile(t, dir, "nb.ipynb", nb)
+		out, handled, err := readNonText(sb, path, int64(len(nb)))
+		if err != nil {
+			t.Fatalf("readNonText: %v", err)
+		}
+		if !handled {
+			t.Fatal("notebook should be handled")
+		}
+		if !strings.Contains(out.Note, "Jupyter notebook") {
+			t.Errorf("note does not mention the notebook rendering: %q", out.Note)
+		}
+	})
+
+	t.Run("unreadable file reports handled so the caller stops", func(t *testing.T) {
+		_, handled, err := readNonText(sb, filepath.Join(dir, "missing.txt"), 1)
+		if err == nil {
+			t.Fatal("expected an error for a missing file")
+		}
+		if !handled {
+			t.Error("an error must still stop the caller from windowing the file")
+		}
+		if !strings.HasPrefix(err.Error(), "reading file: ") {
+			t.Errorf("error lost its wrapper: %v", err)
+		}
+	})
+}
+
+// --- read.go: renderWindow -------------------------------------------------
+
+func TestRenderWindow(t *testing.T) {
+	tests := []struct {
+		name       string
+		win        window
+		offset     int
+		totalLines int
+		wantNote   string
+		wantNext   int
+		wantTrunc  bool
+		wantInBody string
+	}{
+		{
+			name:       "complete window has no note",
+			win:        window{content: "     1\ta\n", lastLine: 1},
+			offset:     1,
+			totalLines: 1,
+		},
+		{
+			name:       "clamped lines are reported without truncating",
+			win:        window{content: "     1\ta\n", lastLine: 1, clampedLines: 2},
+			offset:     1,
+			totalLines: 1,
+			wantNote:   "2 line(s) longer than 2000 characters were clipped; the clipped part is marked inline.",
+		},
+		{
+			name: "limit stop names the resume offset",
+			win: window{
+				content: "     1\ta\n", lastLine: 1,
+				stoppedEarly: true, nextOffset: 2,
+			},
+			offset:     1,
+			totalLines: 9,
+			wantNote:   "showing lines 1-1 of 9; continue with offset=2.",
+			wantNext:   2,
+			wantTrunc:  true,
+			wantInBody: "... (truncated: showing lines 1-1 of 9; continue with offset=2)",
+		},
+		{
+			name: "byte budget stop says so",
+			win: window{
+				content: "     3\tc\n", lastLine: 4,
+				stoppedEarly: true, hitByteBudget: true, nextOffset: 5,
+			},
+			offset:     3,
+			totalLines: 40,
+			wantNote:   fmt.Sprintf("showing lines 3-4 of 40 (stopped at the %dKB output budget); continue with offset=5.", readByteBudget/1024),
+			wantNext:   5,
+			wantTrunc:  true,
+		},
+		{
+			name: "both notes are joined",
+			win: window{
+				content: "     1\ta\n", lastLine: 1, clampedLines: 1,
+				stoppedEarly: true, nextOffset: 2,
+			},
+			offset:     1,
+			totalLines: 5,
+			wantNote: "1 line(s) longer than 2000 characters were clipped; the clipped part is marked inline. " +
+				"showing lines 1-1 of 5; continue with offset=2.",
+			wantNext:  2,
+			wantTrunc: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := renderWindow(tt.win, tt.offset, tt.totalLines)
+			if out.Note != tt.wantNote {
+				t.Errorf("note = %q, want %q", out.Note, tt.wantNote)
+			}
+			if out.NextOffset != tt.wantNext {
+				t.Errorf("next offset = %d, want %d", out.NextOffset, tt.wantNext)
+			}
+			if out.Truncated != tt.wantTrunc {
+				t.Errorf("truncated = %v, want %v", out.Truncated, tt.wantTrunc)
+			}
+			if out.TotalLines != tt.totalLines {
+				t.Errorf("total lines = %d, want %d", out.TotalLines, tt.totalLines)
+			}
+			if tt.wantInBody != "" && !strings.Contains(out.Content, tt.wantInBody) {
+				t.Errorf("content %q does not contain %q", out.Content, tt.wantInBody)
+			}
+		})
+	}
+
+	t.Run("base64 images are stripped from the window", func(t *testing.T) {
+		win := window{content: "     1\t![shot](data:image/png;base64,AAAA)\n", lastLine: 1}
+		out := renderWindow(win, 1, 1)
+		if strings.Contains(out.Content, "AAAA") {
+			t.Errorf("base64 payload survived: %q", out.Content)
+		}
+	})
+}
+
+// --- read.go: readSrcLine, srcLine.endsFile, window.emitLine ---------------
+
+func TestReadSrcLine(t *testing.T) {
+	t.Run("line with terminator is not at EOF", func(t *testing.T) {
+		r := bufio.NewReader(strings.NewReader("alpha\nbeta\n"))
+		src, err := readSrcLine(r)
+		if err != nil {
+			t.Fatalf("readSrcLine: %v", err)
+		}
+		if src.text != "alpha" || src.clipped != 0 || src.atEOF {
+			t.Errorf("got %+v, want {alpha 0 false}", src)
+		}
+	})
+
+	t.Run("final unterminated line carries atEOF", func(t *testing.T) {
+		r := bufio.NewReader(strings.NewReader("tail"))
+		src, err := readSrcLine(r)
+		if err != nil {
+			t.Fatalf("readSrcLine: %v", err)
+		}
+		if src.text != "tail" || !src.atEOF {
+			t.Errorf("got %+v, want {tail 0 true}", src)
+		}
+	})
+
+	t.Run("EOF is not an error", func(t *testing.T) {
+		r := bufio.NewReader(strings.NewReader(""))
+		src, err := readSrcLine(r)
+		if err != nil {
+			t.Fatalf("EOF must not surface as an error: %v", err)
+		}
+		if src.text != "" || !src.atEOF {
+			t.Errorf("got %+v, want the empty phantom line at EOF", src)
+		}
+	})
+
+	t.Run("over-long line is clipped and counted", func(t *testing.T) {
+		long := strings.Repeat("x", maxReadLineChars+37)
+		r := bufio.NewReader(strings.NewReader(long + "\n"))
+		src, err := readSrcLine(r)
+		if err != nil {
+			t.Fatalf("readSrcLine: %v", err)
+		}
+		if len(src.text) != maxReadLineChars {
+			t.Errorf("kept %d bytes, want %d", len(src.text), maxReadLineChars)
+		}
+		if src.clipped != 37 {
+			t.Errorf("clipped = %d, want 37", src.clipped)
+		}
+	})
+}
+
+func TestSrcLineEndsFile(t *testing.T) {
+	tests := []struct {
+		name string
+		src  srcLine
+		line int
+		want bool
+	}{
+		{"phantom line after the final newline", srcLine{atEOF: true}, 3, true},
+		{"empty first read of an empty file", srcLine{atEOF: true}, 0, false},
+		{"blank line in the middle of a file", srcLine{}, 3, false},
+		{"content at EOF is real", srcLine{text: "x", atEOF: true}, 3, false},
+		{"clipped-only line at EOF is real", srcLine{clipped: 5, atEOF: true}, 3, false},
+		// A lone CR is not empty until it is normalized, which happens after
+		// this check — so it still counts as a line.
+		{"lone carriage return at EOF is a line", srcLine{text: "\r", atEOF: true}, 3, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.src.endsFile(tt.line); got != tt.want {
+				t.Errorf("endsFile(%d) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindowEmitLine(t *testing.T) {
+	t.Run("line inside the limit is written and does not close the window", func(t *testing.T) {
+		var b strings.Builder
+		var w window
+		r := bufio.NewReader(strings.NewReader("more\n"))
+		if w.emitLine(&b, r, srcLine{text: "hello"}, 1, 1, 10) {
+			t.Fatal("window closed early")
+		}
+		if b.String() != "     1\thello\n" {
+			t.Errorf("wrote %q", b.String())
+		}
+		if w.lastLine != 1 || w.stoppedEarly {
+			t.Errorf("window = %+v", w)
+		}
+	})
+
+	t.Run("clipped line gets the inline marker", func(t *testing.T) {
+		var b strings.Builder
+		var w window
+		r := bufio.NewReader(strings.NewReader(""))
+		w.emitLine(&b, r, srcLine{text: "abc", clipped: 9}, 1, 1, 10)
+		if !strings.Contains(b.String(), "… [9 more characters on this line, clipped]") {
+			t.Errorf("missing clip marker in %q", b.String())
+		}
+		if w.clampedLines != 1 {
+			t.Errorf("clampedLines = %d, want 1", w.clampedLines)
+		}
+	})
+
+	t.Run("limit reached with more to read truncates", func(t *testing.T) {
+		var b strings.Builder
+		var w window
+		r := bufio.NewReader(strings.NewReader("next line\n"))
+		if !w.emitLine(&b, r, srcLine{text: "last"}, 2, 1, 2) {
+			t.Fatal("hitting the limit must close the window")
+		}
+		if !w.stoppedEarly || w.nextOffset != 3 {
+			t.Errorf("window = %+v, want stoppedEarly with nextOffset 3", w)
+		}
+	})
+
+	t.Run("limit reached exactly at EOF is not truncation", func(t *testing.T) {
+		var b strings.Builder
+		var w window
+		r := bufio.NewReader(strings.NewReader(""))
+		if !w.emitLine(&b, r, srcLine{text: "last", atEOF: true}, 2, 1, 2) {
+			t.Fatal("hitting the limit must close the window")
+		}
+		if w.stoppedEarly || w.nextOffset != 0 {
+			t.Errorf("window = %+v, want a clean end", w)
+		}
+	})
+
+	t.Run("limit reached with an exhausted reader is not truncation", func(t *testing.T) {
+		var b strings.Builder
+		var w window
+		r := bufio.NewReader(strings.NewReader(""))
+		if !w.emitLine(&b, r, srcLine{text: "last"}, 2, 1, 2) {
+			t.Fatal("hitting the limit must close the window")
+		}
+		if w.stoppedEarly {
+			t.Errorf("nothing left to read, yet window = %+v", w)
+		}
+	})
+
+	t.Run("byte budget stops before committing the line", func(t *testing.T) {
+		var b strings.Builder
+		b.WriteString(strings.Repeat("x", readByteBudget))
+		before := b.Len()
+		var w window
+		r := bufio.NewReader(strings.NewReader(""))
+		if !w.emitLine(&b, r, srcLine{text: "overflow"}, 7, 1, 100) {
+			t.Fatal("the byte budget must close the window")
+		}
+		if b.Len() != before {
+			t.Error("the line that did not fit was written anyway")
+		}
+		if !w.hitByteBudget || !w.stoppedEarly || w.nextOffset != 7 {
+			t.Errorf("window = %+v, want a budget stop resuming at line 7", w)
+		}
+	})
+
+	t.Run("the first line is never rejected by the budget", func(t *testing.T) {
+		var b strings.Builder
+		var w window
+		r := bufio.NewReader(strings.NewReader(""))
+		huge := strings.Repeat("y", readByteBudget+1)
+		if w.emitLine(&b, r, srcLine{text: huge}, 1, 1, 100) {
+			t.Fatal("an empty buffer must accept the line whatever its size")
+		}
+		if b.Len() == 0 {
+			t.Error("the first line was dropped")
+		}
+	})
+}
+
+// --- registry.go: effectiveSchemaType, markCoerceProp ----------------------
+
+func TestEffectiveSchemaType(t *testing.T) {
+	tests := []struct {
+		name string
+		prop *jsonschema.Schema
+		want string
+	}{
+		{"single type wins", &jsonschema.Schema{Type: "integer"}, "integer"},
+		{"single type beats Types", &jsonschema.Schema{Type: "integer", Types: []string{"boolean"}}, "integer"},
+		{"first non-null of Types", &jsonschema.Schema{Types: []string{"null", "array"}}, "array"},
+		{"leading non-null of Types", &jsonschema.Schema{Types: []string{"object", "null"}}, "object"},
+		{"only null yields nothing", &jsonschema.Schema{Types: []string{"null"}}, ""},
+		{"no type at all", &jsonschema.Schema{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveSchemaType(tt.prop); got != tt.want {
+				t.Errorf("effectiveSchemaType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarkCoerceProp(t *testing.T) {
+	t.Run("top level registers only the full path", func(t *testing.T) {
+		props := map[string]bool{}
+		markCoerceProp(props, "", "depth", "depth")
+		if len(props) != 1 || !props["depth"] {
+			t.Errorf("props = %v, want only depth", props)
+		}
+	})
+	t.Run("nested also registers the bare name", func(t *testing.T) {
+		props := map[string]bool{}
+		markCoerceProp(props, "tasks.$", "depth", "tasks.$.depth")
+		if !props["tasks.$.depth"] || !props["depth"] {
+			t.Errorf("props = %v, want both the full path and the bare name", props)
+		}
+	})
+}
+
+// TestCollectFromSchemaNested pins the shape the extracted helpers must
+// reproduce: nested objects, array items, and multi-type properties.
+func TestCollectFromSchemaNested(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Properties: map[string]*jsonschema.Schema{
+			"tasks": {
+				Type: "array",
+				Items: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"depth":   {Type: "integer"},
+						"verbose": {Type: "boolean"},
+						"tags":    {Types: []string{"null", "array"}},
+					},
+				},
+			},
+			"opts": {
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"limit": {Type: "number"},
+				},
+			},
+			"label": {Type: "string"},
+		},
+	}
+	intP, boolP, jsonP := collectCoerceProps(schema)
+
+	for _, want := range []string{"tasks.$.depth", "depth", "opts.limit", "limit"} {
+		if !intP[want] {
+			t.Errorf("intProps missing %q (got %v)", want, intP)
+		}
+	}
+	for _, want := range []string{"tasks.$.verbose", "verbose"} {
+		if !boolP[want] {
+			t.Errorf("boolProps missing %q (got %v)", want, boolP)
+		}
+	}
+	for _, want := range []string{"tasks", "opts", "tasks.$.tags", "tags"} {
+		if !jsonP[want] {
+			t.Errorf("jsonProps missing %q (got %v)", want, jsonP)
+		}
+	}
+	if intP["label"] || boolP["label"] || jsonP["label"] {
+		t.Error("a string property must not be registered for coercion")
+	}
+}
+
+// --- registry.go: coerceStringValue, parseStringifiedJSON, numberAsFloat64 --
+
+func TestCoerceStringValue(t *testing.T) {
+	c := &coercingTool{
+		intProps:  map[string]bool{"n": true},
+		boolProps: map[string]bool{"b": true},
+		jsonProps: map[string]bool{"j": true},
+	}
+	tests := []struct {
+		name string
+		in   string
+		path string
+		want any
+	}{
+		{"integer string becomes float64", "42", "n", float64(42)},
+		{"float string becomes float64", "1.5", "n", 1.5},
+		{"negative integer", "-7", "n", float64(-7)},
+		{"unparseable number stays put", "many", "n", nil},
+		{"bool word", "true", "b", true},
+		{"bool digit", "0", "b", false},
+		{"unparseable bool stays put", "yes please", "b", nil},
+		{"stringified array", `["a"]`, "j", []any{"a"}},
+		{"unregistered path is untouched", "42", "other", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.coerceStringValue(tt.in, tt.path)
+			if fmt.Sprint(got) != fmt.Sprint(tt.want) {
+				t.Errorf("coerceStringValue(%q, %q) = %#v, want %#v", tt.in, tt.path, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("int registration takes precedence over bool", func(t *testing.T) {
+		both := &coercingTool{
+			intProps:  map[string]bool{"x": true},
+			boolProps: map[string]bool{"x": true},
+		}
+		if got := both.coerceStringValue("1", "x"); got != float64(1) {
+			t.Errorf("got %#v, want float64(1) — intProps is checked first", got)
+		}
+	})
+}
+
+func TestParseStringifiedJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string // fmt.Sprint of the result
+	}{
+		{"array", `["a","b"]`, "[a b]"},
+		{"object", `{"k":1}`, "map[k:1]"},
+		{"surrounding space is tolerated", "  [1]  ", "[1]"},
+		{"unbracketed string", "plain", "<nil>"},
+		{"quoted scalar is not a document", `"plain"`, "<nil>"},
+		{"mismatched brackets", `[1}`, "<nil>"},
+		{"bracketed but invalid JSON", `[1,]`, "<nil>"},
+		{"empty", "", "<nil>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fmt.Sprint(parseStringifiedJSON(tt.in)); got != tt.want {
+				t.Errorf("parseStringifiedJSON(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNumberAsFloat64(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"float64 passes through", float64(3), float64(3)},
+		{"float32", float32(2.5), 2.5},
+		{"int", int(4), float64(4)},
+		{"int64", int64(5), float64(5)},
+		{"int32", int32(6), float64(6)},
+		{"uint is not converted", uint(7), nil},
+		{"string is not converted", "8", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := numberAsFloat64(tt.in); got != tt.want {
+				t.Errorf("numberAsFloat64(%#v) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTryCoerceByInputType(t *testing.T) {
+	c := &coercingTool{intProps: map[string]bool{"n": true}}
+
+	if got := c.tryCoerce(float64(9), "n"); got != nil {
+		t.Errorf("a float64 is already in JSON form, got %#v", got)
+	}
+	if got := c.tryCoerce(int64(9), "n"); got != float64(9) {
+		t.Errorf("int64 = %#v, want float64(9)", got)
+	}
+	if got := c.tryCoerce(int64(9), "other"); got != nil {
+		t.Errorf("an unregistered path must not coerce, got %#v", got)
+	}
+	if got := c.tryCoerce(json.Number("12"), "n"); got != float64(12) {
+		t.Errorf("json.Number = %#v, want float64(12)", got)
+	}
+	if got := c.tryCoerce(json.Number("nope"), "n"); got != nil {
+		t.Errorf("an unparseable json.Number must stay put, got %#v", got)
+	}
+	if got := c.tryCoerce(json.Number("12"), "other"); got != nil {
+		t.Errorf("an unregistered path must not coerce, got %#v", got)
+	}
+	if got := c.tryCoerce(true, "n"); got != nil {
+		t.Errorf("an unhandled type must stay put, got %#v", got)
+	}
+}
+
+// --- registry.go: coerceAtPath, coerceArrayItemProp ------------------------
+
+func TestCoerceAtPath(t *testing.T) {
+	c := &coercingTool{intProps: map[string]bool{"depth": true}}
+
+	t.Run("registered path coerces", func(t *testing.T) {
+		obj := map[string]any{"depth": "3"}
+		c.coerceAtPath(obj, "depth", "depth", "3")
+		if obj["depth"] != float64(3) {
+			t.Errorf("depth = %#v, want float64(3)", obj["depth"])
+		}
+	})
+
+	t.Run("unregistered path leaves the value alone", func(t *testing.T) {
+		obj := map[string]any{"depth": "3"}
+		c.coerceAtPath(obj, "depth", "other.depth", "3")
+		if obj["depth"] != "3" {
+			t.Errorf("depth = %#v, want the untouched string", obj["depth"])
+		}
+	})
+
+	t.Run("registered but uncoercible leaves the value alone", func(t *testing.T) {
+		obj := map[string]any{"depth": "deep"}
+		c.coerceAtPath(obj, "depth", "depth", "deep")
+		if obj["depth"] != "deep" {
+			t.Errorf("depth = %#v, want the untouched string", obj["depth"])
+		}
+	})
+
+	t.Run("the passed value is used, not the map's current one", func(t *testing.T) {
+		obj := map[string]any{"depth": "999"}
+		c.coerceAtPath(obj, "depth", "depth", "3")
+		if obj["depth"] != float64(3) {
+			t.Errorf("depth = %#v, want float64(3) from the passed value", obj["depth"])
+		}
+	})
+}
+
+func TestCoerceArrayItemProp(t *testing.T) {
+	c := &coercingTool{
+		intProps:  map[string]bool{"tasks.$.depth": true},
+		boolProps: map[string]bool{"tasks.$.verbose": true},
+		jsonProps: map[string]bool{"tasks.$.tags": true},
+	}
+
+	t.Run("parent.$ path coerces an array item property", func(t *testing.T) {
+		obj := map[string]any{"depth": "3", "verbose": "true", "tags": `["x"]`}
+		for _, k := range []string{"depth", "verbose", "tags"} {
+			c.coerceArrayItemProp(obj, k, "tasks")
+		}
+		if obj["depth"] != float64(3) {
+			t.Errorf("depth = %#v", obj["depth"])
+		}
+		if obj["verbose"] != true {
+			t.Errorf("verbose = %#v", obj["verbose"])
+		}
+		if fmt.Sprint(obj["tags"]) != "[x]" {
+			t.Errorf("tags = %#v", obj["tags"])
+		}
+	})
+
+	t.Run("unregistered property is untouched", func(t *testing.T) {
+		obj := map[string]any{"name": "7"}
+		c.coerceArrayItemProp(obj, "name", "tasks")
+		if obj["name"] != "7" {
+			t.Errorf("name = %#v, want the untouched string", obj["name"])
+		}
+	})
+
+	t.Run("nested arrays recurse under the dotted path", func(t *testing.T) {
+		nested := &coercingTool{intProps: map[string]bool{"tasks.chain.$.depth": true}}
+		obj := map[string]any{"chain": []any{map[string]any{"depth": "4"}}}
+		nested.coerceArrayItemProp(obj, "chain", "tasks")
+		inner, ok := obj["chain"].([]any)[0].(map[string]any)
+		if !ok {
+			t.Fatalf("chain item is %#v", obj["chain"])
+		}
+		if inner["depth"] != float64(4) {
+			t.Errorf("nested depth = %#v, want float64(4)", inner["depth"])
+		}
+	})
+}
+
+// TestCoerceArgsEndToEnd exercises the whole coercion path over a payload of
+// the shape the LLM actually sends, so the split helpers are checked together.
+func TestCoerceArgsEndToEnd(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Properties: map[string]*jsonschema.Schema{
+			"tasks": {
+				Type: "array",
+				Items: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"depth":   {Type: "integer"},
+						"verbose": {Type: "boolean"},
+					},
+				},
+			},
+			"limit": {Type: "integer"},
+		},
+	}
+	intP, boolP, jsonP := collectCoerceProps(schema)
+	c := &coercingTool{intProps: intP, boolProps: boolP, jsonProps: jsonP}
+
+	args := map[string]any{
+		"limit": "5",
+		"tasks": `[{"depth":"2","verbose":"false"}]`,
+	}
+	c.coerceArgs(args)
+
+	if args["limit"] != float64(5) {
+		t.Errorf("limit = %#v, want float64(5)", args["limit"])
+	}
+	tasks, ok := args["tasks"].([]any)
+	if !ok {
+		t.Fatalf("tasks was not parsed out of its string form: %#v", args["tasks"])
+	}
+	first, ok := tasks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("task item = %#v", tasks[0])
+	}
+	if first["depth"] != float64(2) {
+		t.Errorf("depth = %#v, want float64(2)", first["depth"])
+	}
+	if first["verbose"] != false {
+		t.Errorf("verbose = %#v, want false", first["verbose"])
+	}
+}
+
+// --- session_stats.go: option resolution and scanning ----------------------
+
+func TestResolveSessionStatsOptions(t *testing.T) {
+	t.Run("defaults fill in", func(t *testing.T) {
+		before := time.Now()
+		opts, err := resolveSessionStatsOptions(SessionStatsInput{SessionDir: "/tmp/x"})
+		if err != nil {
+			t.Fatalf("resolveSessionStatsOptions: %v", err)
+		}
+		if opts.highToolCalls != 20 || opts.highTurns != 5 || opts.hours != 24 {
+			t.Errorf("opts = %+v, want the documented defaults", opts)
+		}
+		if want := before.Add(-24 * time.Hour); opts.cutoff.Before(want.Add(-time.Minute)) {
+			t.Errorf("cutoff %v is not ~24h back from %v", opts.cutoff, before)
+		}
+	})
+
+	t.Run("explicit values win", func(t *testing.T) {
+		opts, err := resolveSessionStatsOptions(SessionStatsInput{
+			SessionDir: "/tmp/x", HighToolCalls: 3, HighTurns: 2, Hours: 1,
+		})
+		if err != nil {
+			t.Fatalf("resolveSessionStatsOptions: %v", err)
+		}
+		if opts.highToolCalls != 3 || opts.highTurns != 2 || opts.hours != 1 {
+			t.Errorf("opts = %+v, want the caller's values", opts)
+		}
+	})
+
+	t.Run("negative values fall back to the defaults", func(t *testing.T) {
+		opts, err := resolveSessionStatsOptions(SessionStatsInput{
+			SessionDir: "/tmp/x", HighToolCalls: -1, HighTurns: -1, Hours: -1,
+		})
+		if err != nil {
+			t.Fatalf("resolveSessionStatsOptions: %v", err)
+		}
+		if opts.highToolCalls != 20 || opts.highTurns != 5 || opts.hours != 24 {
+			t.Errorf("opts = %+v, want the documented defaults", opts)
+		}
+	})
+
+	t.Run("empty dir resolves under the home directory", func(t *testing.T) {
+		opts, err := resolveSessionStatsOptions(SessionStatsInput{})
+		if err != nil {
+			t.Skipf("no home directory available: %v", err)
+		}
+		if !strings.HasSuffix(opts.sessionDir, filepath.Join(".pi-go", "sessions")) {
+			t.Errorf("sessionDir = %q, want it under ~/.pi-go/sessions", opts.sessionDir)
+		}
+	})
+}
+
+func TestScanSessions(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	event := func(author string, turnComplete bool) string {
+		b, err := json.Marshal(map[string]any{
+			"Timestamp": now.Format(time.RFC3339Nano), "Author": author, "TurnComplete": turnComplete,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+
+	writeEvents(t, root, "live", event("pi", true))
+	writeEvents(t, root, "archive", event("pi", true))
+	// A plain file, not a directory, must be skipped.
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A directory without events.jsonl must be skipped.
+	if err := os.MkdirAll(filepath.Join(root, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A session older than the cutoff must be skipped.
+	writeEvents(t, root, "stale", event("pi", true))
+	old := now.Add(-72 * time.Hour)
+	if err := os.Chtimes(filepath.Join(root, "stale", "events.jsonl"), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := sessionStatsOptions{
+		sessionDir: root, highToolCalls: 20, highTurns: 5, hours: 24,
+		cutoff: now.Add(-24 * time.Hour),
+	}
+	stats, totals, err := scanSessions(opts)
+	if err != nil {
+		t.Fatalf("scanSessions: %v", err)
+	}
+	if totals == nil {
+		t.Fatal("totals must be allocated even when nothing accumulates")
+	}
+	if len(stats) != 1 || stats[0].ID != "live" {
+		ids := make([]string, len(stats))
+		for i, s := range stats {
+			ids[i] = s.ID
+		}
+		t.Fatalf("scanned %v, want only [live]", ids)
+	}
+
+	t.Run("a missing directory is an error", func(t *testing.T) {
+		opts := opts
+		opts.sessionDir = filepath.Join(root, "nope")
+		if _, _, err := scanSessions(opts); err == nil {
+			t.Fatal("expected an error for a missing sessions dir")
+		} else if !strings.HasPrefix(err.Error(), "reading sessions dir: ") {
+			t.Errorf("error lost its wrapper: %v", err)
+		}
+	})
+}
+
+// --- session_stats.go: counters and anomalies ------------------------------
+
+func TestSessionCountersObserveTimestamp(t *testing.T) {
+	var c sessionCounters
+	early := "2026-01-01T10:00:00Z"
+	late := "2026-01-01T12:30:00Z"
+
+	c.observeTimestamp("")           // ignored
+	c.observeTimestamp("not a time") // ignored
+	c.observeTimestamp(late)         // sets both ends
+	c.observeTimestamp(early)        // widens the start
+	c.observeTimestamp("2026-01-01T11:00:00Z")
+
+	if got := c.firstTS.Format(time.RFC3339); got != "2026-01-01T10:00:00Z" {
+		t.Errorf("firstTS = %s, want the earliest timestamp", got)
+	}
+	if got := c.lastTS.Format(time.RFC3339); got != "2026-01-01T12:30:00Z" {
+		t.Errorf("lastTS = %s, want the latest timestamp", got)
+	}
+}
+
+func TestSessionCountersObserveContent(t *testing.T) {
+	tests := []struct {
+		name                             string
+		content                          any
+		wantCalls, wantResults, wantGits int
+	}{
+		{"nil content", nil, 0, 0, 0},
+		{"content is not an object", "text", 0, 0, 0},
+		{"no parts key", map[string]any{"role": "user"}, 0, 0, 0},
+		{"parts is not a list", map[string]any{"parts": "nope"}, 0, 0, 0},
+		{"a part that is not an object is skipped", map[string]any{"parts": []any{"nope"}}, 0, 0, 0},
+		{
+			"a plain text part counts for nothing",
+			map[string]any{"parts": []any{map[string]any{"text": "hi"}}},
+			0, 0, 0,
+		},
+		{
+			"function calls and responses are counted separately",
+			map[string]any{"parts": []any{
+				map[string]any{"functionCall": map[string]any{"name": "read"}},
+				map[string]any{"functionResponse": map[string]any{"name": "read"}},
+			}},
+			1, 1, 0,
+		},
+		{
+			"a git tool call is also a git op",
+			map[string]any{"parts": []any{
+				map[string]any{"functionCall": map[string]any{"name": "git-overview"}},
+			}},
+			1, 0, 1,
+		},
+		{
+			"a bash git command is a git op",
+			map[string]any{"parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "bash", "args": map[string]any{"command": "  git status"},
+				}},
+			}},
+			1, 0, 1,
+		},
+		{
+			"a bash non-git command is not",
+			map[string]any{"parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "bash", "args": map[string]any{"command": "ls"},
+				}},
+			}},
+			1, 0, 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c sessionCounters
+			c.observeContent(tt.content)
+			if c.toolCalls != tt.wantCalls || c.toolResults != tt.wantResults || c.gitOps != tt.wantGits {
+				t.Errorf("calls=%d results=%d gits=%d, want %d/%d/%d",
+					c.toolCalls, c.toolResults, c.gitOps, tt.wantCalls, tt.wantResults, tt.wantGits)
+			}
+		})
+	}
+}
+
+func TestSessionCountersObserve(t *testing.T) {
+	t.Run("a model turn counts, a user turn does not", func(t *testing.T) {
+		var c sessionCounters
+		c.observe(&sessionEvent{TurnComplete: true, Author: "pi"})
+		c.observe(&sessionEvent{TurnComplete: true, Author: "user"})
+		c.observe(&sessionEvent{TurnComplete: false, Author: "pi"})
+		if c.turns != 1 {
+			t.Errorf("turns = %d, want 1", c.turns)
+		}
+	})
+
+	t.Run("one event is at most one error", func(t *testing.T) {
+		var c sessionCounters
+		c.observe(&sessionEvent{ErrorCode: "E", ErrorMessage: "boom", Interrupted: true})
+		if c.errors != 1 {
+			t.Errorf("errors = %d, want 1", c.errors)
+		}
+	})
+
+	t.Run("each error signal alone counts", func(t *testing.T) {
+		for _, ev := range []sessionEvent{
+			{ErrorCode: "E"}, {ErrorMessage: "boom"}, {Interrupted: true},
+		} {
+			var c sessionCounters
+			c.observe(&ev)
+			if c.errors != 1 {
+				t.Errorf("%+v gave errors = %d, want 1", ev, c.errors)
+			}
+		}
+	})
+
+	t.Run("a clean event counts nothing", func(t *testing.T) {
+		var c sessionCounters
+		c.observe(&sessionEvent{Author: "pi"})
+		if c.turns != 0 || c.errors != 0 || c.toolCalls != 0 {
+			t.Errorf("counters = %+v, want all zero", c)
+		}
+	})
+}
+
+func TestSessionCountersStat(t *testing.T) {
+	t.Run("counters are carried across verbatim", func(t *testing.T) {
+		c := sessionCounters{
+			lines: 9, toolCalls: 8, toolResults: 7, turns: 6, errors: 5, gitOps: 4,
+			firstTS: time.Unix(1000, 0), lastTS: time.Unix(1090, 0),
+		}
+		s := c.stat("sid")
+		if s.ID != "sid" || s.Lines != 9 || s.ToolCalls != 8 || s.ToolResults != 7 ||
+			s.Turns != 6 || s.Errors != 5 || s.GitOps != 4 {
+			t.Errorf("stat = %+v", s)
+		}
+		if s.Duration != 90*time.Second {
+			t.Errorf("duration = %v, want 90s", s.Duration)
+		}
+	})
+
+	t.Run("no timestamps means no duration", func(t *testing.T) {
+		var c sessionCounters
+		if got := c.stat("sid").Duration; got != 0 {
+			t.Errorf("duration = %v, want 0", got)
+		}
+	})
+
+	t.Run("only one timestamp means no duration", func(t *testing.T) {
+		c := sessionCounters{lastTS: time.Unix(1090, 0)}
+		if got := c.stat("sid").Duration; got != 0 {
+			t.Errorf("duration = %v, want 0", got)
+		}
+	})
+}
+
+func TestSessionAnomalies(t *testing.T) {
+	tests := []struct {
+		name string
+		stat sessionStat
+		want []string
+	}{
+		{"quiet session", sessionStat{ToolCalls: 5, Turns: 2}, nil},
+		{"threshold is exclusive", sessionStat{ToolCalls: 20, Turns: 5}, nil},
+		{"high tool calls", sessionStat{ToolCalls: 21}, []string{"high tool calls (21)"}},
+		{"excessive turns", sessionStat{Turns: 6}, []string{"excessive turns (6)"}},
+		{"errors", sessionStat{Errors: 2}, []string{"errors (2)"}},
+		{"git ops threshold is exclusive", sessionStat{GitOps: defaultHighGitOps}, nil},
+		{"many git ops", sessionStat{GitOps: defaultHighGitOps + 1},
+			[]string{fmt.Sprintf("many git operations (%d)", defaultHighGitOps+1)}},
+		{"long idle needs both a long duration and few calls",
+			sessionStat{Duration: 31 * time.Minute, ToolCalls: 4}, []string{"long idle session"}},
+		{"a long busy session is not idle",
+			sessionStat{Duration: 31 * time.Minute, ToolCalls: 5}, nil},
+		{"a short quiet session is not idle",
+			sessionStat{Duration: 29 * time.Minute, ToolCalls: 1}, nil},
+		{"anomalies come out in a fixed order",
+			sessionStat{ToolCalls: 21, Turns: 6, Errors: 1, GitOps: defaultHighGitOps + 1},
+			[]string{
+				"high tool calls (21)", "excessive turns (6)", "errors (1)",
+				fmt.Sprintf("many git operations (%d)", defaultHighGitOps+1),
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sessionAnomalies(tt.stat, 20, 5)
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("anomalies = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- session_stats.go: table and detail rendering --------------------------
+
+func TestRenderSessionTable(t *testing.T) {
+	stats := []sessionStat{
+		{ID: "quiet", Lines: 3, ToolCalls: 1, Duration: 90 * time.Second},
+		{ID: "noisy", Lines: 9, ToolCalls: 30, Errors: 2, Anomalies: []string{"errors (2)"}},
+	}
+
+	t.Run("only anomalous sessions by default", func(t *testing.T) {
+		var b strings.Builder
+		renderSessionTable(&b, stats, false)
+		if strings.Contains(b.String(), "| quiet |") {
+			t.Errorf("quiet session should be hidden:\n%s", b.String())
+		}
+		if !strings.Contains(b.String(), "| noisy | 9 | 30 | 0 | 2 | 0s | errors (2) |") {
+			t.Errorf("noisy row missing or malformed:\n%s", b.String())
+		}
+	})
+
+	t.Run("all shows every session with an em dash for none", func(t *testing.T) {
+		var b strings.Builder
+		renderSessionTable(&b, stats, true)
+		if !strings.Contains(b.String(), "| quiet | 3 | 1 | 0 | 0 | 1m30s | — |") {
+			t.Errorf("quiet row missing or malformed:\n%s", b.String())
+		}
+	})
+
+	t.Run("the header is written even with no rows", func(t *testing.T) {
+		var b strings.Builder
+		renderSessionTable(&b, nil, false)
+		if !strings.HasPrefix(b.String(), "| Session | Lines |") {
+			t.Errorf("header missing:\n%s", b.String())
+		}
+	})
+}
+
+func TestRenderAnomalyDetails(t *testing.T) {
+	t.Run("nothing is written when no session is anomalous", func(t *testing.T) {
+		var b strings.Builder
+		renderAnomalyDetails(&b, []sessionStat{{ID: "quiet"}})
+		if b.Len() != 0 {
+			t.Errorf("wrote %q, want nothing", b.String())
+		}
+	})
+
+	t.Run("only anomalous sessions get a block", func(t *testing.T) {
+		var b strings.Builder
+		renderAnomalyDetails(&b, []sessionStat{
+			{ID: "quiet"},
+			{ID: "noisy", Lines: 9, ToolCalls: 30, Turns: 7, Errors: 2,
+				Duration: 61 * time.Second, Anomalies: []string{"errors (2)", "excessive turns (7)"}},
+		})
+		out := b.String()
+		if !strings.Contains(out, "### Anomaly Details") {
+			t.Errorf("heading missing:\n%s", out)
+		}
+		if strings.Contains(out, "**quiet**") {
+			t.Errorf("quiet session should not appear:\n%s", out)
+		}
+		for _, want := range []string{
+			"**noisy**",
+			"- Lines: 9, Tool calls: 30, Turns: 7, Errors: 2\n",
+			"- Duration: 1m1s\n",
+			"- Anomalies: errors (2); excessive turns (7)\n",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("missing %q in:\n%s", want, out)
+			}
+		}
+	})
+}
+
+// --- session_sweep.go: the three sweep sections ----------------------------
+
+func TestRenderSweepFailures(t *testing.T) {
+	t.Run("no aborts and no errors", func(t *testing.T) {
+		var b strings.Builder
+		renderSweepFailures(&b, newSweepTotals())
+		out := b.String()
+		if !strings.Contains(out, "## Failures") || !strings.Contains(out, "No aborted runs.") {
+			t.Errorf("unexpected output:\n%s", out)
+		}
+		if strings.Contains(out, "| tool | errors |") {
+			t.Errorf("an error table was written with no errors:\n%s", out)
+		}
+	})
+
+	t.Run("aborts are listed", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.Aborts["repeated tool call"] = 3
+		var b strings.Builder
+		renderSweepFailures(&b, totals)
+		if !strings.Contains(b.String(), "- 3x `repeated tool call`") {
+			t.Errorf("abort line missing:\n%s", b.String())
+		}
+	})
+
+	t.Run("error rates are a rate, and clean tools are cut off", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.tool("bash").Calls = 10
+		totals.tool("bash").Errors = 3
+		totals.tool("read").Calls = 100 // no errors: must not appear
+		var b strings.Builder
+		renderSweepFailures(&b, totals)
+		out := b.String()
+		if !strings.Contains(out, "| bash | 3 | 10 | 30% |") {
+			t.Errorf("bash rate row missing:\n%s", out)
+		}
+		if strings.Contains(out, "| read |") {
+			t.Errorf("a tool with no errors was listed:\n%s", out)
+		}
+		if !strings.Contains(out, "pi-check-session-logs") {
+			t.Errorf("follow-up pointer missing:\n%s", out)
+		}
+	})
+
+	t.Run("a tool with errors but no recorded calls does not divide by zero", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.tool("grep").Errors = 2
+		var b strings.Builder
+		renderSweepFailures(&b, totals)
+		if !strings.Contains(b.String(), "| grep | 2 | 1 | 200% |") {
+			t.Errorf("expected a floor of one call:\n%s", b.String())
+		}
+	})
+}
+
+func TestRenderSweepWaste(t *testing.T) {
+	t.Run("nothing wasted", func(t *testing.T) {
+		var b strings.Builder
+		renderSweepWaste(&b, newSweepTotals())
+		if !strings.Contains(b.String(), "Nothing oversized or duplicated.") {
+			t.Errorf("unexpected output:\n%s", b.String())
+		}
+	})
+
+	t.Run("oversize is attributed and the compactor coverage named", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.ToolBytes = 400000
+		totals.tool("bash").Oversized = 40000
+		totals.tool("session-stats").Oversized = 20000
+		totals.tool("tree").Oversized = 0 // must be cut off
+		var b strings.Builder
+		renderSweepWaste(&b, totals)
+		out := b.String()
+		if !strings.Contains(out, "Reclaimable: **~15,000 tokens** (15% of tool output)") {
+			t.Errorf("reclaim line wrong:\n%s", out)
+		}
+		if !strings.Contains(out, "| bash | 10,000 tok | yes |") {
+			t.Errorf("bash row wrong:\n%s", out)
+		}
+		if !strings.Contains(out, "| session-stats | 5,000 tok | **no — uncapped** |") {
+			t.Errorf("uncapped row wrong:\n%s", out)
+		}
+		if strings.Contains(out, "| tree |") {
+			t.Errorf("a tool with no oversize was listed:\n%s", out)
+		}
+		if strings.Contains(out, "Duplicate results") {
+			t.Errorf("duplicates mentioned with none recorded:\n%s", out)
+		}
+	})
+
+	t.Run("hyphenated tool names match the underscored compactor set", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.tool("git-overview").Oversized = 8000
+		var b strings.Builder
+		renderSweepWaste(&b, totals)
+		if !strings.Contains(b.String(), "| git-overview | 2,000 tok | yes |") {
+			t.Errorf("git-overview should map to git_overview:\n%s", b.String())
+		}
+	})
+
+	t.Run("duplicates alone are still waste", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.DupBytes = 8000
+		var b strings.Builder
+		renderSweepWaste(&b, totals)
+		out := b.String()
+		if !strings.Contains(out, "Reclaimable: **~2,000 tokens** (0% of tool output)") {
+			t.Errorf("reclaim line wrong:\n%s", out)
+		}
+		if !strings.Contains(out, "Duplicate results re-sent inside one session: ~2,000 tokens.") {
+			t.Errorf("duplicate line missing:\n%s", out)
+		}
+	})
+}
+
+func TestRenderSweepSpend(t *testing.T) {
+	t.Run("no usage metadata", func(t *testing.T) {
+		var b strings.Builder
+		renderSweepSpend(&b, newSweepTotals(), 3)
+		if !strings.Contains(b.String(), "No usage metadata") {
+			t.Errorf("unexpected output:\n%s", b.String())
+		}
+	})
+
+	t.Run("totals and per-session average", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.PromptTokens = 30000
+		totals.OutputTokens = 1500
+		var b strings.Builder
+		renderSweepSpend(&b, totals, 3)
+		out := b.String()
+		if !strings.Contains(out, "Prompt 30,000 · output 1,500 (provider-reported, not estimated)") {
+			t.Errorf("totals line wrong:\n%s", out)
+		}
+		if !strings.Contains(out, "Average 10,000 prompt tokens per session across 3 session(s).") {
+			t.Errorf("average line wrong:\n%s", out)
+		}
+	})
+
+	t.Run("no sessions means no average", func(t *testing.T) {
+		totals := newSweepTotals()
+		totals.PromptTokens = 30000
+		var b strings.Builder
+		renderSweepSpend(&b, totals, 0)
+		if strings.Contains(b.String(), "Average") {
+			t.Errorf("averaged over zero sessions:\n%s", b.String())
+		}
+	})
+}
+
+// TestRenderSweepComposition checks that renderSweep still emits the three
+// sections, in order, now that each is its own function.
+func TestRenderSweepComposition(t *testing.T) {
+	totals := newSweepTotals()
+	totals.PromptTokens = 100
+	var b strings.Builder
+	renderSweep(&b, totals, 1)
+	out := b.String()
+	failures := strings.Index(out, "## Failures")
+	waste := strings.Index(out, "## Token waste")
+	spend := strings.Index(out, "## Token spend")
+	if failures < 0 || waste < 0 || spend < 0 {
+		t.Fatalf("a section is missing:\n%s", out)
+	}
+	if failures >= waste || waste >= spend {
+		t.Errorf("sections out of order: failures=%d waste=%d spend=%d", failures, waste, spend)
+	}
+}

--- a/internal/tools/git_overview.go
+++ b/internal/tools/git_overview.go
@@ -54,6 +54,70 @@ func newGitOverviewTool(sb *Sandbox) (tool.Tool, error) {
 	})
 }
 
+// includeOrDefault reports whether an optional include flag is on. Unset means
+// include everything.
+func includeOrDefault(flag *bool) bool {
+	return flag == nil || *flag
+}
+
+// collectGitHead fills in the branch name and recent commits. Either may be
+// unavailable — an empty repo has no HEAD — in which case it is left unset.
+func collectGitHead(ctx agent.Context, dir string, out *GitOverviewOutput) {
+	// Branch name
+	if branch, err := runGit(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		out.Branch = strings.TrimSpace(branch)
+	}
+
+	// Recent commits (may fail in empty repo)
+	if log, err := runGit(ctx, dir, "log", "--oneline", "-10"); err == nil {
+		trimmed := strings.TrimSpace(log)
+		if trimmed != "" {
+			out.RecentCommits = strings.Split(trimmed, "\n")
+		}
+	}
+}
+
+// collectGitStatusFiles parses porcelain status into the file lists the caller
+// asked for. Defaults: include everything unless explicitly set to false.
+func collectGitStatusFiles(ctx agent.Context, dir string, input GitOverviewInput, out *GitOverviewOutput) {
+	status, err := runGit(ctx, dir, "status", "--porcelain")
+	if err != nil {
+		return
+	}
+
+	staged, unstaged, untracked := parsePorcelain(status)
+	if includeOrDefault(input.IncludeStaged) {
+		out.StagedFiles = staged
+	}
+	if includeOrDefault(input.IncludeUnstaged) {
+		out.UnstagedFiles = unstaged
+	}
+	if includeOrDefault(input.IncludeUntracked) {
+		out.UntrackedFiles = untracked
+	}
+}
+
+// collectGitUpstream fills in the tracking branch and its ahead/behind counts,
+// leaving them unset when the branch tracks nothing.
+func collectGitUpstream(ctx agent.Context, dir string, out *GitOverviewOutput) {
+	upstream, err := runGit(ctx, dir, "rev-parse", "--abbrev-ref", "@{upstream}")
+	if err != nil {
+		return
+	}
+	out.Upstream = strings.TrimSpace(upstream)
+
+	// Ahead/behind counts
+	counts, err := runGit(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+	if err != nil {
+		return
+	}
+	parts := strings.Fields(strings.TrimSpace(counts))
+	if len(parts) == 2 {
+		out.Behind, _ = strconv.Atoi(parts[0])
+		out.Ahead, _ = strconv.Atoi(parts[1])
+	}
+}
+
 func gitOverviewHandler(sb *Sandbox, ctx agent.Context, input GitOverviewInput) (GitOverviewOutput, error) {
 	dir := sb.Dir()
 
@@ -73,52 +137,9 @@ func gitOverviewHandler(sb *Sandbox, ctx agent.Context, input GitOverviewInput) 
 	}
 
 	var out GitOverviewOutput
-
-	// Branch name
-	if branch, err := runGit(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
-		out.Branch = strings.TrimSpace(branch)
-	}
-
-	// Recent commits (may fail in empty repo)
-	if log, err := runGit(ctx, dir, "log", "--oneline", "-10"); err == nil {
-		trimmed := strings.TrimSpace(log)
-		if trimmed != "" {
-			out.RecentCommits = strings.Split(trimmed, "\n")
-		}
-	}
-
-	// Defaults: include everything unless explicitly set to false
-	includeStaged := input.IncludeStaged == nil || *input.IncludeStaged
-	includeUnstaged := input.IncludeUnstaged == nil || *input.IncludeUnstaged
-	includeUntracked := input.IncludeUntracked == nil || *input.IncludeUntracked
-
-	// Parse porcelain status
-	if status, err := runGit(ctx, dir, "status", "--porcelain"); err == nil {
-		staged, unstaged, untracked := parsePorcelain(status)
-		if includeStaged {
-			out.StagedFiles = staged
-		}
-		if includeUnstaged {
-			out.UnstagedFiles = unstaged
-		}
-		if includeUntracked {
-			out.UntrackedFiles = untracked
-		}
-	}
-
-	// Upstream tracking info
-	if upstream, err := runGit(ctx, dir, "rev-parse", "--abbrev-ref", "@{upstream}"); err == nil {
-		out.Upstream = strings.TrimSpace(upstream)
-
-		// Ahead/behind counts
-		if counts, err := runGit(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD"); err == nil {
-			parts := strings.Fields(strings.TrimSpace(counts))
-			if len(parts) == 2 {
-				out.Behind, _ = strconv.Atoi(parts[0])
-				out.Ahead, _ = strconv.Atoi(parts[1])
-			}
-		}
-	}
+	collectGitHead(ctx, dir, &out)
+	collectGitStatusFiles(ctx, dir, input, &out)
+	collectGitUpstream(ctx, dir, &out)
 
 	span.SetAttributes(
 		attribute.String("git.branch", out.Branch),

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -135,6 +135,118 @@ func newGrepTool(sb *Sandbox) (tool.Tool, error) {
 	})
 }
 
+// compileGrepPattern compiles the search pattern, reusing the shared regex cache.
+func compileGrepPattern(input GrepInput) (*regexp.Regexp, error) {
+	// Build cache key including case-insensitive flag
+	cacheKey := input.Pattern
+	if input.CaseInsensitive {
+		cacheKey = "(?i)" + cacheKey
+	}
+
+	// Try cache first
+	if re := grepRegexCache.get(cacheKey); re != nil {
+		return re, nil
+	}
+
+	flags := ""
+	if input.CaseInsensitive {
+		flags = "(?i)"
+	}
+	re, err := regexp.Compile(flags + input.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex pattern: %w", err)
+	}
+	grepRegexCache.put(cacheKey, re)
+	return re, nil
+}
+
+// grepDirCollector accumulates matches while walking a directory tree.
+type grepDirCollector struct {
+	sb       *Sandbox
+	re       *regexp.Regexp
+	glob     string
+	patterns []GitignorePattern
+	matches  []GrepMatch
+	total    int
+}
+
+// walk is the fs.WalkDirFunc that prunes ignored directories, applies the glob
+// filter, and greps whatever is left.
+func (c *grepDirCollector) walk(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return nil // skip errors
+	}
+	if d.IsDir() {
+		if shouldSkipDir(d.Name()) {
+			return filepath.SkipDir
+		}
+		if shouldSkipPath(path, d, c.patterns) {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+	if shouldSkipPath(path, d, c.patterns) {
+		return nil
+	}
+	if c.glob != "" {
+		matched, _ := filepath.Match(c.glob, d.Name())
+		if !matched {
+			return nil
+		}
+	}
+	c.collectFile(path)
+	return nil
+}
+
+// collectFile greps one file, counting every match but keeping at most
+// maxGrepMatches of them.
+func (c *grepDirCollector) collectFile(path string) {
+	fileMatches := grepFileSandbox(c.sb, c.re, path)
+	c.total += len(fileMatches)
+	if len(c.matches) >= maxGrepMatches {
+		return
+	}
+	remaining := maxGrepMatches - len(c.matches)
+	if len(fileMatches) > remaining {
+		fileMatches = fileMatches[:remaining]
+	}
+	c.matches = append(c.matches, fileMatches...)
+}
+
+// grepDir searches every file under searchPath.
+func grepDir(sb *Sandbox, re *regexp.Regexp, input GrepInput, searchPath string, patterns []GitignorePattern) (GrepOutput, error) {
+	// Use sandbox ReadDir recursively via fs.WalkDir on the Root's FS
+	fsys := sb.FS()
+	rel, resolveErr := sb.Resolve(searchPath)
+	if resolveErr != nil {
+		return GrepOutput{}, resolveErr
+	}
+
+	c := &grepDirCollector{sb: sb, re: re, glob: input.Glob, patterns: patterns}
+	_ = fs.WalkDir(fsys, rel, c.walk)
+
+	return GrepOutput{
+		Matches:      c.matches,
+		TotalMatches: c.total,
+		Truncated:    c.total > len(c.matches),
+	}, nil
+}
+
+// grepFile searches a single file target.
+func grepFile(sb *Sandbox, re *regexp.Regexp, searchPath string) GrepOutput {
+	matches := grepFileSandbox(sb, re, searchPath)
+	total := len(matches)
+	if len(matches) > maxGrepMatches {
+		matches = matches[:maxGrepMatches]
+	}
+
+	return GrepOutput{
+		Matches:      matches,
+		TotalMatches: total,
+		Truncated:    total > len(matches),
+	}
+}
+
 func grepHandler(sb *Sandbox, input GrepInput) (GrepOutput, error) {
 	if input.Pattern == "" {
 		return GrepOutput{}, fmt.Errorf("pattern is required")
@@ -152,31 +264,15 @@ func grepHandler(sb *Sandbox, input GrepInput) (GrepOutput, error) {
 
 	// Try ripgrep first if available
 	if rgAvailable && !grepRGDisabled {
-		if result, err := grepWithRG(sb, input, searchPath); err == nil {
+		if result, rgErr := grepWithRG(sb, input, searchPath); rgErr == nil {
 			return result, nil
 		}
 		// Fall back to Go implementation on error
 	}
 
-	// Build cache key including case-insensitive flag
-	cacheKey := input.Pattern
-	if input.CaseInsensitive {
-		cacheKey = "(?i)" + cacheKey
-	}
-
-	// Try cache first
-	re := grepRegexCache.get(cacheKey)
-	if re == nil {
-		flags := ""
-		if input.CaseInsensitive {
-			flags = "(?i)"
-		}
-		var err error
-		re, err = regexp.Compile(flags + input.Pattern)
-		if err != nil {
-			return GrepOutput{}, fmt.Errorf("invalid regex pattern: %w", err)
-		}
-		grepRegexCache.put(cacheKey, re)
+	re, err := compileGrepPattern(input)
+	if err != nil {
+		return GrepOutput{}, err
 	}
 
 	// Load .gitignore patterns
@@ -185,63 +281,10 @@ func grepHandler(sb *Sandbox, input GrepInput) (GrepOutput, error) {
 		patterns = nil
 	}
 
-	var matches []GrepMatch
-	total := 0
-
 	if info.IsDir() {
-		walkFn := func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return nil // skip errors
-			}
-			if d.IsDir() {
-				if shouldSkipDir(d.Name()) {
-					return filepath.SkipDir
-				}
-				if shouldSkipPath(path, d, patterns) {
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			if shouldSkipPath(path, d, patterns) {
-				return nil
-			}
-			if input.Glob != "" {
-				matched, _ := filepath.Match(input.Glob, d.Name())
-				if !matched {
-					return nil
-				}
-			}
-			fileMatches := grepFileSandbox(sb, re, path)
-			total += len(fileMatches)
-			if len(matches) < maxGrepMatches {
-				remaining := maxGrepMatches - len(matches)
-				if len(fileMatches) > remaining {
-					fileMatches = fileMatches[:remaining]
-				}
-				matches = append(matches, fileMatches...)
-			}
-			return nil
-		}
-		// Use sandbox ReadDir recursively via fs.WalkDir on the Root's FS
-		fsys := sb.FS()
-		rel, resolveErr := sb.Resolve(searchPath)
-		if resolveErr != nil {
-			return GrepOutput{}, resolveErr
-		}
-		_ = fs.WalkDir(fsys, rel, walkFn)
-	} else {
-		matches = grepFileSandbox(sb, re, searchPath)
-		total = len(matches)
-		if len(matches) > maxGrepMatches {
-			matches = matches[:maxGrepMatches]
-		}
+		return grepDir(sb, re, input, searchPath, patterns)
 	}
-
-	return GrepOutput{
-		Matches:      matches,
-		TotalMatches: total,
-		Truncated:    total > len(matches),
-	}, nil
+	return grepFile(sb, re, searchPath), nil
 }
 
 func grepFileSandbox(sb *Sandbox, re *regexp.Regexp, path string) []GrepMatch {

--- a/internal/tools/lsp.go
+++ b/internal/tools/lsp.go
@@ -559,39 +559,30 @@ func flattenSymbols(symbols []lsp.DocumentSymbol, out []SymbolEntry) []SymbolEnt
 	return out
 }
 
+// symbolKindNames maps the LSP SymbolKind numbers this package recognizes to
+// their display names. The kinds are distinct integers, so the table is the
+// same dispatch the switch it replaced performed.
+var symbolKindNames = map[int]string{
+	lsp.SymbolKindFile:        "file",
+	lsp.SymbolKindModule:      "module",
+	lsp.SymbolKindNamespace:   "namespace",
+	lsp.SymbolKindPackage:     "package",
+	lsp.SymbolKindClass:       "class",
+	lsp.SymbolKindMethod:      "method",
+	lsp.SymbolKindProperty:    "property",
+	lsp.SymbolKindField:       "field",
+	lsp.SymbolKindConstructor: "constructor",
+	lsp.SymbolKindEnum:        "enum",
+	lsp.SymbolKindInterface:   "interface",
+	lsp.SymbolKindFunction:    "function",
+	lsp.SymbolKindVariable:    "variable",
+	lsp.SymbolKindConstant:    "constant",
+	lsp.SymbolKindStruct:      "struct",
+}
+
 func symbolKindName(kind int) string {
-	switch kind {
-	case lsp.SymbolKindFile:
-		return "file"
-	case lsp.SymbolKindModule:
-		return "module"
-	case lsp.SymbolKindNamespace:
-		return "namespace"
-	case lsp.SymbolKindPackage:
-		return "package"
-	case lsp.SymbolKindClass:
-		return "class"
-	case lsp.SymbolKindMethod:
-		return "method"
-	case lsp.SymbolKindProperty:
-		return "property"
-	case lsp.SymbolKindField:
-		return "field"
-	case lsp.SymbolKindConstructor:
-		return "constructor"
-	case lsp.SymbolKindEnum:
-		return "enum"
-	case lsp.SymbolKindInterface:
-		return "interface"
-	case lsp.SymbolKindFunction:
-		return "function"
-	case lsp.SymbolKindVariable:
-		return "variable"
-	case lsp.SymbolKindConstant:
-		return "constant"
-	case lsp.SymbolKindStruct:
-		return "struct"
-	default:
-		return fmt.Sprintf("kind(%d)", kind)
+	if name, ok := symbolKindNames[kind]; ok {
+		return name
 	}
+	return fmt.Sprintf("kind(%d)", kind)
 }

--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -134,18 +134,8 @@ func readHandlerWithLedger(sb *Sandbox, input ReadInput, ledger *ReadLedger) (Re
 		}, nil
 	}
 
-	// Decide what the file is before reading any of it as text, so bytes that
-	// are not text never reach the transcript.
-	prefix, err := readPrefix(sb, path, sniffLen)
-	if err != nil {
-		return ReadOutput{}, fmt.Errorf("reading file: %w", err)
-	}
-	kind := classifyContent(prefix, path)
-	if out := describeNonText(kind, path, prefix, info.Size()); out != nil {
-		return *out, nil
-	}
-	if kind == kindNotebook {
-		return readNotebook(sb, path)
+	if out, handled, err := readNonText(sb, path, info.Size()); handled {
+		return out, err
 	}
 
 	totalLines, err := countFileLines(sb, path)
@@ -175,10 +165,41 @@ func readHandlerWithLedger(sb *Sandbox, input ReadInput, ledger *ReadLedger) (Re
 		return ReadOutput{}, fmt.Errorf("reading file: %w", err)
 	}
 
-	content := stripBase64Images(win.content)
+	out := renderWindow(win, offset, totalLines)
 
+	// A window that stopped early, or one that started past line 1, is a
+	// partial view: overwriting on the strength of it would discard lines the
+	// agent never saw.
+	ledger.Record(path, info, win.stoppedEarly || offset > 1)
+
+	return out, nil
+}
+
+// readNonText decides what the file is before any of it is read as text, so
+// bytes that are not text never reach the transcript. It reports handled=true
+// once it has produced the output for the file — including on error — leaving
+// only plain text for the caller to window.
+func readNonText(sb *Sandbox, path string, size int64) (ReadOutput, bool, error) {
+	prefix, err := readPrefix(sb, path, sniffLen)
+	if err != nil {
+		return ReadOutput{}, true, fmt.Errorf("reading file: %w", err)
+	}
+	kind := classifyContent(prefix, path)
+	if out := describeNonText(kind, path, prefix, size); out != nil {
+		return *out, true, nil
+	}
+	if kind == kindNotebook {
+		out, err := readNotebook(sb, path)
+		return out, true, err
+	}
+	return ReadOutput{}, false, nil
+}
+
+// renderWindow turns one window into the tool output, including the notes that
+// tell the model what it did not see and how to ask for the rest.
+func renderWindow(win window, offset, totalLines int) ReadOutput {
 	out := ReadOutput{
-		Content:    content,
+		Content:    stripBase64Images(win.content),
 		TotalLines: totalLines,
 		Truncated:  win.stoppedEarly,
 	}
@@ -201,13 +222,7 @@ func readHandlerWithLedger(sb *Sandbox, input ReadInput, ledger *ReadLedger) (Re
 		out.Content += fmt.Sprintf("\n... (truncated: %s; continue with offset=%d)", reason, win.nextOffset)
 	}
 	out.Note = strings.Join(notes, " ")
-
-	// A window that stopped early, or one that started past line 1, is a
-	// partial view: overwriting on the strength of it would discard lines the
-	// agent never saw.
-	ledger.Record(path, info, win.stoppedEarly || offset > 1)
-
-	return out, nil
+	return out
 }
 
 // readPrefix reads up to n bytes from the start of a file for classification.
@@ -282,58 +297,90 @@ func readWindow(sb *Sandbox, path string, offset, limit int) (window, error) {
 	w.lastLine = offset - 1
 
 	for {
-		text, clipped, readErr := readLineClamped(r, maxReadLineChars)
-		atEOF := errors.Is(readErr, io.EOF)
-		if readErr != nil && !atEOF {
-			return window{}, readErr
+		src, err := readSrcLine(r)
+		if err != nil {
+			return window{}, err
 		}
-		if text == "" && clipped == 0 && atEOF && line >= 1 {
+		if src.endsFile(line) {
 			break
 		}
 		line++
 
 		if line == 1 {
-			text = strings.TrimPrefix(text, string(utf8BOM))
+			src.text = strings.TrimPrefix(src.text, string(utf8BOM))
 		}
 		// CRLF files are numbered like their LF equivalents; a stray \r would
 		// otherwise land inside every line and defeat exact-match editing.
-		text = strings.TrimSuffix(text, "\r")
+		src.text = strings.TrimSuffix(src.text, "\r")
 
-		if line >= offset {
-			if clipped > 0 {
-				text += fmt.Sprintf("… [%d more characters on this line, clipped]", clipped)
-				w.clampedLines++
-			}
-			// Check the byte budget before committing the line, so the budget
-			// is a ceiling rather than a target that is always overshot.
-			if b.Len() > 0 && b.Len()+len(text) > readByteBudget {
-				w.stoppedEarly = true
-				w.hitByteBudget = true
-				w.nextOffset = line // resume on the line that did not fit
-				return finishWindow(&b, w), nil
-			}
-			fmt.Fprintf(&b, "%6d\t%s\n", line, text)
-			w.lastLine = line
-
-			if line-offset+1 >= limit {
-				// Filling the window is not the same as there being more to
-				// read. A limit that lands exactly on the last line has not
-				// truncated anything, and saying otherwise sends the model
-				// after a page that does not exist.
-				if !atEOF && moreToRead(r) {
-					w.stoppedEarly = true
-					w.nextOffset = line + 1
-				}
-				return finishWindow(&b, w), nil
-			}
+		if line >= offset && w.emitLine(&b, r, src, line, offset, limit) {
+			return finishWindow(&b, w), nil
 		}
 
-		if atEOF {
+		if src.atEOF {
 			break
 		}
 	}
 
 	return finishWindow(&b, w), nil
+}
+
+// srcLine is one line as it came off the reader, before any window ceiling has
+// been applied to it.
+type srcLine struct {
+	text    string
+	clipped int  // bytes past the per-line clamp that were discarded
+	atEOF   bool // the read that produced this line also reached EOF
+}
+
+// readSrcLine reads the next line, treating EOF as an ordinary end rather than
+// an error so the caller can still use the bytes that came with it.
+func readSrcLine(r *bufio.Reader) (srcLine, error) {
+	text, clipped, err := readLineClamped(r, maxReadLineChars)
+	atEOF := errors.Is(err, io.EOF)
+	if err != nil && !atEOF {
+		return srcLine{}, err
+	}
+	return srcLine{text: text, clipped: clipped, atEOF: atEOF}, nil
+}
+
+// endsFile reports whether this is the phantom empty line that follows a
+// file's final newline rather than real content. line is the number of lines
+// consumed so far, so the very first read of an empty file is still content.
+func (s srcLine) endsFile(line int) bool {
+	return s.text == "" && s.clipped == 0 && s.atEOF && line >= 1
+}
+
+// emitLine appends one line to the window, applying the byte budget and the
+// line limit. It reports whether one of those ceilings closed the window.
+func (w *window) emitLine(b *strings.Builder, r *bufio.Reader, src srcLine, line, offset, limit int) bool {
+	text := src.text
+	if src.clipped > 0 {
+		text += fmt.Sprintf("… [%d more characters on this line, clipped]", src.clipped)
+		w.clampedLines++
+	}
+	// Check the byte budget before committing the line, so the budget is a
+	// ceiling rather than a target that is always overshot.
+	if b.Len() > 0 && b.Len()+len(text) > readByteBudget {
+		w.stoppedEarly = true
+		w.hitByteBudget = true
+		w.nextOffset = line // resume on the line that did not fit
+		return true
+	}
+	fmt.Fprintf(b, "%6d\t%s\n", line, text)
+	w.lastLine = line
+
+	if line-offset+1 < limit {
+		return false
+	}
+	// Filling the window is not the same as there being more to read. A limit
+	// that lands exactly on the last line has not truncated anything, and
+	// saying otherwise sends the model after a page that does not exist.
+	if !src.atEOF && moreToRead(r) {
+		w.stoppedEarly = true
+		w.nextOffset = line + 1
+	}
+	return true
 }
 
 func finishWindow(b *strings.Builder, w window) window {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -168,34 +168,13 @@ func collectFromSchema(schema *jsonschema.Schema, prefix string, intProps, boolP
 		if prefix != "" {
 			fullName = prefix + "." + name
 		}
-		// Resolve effective type. The jsonschema library uses Type for single types
-		// and Types for multi-types (e.g., ["null", "array"] for nullable arrays).
-		effectiveType := prop.Type
-		if effectiveType == "" && len(prop.Types) > 0 {
-			for _, t := range prop.Types {
-				if t != "null" {
-					effectiveType = t
-					break
-				}
-			}
-		}
-		switch effectiveType {
+		switch effectiveSchemaType(prop) {
 		case "integer", "number":
-			intProps[fullName] = true
-			// Also register the base name for array item matching flexibility
-			if prefix != "" {
-				intProps[name] = true
-			}
+			markCoerceProp(intProps, prefix, name, fullName)
 		case "boolean":
-			boolProps[fullName] = true
-			if prefix != "" {
-				boolProps[name] = true
-			}
+			markCoerceProp(boolProps, prefix, name, fullName)
 		case "array", "object":
-			jsonProps[fullName] = true
-			if prefix != "" {
-				jsonProps[name] = true
-			}
+			markCoerceProp(jsonProps, prefix, name, fullName)
 		}
 		// Recurse into nested objects
 		if len(prop.Properties) > 0 {
@@ -205,6 +184,31 @@ func collectFromSchema(schema *jsonschema.Schema, prefix string, intProps, boolP
 		if prop.Items != nil {
 			collectFromSchema(prop.Items, fullName+".$", intProps, boolProps, jsonProps)
 		}
+	}
+}
+
+// effectiveSchemaType resolves the type a property coerces as. The jsonschema
+// library uses Type for single types and Types for multi-types (e.g.,
+// ["null", "array"] for nullable arrays), where the first non-null entry wins.
+func effectiveSchemaType(prop *jsonschema.Schema) string {
+	if prop.Type != "" {
+		return prop.Type
+	}
+	for _, t := range prop.Types {
+		if t != "null" {
+			return t
+		}
+	}
+	return ""
+}
+
+// markCoerceProp registers a property in one of the coercion sets under its
+// full dot-notation path, and for a nested property under its bare name as
+// well, so array item matching can find it.
+func markCoerceProp(props map[string]bool, prefix, name, fullName string) {
+	props[fullName] = true
+	if prefix != "" {
+		props[name] = true
 	}
 }
 
@@ -388,33 +392,8 @@ func (c *coercingTool) coerceArrayItem(arr []any, idx int, parentPath string) {
 	switch vv := item.(type) {
 	case map[string]any:
 		// Array of objects - check each property against parent.$ paths
-		for nestedK, nestedV := range vv {
-			// Check both the nested key itself and parent.$ nestedK
-			nestedPath := parentPath + "." + nestedK
-			parentItemPath := parentPath + ".$." + nestedK
-
-			// Try to coerce using the full nested path
-			if c.intProps[nestedPath] || c.boolProps[nestedPath] || c.jsonProps[nestedPath] {
-				if coerced := c.tryCoerce(nestedV, nestedPath); coerced != nil {
-					vv[nestedK] = coerced
-				}
-			}
-			// Also check parent.$ paths (for array item properties)
-			if c.intProps[parentItemPath] || c.boolProps[parentItemPath] || c.jsonProps[parentItemPath] {
-				if coerced := c.tryCoerce(nestedV, parentItemPath); coerced != nil {
-					vv[nestedK] = coerced
-				}
-			}
-
-			// Recurse into nested objects/arrays
-			switch nv := vv[nestedK].(type) {
-			case map[string]any:
-				c.coerceValueAtKey(nv, nestedK)
-			case []any:
-				for i := range nv {
-					c.coerceArrayItem(nv, i, nestedPath)
-				}
-			}
+		for nestedK := range vv {
+			c.coerceArrayItemProp(vv, nestedK, parentPath)
 		}
 	case []any:
 		// Nested array
@@ -424,50 +403,52 @@ func (c *coercingTool) coerceArrayItem(arr []any, idx int, parentPath string) {
 	}
 }
 
+// coerceArrayItemProp coerces one property of an object that is itself an
+// array item, then recurses into whatever that property holds.
+func (c *coercingTool) coerceArrayItemProp(obj map[string]any, key, parentPath string) {
+	// Check both the nested key itself and parent.$ key
+	nestedV := obj[key]
+	nestedPath := parentPath + "." + key
+	c.coerceAtPath(obj, key, nestedPath, nestedV)
+	// Also check parent.$ paths (for array item properties)
+	c.coerceAtPath(obj, key, parentPath+".$."+key, nestedV)
+
+	// Recurse into nested objects/arrays
+	switch nv := obj[key].(type) {
+	case map[string]any:
+		c.coerceValueAtKey(nv, key)
+	case []any:
+		for i := range nv {
+			c.coerceArrayItem(nv, i, nestedPath)
+		}
+	}
+}
+
+// coerceAtPath stores the coercion of val at obj[key], if path is a registered
+// coercion target. val is passed in rather than read back from obj so that two
+// paths checked in sequence both see the value the caller started with.
+func (c *coercingTool) coerceAtPath(obj map[string]any, key, path string, val any) {
+	if !c.intProps[path] && !c.boolProps[path] && !c.jsonProps[path] {
+		return
+	}
+	if coerced := c.tryCoerce(val, path); coerced != nil {
+		obj[key] = coerced
+	}
+}
+
 // tryCoerce attempts to coerce a value based on the property path.
 // Returns the coerced value or nil if coercion was not applied.
 func (c *coercingTool) tryCoerce(val any, path string) any {
 	switch v := val.(type) {
 	case string:
-		if c.intProps[path] {
-			if i, err := strconv.ParseInt(v, 10, 64); err == nil {
-				return float64(i) // JSON numbers are float64 in Go maps
-			} else if f, err := strconv.ParseFloat(v, 64); err == nil {
-				return f
-			}
-		} else if c.boolProps[path] {
-			if b, err := strconv.ParseBool(v); err == nil {
-				return b
-			}
-		} else if c.jsonProps[path] {
-			// LLMs sometimes stringify JSON arrays/objects. Parse them back.
-			v = strings.TrimSpace(v)
-			if (strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]")) ||
-				(strings.HasPrefix(v, "{") && strings.HasSuffix(v, "}")) {
-				var parsed any
-				if err := json.Unmarshal([]byte(v), &parsed); err == nil {
-					return parsed
-				}
-			}
-		}
+		return c.coerceStringValue(v, path)
 	case float64:
 		// Already float64 from JSON
 		return nil
 	case float32, int, int64, int32:
 		// Numbers - keep as-is for intProps, convert to float64
 		if c.intProps[path] {
-			switch n := v.(type) {
-			case float64:
-				return n
-			case float32:
-				return float64(n)
-			case int:
-				return float64(n)
-			case int64:
-				return float64(n)
-			case int32:
-				return float64(n)
-			}
+			return numberAsFloat64(v)
 		}
 	case json.Number:
 		if c.intProps[path] {
@@ -475,6 +456,59 @@ func (c *coercingTool) tryCoerce(val any, path string) any {
 				return f
 			}
 		}
+	}
+	return nil
+}
+
+// coerceStringValue coerces a string the model sent where the schema asked for
+// a number, a boolean, or a nested JSON document.
+func (c *coercingTool) coerceStringValue(v, path string) any {
+	switch {
+	case c.intProps[path]:
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return float64(i) // JSON numbers are float64 in Go maps
+		} else if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	case c.boolProps[path]:
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+	case c.jsonProps[path]:
+		// LLMs sometimes stringify JSON arrays/objects. Parse them back.
+		return parseStringifiedJSON(v)
+	}
+	return nil
+}
+
+// parseStringifiedJSON parses a JSON array or object that arrived as a string,
+// returning nil if the string is not one or does not parse.
+func parseStringifiedJSON(v string) any {
+	v = strings.TrimSpace(v)
+	if (strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]")) ||
+		(strings.HasPrefix(v, "{") && strings.HasSuffix(v, "}")) {
+		var parsed any
+		if err := json.Unmarshal([]byte(v), &parsed); err == nil {
+			return parsed
+		}
+	}
+	return nil
+}
+
+// numberAsFloat64 normalizes a Go numeric value to the float64 that JSON
+// decoding would have produced. It returns nil for anything else.
+func numberAsFloat64(v any) any {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case int32:
+		return float64(n)
 	}
 	return nil
 }

--- a/internal/tools/session_stats.go
+++ b/internal/tools/session_stats.go
@@ -81,38 +81,56 @@ func SessionStats(input SessionStatsInput) (SessionStatsOutput, error) {
 	return sessionStatsHandler(input)
 }
 
-func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
+// sessionStatsOptions is SessionStatsInput with the defaults applied and the
+// lookback window turned into a cutoff time.
+type sessionStatsOptions struct {
+	sessionDir    string
+	highToolCalls int
+	highTurns     int
+	hours         int
+	cutoff        time.Time
+}
+
+func resolveSessionStatsOptions(input SessionStatsInput) (sessionStatsOptions, error) {
+	opts := sessionStatsOptions{
+		sessionDir:    input.SessionDir,
+		highToolCalls: input.HighToolCalls,
+		highTurns:     input.HighTurns,
+		hours:         input.Hours,
+	}
+
 	// Resolve session directory.
-	sessionDir := input.SessionDir
-	if sessionDir == "" {
+	if opts.sessionDir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return SessionStatsOutput{}, fmt.Errorf("getting home dir: %w", err)
+			return sessionStatsOptions{}, fmt.Errorf("getting home dir: %w", err)
 		}
-		sessionDir = filepath.Join(home, ".pi-go", "sessions")
+		opts.sessionDir = filepath.Join(home, ".pi-go", "sessions")
 	}
 
 	// Resolve thresholds.
-	highToolCalls := input.HighToolCalls
-	if highToolCalls <= 0 {
-		highToolCalls = 20
+	if opts.highToolCalls <= 0 {
+		opts.highToolCalls = 20
 	}
-	highTurns := input.HighTurns
-	if highTurns <= 0 {
-		highTurns = 5
+	if opts.highTurns <= 0 {
+		opts.highTurns = 5
 	}
 
 	// Resolve lookback.
-	hours := input.Hours
-	if hours <= 0 {
-		hours = 24
+	if opts.hours <= 0 {
+		opts.hours = 24
 	}
-	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
+	opts.cutoff = time.Now().Add(-time.Duration(opts.hours) * time.Hour)
+	return opts, nil
+}
 
-	// Scan session directories.
-	entries, err := os.ReadDir(sessionDir)
+// scanSessions analyzes every session directory whose events file was touched
+// since the cutoff, returning the per-session stats and the cross-session
+// aggregate the deep sections are built from.
+func scanSessions(opts sessionStatsOptions) ([]sessionStat, *sweepTotals, error) {
+	entries, err := os.ReadDir(opts.sessionDir)
 	if err != nil {
-		return SessionStatsOutput{}, fmt.Errorf("reading sessions dir: %w", err)
+		return nil, nil, fmt.Errorf("reading sessions dir: %w", err)
 	}
 
 	var stats []sessionStat
@@ -125,19 +143,31 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 		if entry.Name() == "archive" {
 			continue
 		}
-		eventsPath := filepath.Join(sessionDir, entry.Name(), "events.jsonl")
+		eventsPath := filepath.Join(opts.sessionDir, entry.Name(), "events.jsonl")
 		info, err := os.Stat(eventsPath)
 		if err != nil {
 			continue
 		}
 		// Skip sessions older than cutoff.
-		if info.ModTime().Before(cutoff) {
+		if info.ModTime().Before(opts.cutoff) {
 			continue
 		}
 
-		stat := analyzeSessionFile(entry.Name(), eventsPath, highToolCalls, highTurns)
-		stats = append(stats, stat)
+		stats = append(stats, analyzeSessionFile(entry.Name(), eventsPath, opts.highToolCalls, opts.highTurns))
 		accumulateSweepFile(totals, eventsPath)
+	}
+	return stats, totals, nil
+}
+
+func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
+	opts, err := resolveSessionStatsOptions(input)
+	if err != nil {
+		return SessionStatsOutput{}, err
+	}
+
+	stats, totals, err := scanSessions(opts)
+	if err != nil {
+		return SessionStatsOutput{}, err
 	}
 
 	// Sort by time (newest first).
@@ -154,7 +184,7 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 		}
 	}
 
-	fmt.Fprintf(&b, "## Session Stats (last %d hours)\n\n", hours)
+	fmt.Fprintf(&b, "## Session Stats (last %d hours)\n\n", opts.hours)
 	fmt.Fprintf(&b, "Scanned %d sessions, %d with anomalies.\n\n", len(stats), totalAnomalous)
 
 	if len(stats) == 0 {
@@ -166,50 +196,14 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 		}, nil
 	}
 
-	// Summary table.
-	b.WriteString("| Session | Lines | Tool Calls | Turns | Errors | Duration | Anomalies |\n")
-	b.WriteString("|---------|-------|------------|-------|--------|----------|-----------|\n")
-	for _, s := range stats {
-		if !input.All && len(s.Anomalies) == 0 {
-			continue
-		}
-		dur := s.Duration.Truncate(time.Second)
-		anomalyStr := strings.Join(s.Anomalies, ", ")
-		if anomalyStr == "" {
-			anomalyStr = "—"
-		}
-		fmt.Fprintf(&b, "| %s | %d | %d | %d | %d | %s | %s |\n",
-			s.ID, s.Lines, s.ToolCalls, s.Turns, s.Errors, dur, anomalyStr)
-	}
-
-	// Detailed breakdown for anomalous sessions.
-	hasAnomalies := false
-	for _, s := range stats {
-		if len(s.Anomalies) == 0 {
-			continue
-		}
-		hasAnomalies = true
-		break
-	}
-	if hasAnomalies {
-		b.WriteString("\n### Anomaly Details\n\n")
-		for _, s := range stats {
-			if len(s.Anomalies) == 0 {
-				continue
-			}
-			fmt.Fprintf(&b, "**%s**\n", s.ID)
-			fmt.Fprintf(&b, "- Lines: %d, Tool calls: %d, Turns: %d, Errors: %d\n",
-				s.Lines, s.ToolCalls, s.Turns, s.Errors)
-			fmt.Fprintf(&b, "- Duration: %s\n", s.Duration.Truncate(time.Second))
-			fmt.Fprintf(&b, "- Anomalies: %s\n\n", strings.Join(s.Anomalies, "; "))
-		}
-	}
+	renderSessionTable(&b, stats, input.All)
+	renderAnomalyDetails(&b, stats)
 
 	// The per-session table above says which runs look odd. These sections say
 	// what went wrong across all of them, what it cost, and whether the
 	// recording pipelines are alive — the questions a nightly check exists for.
 	renderSweep(&b, totals, len(stats))
-	renderPipelineHealth(&b, len(stats), cutoff)
+	renderPipelineHealth(&b, len(stats), opts.cutoff)
 
 	return SessionStatsOutput{
 		Content:           b.String(),
@@ -221,6 +215,52 @@ func sessionStatsHandler(input SessionStatsInput) (SessionStatsOutput, error) {
 	}, nil
 }
 
+// renderSessionTable writes the summary table. Unless all is set, only sessions
+// with anomalies get a row.
+func renderSessionTable(b *strings.Builder, stats []sessionStat, all bool) {
+	b.WriteString("| Session | Lines | Tool Calls | Turns | Errors | Duration | Anomalies |\n")
+	b.WriteString("|---------|-------|------------|-------|--------|----------|-----------|\n")
+	for _, s := range stats {
+		if !all && len(s.Anomalies) == 0 {
+			continue
+		}
+		dur := s.Duration.Truncate(time.Second)
+		anomalyStr := strings.Join(s.Anomalies, ", ")
+		if anomalyStr == "" {
+			anomalyStr = "—"
+		}
+		fmt.Fprintf(b, "| %s | %d | %d | %d | %d | %s | %s |\n",
+			s.ID, s.Lines, s.ToolCalls, s.Turns, s.Errors, dur, anomalyStr)
+	}
+}
+
+// renderAnomalyDetails writes the detailed breakdown for anomalous sessions,
+// and nothing at all when no session has an anomaly.
+func renderAnomalyDetails(b *strings.Builder, stats []sessionStat) {
+	hasAnomalies := false
+	for _, s := range stats {
+		if len(s.Anomalies) == 0 {
+			continue
+		}
+		hasAnomalies = true
+		break
+	}
+	if !hasAnomalies {
+		return
+	}
+	b.WriteString("\n### Anomaly Details\n\n")
+	for _, s := range stats {
+		if len(s.Anomalies) == 0 {
+			continue
+		}
+		fmt.Fprintf(b, "**%s**\n", s.ID)
+		fmt.Fprintf(b, "- Lines: %d, Tool calls: %d, Turns: %d, Errors: %d\n",
+			s.Lines, s.ToolCalls, s.Turns, s.Errors)
+		fmt.Fprintf(b, "- Duration: %s\n", s.Duration.Truncate(time.Second))
+		fmt.Fprintf(b, "- Anomalies: %s\n\n", strings.Join(s.Anomalies, "; "))
+	}
+}
+
 // analyzeSessionFile reads a single events.jsonl and computes stats.
 func analyzeSessionFile(sessionID, path string, highToolCalls, highTurns int) sessionStat {
 	f, err := os.Open(path)
@@ -229,117 +269,153 @@ func analyzeSessionFile(sessionID, path string, highToolCalls, highTurns int) se
 	}
 	defer f.Close()
 
-	stat := sessionStat{ID: sessionID}
 	scanner := bufio.NewScanner(f)
 	// Increase scan buffer for potentially large JSON lines.
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 
-	var firstTS, lastTS time.Time
-	var toolCallCount, toolResultCount, turnCount, errorCount, gitOpCount int
-	var lineCount int
-
+	var counts sessionCounters
 	for scanner.Scan() {
-		line := scanner.Bytes()
-		lineCount++
+		counts.lines++
 
-		// Parse the event.
-		var ev struct {
-			Content      any    `json:"Content"`
-			Partial      bool   `json:"Partial"`
-			TurnComplete bool   `json:"TurnComplete"`
-			Interrupted  bool   `json:"Interrupted"`
-			ErrorCode    string `json:"ErrorCode"`
-			ErrorMessage string `json:"ErrorMessage"`
-			FinishReason string `json:"FinishReason"`
-			ID           string `json:"ID"`
-			Timestamp    string `json:"Timestamp"`
-			Author       string `json:"Author"`
-		}
-
-		if err := json.Unmarshal(line, &ev); err != nil {
+		var ev sessionEvent
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
 			continue
 		}
-
-		// Track time range.
-		if ev.Timestamp != "" {
-			ts, err := time.Parse(time.RFC3339Nano, ev.Timestamp)
-			if err == nil {
-				if firstTS.IsZero() || ts.Before(firstTS) {
-					firstTS = ts
-				}
-				if ts.After(lastTS) {
-					lastTS = ts
-				}
-			}
-		}
-
-		// Count tool calls: events with FunctionCall parts in Content.
-		if ev.Content != nil {
-			contentMap, ok := ev.Content.(map[string]any)
-			if ok {
-				if parts, ok := contentMap["parts"].([]any); ok {
-					for _, p := range parts {
-						pm, ok := p.(map[string]any)
-						if !ok {
-							continue
-						}
-						if fc, ok := pm["functionCall"].(map[string]any); ok {
-							toolCallCount++
-							if isGitOperation(fc) {
-								gitOpCount++
-							}
-						}
-						if _, ok := pm["functionResponse"]; ok {
-							toolResultCount++
-						}
-					}
-				}
-			}
-		}
-
-		// Count turns: TurnComplete events from the model.
-		if ev.TurnComplete && ev.Author != "user" {
-			turnCount++
-		}
-
-		// Count errors: a single event is at most one error, even if both
-		// ErrorCode/ErrorMessage and Interrupted are set.
-		if ev.ErrorCode != "" || ev.ErrorMessage != "" || ev.Interrupted {
-			errorCount++
-		}
+		counts.observe(&ev)
 	}
 
-	stat.Lines = lineCount
-	stat.ToolCalls = toolCallCount
-	stat.ToolResults = toolResultCount
-	stat.Turns = turnCount
-	stat.Errors = errorCount
-	stat.GitOps = gitOpCount
-	stat.FirstTime = firstTS
-	stat.LastTime = lastTS
-
-	if !firstTS.IsZero() && !lastTS.IsZero() {
-		stat.Duration = lastTS.Sub(firstTS)
-	}
-
-	// Detect anomalies.
-	if toolCallCount > highToolCalls {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("high tool calls (%d)", toolCallCount))
-	}
-	if turnCount > highTurns {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("excessive turns (%d)", turnCount))
-	}
-	if errorCount > 0 {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("errors (%d)", errorCount))
-	}
-	if gitOpCount > defaultHighGitOps {
-		stat.Anomalies = append(stat.Anomalies, fmt.Sprintf("many git operations (%d)", gitOpCount))
-	}
-	if stat.Duration > 30*time.Minute && toolCallCount < 5 {
-		stat.Anomalies = append(stat.Anomalies, "long idle session")
-	}
-
+	stat := counts.stat(sessionID)
+	stat.Anomalies = sessionAnomalies(stat, highToolCalls, highTurns)
 	return stat
+}
+
+// sessionEvent is the subset of an events.jsonl record the stats read.
+type sessionEvent struct {
+	Content      any    `json:"Content"`
+	Partial      bool   `json:"Partial"`
+	TurnComplete bool   `json:"TurnComplete"`
+	Interrupted  bool   `json:"Interrupted"`
+	ErrorCode    string `json:"ErrorCode"`
+	ErrorMessage string `json:"ErrorMessage"`
+	FinishReason string `json:"FinishReason"`
+	ID           string `json:"ID"`
+	Timestamp    string `json:"Timestamp"`
+	Author       string `json:"Author"`
+}
+
+// sessionCounters accumulates the per-event tallies for one session file.
+type sessionCounters struct {
+	lines       int
+	toolCalls   int
+	toolResults int
+	turns       int
+	errors      int
+	gitOps      int
+	firstTS     time.Time
+	lastTS      time.Time
+}
+
+// observe folds one decoded event into the counters.
+func (c *sessionCounters) observe(ev *sessionEvent) {
+	c.observeTimestamp(ev.Timestamp)
+	c.observeContent(ev.Content)
+
+	// Count turns: TurnComplete events from the model.
+	if ev.TurnComplete && ev.Author != "user" {
+		c.turns++
+	}
+
+	// Count errors: a single event is at most one error, even if both
+	// ErrorCode/ErrorMessage and Interrupted are set.
+	if ev.ErrorCode != "" || ev.ErrorMessage != "" || ev.Interrupted {
+		c.errors++
+	}
+}
+
+// observeTimestamp widens the session's time range. An absent or unparseable
+// timestamp is ignored rather than treated as the zero time.
+func (c *sessionCounters) observeTimestamp(timestamp string) {
+	if timestamp == "" {
+		return
+	}
+	ts, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return
+	}
+	if c.firstTS.IsZero() || ts.Before(c.firstTS) {
+		c.firstTS = ts
+	}
+	if ts.After(c.lastTS) {
+		c.lastTS = ts
+	}
+}
+
+// observeContent counts tool calls and results: events with FunctionCall or
+// FunctionResponse parts in Content, which is decoded untyped.
+func (c *sessionCounters) observeContent(content any) {
+	contentMap, ok := content.(map[string]any)
+	if !ok {
+		return
+	}
+	parts, ok := contentMap["parts"].([]any)
+	if !ok {
+		return
+	}
+	for _, p := range parts {
+		pm, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if fc, ok := pm["functionCall"].(map[string]any); ok {
+			c.toolCalls++
+			if isGitOperation(fc) {
+				c.gitOps++
+			}
+		}
+		if _, ok := pm["functionResponse"]; ok {
+			c.toolResults++
+		}
+	}
+}
+
+// stat converts the accumulated counters into the stat for one session.
+func (c *sessionCounters) stat(sessionID string) sessionStat {
+	stat := sessionStat{
+		ID:          sessionID,
+		Lines:       c.lines,
+		ToolCalls:   c.toolCalls,
+		ToolResults: c.toolResults,
+		Turns:       c.turns,
+		Errors:      c.errors,
+		GitOps:      c.gitOps,
+		FirstTime:   c.firstTS,
+		LastTime:    c.lastTS,
+	}
+	if !c.firstTS.IsZero() && !c.lastTS.IsZero() {
+		stat.Duration = c.lastTS.Sub(c.firstTS)
+	}
+	return stat
+}
+
+// sessionAnomalies lists what looks wrong about one session's totals.
+func sessionAnomalies(stat sessionStat, highToolCalls, highTurns int) []string {
+	var anomalies []string
+	if stat.ToolCalls > highToolCalls {
+		anomalies = append(anomalies, fmt.Sprintf("high tool calls (%d)", stat.ToolCalls))
+	}
+	if stat.Turns > highTurns {
+		anomalies = append(anomalies, fmt.Sprintf("excessive turns (%d)", stat.Turns))
+	}
+	if stat.Errors > 0 {
+		anomalies = append(anomalies, fmt.Sprintf("errors (%d)", stat.Errors))
+	}
+	if stat.GitOps > defaultHighGitOps {
+		anomalies = append(anomalies, fmt.Sprintf("many git operations (%d)", stat.GitOps))
+	}
+	if stat.Duration > 30*time.Minute && stat.ToolCalls < 5 {
+		anomalies = append(anomalies, "long idle session")
+	}
+	return anomalies
 }
 
 // isGitOperation reports whether a functionCall part represents a git

--- a/internal/tools/session_sweep.go
+++ b/internal/tools/session_sweep.go
@@ -173,6 +173,13 @@ func abortDetail(msg string) string {
 
 // renderSweep writes the deep sections: failures, waste, and real token spend.
 func renderSweep(b *strings.Builder, totals *sweepTotals, sessions int) {
+	renderSweepFailures(b, totals)
+	renderSweepWaste(b, totals)
+	renderSweepSpend(b, totals, sessions)
+}
+
+// renderSweepFailures writes the aborted runs and the per-tool error rates.
+func renderSweepFailures(b *strings.Builder, totals *sweepTotals) {
 	b.WriteString("\n## Failures\n\n")
 	if len(totals.Aborts) == 0 {
 		b.WriteString("No aborted runs.\n")
@@ -184,19 +191,24 @@ func renderSweep(b *strings.Builder, totals *sweepTotals, sessions int) {
 	}
 
 	byErrors := totals.sortedTools(func(u *toolUsage) int { return u.Errors })
-	if len(byErrors) > 0 && byErrors[0].Errors > 0 {
-		b.WriteString("\nTool errors, as a rate — a busy tool with a few failures is not the problem:\n\n")
-		b.WriteString("| tool | errors | calls | rate |\n|---|---:|---:|---:|\n")
-		for _, u := range byErrors {
-			if u.Errors == 0 {
-				break
-			}
-			calls := max(u.Calls, 1)
-			fmt.Fprintf(b, "| %s | %d | %d | %d%% |\n", u.Name, u.Errors, calls, 100*u.Errors/calls)
-		}
-		b.WriteString("\n→ `pi-check-session-logs` dedupes these by pattern.\n")
+	if len(byErrors) == 0 || byErrors[0].Errors == 0 {
+		return
 	}
+	b.WriteString("\nTool errors, as a rate — a busy tool with a few failures is not the problem:\n\n")
+	b.WriteString("| tool | errors | calls | rate |\n|---|---:|---:|---:|\n")
+	for _, u := range byErrors {
+		if u.Errors == 0 {
+			break
+		}
+		calls := max(u.Calls, 1)
+		fmt.Fprintf(b, "| %s | %d | %d | %d%% |\n", u.Name, u.Errors, calls, 100*u.Errors/calls)
+	}
+	b.WriteString("\n→ `pi-check-session-logs` dedupes these by pattern.\n")
+}
 
+// renderSweepWaste writes what capping oversized results and dropping
+// duplicates would give back.
+func renderSweepWaste(b *strings.Builder, totals *sweepTotals) {
 	b.WriteString("\n## Token waste\n\n")
 	overTotal := 0
 	for _, u := range totals.Tools {
@@ -204,41 +216,45 @@ func renderSweep(b *strings.Builder, totals *sweepTotals, sessions int) {
 	}
 	if overTotal == 0 && totals.DupBytes == 0 {
 		b.WriteString("Nothing oversized or duplicated.\n")
-	} else {
-		reclaim := (overTotal + totals.DupBytes) / 4
-		pct := 0
-		if totals.ToolBytes > 0 {
-			pct = 100 * (overTotal + totals.DupBytes) / totals.ToolBytes
-		}
-		fmt.Fprintf(b, "Reclaimable: **~%s tokens** (%d%% of tool output)\n\n", thousands(reclaim), pct)
-		b.WriteString("| tool | excess over 24k | compactor covers it? |\n|---|---:|---|\n")
-		for _, u := range totals.sortedTools(func(u *toolUsage) int { return u.Oversized }) {
-			if u.Oversized == 0 {
-				break
-			}
-			covered := "**no — uncapped**"
-			if compactedTools[strings.ReplaceAll(u.Name, "-", "_")] {
-				covered = "yes"
-			}
-			fmt.Fprintf(b, "| %s | %s tok | %s |\n", u.Name, thousands(u.Oversized/4), covered)
-		}
-		if totals.DupBytes > 0 {
-			fmt.Fprintf(b, "\nDuplicate results re-sent inside one session: ~%s tokens.\n",
-				thousands(totals.DupBytes/4))
-		}
+		return
 	}
 
+	reclaim := (overTotal + totals.DupBytes) / 4
+	pct := 0
+	if totals.ToolBytes > 0 {
+		pct = 100 * (overTotal + totals.DupBytes) / totals.ToolBytes
+	}
+	fmt.Fprintf(b, "Reclaimable: **~%s tokens** (%d%% of tool output)\n\n", thousands(reclaim), pct)
+	b.WriteString("| tool | excess over 24k | compactor covers it? |\n|---|---:|---|\n")
+	for _, u := range totals.sortedTools(func(u *toolUsage) int { return u.Oversized }) {
+		if u.Oversized == 0 {
+			break
+		}
+		covered := "**no — uncapped**"
+		if compactedTools[strings.ReplaceAll(u.Name, "-", "_")] {
+			covered = "yes"
+		}
+		fmt.Fprintf(b, "| %s | %s tok | %s |\n", u.Name, thousands(u.Oversized/4), covered)
+	}
+	if totals.DupBytes > 0 {
+		fmt.Fprintf(b, "\nDuplicate results re-sent inside one session: ~%s tokens.\n",
+			thousands(totals.DupBytes/4))
+	}
+}
+
+// renderSweepSpend writes the provider-reported token totals.
+func renderSweepSpend(b *strings.Builder, totals *sweepTotals, sessions int) {
 	b.WriteString("\n## Token spend\n\n")
 	if totals.PromptTokens == 0 {
 		b.WriteString("No usage metadata — the provider did not report token counts.\n")
-	} else {
-		fmt.Fprintf(b, "Prompt %s · output %s (provider-reported, not estimated)\n",
-			thousands(totals.PromptTokens), thousands(totals.OutputTokens))
-		if sessions > 0 {
-			fmt.Fprintf(b, "\nPrompt tokens are re-sent every request, so this is dominated by the fixed\nblock — system prompt plus tool declarations — not by the work. "+
-				"Average %s prompt tokens per session across %d session(s).\n",
-				thousands(totals.PromptTokens/sessions), sessions)
-		}
+		return
+	}
+	fmt.Fprintf(b, "Prompt %s · output %s (provider-reported, not estimated)\n",
+		thousands(totals.PromptTokens), thousands(totals.OutputTokens))
+	if sessions > 0 {
+		fmt.Fprintf(b, "\nPrompt tokens are re-sent every request, so this is dominated by the fixed\nblock — system prompt plus tool declarations — not by the work. "+
+			"Average %s prompt tokens per session across %d session(s).\n",
+			thousands(totals.PromptTokens/sessions), sessions)
 	}
 }
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -657,124 +657,7 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 			continue
 		}
 
-		var msgBuf strings.Builder
-		switch msg.role {
-		case "user":
-			if i > 0 {
-				msgBuf.WriteString(separator)
-				msgBuf.WriteString("\n")
-			}
-			label := lipgloss.NewStyle().
-				Foreground(p.Primary).
-				Bold(true).
-				Render("> ")
-			msgBuf.WriteString(label)
-			contentWidth := c.Width - 3 // "> " = 3 visible chars
-			if contentWidth < 20 {
-				contentWidth = 20
-			}
-			wrapped := wordWrap(msg.content, contentWidth)
-			for j, line := range wrapped {
-				if j > 0 {
-					msgBuf.WriteString("\n   ")
-				}
-				msgBuf.WriteString(line)
-			}
-			msgBuf.WriteString("\n")
-
-		case "tool":
-			msgBuf.WriteString("\n")
-			msgBuf.WriteString(c.ToolDisplay.RenderToolMessage(*msg))
-
-		case "thinking":
-			if msg.content != "" {
-				thinkStyle := lipgloss.NewStyle().Foreground(p.Faint).Italic(true)
-				thinkBullet := lipgloss.NewStyle().Foreground(p.Faint).Render("💭 ")
-				msgBuf.WriteString("\n")
-				msgBuf.WriteString(thinkBullet)
-				// Show last few lines of thinking to keep it compact.
-				lines := strings.Split(msg.content, "\n")
-				maxLines := 6
-				if len(lines) > maxLines {
-					lines = lines[len(lines)-maxLines:]
-				}
-				// Content width accounting for the bullet prefix.
-				contentWidth := c.Width - 3 // "💭 " = 3 visible chars
-				if contentWidth < 20 {
-					contentWidth = 20
-				}
-				for j, line := range lines {
-					if j > 0 {
-						msgBuf.WriteString("   ")
-					}
-					// Wrap each line to fit available width.
-					wrapped := wordWrap(line, contentWidth)
-					for k, wl := range wrapped {
-						if k > 0 {
-							msgBuf.WriteString("\n")
-						}
-						msgBuf.WriteString(thinkStyle.Render(wl))
-					}
-					if j < len(lines)-1 {
-						msgBuf.WriteString("\n")
-					}
-				}
-				msgBuf.WriteString("\n")
-			}
-
-		case "assistant":
-			content := msg.content
-			if content == "" && isLastAndStreaming {
-				content = "..."
-			}
-			if content != "" {
-				msgBuf.WriteString("\n")
-				if msg.isError {
-					errStyle := lipgloss.NewStyle().Foreground(p.Error).Bold(true)
-					msgBuf.WriteString(errStyle.Render("✖ "))
-					// Provider errors carry the raw JSON body, which is far
-					// wider than the pane. Wrap it like the user/thinking
-					// blocks do — an error truncated by the terminal is barely
-					// better than the silent failure this replaces.
-					contentWidth := c.Width - 3 // "✖ " plus the hanging indent
-					if contentWidth < 20 {
-						contentWidth = 20
-					}
-					for j, line := range wordWrap(content, contentWidth) {
-						if j > 0 {
-							msgBuf.WriteString("\n   ")
-						}
-						msgBuf.WriteString(errStyle.Render(line))
-					}
-				} else if msg.isWarning {
-					// Peach, not Warning: the warning role is a yellow, and
-					// yellow is the classic light-theme casualty — it washes
-					// out to nothing on white. Orange carries the same "look
-					// here, but nothing broke" weight and stays legible on both
-					// backgrounds.
-					warnStyle := lipgloss.NewStyle().Foreground(p.Peach).Bold(true)
-					warnBullet := lipgloss.NewStyle().Foreground(p.Peach).Bold(true).Render("⚠ ")
-					msgBuf.WriteString(warnBullet)
-					msgBuf.WriteString(warnStyle.Render(content))
-				} else if msg.isMeta {
-					// A dim "Σ" prefix marks the line as a per-turn tally rather
-					// than the model's own words — the reply uses "◉", so the
-					// two must never be confusable.
-					metaStyle := lipgloss.NewStyle().Foreground(p.Dim)
-					msgBuf.WriteString(metaStyle.Render("Σ " + content))
-				} else if msg.preRendered {
-					msgBuf.WriteString(bullet)
-					msgBuf.WriteString(content)
-				} else {
-					msgBuf.WriteString(bullet)
-					rendered := c.RenderMarkdown(content)
-					msgBuf.WriteString(rendered)
-				}
-				msgBuf.WriteString("\n")
-			}
-		}
-
-		rendered := msgBuf.String()
+		rendered := c.renderMessageBlock(msg, p, bullet, separator, i > 0, isLastAndStreaming)
 		b.WriteString(rendered)
 		kinds = appendKind(kinds, kindOf(msg), strings.Count(rendered, "\n"))
 
@@ -791,6 +674,158 @@ func (c *ChatModel) renderMessages(running bool) (string, []blockKind) {
 	// lines between blocks — visually noisy when several subagents run in
 	// parallel. Collapse to at most one blank line between content.
 	return collapseBlankLines(b.String(), kinds)
+}
+
+// renderWrapWidth returns the width available to content indented by reserve
+// visible columns, with the floor of 20 every block in renderMessages applies
+// so a very narrow pane still wraps rather than collapsing.
+func renderWrapWidth(total, reserve int) int {
+	if w := total - reserve; w >= 20 {
+		return w
+	}
+	return 20
+}
+
+// renderMessageBlock renders one message's contribution to the chat, or "" for
+// a role that draws nothing (an unknown role, or an empty thinking/assistant
+// message).
+func (c *ChatModel) renderMessageBlock(msg *message, p Palette, bullet, separator string, afterFirst, isLastAndStreaming bool) string {
+	switch msg.role {
+	case "user":
+		return c.renderUserBlock(msg.content, p, separator, afterFirst)
+	case "tool":
+		return "\n" + c.ToolDisplay.RenderToolMessage(*msg)
+	case "thinking":
+		return c.renderThinkingBlock(msg.content, p)
+	case "assistant":
+		return c.renderAssistantBlock(msg, p, bullet, isLastAndStreaming)
+	}
+	return ""
+}
+
+// renderUserBlock renders a user turn: the separator that divides it from the
+// previous turn, the "> " prompt, and the wrapped prompt text.
+func (c *ChatModel) renderUserBlock(content string, p Palette, separator string, afterFirst bool) string {
+	var b strings.Builder
+	if afterFirst {
+		b.WriteString(separator)
+		b.WriteString("\n")
+	}
+	label := lipgloss.NewStyle().
+		Foreground(p.Primary).
+		Bold(true).
+		Render("> ")
+	b.WriteString(label)
+	for j, line := range wordWrap(content, renderWrapWidth(c.Width, 3)) { // "> " = 3 visible chars
+		if j > 0 {
+			b.WriteString("\n   ")
+		}
+		b.WriteString(line)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// maxThinkingLines is how much of a thinking block the chat shows; only the
+// most recent lines are kept, to stay compact.
+const maxThinkingLines = 6
+
+// renderThinkingBlock renders the 💭 block for the model's reasoning.
+func (c *ChatModel) renderThinkingBlock(content string, p Palette) string {
+	if content == "" {
+		return ""
+	}
+	thinkStyle := lipgloss.NewStyle().Foreground(p.Faint).Italic(true)
+	thinkBullet := lipgloss.NewStyle().Foreground(p.Faint).Render("💭 ")
+
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(thinkBullet)
+	// Show last few lines of thinking to keep it compact.
+	lines := strings.Split(content, "\n")
+	if len(lines) > maxThinkingLines {
+		lines = lines[len(lines)-maxThinkingLines:]
+	}
+	// Content width accounting for the bullet prefix.
+	contentWidth := renderWrapWidth(c.Width, 3) // "💭 " = 3 visible chars
+	for j, line := range lines {
+		if j > 0 {
+			b.WriteString("   ")
+		}
+		// Wrap each line to fit available width.
+		for k, wl := range wordWrap(line, contentWidth) {
+			if k > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(thinkStyle.Render(wl))
+		}
+		if j < len(lines)-1 {
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderAssistantBlock renders an assistant turn, or "" when there is nothing
+// to show. A streaming turn with no content yet renders as "..." so the reply
+// has somewhere to appear.
+func (c *ChatModel) renderAssistantBlock(msg *message, p Palette, bullet string, isLastAndStreaming bool) string {
+	content := msg.content
+	if content == "" && isLastAndStreaming {
+		content = "..."
+	}
+	if content == "" {
+		return ""
+	}
+	return "\n" + c.assistantBody(msg, content, p, bullet) + "\n"
+}
+
+// assistantBody renders the assistant content itself, styled by which kind of
+// message it is. Only one of these applies, and the order is the precedence
+// they have always had: error, then warning, then meta, then the reply.
+func (c *ChatModel) assistantBody(msg *message, content string, p Palette, bullet string) string {
+	switch {
+	case msg.isError:
+		return c.assistantErrorBody(content, p)
+	case msg.isWarning:
+		// Peach, not Warning: the warning role is a yellow, and yellow is the
+		// classic light-theme casualty — it washes out to nothing on white.
+		// Orange carries the same "look here, but nothing broke" weight and
+		// stays legible on both backgrounds.
+		warnStyle := lipgloss.NewStyle().Foreground(p.Peach).Bold(true)
+		warnBullet := lipgloss.NewStyle().Foreground(p.Peach).Bold(true).Render("⚠ ")
+		return warnBullet + warnStyle.Render(content)
+	case msg.isMeta:
+		// A dim "Σ" prefix marks the line as a per-turn tally rather than the
+		// model's own words — the reply uses "◉", so the two must never be
+		// confusable.
+		metaStyle := lipgloss.NewStyle().Foreground(p.Dim)
+		return metaStyle.Render("Σ " + content)
+	case msg.preRendered:
+		return bullet + content
+	default:
+		return bullet + c.RenderMarkdown(content)
+	}
+}
+
+// assistantErrorBody renders an error reply. Provider errors carry the raw JSON
+// body, which is far wider than the pane. Wrap it like the user/thinking blocks
+// do — an error truncated by the terminal is barely better than the silent
+// failure this replaces.
+func (c *ChatModel) assistantErrorBody(content string, p Palette) string {
+	errStyle := lipgloss.NewStyle().Foreground(p.Error).Bold(true)
+
+	var b strings.Builder
+	b.WriteString(errStyle.Render("✖ "))
+	contentWidth := renderWrapWidth(c.Width, 3) // "✖ " plus the hanging indent
+	for j, line := range wordWrap(content, contentWidth) {
+		if j > 0 {
+			b.WriteString("\n   ")
+		}
+		b.WriteString(errStyle.Render(line))
+	}
+	return b.String()
 }
 
 // appendKind records that a message opened n lines of output.

--- a/internal/tui/collapse.go
+++ b/internal/tui/collapse.go
@@ -33,23 +33,11 @@ func blankFast(line string) bool {
 	for i := 0; i < len(line); {
 		c := line[i]
 		if c == 0x1b { // ESC
-			if i+1 >= len(line) || line[i+1] != '[' {
-				return slowBlank(line) // not CSI: defer to the parser
+			next := skipFastCSI(line, i)
+			if next < 0 {
+				return slowBlank(line) // not the fast-path grammar: defer to the parser
 			}
-			// Fast-path ONLY the exact CSI grammar lipgloss/glamour emit:
-			//   ESC [ <param bytes 0x30-0x3f> <final byte 0x40-0x7e>
-			// Intermediate bytes (0x20-0x2f) are deliberately excluded: they are
-			// legal CSI but order-sensitive, and ansi.Strip aborts on bad order
-			// (FuzzBlankFast: "\x1b[ 0A"). C0 controls abort too ("\x1b[\x1c").
-			// Every deviation defers to the parser instead of guessing.
-			j := i + 2
-			for j < len(line) && line[j] >= 0x30 && line[j] <= 0x3f {
-				j++
-			}
-			if j >= len(line) || line[j] < 0x40 || line[j] > 0x7e {
-				return slowBlank(line)
-			}
-			i = j + 1 // consume final byte
+			i = next
 			continue
 		}
 		if c < utf8.RuneSelf { // ASCII fast path — the overwhelmingly common case
@@ -73,6 +61,32 @@ func blankFast(line string) bool {
 		i += size
 	}
 	return true
+}
+
+// skipFastCSI reports the index just past the CSI sequence that starts at the
+// ESC byte line[i], or -1 when line[i:] is not the exact grammar the fast path
+// handles and the caller must defer to the parser.
+//
+// It fast-paths ONLY the exact CSI grammar lipgloss/glamour emit:
+//
+//	ESC [ <param bytes 0x30-0x3f> <final byte 0x40-0x7e>
+//
+// Intermediate bytes (0x20-0x2f) are deliberately excluded: they are legal CSI
+// but order-sensitive, and ansi.Strip aborts on bad order (FuzzBlankFast:
+// "\x1b[ 0A"). C0 controls abort too ("\x1b[\x1c"). Every deviation defers to
+// the parser instead of guessing.
+func skipFastCSI(line string, i int) int {
+	if i+1 >= len(line) || line[i+1] != '[' {
+		return -1
+	}
+	j := i + 2
+	for j < len(line) && line[j] >= 0x30 && line[j] <= 0x3f {
+		j++
+	}
+	if j >= len(line) || line[j] < 0x40 || line[j] > 0x7e {
+		return -1
+	}
+	return j + 1 // consume final byte
 }
 
 // slowBlank is the reference implementation blankFast must agree with, and the

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -38,78 +38,131 @@ func (m *model) handleSlashCommand(input string) (tea.Model, tea.Cmd) {
 		m.setSessionTitle(input)
 	}
 
-	switch cmd {
-	case "/help":
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role:    "assistant",
-			content: m.formatHelp(),
-		})
-	case "/clear":
-		m.clearConversation()
-	case "/copy":
-		return m.handleCopyCommand()
-	case "/model":
-		return m.handleModelCommand(parts[1:])
-	case "/session":
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role:    "assistant",
-			content: fmt.Sprintf("Session: `%s`", m.cfg.SessionID),
-		})
-	case "/context":
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role:    "assistant",
-			content: m.formatContextUsage(),
-		})
-	case "/branch":
-		m.handleBranchCommand(parts[1:])
-	case "/compact":
-		m.handleCompactCommand()
-	case "/subagents":
-		m.handleAgentsCommand()
-	case "/history":
-		m.handleHistoryCommand(parts[1:])
-	case "/commit":
-		return m.handleCommitCommand()
-	case "/plan":
-		return m.handlePlanCommand(parts[1:])
-	case "/run":
-		return m.handleRunCommand(parts[1:])
-	case "/login":
-		return m.handleLoginCommand(parts[1:])
-	case "/skills":
-		return m.handleSkillsCommand(parts[1:])
-	case "/skill-create":
-		return m.handleSkillCreateCommand(parts[1:])
-	case "/skill-load":
-		return m.handleSkillLoadCommand()
-	case "/skill-list":
-		return m.handleSkillListCommand()
-	case "/theme":
-		return m.handleThemeCommand(parts[1:])
-	case "/rtk":
-		m.handleRTKCommand(parts[1:])
-	case "/ping":
-		return m.handlePingCommand(parts[1:])
-	case "/restart":
-		return m.handleRestartCommand()
-	case "/mcp":
-		m.handleMCPCommand()
-	case "/exit", "/quit":
-		m.quitting = true
-		return m, tea.Quit
-	default:
-		// Check if it's a dynamic skill command.
-		skillName := strings.TrimPrefix(cmd, "/")
-		if skill, ok := extension.FindSkill(m.cfg.Skills, skillName); ok {
-			return m.handleSkillCommand(skill, parts[1:])
-		}
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role:    "assistant",
-			content: fmt.Sprintf("Unknown command: `%s`. Type `/help` for available commands.", cmd),
-		})
+	if spec, ok := slashCommandByName[cmd]; ok {
+		return spec.run(m, parts[1:])
 	}
 
+	// Check if it's a dynamic skill command.
+	skillName := strings.TrimPrefix(cmd, "/")
+	if skill, ok := extension.FindSkill(m.cfg.Skills, skillName); ok {
+		return m.handleSkillCommand(skill, parts[1:])
+	}
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: fmt.Sprintf("Unknown command: `%s`. Type `/help` for available commands.", cmd),
+	})
+
 	return m, nil
+}
+
+// slashCommandSpec is one built-in slash command: how it is advertised in the
+// command list and autocomplete, and what typing it does. Keeping the name,
+// the description and the handler in one row is what stops the dispatch switch
+// and the description switch from drifting apart.
+type slashCommandSpec struct {
+	name string
+	desc string
+	// hidden keeps a command out of slashCommands — the autocomplete and
+	// /help listing — while it still dispatches and still has a description.
+	hidden bool
+	run    func(m *model, args []string) (tea.Model, tea.Cmd)
+}
+
+// slashCmdArgs adapts a handler that mutates the model and returns nothing.
+func slashCmdArgs(f func(*model, []string)) func(*model, []string) (tea.Model, tea.Cmd) {
+	return func(m *model, args []string) (tea.Model, tea.Cmd) {
+		f(m, args)
+		return m, nil
+	}
+}
+
+// slashCmdBare adapts a handler that takes no args and returns a command.
+func slashCmdBare(f func(*model) (tea.Model, tea.Cmd)) func(*model, []string) (tea.Model, tea.Cmd) {
+	return func(m *model, _ []string) (tea.Model, tea.Cmd) {
+		return f(m)
+	}
+}
+
+// slashCmdVoid adapts a handler that takes no args and returns nothing.
+func slashCmdVoid(f func(*model)) func(*model, []string) (tea.Model, tea.Cmd) {
+	return func(m *model, _ []string) (tea.Model, tea.Cmd) {
+		f(m)
+		return m, nil
+	}
+}
+
+// slashCommandSpecs is the single source of truth for the built-in slash
+// commands. Order matters: slashCommands is derived from it, and autocomplete
+// returns the first prefix match.
+var slashCommandSpecs = []slashCommandSpec{
+	{name: "/help", desc: "Show help", run: slashCmdVoid((*model).showHelpMessage)},
+	{name: "/clear", desc: "Clear conversation", run: slashCmdVoid((*model).clearConversation)},
+	{name: "/copy", desc: "Copy conversation to clipboard", run: slashCmdBare((*model).handleCopyCommand)},
+	{name: "/model", desc: "Show or switch model", run: (*model).handleModelCommand},
+	{name: "/session", desc: "Show session info", run: slashCmdVoid((*model).showSessionMessage)},
+	{name: "/context", desc: "Show context usage", run: slashCmdVoid((*model).showContextMessage)},
+	{name: "/branch", desc: "Manage branches", run: slashCmdArgs((*model).handleBranchCommand)},
+	{name: "/compact", desc: "Compact context", run: slashCmdVoid((*model).handleCompactCommand)},
+	{name: "/subagents", desc: "Show subagents", run: slashCmdVoid((*model).handleAgentsCommand)},
+	{name: "/history", desc: "Command history", run: slashCmdArgs((*model).handleHistoryCommand)},
+	{name: "/login", desc: "Configure API keys (codex, openai, anthropic, gemini)", run: (*model).handleLoginCommand},
+	{name: "/commit", desc: "Create commit from staged changes", run: slashCmdBare((*model).handleCommitCommand)},
+	{name: "/plan", desc: "Start PDD planning session", run: (*model).handlePlanCommand},
+	{
+		name: "/run",
+		desc: "Execute a spec with task agent (verifies subagent exit status before merging)",
+		run:  (*model).handleRunCommand,
+	},
+	{name: "/skills", desc: "List skills (create, load)", run: (*model).handleSkillsCommand},
+	{name: "/skill-list", desc: "List all loaded skills", hidden: true, run: slashCmdBare((*model).handleSkillListCommand)},
+	{name: "/skill-load", desc: "Reload skills from disk", hidden: true, run: slashCmdBare((*model).handleSkillLoadCommand)},
+	{name: "/skill-create", desc: "Create a new skill", hidden: true, run: (*model).handleSkillCreateCommand},
+	{name: "/theme", desc: "Switch theme or list themes", run: (*model).handleThemeCommand},
+	{name: "/ping", desc: "Test LLM connectivity", run: (*model).handlePingCommand},
+	{name: "/rtk", desc: "Output compaction stats", run: slashCmdArgs((*model).handleRTKCommand)},
+	{name: "/mcp", desc: "List MCP servers and tool status", run: slashCmdVoid((*model).handleMCPCommand)},
+	{name: "/restart", desc: "Restart pi process", run: slashCmdBare((*model).handleRestartCommand)},
+	{name: "/exit", desc: "Exit", run: slashCmdBare((*model).handleQuitCommand)},
+	{name: "/quit", desc: "Exit", run: slashCmdBare((*model).handleQuitCommand)},
+}
+
+// slashCommandByName indexes slashCommandSpecs for dispatch and descriptions.
+var slashCommandByName = func() map[string]slashCommandSpec {
+	byName := make(map[string]slashCommandSpec, len(slashCommandSpecs))
+	for _, spec := range slashCommandSpecs {
+		byName[spec.name] = spec
+	}
+	return byName
+}()
+
+// showHelpMessage appends the help text as an assistant message.
+func (m *model) showHelpMessage() {
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: m.formatHelp(),
+	})
+}
+
+// showSessionMessage appends the current session ID as an assistant message.
+func (m *model) showSessionMessage() {
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: fmt.Sprintf("Session: `%s`", m.cfg.SessionID),
+	})
+}
+
+// showContextMessage appends the context usage breakdown as an assistant message.
+func (m *model) showContextMessage() {
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: m.formatContextUsage(),
+	})
+}
+
+// handleQuitCommand tears the program down.
+func (m *model) handleQuitCommand() (tea.Model, tea.Cmd) {
+	m.quitting = true
+	return m, tea.Quit
 }
 
 func (m *model) handleCopyCommand() (tea.Model, tea.Cmd) {
@@ -542,28 +595,70 @@ func saveModelToConfig(modelName, provider string) {
 func (m *model) formatContextUsage() string {
 	var b strings.Builder
 
-	// The breakdown answers "what is filling the window", which is the question
-	// a user asks before deciding what to trim. Lead with it.
-	if bd := m.cfg.ContextBreakdown; bd != nil {
-		used := int64(0)
-		window := int64(0)
-		if tt := m.cfg.TokenTracker; tt != nil {
-			used = tt.LastPromptTokens()
-			window = tt.ContextWindowSize()
+	m.writeCtxBreakdownSection(&b)
+
+	est := m.estimateCtxRoleTokens()
+
+	// Header.
+	b.WriteString("**Context Usage**\n\n")
+
+	m.writeCtxModelLine(&b, est.total)
+	m.writeCtxCategorySection(&b, est)
+	m.writeCtxDailySection(&b)
+	m.writeCtxWindowSection(&b)
+	m.writeCtxSkillsSection(&b)
+	m.writeCtxSubagentSection(&b)
+
+	// Compaction stats.
+	if cm := m.cfg.CompactMetrics; cm != nil {
+		stats := cm.FormatStats()
+		if stats != "" {
+			b.WriteString("\n*Output compaction*\n")
+			b.WriteString(stats)
 		}
-		if used == 0 {
-			used = estimateContextTokenCount(m.chatModel.Messages) + bd.FixedTotal()
-		}
-		if window <= 0 {
-			window = autoRangeWindow(used)
-		}
-		b.WriteString("*Context usage*\n\n")
-		b.WriteString(RenderContextBreakdown(
-			bd.withConversationFrom(used), window, min(m.chatWidth()-4, 64), m.palette))
-		b.WriteString("\n\n")
 	}
 
-	// Same estimate as the status bar's, split by role.
+	return b.String()
+}
+
+// writeCtxBreakdownSection writes the "what is filling the window" breakdown.
+// It answers the question a user asks before deciding what to trim, so it
+// leads the /context output.
+func (m *model) writeCtxBreakdownSection(b *strings.Builder) {
+	bd := m.cfg.ContextBreakdown
+	if bd == nil {
+		return
+	}
+	used := int64(0)
+	window := int64(0)
+	if tt := m.cfg.TokenTracker; tt != nil {
+		used = tt.LastPromptTokens()
+		window = tt.ContextWindowSize()
+	}
+	if used == 0 {
+		used = estimateContextTokenCount(m.chatModel.Messages) + bd.FixedTotal()
+	}
+	if window <= 0 {
+		window = autoRangeWindow(used)
+	}
+	b.WriteString("*Context usage*\n\n")
+	b.WriteString(RenderContextBreakdown(
+		bd.withConversationFrom(used), window, min(m.chatWidth()-4, 64), m.palette))
+	b.WriteString("\n\n")
+}
+
+// ctxRoleTokens is the per-role token estimate behind the /context category
+// breakdown. total is estimated over the summed characters, not as the sum of
+// the per-role estimates, so it can differ from user+assistant+tool by rounding.
+type ctxRoleTokens struct {
+	user      int64
+	assistant int64
+	tool      int64
+	total     int64
+}
+
+// estimateCtxRoleTokens splits the same estimate the status bar shows by role.
+func (m *model) estimateCtxRoleTokens() ctxRoleTokens {
 	userChars, assistantChars, toolChars := 0, 0, 0
 	for _, msg := range m.chatModel.Messages {
 		size := messageChars(msg)
@@ -576,15 +671,16 @@ func (m *model) formatContextUsage() string {
 			toolChars += size
 		}
 	}
-	totalTokens := estimateTokens(userChars + assistantChars + toolChars)
-	userTokens := estimateTokens(userChars)
-	assistantTokens := estimateTokens(assistantChars)
-	toolTokens := estimateTokens(toolChars)
+	return ctxRoleTokens{
+		user:      estimateTokens(userChars),
+		assistant: estimateTokens(assistantChars),
+		tool:      estimateTokens(toolChars),
+		total:     estimateTokens(userChars + assistantChars + toolChars),
+	}
+}
 
-	// Header.
-	b.WriteString("**Context Usage**\n\n")
-
-	// Progress bar (20 blocks).
+// writeCtxModelLine writes the 20-block usage bar and the model label beside it.
+func (m *model) writeCtxModelLine(b *strings.Builder, totalTokens int64) {
 	const barLen = 20
 	var usedBlocks int
 	var limitTokens int64
@@ -602,155 +698,168 @@ func (m *model) formatContextUsage() string {
 	}
 	bar := barGlyphs(usedBlocks, barLen)
 
-	// Model line with bar.
 	modelLabel := m.cfg.ModelName
 	if m.cfg.ProviderName != "" {
 		modelLabel = m.cfg.ProviderName + " | " + modelLabel
 	}
 	if limitTokens > 0 {
 		tt := m.cfg.TokenTracker
-		fmt.Fprintf(&b, "`%s`  %s · %s/%s tokens (%.0f%%)\n\n",
+		fmt.Fprintf(b, "`%s`  %s · %s/%s tokens (%.0f%%)\n\n",
 			bar, modelLabel,
 			formatTokenCount(tt.TotalUsed()), formatTokenCount(limitTokens), tt.PercentUsed())
-	} else {
-		fmt.Fprintf(&b, "`%s`  %s · ctx ~%s tokens\n\n",
-			bar, modelLabel, formatTokenCount(totalTokens))
+		return
 	}
+	fmt.Fprintf(b, "`%s`  %s · ctx ~%s tokens\n\n",
+		bar, modelLabel, formatTokenCount(totalTokens))
+}
 
-	// Category breakdown.
+// writeCtxCategorySection writes the estimated per-role usage list.
+func (m *model) writeCtxCategorySection(b *strings.Builder, est ctxRoleTokens) {
 	b.WriteString("*Estimated usage by category*\n")
-	fmt.Fprintf(&b, "- **User messages**: ~%s tokens (%d msgs)\n",
-		formatTokenCount(userTokens), countByRole(m.chatModel.Messages, "user"))
-	fmt.Fprintf(&b, "- **Assistant messages**: ~%s tokens (%d msgs)\n",
-		formatTokenCount(assistantTokens), countByRole(m.chatModel.Messages, "assistant"))
-	fmt.Fprintf(&b, "- **Tool calls**: ~%s tokens (%d calls)\n",
-		formatTokenCount(toolTokens), countByRole(m.chatModel.Messages, "tool"))
-	fmt.Fprintf(&b, "- **Total context**: ~%s tokens (%d messages)\n",
-		formatTokenCount(totalTokens), len(m.chatModel.Messages))
+	fmt.Fprintf(b, "- **User messages**: ~%s tokens (%d msgs)\n",
+		formatTokenCount(est.user), countByRole(m.chatModel.Messages, "user"))
+	fmt.Fprintf(b, "- **Assistant messages**: ~%s tokens (%d msgs)\n",
+		formatTokenCount(est.assistant), countByRole(m.chatModel.Messages, "assistant"))
+	fmt.Fprintf(b, "- **Tool calls**: ~%s tokens (%d calls)\n",
+		formatTokenCount(est.tool), countByRole(m.chatModel.Messages, "tool"))
+	fmt.Fprintf(b, "- **Total context**: ~%s tokens (%d messages)\n",
+		formatTokenCount(est.total), len(m.chatModel.Messages))
+}
 
-	// Daily token usage (actual, not estimated).
-	if tt := m.cfg.TokenTracker; tt != nil {
-		total := tt.TotalUsed()
-		if total > 0 {
-			b.WriteString("\n*Daily token usage*\n")
-			fmt.Fprintf(&b, "- **Consumed today**: %s tokens\n", formatTokenCount(total))
-			if tt.Limit() > 0 {
-				fmt.Fprintf(&b, "- **Remaining**: %s tokens\n", formatTokenCount(tt.Remaining()))
-			}
+// writeCtxDailySection writes actual (not estimated) daily token consumption.
+func (m *model) writeCtxDailySection(b *strings.Builder) {
+	tt := m.cfg.TokenTracker
+	if tt == nil {
+		return
+	}
+	total := tt.TotalUsed()
+	if total == 0 {
+		return
+	}
+	b.WriteString("\n*Daily token usage*\n")
+	fmt.Fprintf(b, "- **Consumed today**: %s tokens\n", formatTokenCount(total))
+	if tt.Limit() > 0 {
+		fmt.Fprintf(b, "- **Remaining**: %s tokens\n", formatTokenCount(tt.Remaining()))
+	}
+}
+
+// writeCtxWindowSection writes context window occupancy from the last LLM
+// response, followed by the prompt cache section.
+func (m *model) writeCtxWindowSection(b *strings.Builder) {
+	tt := m.cfg.TokenTracker
+	if tt == nil || tt.LastPromptTokens() <= 0 {
+		return
+	}
+	promptTokens := tt.LastPromptTokens()
+	ctxWindow := tt.ContextWindowSize()
+
+	b.WriteString("\n*Context window*\n")
+	if ctxWindow > 0 {
+		pct := tt.ContextPercentUsed()
+		freeTokens := ctxWindow - promptTokens
+		if freeTokens < 0 {
+			freeTokens = 0
 		}
+
+		const ctxBarLen = 20
+		ctxBar := barGlyphs(barFill(pct/100, ctxBarLen), ctxBarLen)
+
+		fmt.Fprintf(b, "`%s`  %s / %s (%.0f%%)\n",
+			ctxBar,
+			formatTokenCount(promptTokens), formatTokenCount(ctxWindow), pct)
+		fmt.Fprintf(b, "- **Used**: %s tokens\n", formatTokenCount(promptTokens))
+		fmt.Fprintf(b, "- **Free**: %s tokens (%.0f%%)\n",
+			formatTokenCount(freeTokens), 100-pct)
+	} else {
+		fmt.Fprintf(b, "- **Last prompt**: %s tokens (window size unknown)\n",
+			formatTokenCount(promptTokens))
 	}
 
-	// Context window usage (from last LLM response).
-	if tt := m.cfg.TokenTracker; tt != nil && tt.LastPromptTokens() > 0 {
-		promptTokens := tt.LastPromptTokens()
-		ctxWindow := tt.ContextWindowSize()
+	m.writeCtxCacheSection(b, promptTokens)
+}
 
-		b.WriteString("\n*Context window*\n")
-		if ctxWindow > 0 {
-			pct := tt.ContextPercentUsed()
-			freeTokens := ctxWindow - promptTokens
-			if freeTokens < 0 {
-				freeTokens = 0
-			}
+// writeCtxCacheSection writes prompt cache statistics. Reported explicitly even
+// at zero hits — a silent section reads the same whether caching works or is
+// entirely absent.
+func (m *model) writeCtxCacheSection(b *strings.Builder, promptTokens int64) {
+	tt := m.cfg.TokenTracker
+	b.WriteString("\n*Prompt cache*\n")
+	cached := tt.LastCachedTokens()
+	if cached > 0 {
+		fmt.Fprintf(b, "- **Last request**: %s of %s prompt tokens cached (%.0f%%)\n",
+			formatTokenCount(cached), formatTokenCount(promptTokens),
+			float64(cached)/float64(promptTokens)*100)
+	} else {
+		b.WriteString("- **Last request**: no cache hit\n")
+	}
+	if today := tt.CachedTokensToday(); today > 0 {
+		fmt.Fprintf(b, "- **Today**: %s tokens read from cache (%.0f%% of input)\n",
+			formatTokenCount(today), tt.CacheHitRateToday())
+	}
+	if prefix := tt.CachePrefixTokens(); prefix > 0 {
+		fmt.Fprintf(b, "- **Stable prefix**: %s tokens · **body since**: %s tokens\n",
+			formatTokenCount(prefix), formatTokenCount(tt.BodyTokens()))
+	}
+}
 
-			const ctxBarLen = 20
-			ctxBar := barGlyphs(barFill(pct/100, ctxBarLen), ctxBarLen)
-
-			fmt.Fprintf(&b, "`%s`  %s / %s (%.0f%%)\n",
-				ctxBar,
-				formatTokenCount(promptTokens), formatTokenCount(ctxWindow), pct)
-			fmt.Fprintf(&b, "- **Used**: %s tokens\n", formatTokenCount(promptTokens))
-			fmt.Fprintf(&b, "- **Free**: %s tokens (%.0f%%)\n",
-				formatTokenCount(freeTokens), 100-pct)
+// writeCtxSkillsSection lists loaded skills alphabetically, for predictable
+// /context output.
+func (m *model) writeCtxSkillsSection(b *strings.Builder) {
+	if len(m.cfg.Skills) == 0 {
+		return
+	}
+	b.WriteString("\n*Skills* ")
+	fmt.Fprintf(b, "(%d loaded)\n", len(m.cfg.Skills))
+	names := make([]string, 0, len(m.cfg.Skills))
+	byName := make(map[string]extension.Skill, len(m.cfg.Skills))
+	for _, s := range m.cfg.Skills {
+		names = append(names, s.Name)
+		byName[s.Name] = s
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		s := byName[name]
+		source := s.Source
+		if source == "" {
+			source = "user"
+		}
+		var bodyDesc string
+		if size, ok := extension.SkillBodySize(m.cfg.Skills, s.Name); ok {
+			bodyDesc = fmt.Sprintf("body: %s", formatTokenCount(int64(size)))
 		} else {
-			fmt.Fprintf(&b, "- **Last prompt**: %s tokens (window size unknown)\n",
-				formatTokenCount(promptTokens))
+			bodyDesc = "body: not loaded"
 		}
+		desc := s.Description
+		if desc == "" {
+			desc = "(no description)"
+		}
+		fmt.Fprintf(b, "- /%s — %s [%s]  %s\n", s.Name, desc, source, bodyDesc)
+	}
+}
 
-		// Prompt cache. Reported explicitly even at zero hits — a silent
-		// section reads the same whether caching works or is entirely absent.
-		b.WriteString("\n*Prompt cache*\n")
-		cached := tt.LastCachedTokens()
-		if cached > 0 {
-			fmt.Fprintf(&b, "- **Last request**: %s of %s prompt tokens cached (%.0f%%)\n",
-				formatTokenCount(cached), formatTokenCount(promptTokens),
-				float64(cached)/float64(promptTokens)*100)
-		} else {
-			b.WriteString("- **Last request**: no cache hit\n")
-		}
-		if today := tt.CachedTokensToday(); today > 0 {
-			fmt.Fprintf(&b, "- **Today**: %s tokens read from cache (%.0f%% of input)\n",
-				formatTokenCount(today), tt.CacheHitRateToday())
-		}
-		if prefix := tt.CachePrefixTokens(); prefix > 0 {
-			fmt.Fprintf(&b, "- **Stable prefix**: %s tokens · **body since**: %s tokens\n",
-				formatTokenCount(prefix), formatTokenCount(tt.BodyTokens()))
+// writeCtxSubagentSection writes the running/done/failed subagent tally.
+func (m *model) writeCtxSubagentSection(b *strings.Builder) {
+	if m.cfg.Orchestrator == nil {
+		return
+	}
+	agents := m.cfg.Orchestrator.List()
+	if len(agents) == 0 {
+		return
+	}
+	running, done, failed := 0, 0, 0
+	for _, a := range agents {
+		switch a.Status {
+		case "running":
+			running++
+		case "failed":
+			failed++
+		default:
+			done++
 		}
 	}
-
-	// Skills.
-	if len(m.cfg.Skills) > 0 {
-		b.WriteString("\n*Skills* ")
-		fmt.Fprintf(&b, "(%d loaded)\n", len(m.cfg.Skills))
-		// Stable, alphabetical listing for predictable /context output.
-		names := make([]string, 0, len(m.cfg.Skills))
-		byName := make(map[string]extension.Skill, len(m.cfg.Skills))
-		for _, s := range m.cfg.Skills {
-			names = append(names, s.Name)
-			byName[s.Name] = s
-		}
-		sort.Strings(names)
-		for _, name := range names {
-			s := byName[name]
-			source := s.Source
-			if source == "" {
-				source = "user"
-			}
-			var bodyDesc string
-			if size, ok := extension.SkillBodySize(m.cfg.Skills, s.Name); ok {
-				bodyDesc = fmt.Sprintf("body: %s", formatTokenCount(int64(size)))
-			} else {
-				bodyDesc = "body: not loaded"
-			}
-			desc := s.Description
-			if desc == "" {
-				desc = "(no description)"
-			}
-			fmt.Fprintf(&b, "- /%s — %s [%s]  %s\n", s.Name, desc, source, bodyDesc)
-		}
-	}
-
-	// Subagents.
-	if m.cfg.Orchestrator != nil {
-		agents := m.cfg.Orchestrator.List()
-		if len(agents) > 0 {
-			running, done, failed := 0, 0, 0
-			for _, a := range agents {
-				switch a.Status {
-				case "running":
-					running++
-				case "failed":
-					failed++
-				default:
-					done++
-				}
-			}
-			b.WriteString("\n*Subagents*\n")
-			fmt.Fprintf(&b, "- **Total**: %d (running: %d, done: %d, failed: %d)\n",
-				len(agents), running, done, failed)
-		}
-	}
-
-	// Compaction stats.
-	if cm := m.cfg.CompactMetrics; cm != nil {
-		stats := cm.FormatStats()
-		if stats != "" {
-			b.WriteString("\n*Output compaction*\n")
-			b.WriteString(stats)
-		}
-	}
-
-	return b.String()
+	b.WriteString("\n*Subagents*\n")
+	fmt.Fprintf(b, "- **Total**: %d (running: %d, done: %d, failed: %d)\n",
+		len(agents), running, done, failed)
 }
 
 // showCommandList displays available slash commands as an assistant message.

--- a/internal/tui/complexity_commands_test.go
+++ b/internal/tui/complexity_commands_test.go
@@ -1,0 +1,1817 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// These tests pin the behavior the cyclomatic-complexity refactor moved out of
+// handleSlashCommand, slashCommandDesc, formatContextUsage, handleRunCommand,
+// buildRunSummaryReport, handleRunAgentEvent, View, updateTerminal,
+// renderSearchPopup and handleSearchPopupKey. Each extracted helper is
+// exercised at the boundaries its original branch encoded.
+
+// cplxModel builds a model that is usable by every helper under test here.
+func cplxModel(t *testing.T) *model {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &model{
+		cfg: Config{
+			ModelName:    "test-model",
+			ProviderName: "test-provider",
+			SessionID:    "sess-1",
+			WorkDir:      t.TempDir(),
+		},
+		ctx:        ctx,
+		cancel:     cancel,
+		inputModel: NewInputModel(make([]HistoryEntry, 0), nil, nil, ""),
+		chatModel:  ChatModel{Messages: make([]message, 0)},
+		face:       NewFaceRenderer(),
+		palette:    darkPalette,
+		width:      100,
+		height:     30,
+	}
+}
+
+// cplxTracker is a fully settable TokenTracker, so the /context branches the
+// package's existing mock hardcodes to zero can be reached.
+type cplxTracker struct {
+	limit       int64
+	remaining   int64
+	percentUsed float64
+	totalUsed   int64
+	lastPrompt  int64
+	window      int64
+	ctxPercent  float64
+	lastCached  int64
+	cachedToday int64
+	hitRate     float64
+	body        int64
+	prefix      int64
+}
+
+func (c *cplxTracker) Limit() int64                { return c.limit }
+func (c *cplxTracker) Remaining() int64            { return c.remaining }
+func (c *cplxTracker) PercentUsed() float64        { return c.percentUsed }
+func (c *cplxTracker) TotalUsed() int64            { return c.totalUsed }
+func (c *cplxTracker) LastPromptTokens() int64     { return c.lastPrompt }
+func (c *cplxTracker) ContextWindowSize() int64    { return c.window }
+func (c *cplxTracker) ContextPercentUsed() float64 { return c.ctxPercent }
+func (c *cplxTracker) SetLastPromptTokens(n int64) { c.lastPrompt = n }
+func (c *cplxTracker) ResetContextWindow()         { c.lastPrompt = 0 }
+func (c *cplxTracker) LastCachedTokens() int64     { return c.lastCached }
+func (c *cplxTracker) CachedTokensToday() int64    { return c.cachedToday }
+func (c *cplxTracker) CacheHitRateToday() float64  { return c.hitRate }
+func (c *cplxTracker) BodyTokens() int64           { return c.body }
+func (c *cplxTracker) CachePrefixTokens() int64    { return c.prefix }
+
+// -----------------------------------------------------------------------------
+// Slash command table — the shared source of truth behind handleSlashCommand,
+// slashCommands and slashCommandDesc.
+// -----------------------------------------------------------------------------
+
+// The dispatch switch and the description switch used to enumerate the command
+// set separately. Merging them is only safe if the table still covers exactly
+// what both did, so pin the full set explicitly.
+func TestCplxSlashCommandSpecs_CoverExpectedSet(t *testing.T) {
+	want := []string{
+		"/help", "/clear", "/copy", "/model", "/session", "/context", "/branch",
+		"/compact", "/subagents", "/history", "/login", "/commit", "/plan", "/run",
+		"/skills", "/skill-list", "/skill-load", "/skill-create", "/theme", "/ping",
+		"/rtk", "/mcp", "/restart", "/exit", "/quit",
+	}
+	if len(slashCommandSpecs) != len(want) {
+		t.Fatalf("slashCommandSpecs has %d entries, want %d", len(slashCommandSpecs), len(want))
+	}
+	for _, name := range want {
+		spec, ok := slashCommandByName[name]
+		if !ok {
+			t.Errorf("command %q missing from the table", name)
+			continue
+		}
+		if spec.desc == "" {
+			t.Errorf("command %q has no description", name)
+		}
+		if spec.run == nil {
+			t.Errorf("command %q has no handler", name)
+		}
+	}
+}
+
+// slashCommands feeds autocomplete, which returns the FIRST prefix match, so
+// its order is behavior and not merely presentation.
+func TestCplxSlashCommands_DerivedOrder(t *testing.T) {
+	want := []string{
+		"/help", "/clear", "/copy", "/model", "/session", "/context", "/branch",
+		"/compact", "/subagents", "/history", "/login", "/commit", "/plan", "/run",
+		"/skills", "/theme", "/ping", "/rtk", "/mcp", "/restart", "/exit", "/quit",
+	}
+	if len(slashCommands) != len(want) {
+		t.Fatalf("slashCommands = %v (%d), want %d entries", slashCommands, len(slashCommands), len(want))
+	}
+	for i, name := range want {
+		if slashCommands[i] != name {
+			t.Errorf("slashCommands[%d] = %q, want %q", i, slashCommands[i], name)
+		}
+	}
+}
+
+// The three skill subcommands are dispatchable and described, but deliberately
+// kept out of the autocomplete list.
+func TestCplxSlashCommands_HiddenAreDispatchableNotListed(t *testing.T) {
+	for _, name := range []string{"/skill-list", "/skill-load", "/skill-create"} {
+		if slashCommandDesc(name) == "" {
+			t.Errorf("hidden command %q lost its description", name)
+		}
+		if _, ok := slashCommandByName[name]; !ok {
+			t.Errorf("hidden command %q is not dispatchable", name)
+		}
+		for _, listed := range slashCommands {
+			if listed == name {
+				t.Errorf("hidden command %q must not appear in slashCommands", name)
+			}
+		}
+	}
+}
+
+func TestCplxSlashCommandDesc(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want string
+	}{
+		{"/help", "Show help"},
+		{"/clear", "Clear conversation"},
+		{"/copy", "Copy conversation to clipboard"},
+		{"/rtk", "Output compaction stats"},
+		{"/mcp", "List MCP servers and tool status"},
+		{"/run", "Execute a spec with task agent (verifies subagent exit status before merging)"},
+		{"/login", "Configure API keys (codex, openai, anthropic, gemini)"},
+		{"/exit", "Exit"},
+		{"/quit", "Exit"},
+		// The switch's default arm: anything not a built-in has no description.
+		{"/nope", ""},
+		{"", ""},
+		{"help", ""},
+	}
+	for _, tt := range tests {
+		if got := slashCommandDesc(tt.cmd); got != tt.want {
+			t.Errorf("slashCommandDesc(%q) = %q, want %q", tt.cmd, got, tt.want)
+		}
+	}
+}
+
+func TestCplxSlashCommandAdapters(t *testing.T) {
+	t.Run("args", func(t *testing.T) {
+		var got []string
+		run := slashCmdArgs(func(_ *model, args []string) { got = args })
+		m := cplxModel(t)
+		gotModel, cmd := run(m, []string{"a", "b"})
+		if cmd != nil {
+			t.Error("slashCmdArgs must not return a command")
+		}
+		if gotModel != tea.Model(m) {
+			t.Error("slashCmdArgs must return the same model")
+		}
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Errorf("args = %v, want [a b]", got)
+		}
+	})
+
+	t.Run("bare", func(t *testing.T) {
+		sentinel := tea.Cmd(func() tea.Msg { return nil })
+		called := false
+		run := slashCmdBare(func(m *model) (tea.Model, tea.Cmd) {
+			called = true
+			return m, sentinel
+		})
+		m := cplxModel(t)
+		if _, cmd := run(m, []string{"ignored"}); cmd == nil {
+			t.Error("slashCmdBare must pass the handler's command through")
+		}
+		if !called {
+			t.Error("slashCmdBare did not call the handler")
+		}
+	})
+
+	t.Run("void", func(t *testing.T) {
+		called := false
+		run := slashCmdVoid(func(_ *model) { called = true })
+		m := cplxModel(t)
+		gotModel, cmd := run(m, nil)
+		if cmd != nil || gotModel != tea.Model(m) {
+			t.Error("slashCmdVoid must return (m, nil)")
+		}
+		if !called {
+			t.Error("slashCmdVoid did not call the handler")
+		}
+	})
+}
+
+func TestCplxHandleSlashCommand_Unknown(t *testing.T) {
+	m := cplxModel(t)
+	m.handleSlashCommand("/definitely-not-a-command")
+	if len(m.chatModel.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(m.chatModel.Messages))
+	}
+	got := m.chatModel.Messages[0].content
+	if !strings.Contains(got, "Unknown command: `/definitely-not-a-command`") {
+		t.Errorf("unknown-command message = %q", got)
+	}
+	if !strings.Contains(got, "Type `/help` for available commands.") {
+		t.Errorf("unknown-command message lost its help hint: %q", got)
+	}
+}
+
+// A dynamic skill shadows nothing in the table, but must still resolve through
+// the same default path the switch used.
+func TestCplxHandleSlashCommand_DynamicSkill(t *testing.T) {
+	m := cplxModel(t)
+	m.cfg.Skills = []extension.Skill{{Name: "mine", Description: "a skill"}}
+	m.handleSlashCommand("/mine")
+	for _, msg := range m.chatModel.Messages {
+		if strings.Contains(msg.content, "Unknown command") {
+			t.Fatalf("a known skill fell through to the unknown-command arm: %q", msg.content)
+		}
+	}
+}
+
+func TestCplxHandleSlashCommand_Quit(t *testing.T) {
+	m := cplxModel(t)
+	_, cmd := m.handleSlashCommand("/quit")
+	if !m.quitting {
+		t.Error("/quit must set quitting")
+	}
+	if cmd == nil {
+		t.Error("/quit must return a command")
+	}
+
+	m2 := cplxModel(t)
+	if _, cmd := m2.handleSlashCommand("/exit"); cmd == nil || !m2.quitting {
+		t.Error("/exit must behave the same as /quit")
+	}
+}
+
+// The title sync is skipped for exactly three commands. That carve-out lived in
+// its own switch and must survive the table.
+func TestCplxHandleSlashCommand_TitleSyncCarveOut(t *testing.T) {
+	tests := []struct {
+		cmd        string
+		wantTitled bool
+	}{
+		{"/clear", false},
+		{"/exit", false},
+		{"/quit", false},
+		{"/session", true},
+		{"/help", true},
+	}
+	for _, tt := range tests {
+		m := cplxModel(t)
+		m.handleSlashCommand(tt.cmd)
+		titled := m.sessionTitle != ""
+		if titled != tt.wantTitled {
+			t.Errorf("%s: sessionTitle set = %v, want %v (title %q)",
+				tt.cmd, titled, tt.wantTitled, m.sessionTitle)
+		}
+	}
+}
+
+func TestCplxShowMessageHelpers(t *testing.T) {
+	t.Run("session", func(t *testing.T) {
+		m := cplxModel(t)
+		m.showSessionMessage()
+		if got := m.chatModel.Messages[0].content; got != "Session: `sess-1`" {
+			t.Errorf("session message = %q", got)
+		}
+	})
+	t.Run("help", func(t *testing.T) {
+		m := cplxModel(t)
+		m.showHelpMessage()
+		if m.chatModel.Messages[0].content == "" {
+			t.Error("help message is empty")
+		}
+	})
+	t.Run("context", func(t *testing.T) {
+		m := cplxModel(t)
+		m.showContextMessage()
+		if !strings.Contains(m.chatModel.Messages[0].content, "**Context Usage**") {
+			t.Errorf("context message = %q", m.chatModel.Messages[0].content)
+		}
+	})
+}
+
+// -----------------------------------------------------------------------------
+// formatContextUsage sections
+// -----------------------------------------------------------------------------
+
+func TestCplxEstimateCtxRoleTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		msgs []message
+	}{
+		{"empty", nil},
+		{"user only", []message{{role: "user", content: strings.Repeat("a", 400)}}},
+		{"assistant only", []message{{role: "assistant", content: strings.Repeat("b", 400)}}},
+		// Anything that is not user or assistant lands in the tool bucket —
+		// that was the switch's default arm.
+		{"tool default", []message{{role: "tool", content: strings.Repeat("c", 400)}}},
+		{"unknown role counts as tool", []message{{role: "weird", content: strings.Repeat("d", 400)}}},
+		{"mixed", []message{
+			{role: "user", content: strings.Repeat("a", 400)},
+			{role: "assistant", content: strings.Repeat("b", 800)},
+			{role: "tool", content: strings.Repeat("c", 1200)},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := cplxModel(t)
+			m.chatModel.Messages = tt.msgs
+			est := m.estimateCtxRoleTokens()
+
+			// Recompute independently from the same primitives.
+			var uc, ac, tc int
+			for _, msg := range tt.msgs {
+				switch msg.role {
+				case "user":
+					uc += messageChars(msg)
+				case "assistant":
+					ac += messageChars(msg)
+				default:
+					tc += messageChars(msg)
+				}
+			}
+			if est.user != estimateTokens(uc) {
+				t.Errorf("user = %d, want %d", est.user, estimateTokens(uc))
+			}
+			if est.assistant != estimateTokens(ac) {
+				t.Errorf("assistant = %d, want %d", est.assistant, estimateTokens(ac))
+			}
+			if est.tool != estimateTokens(tc) {
+				t.Errorf("tool = %d, want %d", est.tool, estimateTokens(tc))
+			}
+			if est.total != estimateTokens(uc+ac+tc) {
+				t.Errorf("total = %d, want %d", est.total, estimateTokens(uc+ac+tc))
+			}
+		})
+	}
+}
+
+func TestCplxWriteCtxBreakdownSection_NilIsSilent(t *testing.T) {
+	m := cplxModel(t)
+	m.cfg.ContextBreakdown = nil
+	var b strings.Builder
+	m.writeCtxBreakdownSection(&b)
+	if b.String() != "" {
+		t.Errorf("no breakdown configured must write nothing, got %q", b.String())
+	}
+}
+
+func TestCplxWriteCtxModelLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		tracker     TokenTracker
+		total       int64
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "with limit shows daily totals",
+			tracker:     &cplxTracker{limit: 100000, totalUsed: 5000, percentUsed: 5},
+			total:       1234,
+			wantContain: []string{"test-provider | test-model", "/", "(5%)"},
+		},
+		{
+			// No tracker at all: the nominal-100k arm.
+			name:        "no tracker falls back to ctx estimate",
+			tracker:     nil,
+			total:       1234,
+			wantContain: []string{"ctx ~", "test-provider | test-model"},
+			wantAbsent:  []string{"tokens (0%)"},
+		},
+		{
+			// Limit of zero is not "unlimited with a tracker" — it takes the
+			// same fallback arm as a nil tracker.
+			name:        "zero limit falls back too",
+			tracker:     &cplxTracker{limit: 0, totalUsed: 999},
+			total:       50000,
+			wantContain: []string{"ctx ~"},
+		},
+		{
+			name:        "zero total draws an empty bar",
+			tracker:     nil,
+			total:       0,
+			wantContain: []string{"ctx ~"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := cplxModel(t)
+			m.cfg.TokenTracker = tt.tracker
+			var b strings.Builder
+			m.writeCtxModelLine(&b, tt.total)
+			got := b.String()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("model line %q missing %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("model line %q unexpectedly contains %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+// The "never less than one block" rule and the 10k threshold above it were two
+// separate branches; both still hold.
+func TestCplxWriteCtxModelLine_BarFloor(t *testing.T) {
+	small := cplxModel(t)
+	var sb strings.Builder
+	small.writeCtxModelLine(&sb, 500)
+
+	big := cplxModel(t)
+	var bb strings.Builder
+	big.writeCtxModelLine(&bb, 90000)
+
+	countFilled := func(s string) int {
+		return strings.Count(s, barGlyphs(1, 1))
+	}
+	if countFilled(sb.String()) < 1 {
+		t.Error("a short conversation must still show at least one filled block")
+	}
+	if countFilled(bb.String()) <= countFilled(sb.String()) {
+		t.Error("90k tokens must fill more blocks than 500 tokens")
+	}
+}
+
+func TestCplxWriteCtxCategorySection(t *testing.T) {
+	m := cplxModel(t)
+	m.chatModel.Messages = []message{
+		{role: "user", content: "hi"},
+		{role: "assistant", content: "hello"},
+		{role: "tool", tool: "read", content: "{}"},
+	}
+	var b strings.Builder
+	m.writeCtxCategorySection(&b, m.estimateCtxRoleTokens())
+	got := b.String()
+	for _, want := range []string{
+		"*Estimated usage by category*",
+		"- **User messages**: ~", "(1 msgs)",
+		"- **Assistant messages**: ~",
+		"- **Tool calls**: ~", "(1 calls)",
+		"- **Total context**: ~", "(3 messages)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("category section %q missing %q", got, want)
+		}
+	}
+}
+
+func TestCplxWriteCtxDailySection(t *testing.T) {
+	tests := []struct {
+		name        string
+		tracker     TokenTracker
+		wantEmpty   bool
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{name: "nil tracker", tracker: nil, wantEmpty: true},
+		// Zero consumption suppresses the whole section, not just the numbers.
+		{name: "zero used", tracker: &cplxTracker{totalUsed: 0, limit: 1000}, wantEmpty: true},
+		{
+			name:        "used without limit",
+			tracker:     &cplxTracker{totalUsed: 4200},
+			wantContain: []string{"*Daily token usage*", "**Consumed today**"},
+			wantAbsent:  []string{"**Remaining**"},
+		},
+		{
+			name:        "used with limit",
+			tracker:     &cplxTracker{totalUsed: 4200, limit: 100000, remaining: 95800},
+			wantContain: []string{"**Consumed today**", "**Remaining**"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := cplxModel(t)
+			m.cfg.TokenTracker = tt.tracker
+			var b strings.Builder
+			m.writeCtxDailySection(&b)
+			got := b.String()
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("expected no output, got %q", got)
+				}
+				return
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("daily section %q missing %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("daily section %q unexpectedly contains %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestCplxWriteCtxWindowSection(t *testing.T) {
+	tests := []struct {
+		name        string
+		tracker     TokenTracker
+		wantEmpty   bool
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{name: "nil tracker", tracker: nil, wantEmpty: true},
+		{name: "no last prompt", tracker: &cplxTracker{lastPrompt: 0, window: 200000}, wantEmpty: true},
+		{
+			name:    "known window",
+			tracker: &cplxTracker{lastPrompt: 50000, window: 200000, ctxPercent: 25},
+			wantContain: []string{
+				"*Context window*", "(25%)",
+				"- **Used**:", "- **Free**:",
+				// The cache section always follows a rendered window section.
+				"*Prompt cache*",
+			},
+			wantAbsent: []string{"window size unknown"},
+		},
+		{
+			name:        "unknown window",
+			tracker:     &cplxTracker{lastPrompt: 50000, window: 0},
+			wantContain: []string{"- **Last prompt**:", "window size unknown", "*Prompt cache*"},
+			wantAbsent:  []string{"- **Free**:"},
+		},
+		{
+			// Free tokens clamp at zero rather than going negative when the
+			// prompt overflows the advertised window.
+			name:        "overflowing window clamps free at zero",
+			tracker:     &cplxTracker{lastPrompt: 300000, window: 200000, ctxPercent: 150},
+			wantContain: []string{"- **Free**: 0 tokens"},
+			wantAbsent:  []string{"-"[0:0] + "**Free**: -"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := cplxModel(t)
+			m.cfg.TokenTracker = tt.tracker
+			var b strings.Builder
+			m.writeCtxWindowSection(&b)
+			got := b.String()
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("expected no output, got %q", got)
+				}
+				return
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("window section %q missing %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if absent != "" && strings.Contains(got, absent) {
+					t.Errorf("window section %q unexpectedly contains %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestCplxWriteCtxCacheSection(t *testing.T) {
+	tests := []struct {
+		name        string
+		tracker     *cplxTracker
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			// Reported explicitly at zero hits — a silent section would read the
+			// same whether caching works or is entirely absent.
+			name:        "no cache hit",
+			tracker:     &cplxTracker{},
+			wantContain: []string{"*Prompt cache*", "- **Last request**: no cache hit"},
+			wantAbsent:  []string{"**Today**", "**Stable prefix**"},
+		},
+		{
+			name:        "cache hit",
+			tracker:     &cplxTracker{lastCached: 5000},
+			wantContain: []string{"prompt tokens cached (50%)"},
+		},
+		{
+			name:        "today only",
+			tracker:     &cplxTracker{cachedToday: 12345, hitRate: 42},
+			wantContain: []string{"**Today**", "(42% of input)"},
+			wantAbsent:  []string{"**Stable prefix**"},
+		},
+		{
+			name:        "prefix and body",
+			tracker:     &cplxTracker{prefix: 8000, body: 2000},
+			wantContain: []string{"**Stable prefix**", "**body since**"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := cplxModel(t)
+			m.cfg.TokenTracker = tt.tracker
+			var b strings.Builder
+			m.writeCtxCacheSection(&b, 10000)
+			got := b.String()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("cache section %q missing %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("cache section %q unexpectedly contains %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestCplxWriteCtxSkillsSection(t *testing.T) {
+	t.Run("no skills is silent", func(t *testing.T) {
+		m := cplxModel(t)
+		var b strings.Builder
+		m.writeCtxSkillsSection(&b)
+		if b.String() != "" {
+			t.Errorf("expected no output, got %q", b.String())
+		}
+	})
+
+	t.Run("alphabetical with defaults", func(t *testing.T) {
+		m := cplxModel(t)
+		m.cfg.Skills = []extension.Skill{
+			{Name: "zebra", Description: "last", Source: "project"},
+			// Empty description and source take the defaulted values.
+			{Name: "alpha"},
+		}
+		var b strings.Builder
+		m.writeCtxSkillsSection(&b)
+		got := b.String()
+		if !strings.Contains(got, "(2 loaded)") {
+			t.Errorf("skills section %q missing the count", got)
+		}
+		ai, zi := strings.Index(got, "/alpha"), strings.Index(got, "/zebra")
+		if ai < 0 || zi < 0 || ai > zi {
+			t.Errorf("skills must list alphabetically, got %q", got)
+		}
+		if !strings.Contains(got, "(no description)") {
+			t.Errorf("a skill with no description must say so, got %q", got)
+		}
+		if !strings.Contains(got, "[user]") {
+			t.Errorf("a skill with no source must default to user, got %q", got)
+		}
+		if !strings.Contains(got, "[project]") {
+			t.Errorf("an explicit source must survive, got %q", got)
+		}
+		if !strings.Contains(got, "body: not loaded") {
+			t.Errorf("an unloaded body must say so, got %q", got)
+		}
+	})
+}
+
+func TestCplxWriteCtxSubagentSection_NilOrchestrator(t *testing.T) {
+	m := cplxModel(t)
+	m.cfg.Orchestrator = nil
+	var b strings.Builder
+	m.writeCtxSubagentSection(&b)
+	if b.String() != "" {
+		t.Errorf("no orchestrator must write nothing, got %q", b.String())
+	}
+}
+
+// The composed output must still arrive in the original section order.
+func TestCplxFormatContextUsage_SectionOrder(t *testing.T) {
+	m := cplxModel(t)
+	m.cfg.TokenTracker = &cplxTracker{
+		limit: 100000, totalUsed: 5000, percentUsed: 5,
+		remaining: 95000, lastPrompt: 40000, window: 200000, ctxPercent: 20,
+	}
+	m.cfg.Skills = []extension.Skill{{Name: "s1", Description: "d"}}
+	m.chatModel.Messages = []message{{role: "user", content: "hi"}}
+
+	out := m.formatContextUsage()
+	order := []string{
+		"**Context Usage**",
+		"*Estimated usage by category*",
+		"*Daily token usage*",
+		"*Context window*",
+		"*Prompt cache*",
+		"*Skills*",
+	}
+	prev := -1
+	for _, section := range order {
+		at := strings.Index(out, section)
+		if at < 0 {
+			t.Fatalf("output missing section %q:\n%s", section, out)
+		}
+		if at < prev {
+			t.Errorf("section %q is out of order", section)
+		}
+		prev = at
+	}
+}
+
+// -----------------------------------------------------------------------------
+// run.go — /run argument parsing, summary report, agent events
+// -----------------------------------------------------------------------------
+
+func TestCplxParseRunArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantSpec     string
+		wantParallel bool
+	}{
+		{"empty", nil, "", false},
+		{"spec only", []string{"my-spec"}, "my-spec", false},
+		{"long flag", []string{"my-spec", "--parallel"}, "my-spec", true},
+		{"short flag", []string{"my-spec", "-p"}, "my-spec", true},
+		{"flag first", []string{"-p", "my-spec"}, "my-spec", true},
+		// The first non-flag argument wins; later ones are ignored.
+		{"extra positional ignored", []string{"first", "second"}, "first", false},
+		{"flag only", []string{"--parallel"}, "", true},
+		{"repeated flags", []string{"-p", "--parallel", "spec"}, "spec", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, parallel := parseRunArgs(tt.args)
+			if spec != tt.wantSpec || parallel != tt.wantParallel {
+				t.Errorf("parseRunArgs(%v) = (%q, %v), want (%q, %v)",
+					tt.args, spec, parallel, tt.wantSpec, tt.wantParallel)
+			}
+		})
+	}
+}
+
+func TestCplxFormatRunGateInfo(t *testing.T) {
+	tests := []struct {
+		name  string
+		gates []Gate
+		want  string
+	}{
+		{"none", nil, "none"},
+		{"empty slice", []Gate{}, "none"},
+		{"one", []Gate{{Name: "build"}}, "build"},
+		{"many", []Gate{{Name: "build"}, {Name: "test"}, {Name: "lint"}}, "build, test, lint"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatRunGateInfo(tt.gates); got != tt.want {
+				t.Errorf("formatRunGateInfo = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCplxHandleRunCommand_NoArgsShowsUsage(t *testing.T) {
+	m := cplxModel(t)
+	m.handleRunCommand(nil)
+	if len(m.chatModel.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(m.chatModel.Messages))
+	}
+	if !strings.Contains(m.chatModel.Messages[0].content, "Usage: `/run <spec-name> [--parallel]`") {
+		t.Errorf("usage message = %q", m.chatModel.Messages[0].content)
+	}
+}
+
+func TestCplxHandleRunCommand_NoOrchestrator(t *testing.T) {
+	m := cplxModel(t)
+	m.cfg.Orchestrator = nil
+	m.handleRunCommand([]string{"some-spec"})
+	if got := m.chatModel.Messages[0].content; got != "Subagent system not available. Cannot run specs." {
+		t.Errorf("message = %q", got)
+	}
+}
+
+// A bare --parallel gives no spec name, and the missing-name arm must fire
+// before anything tries to read a spec off disk.
+func TestCplxHandleRunCommand_MissingSpecName(t *testing.T) {
+	m := cplxModel(t)
+	m.cfg.Orchestrator = &subagent.Orchestrator{}
+	m.handleRunCommand([]string{"--parallel"})
+	if got := m.chatModel.Messages[0].content; got != "Missing spec name." {
+		t.Errorf("message = %q", got)
+	}
+}
+
+func TestCplxShowRunSpecError(t *testing.T) {
+	m := cplxModel(t)
+	m.showRunSpecError(context.DeadlineExceeded)
+	if got := m.chatModel.Messages[0].content; !strings.HasPrefix(got, "Error: ") {
+		t.Errorf("spec error message = %q, want an Error: prefix", got)
+	}
+}
+
+func TestCplxWriteRunSummaryMetadata(t *testing.T) {
+	start := time.Now().Add(-90 * time.Second)
+	tests := []struct {
+		name        string
+		rs          *runState
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "minimal",
+			rs:          &runState{specName: "s", agentID: "a", retries: 1, maxRetries: 10},
+			wantContain: []string{"| Spec | `s` |", "| Agent | `a` |", "| Retries | 1 / 10 |"},
+			wantAbsent:  []string{"| Slices |", "| Started |", "| Duration |"},
+		},
+		{
+			name: "with checklist and start time",
+			rs: &runState{
+				specName: "s", agentID: "a", maxRetries: 10, startTime: start,
+				checklist: []ChecklistStep{{Title: "one", Done: true}, {Title: "two"}},
+			},
+			wantContain: []string{"| Slices | 1 / 2 complete |", "| Started |", "| Duration |"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			writeRunSummaryMetadata(&b, tt.rs, "completed")
+			got := b.String()
+			if !strings.Contains(got, "| Outcome | **completed** |") {
+				t.Errorf("metadata %q missing the outcome row", got)
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("metadata %q missing %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("metadata %q unexpectedly contains %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestCplxWriteRunSummaryGates(t *testing.T) {
+	tests := []struct {
+		name        string
+		rs          *runState
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "none defined",
+			rs:          &runState{},
+			wantContain: []string{"## Gates", "No gates defined."},
+		},
+		{
+			// Defined but never executed is its own arm, distinct from "none".
+			name:        "defined not executed",
+			rs:          &runState{gates: []Gate{{Name: "build", Command: "make build"}}},
+			wantContain: []string{"Gates were defined but not executed.", "- **build**: `make build`"},
+			wantAbsent:  []string{"No gates defined."},
+		},
+		{
+			name: "all passed",
+			rs: &runState{gateResults: []GateResult{
+				{Name: "build", Command: "make build", Passed: true},
+				{Name: "test", Command: "make test", Passed: true},
+			}},
+			wantContain: []string{"**PASS**", "All gates **passed**."},
+			wantAbsent:  []string{"Some gates **failed**.", "FAIL"},
+		},
+		{
+			name: "one failed",
+			rs: &runState{gateResults: []GateResult{
+				{Name: "build", Command: "make build", Passed: true},
+				{Name: "test", Command: "make test", Passed: false, Output: "  boom  "},
+			}},
+			wantContain: []string{"**FAIL**", "boom", "Some gates **failed**."},
+			wantAbsent:  []string{"All gates **passed**."},
+		},
+		{
+			// A failure with no captured output prints the verdict but no block.
+			name: "failed without output",
+			rs: &runState{gateResults: []GateResult{
+				{Name: "test", Command: "make test", Passed: false},
+			}},
+			wantContain: []string{"**FAIL**", "Some gates **failed**."},
+			wantAbsent:  []string{"```"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			writeRunSummaryGates(&b, tt.rs)
+			got := b.String()
+			for _, want := range tt.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("gates section %q missing %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("gates section %q unexpectedly contains %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+// Output over 1000 bytes is truncated with a marker. That boundary is behavior.
+func TestCplxWriteRunSummaryGateResult_TruncatesLongOutput(t *testing.T) {
+	var b strings.Builder
+	writeRunSummaryGateResult(&b, GateResult{
+		Name: "test", Command: "make test", Passed: false,
+		Output: strings.Repeat("x", 1500),
+	})
+	got := b.String()
+	if !strings.Contains(got, "...(truncated)") {
+		t.Error("output over 1000 bytes must be truncated")
+	}
+	if strings.Count(got, "x") != 1000 {
+		t.Errorf("expected exactly 1000 retained bytes, got %d", strings.Count(got, "x"))
+	}
+
+	var short strings.Builder
+	writeRunSummaryGateResult(&short, GateResult{
+		Name: "test", Command: "make test", Passed: false,
+		Output: strings.Repeat("y", 1000),
+	})
+	if strings.Contains(short.String(), "...(truncated)") {
+		t.Error("output of exactly 1000 bytes must not be truncated")
+	}
+}
+
+func TestCplxWriteRunSummaryResult(t *testing.T) {
+	tests := []struct {
+		outcome string
+		want    string
+	}{
+		{"completed", "All gates passed, the plan checklist was complete, and changes were merged successfully."},
+		{"gate_failed", "Gate validation failed after 3 retries."},
+		{"verify_failed", "Gates passed but the plan was still incomplete after 3 retries"},
+		{"merge_failed", "Gates passed but merge into the main branch failed."},
+		{"agent_failed", "Subagent process exited with non-zero status"},
+		// The default arm echoes whatever status it was handed.
+		{"something_else", "Run ended with status: something_else"},
+		{"", "Run ended with status: "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			var b strings.Builder
+			writeRunSummaryResult(&b, &runState{retries: 3}, tt.outcome)
+			got := b.String()
+			if !strings.HasPrefix(got, "## Result\n\n") {
+				t.Errorf("result section %q missing its heading", got)
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("result for %q = %q, want it to contain %q", tt.outcome, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCplxBuildRunSummaryReport_Composition(t *testing.T) {
+	rs := &runState{
+		specName: "spec-1", agentID: "agent-1", retries: 2, maxRetries: 10,
+		checklist:   []ChecklistStep{{Title: "done one", Done: true}, {Title: "pending two"}},
+		gateResults: []GateResult{{Name: "build", Command: "make build", Passed: true}},
+	}
+	out := buildRunSummaryReport(rs, "completed")
+	for _, want := range []string{
+		"# Run Summary", "## Metadata", "## Gates",
+		"## Unfinished Slices", "pending two", "## Result",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q:\n%s", want, out)
+		}
+	}
+	// Section order must be stable.
+	if strings.Index(out, "## Metadata") > strings.Index(out, "## Gates") {
+		t.Error("metadata must precede gates")
+	}
+	if strings.Index(out, "## Unfinished Slices") > strings.Index(out, "## Result") {
+		t.Error("unfinished slices must precede the result")
+	}
+}
+
+// A run with every slice ticked has no Unfinished Slices section at all.
+func TestCplxBuildRunSummaryReport_NoUnfinishedSection(t *testing.T) {
+	rs := &runState{
+		specName:  "spec-1",
+		checklist: []ChecklistStep{{Title: "one", Done: true}},
+	}
+	if out := buildRunSummaryReport(rs, "completed"); strings.Contains(out, "## Unfinished Slices") {
+		t.Errorf("a fully ticked checklist must not produce an unfinished section:\n%s", out)
+	}
+}
+
+func TestCplxApplyRunTextDelta(t *testing.T) {
+	t.Run("fills the open assistant message", func(t *testing.T) {
+		m := cplxModel(t)
+		m.chatModel.Messages = []message{
+			{role: "assistant", content: "stale"},
+			{role: "tool", content: "t"},
+		}
+		m.chatModel.Scroll = 7
+		m.applyRunTextDelta(subagent.Event{Type: "text_delta", Content: "hel"})
+		m.applyRunTextDelta(subagent.Event{Type: "text_delta", Content: "lo"})
+
+		if m.chatModel.Streaming != "hello" {
+			t.Errorf("Streaming = %q, want %q", m.chatModel.Streaming, "hello")
+		}
+		if m.chatModel.Messages[0].content != "hello" {
+			t.Errorf("assistant message = %q, want %q", m.chatModel.Messages[0].content, "hello")
+		}
+		if m.chatModel.Scroll != 0 {
+			t.Errorf("Scroll = %d, want 0 (a delta jumps to the bottom)", m.chatModel.Scroll)
+		}
+	})
+
+	t.Run("folds into a trailing llm trace entry", func(t *testing.T) {
+		m := cplxModel(t)
+		m.chatModel.Messages = []message{{role: "assistant"}}
+		m.applyRunTextDelta(subagent.Event{Content: "a"})
+		m.applyRunTextDelta(subagent.Event{Content: "b"})
+		if len(m.chatModel.TraceLog) != 1 {
+			t.Fatalf("expected the second delta to fold into one trace entry, got %d",
+				len(m.chatModel.TraceLog))
+		}
+		if got := m.chatModel.TraceLog[0].detail; got != "ab" {
+			t.Errorf("trace detail = %q, want %q", got, "ab")
+		}
+	})
+
+	t.Run("opens a new trace entry after a tool call", func(t *testing.T) {
+		m := cplxModel(t)
+		m.chatModel.Messages = []message{{role: "assistant"}}
+		m.chatModel.TraceLog = []traceEntry{{kind: "tool_call"}}
+		m.applyRunTextDelta(subagent.Event{Content: "a"})
+		if len(m.chatModel.TraceLog) != 2 {
+			t.Fatalf("expected a new llm trace entry, got %d", len(m.chatModel.TraceLog))
+		}
+		if m.chatModel.TraceLog[1].kind != "llm" {
+			t.Errorf("new trace entry kind = %q, want llm", m.chatModel.TraceLog[1].kind)
+		}
+	})
+}
+
+func TestCplxApplyRunToolCall(t *testing.T) {
+	t.Run("with args", func(t *testing.T) {
+		m := cplxModel(t)
+		m.applyRunToolCall(subagent.Event{
+			Type: "tool_call", Content: "read",
+			ToolArgs: map[string]any{"file_path": "/tmp/x.go"},
+		})
+		if m.statusModel.ActiveTool != "read" {
+			t.Errorf("ActiveTool = %q, want read", m.statusModel.ActiveTool)
+		}
+		last := m.chatModel.Messages[len(m.chatModel.Messages)-1]
+		if last.role != "tool" || last.tool != "read" {
+			t.Errorf("expected a tool message for read, got %+v", last)
+		}
+		if last.toolIn == "" {
+			t.Error("tool args must produce a toolIn one-liner")
+		}
+	})
+
+	t.Run("without args", func(t *testing.T) {
+		m := cplxModel(t)
+		// A non-map ToolArgs takes the other arm and leaves toolIn empty.
+		m.applyRunToolCall(subagent.Event{Content: "read", ToolArgs: "not-a-map"})
+		last := m.chatModel.Messages[len(m.chatModel.Messages)-1]
+		if last.toolIn != "" {
+			t.Errorf("toolIn = %q, want empty when args are not a map", last.toolIn)
+		}
+		if len(m.chatModel.TraceLog) != 1 || m.chatModel.TraceLog[0].kind != "tool_call" {
+			t.Errorf("expected one tool_call trace entry, got %+v", m.chatModel.TraceLog)
+		}
+	})
+}
+
+func TestCplxApplyRunToolResult(t *testing.T) {
+	t.Run("fills the open tool message", func(t *testing.T) {
+		m := cplxModel(t)
+		m.statusModel.ActiveTool = "read"
+		m.chatModel.Messages = []message{
+			{role: "tool", tool: "read", content: "already done"},
+			{role: "tool", tool: "read", content: ""},
+		}
+		m.applyRunToolResult(subagent.Event{Type: "tool_result", Content: "ok"})
+
+		if m.statusModel.ActiveTool != "" {
+			t.Errorf("ActiveTool = %q, want cleared", m.statusModel.ActiveTool)
+		}
+		if m.chatModel.Messages[0].content != "already done" {
+			t.Error("a completed tool message must not be overwritten")
+		}
+		if m.chatModel.Messages[1].content == "" {
+			t.Error("the open tool message must receive the result")
+		}
+	})
+
+	t.Run("no open tool message", func(t *testing.T) {
+		m := cplxModel(t)
+		m.chatModel.Messages = []message{{role: "assistant", content: "x"}}
+		m.applyRunToolResult(subagent.Event{Content: "ok"})
+		if m.chatModel.Messages[0].content != "x" {
+			t.Error("with nothing open, no message may change")
+		}
+	})
+
+	t.Run("nil run skips the checklist refresh", func(t *testing.T) {
+		m := cplxModel(t)
+		m.run = nil
+		m.statusModel.ActiveTool = "write"
+		// Must not panic: the refresh is guarded on m.run.
+		m.applyRunToolResult(subagent.Event{Content: "ok"})
+	})
+}
+
+func TestCplxApplyRunError(t *testing.T) {
+	m := cplxModel(t)
+	m.applyRunError(subagent.Event{Type: "error", Error: "it broke"})
+	if got := m.chatModel.Messages[0].content; got != "Agent error: it broke" {
+		t.Errorf("message = %q", got)
+	}
+	if len(m.chatModel.TraceLog) != 1 || m.chatModel.TraceLog[0].kind != "error" {
+		t.Errorf("expected one error trace entry, got %+v", m.chatModel.TraceLog)
+	}
+}
+
+// handleRunAgentEvent still routes every event type, and always keeps consuming.
+func TestCplxHandleRunAgentEvent_Routing(t *testing.T) {
+	tests := []struct {
+		name  string
+		event subagent.Event
+		check func(t *testing.T, m *model)
+	}{
+		{
+			name:  "text_delta",
+			event: subagent.Event{Type: "text_delta", Content: "hi"},
+			check: func(t *testing.T, m *model) {
+				if m.chatModel.Streaming != "hi" {
+					t.Errorf("Streaming = %q", m.chatModel.Streaming)
+				}
+			},
+		},
+		{
+			name:  "tool_call",
+			event: subagent.Event{Type: "tool_call", Content: "read"},
+			check: func(t *testing.T, m *model) {
+				if m.statusModel.ActiveTool != "read" {
+					t.Errorf("ActiveTool = %q", m.statusModel.ActiveTool)
+				}
+			},
+		},
+		{
+			name:  "tool_result",
+			event: subagent.Event{Type: "tool_result", Content: "ok"},
+			check: func(t *testing.T, m *model) {
+				if m.statusModel.ActiveTool != "" {
+					t.Errorf("ActiveTool = %q, want cleared", m.statusModel.ActiveTool)
+				}
+			},
+		},
+		{
+			name:  "message_start",
+			event: subagent.Event{Type: "message_start"},
+			check: func(t *testing.T, m *model) {
+				if m.chatModel.Streaming != "" {
+					t.Error("message_start must reset the accumulator")
+				}
+				last := m.chatModel.Messages[len(m.chatModel.Messages)-1]
+				if last.role != "assistant" || last.content != "" {
+					t.Errorf("expected an empty assistant placeholder, got %+v", last)
+				}
+			},
+		},
+		{
+			name:  "message_end",
+			event: subagent.Event{Type: "message_end"},
+			check: func(t *testing.T, m *model) {
+				if m.chatModel.Streaming != "" {
+					t.Error("message_end must reset the accumulator")
+				}
+			},
+		},
+		{
+			name:  "error",
+			event: subagent.Event{Type: "error", Error: "boom"},
+			check: func(t *testing.T, m *model) {
+				if !strings.Contains(m.chatModel.Messages[0].content, "boom") {
+					t.Errorf("messages = %+v", m.chatModel.Messages)
+				}
+			},
+		},
+		{
+			// An unrecognized type falls through untouched but still keeps the
+			// event pump alive.
+			name:  "unknown type",
+			event: subagent.Event{Type: "never_heard_of_it"},
+			check: func(t *testing.T, m *model) {
+				if len(m.chatModel.Messages) != 0 {
+					t.Errorf("an unknown event must change nothing, got %+v", m.chatModel.Messages)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := cplxModel(t)
+			// A live run with an open channel, so the "keep consuming" cmd is
+			// actually produced rather than short-circuited by a nil run.
+			events := make(chan subagent.Event, 1)
+			m.run = &runState{agentID: "a1", events: events, phase: "running"}
+			m.chatModel.Streaming = "leftover"
+			if tt.event.Type == "text_delta" {
+				m.chatModel.Streaming = ""
+			}
+			_, cmd := m.handleRunAgentEvent(runAgentEventMsg{event: tt.event, agentID: "a1"})
+			if cmd == nil {
+				t.Error("handleRunAgentEvent must keep consuming events")
+			}
+			tt.check(t, m)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// tui.go — search popup keys, styles, viewport clipping, terminal dispatch
+// -----------------------------------------------------------------------------
+
+func cplxPopup(mode searchMode, n, height int) *searchPopupState {
+	items := make([]SearchItem, n)
+	for i := range items {
+		items[i] = SearchItem{Text: string(rune('a' + i)), Description: "desc"}
+	}
+	return &searchPopupState{mode: mode, entries: items, filtered: items, height: height}
+}
+
+func TestCplxSearchPopupSelectPrev(t *testing.T) {
+	tests := []struct {
+		name          string
+		items         int
+		selected      int
+		height        int
+		wantSelected  int
+		wantScrollOff int
+	}{
+		{"moves up", 5, 3, 3, 2, 0},
+		{"wraps from first", 5, 0, 3, 4, 2},
+		// A single item has nowhere to wrap to.
+		{"single item stays", 1, 0, 3, 0, 0},
+		{"empty stays", 0, 0, 3, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := cplxPopup(searchModeCommands, tt.items, tt.height)
+			sp.selected = tt.selected
+			sp.selectPrev()
+			if sp.selected != tt.wantSelected {
+				t.Errorf("selected = %d, want %d", sp.selected, tt.wantSelected)
+			}
+			if sp.scrollOff != tt.wantScrollOff {
+				t.Errorf("scrollOff = %d, want %d", sp.scrollOff, tt.wantScrollOff)
+			}
+		})
+	}
+}
+
+func TestCplxSearchPopupSelectNext(t *testing.T) {
+	tests := []struct {
+		name          string
+		items         int
+		selected      int
+		scrollOff     int
+		height        int
+		wantSelected  int
+		wantScrollOff int
+	}{
+		{"moves down", 5, 1, 0, 3, 2, 0},
+		// Advancing past the visible window scrolls it.
+		{"scrolls when past the window", 5, 2, 0, 3, 3, 1},
+		{"wraps from last", 5, 4, 2, 3, 0, 2},
+		{"single item stays", 1, 0, 0, 3, 0, 0},
+		{"empty stays", 0, 0, 0, 3, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := cplxPopup(searchModeCommands, tt.items, tt.height)
+			sp.selected, sp.scrollOff = tt.selected, tt.scrollOff
+			sp.selectNext()
+			if sp.selected != tt.wantSelected {
+				t.Errorf("selected = %d, want %d", sp.selected, tt.wantSelected)
+			}
+			if sp.scrollOff != tt.wantScrollOff {
+				t.Errorf("scrollOff = %d, want %d", sp.scrollOff, tt.wantScrollOff)
+			}
+		})
+	}
+}
+
+func TestCplxSearchPopupSelectByTab(t *testing.T) {
+	tests := []struct {
+		name         string
+		items        int
+		selected     int
+		backwards    bool
+		wantSelected int
+	}{
+		{"tab advances", 5, 1, false, 2},
+		// Tab stops at the last item — unlike Down, it does not wrap.
+		{"tab stops at last", 5, 4, false, 4},
+		{"shift-tab retreats", 5, 3, true, 2},
+		{"shift-tab wraps from first", 5, 0, true, 4},
+		{"empty is a no-op", 0, 0, false, 0},
+		{"empty backwards is a no-op", 0, 0, true, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := cplxPopup(searchModeCommands, tt.items, 3)
+			sp.selected = tt.selected
+			sp.selectByTab(tt.backwards)
+			if sp.selected != tt.wantSelected {
+				t.Errorf("selected = %d, want %d", sp.selected, tt.wantSelected)
+			}
+		})
+	}
+}
+
+func TestCplxAcceptSearchPopupSelection(t *testing.T) {
+	t.Run("command gets a trailing space", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		m.searchPopup.selected = 1
+		m.acceptSearchPopupSelection()
+		if got := m.inputModel.Text; got != "b " {
+			t.Errorf("input = %q, want %q", got, "b ")
+		}
+		if m.searchPopup != nil {
+			t.Error("accepting must close the popup")
+		}
+	})
+
+	t.Run("history is inserted verbatim", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeHistory, 3, 3)
+		m.searchPopup.selected = 2
+		m.acceptSearchPopupSelection()
+		if got := m.inputModel.Text; got != "c" {
+			t.Errorf("input = %q, want %q", got, "c")
+		}
+		if m.searchPopup != nil {
+			t.Error("accepting must close the popup")
+		}
+	})
+
+	t.Run("empty list leaves the popup open", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 0, 3)
+		m.acceptSearchPopupSelection()
+		if m.searchPopup == nil {
+			t.Error("nothing to accept must leave the popup open")
+		}
+		if m.inputModel.Text != "" {
+			t.Errorf("input = %q, want empty", m.inputModel.Text)
+		}
+	})
+
+	t.Run("out of range selection is ignored", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 2, 3)
+		m.searchPopup.selected = 9
+		m.acceptSearchPopupSelection()
+		if m.searchPopup == nil || m.inputModel.Text != "" {
+			t.Error("an out-of-range selection must change nothing")
+		}
+	})
+}
+
+func TestCplxHandleSearchPopupKey(t *testing.T) {
+	t.Run("nil popup is not handled", func(t *testing.T) {
+		m := cplxModel(t)
+		if m.handleSearchPopupKey(tea.Key{Code: tea.KeyUp}) {
+			t.Error("with no popup the key must not be consumed")
+		}
+	})
+
+	t.Run("esc closes", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		if !m.handleSearchPopupKey(tea.Key{Code: tea.KeyEsc}) {
+			t.Error("esc must be consumed")
+		}
+		if m.searchPopup != nil {
+			t.Error("esc must close the popup")
+		}
+	})
+
+	t.Run("backspace trims then closes", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		m.searchPopup.search = "ab"
+		m.handleSearchPopupKey(tea.Key{Code: tea.KeyBackspace})
+		if m.searchPopup == nil || m.searchPopup.search != "a" {
+			t.Fatalf("backspace must trim the query, got %+v", m.searchPopup)
+		}
+		m.handleSearchPopupKey(tea.Key{Code: tea.KeyBackspace})
+		if m.searchPopup == nil || m.searchPopup.search != "" {
+			t.Fatal("backspace must empty the query before closing")
+		}
+		m.handleSearchPopupKey(tea.Key{Code: tea.KeyBackspace})
+		if m.searchPopup != nil {
+			t.Error("backspace on an empty query must close the popup")
+		}
+	})
+
+	t.Run("printable runes filter", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		if !m.handleSearchPopupKey(tea.Key{Code: 'x', Text: "x"}) {
+			t.Error("a printable rune must be consumed")
+		}
+		if m.searchPopup.search != "x" {
+			t.Errorf("search = %q, want x", m.searchPopup.search)
+		}
+	})
+
+	t.Run("modified and multi-rune keys fall through", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		if m.handleSearchPopupKey(tea.Key{Code: 'x', Text: "x", Mod: tea.ModCtrl}) {
+			t.Error("ctrl+x must not be swallowed as search text")
+		}
+		if m.handleSearchPopupKey(tea.Key{Code: 'x', Text: "xy"}) {
+			t.Error("multi-rune text must not be swallowed as search text")
+		}
+		if m.handleSearchPopupKey(tea.Key{Code: tea.KeyF1}) {
+			t.Error("an unhandled key must not be consumed")
+		}
+	})
+
+	t.Run("navigation keys are consumed", func(t *testing.T) {
+		for _, key := range []tea.Key{
+			{Code: tea.KeyUp}, {Code: tea.KeyDown},
+			{Code: tea.KeyTab}, {Code: tea.KeyTab, Mod: tea.ModShift},
+			{Code: tea.KeyEnter},
+		} {
+			m := cplxModel(t)
+			m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+			if !m.handleSearchPopupKey(key) {
+				t.Errorf("key %v must be consumed", key.Code)
+			}
+		}
+	})
+}
+
+func TestCplxSearchPopupStyles(t *testing.T) {
+	m := cplxModel(t)
+	commands := m.searchPopupStyles(searchModeCommands, 40)
+	if commands.header != "Commands" {
+		t.Errorf("commands header = %q", commands.header)
+	}
+	history := m.searchPopupStyles(searchModeHistory, 40)
+	if history.header != "History" {
+		t.Errorf("history header = %q", history.header)
+	}
+	// The two modes must differ, or the accent coloring was lost in the move.
+	if commands.itemStyle.Render("x") == history.itemStyle.Render("x") {
+		t.Error("commands and history must render items differently")
+	}
+	// An unknown mode keeps the unaccented base styles and an empty header.
+	unknown := m.searchPopupStyles(searchMode("nope"), 40)
+	if unknown.header != "" {
+		t.Errorf("unknown mode header = %q, want empty", unknown.header)
+	}
+}
+
+func TestCplxRenderSearchPopup(t *testing.T) {
+	t.Run("nil popup renders nothing", func(t *testing.T) {
+		m := cplxModel(t)
+		if got := m.renderSearchPopup(40); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("empty results per mode", func(t *testing.T) {
+		for mode, want := range map[searchMode]string{
+			searchModeCommands: "No matching commands",
+			searchModeHistory:  "No matching history",
+		} {
+			m := cplxModel(t)
+			m.searchPopup = cplxPopup(mode, 0, 3)
+			if got := m.renderSearchPopup(40); !strings.Contains(got, want) {
+				t.Errorf("mode %q: output missing %q", mode, want)
+			}
+		}
+	})
+
+	t.Run("search prompt line", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		if got := m.renderSearchPopup(40); !strings.Contains(got, "Search... (type to filter)") {
+			t.Errorf("an empty query must show the placeholder, got %q", got)
+		}
+		m.searchPopup.search = "abc"
+		if got := m.renderSearchPopup(40); !strings.Contains(got, "Search: abc") {
+			t.Errorf("a query must be echoed, got %q", got)
+		}
+	})
+
+	t.Run("header carries the count", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		if got := m.renderSearchPopup(40); !strings.Contains(got, "Commands (3)") {
+			t.Errorf("header missing its count, got %q", got)
+		}
+	})
+
+	// A width under the floor is widened rather than producing a broken frame.
+	t.Run("narrow width does not panic", func(t *testing.T) {
+		m := cplxModel(t)
+		m.searchPopup = cplxPopup(searchModeCommands, 3, 3)
+		if got := m.renderSearchPopup(2); got == "" {
+			t.Error("a narrow popup must still render")
+		}
+	})
+}
+
+func TestCplxWriteSearchPopupItems(t *testing.T) {
+	t.Run("marks the selection and stops at the end", func(t *testing.T) {
+		m := cplxModel(t)
+		sp := cplxPopup(searchModeCommands, 2, 5) // height exceeds the item count
+		sp.selected = 1
+		var b strings.Builder
+		writeSearchPopupItems(&b, sp, m.searchPopupStyles(searchModeCommands, 40), 40)
+		got := b.String()
+		if strings.Count(got, "\n") != 2 {
+			t.Errorf("expected exactly 2 item rows, got %q", got)
+		}
+		if !strings.Contains(got, "> ") {
+			t.Error("the selected row must carry the > marker")
+		}
+	})
+
+	t.Run("a stale scroll offset cannot index past the end", func(t *testing.T) {
+		m := cplxModel(t)
+		sp := cplxPopup(searchModeCommands, 2, 5)
+		sp.scrollOff = 99
+		var b strings.Builder
+		writeSearchPopupItems(&b, sp, m.searchPopupStyles(searchModeCommands, 40), 40)
+		if b.String() != "" {
+			t.Errorf("an out-of-range offset must render nothing, got %q", b.String())
+		}
+	})
+
+	t.Run("descriptions only in command mode", func(t *testing.T) {
+		m := cplxModel(t)
+		var withDesc, noDesc strings.Builder
+		writeSearchPopupItems(&withDesc, cplxPopup(searchModeCommands, 1, 3),
+			m.searchPopupStyles(searchModeCommands, 60), 60)
+		writeSearchPopupItems(&noDesc, cplxPopup(searchModeHistory, 1, 3),
+			m.searchPopupStyles(searchModeHistory, 60), 60)
+		if !strings.Contains(withDesc.String(), "desc") {
+			t.Error("command rows must carry their description")
+		}
+		if strings.Contains(noDesc.String(), "desc") {
+			t.Error("history rows must not carry a description")
+		}
+	})
+}
+
+func TestCplxClipMessagesToViewport(t *testing.T) {
+	tests := []struct {
+		name          string
+		view          string
+		height        int
+		scroll        int
+		wantStart     int
+		wantEnd       int
+		wantRowsAtMin int
+	}{
+		// Shorter than the viewport: clamped to 0 and padded out to height.
+		{"pads a short block", "a\nb", 5, 0, 0, 2, 5},
+		{"exact fit", "a\nb\nc", 3, 0, 0, 3, 3},
+		{"trims the top", "a\nb\nc\nd\ne", 3, 0, 2, 5, 3},
+		{"scroll moves the window back", "a\nb\nc\nd\ne", 3, 2, 0, 3, 3},
+		// Scrolling past the start clamps rather than going negative.
+		{"scroll past the start clamps", "a\nb\nc", 2, 99, 0, 2, 2},
+		{"single line", "only", 1, 0, 0, 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			visible, start, end := clipMessagesToViewport(tt.view, tt.height, tt.scroll)
+			if start != tt.wantStart || end != tt.wantEnd {
+				t.Errorf("range = [%d,%d), want [%d,%d)", start, end, tt.wantStart, tt.wantEnd)
+			}
+			if rows := strings.Count(visible, "\n") + 1; rows != tt.wantRowsAtMin {
+				t.Errorf("rows = %d, want %d (visible %q)", rows, tt.wantRowsAtMin, visible)
+			}
+		})
+	}
+}
+
+// Padding rows must stay materialized — a bare trailing newline made the
+// composed frame one line shorter than the terminal.
+func TestCplxClipMessagesToViewport_PaddingRowsAreMaterialized(t *testing.T) {
+	visible, _, _ := clipMessagesToViewport("a", 4, 0)
+	if !strings.HasSuffix(visible, "\n ") {
+		t.Errorf("padded block must end in a materialized row, got %q", visible)
+	}
+}
+
+func TestCplxStartupView(t *testing.T) {
+	t.Run("without loading items", func(t *testing.T) {
+		m := cplxModel(t)
+		m.loadingItems = nil
+		if got := m.startupView().Content; got == "" || strings.Contains(got, "✓") {
+			t.Errorf("startup view = %q", got)
+		}
+	})
+
+	t.Run("with loading items", func(t *testing.T) {
+		m := cplxModel(t)
+		m.loadingItems = map[string]bool{"skills": true, "mcp": false}
+		m.loadingTotal = 2
+		got := m.startupView().Content
+		if !strings.Contains(got, "✓") {
+			t.Errorf("a finished item must be ticked, got %q", got)
+		}
+		if !strings.Contains(got, "skills") || !strings.Contains(got, "mcp") {
+			t.Errorf("both items must be listed, got %q", got)
+		}
+		// Sorted for a stable splash.
+		if strings.Index(got, "mcp") > strings.Index(got, "skills") {
+			t.Errorf("items must be listed in sorted order, got %q", got)
+		}
+	})
+}
+
+func TestCplxSidebarRenderInput(t *testing.T) {
+	t.Run("without a run", func(t *testing.T) {
+		m := cplxModel(t)
+		in := m.sidebarRenderInput(30, 20)
+		if in.Width != 30 || in.Height != 20 {
+			t.Errorf("size = %dx%d, want 30x20", in.Width, in.Height)
+		}
+		if in.ModelName != "test-model" {
+			t.Errorf("ModelName = %q", in.ModelName)
+		}
+		if in.RunPhase != "" || in.RunSpec != "" {
+			t.Errorf("no run must leave the run fields empty, got %+v", in)
+		}
+	})
+
+	t.Run("with a run", func(t *testing.T) {
+		m := cplxModel(t)
+		m.run = &runState{
+			phase: "running", specName: "spec-1", retries: 2, maxRetries: 10,
+			checklist: []ChecklistStep{{Title: "one"}},
+		}
+		in := m.sidebarRenderInput(30, 20)
+		if in.RunPhase != "running" || in.RunSpec != "spec-1" {
+			t.Errorf("run fields = %+v", in)
+		}
+		// The cycle counter is one-based.
+		if in.RunCycle != 3 || in.RunMaxCycle != 10 {
+			t.Errorf("cycle = %d/%d, want 3/10", in.RunCycle, in.RunMaxCycle)
+		}
+		if len(in.RunChecklist) != 1 {
+			t.Errorf("checklist = %+v", in.RunChecklist)
+		}
+	})
+
+	t.Run("a run with no phase is not shown", func(t *testing.T) {
+		m := cplxModel(t)
+		m.run = &runState{specName: "spec-1"}
+		if in := m.sidebarRenderInput(30, 20); in.RunSpec != "" {
+			t.Errorf("a phaseless run must stay hidden, got %+v", in)
+		}
+	})
+}
+
+func TestCplxHandleLoadingTick(t *testing.T) {
+	t.Run("re-arms while loading", func(t *testing.T) {
+		m := cplxModel(t)
+		m.loading = true
+		m.loadingDots = 3
+		_, cmd, handled := m.handleLoadingTick()
+		if !handled || cmd == nil {
+			t.Error("a tick while loading must re-arm")
+		}
+		if m.loadingDots != 0 {
+			t.Errorf("loadingDots = %d, want the counter to wrap to 0", m.loadingDots)
+		}
+	})
+
+	// The re-arm belongs to the init splash lifecycle, not to process uptime:
+	// once loading ends the chain must stop.
+	t.Run("stops when not loading", func(t *testing.T) {
+		m := cplxModel(t)
+		m.loading = false
+		m.loadingDots = 1
+		_, cmd, handled := m.handleLoadingTick()
+		if !handled {
+			t.Error("the tick must still be marked handled")
+		}
+		if cmd != nil {
+			t.Error("a tick outside loading must not re-arm")
+		}
+		if m.loadingDots != 1 {
+			t.Errorf("loadingDots = %d, want it untouched", m.loadingDots)
+		}
+	})
+}
+
+func TestCplxHandleMatrixTick(t *testing.T) {
+	t.Run("running", func(t *testing.T) {
+		m := cplxModel(t)
+		m.running = true
+		m.matrix.feed("init", 100)
+		_, cmd, handled := m.handleMatrixTick()
+		if !handled || cmd == nil {
+			t.Error("a tick while running must re-arm")
+		}
+	})
+
+	t.Run("idle", func(t *testing.T) {
+		m := cplxModel(t)
+		m.running = false
+		_, cmd, handled := m.handleMatrixTick()
+		if !handled {
+			t.Error("the tick must still be marked handled")
+		}
+		if cmd != nil {
+			t.Error("an idle tick must not re-arm")
+		}
+	})
+}
+
+func TestCplxHandleInputSubmit(t *testing.T) {
+	t.Run("slash command dispatches", func(t *testing.T) {
+		m := cplxModel(t)
+		_, _, handled := m.handleInputSubmit(InputSubmitMsg{Text: "/session"})
+		if !handled {
+			t.Error("a submitted line must be handled")
+		}
+		if len(m.chatModel.Messages) == 0 ||
+			!strings.Contains(m.chatModel.Messages[0].content, "Session:") {
+			t.Errorf("expected the slash command to run, got %+v", m.chatModel.Messages)
+		}
+	})
+
+	// A slash command typed mid-turn is dropped rather than queued.
+	t.Run("slash command ignored while running", func(t *testing.T) {
+		m := cplxModel(t)
+		m.running = true
+		_, cmd, handled := m.handleInputSubmit(InputSubmitMsg{Text: "/session"})
+		if !handled || cmd != nil {
+			t.Error("a slash command while running must be swallowed")
+		}
+		if len(m.chatModel.Messages) != 0 {
+			t.Errorf("nothing may be appended, got %+v", m.chatModel.Messages)
+		}
+	})
+
+	t.Run("plain text is enqueued", func(t *testing.T) {
+		m := cplxModel(t)
+		_, _, handled := m.handleInputSubmit(InputSubmitMsg{Text: "hello there"})
+		if !handled {
+			t.Error("plain text must be handled")
+		}
+	})
+}
+
+func TestCplxHandleKeyPressMsg_DropsResizeFragments(t *testing.T) {
+	m := cplxModel(t)
+	m.resizeAt = time.Now()
+	// While draining, a fragment is swallowed and only re-arms the drain timer.
+	_, cmd, handled := m.handleKeyPressMsg(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	if !handled || cmd == nil {
+		t.Error("a resize fragment must be swallowed and re-arm the drain")
+	}
+	if m.inputModel.Text != "" {
+		t.Errorf("a fragment must not reach the input, got %q", m.inputModel.Text)
+	}
+}
+
+// updateTerminal reports handled=false for anything it does not own, so the
+// caller can go on to the agent-event handlers.
+func TestCplxUpdateTerminal_UnhandledFallsThrough(t *testing.T) {
+	m := cplxModel(t)
+	if _, _, handled := m.updateTerminal(struct{ nope bool }{}); handled {
+		t.Error("an unknown message must not be claimed")
+	}
+}

--- a/internal/tui/complexity_render_test.go
+++ b/internal/tui/complexity_render_test.go
@@ -1,0 +1,1409 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// This file is the behavior-preservation evidence for the cyclomatic-complexity
+// refactor of the four render hotspots in this package: renderMessages,
+// renderRegularTool / renderAgentTool, toolCallSummary / formatToolResult,
+// StatusModel.Render and blankFast.
+//
+// Two kinds of test live here.
+//
+//   - renderGoldenCorpus + TestRenderGoldenDump produce the exact bytes every
+//     one of those paths emits across 350 input combinations. Dumping the
+//     corpus before and after the refactor and diffing it is what proved the
+//     refactor is a no-op; the dump stays as the tool for the next one.
+//   - The table-driven tests pin the boundaries the original branch structure
+//     encoded, one table per extracted helper, so a branch that goes missing
+//     fails a named case rather than shifting a wall of ANSI.
+
+// ---------------------------------------------------------------------------
+// Golden corpus
+// ---------------------------------------------------------------------------
+
+// renderGoldenCorpus produces the exact bytes every render path under test
+// emits, keyed by case name.
+func renderGoldenCorpus() map[string]string {
+	out := map[string]string{}
+
+	for _, w := range []int{10, 40, 120} {
+		for name, msgs := range renderGoldenMessageSets() {
+			for _, running := range []bool{false, true} {
+				c := NewChatModel(nil)
+				c.Width = w
+				c.Messages = append(c.Messages, msgs...)
+				text, kinds := c.renderMessages(running)
+				out[fmt.Sprintf("chat/%s/w=%d/run=%v", name, w, running)] = fmt.Sprintf("%s\n--kinds--\n%v", text, kinds)
+			}
+		}
+	}
+
+	for _, w := range []int{0, 40, 200} {
+		for _, compact := range []bool{false, true} {
+			for _, blink := range []bool{false, true} {
+				td := ToolDisplayModel{Width: w, CompactTools: compact, BlinkOn: blink}
+				for name, msg := range renderGoldenToolMessages() {
+					key := fmt.Sprintf("tool/%s/w=%d/compact=%v/blink=%v", name, w, compact, blink)
+					out[key] = td.RenderToolMessage(msg)
+				}
+			}
+		}
+	}
+
+	for name, tc := range renderGoldenStatusCases() {
+		out["status/"+name] = tc.model.Render(tc.in)
+	}
+
+	for i, tc := range renderGoldenSummaryArgs() {
+		out[fmt.Sprintf("summary/%02d/%s", i, tc.name)] = toolCallSummary(tc.name, tc.args)
+	}
+	for i, data := range renderGoldenResultData() {
+		out[fmt.Sprintf("result/%02d", i)] = formatToolResult(data)
+	}
+	for i, s := range renderGoldenBlankLines() {
+		out[fmt.Sprintf("blank/%02d", i)] = fmt.Sprintf("%v", blankFast(s))
+	}
+	return out
+}
+
+func renderGoldenMessageSets() map[string][]message {
+	return map[string][]message{
+		"empty": nil,
+		"mixed": {
+			{role: "user", content: "hello there this is a fairly long user line that must wrap somewhere"},
+			{role: "assistant", content: "plain **assistant** reply"},
+			{role: "user", content: "second"},
+			{role: "thinking", content: "a\nb\nc\nd\ne\nf\ng\nh"},
+			{role: "assistant", content: "boom: {\"error\":\"a very long provider error body that wraps\"}", isError: true},
+			{role: "assistant", content: "careful", isWarning: true},
+			{role: "assistant", content: "12 in, 34 out", isMeta: true},
+			{role: "assistant", content: "\x1b[31mpre\x1b[0m", preRendered: true},
+			{role: "tool", tool: "bash", toolIn: "ls -la", content: "a\nb"},
+			{role: "assistant", content: ""},
+			{role: "", content: "unknown role"},
+		},
+		"emptythink": {
+			{role: "thinking", content: ""},
+			{role: "assistant", content: ""},
+		},
+		"single-user": {
+			{role: "user", content: "only"},
+		},
+	}
+}
+
+func renderGoldenToolMessages() map[string]message {
+	long := strings.Repeat("x", 300)
+	manyLines := make([]string, 0, 30)
+	for i := range 30 {
+		manyLines = append(manyLines, fmt.Sprintf("line %d", i))
+	}
+	body := strings.Join(manyLines, "\n")
+
+	return map[string]message{
+		"skill":      {role: "tool", tool: "skill", toolIn: "disk-check", content: "loaded"},
+		"skill-bare": {role: "tool", tool: "skill"},
+		"read":       {role: "tool", tool: "read", toolIn: "/tmp/x.go", content: "package main\nfunc main() {}"},
+		"bash":       {role: "tool", tool: "bash", toolIn: "go test ./...", content: body},
+		"bash-wait":  {role: "tool", tool: "bash_wait", toolIn: "bg_1", content: "still going", pollCount: 5},
+		"grep":       {role: "tool", tool: "grep", toolIn: "foo", content: "a.go:1: foo\nb.go:2: foo"},
+		"ripgrep":    {role: "tool", tool: "ripgrep", toolIn: "foo", content: "a.go:1: foo"},
+		"find":       {role: "tool", tool: "find", toolIn: "*.go", content: "a.go\nb.go"},
+		"other":      {role: "tool", tool: "ls", toolIn: ".", content: "a\nb\nc"},
+		"pending":    {role: "tool", tool: "bash", toolIn: "sleep 1"},
+		"longargs":   {role: "tool", tool: "bash", toolIn: long, content: "ok"},
+		"jsonresult": {role: "tool", tool: "ls", toolIn: ".", content: `{"entries":[{"name":"a","is_dir":true},{"name":"b"}]}`},
+		"live": {role: "tool", tool: "bash", toolIn: "make", agentEvents: []agentEv{
+			{kind: "output", content: "compiling"},
+			{kind: "stderr", content: "warn: x"},
+			{kind: "output", content: "o1"}, {kind: "output", content: "o2"},
+			{kind: "output", content: "o3"}, {kind: "output", content: "o4"},
+			{kind: "heartbeat", content: "1m30s — no output"},
+		}},
+		"agent-empty": {role: "tool", tool: "agent", agentType: "", agentTitle: ""},
+		"agent-basic": {role: "tool", tool: "agent", agentType: "claude", agentTitle: "look at x", content: "done\nwith it"},
+		"agent-multi": {role: "tool", tool: "subagent", agentType: "claude+explore+task+gemini", agentTitle: "t", agentEvents: []agentEv{
+			{kind: "spawn", content: "s"},
+			{kind: "message_start"},
+			{kind: "text", content: "   "},
+			{kind: "tool_call", content: "read\n\nfoo"},
+			{kind: "tool_result", content: `{"total_lines": 4}`},
+			{kind: "stderr", content: strings.Repeat("e", 200)},
+			{kind: "text_delta", content: "hello\n\nworld"},
+			{kind: "thinking_delta", content: "hmm"},
+			{kind: "custom", content: "c"},
+			{kind: "custom", content: ""},
+			{kind: "message_end"},
+			{kind: "done"},
+		}},
+		"agent-onebig": {role: "tool", tool: "agent", agentType: "cursor", agentTitle: "big", agentEvents: []agentEv{
+			{kind: "text", content: strings.Repeat("word ", 200)},
+		}},
+		"agent-longsum": {role: "tool", tool: "agent", agentType: "gemini", content: long},
+	}
+}
+
+type renderGoldenStatusCase struct {
+	model StatusModel
+	in    StatusRenderInput
+}
+
+func renderGoldenStatusCases() map[string]renderGoldenStatusCase {
+	fixed := time.Now()
+	return map[string]renderGoldenStatusCase{
+		"bare":  {StatusModel{Width: 100}, StatusRenderInput{}},
+		"flash": {StatusModel{Width: 100}, StatusRenderInput{Flash: "Copied!", Mode: "plan"}},
+		"plan":  {StatusModel{Width: 100}, StatusRenderInput{Mode: "plan"}},
+		"loading": {StatusModel{Width: 100}, StatusRenderInput{
+			LoadingItems: map[string]bool{"mcp": true, "lsp": false, "skills": true},
+			Pending:      3,
+		}},
+		"loading-empty": {StatusModel{Width: 100}, StatusRenderInput{LoadingItems: map[string]bool{}}},
+		"queued":        {StatusModel{Width: 100}, StatusRenderInput{Pending: 2}},
+		"ctx-small":     {StatusModel{Width: 100}, StatusRenderInput{Messages: []message{{role: "user", content: "hi"}}}},
+		"ctx-big": {StatusModel{Width: 100}, StatusRenderInput{
+			Messages: []message{{role: "user", content: strings.Repeat("word ", 3000)}},
+		}},
+		"tkn-green":  {StatusModel{Width: 100}, StatusRenderInput{TokenTracker: flexTokenTracker{limit: 1000, totalUsed: 100, percentUsed: 10}}},
+		"tkn-orange": {StatusModel{Width: 100}, StatusRenderInput{TokenTracker: flexTokenTracker{limit: 1000, totalUsed: 850, percentUsed: 85}}},
+		"tkn-red":    {StatusModel{Width: 100}, StatusRenderInput{TokenTracker: flexTokenTracker{limit: 1000, totalUsed: 1500, percentUsed: 150}}},
+		"tkn-nolimit": {StatusModel{Width: 100}, StatusRenderInput{
+			TokenTracker: flexTokenTracker{limit: 0, totalUsed: 4321},
+		}},
+		"tkn-nolimit-zero": {StatusModel{Width: 100}, StatusRenderInput{TokenTracker: flexTokenTracker{}}},
+		"loc-both":         {StatusModel{Width: 100}, StatusRenderInput{FolderName: "pi-go", HostName: "mac"}},
+		"loc-dir":          {StatusModel{Width: 100}, StatusRenderInput{FolderName: "pi-go"}},
+		"loc-host":         {StatusModel{Width: 100}, StatusRenderInput{HostName: "mac"}},
+		"tools-many":       {StatusModel{Width: 200, ActiveTools: map[string]time.Time{"b": fixed, "a": fixed}}, StatusRenderInput{}},
+		"tools-one-map":    {StatusModel{Width: 200, ActiveTools: map[string]time.Time{"a": fixed}, ActiveTool: ""}, StatusRenderInput{}},
+		"runcycle":         {StatusModel{Width: 100}, StatusRenderInput{RunCycle: &runCycleInfo{SpecName: "s", Cycle: 2, MaxRetries: 5}}},
+		"running-tool":     {StatusModel{Width: 100, ActiveTool: ""}, StatusRenderInput{Running: false}},
+	}
+}
+
+type renderGoldenSummaryCase struct {
+	name string
+	args map[string]any
+}
+
+func renderGoldenSummaryArgs() []renderGoldenSummaryCase {
+	return []renderGoldenSummaryCase{
+		{"read", map[string]any{"file_path": "/a/b.go"}},
+		{"read", map[string]any{}},
+		{"read", map[string]any{"file_path": 7}},
+		{"write", map[string]any{"file_path": "/w.go"}},
+		{"write", nil},
+		{"edit", map[string]any{"file_path": "/e.go"}},
+		{"edit", map[string]any{"other": "x"}},
+		{"bash", map[string]any{"command": "ls -la"}},
+		{"bash", map[string]any{}},
+		{"bash_wait", map[string]any{"handle": "bg_1"}},
+		{"bash_output", map[string]any{"handle": "bg_2"}},
+		{"bash_kill", map[string]any{"handle": "bg_3"}},
+		{"bash_kill", map[string]any{}},
+		{"grep", map[string]any{"pattern": "foo"}},
+		{"ripgrep", map[string]any{"pattern": "bar"}},
+		{"ripgrep", map[string]any{}},
+		{groundingToolName, map[string]any{"query": "who is x"}},
+		{groundingToolName, map[string]any{}},
+		{"find", map[string]any{"pattern": "*.go"}},
+		{"find", map[string]any{}},
+		{"ls", map[string]any{"path": "/tmp"}},
+		{"ls", map[string]any{}},
+		{"ls", map[string]any{"path": ""}},
+		{"ls", map[string]any{"path": 3}},
+		{"tree", map[string]any{"path": "/t", "depth": 3.0}},
+		{"tree", map[string]any{"path": "/t"}},
+		{"tree", map[string]any{}},
+		{"tree", map[string]any{"path": "", "depth": 0.0}},
+		{"tree", map[string]any{"depth": -1.0}},
+		{"agent", map[string]any{"type": "explore", "prompt": "find the thing"}},
+		{"agent", map[string]any{"type": "explore"}},
+		{"agent", map[string]any{"prompt": "just a prompt"}},
+		{"agent", map[string]any{}},
+		{"agent", map[string]any{"type": "t", "prompt": "first line\nsecond line"}},
+		{"agent", map[string]any{"type": "t", "prompt": "\nleading newline"}},
+		{"agent", map[string]any{"type": "t", "prompt": strings.Repeat("p", 100)}},
+		{"unknown", map[string]any{"x": "y"}},
+		{"", nil},
+	}
+}
+
+func renderGoldenResultData() []map[string]any {
+	return []map[string]any{
+		{"entries": []any{map[string]any{"name": "a", "is_dir": true}, map[string]any{"name": "b"}, "junk"}},
+		{"entries": []any{}},
+		{"entries": []any{map[string]any{"name": strings.Repeat("n", 200)}}},
+		{"tree": "x", "dirs": 2.0, "files": 3.0},
+		{"tree": "x"},
+		{"matches": []any{map[string]any{"file": "a.go", "line": 3.0, "content": "hit"}, 1}, "total_matches": 9.0, "truncated": true},
+		{"matches": []any{}, "total_matches": 2.0},
+		{"total_matches": 4.0},
+		{"files": []any{"a.go", "b.go", 3}, "total_files": 7.0, "truncated": true},
+		{"files": []any{}},
+		{"total_files": 12.0},
+		{"content": "hello", "total_lines": 3.0, "truncated": true},
+		{"content": "hello"},
+		{"total_lines": 8.0, "truncated": true},
+		{"total_lines": 8.0},
+		{"total_lines": 8.0, "truncated": false},
+		{"bytes_written": 42.0, "path": "/p"},
+		{"bytes_written": 42.0},
+		{"replacements": 3.0},
+		{"lsp_diagnostics": "⚠ boom"},
+		{"lsp_diagnostics": ""},
+		{"handle": "bg_1", "running": true, "stdout": "out", "stderr": "err"},
+		{"handle": "", "exit_code": 0.0, "stdout": "hi"},
+		{"exit_code": 0.0, "stdout": "hi", "stderr": ""},
+		{"exit_code": 1.0, "stdout": "", "stderr": "bad"},
+		{"exit_code": 0.0},
+		{"unknown": "value"},
+		{"unknown": strings.Repeat("v", 300)},
+		{},
+	}
+}
+
+func renderGoldenBlankLines() []string {
+	return []string{
+		"", " ", "\t\v\f\r ", "x", " x ",
+		"\x1b[0m", "\x1b[38;5;245m\x1b[0m", "\x1b[38;5;245m▌\x1b[0m",
+		"\x1b[", "\x1b[3", "\x1b", "\x1bX0", "\x1bX\xd0", "\x1b[ 0A", "\x1b[\x1c",
+		" ", "\xa0", " ", " x", "▌", "😀",
+		"\x1b]8;;http://x\x07", "\x1b[38;5;245m   \x1b[0m\t",
+	}
+}
+
+// TestRenderGoldenDump writes the corpus to the file named by
+// PI_RENDER_GOLDEN_OUT. Without the variable it is a no-op; with it, dump the
+// corpus on both sides of a change and diff the two files to prove the change
+// is invisible to the terminal.
+func TestRenderGoldenDump(t *testing.T) {
+	path := os.Getenv("PI_RENDER_GOLDEN_OUT")
+	if path == "" {
+		t.Skip("PI_RENDER_GOLDEN_OUT not set")
+	}
+	corpus := renderGoldenCorpus()
+	keys := make([]string, 0, len(corpus))
+	for k := range corpus {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&b, "===== %s =====\n%s\n", k, corpus[k])
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRenderGoldenCorpusCovers walks the whole corpus so every render path it
+// names executes at least once, and guards its size: a corpus that silently
+// shrinks stops being evidence.
+func TestRenderGoldenCorpusCovers(t *testing.T) {
+	corpus := renderGoldenCorpus()
+	if len(corpus) < 350 {
+		t.Fatalf("corpus has %d cases, want at least 350", len(corpus))
+	}
+	for name, out := range corpus {
+		if strings.Contains(out, "%!") {
+			t.Errorf("%s: bad format verb in output: %q", name, out)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// toolCallSummary and its extracted helpers
+// ---------------------------------------------------------------------------
+
+// TestToolCallSummaryRender pins every branch the original switch encoded,
+// including the ones the table lookup now serves: a missing key and a key
+// holding a non-string both summarize as "".
+func TestToolCallSummaryRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		tool string
+		args map[string]any
+		want string
+	}{
+		{"read path", "read", map[string]any{"file_path": "/a/b.go"}, "/a/b.go"},
+		{"read missing", "read", map[string]any{}, ""},
+		{"read wrong type", "read", map[string]any{"file_path": 7}, ""},
+		{"read nil args", "read", nil, ""},
+		{"write path", "write", map[string]any{"file_path": "/w.go"}, "/w.go"},
+		{"edit path", "edit", map[string]any{"file_path": "/e.go"}, "/e.go"},
+		{"edit other key", "edit", map[string]any{"other": "x"}, ""},
+		{"bash command", "bash", map[string]any{"command": "ls -la"}, "ls -la"},
+		{"bash missing", "bash", map[string]any{}, ""},
+		{"bash_wait handle", "bash_wait", map[string]any{"handle": "bg_1"}, "bg_1"},
+		{"bash_output handle", "bash_output", map[string]any{"handle": "bg_2"}, "bg_2"},
+		{"bash_kill handle", "bash_kill", map[string]any{"handle": "bg_3"}, "bg_3"},
+		{"bash_kill missing", "bash_kill", map[string]any{}, ""},
+		{"grep pattern", "grep", map[string]any{"pattern": "foo"}, "foo"},
+		{"ripgrep pattern", "ripgrep", map[string]any{"pattern": "bar"}, "bar"},
+		{"find pattern", "find", map[string]any{"pattern": "*.go"}, "*.go"},
+		{"grounding query", groundingToolName, map[string]any{"query": "who is x"}, "who is x"},
+		{"grounding missing", groundingToolName, map[string]any{}, ""},
+
+		// ls keeps its own branch: a present-but-empty path is a path, and only
+		// an absent one falls back to ".".
+		{"ls path", "ls", map[string]any{"path": "/tmp"}, "/tmp"},
+		{"ls missing defaults to dot", "ls", map[string]any{}, "."},
+		{"ls empty string is not the default", "ls", map[string]any{"path": ""}, ""},
+		{"ls wrong type defaults to dot", "ls", map[string]any{"path": 3}, "."},
+
+		{"unknown tool", "unknown", map[string]any{"x": "y"}, ""},
+		{"empty tool", "", nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := toolCallSummary(tc.tool, tc.args); got != tc.want {
+				t.Errorf("toolCallSummary(%q) = %q, want %q", tc.tool, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTreeCallSummaryRender pins the tree branch, where an empty or absent path
+// becomes "." and only a positive depth is appended.
+func TestTreeCallSummaryRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		args map[string]any
+		want string
+	}{
+		{"path and depth", map[string]any{"path": "/t", "depth": 3.0}, "/t (depth 3)"},
+		{"path only", map[string]any{"path": "/t"}, "/t"},
+		{"neither", map[string]any{}, "."},
+		{"empty path zero depth", map[string]any{"path": "", "depth": 0.0}, "."},
+		{"negative depth is dropped", map[string]any{"depth": -1.0}, "."},
+		{"depth wrong type", map[string]any{"path": "/t", "depth": "3"}, "/t"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := treeCallSummary(tc.args); got != tc.want {
+				t.Errorf("treeCallSummary(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+			if got := toolCallSummary("tree", tc.args); got != tc.want {
+				t.Errorf("toolCallSummary(tree) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAgentCallSummaryRender pins the three-way "type: prompt" join and both
+// prompt truncations.
+func TestAgentCallSummaryRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		args map[string]any
+		want string
+	}{
+		{"both", map[string]any{"type": "explore", "prompt": "find the thing"}, "explore: find the thing"},
+		{"type only", map[string]any{"type": "explore"}, "explore"},
+		{"prompt only", map[string]any{"prompt": "just a prompt"}, "just a prompt"},
+		{"neither", map[string]any{}, ""},
+		{"first line only", map[string]any{"type": "t", "prompt": "first line\nsecond line"}, "t: first line"},
+		{"leading newline is not a cut", map[string]any{"type": "t", "prompt": "\nleading newline"}, "t: \nleading newline"},
+		{
+			"long prompt clipped to 60",
+			map[string]any{"type": "t", "prompt": strings.Repeat("p", 100)},
+			"t: " + strings.Repeat("p", 57) + "...",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := agentCallSummary(tc.args); got != tc.want {
+				t.Errorf("agentCallSummary(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+			if got := toolCallSummary("agent", tc.args); got != tc.want {
+				t.Errorf("toolCallSummary(agent) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatToolResult and its extracted shapes
+// ---------------------------------------------------------------------------
+
+// TestFormatToolResultRender pins one case per shape plus the fallback, in the
+// order formatToolResult tries them.
+func TestFormatToolResultRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		data map[string]any
+		want string
+	}{
+		{"ls entries", map[string]any{"entries": []any{
+			map[string]any{"name": "a", "is_dir": true},
+			map[string]any{"name": "b"},
+			"junk",
+		}}, "a/  b"},
+		{"ls empty", map[string]any{"entries": []any{}}, ""},
+		{
+			"ls clipped at 120 bytes",
+			map[string]any{"entries": []any{map[string]any{"name": strings.Repeat("n", 200)}}},
+			strings.Repeat("n", 117) + "...",
+		},
+		{"tree counts", map[string]any{"tree": "x", "dirs": 2.0, "files": 3.0}, "2 dirs, 3 files"},
+		{"tree missing counts", map[string]any{"tree": "x"}, "0 dirs, 0 files"},
+		{"grep matches", map[string]any{
+			"matches":       []any{map[string]any{"file": "a.go", "line": 3.0, "content": "hit"}, 1},
+			"total_matches": 9.0, "truncated": true,
+		}, "a.go:3: hit\n... (9 total matches, truncated)"},
+		{"grep matches wins over count", map[string]any{"matches": []any{}, "total_matches": 2.0}, ""},
+		{"grep count only", map[string]any{"total_matches": 4.0}, "4 matches"},
+		{"find files", map[string]any{
+			"files": []any{"a.go", "b.go", 3}, "total_files": 7.0, "truncated": true,
+		}, "a.go\nb.go\n... (7 total files, truncated)"},
+		{"find count only", map[string]any{"total_files": 12.0}, "12 files"},
+		{"read content truncated", map[string]any{
+			"content": "hello", "total_lines": 3.0, "truncated": true,
+		}, "hello\n... (3 total lines, truncated)"},
+		{"read content plain", map[string]any{"content": "hello"}, "hello"},
+		{"read count truncated", map[string]any{"total_lines": 8.0, "truncated": true}, "8 lines (truncated)"},
+		{"read count plain", map[string]any{"total_lines": 8.0}, "8 lines"},
+		{"write bytes", map[string]any{"bytes_written": 42.0, "path": "/p"}, "/p (42 bytes)"},
+		{"edit replacements", map[string]any{"replacements": 3.0}, "3 replacements"},
+		{"diagnostics", map[string]any{"lsp_diagnostics": "⚠ boom"}, "⚠ boom"},
+		{"bash exit zero", map[string]any{"exit_code": 0.0, "stdout": "hi", "stderr": ""}, "hi"},
+		{"bash exit nonzero", map[string]any{"exit_code": 1.0, "stdout": "", "stderr": "bad"}, "exit 1: bad"},
+		{"bash no output", map[string]any{"exit_code": 0.0}, "(No output)"},
+		{"fallback json", map[string]any{"unknown": "value"}, `{"unknown":"value"}`},
+		{"fallback empty", map[string]any{}, "{}"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := formatToolResult(tc.data); got != tc.want {
+				t.Errorf("formatToolResult(%v) =\n%q\nwant\n%q", tc.data, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatToolResultShapeOrder pins the fall-through decisions that the
+// original if-chain encoded by position. Each case carries keys for more than
+// one shape, or keys that look like a shape but must not match it.
+func TestFormatToolResultShapeOrder(t *testing.T) {
+	tests := []struct {
+		desc string
+		data map[string]any
+		want string
+	}{
+		{
+			"handle beats exit_code",
+			map[string]any{"handle": "bg_1", "exit_code": -1.0, "running": true, "stdout": "out"},
+			formatBashWindow("bg_1", map[string]any{"handle": "bg_1", "exit_code": -1.0, "running": true, "stdout": "out"}),
+		},
+		{
+			"empty handle falls through to exit_code",
+			map[string]any{"handle": "", "exit_code": 0.0, "stdout": "hi"},
+			"hi",
+		},
+		{
+			"empty diagnostics falls through to the fallback",
+			map[string]any{"lsp_diagnostics": ""},
+			`{"lsp_diagnostics":""}`,
+		},
+		{
+			"bytes_written without a path falls through",
+			map[string]any{"bytes_written": 42.0},
+			`{"bytes_written":42}`,
+		},
+		{
+			"bytes_written without a path still reaches replacements",
+			map[string]any{"bytes_written": 42.0, "replacements": 2.0},
+			"2 replacements",
+		},
+		{
+			"content beats total_lines",
+			map[string]any{"content": "body", "total_lines": 9.0},
+			"body",
+		},
+		{
+			"files list beats total_files",
+			map[string]any{"files": []any{"a"}, "total_files": 9.0},
+			"a",
+		},
+		{
+			"long fallback json is clipped",
+			map[string]any{"u": strings.Repeat("v", 300)},
+			`{"u":"` + strings.Repeat("v", 111) + "...",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := formatToolResult(tc.data); got != tc.want {
+				t.Errorf("formatToolResult =\n%q\nwant\n%q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestToolResultShapesReject pins that every shape declines input that is not
+// its own — the "false" half of each probe, which is what keeps the ordering
+// above meaningful.
+func TestToolResultShapesReject(t *testing.T) {
+	other := map[string]any{"nothing": "here"}
+	shapes := map[string]toolResultShape{
+		"ls":          lsResultSummary,
+		"tree":        treeResultSummary,
+		"grep":        grepResultSummary,
+		"grepCount":   grepCountSummary,
+		"find":        findResultSummary,
+		"findCount":   findCountSummary,
+		"read":        readResultSummary,
+		"readCount":   readCountSummary,
+		"write":       writeResultSummary,
+		"edit":        editResultSummary,
+		"diagnostics": diagnosticsResultSummary,
+		"bashWindow":  bashWindowResultSummary,
+		"bashExit":    bashExitResultSummary,
+	}
+	if len(shapes) != len(toolResultShapes) {
+		t.Fatalf("test covers %d shapes but formatToolResult tries %d", len(shapes), len(toolResultShapes))
+	}
+	for name, shape := range shapes {
+		t.Run(name, func(t *testing.T) {
+			if s, ok := shape(other); ok {
+				t.Errorf("%s matched unrelated data, returning %q", name, s)
+			}
+		})
+	}
+}
+
+// TestClipToolSummaryRender pins the 120-byte limit and its exact cut point.
+func TestClipToolSummaryRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+		want string
+	}{
+		{"short", "abc", "abc"},
+		{"exactly 120", strings.Repeat("a", 120), strings.Repeat("a", 120)},
+		{"121 clips to 117 plus ellipsis", strings.Repeat("a", 121), strings.Repeat("a", 117) + "..."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := clipToolSummary(tc.in); got != tc.want {
+				t.Errorf("clipToolSummary(len %d) = %q, want %q", len(tc.in), got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// blankFast / skipFastCSI
+// ---------------------------------------------------------------------------
+
+// TestSkipFastCSIRender pins the exact CSI grammar the fast path accepts and
+// every deviation it must hand back to the parser. The -1 cases are what keep
+// blankFast agreeing with ansi.Strip on malformed input.
+func TestSkipFastCSIRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		line string
+		i    int
+		want int
+	}{
+		{"reset", "\x1b[0m", 0, 4},
+		{"sgr 256 color", "\x1b[38;5;245m", 0, 11},
+		{"no params", "\x1b[m", 0, 3},
+		{"trailing content", "\x1b[0mx", 0, 4},
+		{"mid-string", "x\x1b[0m", 1, 5},
+		{"esc at end", "\x1b", 0, -1},
+		{"not a bracket", "\x1bX0", 0, -1},
+		{"unterminated params", "\x1b[3", 0, -1},
+		{"bracket at end", "\x1b[", 0, -1},
+		{"intermediate byte defers", "\x1b[ 0A", 0, -1},
+		{"c0 control defers", "\x1b[\x1c", 0, -1},
+		{"osc defers", "\x1b]8;;http://x\x07", 0, -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := skipFastCSI(tc.line, tc.i); got != tc.want {
+				t.Errorf("skipFastCSI(%q, %d) = %d, want %d", tc.line, tc.i, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBlankFastRenderMatchesStrip re-checks the whole blank corpus against the
+// reference implementation. FuzzBlankFast in collapse_bench_test.go covers
+// arbitrary input; this pins the specific escapes the fast path reasons about.
+func TestBlankFastRenderMatchesStrip(t *testing.T) {
+	for i, line := range renderGoldenBlankLines() {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			if got, want := blankFast(line), slowBlank(line); got != want {
+				t.Errorf("blankFast(%q) = %v, want %v", line, got, want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderMessages and its extracted blocks
+// ---------------------------------------------------------------------------
+
+// renderStripChat renders a chat at the given width and returns the text with
+// ANSI removed, which is what the reader actually sees.
+func renderStripChat(width int, running bool, msgs ...message) string {
+	c := NewChatModel(nil)
+	c.Width = width
+	c.Messages = append(c.Messages, msgs...)
+	text, _ := c.renderMessages(running)
+	return ansi.Strip(text)
+}
+
+// TestRenderMessagesBlocksRender pins the exact laid-out text each role
+// produces, which is where the role switch used to live.
+func TestRenderMessagesBlocksRender(t *testing.T) {
+	tests := []struct {
+		desc    string
+		width   int
+		running bool
+		msgs    []message
+		want    string
+	}{
+		{
+			desc: "single user turn has no separator",
+			msgs: []message{{role: "user", content: "only"}}, width: 40,
+			want: "> only\n",
+		},
+		{
+			desc:  "second user turn opens with the separator",
+			width: 24,
+			msgs: []message{
+				{role: "user", content: "one"},
+				{role: "user", content: "two"},
+			},
+			want: "> one\n" + strings.Repeat("─", 24) + "\n> two\n",
+		},
+		{
+			desc: "user text wraps with a hanging indent", width: 24,
+			msgs: []message{{role: "user", content: "alpha beta gamma delta epsilon"}},
+			want: "> alpha beta gamma\n   delta epsilon\n",
+		},
+		{
+			desc: "narrow width still wraps at the floor of 20", width: 5,
+			msgs: []message{{role: "user", content: "alpha beta gamma delta"}},
+			want: "> alpha beta gamma\n   delta\n",
+		},
+		{
+			desc: "assistant reply gets the bullet", width: 40,
+			msgs: []message{{role: "assistant", content: "hello"}},
+			want: "\n◉ hello\n",
+		},
+		{
+			desc: "empty assistant renders nothing", width: 40,
+			msgs: []message{{role: "assistant", content: ""}},
+			want: "",
+		},
+		{
+			desc: "empty assistant streams an ellipsis", width: 40, running: true,
+			msgs: []message{{role: "assistant", content: ""}},
+			want: "\n◉ ...\n",
+		},
+		{
+			desc: "error reply gets the cross and wraps", width: 24,
+			msgs: []message{{role: "assistant", content: "alpha beta gamma delta", isError: true}},
+			want: "\n✖ alpha beta gamma\n   delta\n",
+		},
+		{
+			desc: "warning reply gets the triangle", width: 40,
+			msgs: []message{{role: "assistant", content: "careful", isWarning: true}},
+			want: "\n⚠ careful\n",
+		},
+		{
+			desc: "meta reply gets sigma and no bullet", width: 40,
+			msgs: []message{{role: "assistant", content: "12 in", isMeta: true}},
+			want: "\nΣ 12 in\n",
+		},
+		{
+			desc: "pre-rendered content bypasses markdown", width: 40,
+			msgs: []message{{role: "assistant", content: "\x1b[31mred\x1b[0m", preRendered: true}},
+			want: "\n◉ red\n",
+		},
+		{
+			desc: "error beats warning beats meta", width: 40,
+			msgs: []message{{role: "assistant", content: "x", isError: true, isWarning: true, isMeta: true}},
+			want: "\n✖ x\n",
+		},
+		{
+			desc: "warning beats meta", width: 40,
+			msgs: []message{{role: "assistant", content: "x", isWarning: true, isMeta: true}},
+			want: "\n⚠ x\n",
+		},
+		{
+			desc: "thinking keeps only the last six lines", width: 40,
+			msgs: []message{{role: "thinking", content: "a\nb\nc\nd\ne\nf\ng\nh"}},
+			want: "\n💭 c\n   d\n   e\n   f\n   g\n   h\n",
+		},
+		{
+			desc: "empty thinking renders nothing", width: 40,
+			msgs: []message{{role: "thinking", content: ""}},
+			want: "",
+		},
+		{
+			desc: "unknown role renders nothing", width: 40,
+			msgs: []message{{role: "wat", content: "ignored"}},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := renderStripChat(tc.width, tc.running, tc.msgs...); got != tc.want {
+				t.Errorf("renderMessages =\n%q\nwant\n%q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderMessagesKindsStayAlignedRender guards the invariant the loop exists
+// to keep: one blockKind per line of the returned text.
+func TestRenderMessagesKindsStayAlignedRender(t *testing.T) {
+	c := NewChatModel(nil)
+	c.Width = 40
+	c.Messages = append(c.Messages, renderGoldenMessageSets()["mixed"]...)
+	for _, running := range []bool{false, true} {
+		text, kinds := c.renderMessages(running)
+		if want := strings.Count(text, "\n") + 1; len(kinds) != want {
+			t.Errorf("running=%v: %d kinds for %d lines", running, len(kinds), want)
+		}
+	}
+}
+
+// TestRenderMessagesCacheRender proves the extracted blocks are still routed
+// through the render cache: a second render of an unchanged model must reuse
+// the cached bytes and produce identical output.
+func TestRenderMessagesCacheRender(t *testing.T) {
+	c := NewChatModel(nil)
+	c.Width = 40
+	c.Messages = append(c.Messages, renderGoldenMessageSets()["mixed"]...)
+
+	first, firstKinds := c.renderMessages(false)
+	for i := range c.Messages {
+		if c.Messages[i].role == "" || c.Messages[i].content == "" {
+			continue
+		}
+		if !c.Messages[i].renderCached {
+			t.Errorf("message %d (%s) was not cached", i, c.Messages[i].role)
+		}
+	}
+	second, secondKinds := c.renderMessages(false)
+	if first != second {
+		t.Errorf("cached render differs:\n%q\nvs\n%q", first, second)
+	}
+	if len(firstKinds) != len(secondKinds) {
+		t.Errorf("cached kinds length %d != %d", len(firstKinds), len(secondKinds))
+	}
+}
+
+// TestRenderWrapWidthRender pins the floor every wrapped block shares.
+func TestRenderWrapWidthRender(t *testing.T) {
+	tests := []struct {
+		total, reserve, want int
+	}{
+		{80, 3, 77},
+		{23, 3, 20},
+		{22, 3, 20},
+		{10, 3, 20},
+		{0, 3, 20},
+		{-5, 3, 20},
+		{25, 0, 25},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("total=%d/reserve=%d", tc.total, tc.reserve), func(t *testing.T) {
+			if got := renderWrapWidth(tc.total, tc.reserve); got != tc.want {
+				t.Errorf("renderWrapWidth(%d, %d) = %d, want %d", tc.total, tc.reserve, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderMessageBlockRender exercises the role dispatch directly, including
+// the tool role's leading newline, which no other test isolates.
+func TestRenderMessageBlockRender(t *testing.T) {
+	c := NewChatModel(nil)
+	c.Width = 60
+	p := paletteOrDark(c.Palette)
+
+	toolMsg := message{role: "tool", tool: "ls", toolIn: ".", content: "a"}
+	got := c.renderMessageBlock(&toolMsg, p, "◉ ", "----", false, false)
+	want := "\n" + c.ToolDisplay.RenderToolMessage(toolMsg)
+	if got != want {
+		t.Errorf("tool block = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, "\n") {
+		t.Error("tool block must open with a newline")
+	}
+
+	unknown := message{role: "nope", content: "x"}
+	if got := c.renderMessageBlock(&unknown, p, "◉ ", "----", true, true); got != "" {
+		t.Errorf("unknown role = %q, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool cards
+// ---------------------------------------------------------------------------
+
+// TestRenderToolCardsRender pins the laid-out text of each card kind. Width 0
+// means "unknown", which both argWidth and contentWidth resolve to 80.
+func TestRenderToolCardsRender(t *testing.T) {
+	tests := []struct {
+		desc    string
+		display ToolDisplayModel
+		msg     message
+		want    string
+	}{
+		{
+			desc: "skill card is a single notice line",
+			msg:  message{role: "tool", tool: "skill", toolIn: "disk-check", content: "loaded"},
+			want: "◉ skill(disk-check) loaded\n",
+		},
+		{
+			desc: "skill card without args or content",
+			msg:  message{role: "tool", tool: "skill"},
+			want: "◉ skill\n",
+		},
+		{
+			desc: "regular card opens a content gutter",
+			msg:  message{role: "tool", tool: "ls", toolIn: ".", content: "a\nb"},
+			want: "◉ ls(.)\n  │ a\n  │ b\n",
+		},
+		{
+			desc: "poll tally is appended to the header",
+			msg:  message{role: "tool", tool: "bash_wait", toolIn: "bg_1", content: "going", pollCount: 5},
+			want: "◉ bash_wait(bg_1) ×5\n  │ going\n",
+		},
+		{
+			desc: "a card polled once carries no tally",
+			msg:  message{role: "tool", tool: "bash_wait", toolIn: "bg_1", content: "going", pollCount: 1},
+			want: "◉ bash_wait(bg_1)\n  │ going\n",
+		},
+		{
+			desc: "pending card blinks its bullet off",
+			msg:  message{role: "tool", tool: "bash", toolIn: "sleep 1"},
+			want: "  bash(sleep 1)\n",
+		},
+		{
+			desc:    "pending card blinks its bullet on",
+			display: ToolDisplayModel{BlinkOn: true},
+			msg:     message{role: "tool", tool: "bash", toolIn: "sleep 1"},
+			want:    "◉ bash(sleep 1)\n",
+		},
+		{
+			// The summary collapses newlines to spaces before the first-line
+			// cut, so a two-line result folds onto one row rather than losing
+			// its tail.
+			desc:    "compact card folds the result onto the header",
+			display: ToolDisplayModel{CompactTools: true},
+			msg:     message{role: "tool", tool: "ls", toolIn: ".", content: "a\nb"},
+			want:    "◉ ls(.) ✓ a b\n",
+		},
+		{
+			desc: "agent card without a type omits the bracket",
+			msg:  message{role: "tool", tool: "agent"},
+			want: "  agent\n",
+		},
+		{
+			desc: "agent card brackets the label and shows the title",
+			msg:  message{role: "tool", tool: "agent", agentType: "claude", agentTitle: "look at x", content: "done"},
+			want: "◉ agent[claude] look at x\n  │ → done\n",
+		},
+		{
+			desc: "subagent types are mapped and deduped",
+			msg:  message{role: "tool", tool: "subagent", agentType: "claude+explore+task+gemini", content: "ok"},
+			want: "◉ agent[claude+pi+gemini]\n  │ → ok\n",
+		},
+		{
+			desc: "agent result collapses newlines into one gutter line",
+			msg:  message{role: "tool", tool: "agent", agentType: "gemini", content: "one\ntwo\n\nthree"},
+			want: "◉ agent[gemini]\n  │ → one two three\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := ansi.Strip(tc.display.RenderToolMessage(tc.msg))
+			if got != tc.want {
+				t.Errorf("RenderToolMessage =\n%q\nwant\n%q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRegularToolOutputClipRender pins the line budget and the marker that
+// reports what was clipped — the marker must be styled after highlighting, so
+// it lands on its own gutter line with no escape debris.
+func TestRegularToolOutputClipRender(t *testing.T) {
+	lines := make([]string, 0, 30)
+	for i := range 30 {
+		lines = append(lines, fmt.Sprintf("l%d", i))
+	}
+	var td ToolDisplayModel
+	got := ansi.Strip(td.RenderToolMessage(message{
+		role: "tool", tool: "ls", toolIn: ".", content: strings.Join(lines, "\n"),
+	}))
+
+	want := "◉ ls(.)\n"
+	for i := range maxRegularToolLines {
+		want += fmt.Sprintf("  │ l%d\n", i)
+	}
+	want += "  │ ... (15 more lines)\n"
+	if got != want {
+		t.Errorf("clipped card =\n%q\nwant\n%q", got, want)
+	}
+
+	// Exactly at the budget, nothing is hidden and no marker appears.
+	atBudget := ansi.Strip(td.RenderToolMessage(message{
+		role: "tool", tool: "ls", toolIn: ".", content: strings.Join(lines[:maxRegularToolLines], "\n"),
+	}))
+	if strings.Contains(atBudget, "more lines") {
+		t.Errorf("card at the budget should carry no marker:\n%q", atBudget)
+	}
+}
+
+// TestHighlightToolOutputRender pins which tool selects which highlighter. The
+// highlighters themselves are covered by highlight_test.go; what matters here
+// is that the dispatch survived being lifted out of renderRegularTool.
+func TestHighlightToolOutputRender(t *testing.T) {
+	dim := lipgloss.NewStyle().Foreground(paletteOrDark(Palette{}).Dim)
+	p := paletteOrDark(Palette{})
+	lines := []string{"a.go:1: hit", "second"}
+
+	tests := []struct {
+		desc string
+		msg  message
+		want []string
+	}{
+		{"read with a path", message{tool: "read", toolIn: "/x.go"}, highlightReadOutput(lines, "/x.go", p)},
+		{"read without a path falls back", message{tool: "read"}, nil},
+		{"bash", message{tool: "bash"}, highlightBashOutput(lines, p)},
+		{"grep", message{tool: "grep"}, highlightGrepOutput(lines, p)},
+		{"ripgrep is grep", message{tool: "ripgrep"}, highlightGrepOutput(lines, p)},
+		{"find", message{tool: "find"}, highlightFindOutput(lines, p)},
+		{"anything else is dim", message{tool: "ls"}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := highlightToolOutput(tc.msg, lines, dim, p)
+			want := tc.want
+			if want == nil {
+				want = []string{dim.Render(lines[0]), dim.Render(lines[1])}
+			}
+			if len(got) != len(want) {
+				t.Fatalf("got %d lines, want %d", len(got), len(want))
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
+
+	// bash_wait and friends take the bash branch via isBashControl.
+	for _, name := range []string{"bash_wait", "bash_output", "bash_kill"} {
+		if !isBashControl(name) {
+			continue
+		}
+		got := highlightToolOutput(message{tool: name}, lines, dim, p)
+		want := highlightBashOutput(lines, p)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("%s line %d = %q, want %q", name, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestWriteGutterLinesRender pins the gutter prefix every card body shares.
+func TestWriteGutterLinesRender(t *testing.T) {
+	dim := lipgloss.NewStyle().Foreground(paletteOrDark(Palette{}).Dim)
+
+	var b strings.Builder
+	writeGutterLines(&b, dim)
+	if b.String() != "" {
+		t.Errorf("no lines should write nothing, got %q", b.String())
+	}
+
+	b.Reset()
+	writeGutterLines(&b, dim, "one", "two")
+	if got, want := ansi.Strip(b.String()), "  │ one\n  │ two\n"; got != want {
+		t.Errorf("writeGutterLines = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Agent card internals
+// ---------------------------------------------------------------------------
+
+// TestRenderableAgentEventsRender pins the filter: structural events never
+// reach the window, and whitespace-only message text does not either.
+func TestRenderableAgentEventsRender(t *testing.T) {
+	in := []agentEv{
+		{kind: "spawn", content: "s"},
+		{kind: "message_start"},
+		{kind: "message_end"},
+		{kind: "done"},
+		{kind: "text", content: "  \n "},
+		{kind: "text_delta", content: ""},
+		{kind: "text", content: "real"},
+		{kind: "tool_call", content: "read"},
+		{kind: "stderr", content: ""},
+		{kind: "custom"},
+	}
+	got := renderableAgentEvents(in)
+	want := []string{"text", "tool_call", "stderr", "custom"}
+	if len(got) != len(want) {
+		t.Fatalf("kept %d events (%v), want %d", len(got), got, len(want))
+	}
+	for i := range got {
+		if got[i].kind != want[i] {
+			t.Errorf("event %d = %q, want %q", i, got[i].kind, want[i])
+		}
+	}
+}
+
+// TestAgentWindowLinesRender pins the line budget and both withheld-output
+// notes: whole events dropped reports a count, a single over-long event
+// reports that its head was cut.
+func TestAgentWindowLinesRender(t *testing.T) {
+	st := lipgloss.NewStyle()
+
+	t.Run("empty stream has no lines and no note", func(t *testing.T) {
+		lines, note := agentWindowLines(nil, st, st, 60)
+		if len(lines) != 0 || note != "" {
+			t.Errorf("got %d lines, note %q", len(lines), note)
+		}
+	})
+
+	t.Run("under budget shows everything with no note", func(t *testing.T) {
+		evs := []agentEv{{kind: "text", content: "a"}, {kind: "text", content: "b"}}
+		lines, note := agentWindowLines(evs, st, st, 60)
+		if len(lines) != 2 || note != "" {
+			t.Errorf("got %d lines %v, note %q", len(lines), lines, note)
+		}
+		if !strings.HasSuffix(ansi.Strip(lines[1]), "b") {
+			t.Errorf("newest event must be last, got %q", lines[1])
+		}
+	})
+
+	t.Run("dropped events report a count", func(t *testing.T) {
+		evs := make([]agentEv, 10)
+		for i := range evs {
+			evs[i] = agentEv{kind: "text", content: fmt.Sprintf("e%d", i)}
+		}
+		lines, note := agentWindowLines(evs, st, st, 60)
+		if len(lines) != maxAgentOutputLines {
+			t.Errorf("got %d lines, want %d", len(lines), maxAgentOutputLines)
+		}
+		if note != "... 7 earlier events" {
+			t.Errorf("note = %q", note)
+		}
+		if got := ansi.Strip(lines[len(lines)-1]); !strings.HasSuffix(got, "e9") {
+			t.Errorf("last line = %q, want the newest event", got)
+		}
+	})
+
+	t.Run("one over-long event reports a clip", func(t *testing.T) {
+		evs := []agentEv{{kind: "text", content: strings.Repeat("word ", 200)}}
+		lines, note := agentWindowLines(evs, st, st, 40)
+		if len(lines) != maxAgentOutputLines {
+			t.Errorf("got %d lines, want %d", len(lines), maxAgentOutputLines)
+		}
+		if note != "... earlier output" {
+			t.Errorf("note = %q", note)
+		}
+	})
+}
+
+// TestAgentResultSummaryRender pins the 160-byte clip on the result line.
+func TestAgentResultSummaryRender(t *testing.T) {
+	dim := lipgloss.NewStyle().Foreground(paletteOrDark(Palette{}).Dim)
+
+	got := ansi.Strip(agentResultSummary("short\nresult", dim, 200))
+	if want := "  │ → short result\n"; got != want {
+		t.Errorf("short summary = %q, want %q", got, want)
+	}
+
+	got = ansi.Strip(agentResultSummary(strings.Repeat("x", 300), dim, 400))
+	if want := "  │ → " + strings.Repeat("x", 157) + "...\n"; got != want {
+		t.Errorf("clipped summary = %q, want %q", got, want)
+	}
+}
+
+// TestAgentCardHeaderRender pins the header row, including the blinking bullet
+// that marks a card whose subagent has not answered yet.
+func TestAgentCardHeaderRender(t *testing.T) {
+	tests := []struct {
+		desc    string
+		display ToolDisplayModel
+		msg     message
+		want    string
+	}{
+		{"bare", ToolDisplayModel{}, message{}, "  agent\n"},
+		{"bare, blink on", ToolDisplayModel{BlinkOn: true}, message{}, "◉ agent\n"},
+		{"done cards never blink", ToolDisplayModel{}, message{content: "x"}, "◉ agent\n"},
+		{"label only", ToolDisplayModel{}, message{agentType: "task", content: "x"}, "◉ agent[pi]\n"},
+		{"title only", ToolDisplayModel{}, message{agentTitle: "hi", content: "x"}, "◉ agent hi\n"},
+		{"both", ToolDisplayModel{}, message{agentType: "gemini", agentTitle: "hi", content: "x"}, "◉ agent[gemini] hi\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := ansi.Strip(tc.display.agentCardHeader(tc.msg, paletteOrDark(tc.display.Palette)))
+			if got != tc.want {
+				t.Errorf("agentCardHeader = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Status bar fields
+// ---------------------------------------------------------------------------
+
+// TestStatusFieldsRender pins each field of the bar in isolation: the exact
+// text, and whether the field appears at all. A field that returns nil is one
+// the joined bar must not open a separator for.
+func TestStatusFieldsRender(t *testing.T) {
+	p := paletteOrDark(Palette{})
+	dim := lipgloss.NewStyle().Foreground(p.Dim)
+
+	t.Run("queued", func(t *testing.T) {
+		if got := statusQueuedField(StatusRenderInput{}, p); got != nil {
+			t.Errorf("no pending prompts should render nothing, got %v", got)
+		}
+		if got := statusQueuedField(StatusRenderInput{Pending: -1}, p); got != nil {
+			t.Errorf("negative pending should render nothing, got %v", got)
+		}
+		got := statusQueuedField(StatusRenderInput{Pending: 2}, p)
+		if len(got) != 1 || ansi.Strip(got[0]) != "queued: 2" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("context", func(t *testing.T) {
+		tests := []struct {
+			desc string
+			in   StatusRenderInput
+			want string
+		}{
+			{"no tracker, no messages", StatusRenderInput{}, "ctx: 0"},
+			{
+				"no tracker, big conversation",
+				StatusRenderInput{Messages: []message{{role: "user", content: strings.Repeat("word ", 3000)}}},
+				"", // asserted by prefix below
+			},
+			{
+				"tracker with a limit draws the bar",
+				StatusRenderInput{TokenTracker: flexTokenTracker{limit: 1000, percentUsed: 42}},
+				"████░░░░░░ 42%",
+			},
+			{
+				"tracker without a limit falls back to the estimate",
+				StatusRenderInput{TokenTracker: flexTokenTracker{}},
+				"ctx: 0",
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.desc, func(t *testing.T) {
+				got := ansi.Strip(statusContextField(tc.in, dim, p))
+				if tc.want == "" {
+					if !strings.HasPrefix(got, "ctx: ") || !strings.HasSuffix(got, "k") {
+						t.Errorf("got %q, want a k-suffixed estimate", got)
+					}
+					return
+				}
+				if got != tc.want {
+					t.Errorf("got %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("token", func(t *testing.T) {
+		tests := []struct {
+			desc string
+			tt   TokenTracker
+			want string
+		}{
+			{"nil tracker", nil, ""},
+			{"no limit and nothing used", flexTokenTracker{}, ""},
+			{"no limit but used", flexTokenTracker{totalUsed: 4321}, "tkn: 4.3k"},
+			{"under 80%", flexTokenTracker{limit: 1000, totalUsed: 100, percentUsed: 10}, "tkn: 100/1.0k"},
+			{"at 80%", flexTokenTracker{limit: 1000, totalUsed: 800, percentUsed: 80}, "tkn: 800/1.0k"},
+			{"over 100%", flexTokenTracker{limit: 1000, totalUsed: 1500, percentUsed: 150}, "tkn: 1.5k/1.0k"},
+		}
+		for _, tc := range tests {
+			t.Run(tc.desc, func(t *testing.T) {
+				got := statusTokenField(StatusRenderInput{TokenTracker: tc.tt}, dim, p)
+				if tc.want == "" {
+					if got != nil {
+						t.Errorf("want no field, got %q", got)
+					}
+					return
+				}
+				if len(got) != 1 || ansi.Strip(got[0]) != tc.want {
+					t.Errorf("got %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("location", func(t *testing.T) {
+		tests := []struct {
+			desc, folder, host, want string
+		}{
+			{"neither", "", "", ""},
+			{"both", "pi-go", "mac", "pi-go | mac"},
+			{"folder only", "pi-go", "", "pi-go"},
+			{"host only", "", "mac", "mac"},
+		}
+		for _, tc := range tests {
+			t.Run(tc.desc, func(t *testing.T) {
+				got := statusLocationField(StatusRenderInput{FolderName: tc.folder, HostName: tc.host}, dim, p)
+				if tc.want == "" {
+					if got != nil {
+						t.Errorf("want no field, got %q", got)
+					}
+					return
+				}
+				if len(got) != 1 || ansi.Strip(got[0]) != tc.want {
+					t.Errorf("got %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("tools", func(t *testing.T) {
+		now := time.Now()
+		if got := (&StatusModel{}).statusToolField(p); got != nil {
+			t.Errorf("idle bar should render no tool field, got %q", got)
+		}
+		// One entry in the map is not "parallel"; only ActiveTool speaks then.
+		one := &StatusModel{ActiveTools: map[string]time.Time{"a": now}}
+		if got := one.statusToolField(p); got != nil {
+			t.Errorf("single map entry should render nothing, got %q", got)
+		}
+		many := &StatusModel{ActiveTools: map[string]time.Time{"b": now, "a": now}}
+		got := many.statusToolField(p)
+		if len(got) != 1 || ansi.Strip(got[0]) != "tools[2]: a, b" {
+			t.Errorf("got %q, want sorted names", got)
+		}
+		single := &StatusModel{ActiveTool: "bash", ToolStart: now}
+		got = single.statusToolField(p)
+		if len(got) != 1 || !strings.HasPrefix(ansi.Strip(got[0]), "tool: bash (") {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("run cycle", func(t *testing.T) {
+		if got := statusRunCycleField(StatusRenderInput{}, p); got != nil {
+			t.Errorf("want no field, got %q", got)
+		}
+		got := statusRunCycleField(StatusRenderInput{RunCycle: &runCycleInfo{Cycle: 2, MaxRetries: 5}}, p)
+		if len(got) != 1 || ansi.Strip(got[0]) != "cycle 2/5" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("loading", func(t *testing.T) {
+		got := ansi.Strip(statusLoadingField(map[string]bool{"mcp": true, "lsp": false, "skills": true}, dim, p))
+		if want := "load: lsp... mcp ✓ skills ✓"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if got := ansi.Strip(statusLoadingField(map[string]bool{}, dim, p)); got != "load: " {
+			t.Errorf("empty loading = %q", got)
+		}
+	})
+}
+
+// TestStatusBracketFieldRender pins the precedence in the bracketed slot: a
+// flash borrows it from the mode, plan outranks the spinner, and the spinner
+// only appears while running with no tool of its own to name.
+func TestStatusBracketFieldRender(t *testing.T) {
+	p := paletteOrDark(Palette{})
+
+	tests := []struct {
+		desc  string
+		model StatusModel
+		in    StatusRenderInput
+		want  string
+	}{
+		{"default is chat", StatusModel{}, StatusRenderInput{}, " [" + paddedStatusMode("chat") + "]"},
+		{"explicit mode", StatusModel{}, StatusRenderInput{Mode: "plan"}, " [" + paddedStatusMode("plan") + "]"},
+		{"flash wins over plan", StatusModel{}, StatusRenderInput{Mode: "plan", Flash: "Copied!"}, " [" + paddedStatusMode("Copied!") + "]"},
+		{"plan wins over the spinner", StatusModel{}, StatusRenderInput{Mode: "plan", Running: true}, " [" + paddedStatusMode("plan") + "]"},
+		{"running with an active tool keeps the mode", StatusModel{ActiveTool: "bash"}, StatusRenderInput{Running: true}, " [" + paddedStatusMode("chat") + "]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := ansi.Strip(tc.model.statusBracketField(tc.in, p)); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// Running with no active tool shows the spinner verb, whose text rotates
+	// with the clock — assert its shape, not its wording.
+	running := (&StatusModel{}).statusBracketField(StatusRenderInput{Running: true}, p)
+	got := ansi.Strip(running)
+	if !strings.HasPrefix(got, " [") || !strings.HasSuffix(got, "]") {
+		t.Errorf("spinner field = %q, want a bracketed verb", got)
+	}
+}
+
+// TestStatusRenderCompositionRender pins the assembled bar: which fields appear
+// together, and that loading short-circuits everything after it.
+func TestStatusRenderCompositionRender(t *testing.T) {
+	s := &StatusModel{Width: 200}
+
+	full := ansi.Strip(s.Render(StatusRenderInput{
+		Pending:      2,
+		TokenTracker: flexTokenTracker{limit: 1000, totalUsed: 100, percentUsed: 10},
+		FolderName:   "pi-go",
+		HostName:     "mac",
+		RunCycle:     &runCycleInfo{Cycle: 1, MaxRetries: 3},
+	}))
+	for _, want := range []string{"queued: 2", "█", "tkn: 100/1.0k", "pi-go | mac", "cycle 1/3"} {
+		if !strings.Contains(full, want) {
+			t.Errorf("bar %q is missing %q", full, want)
+		}
+	}
+	if n := strings.Count(full, "│"); n != 5 {
+		t.Errorf("bar %q has %d separators, want 5 between 6 fields", full, n)
+	}
+
+	loading := ansi.Strip(s.Render(StatusRenderInput{
+		Pending:      2,
+		LoadingItems: map[string]bool{"mcp": true},
+		FolderName:   "pi-go",
+	}))
+	if !strings.Contains(loading, "load: mcp ✓") {
+		t.Errorf("loading bar = %q", loading)
+	}
+	for _, unwanted := range []string{"queued", "pi-go", "ctx:"} {
+		if strings.Contains(loading, unwanted) {
+			t.Errorf("loading bar %q must not carry %q", loading, unwanted)
+		}
+	}
+
+	// A bare bar is the bracket plus the context estimate, and nothing else.
+	bare := ansi.Strip(s.Render(StatusRenderInput{}))
+	if n := strings.Count(bare, "│"); n != 1 {
+		t.Errorf("bare bar %q has %d separators, want 1", bare, n)
+	}
+}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -302,85 +302,22 @@ func isLineEndKey(key tea.Key) bool {
 // slashCommands is the list of available slash commands for autocomplete.
 // Skill subcommands (/skill-list, /skill-load, /skill-create) are handled
 // as args to /skills and omitted from the top-level list to keep it concise.
-var slashCommands = []string{
-	"/help",
-	"/clear",
-	"/copy",
-	"/model",
-	"/session",
-	"/context",
-	"/branch",
-	"/compact",
-	"/subagents",
-	"/history",
-	"/login",
-	"/commit",
-	"/plan",
-	"/run",
-	"/skills",
-	"/theme",
-	"/ping",
-	"/rtk",
-	"/mcp",
-	"/restart",
-	"/exit",
-	"/quit",
-}
+// It is derived from slashCommandSpecs (commands.go), which is the single
+// source of truth for name, description and handler.
+var slashCommands = func() []string {
+	names := make([]string, 0, len(slashCommandSpecs))
+	for _, spec := range slashCommandSpecs {
+		if spec.hidden {
+			continue
+		}
+		names = append(names, spec.name)
+	}
+	return names
+}()
 
 // slashCommandDesc returns the description for a slash command.
 func slashCommandDesc(cmd string) string {
-	switch cmd {
-	case "/help":
-		return "Show help"
-	case "/clear":
-		return "Clear conversation"
-	case "/copy":
-		return "Copy conversation to clipboard"
-	case "/model":
-		return "Show or switch model"
-	case "/session":
-		return "Show session info"
-	case "/context":
-		return "Show context usage"
-	case "/branch":
-		return "Manage branches"
-	case "/compact":
-		return "Compact context"
-	case "/subagents":
-		return "Show subagents"
-	case "/rtk":
-		return "Output compaction stats"
-	case "/mcp":
-		return "List MCP servers and tool status"
-	case "/history":
-		return "Command history"
-	case "/login":
-		return "Configure API keys (codex, openai, anthropic, gemini)"
-	case "/commit":
-		return "Create commit from staged changes"
-	case "/plan":
-		return "Start PDD planning session"
-	case "/run":
-		return "Execute a spec with task agent (verifies subagent exit status before merging)"
-	case "/theme":
-		return "Switch theme or list themes"
-	case "/skills":
-		return "List skills (create, load)"
-	case "/skill-list":
-		return "List all loaded skills"
-	case "/skill-load":
-		return "Reload skills from disk"
-	case "/skill-create":
-		return "Create a new skill"
-	case "/ping":
-		return "Test LLM connectivity"
-	case "/restart":
-		return "Restart pi process"
-	case "/exit", "/quit":
-		return "Exit"
-	default:
-		return ""
-	}
+	return slashCommandByName[cmd].desc
 }
 
 // completeSlashCommand returns the best matching slash command for the current input.

--- a/internal/tui/refs/complexity_expander_test.go
+++ b/internal/tui/refs/complexity_expander_test.go
@@ -1,0 +1,273 @@
+package refs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// selectLines carries the clamping that expandFile used to do inline. The
+// table pins every boundary the original branch chain encoded: an absent
+// range, a range that runs off either end, an inverted range, and the line cap
+// applied with and without a range.
+func TestSelectLines(t *testing.T) {
+	tenLines := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
+
+	tests := []struct {
+		name          string
+		lines         []string
+		lineRange     *LineRange
+		maxLines      int
+		wantStart     int
+		wantEnd       int
+		wantTruncated bool
+	}{
+		{
+			name:      "no range selects the whole file",
+			lines:     tenLines,
+			maxLines:  500,
+			wantStart: 0,
+			wantEnd:   9,
+		},
+		{
+			name:      "single line file",
+			lines:     []string{"only"},
+			maxLines:  500,
+			wantStart: 0,
+			wantEnd:   0,
+		},
+		{
+			name:      "range converts from 1-based to 0-based",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 2, End: 4},
+			maxLines:  500,
+			wantStart: 1,
+			wantEnd:   3,
+		},
+		{
+			name:      "single line range",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 5, End: 5},
+			maxLines:  500,
+			wantStart: 4,
+			wantEnd:   4,
+		},
+		{
+			name:      "start below one clamps to the first line",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 0, End: 3},
+			maxLines:  500,
+			wantStart: 0,
+			wantEnd:   2,
+		},
+		{
+			name:      "end past EOF clamps to the last line",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 8, End: 99},
+			maxLines:  500,
+			wantStart: 7,
+			wantEnd:   9,
+		},
+		{
+			name:      "start past EOF collapses onto the last line",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 50, End: 60},
+			maxLines:  500,
+			wantStart: 9,
+			wantEnd:   9,
+		},
+		{
+			name:      "inverted range collapses to the end line",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 7, End: 3},
+			maxLines:  500,
+			wantStart: 2,
+			wantEnd:   2,
+		},
+		{
+			name:          "cap truncates a whole file",
+			lines:         tenLines,
+			maxLines:      3,
+			wantStart:     0,
+			wantEnd:       2,
+			wantTruncated: true,
+		},
+		{
+			name:          "cap truncates inside a range",
+			lines:         tenLines,
+			lineRange:     &LineRange{Start: 4, End: 10},
+			maxLines:      2,
+			wantStart:     3,
+			wantEnd:       4,
+			wantTruncated: true,
+		},
+		{
+			name:      "cap larger than the selection leaves it alone",
+			lines:     tenLines,
+			lineRange: &LineRange{Start: 3, End: 5},
+			maxLines:  100,
+			wantStart: 2,
+			wantEnd:   4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, truncated := selectLines(tt.lines, tt.lineRange, tt.maxLines)
+			if start != tt.wantStart || end != tt.wantEnd || truncated != tt.wantTruncated {
+				t.Fatalf("selectLines() = (%d, %d, %v), want (%d, %d, %v)",
+					start, end, truncated, tt.wantStart, tt.wantEnd, tt.wantTruncated)
+			}
+			// Whatever the inputs, the bounds must be a legal slice of lines.
+			if start < 0 || end >= len(tt.lines) || start > end {
+				t.Fatalf("bounds (%d, %d) are not a valid slice of %d lines", start, end, len(tt.lines))
+			}
+		})
+	}
+}
+
+// readRefFile is the validate-resolve-read step expandFile used to inline.
+// Every rejection must come back as a warning with no content.
+func TestReadRefFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	writeFile := func(name string, data []byte) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(tempDir, name), data, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	writeFile("plain.txt", []byte("hello\nworld"))
+	writeFile("blob.txt", append([]byte("text"), make([]byte, 512)...))
+
+	e := NewExpander(tempDir)
+
+	tests := []struct {
+		name        string
+		path        string
+		wantContent string
+		wantWarning string // substring; empty means no warning expected
+	}{
+		{
+			name:        "reads a relative path against the work dir",
+			path:        "plain.txt",
+			wantContent: "hello\nworld",
+		},
+		{
+			name:        "reads an absolute path unchanged",
+			path:        filepath.Join(tempDir, "plain.txt"),
+			wantContent: "hello\nworld",
+		},
+		{
+			name:        "empty path",
+			path:        "",
+			wantWarning: "file path is empty",
+		},
+		{
+			name:        "path rejected by the validator",
+			path:        "../escape.txt",
+			wantWarning: "file ../escape.txt:",
+		},
+		{
+			name:        "binary extension rejected by the validator",
+			path:        "image.png",
+			wantWarning: "binary files are not supported",
+		},
+		{
+			name:        "missing file",
+			path:        "nope.txt",
+			wantWarning: "file nope.txt:",
+		},
+		{
+			name:        "binary content behind a text extension",
+			path:        "blob.txt",
+			wantWarning: "file blob.txt: binary files are not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, warning := e.readRefFile(tt.path)
+			if tt.wantWarning != "" {
+				if !strings.Contains(warning, tt.wantWarning) {
+					t.Fatalf("warning = %q, want it to contain %q", warning, tt.wantWarning)
+				}
+				if data != nil {
+					t.Fatalf("data = %q, want nil alongside a warning", data)
+				}
+				return
+			}
+			if warning != "" {
+				t.Fatalf("unexpected warning: %s", warning)
+			}
+			if string(data) != tt.wantContent {
+				t.Fatalf("data = %q, want %q", data, tt.wantContent)
+			}
+		})
+	}
+}
+
+// An Expander with no work dir must not join relative paths onto "".
+func TestReadRefFile_NoWorkDirUsesPathAsGiven(t *testing.T) {
+	tempDir := t.TempDir()
+	abs := filepath.Join(tempDir, "plain.txt")
+	if err := os.WriteFile(abs, []byte("body"), 0o600); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	e := NewExpander("")
+	data, warning := e.readRefFile(abs)
+	if warning != "" {
+		t.Fatalf("unexpected warning: %s", warning)
+	}
+	if string(data) != "body" {
+		t.Fatalf("data = %q, want %q", data, "body")
+	}
+}
+
+// expandFile's own remaining branches: the header shape with and without a
+// range, and the truncation footer.
+func TestExpandFile_HeaderAndTruncationFooter(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "many.txt"), []byte("a\nb\nc\nd"), 0o600); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	e := NewExpander(tempDir)
+	e.maxLines = 2
+
+	whole, warning := e.expandFile(ParsedRef{Type: RefFile, RawValue: "many.txt", Value: "many.txt"})
+	if warning != "" {
+		t.Fatalf("unexpected warning: %s", warning)
+	}
+	if !strings.HasPrefix(whole, "[Referenced file: many.txt]") {
+		t.Fatalf("content = %q, want the plain header", whole)
+	}
+	if !strings.Contains(whole, "[Truncated: file exceeds 2 line limit]") {
+		t.Fatalf("content = %q, want the truncation footer", whole)
+	}
+	if !strings.Contains(whole, "```\na\nb\n```") {
+		t.Fatalf("content = %q, want only the first 2 lines", whole)
+	}
+
+	ranged, warning := e.expandFile(ParsedRef{
+		Type:      RefFile,
+		RawValue:  "many.txt",
+		Value:     "many.txt",
+		LineRange: &LineRange{Start: 3, End: 4},
+	})
+	if warning != "" {
+		t.Fatalf("unexpected warning: %s", warning)
+	}
+	if !strings.HasPrefix(ranged, "[Referenced file: many.txt:3-4]") {
+		t.Fatalf("content = %q, want the ranged header", ranged)
+	}
+	if strings.Contains(ranged, "[Truncated") {
+		t.Fatalf("content = %q, want no truncation footer for a 2-line range", ranged)
+	}
+
+	if _, warning := e.expandFile(ParsedRef{Type: RefFile}); warning != "file path is empty" {
+		t.Fatalf("warning = %q, want the empty-path warning to reach the caller", warning)
+	}
+}

--- a/internal/tui/refs/expander.go
+++ b/internal/tui/refs/expander.go
@@ -123,66 +123,15 @@ func (e *Expander) expandRef(ref ParsedRef) (string, string) {
 // expandFile expands a file reference to its contents.
 func (e *Expander) expandFile(ref ParsedRef) (string, string) {
 	path := ref.Value
-	if path == "" {
-		return "", "file path is empty"
-	}
-
-	// Validate the file path.
-	if err := e.validator.ValidateFile(path); err != nil {
-		return "", fmt.Sprintf("file %s: %v", path, err)
-	}
-
-	// Resolve the full path.
-	fullPath := path
-	if !filepath.IsAbs(path) && e.workDir != "" {
-		fullPath = filepath.Join(e.workDir, path)
-	}
-
-	// Read the file.
-	data, err := readFile(fullPath)
-	if err != nil {
-		return "", fmt.Sprintf("file %s: %v", path, err)
-	}
-
-	// Check for binary content.
-	if e.validator.IsBinaryFile(data) {
-		return "", fmt.Sprintf("file %s: binary files are not supported", path)
+	data, warning := e.readRefFile(path)
+	if warning != "" {
+		return "", warning
 	}
 
 	// Split into lines for range selection and truncation.
 	lines := strings.Split(string(data), "\n")
 
-	// Apply line range if specified.
-	start, end := 0, len(lines)-1
-	if ref.LineRange != nil {
-		// Convert from 1-based to 0-based indexing.
-		start = ref.LineRange.Start - 1
-		end = ref.LineRange.End - 1
-		if start < 0 {
-			start = 0
-		}
-		if end >= len(lines) {
-			end = len(lines) - 1
-		}
-		if start > end {
-			start = end
-		}
-	}
-
-	// Apply truncation.
-	truncated := false
-	if end-start+1 > e.maxLines {
-		end = start + e.maxLines - 1
-		truncated = true
-	}
-
-	if end >= len(lines) {
-		end = len(lines) - 1
-	}
-	if start > end {
-		start = end
-	}
-
+	start, end, truncated := selectLines(lines, ref.LineRange, e.maxLines)
 	selectedLines := lines[start : end+1]
 	content := strings.Join(selectedLines, "\n")
 
@@ -205,6 +154,76 @@ func (e *Expander) expandFile(ref ParsedRef) (string, string) {
 	}
 
 	return sb.String(), ""
+}
+
+// readRefFile validates path, resolves it against the work directory and reads
+// it. Every rejection comes back as the warning string the caller shows the
+// user, with no content.
+func (e *Expander) readRefFile(path string) ([]byte, string) {
+	if path == "" {
+		return nil, "file path is empty"
+	}
+
+	// Validate the file path.
+	if err := e.validator.ValidateFile(path); err != nil {
+		return nil, fmt.Sprintf("file %s: %v", path, err)
+	}
+
+	// Resolve the full path.
+	fullPath := path
+	if !filepath.IsAbs(path) && e.workDir != "" {
+		fullPath = filepath.Join(e.workDir, path)
+	}
+
+	// Read the file.
+	data, err := readFile(fullPath)
+	if err != nil {
+		return nil, fmt.Sprintf("file %s: %v", path, err)
+	}
+
+	// Check for binary content.
+	if e.validator.IsBinaryFile(data) {
+		return nil, fmt.Sprintf("file %s: binary files are not supported", path)
+	}
+
+	return data, ""
+}
+
+// selectLines resolves a reference's optional line range against the file's
+// lines and applies the per-ref line cap. It returns inclusive 0-based bounds,
+// clamped to lines, and whether the cap cut the selection short.
+func selectLines(lines []string, lineRange *LineRange, maxLines int) (start, end int, truncated bool) {
+	// Apply line range if specified.
+	start, end = 0, len(lines)-1
+	if lineRange != nil {
+		// Convert from 1-based to 0-based indexing.
+		start = lineRange.Start - 1
+		end = lineRange.End - 1
+		if start < 0 {
+			start = 0
+		}
+		if end >= len(lines) {
+			end = len(lines) - 1
+		}
+		if start > end {
+			start = end
+		}
+	}
+
+	// Apply truncation.
+	if end-start+1 > maxLines {
+		end = start + maxLines - 1
+		truncated = true
+	}
+
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+	if start > end {
+		start = end
+	}
+
+	return start, end, truncated
 }
 
 // expandFolder expands a folder reference to a directory tree.

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -325,12 +325,7 @@ func escapeMarkdownTableCell(s string) string {
 // handleRunCommand handles the /run <spec-name> [--parallel] slash command.
 func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 	if len(args) == 0 {
-		specs, _ := listAvailableSpecs(m.cfg.WorkDir)
-		msg := "Usage: `/run <spec-name> [--parallel]`\n\nExecutes a spec's PROMPT.md using an isolated task agent.\nUse `--parallel` to split independent slices across 2 agents."
-		if len(specs) > 0 {
-			msg += "\n\n" + formatAvailableRunSpecsTable(specs)
-		}
-		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: msg})
+		m.showRunUsage()
 		return m, nil
 	}
 
@@ -342,19 +337,7 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Parse args: spec-name [--parallel|-p]
-	var specName string
-	parallel := false
-	for _, arg := range args {
-		switch arg {
-		case "--parallel", "-p":
-			parallel = true
-		default:
-			if specName == "" {
-				specName = arg
-			}
-		}
-	}
+	specName, parallel := parseRunArgs(args)
 	if specName == "" {
 		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: "Missing spec name."})
 		return m, nil
@@ -363,12 +346,7 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 	// Read PROMPT.md.
 	promptMD, err := readPromptMD(m.cfg.WorkDir, specName)
 	if err != nil {
-		specs, _ := listAvailableSpecs(m.cfg.WorkDir)
-		errMsg := fmt.Sprintf("Error: %v", err)
-		if len(specs) > 0 {
-			errMsg += "\n\n" + formatAvailableRunSpecsTable(specs)
-		}
-		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: errMsg})
+		m.showRunSpecError(err)
 		return m, nil
 	}
 
@@ -389,22 +367,71 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 		})
 	}
 
-	// Format gate info for display.
-	gateInfo := "none"
-	if len(gates) > 0 {
-		names := make([]string, len(gates))
-		for i, g := range gates {
-			names[i] = g.Name
-		}
-		gateInfo = strings.Join(names, ", ")
-	}
+	gateInfo := formatRunGateInfo(gates)
 
 	// Parallel mode: split slices across 2 agents.
 	if parallel && len(checklist) >= 2 {
 		return m.handleRunParallel(specName, promptMD, gates, checklist, gateInfo)
 	}
 
-	// Single-agent mode.
+	return m.startRunAgent(specName, promptMD, gates, checklist, gateInfo)
+}
+
+// showRunUsage appends the /run usage text, listing the specs that are
+// available to run when there are any.
+func (m *model) showRunUsage() {
+	specs, _ := listAvailableSpecs(m.cfg.WorkDir)
+	msg := "Usage: `/run <spec-name> [--parallel]`\n\nExecutes a spec's PROMPT.md using an isolated task agent.\nUse `--parallel` to split independent slices across 2 agents."
+	if len(specs) > 0 {
+		msg += "\n\n" + formatAvailableRunSpecsTable(specs)
+	}
+	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: msg})
+}
+
+// showRunSpecError reports a failure to read the named spec, listing the specs
+// that do exist so a typo is immediately visible.
+func (m *model) showRunSpecError(err error) {
+	specs, _ := listAvailableSpecs(m.cfg.WorkDir)
+	errMsg := fmt.Sprintf("Error: %v", err)
+	if len(specs) > 0 {
+		errMsg += "\n\n" + formatAvailableRunSpecsTable(specs)
+	}
+	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: errMsg})
+}
+
+// parseRunArgs splits /run arguments into the spec name and the parallel flag.
+// The first non-flag argument wins; later ones are ignored.
+func parseRunArgs(args []string) (specName string, parallel bool) {
+	for _, arg := range args {
+		switch arg {
+		case "--parallel", "-p":
+			parallel = true
+		default:
+			if specName == "" {
+				specName = arg
+			}
+		}
+	}
+	return specName, parallel
+}
+
+// formatRunGateInfo renders gate names for the spawn announcement.
+func formatRunGateInfo(gates []Gate) string {
+	if len(gates) == 0 {
+		return "none"
+	}
+	names := make([]string, len(gates))
+	for i, g := range gates {
+		names[i] = g.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+// startRunAgent spawns the single-agent /run worker and installs the run state
+// the event loop drives from there.
+func (m *model) startRunAgent(
+	specName, promptMD string, gates []Gate, checklist []ChecklistStep, gateInfo string,
+) (tea.Model, tea.Cmd) {
 	prompt := buildRunPrompt(specName, promptMD, checklist)
 
 	events, agentID, err := m.cfg.Orchestrator.SpawnWithInput(m.ctx, subagent.AgentInput{
@@ -613,62 +640,13 @@ func (m *model) handleRunAgentEvent(msg runAgentEventMsg) (tea.Model, tea.Cmd) {
 
 	switch ev.Type {
 	case "text_delta":
-		m.chatModel.Streaming += ev.Content
-		// Update the last assistant message with accumulated text.
-		for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
-			if m.chatModel.Messages[i].role == "assistant" {
-				m.chatModel.Messages[i].content = m.chatModel.Streaming
-				break
-			}
-		}
-		m.chatModel.Scroll = 0
-		// Trace.
-		if len(m.chatModel.TraceLog) > 0 && m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1].kind == "llm" {
-			m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1].detail = m.chatModel.Streaming
-		} else {
-			m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-				time: time.Now(), kind: "llm", summary: "agent response", detail: ev.Content,
-			})
-		}
+		m.applyRunTextDelta(ev)
 
 	case "tool_call":
-		m.statusModel.ActiveTool = ev.Content
-		m.statusModel.ToolStart = time.Now()
-		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-			time: time.Now(), kind: "tool_call", summary: fmt.Sprintf(">>> %s", ev.Content),
-		})
-		// Compute a one-liner from the tool args so the chat card can render
-		// the file path / command alongside the tool name — without this the
-		// header would only show the bare tool name (e.g. "read") in gray,
-		// while the parent path (see agent_loop.go) already fills toolIn.
-		var toolIn string
-		if args, ok := ev.ToolArgs.(map[string]any); ok {
-			toolIn = toolCallSummary(ev.Content, args)
-		}
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role: "tool", tool: ev.Content, toolIn: toolIn,
-		})
+		m.applyRunToolCall(ev)
 
 	case "tool_result":
-		prevTool := m.statusModel.ActiveTool
-		m.statusModel.ActiveTool = ""
-		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-			time: time.Now(), kind: "tool_result", summary: "<<< result",
-			detail: ev.Content,
-		})
-		// Update the last tool message with the result.
-		for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
-			if m.chatModel.Messages[i].role == "tool" && m.chatModel.Messages[i].content == "" {
-				m.chatModel.Messages[i].content = toolResultSummary(ev.Content)
-				break
-			}
-		}
-
-		// Refresh checklist after write/edit operations — the agent may have
-		// updated plan.md checkboxes. This is a cheap disk read.
-		if m.run != nil && (prevTool == "write" || prevTool == "edit") {
-			m.refreshRunChecklist()
-		}
+		m.applyRunToolResult(ev)
 
 	case "message_start":
 		// New message from the agent — add an empty assistant placeholder.
@@ -680,17 +658,88 @@ func (m *model) handleRunAgentEvent(msg runAgentEventMsg) (tea.Model, tea.Cmd) {
 		m.chatModel.Streaming = ""
 
 	case "error":
-		m.chatModel.Messages = append(m.chatModel.Messages, message{
-			role:    "assistant",
-			content: fmt.Sprintf("Agent error: %s", ev.Error),
-		})
-		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
-			time: time.Now(), kind: "error", summary: "agent error", detail: ev.Error,
-		})
+		m.applyRunError(ev)
 	}
 
 	// Keep consuming events from the subagent.
 	return m, m.waitForRunEvents()
+}
+
+// applyRunTextDelta appends streamed text to the open assistant message and
+// folds it into the trailing LLM trace entry.
+func (m *model) applyRunTextDelta(ev subagent.Event) {
+	m.chatModel.Streaming += ev.Content
+	// Update the last assistant message with accumulated text.
+	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
+		if m.chatModel.Messages[i].role == "assistant" {
+			m.chatModel.Messages[i].content = m.chatModel.Streaming
+			break
+		}
+	}
+	m.chatModel.Scroll = 0
+	// Trace.
+	if len(m.chatModel.TraceLog) > 0 && m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1].kind == "llm" {
+		m.chatModel.TraceLog[len(m.chatModel.TraceLog)-1].detail = m.chatModel.Streaming
+	} else {
+		m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+			time: time.Now(), kind: "llm", summary: "agent response", detail: ev.Content,
+		})
+	}
+}
+
+// applyRunToolCall opens a tool card for a subagent tool invocation.
+func (m *model) applyRunToolCall(ev subagent.Event) {
+	m.statusModel.ActiveTool = ev.Content
+	m.statusModel.ToolStart = time.Now()
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "tool_call", summary: fmt.Sprintf(">>> %s", ev.Content),
+	})
+	// Compute a one-liner from the tool args so the chat card can render
+	// the file path / command alongside the tool name — without this the
+	// header would only show the bare tool name (e.g. "read") in gray,
+	// while the parent path (see agent_loop.go) already fills toolIn.
+	var toolIn string
+	if args, ok := ev.ToolArgs.(map[string]any); ok {
+		toolIn = toolCallSummary(ev.Content, args)
+	}
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role: "tool", tool: ev.Content, toolIn: toolIn,
+	})
+}
+
+// applyRunToolResult closes the open tool card and, after a write or edit,
+// re-reads the plan checklist the agent may have ticked.
+func (m *model) applyRunToolResult(ev subagent.Event) {
+	prevTool := m.statusModel.ActiveTool
+	m.statusModel.ActiveTool = ""
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "tool_result", summary: "<<< result",
+		detail: ev.Content,
+	})
+	// Update the last tool message with the result.
+	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
+		if m.chatModel.Messages[i].role == "tool" && m.chatModel.Messages[i].content == "" {
+			m.chatModel.Messages[i].content = toolResultSummary(ev.Content)
+			break
+		}
+	}
+
+	// Refresh checklist after write/edit operations — the agent may have
+	// updated plan.md checkboxes. This is a cheap disk read.
+	if m.run != nil && (prevTool == "write" || prevTool == "edit") {
+		m.refreshRunChecklist()
+	}
+}
+
+// applyRunError surfaces a subagent error in the transcript and the trace.
+func (m *model) applyRunError(ev subagent.Event) {
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: fmt.Sprintf("Agent error: %s", ev.Error),
+	})
+	m.chatModel.TraceLog = append(m.chatModel.TraceLog, traceEntry{
+		time: time.Now(), kind: "error", summary: "agent error", detail: ev.Error,
+	})
 }
 
 // handleRunAgentDone is called when a subagent events channel closes.
@@ -1313,58 +1362,8 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 	var b strings.Builder
 
 	b.WriteString("# Run Summary\n\n")
-
-	// Metadata.
-	b.WriteString("## Metadata\n\n")
-	b.WriteString("| Field | Value |\n")
-	b.WriteString("|-------|-------|\n")
-	fmt.Fprintf(&b, "| Spec | `%s` |\n", rs.specName)
-	fmt.Fprintf(&b, "| Agent | `%s` |\n", rs.agentID)
-	fmt.Fprintf(&b, "| Outcome | **%s** |\n", outcome)
-	fmt.Fprintf(&b, "| Retries | %d / %d |\n", rs.retries, rs.maxRetries)
-	if n := len(rs.checklist); n > 0 {
-		fmt.Fprintf(&b, "| Slices | %d / %d complete |\n", n-len(rs.unfinishedSlices()), n)
-	}
-	if !rs.startTime.IsZero() {
-		fmt.Fprintf(&b, "| Started | %s |\n", rs.startTime.Format(time.RFC3339))
-		fmt.Fprintf(&b, "| Duration | %s |\n", time.Since(rs.startTime).Truncate(time.Second))
-	}
-	b.WriteString("\n")
-
-	// Gate results.
-	b.WriteString("## Gates\n\n")
-	if len(rs.gateResults) == 0 && len(rs.gates) == 0 {
-		b.WriteString("No gates defined.\n\n")
-	} else if len(rs.gateResults) == 0 {
-		b.WriteString("Gates were defined but not executed.\n\n")
-		for _, g := range rs.gates {
-			fmt.Fprintf(&b, "- **%s**: `%s`\n", g.Name, g.Command)
-		}
-		b.WriteString("\n")
-	} else {
-		allPassed := true
-		for _, r := range rs.gateResults {
-			status := "PASS"
-			if !r.Passed {
-				status = "FAIL"
-				allPassed = false
-			}
-			fmt.Fprintf(&b, "- **%s** (`%s`): **%s**\n", r.Name, r.Command, status)
-			if !r.Passed && r.Output != "" {
-				out := strings.TrimSpace(r.Output)
-				if len(out) > 1000 {
-					out = out[:1000] + "\n...(truncated)"
-				}
-				fmt.Fprintf(&b, "  ```\n  %s\n  ```\n", out)
-			}
-		}
-		b.WriteString("\n")
-		if allPassed {
-			b.WriteString("All gates **passed**.\n\n")
-		} else {
-			b.WriteString("Some gates **failed**.\n\n")
-		}
-	}
+	writeRunSummaryMetadata(&b, rs, outcome)
+	writeRunSummaryGates(&b, rs)
 
 	// Unfinished slices, when the run stopped short of the plan.
 	if pending := rs.unfinishedSlices(); len(pending) > 0 {
@@ -1375,24 +1374,96 @@ func buildRunSummaryReport(rs *runState, outcome string) string {
 		b.WriteString("\n")
 	}
 
-	// Outcome details.
+	writeRunSummaryResult(&b, rs, outcome)
+
+	return b.String()
+}
+
+// writeRunSummaryMetadata writes the spec/agent/outcome table.
+func writeRunSummaryMetadata(b *strings.Builder, rs *runState, outcome string) {
+	b.WriteString("## Metadata\n\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("|-------|-------|\n")
+	fmt.Fprintf(b, "| Spec | `%s` |\n", rs.specName)
+	fmt.Fprintf(b, "| Agent | `%s` |\n", rs.agentID)
+	fmt.Fprintf(b, "| Outcome | **%s** |\n", outcome)
+	fmt.Fprintf(b, "| Retries | %d / %d |\n", rs.retries, rs.maxRetries)
+	if n := len(rs.checklist); n > 0 {
+		fmt.Fprintf(b, "| Slices | %d / %d complete |\n", n-len(rs.unfinishedSlices()), n)
+	}
+	if !rs.startTime.IsZero() {
+		fmt.Fprintf(b, "| Started | %s |\n", rs.startTime.Format(time.RFC3339))
+		fmt.Fprintf(b, "| Duration | %s |\n", time.Since(rs.startTime).Truncate(time.Second))
+	}
+	b.WriteString("\n")
+}
+
+// writeRunSummaryGates writes the gate section: nothing defined, defined but
+// never executed, or the pass/fail roll-up with failure output.
+func writeRunSummaryGates(b *strings.Builder, rs *runState) {
+	b.WriteString("## Gates\n\n")
+	if len(rs.gateResults) == 0 && len(rs.gates) == 0 {
+		b.WriteString("No gates defined.\n\n")
+		return
+	}
+	if len(rs.gateResults) == 0 {
+		b.WriteString("Gates were defined but not executed.\n\n")
+		for _, g := range rs.gates {
+			fmt.Fprintf(b, "- **%s**: `%s`\n", g.Name, g.Command)
+		}
+		b.WriteString("\n")
+		return
+	}
+	allPassed := true
+	for _, r := range rs.gateResults {
+		if !r.Passed {
+			allPassed = false
+		}
+		writeRunSummaryGateResult(b, r)
+	}
+	b.WriteString("\n")
+	if allPassed {
+		b.WriteString("All gates **passed**.\n\n")
+		return
+	}
+	b.WriteString("Some gates **failed**.\n\n")
+}
+
+// writeRunSummaryGateResult writes one gate's verdict, with its output block
+// when it failed and produced any.
+func writeRunSummaryGateResult(b *strings.Builder, r GateResult) {
+	status := "PASS"
+	if !r.Passed {
+		status = "FAIL"
+	}
+	fmt.Fprintf(b, "- **%s** (`%s`): **%s**\n", r.Name, r.Command, status)
+	if r.Passed || r.Output == "" {
+		return
+	}
+	out := strings.TrimSpace(r.Output)
+	if len(out) > 1000 {
+		out = out[:1000] + "\n...(truncated)"
+	}
+	fmt.Fprintf(b, "  ```\n  %s\n  ```\n", out)
+}
+
+// writeRunSummaryResult explains the outcome in prose.
+func writeRunSummaryResult(b *strings.Builder, rs *runState, outcome string) {
 	b.WriteString("## Result\n\n")
 	switch outcome {
 	case "completed":
 		b.WriteString("All gates passed, the plan checklist was complete, and changes were merged successfully.\n")
 	case "gate_failed":
-		fmt.Fprintf(&b, "Gate validation failed after %d retries. Worktree preserved for manual inspection.\n", rs.retries)
+		fmt.Fprintf(b, "Gate validation failed after %d retries. Worktree preserved for manual inspection.\n", rs.retries)
 	case "verify_failed":
-		fmt.Fprintf(&b, "Gates passed but the plan was still incomplete after %d retries — the run stopped short of the checklist. Nothing was merged; the worktree is preserved so the finished slices are not lost.\n", rs.retries)
+		fmt.Fprintf(b, "Gates passed but the plan was still incomplete after %d retries — the run stopped short of the checklist. Nothing was merged; the worktree is preserved so the finished slices are not lost.\n", rs.retries)
 	case "merge_failed":
 		b.WriteString("Gates passed but merge into the main branch failed. Worktree preserved for manual resolution.\n")
 	case "agent_failed":
 		b.WriteString("Subagent process exited with non-zero status (or was killed) before gates could run. Worktree preserved for manual inspection — see chat for the failing agent IDs and their worktree paths.\n")
 	default:
-		fmt.Fprintf(&b, "Run ended with status: %s\n", outcome)
+		fmt.Fprintf(b, "Run ended with status: %s\n", outcome)
 	}
-
-	return b.String()
 }
 
 // formatGateFailures formats gate results into a string for retry prompts.

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -82,6 +82,11 @@ func renderContextBar(pct float64, bg color.Color, p Palette) string {
 }
 
 // Render renders the status bar string.
+//
+// The bar is a list of fields joined by a separator, and each statusXxxField
+// helper below owns exactly one of them. A helper returns nil when its field is
+// not shown this frame, so appending with "..." keeps the separator bookkeeping
+// here and out of every field.
 func (s *StatusModel) Render(in StatusRenderInput) string {
 	p := paletteOrDark(in.Palette)
 
@@ -91,16 +96,33 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	sepStyle := lipgloss.NewStyle().Foreground(p.Surface)
 	sep := sepStyle.Render("  │  ")
 
-	var parts []string
+	parts := []string{s.statusBracketField(in, p)}
 
-	// The bracketed field: [chat], [plan], the spinner verb while running — and a
-	// flash when there is one.
-	//
-	// A flash takes this slot over rather than adding a segment of its own. It is
-	// already the fixed-width, bracketed field the eye returns to, so a notice
-	// lands where the user is looking and the bar's geometry does not shift. The
-	// mode is not lost by borrowing it for three seconds: it has not changed, and
-	// it comes straight back.
+	// Loading progress (replaces normal status content during init).
+	if in.LoadingItems != nil {
+		parts = append(parts, statusLoadingField(in.LoadingItems, dim, p))
+		return bar.Render(strings.Join(parts, sep))
+	}
+
+	parts = append(parts, statusQueuedField(in, p)...)
+	parts = append(parts, statusContextField(in, dim, p))
+	parts = append(parts, statusTokenField(in, dim, p)...)
+	parts = append(parts, statusLocationField(in, dim, p)...)
+	parts = append(parts, s.statusToolField(p)...)
+	parts = append(parts, statusRunCycleField(in, p)...)
+
+	return bar.Render(strings.Join(parts, sep))
+}
+
+// statusBracketField renders the bracketed field: [chat], [plan], the spinner
+// verb while running — and a flash when there is one.
+//
+// A flash takes this slot over rather than adding a segment of its own. It is
+// already the fixed-width, bracketed field the eye returns to, so a notice
+// lands where the user is looking and the bar's geometry does not shift. The
+// mode is not lost by borrowing it for three seconds: it has not changed, and
+// it comes straight back.
+func (s *StatusModel) statusBracketField(in StatusRenderInput, p Palette) string {
 	mode := in.Mode
 	if mode == "" {
 		mode = "chat"
@@ -108,96 +130,111 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 	switch {
 	case in.Flash != "":
 		flashStyle := lipgloss.NewStyle().Foreground(p.Green).Bold(true)
-		parts = append(parts, flashStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(in.Flash))))
+		return flashStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(in.Flash)))
 	case mode == "plan":
 		modeStyle := lipgloss.NewStyle().Foreground(p.Peach)
-		parts = append(parts, modeStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode))))
+		return modeStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode)))
 	case in.Running && s.ActiveTool == "":
 		verbStyle := lipgloss.NewStyle().Foreground(p.Blue)
-		parts = append(parts, verbStyle.Render(fmt.Sprintf(" [%s]", spinnerVerb())))
+		return verbStyle.Render(fmt.Sprintf(" [%s]", spinnerVerb()))
 	default:
 		verbStyle := lipgloss.NewStyle().Foreground(p.Blue)
-		parts = append(parts, verbStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode))))
+		return verbStyle.Render(fmt.Sprintf(" [%s]", paddedStatusMode(mode)))
 	}
+}
 
-	// Loading progress (replaces normal status content during init).
-	if in.LoadingItems != nil {
-		var items []string
-		for _, name := range sortedKeys(in.LoadingItems) {
-			if in.LoadingItems[name] {
-				okStyle := lipgloss.NewStyle().Foreground(p.Green)
-				items = append(items, okStyle.Render(name+" \u2713"))
-			} else {
-				loadStyle := lipgloss.NewStyle().Foreground(p.Peach)
-				items = append(items, loadStyle.Render(name+"..."))
-			}
+// statusLoadingField renders the init progress list: each item green with a
+// tick once done, orange with an ellipsis while still loading.
+func statusLoadingField(loading map[string]bool, dim lipgloss.Style, p Palette) string {
+	var items []string
+	for _, name := range sortedKeys(loading) {
+		if loading[name] {
+			okStyle := lipgloss.NewStyle().Foreground(p.Green)
+			items = append(items, okStyle.Render(name+" \u2713"))
+		} else {
+			loadStyle := lipgloss.NewStyle().Foreground(p.Peach)
+			items = append(items, loadStyle.Render(name+"..."))
 		}
-		parts = append(parts, dim.Render("load: ")+strings.Join(items, dim.Render(" ")))
-		return bar.Render(strings.Join(parts, sep))
 	}
+	return dim.Render("load: ") + strings.Join(items, dim.Render(" "))
+}
 
-	// Pending prompts are shown even while the active response is streaming,
-	// so the user can see that Enter was accepted without waiting for it.
-	if in.Pending > 0 {
-		queueStyle := lipgloss.NewStyle().Foreground(p.Peach)
-		parts = append(parts, queueStyle.Render(fmt.Sprintf("queued: %d", in.Pending)))
+// statusQueuedField renders the queued-prompt count. Pending prompts are shown
+// even while the active response is streaming, so the user can see that Enter
+// was accepted without waiting for it.
+func statusQueuedField(in StatusRenderInput, p Palette) []string {
+	if in.Pending <= 0 {
+		return nil
 	}
+	queueStyle := lipgloss.NewStyle().Foreground(p.Peach)
+	return []string{queueStyle.Render(fmt.Sprintf("queued: %d", in.Pending))}
+}
 
-	// Context % bar (visual bar with color coding).
-	noBg := p.Transparent
+// statusContextField renders the context % bar (visual bar with color coding),
+// or — with no tracker limit to scale against — the same rough estimate
+// /context shows, so the two cannot disagree about the same conversation.
+func statusContextField(in StatusRenderInput, dim lipgloss.Style, p Palette) string {
 	if tt := in.TokenTracker; tt != nil && tt.Limit() > 0 {
-		pct := tt.PercentUsed()
-		parts = append(parts, renderContextBar(pct, noBg, p))
-	} else {
-		// Fallback: the same rough estimate /context shows, so the two cannot
-		// disagree about the same conversation.
-		ctxTokens := estimateContextTokenCount(in.Messages)
-		switch {
-		case ctxTokens >= 1000:
-			parts = append(parts, dim.Render(fmt.Sprintf("ctx: %.1fk", float64(ctxTokens)/1000)))
-		default:
-			parts = append(parts, dim.Render(fmt.Sprintf("ctx: %d", ctxTokens)))
+		noBg := p.Transparent
+		return renderContextBar(tt.PercentUsed(), noBg, p)
+	}
+	ctxTokens := estimateContextTokenCount(in.Messages)
+	if ctxTokens >= 1000 {
+		return dim.Render(fmt.Sprintf("ctx: %.1fk", float64(ctxTokens)/1000))
+	}
+	return dim.Render(fmt.Sprintf("ctx: %d", ctxTokens))
+}
+
+// statusTokenField renders the numeric token tally, colored by how close the
+// session is to its limit.
+func statusTokenField(in StatusRenderInput, dim lipgloss.Style, p Palette) []string {
+	tt := in.TokenTracker
+	if tt == nil {
+		return nil
+	}
+	total := tt.TotalUsed()
+	limit := tt.Limit()
+	if limit <= 0 {
+		if total <= 0 {
+			return nil
 		}
+		return []string{dim.Render(fmt.Sprintf("tkn: %s", formatTokenCount(total)))}
 	}
 
-	// Token usage (numeric).
-	if tt := in.TokenTracker; tt != nil {
-		total := tt.TotalUsed()
-		limit := tt.Limit()
-		if limit > 0 {
-			pct := tt.PercentUsed()
-			var tokenStyle lipgloss.Style
-			switch {
-			case pct >= 100:
-				tokenStyle = lipgloss.NewStyle().Foreground(p.Red)
-			case pct >= 80:
-				tokenStyle = lipgloss.NewStyle().Foreground(p.Peach)
-			default:
-				tokenStyle = dim
-			}
-			parts = append(parts, tokenStyle.Render(fmt.Sprintf("tkn: %s/%s",
-				formatTokenCount(total), formatTokenCount(limit))))
-		} else if total > 0 {
-			parts = append(parts, dim.Render(fmt.Sprintf("tkn: %s", formatTokenCount(total))))
-		}
+	var tokenStyle lipgloss.Style
+	switch pct := tt.PercentUsed(); {
+	case pct >= 100:
+		tokenStyle = lipgloss.NewStyle().Foreground(p.Red)
+	case pct >= 80:
+		tokenStyle = lipgloss.NewStyle().Foreground(p.Peach)
+	default:
+		tokenStyle = dim
 	}
+	return []string{tokenStyle.Render(fmt.Sprintf("tkn: %s/%s",
+		formatTokenCount(total), formatTokenCount(limit)))}
+}
 
-	// Directory | host.
-	if in.FolderName != "" || in.HostName != "" {
-		dirStyle := lipgloss.NewStyle().Foreground(p.Mauve)
-		hostStyle := lipgloss.NewStyle().Foreground(p.Sky)
-
-		var locationParts []string
-		if in.FolderName != "" {
-			locationParts = append(locationParts, dirStyle.Render(in.FolderName))
-		}
-		if in.HostName != "" {
-			locationParts = append(locationParts, hostStyle.Render(in.HostName))
-		}
-		parts = append(parts, strings.Join(locationParts, dim.Render(" | ")))
+// statusLocationField renders "directory | host".
+func statusLocationField(in StatusRenderInput, dim lipgloss.Style, p Palette) []string {
+	if in.FolderName == "" && in.HostName == "" {
+		return nil
 	}
+	dirStyle := lipgloss.NewStyle().Foreground(p.Mauve)
+	hostStyle := lipgloss.NewStyle().Foreground(p.Sky)
 
-	// Active tools or thinking status.
+	var locationParts []string
+	if in.FolderName != "" {
+		locationParts = append(locationParts, dirStyle.Render(in.FolderName))
+	}
+	if in.HostName != "" {
+		locationParts = append(locationParts, hostStyle.Render(in.HostName))
+	}
+	return []string{strings.Join(locationParts, dim.Render(" | "))}
+}
+
+// statusToolField renders the parallel-tool list, or the single active tool
+// with how long it has been running.
+func (s *StatusModel) statusToolField(p Palette) []string {
 	toolStyle := lipgloss.NewStyle().Foreground(p.Sapphire)
 	if len(s.ActiveTools) > 1 {
 		var toolNames []string
@@ -205,21 +242,25 @@ func (s *StatusModel) Render(in StatusRenderInput) string {
 			toolNames = append(toolNames, name)
 		}
 		sort.Strings(toolNames)
-		parts = append(parts, toolStyle.Render(fmt.Sprintf("tools[%d]: %s", len(toolNames), strings.Join(toolNames, ", "))))
-	} else if s.ActiveTool != "" {
+		return []string{toolStyle.Render(fmt.Sprintf("tools[%d]: %s", len(toolNames), strings.Join(toolNames, ", ")))}
+	}
+	if s.ActiveTool != "" {
 		elapsed := time.Since(s.ToolStart).Truncate(time.Millisecond)
-		parts = append(parts, toolStyle.Render(fmt.Sprintf("tool: %s (%s)", s.ActiveTool, elapsed)))
+		return []string{toolStyle.Render(fmt.Sprintf("tool: %s (%s)", s.ActiveTool, elapsed))}
 	}
+	return nil
+}
 
-	// /run cycle indicator. The spec name is omitted: it is long enough to wrap
-	// the status bar onto a second line, and it is already shown in the sidebar.
-	if in.RunCycle != nil {
-		runStyle := lipgloss.NewStyle().Foreground(p.Peach)
-		parts = append(parts, runStyle.Render(fmt.Sprintf("cycle %d/%d",
-			in.RunCycle.Cycle, in.RunCycle.MaxRetries)))
+// statusRunCycleField renders the /run cycle indicator. The spec name is
+// omitted: it is long enough to wrap the status bar onto a second line, and it
+// is already shown in the sidebar.
+func statusRunCycleField(in StatusRenderInput, p Palette) []string {
+	if in.RunCycle == nil {
+		return nil
 	}
-
-	return bar.Render(strings.Join(parts, sep))
+	runStyle := lipgloss.NewStyle().Foreground(p.Peach)
+	return []string{runStyle.Render(fmt.Sprintf("cycle %d/%d",
+		in.RunCycle.Cycle, in.RunCycle.MaxRetries))}
 }
 
 // sortedKeys returns map keys in sorted order.

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -207,9 +207,37 @@ func (t *ToolDisplayModel) renderCompactTool(msg message, dim lipgloss.Style, p 
 	return b.String()
 }
 
+// writeGutterLines writes each already-styled line under the card's "  │ "
+// content gutter, one output row per line — no soft-wrapping.
+func writeGutterLines(b *strings.Builder, dim lipgloss.Style, lines ...string) {
+	gutter := dim.Render("│ ")
+	for _, l := range lines {
+		b.WriteString("  ")
+		b.WriteString(gutter)
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+}
+
 // renderAgentTool renders an agent/subagent tool message with type, title,
 // event stream, and result summary.
 func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style, p Palette) string {
+	var b strings.Builder
+	b.WriteString(t.agentCardHeader(msg, p))
+
+	cw := t.contentWidth()
+	if len(msg.agentEvents) > 0 {
+		b.WriteString(agentEventWindow(msg, dim, p, cw))
+	}
+	if msg.content != "" {
+		b.WriteString(agentResultSummary(msg.content, dim, cw))
+	}
+	return b.String()
+}
+
+// agentCardHeader renders the card's first row: bullet, "agent", the bracketed
+// agent label, and the title.
+func (t *ToolDisplayModel) agentCardHeader(msg message, p Palette) string {
 	agentBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Mauve).Bold(true), msg.content == "")
 	typeStyle := lipgloss.NewStyle().Foreground(p.Mauve).Bold(true)
 	titleStyle := lipgloss.NewStyle().Foreground(p.Text)
@@ -225,86 +253,90 @@ func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style, p Pa
 		b.WriteString(titleStyle.Render(msg.agentTitle))
 	}
 	b.WriteString("\n")
+	return b.String()
+}
 
-	cw := t.contentWidth()
+// agentEventWindow renders the card's live event stream, newest activity last,
+// preceded by a note whenever output was withheld.
+func agentEventWindow(msg message, dim lipgloss.Style, p Palette, cw int) string {
+	evStyle := lipgloss.NewStyle().Foreground(p.Dim)
+	evToolStyle := lipgloss.NewStyle().Foreground(agentToolColor(msg.agentType, p))
 
-	// Show event stream. Structural events (message_start/end/done/spawn) are
-	// filtered out first so they never crowd the visible window; from the
-	// renderable remainder, keep the newest maxAgentOutputLines so the user
-	// always sees the latest activity — not a stream truncated into silence.
-	if len(msg.agentEvents) > 0 {
-		evStyle := lipgloss.NewStyle().Foreground(p.Dim)
-		evToolStyle := lipgloss.NewStyle().Foreground(agentToolColor(msg.agentType, p))
+	renderable := renderableAgentEvents(msg.agentEvents)
+	lines, note := agentWindowLines(renderable, evStyle, evToolStyle, cw)
 
-		renderable := make([]agentEv, 0, len(msg.agentEvents))
-		for _, ev := range msg.agentEvents {
-			switch ev.kind {
-			case "message_start", "message_end", "done", "spawn":
+	var b strings.Builder
+	if note != "" {
+		writeGutterLines(&b, dim, dim.Render(note))
+	}
+	writeGutterLines(&b, dim, lines...)
+	return b.String()
+}
+
+// renderableAgentEvents drops the events that carry no content for the card.
+// Structural events (message_start/end/done/spawn) are filtered out so they
+// never crowd the visible window, as is whitespace-only message text.
+func renderableAgentEvents(evs []agentEv) []agentEv {
+	renderable := make([]agentEv, 0, len(evs))
+	for _, ev := range evs {
+		switch ev.kind {
+		case "message_start", "message_end", "done", "spawn":
+			continue
+		case "text", "text_delta":
+			if strings.TrimSpace(ev.content) == "" {
 				continue
-			case "text", "text_delta":
-				if strings.TrimSpace(ev.content) == "" {
-					continue
-				}
 			}
-			renderable = append(renderable, ev)
 		}
+		renderable = append(renderable, ev)
+	}
+	return renderable
+}
 
-		// Budget in rendered lines, not events. A single event carries an
-		// unbounded amount of text — a subagent's final analysis is one "text"
-		// event — so an event count caps nothing: five of them still soft-wrap
-		// into a screenful. Walk newest-first and stop once the window is full.
-		var lines []string
-		used := 0
-		for i := len(renderable) - 1; i >= 0 && len(lines) < maxAgentOutputLines; i-- {
-			lines = append(agentEventLines(renderable[i], evStyle, evToolStyle, cw), lines...)
-			used++
-		}
-		skipped := len(renderable) - used
-		clipped := len(lines) > maxAgentOutputLines
-		if clipped {
-			// The oldest event still in the window overflows it; show its tail,
-			// which is the part nearest the newer output below it.
-			lines = lines[len(lines)-maxAgentOutputLines:]
-		}
-
-		// Say so whenever output was withheld. A single huge event is clipped
-		// without any whole event being dropped, and hiding 60-odd lines with no
-		// mark would read as if that were all the agent said.
-		note := ""
-		switch {
-		case skipped > 0:
-			note = fmt.Sprintf("... %d earlier events", skipped)
-		case clipped:
-			note = "... earlier output"
-		}
-		if note != "" {
-			b.WriteString("  ")
-			b.WriteString(dim.Render("│ "))
-			b.WriteString(dim.Render(note))
-			b.WriteString("\n")
-		}
-		for _, sl := range lines {
-			b.WriteString("  ")
-			b.WriteString(dim.Render("│ "))
-			b.WriteString(sl)
-			b.WriteString("\n")
-		}
+// agentWindowLines renders the newest maxAgentOutputLines lines of the event
+// stream, so the user always sees the latest activity — not a stream truncated
+// into silence — plus the note describing what was withheld.
+//
+// The budget is in rendered lines, not events. A single event carries an
+// unbounded amount of text — a subagent's final analysis is one "text" event —
+// so an event count caps nothing: five of them still soft-wrap into a
+// screenful. Walk newest-first and stop once the window is full.
+//
+// The note is written whenever output was withheld. A single huge event is
+// clipped without any whole event being dropped, and hiding 60-odd lines with
+// no mark would read as if that were all the agent said.
+func agentWindowLines(renderable []agentEv, evStyle, evToolStyle lipgloss.Style, cw int) (lines []string, note string) {
+	used := 0
+	for i := len(renderable) - 1; i >= 0 && len(lines) < maxAgentOutputLines; i-- {
+		lines = append(agentEventLines(renderable[i], evStyle, evToolStyle, cw), lines...)
+		used++
+	}
+	skipped := len(renderable) - used
+	clipped := len(lines) > maxAgentOutputLines
+	if clipped {
+		// The oldest event still in the window overflows it; show its tail,
+		// which is the part nearest the newer output below it.
+		lines = lines[len(lines)-maxAgentOutputLines:]
 	}
 
-	// Show result summary when done. Collapse newlines so multiline JSON
-	// results render as a single wrapped line under the "│ " gutter.
-	if msg.content != "" {
-		summary := collapseToSingleLine(msg.content)
-		if len(summary) > 160 {
-			summary = summary[:157] + "..."
-		}
-		for _, sl := range softWrap(dim.Render("→ "+summary), cw) {
-			b.WriteString("  ")
-			b.WriteString(dim.Render("│ "))
-			b.WriteString(sl)
-			b.WriteString("\n")
-		}
+	switch {
+	case skipped > 0:
+		note = fmt.Sprintf("... %d earlier events", skipped)
+	case clipped:
+		note = "... earlier output"
 	}
+	return lines, note
+}
+
+// agentResultSummary renders the card's result summary once the subagent is
+// done. Newlines are collapsed so multiline JSON results render as a single
+// wrapped line under the "│ " gutter.
+func agentResultSummary(content string, dim lipgloss.Style, cw int) string {
+	summary := collapseToSingleLine(content)
+	if len(summary) > 160 {
+		summary = summary[:157] + "..."
+	}
+	var b strings.Builder
+	writeGutterLines(&b, dim, softWrap(dim.Render("→ "+summary), cw)...)
 	return b.String()
 }
 
@@ -473,6 +505,22 @@ func softWrap(s string, width int) []string {
 // renderRegularTool renders a standard tool message with name, args, and
 // syntax-highlighted output.
 func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p Palette) string {
+	var b strings.Builder
+	b.WriteString(t.regularToolHeader(msg, dim, p))
+	if msg.content == "" && len(msg.agentEvents) > 0 {
+		// Still running: show the live tail instead of an empty card. Once the
+		// result arrives, msg.content takes over and the final output replaces
+		// this window — the stream is a progress indicator, not a transcript.
+		b.WriteString(t.renderLiveOutput(msg, dim, p))
+	}
+	if msg.content != "" {
+		b.WriteString(t.regularToolOutput(msg, dim, p))
+	}
+	return b.String()
+}
+
+// regularToolHeader renders the card's first row: "◉ tool(args) ×N".
+func (t *ToolDisplayModel) regularToolHeader(msg message, dim lipgloss.Style, p Palette) string {
 	toolStyle := lipgloss.NewStyle().Foreground(p.Tool).Bold(true)
 	argStyle := lipgloss.NewStyle().Foreground(p.Dim)
 	toolBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Tool).Bold(true), msg.toolPending())
@@ -488,146 +536,155 @@ func (t *ToolDisplayModel) renderRegularTool(msg message, dim lipgloss.Style, p 
 	}
 	b.WriteString(pollTally(msg, dim))
 	b.WriteString("\n")
-	if msg.content == "" && len(msg.agentEvents) > 0 {
-		// Still running: show the live tail instead of an empty card. Once the
-		// result arrives, msg.content takes over and the final output replaces
-		// this window — the stream is a progress indicator, not a transcript.
-		b.WriteString(t.renderLiveOutput(msg, dim, p))
+	return b.String()
+}
+
+// maxRegularToolLines bounds how much of a finished tool result the card shows
+// before it starts counting the rest.
+const maxRegularToolLines = 15
+
+// regularToolOutput renders a finished tool result: clipped, syntax
+// highlighted, and laid under the content gutter.
+func (t *ToolDisplayModel) regularToolOutput(msg message, dim lipgloss.Style, p Palette) string {
+	lines := strings.Split(msg.content, "\n")
+
+	// Clip first, and keep the "N more lines" marker OUT of the clipped set.
+	// It used to be styled and appended to lines before they were handed to
+	// the syntax highlighter, so chroma re-tokenized a string that already
+	// held ANSI escapes and shredded them — that is what printed a literal
+	// "[38;5;240m... (81 more lines)[m" into the chat. A half-eaten escape
+	// also makes the terminal swallow columns, which knocked the rail out of
+	// its column.
+	hidden := 0
+	if len(lines) > maxRegularToolLines {
+		hidden = len(lines) - maxRegularToolLines
+		lines = lines[:maxRegularToolLines]
 	}
-	if msg.content != "" {
-		lines := strings.Split(msg.content, "\n")
 
-		// Clip first, and keep the "N more lines" marker OUT of the clipped set.
-		// It used to be styled and appended to lines before they were handed to
-		// the syntax highlighter, so chroma re-tokenized a string that already
-		// held ANSI escapes and shredded them — that is what printed a literal
-		// "[38;5;240m... (81 more lines)[m" into the chat. A half-eaten escape
-		// also makes the terminal swallow columns, which knocked the rail out of
-		// its column.
-		const maxLines = 15
-		hidden := 0
-		if len(lines) > maxLines {
-			hidden = len(lines) - maxLines
-			lines = lines[:maxLines]
-		}
+	styled := highlightToolOutput(msg, lines, dim, p)
 
-		var styled []string
-		switch {
-		case msg.tool == "read" && msg.toolIn != "":
-			styled = highlightReadOutput(lines, msg.toolIn, p)
-		case msg.tool == "bash" || isBashControl(msg.tool):
-			// Bash output is plain text most of the time but frequently contains
-			// runnable snippets (`cat file`, `curl ...`, `go test` output). Run it
-			// through chroma's content-sniffing lexer so it gets at least some
-			// coloring; if chroma cannot place it the fallback lexer still gives
-			// a non-gray foreground. Without this branch the output is dim (240)
-			// and reads as an afterthought next to the brightly-highlighted
-			// read/grep/find blocks above it.
-			styled = highlightBashOutput(lines, p)
-		// The grep tool registers itself as "ripgrep" whenever rg is installed
-		// (internal/tools/grep.go), which is the common case — so matching only
-		// "grep" here meant grep output was never highlighted in practice and
-		// fell through to the dim default.
-		case msg.tool == "grep" || msg.tool == "ripgrep":
-			styled = highlightGrepOutput(lines, p)
-		case msg.tool == "find":
-			styled = highlightFindOutput(lines, p)
-		default:
-			styled = make([]string, len(lines))
-			for i, line := range lines {
-				styled[i] = dim.Render(line)
-			}
-		}
+	// Style the marker only now that highlighting is done.
+	if hidden > 0 {
+		styled = append(styled, dim.Render(fmt.Sprintf("... (%d more lines)", hidden)))
+	}
 
-		// Style the marker only now that highlighting is done.
-		if hidden > 0 {
-			styled = append(styled, dim.Render(fmt.Sprintf("... (%d more lines)", hidden)))
-		}
-
-		cw := t.contentWidth()
-		for _, line := range styled {
-			for _, sl := range softWrap(line, cw) {
-				b.WriteString("  ")
-				b.WriteString(dim.Render("│ "))
-				b.WriteString(sl)
-				b.WriteString("\n")
-			}
-		}
+	cw := t.contentWidth()
+	var b strings.Builder
+	for _, line := range styled {
+		writeGutterLines(&b, dim, softWrap(line, cw)...)
 	}
 	return b.String()
 }
 
+// highlightToolOutput syntax-highlights a tool's output lines according to
+// which tool produced them, falling back to a dim render.
+func highlightToolOutput(msg message, lines []string, dim lipgloss.Style, p Palette) []string {
+	switch {
+	case msg.tool == "read" && msg.toolIn != "":
+		return highlightReadOutput(lines, msg.toolIn, p)
+	case msg.tool == "bash" || isBashControl(msg.tool):
+		// Bash output is plain text most of the time but frequently contains
+		// runnable snippets (`cat file`, `curl ...`, `go test` output). Run it
+		// through chroma's content-sniffing lexer so it gets at least some
+		// coloring; if chroma cannot place it the fallback lexer still gives
+		// a non-gray foreground. Without this branch the output is dim (240)
+		// and reads as an afterthought next to the brightly-highlighted
+		// read/grep/find blocks above it.
+		return highlightBashOutput(lines, p)
+	// The grep tool registers itself as "ripgrep" whenever rg is installed
+	// (internal/tools/grep.go), which is the common case — so matching only
+	// "grep" here meant grep output was never highlighted in practice and
+	// fell through to the dim default.
+	case msg.tool == "grep" || msg.tool == "ripgrep":
+		return highlightGrepOutput(lines, p)
+	case msg.tool == "find":
+		return highlightFindOutput(lines, p)
+	default:
+		styled := make([]string, len(lines))
+		for i, line := range lines {
+			styled[i] = dim.Render(line)
+		}
+		return styled
+	}
+}
+
+// toolSummaryArgKey maps a tool to the single argument that stands in for its
+// call in a one-line summary. A tool whose summary needs more than one argument
+// — or a default when the argument is missing — is handled in the switch in
+// toolCallSummary instead.
+//
+// "ripgrep" is the name the grep tool registers under when rg is installed.
+// groundingToolName is Gemini's server-side search, surfaced as a synthetic
+// tool call so a grounded answer shows the query it searched for.
+var toolSummaryArgKey = map[string]string{
+	"read":            "file_path",
+	"write":           "file_path",
+	"edit":            "file_path",
+	"bash":            "command",
+	"bash_wait":       "handle",
+	"bash_output":     "handle",
+	"bash_kill":       "handle",
+	"grep":            "pattern",
+	"ripgrep":         "pattern",
+	"find":            "pattern",
+	groundingToolName: "query",
+}
+
 // toolCallSummary returns a short one-line summary of tool arguments.
 func toolCallSummary(name string, args map[string]any) string {
+	if key, ok := toolSummaryArgKey[name]; ok {
+		// A missing key, or one holding a non-string, summarizes as "" — the
+		// same fallthrough the per-tool type assertions used.
+		s, _ := args[key].(string)
+		return s
+	}
 	switch name {
-	case "read":
-		if fp, ok := args["file_path"].(string); ok {
-			return fp
-		}
-	case "write":
-		if fp, ok := args["file_path"].(string); ok {
-			return fp
-		}
-	case "edit":
-		if fp, ok := args["file_path"].(string); ok {
-			return fp
-		}
-	case "bash":
-		if cmd, ok := args["command"].(string); ok {
-			return cmd
-		}
-	case "bash_wait", "bash_output", "bash_kill":
-		if h, ok := args["handle"].(string); ok {
-			return h
-		}
-	// "ripgrep" is the name the grep tool registers under when rg is installed.
-	case "grep", "ripgrep":
-		if p, ok := args["pattern"].(string); ok {
-			return p
-		}
-	// Gemini's server-side search, surfaced as a synthetic tool call so a
-	// grounded answer shows the query it searched for.
-	case groundingToolName:
-		if q, ok := args["query"].(string); ok {
-			return q
-		}
-	case "find":
-		if p, ok := args["pattern"].(string); ok {
-			return p
-		}
 	case "ls":
 		if p, ok := args["path"].(string); ok {
 			return p
 		}
 		return "."
 	case "tree":
-		p, _ := args["path"].(string)
-		if p == "" {
-			p = "."
-		}
-		if d, ok := args["depth"].(float64); ok && d > 0 {
-			return fmt.Sprintf("%s (depth %d)", p, int(d))
-		}
-		return p
+		return treeCallSummary(args)
 	case "agent":
-		typ, _ := args["type"].(string)
-		prompt, _ := args["prompt"].(string)
-		// Truncate prompt to first line, max 60 chars.
-		if idx := strings.IndexByte(prompt, '\n'); idx > 0 {
-			prompt = prompt[:idx]
-		}
-		if len(prompt) > 60 {
-			prompt = prompt[:57] + "..."
-		}
-		if typ != "" && prompt != "" {
-			return fmt.Sprintf("%s: %s", typ, prompt)
-		}
-		if typ != "" {
-			return typ
-		}
-		return prompt
+		return agentCallSummary(args)
 	}
 	return ""
+}
+
+// treeCallSummary summarizes a tree call as its path, with the depth appended
+// when one was requested.
+func treeCallSummary(args map[string]any) string {
+	p, _ := args["path"].(string)
+	if p == "" {
+		p = "."
+	}
+	if d, ok := args["depth"].(float64); ok && d > 0 {
+		return fmt.Sprintf("%s (depth %d)", p, int(d))
+	}
+	return p
+}
+
+// agentCallSummary summarizes a subagent call as "type: prompt", dropping
+// whichever half is absent.
+func agentCallSummary(args map[string]any) string {
+	typ, _ := args["type"].(string)
+	prompt, _ := args["prompt"].(string)
+	// Truncate prompt to first line, max 60 chars.
+	if idx := strings.IndexByte(prompt, '\n'); idx > 0 {
+		prompt = prompt[:idx]
+	}
+	if len(prompt) > 60 {
+		prompt = prompt[:57] + "..."
+	}
+	switch {
+	case typ != "" && prompt != "":
+		return fmt.Sprintf("%s: %s", typ, prompt)
+	case typ != "":
+		return typ
+	default:
+		return prompt
+	}
 }
 
 // toolResultSummary returns a short one-line summary of a tool result.
@@ -645,135 +702,240 @@ func toolResultSummary(content string) string {
 	return content
 }
 
-// formatToolResult extracts a readable summary from a parsed tool result.
-func formatToolResult(data map[string]any) string {
-	// ls tool: show file/dir names
-	if entries, ok := data["entries"].([]any); ok {
-		var names []string
-		for _, e := range entries {
-			if m, ok := e.(map[string]any); ok {
-				name, _ := m["name"].(string)
-				if isDir, ok := m["is_dir"].(bool); ok && isDir {
-					name += "/"
-				}
-				names = append(names, name)
-			}
-		}
-		result := strings.Join(names, "  ")
-		if len(result) > 120 {
-			return result[:117] + "..."
-		}
-		return result
-	}
-	// tree tool: show dirs/files count
-	if _, ok := data["tree"].(string); ok {
-		d, _ := data["dirs"].(float64)
-		f, _ := data["files"].(float64)
-		return fmt.Sprintf("%d dirs, %d files", int(d), int(f))
-	}
-	// grep tool: show matches with file:line: content
-	if matchList, ok := data["matches"].([]any); ok {
-		total, _ := data["total_matches"].(float64)
-		trunc, _ := data["truncated"].(bool)
-		var sb strings.Builder
-		for _, m := range matchList {
-			if entry, ok := m.(map[string]any); ok {
-				file, _ := entry["file"].(string)
-				line, _ := entry["line"].(float64)
-				content, _ := entry["content"].(string)
-				fmt.Fprintf(&sb, "%s:%d: %s\n", file, int(line), content)
-			}
-		}
-		if trunc {
-			fmt.Fprintf(&sb, "... (%d total matches, truncated)", int(total))
-		}
-		return strings.TrimRight(sb.String(), "\n")
-	}
-	if matches, ok := data["total_matches"].(float64); ok {
-		return fmt.Sprintf("%d matches", int(matches))
-	}
-	// find tool: show file list
-	if fileList, ok := data["files"].([]any); ok {
-		total, _ := data["total_files"].(float64)
-		trunc, _ := data["truncated"].(bool)
-		var sb strings.Builder
-		for _, f := range fileList {
-			if name, ok := f.(string); ok {
-				sb.WriteString(name)
-				sb.WriteByte('\n')
-			}
-		}
-		if trunc {
-			fmt.Fprintf(&sb, "... (%d total files, truncated)", int(total))
-		}
-		return strings.TrimRight(sb.String(), "\n")
-	}
-	if total, ok := data["total_files"].(float64); ok {
-		return fmt.Sprintf("%d files", int(total))
-	}
-	// read tool: show actual content with line numbers
-	if content, ok := data["content"].(string); ok {
-		total, _ := data["total_lines"].(float64)
-		trunc, _ := data["truncated"].(bool)
-		if trunc {
-			content += fmt.Sprintf("\n... (%d total lines, truncated)", int(total))
-		}
-		return content
-	}
-	if total, ok := data["total_lines"].(float64); ok {
-		trunc := ""
-		if t, ok := data["truncated"].(bool); ok && t {
-			trunc = " (truncated)"
-		}
-		return fmt.Sprintf("%d lines%s", int(total), trunc)
-	}
-	// write tool: show bytes written
-	if bw, ok := data["bytes_written"].(float64); ok {
-		if p, ok := data["path"].(string); ok {
-			return fmt.Sprintf("%s (%d bytes)", p, int(bw))
-		}
-	}
-	// edit tool: show replacements
-	if r, ok := data["replacements"].(float64); ok {
-		return fmt.Sprintf("%d replacements", int(r))
-	}
-	// lsp_diagnostics: show diagnostics (already prefixed with ⚠ by formatDiagnosticsForDisplay)
-	if diag, ok := data["lsp_diagnostics"].(string); ok && diag != "" {
-		return diag
-	}
-	// A backgrounded command, either at the moment of handoff (the bash tool) or
-	// on any later poll of it (bash_wait, bash_kill). Both carry a handle, and
-	// both have to be taken before the exit-code branch below.
-	//
-	// While such a command is still running it has no exit status: the bash tool
-	// reports the -1 placeholder, which the exit-code branch renders as
-	// "exit -1: <first line of output>" — a live lint run reading as a crashed
-	// one. A poll is worse: BashStatus omits exit_code entirely while running, so
-	// it missed the branch altogether and fell through to the raw-JSON fallback,
-	// printing &-escaped argument soup instead of the command's output.
-	if handle, ok := data["handle"].(string); ok && handle != "" {
-		return formatBashWindow(handle, data)
-	}
-	// bash tool: show exit code + first 2 and last 2 output lines (preserve newlines for better visibility)
-	if code, ok := data["exit_code"].(float64); ok {
-		stdout, _ := data["stdout"].(string)
-		stderr, _ := data["stderr"].(string)
-		result := bashOutputPreview(stdout, stderr)
-		if result == "" {
-			result = "(No output)"
-		}
-		if int(code) != 0 {
-			return fmt.Sprintf("exit %d: %s", int(code), result)
-		}
-		return result
-	}
-	// Fallback: compact JSON
-	b, _ := json.Marshal(data)
-	s := string(b)
+// clipToolSummary clips s to 120 bytes, marking the cut — the byte-wise limit
+// every one-line tool summary is held to.
+func clipToolSummary(s string) string {
 	if len(s) > 120 {
 		return s[:117] + "..."
 	}
 	return s
+}
+
+// toolResultShape formats one recognized tool-result shape, reporting false
+// when data is not that shape and the next shape should be tried.
+type toolResultShape func(data map[string]any) (string, bool)
+
+// toolResultShapes are the shapes formatToolResult recognizes, in the order it
+// tries them. The order is behavior, not taste: results carry overlapping keys
+// (a grep result has both "matches" and "total_matches"; a backgrounded bash
+// poll has both "handle" and "exit_code"), and the first shape that matches
+// wins.
+var toolResultShapes = []toolResultShape{
+	lsResultSummary,
+	treeResultSummary,
+	grepResultSummary,
+	grepCountSummary,
+	findResultSummary,
+	findCountSummary,
+	readResultSummary,
+	readCountSummary,
+	writeResultSummary,
+	editResultSummary,
+	diagnosticsResultSummary,
+	bashWindowResultSummary,
+	bashExitResultSummary,
+}
+
+// formatToolResult extracts a readable summary from a parsed tool result.
+func formatToolResult(data map[string]any) string {
+	for _, shape := range toolResultShapes {
+		if s, ok := shape(data); ok {
+			return s
+		}
+	}
+	// Fallback: compact JSON
+	b, _ := json.Marshal(data)
+	return clipToolSummary(string(b))
+}
+
+// lsResultSummary formats an ls result as its file/dir names.
+func lsResultSummary(data map[string]any) (string, bool) {
+	entries, ok := data["entries"].([]any)
+	if !ok {
+		return "", false
+	}
+	var names []string
+	for _, e := range entries {
+		if m, ok := e.(map[string]any); ok {
+			name, _ := m["name"].(string)
+			if isDir, ok := m["is_dir"].(bool); ok && isDir {
+				name += "/"
+			}
+			names = append(names, name)
+		}
+	}
+	return clipToolSummary(strings.Join(names, "  ")), true
+}
+
+// treeResultSummary formats a tree result as its dirs/files counts.
+func treeResultSummary(data map[string]any) (string, bool) {
+	if _, ok := data["tree"].(string); !ok {
+		return "", false
+	}
+	d, _ := data["dirs"].(float64)
+	f, _ := data["files"].(float64)
+	return fmt.Sprintf("%d dirs, %d files", int(d), int(f)), true
+}
+
+// grepResultSummary formats a grep result as "file:line: content" per match.
+func grepResultSummary(data map[string]any) (string, bool) {
+	matchList, ok := data["matches"].([]any)
+	if !ok {
+		return "", false
+	}
+	total, _ := data["total_matches"].(float64)
+	trunc, _ := data["truncated"].(bool)
+	var sb strings.Builder
+	for _, m := range matchList {
+		if entry, ok := m.(map[string]any); ok {
+			file, _ := entry["file"].(string)
+			line, _ := entry["line"].(float64)
+			content, _ := entry["content"].(string)
+			fmt.Fprintf(&sb, "%s:%d: %s\n", file, int(line), content)
+		}
+	}
+	if trunc {
+		fmt.Fprintf(&sb, "... (%d total matches, truncated)", int(total))
+	}
+	return strings.TrimRight(sb.String(), "\n"), true
+}
+
+// grepCountSummary formats a grep result that carries only a match count.
+func grepCountSummary(data map[string]any) (string, bool) {
+	matches, ok := data["total_matches"].(float64)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%d matches", int(matches)), true
+}
+
+// findResultSummary formats a find result as its file list.
+func findResultSummary(data map[string]any) (string, bool) {
+	fileList, ok := data["files"].([]any)
+	if !ok {
+		return "", false
+	}
+	total, _ := data["total_files"].(float64)
+	trunc, _ := data["truncated"].(bool)
+	var sb strings.Builder
+	for _, f := range fileList {
+		if name, ok := f.(string); ok {
+			sb.WriteString(name)
+			sb.WriteByte('\n')
+		}
+	}
+	if trunc {
+		fmt.Fprintf(&sb, "... (%d total files, truncated)", int(total))
+	}
+	return strings.TrimRight(sb.String(), "\n"), true
+}
+
+// findCountSummary formats a find result that carries only a file count.
+func findCountSummary(data map[string]any) (string, bool) {
+	total, ok := data["total_files"].(float64)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%d files", int(total)), true
+}
+
+// readResultSummary formats a read result as its actual content.
+func readResultSummary(data map[string]any) (string, bool) {
+	content, ok := data["content"].(string)
+	if !ok {
+		return "", false
+	}
+	total, _ := data["total_lines"].(float64)
+	if trunc, _ := data["truncated"].(bool); trunc {
+		content += fmt.Sprintf("\n... (%d total lines, truncated)", int(total))
+	}
+	return content, true
+}
+
+// readCountSummary formats a read result that carries only a line count.
+func readCountSummary(data map[string]any) (string, bool) {
+	total, ok := data["total_lines"].(float64)
+	if !ok {
+		return "", false
+	}
+	trunc := ""
+	if t, ok := data["truncated"].(bool); ok && t {
+		trunc = " (truncated)"
+	}
+	return fmt.Sprintf("%d lines%s", int(total), trunc), true
+}
+
+// writeResultSummary formats a write result as its path and byte count. A
+// byte count with no path is not this shape: it falls through to the shapes
+// below, as it always has.
+func writeResultSummary(data map[string]any) (string, bool) {
+	bw, ok := data["bytes_written"].(float64)
+	if !ok {
+		return "", false
+	}
+	p, ok := data["path"].(string)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s (%d bytes)", p, int(bw)), true
+}
+
+// editResultSummary formats an edit result as its replacement count.
+func editResultSummary(data map[string]any) (string, bool) {
+	r, ok := data["replacements"].(float64)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%d replacements", int(r)), true
+}
+
+// diagnosticsResultSummary returns lsp_diagnostics verbatim (already prefixed
+// with ⚠ by formatDiagnosticsForDisplay). An empty string is not a summary, so
+// it falls through.
+func diagnosticsResultSummary(data map[string]any) (string, bool) {
+	diag, ok := data["lsp_diagnostics"].(string)
+	if !ok || diag == "" {
+		return "", false
+	}
+	return diag, true
+}
+
+// bashWindowResultSummary formats a backgrounded command, either at the moment
+// of handoff (the bash tool) or on any later poll of it (bash_wait, bash_kill).
+// Both carry a handle, and both have to be taken before the exit-code shape
+// below.
+//
+// While such a command is still running it has no exit status: the bash tool
+// reports the -1 placeholder, which the exit-code shape renders as
+// "exit -1: <first line of output>" — a live lint run reading as a crashed one.
+// A poll is worse: BashStatus omits exit_code entirely while running, so it
+// missed the branch altogether and fell through to the raw-JSON fallback,
+// printing &-escaped argument soup instead of the command's output.
+func bashWindowResultSummary(data map[string]any) (string, bool) {
+	handle, ok := data["handle"].(string)
+	if !ok || handle == "" {
+		return "", false
+	}
+	return formatBashWindow(handle, data), true
+}
+
+// bashExitResultSummary formats a finished command as its exit code plus the
+// first 2 and last 2 output lines (newlines preserved for better visibility).
+func bashExitResultSummary(data map[string]any) (string, bool) {
+	code, ok := data["exit_code"].(float64)
+	if !ok {
+		return "", false
+	}
+	stdout, _ := data["stdout"].(string)
+	stderr, _ := data["stderr"].(string)
+	result := bashOutputPreview(stdout, stderr)
+	if result == "" {
+		result = "(No output)"
+	}
+	if int(code) != 0 {
+		return fmt.Sprintf("exit %d: %s", int(code), result), true
+	}
+	return result, true
 }
 
 // formatBashWindow renders the card for a backgrounded command: what state it

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -4,6 +4,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"image/color"
 	"os"
 	"os/exec"
 	"sort"
@@ -651,27 +652,14 @@ func (m *model) updateTerminal(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return m.handlePaste(msg)
 
 	case tea.KeyPressMsg:
-		// A resize can leave stray text fragments in the input queue.
-		if m.resizeDraining() && isResizeTextFragment(msg) {
-			return m, resizeDrainDoneCmd(m.resizeAt), true
-		}
-		model, cmd := m.handleKey(msg)
-		return model, cmd, true
+		return m.handleKeyPressMsg(msg)
 
 	case tea.MouseMsg:
 		model, cmd := m.handleMouse(msg)
 		return model, cmd, true
 
 	case InputSubmitMsg:
-		if strings.HasPrefix(msg.Text, "/") {
-			if m.running {
-				return m, nil, true
-			}
-			model, cmd := m.handleSlashCommand(msg.Text)
-			return model, cmd, true
-		}
-		model, cmd := m.enqueuePrompt(msg.Text, msg.Mentions)
-		return model, cmd, true
+		return m.handleInputSubmit(msg)
 
 	case resetCtrlCCountMsg:
 		model, cmd := m.handleResetCtrlCCount()
@@ -691,37 +679,71 @@ func (m *model) updateTerminal(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return m, nil, true
 
 	case loadingTickMsg:
-		// The loading-dots ticker was the engine behind TODO §30/§42: every
-		// 300 ms fire it mutated m.loadingDots and re-armed unconditionally,
-		// producing a 3.3 Hz full-history re-render for the life of the
-		// process. The dots only animate the deferred-init splash
-		// (m.loading is set at tui.go:455 and cleared at :1963/:1985), so
-		// the re-arm belongs to that lifecycle, not to process uptime.
-		// Re-arming only while m.loading is true stops the chain at init
-		// completion and removes the idle 3.3 Hz floor.
-		if !m.loading {
-			return m, nil, true
-		}
-		m.loadingDots = (m.loadingDots + 1) % 4
-		return m, tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg { return loadingTickMsg{} }), true
+		return m.handleLoadingTick()
 
 	case matrixTickMsg:
-		if m.running {
-			m.matrix.tick(m.mainWidth())
-			// The pending-tool bullet blinks on a ~1s cycle. The phase advances
-			// here, in Update, so View stays a pure function of model state —
-			// the matrix tick (150ms while running) re-renders often enough to
-			// animate it.
-			now := time.Now()
-			m.chatModel.ToolDisplay.BlinkOn = now.UnixMilli()/500%2 == 0
-			// Same idea one level out: the tab title's prefix symbol rotates so
-			// a backgrounded session still shows it is working.
-			m.titleSpin = terminalTitleSpinIndex(now)
-			return m, matrixTickCmd(), true
-		}
-		return m, nil, true
+		return m.handleMatrixTick()
 	}
 	return nil, nil, false
+}
+
+// handleKeyPressMsg routes a keystroke, dropping the stray text fragments a
+// resize can leave in the input queue.
+func (m *model) handleKeyPressMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
+	if m.resizeDraining() && isResizeTextFragment(msg) {
+		return m, resizeDrainDoneCmd(m.resizeAt), true
+	}
+	model, cmd := m.handleKey(msg)
+	return model, cmd, true
+}
+
+// handleInputSubmit runs a submitted line: a slash command directly, anything
+// else queued as a prompt. Slash commands are ignored while a turn is running.
+func (m *model) handleInputSubmit(msg InputSubmitMsg) (tea.Model, tea.Cmd, bool) {
+	if strings.HasPrefix(msg.Text, "/") {
+		if m.running {
+			return m, nil, true
+		}
+		model, cmd := m.handleSlashCommand(msg.Text)
+		return model, cmd, true
+	}
+	model, cmd := m.enqueuePrompt(msg.Text, msg.Mentions)
+	return model, cmd, true
+}
+
+// handleLoadingTick advances the loading dots.
+//
+// The loading-dots ticker was the engine behind TODO §30/§42: every 300 ms fire
+// it mutated m.loadingDots and re-armed unconditionally, producing a 3.3 Hz
+// full-history re-render for the life of the process. The dots only animate the
+// deferred-init splash (m.loading is set at tui.go:455 and cleared at
+// :1963/:1985), so the re-arm belongs to that lifecycle, not to process uptime.
+// Re-arming only while m.loading is true stops the chain at init completion and
+// removes the idle 3.3 Hz floor.
+func (m *model) handleLoadingTick() (tea.Model, tea.Cmd, bool) {
+	if !m.loading {
+		return m, nil, true
+	}
+	m.loadingDots = (m.loadingDots + 1) % 4
+	return m, tea.Tick(300*time.Millisecond, func(time.Time) tea.Msg { return loadingTickMsg{} }), true
+}
+
+// handleMatrixTick advances the matrix rain and the animations that ride on it.
+func (m *model) handleMatrixTick() (tea.Model, tea.Cmd, bool) {
+	if !m.running {
+		return m, nil, true
+	}
+	m.matrix.tick(m.mainWidth())
+	// The pending-tool bullet blinks on a ~1s cycle. The phase advances
+	// here, in Update, so View stays a pure function of model state —
+	// the matrix tick (150ms while running) re-renders often enough to
+	// animate it.
+	now := time.Now()
+	m.chatModel.ToolDisplay.BlinkOn = now.UnixMilli()/500%2 == 0
+	// Same idea one level out: the tab title's prefix symbol rotates so
+	// a backgrounded session still shows it is working.
+	m.titleSpin = terminalTitleSpinIndex(now)
+	return m, matrixTickCmd(), true
 }
 
 // handleWindowSize re-lays out the frame, and keeps the agent listener alive
@@ -1323,68 +1345,28 @@ func (m *model) handleSearchPopupKey(key tea.Key) bool {
 
 	switch key.Code {
 	case tea.KeyUp:
-		if sp.selected > 0 {
-			sp.selected--
-		} else if len(sp.filtered) > 1 {
-			// Wrap to last item on Up from first.
-			sp.selected = len(sp.filtered) - 1
-		}
-		sp.scrollOff = max(0, sp.selected-sp.height+1)
+		sp.selectPrev()
 		return true
 	case tea.KeyDown:
-		if sp.selected < len(sp.filtered)-1 {
-			sp.selected++
-		} else if len(sp.filtered) > 1 {
-			// Wrap to first item on Down from last.
-			sp.selected = 0
-		}
-		if sp.selected >= sp.scrollOff+sp.height {
-			sp.scrollOff = sp.selected - sp.height + 1
-		}
+		sp.selectNext()
 		return true
 	case tea.KeyTab:
-		if len(sp.filtered) == 0 {
-			return true
-		}
-		if key.Mod == tea.ModShift {
-			if sp.selected > 0 {
-				sp.selected--
-			} else {
-				// Wrap to last item on Shift+Tab from first.
-				sp.selected = len(sp.filtered) - 1
-			}
-		} else {
-			// Tab advances; stays at last item (no wrap).
-			if sp.selected < len(sp.filtered)-1 {
-				sp.selected++
-			}
-		}
-		sp.scrollOff = max(0, sp.selected-sp.height+1)
+		sp.selectByTab(key.Mod == tea.ModShift)
 		return true
 	case tea.KeyEnter:
-		if len(sp.filtered) > 0 && sp.selected < len(sp.filtered) {
-			item := sp.filtered[sp.selected]
-			switch sp.mode {
-			case searchModeCommands:
-				m.inputModel.SetText(item.Text + " ")
-				m.searchPopup = nil
-			case searchModeHistory:
-				m.inputModel.SetText(item.Text)
-				m.searchPopup = nil
-			}
-		}
+		m.acceptSearchPopupSelection()
 		return true
 	case tea.KeyEsc:
 		m.searchPopup = nil
 		return true
 	case tea.KeyBackspace:
-		if len(sp.search) > 0 {
-			sp.search = sp.search[:len(sp.search)-1]
-			sp.filterSearch()
-		} else {
+		if len(sp.search) == 0 {
 			// If search is empty, close popup on backspace
 			m.searchPopup = nil
+			return true
 		}
+		sp.search = sp.search[:len(sp.search)-1]
+		sp.filterSearch()
 		return true
 	default:
 		// Type to search (only for printable single characters).
@@ -1397,6 +1379,71 @@ func (m *model) handleSearchPopupKey(key tea.Key) bool {
 	}
 }
 
+// selectPrev moves the selection up one, wrapping to the last item from the
+// first, and scrolls to keep the selection visible.
+func (sp *searchPopupState) selectPrev() {
+	if sp.selected > 0 {
+		sp.selected--
+	} else if len(sp.filtered) > 1 {
+		// Wrap to last item on Up from first.
+		sp.selected = len(sp.filtered) - 1
+	}
+	sp.scrollOff = max(0, sp.selected-sp.height+1)
+}
+
+// selectNext moves the selection down one, wrapping to the first item from the
+// last, and scrolls only when the selection would fall past the visible window.
+func (sp *searchPopupState) selectNext() {
+	if sp.selected < len(sp.filtered)-1 {
+		sp.selected++
+	} else if len(sp.filtered) > 1 {
+		// Wrap to first item on Down from last.
+		sp.selected = 0
+	}
+	if sp.selected >= sp.scrollOff+sp.height {
+		sp.scrollOff = sp.selected - sp.height + 1
+	}
+}
+
+// selectByTab moves the selection for Tab / Shift+Tab. Shift+Tab wraps from the
+// first item to the last; Tab stops at the last item rather than wrapping.
+func (sp *searchPopupState) selectByTab(backwards bool) {
+	if len(sp.filtered) == 0 {
+		return
+	}
+	if backwards {
+		if sp.selected > 0 {
+			sp.selected--
+		} else {
+			// Wrap to last item on Shift+Tab from first.
+			sp.selected = len(sp.filtered) - 1
+		}
+	} else if sp.selected < len(sp.filtered)-1 {
+		// Tab advances; stays at last item (no wrap).
+		sp.selected++
+	}
+	sp.scrollOff = max(0, sp.selected-sp.height+1)
+}
+
+// acceptSearchPopupSelection puts the selected item into the prompt and closes
+// the popup. A command gets a trailing space so its arguments can be typed
+// straight on; a history entry is inserted verbatim.
+func (m *model) acceptSearchPopupSelection() {
+	sp := m.searchPopup
+	if len(sp.filtered) == 0 || sp.selected >= len(sp.filtered) {
+		return
+	}
+	item := sp.filtered[sp.selected]
+	switch sp.mode {
+	case searchModeCommands:
+		m.inputModel.SetText(item.Text + " ")
+		m.searchPopup = nil
+	case searchModeHistory:
+		m.inputModel.SetText(item.Text)
+		m.searchPopup = nil
+	}
+}
+
 func (m *model) View() tea.View {
 	if m.quitting {
 		return tea.NewView("Goodbye!\n")
@@ -1405,22 +1452,7 @@ func (m *model) View() tea.View {
 	m.syncPalette()
 
 	if m.width == 0 {
-		// Show matrix-style startup text before the first terminal size arrives.
-		matrixLine := renderStartupMatrixLine(m.loadingDots, m.cfg.AppVersion, m.loadingItems, m.loadingTotal, m.palette)
-		if m.loadingItems != nil {
-			var lines []string
-			lines = append(lines, matrixLine)
-			for _, item := range sortedKeys(m.loadingItems) {
-				done := m.loadingItems[item]
-				mark := " "
-				if done {
-					mark = "✓"
-				}
-				lines = append(lines, "  "+mark+" "+item)
-			}
-			return tea.NewView(strings.Join(lines, "\n") + "\n")
-		}
-		return tea.NewView(matrixLine + "\n")
+		return m.startupView()
 	}
 
 	// Layout: messages + sidebar on top, status bar + input spanning the full
@@ -1449,30 +1481,8 @@ func (m *model) View() tea.View {
 	availableHeight := m.messageViewportHeight()
 
 	// Truncate messages to fit viewport.
-	msgLines := strings.Split(messagesView, "\n")
-	totalLines := len(msgLines)
-
-	startLine := totalLines - availableHeight - m.chatModel.Scroll
-	if startLine < 0 {
-		startLine = 0
-	}
-	endLine := startLine + availableHeight
-	if endLine > totalLines {
-		endLine = totalLines
-	}
-
-	visibleMessages := strings.Join(msgLines[startLine:endLine], "\n")
-
-	// Pad to fill the viewport. availableHeight is message rows only — the blank
-	// rows that inset the block from the rules are budgeted separately.
-	visibleLineCount := strings.Count(visibleMessages, "\n") + 1
-	for visibleLineCount < availableHeight {
-		// Keep the final padding row materialized. A trailing newline only
-		// terminates the preceding row; treating its trailing empty string as a
-		// row made the composed frame one line shorter than the terminal.
-		visibleMessages += "\n "
-		visibleLineCount++
-	}
+	visibleMessages, startLine, endLine := clipMessagesToViewport(
+		messagesView, availableHeight, m.chatModel.Scroll)
 	visibleMessages = m.overlaySearchPopup(visibleMessages, bodyWidth)
 
 	// Note: width constraint is handled by glamour's WithWordWrap(contentWidth) in chatModel.UpdateRenderer.
@@ -1542,45 +1552,7 @@ func (m *model) View() tea.View {
 
 	var topSection string
 	if showSidebar {
-		hostName := cachedHostname()
-		sidebarInput := SidebarRenderInput{
-			Width: sidebarWidth,
-			// Exactly as tall as the panel beside it. Sized to the terminal
-			// instead, the sidebar outran the panel — JoinHorizontal padded the
-			// panel with blank rows, leaving a gap below the prompt while the
-			// sidebar's filler dots carried on past it.
-			Height:       panelRows,
-			Mascot:       m.mascot(),
-			Mode:         m.mode,
-			ProviderName: m.providerDisplayName(),
-			ModelName:    m.cfg.ModelName,
-			GitBranch:    m.statusModel.GitBranch,
-			DiffAdded:    m.diffAdded,
-			DiffRemoved:  m.diffRemoved,
-			Running:      m.running,
-			TokenTracker: m.cfg.TokenTracker,
-			AppVersion:   m.cfg.AppVersion,
-			HostName:     hostName,
-			FolderName:   sidebarFolderName(m.cwd()),
-			Messages:     m.chatModel.Messages,
-			ActiveTool:   m.statusModel.ActiveTool,
-			LoadingItems: m.loadingItems,
-			MatrixLines:  "",
-			StatusLine:   "",
-			Orchestrator: m.cfg.Orchestrator,
-			MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
-			MemoryStatus: m.memoryStatus,
-			Artifacts:    m.artifactList(),
-			Palette:      m.palette,
-		}
-		if m.run != nil && m.run.phase != "" {
-			sidebarInput.RunChecklist = m.run.checklist
-			sidebarInput.RunPhase = m.run.phase
-			sidebarInput.RunSpec = m.run.specName
-			sidebarInput.RunCycle = m.run.retries + 1
-			sidebarInput.RunMaxCycle = m.run.maxRetries
-		}
-		sidebar := RenderSidebar(sidebarInput)
+		sidebar := RenderSidebar(m.sidebarRenderInput(sidebarWidth, panelRows))
 		topSection = joinPanelSidebar(leftPanel, sidebar, mainWidth, sidebarWidth)
 	} else {
 		topSection = padLinesTo(leftPanel, m.width)
@@ -1651,6 +1623,100 @@ func (m *model) View() tea.View {
 	v.AltScreen = false
 	v.MouseMode = tea.MouseModeCellMotion
 	return v
+}
+
+// startupView is the matrix-style startup text shown before the first terminal
+// size arrives, listing deferred-init progress once there is any to show.
+func (m *model) startupView() tea.View {
+	matrixLine := renderStartupMatrixLine(m.loadingDots, m.cfg.AppVersion, m.loadingItems, m.loadingTotal, m.palette)
+	if m.loadingItems == nil {
+		return tea.NewView(matrixLine + "\n")
+	}
+	var lines []string
+	lines = append(lines, matrixLine)
+	for _, item := range sortedKeys(m.loadingItems) {
+		done := m.loadingItems[item]
+		mark := " "
+		if done {
+			mark = "✓"
+		}
+		lines = append(lines, "  "+mark+" "+item)
+	}
+	return tea.NewView(strings.Join(lines, "\n") + "\n")
+}
+
+// clipMessagesToViewport takes the rendered message block down to the rows the
+// viewport can show, scrolled back by scroll rows, and pads it out when the
+// conversation is shorter than the viewport. It returns the visible block along
+// with the line range it covers, which the minimap needs to place its bar.
+func clipMessagesToViewport(messagesView string, availableHeight, scroll int) (visible string, startLine, endLine int) {
+	msgLines := strings.Split(messagesView, "\n")
+	totalLines := len(msgLines)
+
+	startLine = totalLines - availableHeight - scroll
+	if startLine < 0 {
+		startLine = 0
+	}
+	endLine = startLine + availableHeight
+	if endLine > totalLines {
+		endLine = totalLines
+	}
+
+	visible = strings.Join(msgLines[startLine:endLine], "\n")
+
+	// Pad to fill the viewport. availableHeight is message rows only — the blank
+	// rows that inset the block from the rules are budgeted separately.
+	visibleLineCount := strings.Count(visible, "\n") + 1
+	for visibleLineCount < availableHeight {
+		// Keep the final padding row materialized. A trailing newline only
+		// terminates the preceding row; treating its trailing empty string as a
+		// row made the composed frame one line shorter than the terminal.
+		visible += "\n "
+		visibleLineCount++
+	}
+	return visible, startLine, endLine
+}
+
+// sidebarRenderInput gathers everything the sidebar draws for this frame.
+func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInput {
+	in := SidebarRenderInput{
+		Width: sidebarWidth,
+		// Exactly as tall as the panel beside it. Sized to the terminal
+		// instead, the sidebar outran the panel — JoinHorizontal padded the
+		// panel with blank rows, leaving a gap below the prompt while the
+		// sidebar's filler dots carried on past it.
+		Height:       panelRows,
+		Mascot:       m.mascot(),
+		Mode:         m.mode,
+		ProviderName: m.providerDisplayName(),
+		ModelName:    m.cfg.ModelName,
+		GitBranch:    m.statusModel.GitBranch,
+		DiffAdded:    m.diffAdded,
+		DiffRemoved:  m.diffRemoved,
+		Running:      m.running,
+		TokenTracker: m.cfg.TokenTracker,
+		AppVersion:   m.cfg.AppVersion,
+		HostName:     cachedHostname(),
+		FolderName:   sidebarFolderName(m.cwd()),
+		Messages:     m.chatModel.Messages,
+		ActiveTool:   m.statusModel.ActiveTool,
+		LoadingItems: m.loadingItems,
+		MatrixLines:  "",
+		StatusLine:   "",
+		Orchestrator: m.cfg.Orchestrator,
+		MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
+		MemoryStatus: m.memoryStatus,
+		Artifacts:    m.artifactList(),
+		Palette:      m.palette,
+	}
+	if m.run != nil && m.run.phase != "" {
+		in.RunChecklist = m.run.checklist
+		in.RunPhase = m.run.phase
+		in.RunSpec = m.run.specName
+		in.RunCycle = m.run.retries + 1
+		in.RunMaxCycle = m.run.maxRetries
+	}
+	return in
 }
 
 // drainTerminalResponses discards any pending terminal response sequences
@@ -2282,78 +2348,98 @@ func (m *model) renderSearchPopup(width int) string {
 	}
 
 	sp := m.searchPopup
-	bg := m.palette.Surface0
-
-	// Get colors based on mode.
-	popupStyle := lipgloss.NewStyle().Background(bg)
-	headerStyle := lipgloss.NewStyle().Background(bg).Bold(true)
-	searchStyle := lipgloss.NewStyle().Background(bg)
-	itemStyle := lipgloss.NewStyle().Background(bg)
-	// Each mode below sets its own selection background; this is just the
-	// starting point.
-	selectedItemStyle := lipgloss.NewStyle().Background(m.palette.Surface0)
-
-	var header string
-
-	switch sp.mode {
-	case searchModeCommands:
-		border := m.palette.Cyan // cyan for commands
-		popupStyle = popupStyle.
-			Foreground(m.palette.Subtext).
-			Border(lipgloss.RoundedBorder(), true, true, true, true).
-			BorderForeground(border).
-			Width(width)
-		headerStyle = headerStyle.Foreground(m.palette.Subtext).Width(width)
-		searchStyle = searchStyle.Foreground(m.palette.Dim)
-		itemStyle = itemStyle.Foreground(m.palette.Teal) // teal
-		selectedItemStyle = selectedItemStyle.Background(m.palette.Cyan)
-		header = "Commands"
-	case searchModeHistory:
-		border := m.palette.Peach // orange for history
-		popupStyle = popupStyle.
-			Foreground(m.palette.Subtext).
-			Border(lipgloss.RoundedBorder(), true, true, true, true).
-			BorderForeground(border).
-			Width(width)
-		headerStyle = headerStyle.Foreground(m.palette.Subtext).Width(width)
-		searchStyle = searchStyle.Foreground(m.palette.Dim)
-		itemStyle = itemStyle.Foreground(m.palette.Peach) // orange
-		selectedItemStyle = selectedItemStyle.Background(m.palette.Peach)
-		header = "History"
-	}
+	st := m.searchPopupStyles(sp.mode, width)
 
 	var b strings.Builder
 
 	// Header with count.
+	header := st.header
 	if len(sp.filtered) > 0 {
 		header = fmt.Sprintf("%s (%d)", header, len(sp.filtered))
 	}
-	b.WriteString(headerStyle.Render(header))
+	b.WriteString(st.headerStyle.Render(header))
 
 	// Search prompt line.
 	if sp.search != "" {
 		b.WriteString("\n")
 		searchLine := fmt.Sprintf("  Search: %s", sp.search)
-		b.WriteString(searchStyle.Width(width).Render(clipRunes(searchLine, width)))
+		b.WriteString(st.searchStyle.Width(width).Render(clipRunes(searchLine, width)))
 	} else {
 		b.WriteString("\n")
-		b.WriteString(searchStyle.Width(width).Render("  Search... (type to filter)"))
+		b.WriteString(st.searchStyle.Width(width).Render("  Search... (type to filter)"))
 	}
 
 	if len(sp.filtered) == 0 {
 		b.WriteString("\n")
 		if sp.mode == searchModeCommands {
-			b.WriteString(searchStyle.Width(width).Render("  No matching commands"))
+			b.WriteString(st.searchStyle.Width(width).Render("  No matching commands"))
 		} else {
-			b.WriteString(searchStyle.Width(width).Render("  No matching history"))
+			b.WriteString(st.searchStyle.Width(width).Render("  No matching history"))
 		}
-		return popupStyle.Render(b.String())
+		return st.popupStyle.Render(b.String())
 	}
 
-	// Item list. Both i and scrollOff+i are bounded by len(filtered) so a
-	// stale scrollOff from before a resize cannot index past the end and
-	// panic — refreshSearchPopupHeight is the primary guard, this is the
-	// belt to its braces.
+	writeSearchPopupItems(&b, sp, st, width)
+
+	return st.popupStyle.Render(b.String())
+}
+
+// searchPopupStyleSet is the per-mode palette of the search popup: the same
+// chrome with a different accent color and title for commands and for history.
+type searchPopupStyleSet struct {
+	header            string
+	popupStyle        lipgloss.Style
+	headerStyle       lipgloss.Style
+	searchStyle       lipgloss.Style
+	itemStyle         lipgloss.Style
+	selectedItemStyle lipgloss.Style
+}
+
+// searchPopupStyles builds the style set for a popup mode. Commands are cyan
+// and history is orange; an unknown mode gets the unaccented base styles.
+func (m *model) searchPopupStyles(mode searchMode, width int) searchPopupStyleSet {
+	bg := m.palette.Surface0
+	st := searchPopupStyleSet{
+		popupStyle:  lipgloss.NewStyle().Background(bg),
+		headerStyle: lipgloss.NewStyle().Background(bg).Bold(true),
+		searchStyle: lipgloss.NewStyle().Background(bg),
+		itemStyle:   lipgloss.NewStyle().Background(bg),
+		// Each mode below sets its own selection background; this is just the
+		// starting point.
+		selectedItemStyle: lipgloss.NewStyle().Background(m.palette.Surface0),
+	}
+
+	var accent color.Color
+	switch mode {
+	case searchModeCommands:
+		accent = m.palette.Cyan                                // cyan for commands
+		st.itemStyle = st.itemStyle.Foreground(m.palette.Teal) // teal
+		st.header = "Commands"
+	case searchModeHistory:
+		accent = m.palette.Peach                                // orange for history
+		st.itemStyle = st.itemStyle.Foreground(m.palette.Peach) // orange
+		st.header = "History"
+	default:
+		return st
+	}
+
+	st.popupStyle = st.popupStyle.
+		Foreground(m.palette.Subtext).
+		Border(lipgloss.RoundedBorder(), true, true, true, true).
+		BorderForeground(accent).
+		Width(width)
+	st.headerStyle = st.headerStyle.Foreground(m.palette.Subtext).Width(width)
+	st.searchStyle = st.searchStyle.Foreground(m.palette.Dim)
+	st.selectedItemStyle = st.selectedItemStyle.Background(accent)
+	return st
+}
+
+// writeSearchPopupItems renders the visible slice of the item list.
+//
+// Both i and scrollOff+i are bounded by len(filtered) so a stale scrollOff from
+// before a resize cannot index past the end and panic —
+// refreshSearchPopupHeight is the primary guard, this is the belt to its braces.
+func writeSearchPopupItems(b *strings.Builder, sp *searchPopupState, st searchPopupStyleSet, width int) {
 	for i := 0; i < sp.height; i++ {
 		idx := sp.scrollOff + i
 		if idx < 0 || idx >= len(sp.filtered) {
@@ -2361,11 +2447,11 @@ func (m *model) renderSearchPopup(width int) string {
 		}
 		item := sp.filtered[idx]
 		prefix := "  "
-		currentItemStyle := itemStyle
+		currentItemStyle := st.itemStyle
 		if idx == sp.selected {
 			// Always highlight the selected item.
 			prefix = "> "
-			currentItemStyle = selectedItemStyle
+			currentItemStyle = st.selectedItemStyle
 		}
 
 		line := prefix + item.Text
@@ -2380,8 +2466,6 @@ func (m *model) renderSearchPopup(width int) string {
 		b.WriteString("\n")
 		b.WriteString(currentItemStyle.Width(width).Render(clipRunes(line, width)))
 	}
-
-	return popupStyle.Render(b.String())
 }
 
 func (m *model) slashCommandCandidates(prefix string) []CompletionCandidate {

--- a/internal/webserver/complexity_web_test.go
+++ b/internal/webserver/complexity_web_test.go
@@ -1,0 +1,431 @@
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/voicegemini"
+)
+
+// This file pins the branch structure of the functions the complexity refactor
+// reshaped:
+//
+//   - (*screenBuf).csi, whose one switch over the CSI final byte became the
+//     csiOps table. A dispatch table is easy to get subtly wrong on parameter
+//     defaults and on which finals it does NOT handle, so every final the old
+//     switch named is exercised here, together with finals it never named.
+//   - the four voice tool bodies lifted out of (*ServerV2).executeVoiceTool.
+//   - (*ServerV2).voiceRelayTarget, the guard block lifted out of
+//     handleGeminiVoiceWS.
+
+// ---------------------------------------------------------------------------
+// CSI dispatch
+// ---------------------------------------------------------------------------
+
+// csiState drives one CSI sequence against a screen whose cursor has been
+// parked at (row, col) on a known body of text, and reports where the cursor
+// ended up and what the screen holds. Driving csi through feed is deliberate:
+// it is the only way the dispatch is reached in production.
+func csiState(t *testing.T, seq string) (*screenBuf, string) {
+	t.Helper()
+	s := newScreenBuf(100)
+	feedString(s, seq)
+	return s, s.snapshot(0)
+}
+
+// TestCSICursorMoves pins every cursor-moving final the old switch named,
+// including the aliases ('e' for 'B', 'a' for 'C', '`' for 'G', 'f' for 'H')
+// that a hand-written table is most likely to drop.
+func TestCSICursorMoves(t *testing.T) {
+	tests := []struct {
+		name    string
+		feed    string
+		wantRow int
+		wantCol int
+	}{
+		// CUU: up, clamped at the top of the buffer.
+		{"CUU moves up by the parameter", "a\r\nb\r\nc\r\n\x1b[2A", 1, 0},
+		{"CUU defaults to one", "a\r\nb\r\n\x1b[A", 1, 0},
+		{"CUU clamps at row zero", "a\r\nb\r\n\x1b[99A", 0, 0},
+		// An explicit zero is taken literally: csiNum only falls back to the
+		// default for an absent, empty or unparseable parameter, so "\x1b[0A"
+		// moves nothing. A real terminal would treat 0 as 1; this does not, and
+		// that difference predates the dispatch table.
+		{"CUU with an explicit zero moves nothing", "a\r\nb\r\nc\r\n\x1b[0A", 3, 0},
+		{"CUD with an explicit zero moves nothing", "\x1b[0B", 0, 0},
+		{"CUF with an explicit zero moves nothing", "abc\x1b[0C", 0, 3},
+
+		// CUD and its alias 'e'.
+		{"CUD moves down by the parameter", "\x1b[3B", 3, 0},
+		{"CUD defaults to one", "\x1b[B", 1, 0},
+		{"CUD alias e behaves identically", "\x1b[3e", 3, 0},
+		{"CUD alias e defaults to one", "\x1b[e", 1, 0},
+
+		// CUF and its alias 'a', clamped at maxScreenCols.
+		{"CUF moves right by the parameter", "\x1b[5C", 0, 5},
+		{"CUF defaults to one", "\x1b[C", 0, 1},
+		{"CUF alias a behaves identically", "\x1b[5a", 0, 5},
+		{"CUF clamps at maxScreenCols", "\x1b[999999C", 0, maxScreenCols},
+
+		// CUB, clamped at column zero.
+		{"CUB moves left by the parameter", "abcdef\x1b[2D", 0, 4},
+		{"CUB defaults to one", "abcdef\x1b[D", 0, 5},
+		{"CUB clamps at column zero", "abc\x1b[99D", 0, 0},
+
+		// CHA and its alias '`': one-based absolute column.
+		{"CHA is one-based", "abcdef\x1b[3G", 0, 2},
+		{"CHA defaults to column one, meaning zero", "abcdef\x1b[G", 0, 0},
+		{"CHA with parameter zero clamps to zero", "abcdef\x1b[0G", 0, 0},
+		{"CHA alias backtick behaves identically", "abcdef\x1b[3`", 0, 2},
+		{"CHA clamps at maxScreenCols", "\x1b[999999G", 0, maxScreenCols},
+
+		// CNL: down and to column zero.
+		{"CNL moves down and to column zero", "abc\x1b[2E", 2, 0},
+		{"CNL defaults to one", "abc\x1b[E", 1, 0},
+
+		// CPL: up and to column zero.
+		{"CPL moves up and to column zero", "a\r\nb\r\nabc\x1b[2F", 0, 0},
+		{"CPL defaults to one", "a\r\nb\r\nabc\x1b[F", 1, 0},
+		{"CPL clamps at row zero", "a\r\nabc\x1b[99F", 0, 0},
+
+		// CUP: the ROW half is deliberately ignored — an inline renderer has no
+		// window to be absolute against — and the column half is honored.
+		{"CUP honors the column and ignores the row", "a\r\nb\r\nc\x1b[1;4H", 2, 3},
+		{"CUP alias f behaves identically", "a\r\nb\r\nc\x1b[1;4f", 2, 3},
+		{"CUP with no parameters lands at column zero", "a\r\nb\r\nc\x1b[H", 2, 0},
+		{"CUP with only a row lands at column zero", "a\r\nb\r\nc\x1b[9H", 2, 0},
+		{"CUP with an empty second parameter takes the default", "a\r\nb\r\nc\x1b[9;H", 2, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := csiState(t, tt.feed)
+			if s.row != tt.wantRow || s.col != tt.wantCol {
+				t.Errorf("after %q cursor is (row %d, col %d), want (row %d, col %d)",
+					tt.feed, s.row, s.col, tt.wantRow, tt.wantCol)
+			}
+		})
+	}
+}
+
+// TestCSIEditsTheScreen pins the finals that change what a line holds. These
+// used to be inline switch arms; each is now a table entry calling into
+// eraseLine, eraseDisplay, deleteChars or blank.
+func TestCSIEditsTheScreen(t *testing.T) {
+	tests := []struct {
+		name string
+		feed string
+		want string
+	}{
+		// EL — note the default is mode 0, not mode 1 as with the cursor moves.
+		{"EL default erases from the cursor to the end", "abcdef\x1b[3G\x1b[K", "ab"},
+		{"EL mode 0 erases from the cursor to the end", "abcdef\x1b[3G\x1b[0K", "ab"},
+		{"EL mode 1 erases up to and including the cursor", "abcdef\x1b[3G\x1b[1K", "   def"},
+		{"EL mode 2 erases the whole line", "abcdef\x1b[3G\x1b[2K", ""},
+		{"EL past the end of a short line is a no-op", "ab\x1b[9G\x1b[K", "ab"},
+
+		// ED — default mode 0 as well.
+		{"ED mode 2 clears everything", "a\r\nb\r\nc\x1b[2J", ""},
+		{"ED mode 3 clears everything too", "a\r\nb\r\nc\x1b[3J", ""},
+		// ED mode 1 clears the lines above the cursor AND blanks the cursor line
+		// up to and including the cursor, so only the tail of it survives.
+		{"ED mode 1 clears above the cursor and the line's head", "a\r\nb\r\nxyz\x1b[2G\x1b[1J", "  z"},
+		{"ED mode 1 at the line start still blanks one cell", "a\r\nb\r\nxyz\x1b[G\x1b[1J", " yz"},
+		{"ED default clears from the cursor down", "aa\r\nbb\r\ncc\x1b[2A\x1b[G\x1b[J", ""},
+		{"ED mode 0 clears from the cursor down", "aa\r\nbb\r\ncc\x1b[2A\x1b[2G\x1b[0J", "a"},
+
+		// DCH — shift the rest of the line left.
+		{"DCH deletes one character by default", "abcdef\x1b[3G\x1b[P", "abdef"},
+		{"DCH deletes the parameter count", "abcdef\x1b[3G\x1b[3P", "abf"},
+		{"DCH past the end truncates the line", "abcdef\x1b[3G\x1b[99P", "ab"},
+
+		// ECH — blank in place, so the line keeps its length.
+		{"ECH blanks one character by default", "abcdef\x1b[3G\x1b[X", "ab def"},
+		{"ECH blanks the parameter count", "abcdef\x1b[3G\x1b[3X", "ab   f"},
+		{"ECH past the end blanks to the end", "abcdef\x1b[3G\x1b[99X", "ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := csiState(t, tt.feed)
+			if got != tt.want {
+				t.Errorf("after %q screen = %q, want %q", tt.feed, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCSIIgnoresUnhandledFinals is the other half of the dispatch contract: a
+// final byte with no table entry must be consumed and dropped, leaving both the
+// cursor and the screen exactly as they were, and never printing its own bytes.
+//
+// The old switch got this from having no default arm. A table gets it from the
+// lookup miss, which is the branch most likely to regress.
+func TestCSIIgnoresUnhandledFinals(t *testing.T) {
+	// Every unhandled final the terminal actually sees, plus neighbors of the
+	// handled ones ('I' next to 'H'/'J', 'b' between 'a' and 'e', 'd', 'Z').
+	unhandled := []string{
+		"\x1b[m",         // SGR reset
+		"\x1b[0m",        // SGR reset, explicit
+		"\x1b[1;31;47m",  // SGR with several parameters
+		"\x1b[?25l",      // cursor hide
+		"\x1b[?25h",      // cursor show
+		"\x1b[?2004h",    // bracketed paste on
+		"\x1b[?2004l",    // bracketed paste off
+		"\x1b[?1049h",    // alternate screen
+		"\x1b[2 q",       // DECSCUSR, with an intermediate byte
+		"\x1b[6n",        // DSR, a query
+		"\x1b[3I",        // CHT
+		"\x1b[3Z",        // CBT
+		"\x1b[2L",        // IL
+		"\x1b[2M",        // DL
+		"\x1b[2S",        // SU
+		"\x1b[2T",        // SD
+		"\x1b[2b",        // REP
+		"\x1b[2d",        // VPA
+		"\x1b[2@",        // ICH
+		"\x1b[1;3r",      // DECSTBM
+		"\x1b[c",         // DA
+		"\x1b[!p",        // DECSTR, with an intermediate byte
+		"\x1b[999999999", // no final byte at all, on this chunk
+	}
+
+	for _, seq := range unhandled {
+		t.Run(strings.ReplaceAll(seq, "\x1b", "ESC"), func(t *testing.T) {
+			s := newScreenBuf(100)
+			feedString(s, "abcdef")
+			// Park the cursor somewhere non-trivial so a stray move shows.
+			feedString(s, "\x1b[3G")
+			row, col := s.row, s.col
+
+			feedString(s, seq)
+
+			if s.row != row || s.col != col {
+				t.Errorf("%q moved the cursor from (%d,%d) to (%d,%d)", seq, row, col, s.row, s.col)
+			}
+			if got := s.snapshot(0); got != "abcdef" {
+				t.Errorf("%q changed the screen to %q, want %q", seq, got, "abcdef")
+			}
+		})
+	}
+}
+
+// A sequence split across chunk boundaries must dispatch exactly once, on the
+// chunk that completes it — the carry in `pending` is what the table lookup
+// depends on seeing a whole sequence.
+func TestCSIDispatchesOnceAcrossChunkBoundaries(t *testing.T) {
+	whole := newScreenBuf(100)
+	feedString(whole, "abcdef\x1b[3G\x1b[3P")
+
+	// The same bytes, cut at every interior position.
+	seq := "abcdef\x1b[3G\x1b[3P"
+	for cut := 1; cut < len(seq); cut++ {
+		split := newScreenBuf(100)
+		feedString(split, seq[:cut], seq[cut:])
+		if got, want := split.snapshot(0), whole.snapshot(0); got != want {
+			t.Errorf("split at %d gave %q, want %q", cut, got, want)
+		}
+		if split.row != whole.row || split.col != whole.col {
+			t.Errorf("split at %d left the cursor at (%d,%d), want (%d,%d)",
+				cut, split.row, split.col, whole.row, whole.col)
+		}
+	}
+}
+
+// csiOps is the table csi dispatches through. Its key set IS the set of finals
+// the old switch named, so a dropped alias is a dropped behavior.
+func TestCSIOpsCoversExactlyTheHandledFinals(t *testing.T) {
+	want := []byte{'A', 'B', 'e', 'C', 'a', 'D', 'G', '`', 'E', 'F', 'K', 'J', 'H', 'f', 'P', 'X'}
+	if len(csiOps) != len(want) {
+		t.Errorf("csiOps has %d entries, want %d", len(csiOps), len(want))
+	}
+	for _, f := range want {
+		if _, ok := csiOps[f]; !ok {
+			t.Errorf("csiOps is missing the %q final", f)
+		}
+	}
+	// The aliases must be the same operation, not two that drifted apart.
+	for _, pair := range [][2]byte{{'B', 'e'}, {'C', 'a'}, {'G', '`'}, {'H', 'f'}} {
+		for _, params := range []string{"", "0", "1", "4", "2;5", "999999"} {
+			a := newScreenBuf(100)
+			b := newScreenBuf(100)
+			feedString(a, "abcdef\r\nghijkl\x1b[4G")
+			feedString(b, "abcdef\r\nghijkl\x1b[4G")
+
+			csiOps[pair[0]](a, params)
+			csiOps[pair[1]](b, params)
+
+			if a.row != b.row || a.col != b.col || a.snapshot(0) != b.snapshot(0) {
+				t.Errorf("%q and %q disagree on params %q: (%d,%d)%q vs (%d,%d)%q",
+					pair[0], pair[1], params, a.row, a.col, a.snapshot(0), b.row, b.col, b.snapshot(0))
+			}
+		}
+	}
+}
+
+// csi's return value is the other half of its contract: how many bytes it
+// consumed, and whether the sequence was complete. A truncated sequence must
+// report incomplete so feed carries it rather than printing it.
+func TestCSIConsumesTheWholeSequence(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantN    int
+		wantDone bool
+	}{
+		{"\x1b[3P", 4, true},
+		{"\x1b[X", 3, true},
+		{"\x1b[1;31;47m", 10, true},  // an unhandled final is still consumed
+		{"\x1b[2 q", 5, true},        // parameter bytes, then an intermediate
+		{"\x1b[?2004h", 8, true},     // '?' is a parameter byte
+		{"\x1b[3PTRAILING", 4, true}, // only the sequence, not what follows
+		{"\x1b[3", 0, false},         // no final byte yet
+		{"\x1b[", 0, false},          // nothing at all yet
+		{"\x1b[999999999", 0, false}, // still parameters
+		{"\x1b[2 ", 0, false},        // an intermediate with no final
+	}
+	for _, tt := range tests {
+		s := newScreenBuf(100)
+		n, done := s.csi([]byte(tt.in))
+		if n != tt.wantN || done != tt.wantDone {
+			t.Errorf("csi(%q) = (%d, %t), want (%d, %t)", tt.in, n, done, tt.wantN, tt.wantDone)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Voice tool bodies
+// ---------------------------------------------------------------------------
+
+// Every tool body decodes its own arguments, and every one of them turns a
+// malformed payload into a tool failure rather than an error — a provider left
+// waiting on a function response stalls the whole conversation.
+func TestVoiceToolsRejectMalformedArgs(t *testing.T) {
+	s := withVoice(t, testServer(t))
+	testBridge(t, s, "term-1")
+	vs := &voiceSession{ID: "vs-1", Terminal: "term-1"}
+
+	// Each tool's argument struct has a differently typed field, so one bad
+	// payload per tool: a string where a number belongs and vice versa.
+	tests := []struct {
+		tool string
+		args string
+	}{
+		{voiceToolSendPrompt, `{"prompt": 42}`},
+		{voiceToolSendPrompt, `{`},
+		{voiceToolReadScreen, `{"lines": "many"}`},
+		{voiceToolReadScreen, `[]`},
+		{voiceToolWait, `{"seconds": "a while"}`},
+		{voiceToolWait, `"nope"`},
+		{voiceToolSendKey, `{"key": ["enter"]}`},
+		{voiceToolSendKey, `{"key":}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tool+" "+tt.args, func(t *testing.T) {
+			res := s.executeVoiceTool(t.Context(), vs, voicegemini.FunctionCall{
+				Name: tt.tool,
+				Args: json.RawMessage(tt.args),
+			})
+			if _, failed := res.Response["error"]; !failed {
+				t.Fatalf("%s with args %s returned %+v, want an error response", tt.tool, tt.args, res.Response)
+			}
+			if !strings.HasPrefix(res.Summary, tt.tool+" failed: ") {
+				t.Errorf("summary = %q, want it to name the failing tool", res.Summary)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Relay admission
+// ---------------------------------------------------------------------------
+
+// voiceRelayTarget is the guard block lifted out of handleGeminiVoiceWS. Each
+// rejection has its own status, and the caller relies on the boolean rather
+// than on the response having been written.
+func TestVoiceRelayTargetRejections(t *testing.T) {
+	// relayTarget runs one admission attempt against s for the given session id
+	// and reports the session, whether it was admitted, and the status written.
+	relayTarget := func(t *testing.T, s *ServerV2, id string) (*voiceSession, bool, int) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		r := voiceReq(t, s, http.MethodGet, "/api/voice/ws?session="+id, nil)
+		vs, ok := s.voiceRelayTarget(rec, r)
+		return vs, ok, rec.Code
+	}
+
+	t.Run("voice not configured", func(t *testing.T) {
+		// A server started without --voice: paired, but with no transport.
+		s := testServer(t)
+		_, ok, code := relayTarget(t, s, "anything")
+		if ok {
+			t.Fatal("admitted a request while voice was disabled")
+		}
+		if code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want %d", code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("no session id", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		_, ok, code := relayTarget(t, s, "")
+		if ok {
+			t.Fatal("admitted a request with no session id")
+		}
+		if code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
+		}
+	})
+
+	t.Run("unknown session id", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		_, ok, code := relayTarget(t, s, "never-created")
+		if ok {
+			t.Fatal("admitted an unknown session id")
+		}
+		if code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
+		}
+	})
+
+	t.Run("unpaired browser", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		rec := httptest.NewRecorder()
+		// No token at all: the relay re-checks the pairing rather than
+		// inheriting trust from the POST that created the session.
+		r := httptest.NewRequest(http.MethodGet, "/api/voice/ws?session=x", nil)
+		if _, ok := s.voiceRelayTarget(rec, r); ok {
+			t.Fatal("admitted an unpaired browser")
+		}
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("first admission wins, second is refused", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		created, err := s.voiceStore.create("", "term-1")
+		if err != nil {
+			t.Fatalf("create() = %v", err)
+		}
+
+		vs, ok, code := relayTarget(t, s, created.ID)
+		if !ok {
+			t.Fatalf("first admission was refused with status %d", code)
+		}
+		if vs != created {
+			t.Errorf("admitted %+v, want the stored session %+v", vs, created)
+		}
+
+		// claimed() is one-shot, so the second relay for the same session is a
+		// conflict — that is what keeps two tabs off one coding agent.
+		if _, ok, code := relayTarget(t, s, created.ID); ok {
+			t.Fatal("admitted a second relay for the same session")
+		} else if code != http.StatusConflict {
+			t.Errorf("status = %d, want %d", code, http.StatusConflict)
+		}
+	})
+}

--- a/internal/webserver/screen.go
+++ b/internal/webserver/screen.go
@@ -179,40 +179,90 @@ func (s *screenBuf) csi(b []byte) (int, bool) {
 	final := b[i]
 	i++
 
-	switch final {
-	case 'A': // CUU — the move an inline renderer makes to redraw its frame
-		s.row = max(s.row-csiNum(params, 0, 1), 0)
-	case 'B', 'e': // CUD
-		s.row += csiNum(params, 0, 1)
-		s.ensureRow()
-	case 'C', 'a': // CUF — how a differential repaint skips an unchanged prefix
-		s.col = min(s.col+csiNum(params, 0, 1), maxScreenCols)
-	case 'D': // CUB
-		s.col = max(s.col-csiNum(params, 0, 1), 0)
-	case 'G', '`': // CHA — absolute column, the other half of a partial repaint
-		s.col = clampCol(csiNum(params, 0, 1) - 1)
-	case 'E': // CNL
-		s.row += csiNum(params, 0, 1)
-		s.col = 0
-		s.ensureRow()
-	case 'F': // CPL
-		s.row = max(s.row-csiNum(params, 0, 1), 0)
-		s.col = 0
-	case 'K': // EL
-		s.eraseLine(csiNum(params, 0, 0))
-	case 'J': // ED
-		s.eraseDisplay(csiNum(params, 0, 0))
-	case 'H', 'f': // CUP
-		// The row is absolute against the window, which an inline renderer does
-		// not have — it never emits CUP for that reason. The column is still
-		// meaningful, so honor it and leave the row alone.
-		s.col = clampCol(csiNum(params, 1, 1) - 1)
-	case 'P': // DCH — delete characters, shifting the rest of the line left
-		s.deleteChars(csiNum(params, 0, 1))
-	case 'X': // ECH — blank characters in place
-		s.blank(s.col, s.col+csiNum(params, 0, 1))
+	// A final byte with no entry is a sequence that does not change what the
+	// screen holds (SGR color, cursor visibility, bracketed-paste mode); it is
+	// consumed and dropped.
+	if op, ok := csiOps[final]; ok {
+		op(s, params)
 	}
 	return i, true
+}
+
+// csiOps maps a CSI final byte to the edit it makes. Only the sequences that
+// change what a line holds appear here; everything else is dropped by csi.
+var csiOps = map[byte]func(s *screenBuf, params string){
+	// CUU — the move an inline renderer makes to redraw its frame.
+	'A': func(s *screenBuf, params string) {
+		s.row = max(s.row-csiNum(params, 0, 1), 0)
+	},
+	// CUD.
+	'B': csiCursorDown,
+	'e': csiCursorDown,
+	// CUF — how a differential repaint skips an unchanged prefix.
+	'C': csiCursorForward,
+	'a': csiCursorForward,
+	// CUB.
+	'D': func(s *screenBuf, params string) {
+		s.col = max(s.col-csiNum(params, 0, 1), 0)
+	},
+	// CHA — absolute column, the other half of a partial repaint.
+	'G': csiCursorColumn,
+	'`': csiCursorColumn,
+	// CNL.
+	'E': func(s *screenBuf, params string) {
+		s.row += csiNum(params, 0, 1)
+		s.col = 0
+		s.ensureRow()
+	},
+	// CPL.
+	'F': func(s *screenBuf, params string) {
+		s.row = max(s.row-csiNum(params, 0, 1), 0)
+		s.col = 0
+	},
+	// EL.
+	'K': func(s *screenBuf, params string) {
+		s.eraseLine(csiNum(params, 0, 0))
+	},
+	// ED.
+	'J': func(s *screenBuf, params string) {
+		s.eraseDisplay(csiNum(params, 0, 0))
+	},
+	// CUP.
+	'H': csiCursorPosition,
+	'f': csiCursorPosition,
+	// DCH — delete characters, shifting the rest of the line left.
+	'P': func(s *screenBuf, params string) {
+		s.deleteChars(csiNum(params, 0, 1))
+	},
+	// ECH — blank characters in place.
+	'X': func(s *screenBuf, params string) {
+		s.blank(s.col, s.col+csiNum(params, 0, 1))
+	},
+}
+
+// csiCursorDown applies CUD, the 'B' and 'e' finals.
+func csiCursorDown(s *screenBuf, params string) {
+	s.row += csiNum(params, 0, 1)
+	s.ensureRow()
+}
+
+// csiCursorForward applies CUF, the 'C' and 'a' finals.
+func csiCursorForward(s *screenBuf, params string) {
+	s.col = min(s.col+csiNum(params, 0, 1), maxScreenCols)
+}
+
+// csiCursorColumn applies CHA, the 'G' and '`' finals.
+func csiCursorColumn(s *screenBuf, params string) {
+	s.col = clampCol(csiNum(params, 0, 1) - 1)
+}
+
+// csiCursorPosition applies CUP, the 'H' and 'f' finals.
+//
+// The row is absolute against the window, which an inline renderer does not
+// have — it never emits CUP for that reason. The column is still meaningful, so
+// honor it and leave the row alone.
+func csiCursorPosition(s *screenBuf, params string) {
+	s.col = clampCol(csiNum(params, 1, 1) - 1)
 }
 
 // eraseLine applies EL with the given mode.

--- a/internal/webserver/voice_agent.go
+++ b/internal/webserver/voice_agent.go
@@ -208,91 +208,13 @@ func (s *ServerV2) executeVoiceTool(ctx context.Context, vs *voiceSession, fc vo
 
 	switch fc.Name {
 	case voiceToolSendPrompt:
-		var args struct {
-			Prompt string `json:"prompt"`
-		}
-		if err := decodeVoiceArgs(fc.Args, &args); err != nil {
-			return voiceToolFailure(fc.Name, err)
-		}
-		if err := bridge.SendPrompt(args.Prompt); err != nil {
-			return voiceToolFailure(fc.Name, err)
-		}
-		sent := sanitizePromptText(args.Prompt)
-		return voiceToolResult{
-			Response: map[string]any{
-				"sent":   sent,
-				"status": "The prompt was typed into the pi session and submitted. It is working now; wait, then read the screen.",
-			},
-			Summary: "→ pi: " + sent,
-		}
-
+		return voiceSendPrompt(bridge, fc)
 	case voiceToolReadScreen:
-		var args struct {
-			Lines int `json:"lines"`
-		}
-		if err := decodeVoiceArgs(fc.Args, &args); err != nil {
-			return voiceToolFailure(fc.Name, err)
-		}
-		n := args.Lines
-		if n <= 0 {
-			n = voiceScreenDefaultLines
-		}
-		if n > voiceScreenMaxLines {
-			n = voiceScreenMaxLines
-		}
-		screen := bridge.Screen(n)
-		if strings.TrimSpace(screen) == "" {
-			return voiceToolResult{
-				Response: map[string]any{"screen": "", "note": "pi's terminal has not drawn anything yet."},
-				Summary:  "read screen (empty)",
-			}
-		}
-		return voiceToolResult{
-			Response: map[string]any{"screen": screen, "running": bridge.Alive()},
-			Summary:  fmt.Sprintf("read screen (%d lines)", strings.Count(screen, "\n")+1),
-		}
-
+		return voiceReadScreen(bridge, fc)
 	case voiceToolWait:
-		var args struct {
-			Seconds int `json:"seconds"`
-		}
-		if err := decodeVoiceArgs(fc.Args, &args); err != nil {
-			return voiceToolFailure(fc.Name, err)
-		}
-		secs := args.Seconds
-		if secs <= 0 {
-			secs = voiceWaitDefaultSeconds
-		}
-		if secs > voiceWaitMaxSeconds {
-			secs = voiceWaitMaxSeconds
-		}
-		idle := bridge.WaitForIdle(ctx, voiceWaitQuiet, time.Duration(secs)*time.Second)
-		if idle {
-			return voiceToolResult{
-				Response: map[string]any{"idle": true, "status": "The agent has stopped producing output. Read the screen to see what it did."},
-				Summary:  "waited — agent idle",
-			}
-		}
-		return voiceToolResult{
-			Response: map[string]any{"idle": false, "status": fmt.Sprintf("Still working after %ds. Tell the user it is still going, then wait again.", secs)},
-			Summary:  fmt.Sprintf("waited %ds — still working", secs),
-		}
-
+		return voiceWaitForAgent(ctx, bridge, fc)
 	case voiceToolSendKey:
-		var args struct {
-			Key string `json:"key"`
-		}
-		if err := decodeVoiceArgs(fc.Args, &args); err != nil {
-			return voiceToolFailure(fc.Name, err)
-		}
-		if err := bridge.SendKey(args.Key); err != nil {
-			return voiceToolFailure(fc.Name, err)
-		}
-		return voiceToolResult{
-			Response: map[string]any{"sent": args.Key, "status": "Key sent. Read the screen to see what changed."},
-			Summary:  "key: " + args.Key,
-		}
-
+		return voiceSendKey(bridge, fc)
 	default:
 		// The model invented a name. Saying so is better than silence, which
 		// would leave the turn hanging.
@@ -300,6 +222,102 @@ func (s *ServerV2) executeVoiceTool(ctx context.Context, vs *voiceSession, fc vo
 			Response: map[string]any{"error": fmt.Sprintf("%q is not a tool this session exposes", fc.Name)},
 			Summary:  "unknown tool: " + fc.Name,
 		}
+	}
+}
+
+// voiceSendPrompt types a prompt into the pi session and submits it.
+func voiceSendPrompt(bridge *PtyBridge, fc voicegemini.FunctionCall) voiceToolResult {
+	var args struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := decodeVoiceArgs(fc.Args, &args); err != nil {
+		return voiceToolFailure(fc.Name, err)
+	}
+	if err := bridge.SendPrompt(args.Prompt); err != nil {
+		return voiceToolFailure(fc.Name, err)
+	}
+	sent := sanitizePromptText(args.Prompt)
+	return voiceToolResult{
+		Response: map[string]any{
+			"sent":   sent,
+			"status": "The prompt was typed into the pi session and submitted. It is working now; wait, then read the screen.",
+		},
+		Summary: "→ pi: " + sent,
+	}
+}
+
+// voiceReadScreen returns the tail of pi's terminal, clamped to the line budget
+// a spoken answer can carry.
+func voiceReadScreen(bridge *PtyBridge, fc voicegemini.FunctionCall) voiceToolResult {
+	var args struct {
+		Lines int `json:"lines"`
+	}
+	if err := decodeVoiceArgs(fc.Args, &args); err != nil {
+		return voiceToolFailure(fc.Name, err)
+	}
+	n := args.Lines
+	if n <= 0 {
+		n = voiceScreenDefaultLines
+	}
+	if n > voiceScreenMaxLines {
+		n = voiceScreenMaxLines
+	}
+	screen := bridge.Screen(n)
+	if strings.TrimSpace(screen) == "" {
+		return voiceToolResult{
+			Response: map[string]any{"screen": "", "note": "pi's terminal has not drawn anything yet."},
+			Summary:  "read screen (empty)",
+		}
+	}
+	return voiceToolResult{
+		Response: map[string]any{"screen": screen, "running": bridge.Alive()},
+		Summary:  fmt.Sprintf("read screen (%d lines)", strings.Count(screen, "\n")+1),
+	}
+}
+
+// voiceWaitForAgent blocks until pi's terminal goes quiet or the requested
+// budget runs out, clamped so one call cannot hold the turn open indefinitely.
+func voiceWaitForAgent(ctx context.Context, bridge *PtyBridge, fc voicegemini.FunctionCall) voiceToolResult {
+	var args struct {
+		Seconds int `json:"seconds"`
+	}
+	if err := decodeVoiceArgs(fc.Args, &args); err != nil {
+		return voiceToolFailure(fc.Name, err)
+	}
+	secs := args.Seconds
+	if secs <= 0 {
+		secs = voiceWaitDefaultSeconds
+	}
+	if secs > voiceWaitMaxSeconds {
+		secs = voiceWaitMaxSeconds
+	}
+	idle := bridge.WaitForIdle(ctx, voiceWaitQuiet, time.Duration(secs)*time.Second)
+	if idle {
+		return voiceToolResult{
+			Response: map[string]any{"idle": true, "status": "The agent has stopped producing output. Read the screen to see what it did."},
+			Summary:  "waited — agent idle",
+		}
+	}
+	return voiceToolResult{
+		Response: map[string]any{"idle": false, "status": fmt.Sprintf("Still working after %ds. Tell the user it is still going, then wait again.", secs)},
+		Summary:  fmt.Sprintf("waited %ds — still working", secs),
+	}
+}
+
+// voiceSendKey sends one key to pi's terminal.
+func voiceSendKey(bridge *PtyBridge, fc voicegemini.FunctionCall) voiceToolResult {
+	var args struct {
+		Key string `json:"key"`
+	}
+	if err := decodeVoiceArgs(fc.Args, &args); err != nil {
+		return voiceToolFailure(fc.Name, err)
+	}
+	if err := bridge.SendKey(args.Key); err != nil {
+		return voiceToolFailure(fc.Name, err)
+	}
+	return voiceToolResult{
+		Response: map[string]any{"sent": args.Key, "status": "Key sent. Read the screen to see what changed."},
+		Summary:  "key: " + args.Key,
 	}
 }
 

--- a/internal/webserver/voice_gemini.go
+++ b/internal/webserver/voice_gemini.go
@@ -65,27 +65,9 @@ const maxVoiceCloseText = 400
 // handleGeminiVoiceWS relays one live session between the browser and the
 // Gemini Live API.
 func (s *ServerV2) handleGeminiVoiceWS(w http.ResponseWriter, r *http.Request) {
-	// The session id is already a single-use secret only an authorized caller
-	// could hold, but the relay is the socket that reaches the coding agent, so
-	// it re-checks the pairing rather than inheriting trust from a POST that
-	// happened minutes ago.
-	if !s.voiceAuthorized(w, r) {
-		return
-	}
-	if !s.voiceEnabled() {
-		voiceHTTPError(w, http.StatusServiceUnavailable,
-			fmt.Errorf("voice is not configured — set GEMINI_API_KEY and run `pi serve --voice`"))
-		return
-	}
-	sessionID := r.URL.Query().Get("session")
-	vs, ok := s.voiceStore.get(sessionID)
+	vs, ok := s.voiceRelayTarget(w, r)
 	if !ok {
-		voiceHTTPError(w, http.StatusNotFound, fmt.Errorf("unknown or expired voice session"))
-		return
-	}
-	if vs.claimed() {
-		voiceHTTPError(w, http.StatusConflict, fmt.Errorf("this voice session already has a relay"))
-		return
+		return // voiceRelayTarget already wrote the response
 	}
 
 	up := &websocket.Upgrader{CheckOrigin: s.voiceOriginOK}
@@ -159,38 +141,77 @@ func (s *ServerV2) handleGeminiVoiceWS(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// browser → provider: mic audio.
-	go func() {
-		// A vanished browser has to end the WHOLE relay. Canceling the context
-		// cannot do it on its own — the loop below sits in provider.ReadJSON,
-		// which blocks outside any context — so closing the provider socket is
-		// what unblocks it and frees the slot in milliseconds instead of at the
-		// TTL.
-		//
-		// This needs the dead peer to actually surface as a read error (a close
-		// frame, FIN or RST). A half-open TCP connection — a phone that locks
-		// and never sends anything again — is only noticed when the provider
-		// itself times out. Add a read deadline plus a ping ticker here if that
-		// idle window ever needs to be bounded.
-		defer func() {
-			cancel()
-			_ = provider.Close()
-		}()
-		for {
-			kind, data, err := browser.ReadMessage()
-			if err != nil {
-				return
-			}
-			if kind != websocket.BinaryMessage || len(data) == 0 {
-				continue
-			}
-			msg := voicegemini.RealtimeAudioMessage(base64.StdEncoding.EncodeToString(data))
-			if err := pw.writeJSON(msg); err != nil {
-				return
-			}
-		}
-	}()
+	go pumpBrowserAudio(browser, provider, pw, cancel)
 
 	// provider → browser: audio, transcripts, tool calls.
+	s.relayProviderMessages(ctx, provider, pw, bw, vs, creator.Model)
+}
+
+// voiceRelayTarget resolves and claims the voice session this upgrade is for,
+// writing the HTTP error itself and reporting false when it cannot.
+//
+// The session id is already a single-use secret only an authorized caller could
+// hold, but the relay is the socket that reaches the coding agent, so it
+// re-checks the pairing rather than inheriting trust from a POST that happened
+// minutes ago.
+func (s *ServerV2) voiceRelayTarget(w http.ResponseWriter, r *http.Request) (*voiceSession, bool) {
+	if !s.voiceAuthorized(w, r) {
+		return nil, false
+	}
+	if !s.voiceEnabled() {
+		voiceHTTPError(w, http.StatusServiceUnavailable,
+			fmt.Errorf("voice is not configured — set GEMINI_API_KEY and run `pi serve --voice`"))
+		return nil, false
+	}
+	sessionID := r.URL.Query().Get("session")
+	vs, ok := s.voiceStore.get(sessionID)
+	if !ok {
+		voiceHTTPError(w, http.StatusNotFound, fmt.Errorf("unknown or expired voice session"))
+		return nil, false
+	}
+	if vs.claimed() {
+		voiceHTTPError(w, http.StatusConflict, fmt.Errorf("this voice session already has a relay"))
+		return nil, false
+	}
+	return vs, true
+}
+
+// pumpBrowserAudio forwards mic frames from the browser to the provider until
+// the browser socket ends.
+//
+// A vanished browser has to end the WHOLE relay. Canceling the context cannot
+// do it on its own — the provider read loop sits in provider.ReadJSON, which
+// blocks outside any context — so closing the provider socket is what unblocks
+// it and frees the slot in milliseconds instead of at the TTL.
+//
+// This needs the dead peer to actually surface as a read error (a close frame,
+// FIN or RST). A half-open TCP connection — a phone that locks and never sends
+// anything again — is only noticed when the provider itself times out. Add a
+// read deadline plus a ping ticker here if that idle window ever needs to be
+// bounded.
+func pumpBrowserAudio(browser, provider *websocket.Conn, pw *wsWriter, cancel context.CancelFunc) {
+	defer func() {
+		cancel()
+		_ = provider.Close()
+	}()
+	for {
+		kind, data, err := browser.ReadMessage()
+		if err != nil {
+			return
+		}
+		if kind != websocket.BinaryMessage || len(data) == 0 {
+			continue
+		}
+		msg := voicegemini.RealtimeAudioMessage(base64.StdEncoding.EncodeToString(data))
+		if err := pw.writeJSON(msg); err != nil {
+			return
+		}
+	}
+}
+
+// relayProviderMessages reads the provider until the relay ends, forwarding
+// audio, transcripts and tool calls to the browser.
+func (s *ServerV2) relayProviderMessages(ctx context.Context, provider *websocket.Conn, pw, bw *wsWriter, vs *voiceSession, model string) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -206,7 +227,7 @@ func (s *ServerV2) handleGeminiVoiceWS(w http.ResponseWriter, r *http.Request) {
 		}
 		switch {
 		case sm.SetupComplete != nil:
-			s.log.Info("voice setup complete", "session", vs.ID, "model", creator.Model)
+			s.log.Info("voice setup complete", "session", vs.ID, "model", model)
 			_ = bw.writeJSON(map[string]any{"type": "ready"})
 		case sm.ServerContent != nil:
 			relayGeminiContent(bw, sm.ServerContent)

--- a/piagent/agent.go
+++ b/piagent/agent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/memory"
 	pisession "github.com/dimetron/pi-go/internal/session"
+	"github.com/dimetron/pi-go/internal/subagent"
 	"github.com/dimetron/pi-go/internal/tools"
 )
 
@@ -92,6 +93,90 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 		afterTurn:  o.afterTurn,
 	}
 
+	rt, err := a.buildRuntime(ctx, o, &cfg, providerName)
+	if err != nil {
+		return nil, err
+	}
+	a.tools = rt.tools
+
+	instruction := buildInstruction(o, workDir)
+	if rt.palaceContext != "" {
+		instruction += "\n\n## Palace Memory Context\n\n" + rt.palaceContext
+	}
+	instruction += memoryContext(ctx, a.memStore, cfg, workDir)
+
+	sessionSvc, err := pisession.NewFileService(sessionDir)
+	if err != nil {
+		return nil, a.abort(fmt.Errorf("creating session service: %w", err))
+	}
+
+	// Created before the agent so it captures the agent's own non-fatal
+	// diagnostics (unresolved instruction placeholders, say) instead of
+	// letting them reach stderr.
+	sessionLog, err := logger.New()
+	if err != nil {
+		slog.Warn("piagent: session log unavailable", "error", err)
+	}
+	a.push(sessionLog.Close)
+
+	// memSessionID is only known once a session exists; the memory callback
+	// reads it through the pointer, so recording starts from that point.
+	var memSessionID string
+	before, after := buildCallbacks(callbackDeps{
+		cfg:       cfg,
+		sandbox:   rt.sandbox,
+		lspMgr:    rt.lspMgr,
+		provider:  providerName,
+		worker:    rt.memWorker,
+		project:   workDir,
+		sessionID: &memSessionID,
+		opts:      o,
+	})
+
+	inner, err := agent.New(agent.Config{
+		Model:                llm,
+		Tools:                rt.tools,
+		Toolsets:             append(buildToolsets(cfg), o.toolsets...),
+		Instruction:          instruction,
+		SessionService:       sessionSvc,
+		WorkingDir:           workDir,
+		BeforeToolCallbacks:  before.tool,
+		AfterToolCallbacks:   after.tool,
+		BeforeModelCallbacks: before.model,
+		AfterModelCallbacks:  after.model,
+		Logger:               sessionLog,
+	})
+	if err != nil {
+		return nil, a.abort(fmt.Errorf("creating agent: %w", err))
+	}
+	a.inner = inner
+	a.onNewSession = func(sessionID string) {
+		memSessionID = sessionID
+		rt.orch.SetACPLogPath(filepath.Join(sessionDir, sessionID, "acp.jsonl"))
+	}
+	a.sessionLog = sessionLog
+	return a, nil
+}
+
+// runtimeParts are the subsystems [New] assembles before the inner agent
+// exists. tools is the finished tool list; the rest is what callback wiring
+// and session bookkeeping still need afterwards.
+type runtimeParts struct {
+	sandbox       *tools.Sandbox
+	orch          *subagent.Orchestrator
+	lspMgr        *lsp.Manager
+	memWorker     *memory.Worker
+	palaceContext string
+	tools         []adktool.Tool
+}
+
+// buildRuntime assembles the sandbox, bash supervisor, tools, subagents,
+// memory, palace and LSP subsystems. Every acquisition registers its cleanup
+// on a first, so a failure partway through releases what already succeeded.
+// It also sets a.memStore, which the memory tools and instruction need.
+func (a *Agent) buildRuntime(ctx context.Context, o options, cfg *config.Config, providerName string) (*runtimeParts, error) {
+	workDir := a.workDir
+
 	sandbox, err := buildSandbox(workDir, o.extraSandbox)
 	if err != nil {
 		return nil, err
@@ -119,7 +204,7 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 	}
 	bashSup.SetSink(func(execID, kind, content string) { onEvent(execID, kind, content) })
 
-	orch := buildSubagents(ctx, &cfg, workDir)
+	orch := buildSubagents(ctx, cfg, workDir)
 	a.push(func() error { orch.Shutdown(); return nil })
 	if o.subagentEnabled {
 		agentTools, aErr := tools.AgentTools(orch, tools.AgentEventCallback(onEvent))
@@ -129,7 +214,7 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 		coreTools = append(coreTools, agentTools...)
 	}
 
-	memStore, memWorker, closeMemory := setupMemory(ctx, o, cfg, orch)
+	memStore, memWorker, closeMemory := setupMemory(ctx, o, *cfg, orch)
 	a.push(func() error { closeMemory(); return nil })
 	a.memStore = memStore
 	if memStore != nil {
@@ -141,7 +226,7 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 		}
 	}
 
-	palaceTools, palaceContext, closePalace := setupPalace(o, cfg, memWorker)
+	palaceTools, palaceContext, closePalace := setupPalace(o, *cfg, memWorker)
 	a.push(func() error { closePalace(); return nil })
 	coreTools = append(coreTools, palaceTools...)
 
@@ -160,65 +245,15 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 		coreTools = append(coreTools, gTool)
 	}
 	coreTools = append(coreTools, o.tools...)
-	a.tools = coreTools
 
-	instruction := buildInstruction(o, workDir)
-	if palaceContext != "" {
-		instruction += "\n\n## Palace Memory Context\n\n" + palaceContext
-	}
-	instruction += memoryContext(ctx, memStore, cfg, workDir)
-
-	sessionSvc, err := pisession.NewFileService(sessionDir)
-	if err != nil {
-		return nil, a.abort(fmt.Errorf("creating session service: %w", err))
-	}
-
-	// Created before the agent so it captures the agent's own non-fatal
-	// diagnostics (unresolved instruction placeholders, say) instead of
-	// letting them reach stderr.
-	sessionLog, err := logger.New()
-	if err != nil {
-		slog.Warn("piagent: session log unavailable", "error", err)
-	}
-	a.push(sessionLog.Close)
-
-	// memSessionID is only known once a session exists; the memory callback
-	// reads it through the pointer, so recording starts from that point.
-	var memSessionID string
-	before, after := buildCallbacks(callbackDeps{
-		cfg:       cfg,
-		sandbox:   sandbox,
-		lspMgr:    lspMgr,
-		provider:  providerName,
-		worker:    memWorker,
-		project:   workDir,
-		sessionID: &memSessionID,
-		opts:      o,
-	})
-
-	inner, err := agent.New(agent.Config{
-		Model:                llm,
-		Tools:                coreTools,
-		Toolsets:             append(buildToolsets(cfg), o.toolsets...),
-		Instruction:          instruction,
-		SessionService:       sessionSvc,
-		WorkingDir:           workDir,
-		BeforeToolCallbacks:  before.tool,
-		AfterToolCallbacks:   after.tool,
-		BeforeModelCallbacks: before.model,
-		AfterModelCallbacks:  after.model,
-		Logger:               sessionLog,
-	})
-	if err != nil {
-		return nil, a.abort(fmt.Errorf("creating agent: %w", err))
-	}
-	a.inner = inner
-	a.onNewSession = func(sessionID string) {
-		memSessionID = sessionID
-		orch.SetACPLogPath(filepath.Join(sessionDir, sessionID, "acp.jsonl"))
-	}
-	a.sessionLog = sessionLog
-	return a, nil
+	return &runtimeParts{
+		sandbox:       sandbox,
+		orch:          orch,
+		lspMgr:        lspMgr,
+		memWorker:     memWorker,
+		palaceContext: palaceContext,
+		tools:         coreTools,
+	}, nil
 }
 
 // push registers a cleanup function, to be run in reverse order by Close.

--- a/piagent/complexity_piagent_test.go
+++ b/piagent/complexity_piagent_test.go
@@ -1,0 +1,298 @@
+package piagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	adkagent "google.golang.org/adk/v2/agent"
+	adktool "google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/functiontool"
+
+	"github.com/dimetron/pi-go/internal/config"
+)
+
+// markerTool is a do-nothing tool whose only job is to be identifiable by name
+// at a known position in the assembled tool list.
+func markerTool(t *testing.T, name string) adktool.Tool {
+	t.Helper()
+	tl, err := functiontool.New(
+		functiontool.Config{Name: name, Description: "a marker tool"},
+		func(_ adkagent.Context, _ struct{}) (string, error) { return "", nil },
+	)
+	if err != nil {
+		t.Fatalf("building marker tool: %v", err)
+	}
+	return tl
+}
+
+// buildTestRuntime runs the subsystem assembly New extracted into
+// buildRuntime, on a bare Agent, with cleanup registered.
+func buildTestRuntime(t *testing.T, providerName string, extra ...Option) (*Agent, *runtimeParts) {
+	t.Helper()
+	isolate(t)
+
+	o := defaultOptions()
+	// Match newTestAgent: every optional subsystem off, so the assertions are
+	// about wiring rather than about which subsystems happen to be enabled.
+	for _, opt := range append([]Option{WithSubagents(false), WithLSP(LSPOff)}, extra...) {
+		opt(&o)
+	}
+
+	a := &Agent{workDir: t.TempDir()}
+	cfg := config.Config{}
+	rt, err := a.buildRuntime(t.Context(), o, &cfg, providerName)
+	if err != nil {
+		t.Fatalf("buildRuntime: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := a.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	})
+	return a, rt
+}
+
+func toolNames(ts []adktool.Tool) []string {
+	names := make([]string, 0, len(ts))
+	for _, tl := range ts {
+		names = append(names, tl.Name())
+	}
+	return names
+}
+
+func hasTool(ts []adktool.Tool, name string) bool {
+	for _, n := range toolNames(ts) {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildRuntimeWiresEverySubsystem checks the struct buildRuntime returns
+// carries exactly what New still needs afterwards: the sandbox and LSP manager
+// for callbacks, the orchestrator for the ACP log path, and the tool list.
+// A nil in any of these is a silent miswiring rather than a build failure.
+func TestBuildRuntimeWiresEverySubsystem(t *testing.T) {
+	_, rt := buildTestRuntime(t, "anthropic")
+
+	if rt.sandbox == nil {
+		t.Error("sandbox is nil; buildCallbacks needs it")
+	}
+	if rt.orch == nil {
+		t.Error("orch is nil; onNewSession needs it for the ACP log path")
+	}
+	if rt.lspMgr == nil {
+		t.Error("lspMgr is nil; buildCallbacks needs it")
+	}
+	if len(rt.tools) == 0 {
+		t.Error("tools is empty; the model would have nothing to call")
+	}
+}
+
+// TestBuildRuntimeRegistersClosers checks every acquisition still pushes its
+// cleanup. Losing one leaks a sandbox, a process tree, or an LSP server.
+func TestBuildRuntimeRegistersClosers(t *testing.T) {
+	isolate(t)
+	o := defaultOptions()
+	for _, opt := range []Option{WithSubagents(false), WithLSP(LSPOff)} {
+		opt(&o)
+	}
+
+	a := &Agent{workDir: t.TempDir()}
+	cfg := config.Config{}
+	if _, err := a.buildRuntime(t.Context(), o, &cfg, "anthropic"); err != nil {
+		t.Fatalf("buildRuntime: %v", err)
+	}
+
+	// sandbox, bash supervisor, orchestrator, memory, palace, LSP.
+	if want := 6; len(a.closers) != want {
+		t.Errorf("registered %d closers, want %d: one subsystem is not being released", len(a.closers), want)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if a.closers != nil {
+		t.Error("Close did not clear the closer list")
+	}
+	// Close is documented as safe to call more than once.
+	if err := a.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+// TestBuildRuntimeCoreToolsPresent checks the base tool set survives the move.
+func TestBuildRuntimeCoreToolsPresent(t *testing.T) {
+	_, rt := buildTestRuntime(t, "anthropic")
+	for _, name := range []string{"bash", "read", "write", "edit", "bash_wait", "bash_kill"} {
+		if !hasTool(rt.tools, name) {
+			t.Errorf("core tool %q is missing; got %v", name, toolNames(rt.tools))
+		}
+	}
+}
+
+// TestBuildRuntimeExtraToolsComeLast pins the append order the original
+// comment insisted on: caller-supplied tools are appended, never substituted,
+// so the core set is still there in front of them.
+func TestBuildRuntimeExtraToolsComeLast(t *testing.T) {
+	extra := markerTool(t, "piagent_test_marker")
+
+	_, rt := buildTestRuntime(t, "anthropic", WithTools(extra))
+
+	if len(rt.tools) < 2 {
+		t.Fatalf("got %d tools, want the core set plus the extra", len(rt.tools))
+	}
+	if got := rt.tools[len(rt.tools)-1].Name(); got != "piagent_test_marker" {
+		t.Errorf("last tool = %q, want the caller's tool appended last", got)
+	}
+	if !hasTool(rt.tools, "bash") {
+		t.Error("core tools were replaced rather than appended to")
+	}
+}
+
+// TestBuildRuntimeSubagentToolsAreOptional covers the one conditional block in
+// the tool assembly.
+func TestBuildRuntimeSubagentToolsAreOptional(t *testing.T) {
+	_, off := buildTestRuntime(t, "anthropic", WithSubagents(false))
+	_, on := buildTestRuntime(t, "anthropic", WithSubagents(true))
+
+	if len(on.tools) <= len(off.tools) {
+		t.Fatalf("subagents on gave %d tools, off gave %d; enabling them must add tools",
+			len(on.tools), len(off.tools))
+	}
+	// Whatever the extra tools are called, none of them may appear when
+	// subagents are disabled.
+	offNames := map[string]bool{}
+	for _, n := range toolNames(off.tools) {
+		offNames[n] = true
+	}
+	added := 0
+	for _, n := range toolNames(on.tools) {
+		if !offNames[n] {
+			added++
+		}
+	}
+	if added == 0 {
+		t.Error("enabling subagents added no uniquely named tool")
+	}
+}
+
+// TestBuildRuntimeGeminiGrounding pins the provider-conditional tool. It is
+// appended, so on a non-Gemini provider the list must be otherwise identical.
+func TestBuildRuntimeGeminiGrounding(t *testing.T) {
+	_, gemini := buildTestRuntime(t, "gemini")
+	_, anthropic := buildTestRuntime(t, "anthropic")
+
+	if len(gemini.tools) != len(anthropic.tools)+1 {
+		t.Fatalf("gemini gave %d tools, anthropic %d; want exactly one more",
+			len(gemini.tools), len(anthropic.tools))
+	}
+	// The grounding tool is the last thing appended before the caller's tools,
+	// and there are none here.
+	if gemini.tools[len(gemini.tools)-1].Name() == anthropic.tools[len(anthropic.tools)-1].Name() {
+		t.Error("gemini's extra tool is not at the tail where it was appended")
+	}
+}
+
+// TestBuildRuntimeGroundingDisabledByEnv checks the escape hatch still works
+// through the extracted path.
+func TestBuildRuntimeGroundingDisabledByEnv(t *testing.T) {
+	t.Setenv("PI_NO_GROUNDING", "1")
+	_, gemini := buildTestRuntime(t, "gemini")
+	_, anthropic := buildTestRuntime(t, "anthropic")
+
+	if len(gemini.tools) != len(anthropic.tools) {
+		t.Errorf("grounding disabled: gemini gave %d tools, anthropic %d; want equal",
+			len(gemini.tools), len(anthropic.tools))
+	}
+}
+
+// TestBuildRuntimeMemoryOffLeavesStoreNil checks buildRuntime's one write to
+// the Agent it is a method on. New reads a.memStore afterwards to build the
+// memory context, so this is a real cross-function dependency.
+func TestBuildRuntimeMemoryOffLeavesStoreNil(t *testing.T) {
+	a, rt := buildTestRuntime(t, "anthropic")
+	if a.memStore != nil {
+		t.Error("memStore is set with memory disabled")
+	}
+	if rt.memWorker != nil {
+		t.Error("memWorker is set with memory disabled")
+	}
+	// No memory means no memory tools.
+	if hasTool(rt.tools, "memory_recall") {
+		t.Error("memory tools present with memory disabled")
+	}
+}
+
+// TestBuildRuntimePalaceOffLeavesContextEmpty covers the field New appends to
+// the instruction only when non-empty.
+func TestBuildRuntimePalaceOffLeavesContextEmpty(t *testing.T) {
+	_, rt := buildTestRuntime(t, "anthropic")
+	if rt.palaceContext != "" {
+		t.Errorf("palaceContext = %q, want empty with palace disabled", rt.palaceContext)
+	}
+}
+
+// TestNewWiresRuntimeIntoTheAgent checks the seam between New and
+// buildRuntime end to end: the tool list the runtime produced is the one the
+// agent exposes, and the agent is usable afterwards.
+func TestNewWiresRuntimeIntoTheAgent(t *testing.T) {
+	marker := markerTool(t, "piagent_new_marker")
+
+	llm := &fakeLLM{name: "claude-test", reply: "ok"}
+	ag := newTestAgent(t, llm, WithTools(marker))
+
+	tools := ag.Tools()
+	if len(tools) == 0 {
+		t.Fatal("agent exposes no tools")
+	}
+	if got := tools[len(tools)-1].Name(); got != "piagent_new_marker" {
+		t.Errorf("last tool = %q, want the caller's tool", got)
+	}
+	if !hasTool(tools, "bash") {
+		t.Error("core tools missing from the assembled agent")
+	}
+
+	// The orchestrator reached onNewSession, which is where rt.orch is used.
+	sessionID, err := ag.NewSession(t.Context())
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if sessionID == "" {
+		t.Error("NewSession returned an empty id")
+	}
+}
+
+// TestNewRejectsMalformedConfig covers New's third early return, and pins that
+// it fires before any subsystem is acquired — the assembly buildRuntime now
+// owns must not have started, so there is nothing to leak.
+func TestNewRejectsMalformedConfig(t *testing.T) {
+	isolate(t)
+	workDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workDir, ".pi-go"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".pi-go", "config.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ag, err := New(t.Context(),
+		WithModel(&fakeLLM{name: "claude-test", reply: "ok"}),
+		WithWorkingDir(workDir),
+		WithSessionDir(t.TempDir()),
+		WithSubagents(false),
+		WithLSP(LSPOff),
+	)
+	if err == nil {
+		_ = ag.Close()
+		t.Fatal("expected an error for a malformed config")
+	}
+	if ag != nil {
+		t.Error("expected a nil agent alongside the error")
+	}
+	if !strings.Contains(err.Error(), "loading config") {
+		t.Errorf("error = %q, want a config-loading failure", err)
+	}
+}


### PR DESCRIPTION
Replaces #189, which was closed. That branch made the same kind of change but landed 96 files as one 13k-line commit with no measurements, which made the behaviour-preservation argument unauditable. This one carries the numbers.

## What this does

Reduces **all 81 functions above cyclomatic complexity 15** — across 18 packages — to 15 or below.

| Metric | before | after |
|---|---|---|
| **Max CC** | **37** | **15** |
| **Functions over CC 15** | **81** | **0** |
| Functions over CC 20 / 30 | 38 / 5 | 0 / 0 |
| **Decision points** (total CC − functions) | **8972** | **8809** |
| Average CC | 4.514 | 4.082 |
| Total cognitive complexity | 12039 | 11188 |
| Max cognitive complexity | 89 | 41 |

Total CC rises 11525 → 11667 while function count rises 2553 → 2858. That is the +1 baseline every function carries, not complexity moving sideways — decision points fall by 163, and cognitive complexity, which has no such baseline, falls by 851. **No function anywhere in the repo got more complex**, verified by joining the before/after measurements on package+function+file.

Both metrics are reported because they disagree usefully: a flat `switch` scores high CC and near-zero cognitive complexity. Chasing CC alone would have rewritten harmless dispatch tables and left the genuinely unreadable code alone.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test ./... -count=1` | **45 packages, 0 failures** |
| `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` | **0 issues** |

The lint run disables golangci-lint's configured truncation (`max-issues-per-linter: 50`, `max-same-issues: 5`) — a default run hides a systematic problem behind a count of 5.

Tests ran with `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `GEMINI_API_KEY` and `GOOGLE_API_KEY` stripped, so nothing can pass locally by reaching a real endpoint and then fail in CI. The baseline was measured the same way in a pristine worktree at the branch point — before and after are two runs of one command, not one measurement and one recollection.

## Coverage

**Every package touched gained coverage. None regressed.** Mean across all 45 packages: **89.64% → 90.29%**.

| Package | before | after | |
|---|---|---|---|
| `internal/tui/refs` | 87.0% | 90.7% | +3.7 |
| `internal/palace` | 83.7% | 87.1% | +3.4 |
| `internal/subagent` | 88.5% | 91.8% | +3.3 |
| `internal/webserver` | 87.5% | 90.4% | +2.9 |
| `internal/tools` | 87.5% | 89.8% | +2.3 |
| `internal/codex` | 83.7% | 86.0% | +2.3 |
| `internal/cli` | 80.5% | 82.8% | +2.3 |
| `internal/tui` | 90.5% | 92.2% | +1.7 |
| `internal/extension` | 85.9% | 87.5% | +1.6 |
| `internal/config` | 90.7% | 92.3% | +1.6 |
| `internal/provider` | 92.5% | 93.5% | +1.0 |
| `internal/auth` | 89.6% | 90.5% | +0.9 |
| `internal/pirpc` | 96.6% | 97.4% | +0.8 |
| `internal/acp/server/adapter` | 99.5% | 100.0% | +0.5 |
| `piagent` | 91.4% | 91.7% | +0.3 |
| `internal/acp/server` | 88.8% | 89.0% | +0.2 |
| `internal/session` | 88.4% | 88.6% | +0.2 |
| `internal/audit` | 95.3% | 95.4% | +0.1 |

~1,400 new cases in 21 new `complexity_*_test.go` files. **No existing test file was modified** — nothing was weakened to make the refactor pass.

## How behaviour preservation was established

Not by "the tests still pass". The pre-existing tests did not reach many of these branches — which is precisely how the functions grew this large.

1. **Byte-identical golden corpora captured from pre-refactor code**, via read-only `git archive HEAD` exports taken *before* any source edit. `internal/tui` has a 350-case / 86KB rendering corpus (`renderMessages` across 4 message sets × 3 widths × streaming on/off, every tool-card kind, 20 status-bar configs, 38 `toolCallSummary` arg shapes, 29 `formatToolResult` payloads); `cmp` before/after is **identical**. The harness stays behind `PI_RENDER_GOLDEN_OUT` so the next refactor gets the same diff free. `internal/provider`'s goldens are additionally **mutation-checked** — altering the tool-result placeholder in the pre-refactor source makes them fail, proving the assertions aren't vacuous.
2. **Exhaustive equivalence proof** where the domain is finite: `audit.isEmoji`'s new range table is asserted against a verbatim transcription of the original condition chain across **every code point from 0 to 0x10FFFF**.
3. **Mechanical diffs against `main`** for table conversions — including the slash-command autocomplete list diffed *in order*, because `completeSlashCommand` returns the first prefix match, so order is behaviour rather than presentation.

## Where reduction was deliberately refused

- `tui.blankFast` stops at CC 9 / COG 16. Documented hot path; `skipFastCSI` confirmed inlined via `-gcflags=-m`, benchmarked 308µs → 302µs, allocations unchanged. Going lower means splitting the per-byte scan loop, which would not inline.
- `tui.updateTerminal` stops at CC 14 — its ~12-case type switch is the floor. The case *bodies* were extracted (COG 17 → 5) rather than shredding arms to move CC elsewhere.
- `toolCallSummary`'s table conversion is partial: `ls` stayed in the switch because a *present but empty* `path` returns `""` while an *absent* one returns `"."`.
- Several flat dispatch switches left alone. A flat switch is not a defect.

## ⚠️ Pre-existing bug found, deliberately not fixed here

**`subagent.(*WorktreeManager).Create` destroys uncommitted work on failure.** The failure path is commented *"Restore stashed changes on failure"* but runs `git stash drop` — which deletes the entry **without applying it**, and `stash push -u` has already reverted the working tree. Verified empirically in a throwaway repo: the changes do not come back, the stash list is empty, and they survive only as a dangling commit until gc. `MergeBack` in the same file does it correctly via `popStashByMessage` (apply, then drop).

This is on `main` today and is a live mechanism for what CLAUDE.md warns about — *"Work has been lost to this."* Any subagent spawn while the primary checkout is dirty is one failed `worktree add` away from losing it.

It is **not fixed here**, because this PR is behaviour-preserving. Current behaviour is pinned by `TestCreate_DropsStashWhenWorktreeAddFails`, which asserts the dirty file does *not* return, with a comment stating this is the bug and that a fixer should expect the test to fail and flip its assertions. The fix is one line (`popStashByMessage(stashMsg)`) and belongs in its own reviewable commit.

## Other findings recorded, not fixed

- `spawner_timeout_test.go` flakes ~1 run in 5 under load (700ms cap racing a 500ms window). Confirmed pre-existing: a scratch build with all five source files restored from `HEAD` flakes identically.
- `internal/codex` coverage is nondeterministic (85.5–86.7%); variance is in pre-existing app-server subprocess tests.
- `piagent.buildRuntime` takes `cfg *config.Config` deliberately — `NewOrchestrator` retains the pointer. `Orchestrator` exposes no config accessor, so this is the one behaviour-preservation claim resting on inspection rather than a test.

Full per-function tables, load-bearing ordering notes, and follow-up list: **`docs/complexity-refactor.md`**.

https://claude.ai/code/session_011EA5xKa7i4BnC1TzWADXCE
