### PR TITLE
fix(subagent): stop destroying uncommitted work on every stash disposal path

### DIFF
--- a/internal/subagent/complexity_subagent_test.go
+++ b/internal/subagent/complexity_subagent_test.go
@@ -402,22 +402,22 @@ func TestAddWorktree_AttachesExistingBranch(t *testing.T) {
 	}
 }
 
-// TestCreate_DropsStashWhenWorktreeAddFails is the safety-critical case: the
-// stash push succeeded, then `git worktree add` failed. Create must not record
-// the agent, and must not leave the entry orphaned in the stash list.
+// TestCreate_RecordsNothingWhenWorktreeAddFails is the safety-critical case:
+// the stash push succeeded, then `git worktree add` failed. Create must not
+// record the agent, and must not leave the entry orphaned in the stash list.
 //
-// It pins CURRENT behavior, which is not the behavior the code's own comment
-// claims. The comment says "Restore stashed changes on failure"; the code runs
-// `git stash drop`, which deletes the entry WITHOUT applying it — so the
-// uncommitted work the stash was protecting is destroyed. The assertions below
-// spell that out (the dirty file does not come back). This is pre-existing on
-// main and was preserved deliberately: this refactor is behavior-preserving, so
-// fixing it is a separate change. Compare (*WorktreeManager).MergeBack, which
-// gets it right via popStashByMessage (apply, then drop).
+// This test used to be TestCreate_DropsStashWhenWorktreeAddFails and pinned the
+// opposite outcome — it asserted that dirty.txt did NOT come back, because the
+// failure path ran `git stash drop`, deleting the entry WITHOUT applying it and
+// destroying the uncommitted work the stash was protecting. That was left in
+// place deliberately (the refactor it shipped with was behavior-preserving) with
+// a note telling whoever fixed it to flip the assertions to "dirty.txt is
+// restored". That fix has landed, so the assertion below is flipped.
 //
-// Whoever fixes it should expect this test to fail and should flip these
-// assertions to "dirty.txt is restored".
-func TestCreate_DropsStashWhenWorktreeAddFails(t *testing.T) {
+// The restore itself is covered in depth by worktree_stash_test.go; what this
+// test still uniquely pins is Create's bookkeeping after a failure — no active
+// entry, no path recorded.
+func TestCreate_RecordsNothingWhenWorktreeAddFails(t *testing.T) {
 	repo := initTestRepo(t)
 	mgr := NewWorktreeManager(repo)
 
@@ -444,11 +444,11 @@ func TestCreate_DropsStashWhenWorktreeAddFails(t *testing.T) {
 	if n := stashCount(t, repo); n != 0 {
 		t.Errorf("stash list has %d entries after a failed Create, want 0", n)
 	}
-	// The stash was dropped, not applied: the user's uncommitted file is gone
-	// and is no longer recoverable from the stash list. See the doc comment.
-	if _, statErr := os.Stat(filepath.Join(repo, "dirty.txt")); !os.IsNotExist(statErr) {
-		t.Errorf("dirty.txt was restored (stat err = %v); the drop-without-apply "+
-			"behavior this test pins has changed — update the test if that was intended", statErr)
+	// The stash was applied, not dropped: the user's uncommitted file is back
+	// in the working tree. See the doc comment.
+	if _, statErr := os.Stat(filepath.Join(repo, "dirty.txt")); statErr != nil {
+		t.Errorf("dirty.txt was not restored (stat err = %v); the failed "+
+			"worktree add destroyed the user's uncommitted work", statErr)
 	}
 	if mgr.Active() != 0 {
 		t.Errorf("Active() = %d after a failed Create, want 0", mgr.Active())

--- a/internal/subagent/complexity_subagent_test.go
+++ b/internal/subagent/complexity_subagent_test.go
@@ -332,9 +332,14 @@ func TestStashBeforeWorktreeAdd_DirtyTree(t *testing.T) {
 		t.Fatalf("stash list has %d entries, want 1", n)
 	}
 	// The message must be the one findStashByMessage can locate, which is what
-	// makes the eventual pop deterministic.
-	if _, found := mgr.findStashByMessage(msg); !found {
+	// makes the eventual pop deterministic. It must also yield an object id —
+	// that is what the apply addresses the entry by.
+	ref, oid, found := mgr.findStashByMessage(msg)
+	if !found {
 		t.Errorf("stash entry for message %q not found", msg)
+	}
+	if ref == "" || oid == "" {
+		t.Errorf("findStashByMessage returned ref=%q oid=%q, want both non-empty", ref, oid)
 	}
 }
 

--- a/internal/subagent/worktree.go
+++ b/internal/subagent/worktree.go
@@ -19,6 +19,13 @@ type WorktreeManager struct {
 	mu       sync.Mutex
 	inflight sync.WaitGroup // tracks in-flight Cleanup calls
 	closed   bool           // set by CleanupAll to reject late Cleanup calls
+
+	// gitRunner replaces the git exec when non-nil; nil means real git.
+	// Create's recovery paths depend on what the repo looks like *between*
+	// two of its git invocations (another process pushing a stash, a file
+	// reappearing), which is otherwise unreachable from a test. Set it before
+	// the manager is used; it is not guarded by mu.
+	gitRunner func(dir string, args ...string) (string, error)
 }
 
 type worktreeInfo struct {
@@ -92,20 +99,59 @@ func (m *WorktreeManager) stashIndexAfter() (int, error) {
 	return len(strings.Split(out, "\n")), nil
 }
 
-// popStashByMessage pops the most recent stash entry whose message matches.
-// Falls back to a plain `stash pop` if the by-message approach fails.
+// The stash lifecycle
+//
+// Create takes a stash so that `git worktree add` sees a clean tree. That
+// entry holds the *user's* uncommitted work — not the agent's, which lives on
+// the worktree branch — and for as long as it exists the working tree no
+// longer holds a copy of it. One rule follows, and every disposal site in this
+// file obeys it:
+//
+//	An entry Create pushed may leave the stash list only after it has been
+//	successfully applied back to the working tree. Every other exit — a failed
+//	`worktree add`, a failed apply, a run abandoned before MergeBack — leaves
+//	the entry where the user can see it and reports why.
+//
+// `git stash drop` on an entry that was never applied is therefore never
+// correct here: it deletes the content instead of restoring it, leaving it
+// reachable only as a dangling commit until gc. A stash list with one extra
+// entry in it is cheap; the work inside that entry is not.
+
+// errStashEntryGone reports that no stash entry carries the requested message.
+// Callers for which a vanished entry is benign — MergeBack and cleanupWorktree
+// both run after something else may already have restored it — filter it out
+// with errors.Is. Create does not: it pushed the entry moments earlier, so its
+// absence there means something went wrong.
+var errStashEntryGone = errors.New("stash entry not found")
+
+// popStashByMessage restores the stash entry whose message matches msg and
+// then removes it from the stash list. A failed apply leaves the entry in
+// place, per "The stash lifecycle" above.
+//
+// The entry is located by message rather than assumed to sit at stash@{0}:
+// anything else with access to the repo — the user, an editor plugin, another
+// pi-go agent — can push a stash between our push and our pop, and applying
+// the top entry blindly would then restore someone else's work over the
+// working tree while leaving ours behind. A message that matches no entry is
+// reported as errStashEntryGone; it never falls back to whatever happens to be
+// on top.
 func (m *WorktreeManager) popStashByMessage(msg string) error {
+	entry, found := m.findStashByMessage(msg)
+	if !found {
+		return fmt.Errorf("%w: %q", errStashEntryGone, msg)
+	}
 	// `git stash pop` is destructive and may collide with new edits.
-	// Try `git stash apply` first so the entry survives if anything goes
+	// Use `git stash apply` first so the entry survives if anything goes
 	// wrong; then drop it explicitly.
-	if out, err := m.git("stash", "apply", "--quiet", "stash@{0}"); err != nil {
+	if out, err := m.git("stash", "apply", "--quiet", entry); err != nil {
 		// If apply failed, the entry is still in the stash list — return the
 		// error but don't drop, so the user can recover manually.
-		return fmt.Errorf("git stash apply: %w: %s", err, out)
+		return fmt.Errorf("git stash apply %s (%s): %w: %s", entry, msg, err, out)
 	}
-	// Best-effort drop. If drop fails (rare), the entry stays in the list
-	// and the user can clean up with `git stash drop`.
-	_, _ = m.git("stash", "drop", "--quiet", "stash@{0}")
+	// `git stash apply` leaves the stash list untouched, so `entry` still
+	// addresses the same commit. Best-effort drop: if it fails (rare), the
+	// entry stays in the list and the user can clean up with `git stash drop`.
+	_, _ = m.git("stash", "drop", "--quiet", entry)
 	return nil
 }
 
@@ -188,8 +234,8 @@ func (m *WorktreeManager) addWorktree(wtPath, branch string, branchExists bool) 
 
 // Create creates a new git worktree for the given agent ID.
 // If the current branch has uncommitted changes, they are stashed before
-// creating the worktree and tracked in `pendingStash` so that MergeBack
-// or Cleanup can pop them later (with a unique message).
+// creating the worktree and recorded in worktreeInfo.StashMsg so that MergeBack
+// or Cleanup can restore them later (looked up by that unique message).
 // Returns the filesystem path to the worktree.
 func (m *WorktreeManager) Create(agentID string, requestedName ...string) (string, error) {
 	m.mu.Lock()
@@ -236,21 +282,30 @@ func (m *WorktreeManager) Create(agentID string, requestedName ...string) (strin
 
 	// Everything from here to the success path below is paired with that
 	// stash: the only exit between the two is the failure branch immediately
-	// after `worktree add`, which disposes of the stash entry explicitly.
-	if err := m.addWorktree(wtPath, branch, branchExists); err != nil {
-		// Restore stashed changes on failure. We do this regardless of
-		// what the stash list held beforehand — if anything landed in
-		// the stash list, drop it so the user isn't left with orphaned
-		// entries after a failed Create.
-		if stashedSomething {
-			_, _ = m.git("stash", "drop", "--quiet", "stash@{0}")
+	// after `worktree add`, which restores the stash entry explicitly.
+	if addErr := m.addWorktree(wtPath, branch, branchExists); addErr != nil {
+		if !stashedSomething {
+			return "", addErr
 		}
-		return "", err
+		// Put the stashed changes back. `git stash push -u` has already
+		// reverted the working tree, so at this point the user's uncommitted
+		// work exists *only* as a stash entry: dropping it here (which is what
+		// this branch used to do) deletes it without applying it, leaving the
+		// content reachable only as a dangling commit until gc.
+		if restoreErr := m.popStashByMessage(stashMsg); restoreErr != nil {
+			// A failed restore is worse for the user than the failed worktree
+			// add that got us here, and neither cause may be dropped: they
+			// need to know why the worktree failed *and* that their work is
+			// still sitting in the stash. Both are wrapped so errors.Is/As
+			// still sees them.
+			return "", fmt.Errorf("%w; uncommitted changes could NOT be restored and remain stashed as %q — recover them with `git stash list` and `git stash apply`: %w", addErr, stashMsg, restoreErr)
+		}
+		return "", addErr
 	}
 
-	// Stash survives on success — MergeBack/Cleanup will pop it via
-	// pendingStash. Storing the message here makes the pop deterministic
-	// even if other stash entries appear between Create and pop.
+	// Stash survives on success — MergeBack or, failing that, Cleanup restores
+	// it. Storing the message here is what makes that restore deterministic
+	// even if other stash entries appear between Create and it.
 	info := worktreeInfo{Path: wtPath, Branch: branch}
 	if stashedSomething {
 		info.StashMsg = stashMsg
@@ -379,9 +434,9 @@ func (m *WorktreeManager) Cleanup(agentID string) error {
 
 // cleanupWorktree performs the git operations to remove a worktree and its branch.
 // If cleanup fails, the entry is re-added to the active map so callers can retry.
-// If a stash was created during Create and not yet popped (e.g. MergeBack was
-// never called), the stash entry is best-effort dropped here so it doesn't
-// accumulate in the stash list.
+// If a stash was created during Create and not yet restored (e.g. MergeBack
+// was never called), it is applied back to the working tree here and only then
+// dropped; a failed restore is reported and leaves the entry in place.
 func (m *WorktreeManager) cleanupWorktree(agentID string, info worktreeInfo) error {
 	var errs []string
 
@@ -408,12 +463,20 @@ func (m *WorktreeManager) cleanupWorktree(agentID string, info worktreeInfo) err
 		}
 	}
 
-	// Best-effort: drop any stash entry this worktree created. We do this
-	// after the worktree/branch are removed because applying a stash to a
-	// dirty working tree would just re-introduce the conflict.
+	// Restore any stash still outstanding from Create. Reaching here with one
+	// means MergeBack never ran — a spawn that failed, a shutdown mid-setup, a
+	// result the caller discarded — so this is the last place that can hand
+	// the user's uncommitted work back to them. Dropping it instead, which is
+	// what this did, destroyed work that had nothing to do with the agent on
+	// paths that are not even error paths (see "The stash lifecycle").
+	//
+	// It runs after the worktree and branch are gone so the checkout the stash
+	// restores into is the main tree, never one git is about to remove.
 	if info.StashMsg != "" {
-		if entry, found := m.findStashByMessage(info.StashMsg); found {
-			_, _ = m.git("stash", "drop", "--quiet", entry)
+		// errStashEntryGone is expected and benign: MergeBack already restored
+		// and dropped the entry, or the user popped it themselves.
+		if err := m.popStashByMessage(info.StashMsg); err != nil && !errors.Is(err, errStashEntryGone) {
+			errs = append(errs, fmt.Sprintf("restore stashed changes: %v (your uncommitted work is still stashed as %q — recover it with `git stash list` and `git stash apply`)", err, info.StashMsg))
 		}
 	}
 
@@ -430,8 +493,9 @@ func (m *WorktreeManager) cleanupWorktree(agentID string, info worktreeInfo) err
 // MergeBack merges the worktree branch back into the current branch of the
 // main worktree. Returns the merge output.
 //
-// On a successful merge, any stash created during Create is applied back
-// to the main repo and dropped from the stash list.
+// On a successful merge, any stash created during Create is applied back to
+// the main repo and then dropped. If that apply fails the entry is left in the
+// stash list and the failure is returned, per "The stash lifecycle".
 //
 // On a merge conflict, the merge is aborted (so the main repo is left in a
 // clean state) and the worktree is preserved so the user can inspect and
@@ -466,15 +530,15 @@ func (m *WorktreeManager) MergeBack(agentID string) (string, error) {
 	// We do this only if a stash was recorded; otherwise the main repo
 	// is already clean.
 	if info.StashMsg != "" {
-		if entry, found := m.findStashByMessage(info.StashMsg); found {
-			if applyErr := m.popStashByMessage(info.StashMsg); applyErr != nil {
-				// Stash apply failed (likely conflicts with the merge).
-				// Drop the entry anyway so the stash list stays bounded —
-				// the user can recover via `git stash show` + cherry-pick
-				// or by checking the worktree branch.
-				_, _ = m.git("stash", "drop", "--quiet", entry)
-				return out, fmt.Errorf("merge succeeded but stash apply failed: %w (merge output: %s)", applyErr, out)
-			}
+		// errStashEntryGone is benign here: nothing was outstanding to restore.
+		if applyErr := m.popStashByMessage(info.StashMsg); applyErr != nil && !errors.Is(applyErr, errStashEntryGone) {
+			// The entry stays in the stash list. Apply usually fails because
+			// the merge just landed changes that collide with it, which means
+			// the stash is now the only copy of the user's work — this used to
+			// drop it "so the stash list stays bounded" while pointing the
+			// user at `git stash show`, which by then had nothing left to
+			// show. See "The stash lifecycle".
+			return out, fmt.Errorf("merge succeeded but restoring your stashed changes failed: %w — they are still stashed as %q, recover them with `git stash list` and `git stash apply` (merge output: %s)", applyErr, info.StashMsg, out)
 		}
 	}
 
@@ -614,6 +678,14 @@ func (m *WorktreeManager) git(args ...string) (string, error) {
 
 // gitIn runs a git command in the given directory and returns combined output.
 func (m *WorktreeManager) gitIn(dir string, args ...string) (string, error) {
+	if m.gitRunner != nil {
+		return m.gitRunner(dir, args...)
+	}
+	return runGit(dir, args...)
+}
+
+// runGit shells out to git in dir and returns trimmed combined output.
+func runGit(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()

--- a/internal/subagent/worktree.go
+++ b/internal/subagent/worktree.go
@@ -135,24 +135,55 @@ var errStashEntryGone = errors.New("stash entry not found")
 // working tree while leaving ours behind. A message that matches no entry is
 // reported as errStashEntryGone; it never falls back to whatever happens to be
 // on top.
+//
+// Both git commands address the entry by its immutable object id wherever git
+// allows it, because `stash@{N}` is positional: an external push or drop
+// between our lookup and our command renumbers every entry beneath it. Apply
+// takes the object id directly. Drop does not accept one ("is not a stash
+// reference"), so the ref is re-resolved and its object id re-checked
+// immediately beforehand; if it no longer names the entry we just applied we
+// leave the list alone rather than delete a stranger's stash. The manager
+// mutex cannot help here — it does not serialize git invocations from other
+// processes.
 func (m *WorktreeManager) popStashByMessage(msg string) error {
-	entry, found := m.findStashByMessage(msg)
+	entry, oid, found := m.findStashByMessage(msg)
 	if !found {
 		return fmt.Errorf("%w: %q", errStashEntryGone, msg)
 	}
 	// `git stash pop` is destructive and may collide with new edits.
 	// Use `git stash apply` first so the entry survives if anything goes
-	// wrong; then drop it explicitly.
-	if out, err := m.git("stash", "apply", "--quiet", entry); err != nil {
+	// wrong; then drop it explicitly. Applying by object id cannot pick up a
+	// different entry if the list shifted since the lookup.
+	if out, err := m.git("stash", "apply", "--quiet", oid); err != nil {
 		// If apply failed, the entry is still in the stash list — return the
 		// error but don't drop, so the user can recover manually.
-		return fmt.Errorf("git stash apply %s (%s): %w: %s", entry, msg, err, out)
+		return fmt.Errorf("git stash apply %s (%s): %w: %s", oid, msg, err, out)
 	}
-	// `git stash apply` leaves the stash list untouched, so `entry` still
-	// addresses the same commit. Best-effort drop: if it fails (rare), the
-	// entry stays in the list and the user can clean up with `git stash drop`.
-	_, _ = m.git("stash", "drop", "--quiet", entry)
+	m.dropStashEntry(entry, oid, msg)
 	return nil
+}
+
+// dropStashEntry removes the stash entry that popStashByMessage just applied,
+// but only if `stash@{N}` still names that exact object.
+//
+// Every failure here is deliberately silent and non-fatal: the content is
+// already back in the working tree, so the worst outcome is a stale entry the
+// user can clear with `git stash drop`. Deleting the wrong entry, by contrast,
+// destroys work — so a mismatch is always resolved in favor of keeping both.
+func (m *WorktreeManager) dropStashEntry(entry, oid, msg string) {
+	// Re-resolve rather than trusting the ref captured before the apply: an
+	// external `git stash push` in that window shifts every index by one, and
+	// dropping the stale ref would delete whatever now sits at that position.
+	nowEntry, nowOID, ok := m.findStashByMessage(msg)
+	if !ok || nowOID != oid {
+		return
+	}
+	if nowEntry != entry {
+		// The list renumbered under us but the entry survived; drop where it
+		// actually is now.
+		entry = nowEntry
+	}
+	_, _ = m.git("stash", "drop", "--quiet", entry)
 }
 
 // claimExistingWorktree decides what to do about a branch or directory that is
@@ -547,36 +578,37 @@ func (m *WorktreeManager) MergeBack(agentID string) (string, error) {
 	return out, nil
 }
 
-// findStashByMessage returns the stash ref (e.g. "stash@{0}") whose message
-// matches msg, or "" + false if no match is found.
+// findStashByMessage returns the stash ref (e.g. "stash@{0}") AND the entry's
+// immutable object id, for the entry whose message matches msg. Callers need
+// both: the ref is what `git stash drop` accepts, the object id is what makes
+// an operation safe against another process renumbering the list underneath us.
 //
 // Note: `git stash list --format=%s` renders the subject as
 // "On <branch>: <original-message>", so we strip that prefix before comparing.
-func (m *WorktreeManager) findStashByMessage(msg string) (string, bool) {
+func (m *WorktreeManager) findStashByMessage(msg string) (ref, oid string, found bool) {
 	if msg == "" {
-		return "", false
+		return "", "", false
 	}
-	out, err := m.git("stash", "list", "--format=%gd|%s")
+	out, err := m.git("stash", "list", "--format=%gd|%H|%s")
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	for _, line := range strings.Split(out, "\n") {
-		// Format: "stash@{N}|On <branch>: <message>"
-		sep := strings.Index(line, "|")
-		if sep < 0 {
+		// Format: "stash@{N}|<sha>|On <branch>: <message>"
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
 			continue
 		}
-		ref := line[:sep]
-		subject := line[sep+1:]
+		subject := parts[2]
 		// Strip "On <branch>: " prefix.
 		if colon := strings.Index(subject, ": "); colon >= 0 {
 			subject = subject[colon+2:]
 		}
 		if subject == msg {
-			return ref, true
+			return parts[0], parts[1], true
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
 func (m *WorktreeManager) recoverWorktreeInfo(agentID string) (worktreeInfo, error) {

--- a/internal/subagent/worktree_stash_test.go
+++ b/internal/subagent/worktree_stash_test.go
@@ -151,7 +151,7 @@ func TestCreate_RestoreIgnoresDecoyStashEntry(t *testing.T) {
 	if n := stashCount(t, repo); n != 1 {
 		t.Errorf("stash count = %d, want 1 (only the decoy should remain)", n)
 	}
-	if _, found := mgr.findStashByMessage("decoy-entry"); !found {
+	if _, _, found := mgr.findStashByMessage("decoy-entry"); !found {
 		t.Error("decoy entry is gone from the stash list")
 	}
 }
@@ -232,7 +232,7 @@ func TestCreate_KeepsStashOnSuccess(t *testing.T) {
 	if info.StashMsg == "" {
 		t.Fatal("StashMsg not recorded after a successful Create")
 	}
-	if _, found := mgr.findStashByMessage(info.StashMsg); !found {
+	if _, _, found := mgr.findStashByMessage(info.StashMsg); !found {
 		t.Errorf("recorded StashMsg %q does not match any stash entry", info.StashMsg)
 	}
 
@@ -270,7 +270,7 @@ func TestMergeBack_AppliesOwnStashNotDecoy(t *testing.T) {
 	if n := stashCount(t, repo); n != 1 {
 		t.Errorf("stash count = %d, want 1 (only the decoy should remain)", n)
 	}
-	if _, found := mgr.findStashByMessage("decoy-entry"); !found {
+	if _, _, found := mgr.findStashByMessage("decoy-entry"); !found {
 		t.Error("decoy entry is gone from the stash list")
 	}
 }
@@ -409,7 +409,7 @@ func TestCleanup_IgnoresDecoyStashEntry(t *testing.T) {
 	if n := stashCount(t, repo); n != 1 {
 		t.Errorf("stash count = %d, want 1 (only the decoy should remain)", n)
 	}
-	if _, found := mgr.findStashByMessage("decoy-entry"); !found {
+	if _, _, found := mgr.findStashByMessage("decoy-entry"); !found {
 		t.Error("decoy entry is gone from the stash list")
 	}
 }
@@ -472,5 +472,76 @@ func TestMergeBack_KeepsStashWhenApplyFails(t *testing.T) {
 	}
 	if list := stashGit(t, repo, "stash", "list"); !strings.Contains(list, "pi-go-worktree-agent-merge-blocked-") {
 		t.Errorf("stash list %q no longer holds the entry the error points at", list)
+	}
+}
+
+// dropStashEntry is the half of popStashByMessage that git will not let us
+// address by object id. This pins the failure codex flagged: our entry is gone
+// and something else now occupies the ref we captured, so a positional drop
+// would destroy a stranger's work. It must delete nothing.
+func TestDropStashEntry_RefusesWhenOurEntryIsGone(t *testing.T) {
+	repo := initTestRepo(t)
+	m := NewWorktreeManager(repo)
+
+	writeStashFile(t, repo, "tracked.txt", "ours\n")
+	if _, err := m.git("stash", "push", "-u", "-q", "-m", "pi-agent-ours"); err != nil {
+		t.Fatalf("stash ours: %v", err)
+	}
+	ref, oursOID, ok := m.findStashByMessage("pi-agent-ours")
+	if !ok {
+		t.Fatal("our stash entry not found after push")
+	}
+
+	// Our entry disappears (an impatient user, another agent, a manual drop)
+	// and someone else's stash takes the ref we were holding.
+	if _, err := m.git("stash", "drop", "--quiet", ref); err != nil {
+		t.Fatalf("drop ours: %v", err)
+	}
+	writeStashFile(t, repo, "tracked.txt", "theirs\n")
+	if _, err := m.git("stash", "push", "-u", "-q", "-m", "someone-elses-work"); err != nil {
+		t.Fatalf("stash decoy: %v", err)
+	}
+
+	// Same ref, same object id we captured — but that object is no longer in
+	// the list, so nothing may be dropped.
+	m.dropStashEntry(ref, oursOID, "pi-agent-ours")
+
+	if _, _, found := m.findStashByMessage("someone-elses-work"); !found {
+		t.Error("dropStashEntry deleted an unrelated stash entry that had taken our ref")
+	}
+}
+
+// The companion case: the list shifted but our entry is still there, so the
+// drop should find it at its new position and remove exactly that one.
+func TestDropStashEntry_FollowsEntryToItsNewIndex(t *testing.T) {
+	repo := initTestRepo(t)
+	m := NewWorktreeManager(repo)
+
+	writeStashFile(t, repo, "tracked.txt", "ours\n")
+	if _, err := m.git("stash", "push", "-u", "-q", "-m", "pi-agent-ours"); err != nil {
+		t.Fatalf("stash ours: %v", err)
+	}
+	ref, oid, ok := m.findStashByMessage("pi-agent-ours")
+	if !ok {
+		t.Fatal("our stash entry not found after push")
+	}
+	if ref != "stash@{0}" {
+		t.Fatalf("precondition: want our entry at stash@{0}, got %s", ref)
+	}
+
+	writeStashFile(t, repo, "tracked.txt", "theirs\n")
+	if _, err := m.git("stash", "push", "-u", "-q", "-m", "someone-elses-work"); err != nil {
+		t.Fatalf("stash decoy: %v", err)
+	}
+
+	// Same stale ref as the test above, but this time the object id still
+	// resolves, so the entry is followed to stash@{1} and dropped there.
+	m.dropStashEntry(ref, oid, "pi-agent-ours")
+
+	if _, _, found := m.findStashByMessage("pi-agent-ours"); found {
+		t.Error("our entry survived a drop that should have found it at its new index")
+	}
+	if _, _, found := m.findStashByMessage("someone-elses-work"); !found {
+		t.Error("the unrelated entry was destroyed")
 	}
 }

--- a/internal/subagent/worktree_stash_test.go
+++ b/internal/subagent/worktree_stash_test.go
@@ -1,0 +1,476 @@
+package subagent
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests cover the stash round trip Create performs so that
+// `git worktree add` sees a clean tree. Between the `stash push -u` and the
+// matching restore, the user's uncommitted work exists *only* as a stash
+// entry, so every exit from that window has to put it back or say loudly that
+// it could not.
+//
+// Every test here runs against a throwaway repo from initTestRepo (t.TempDir),
+// never the checkout the test binary itself lives in.
+
+// stashGit runs a git command in dir and fails the test if it errors.
+func stashGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s in %s: %v: %s", strings.Join(args, " "), dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// writeStashFile writes name under repo with the given content.
+func writeStashFile(t *testing.T, repo, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// wantStashFile asserts that name exists under repo with exactly content.
+func wantStashFile(t *testing.T, repo, name, content string) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(repo, name))
+	if err != nil {
+		t.Fatalf("%s not restored: %v", name, err)
+	}
+	if string(got) != content {
+		t.Errorf("%s = %q, want %q", name, got, content)
+	}
+}
+
+// dirtyRepo returns a repo holding a committed tracked.txt that has since been
+// modified in the working tree, plus an untracked file. Both halves matter:
+// Create stashes with `-u`, so a restore that only covers tracked changes
+// would still lose the untracked file.
+func dirtyRepo(t *testing.T) string {
+	t.Helper()
+	repo := initTestRepo(t)
+	writeStashFile(t, repo, "tracked.txt", "committed\n")
+	stashGit(t, repo, "add", "tracked.txt")
+	stashGit(t, repo, "commit", "-m", "add tracked.txt")
+
+	writeStashFile(t, repo, "tracked.txt", "user edit\n")
+	writeStashFile(t, repo, "untracked.txt", "user note\n")
+	return repo
+}
+
+// blockedName is a worktree name that survives sanitizeWorktreeName but that
+// git rejects as a branch name (refs may not end in ".lock"). It makes
+// `git worktree add -b` fail *after* Create has already taken the stash, which
+// is the only way to reach the recovery path under test.
+const blockedName = "blocked.lock"
+
+// TestSanitizeWorktreeName_KeepsBlockedName pins the assumption the failure
+// injection rests on. If the sanitizer ever starts rewriting "blocked.lock",
+// `git worktree add` would succeed and the tests below would silently stop
+// exercising the recovery path — this fails loudly instead.
+func TestSanitizeWorktreeName_KeepsBlockedName(t *testing.T) {
+	if got := sanitizeWorktreeName(blockedName); got != blockedName {
+		t.Fatalf("sanitizeWorktreeName(%q) = %q; the worktree-add failure injection no longer works", blockedName, got)
+	}
+}
+
+// TestCreate_RestoresStashWhenWorktreeAddFails is the regression test for the
+// data-loss bug: the failure path used to run `git stash drop`, which deletes
+// the entry without applying it, so the user's uncommitted work survived only
+// as a dangling commit until gc.
+func TestCreate_RestoresStashWhenWorktreeAddFails(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	_, err := mgr.Create("agent-restore", blockedName)
+	if err == nil {
+		t.Fatal("Create succeeded; expected git worktree add to reject the branch name")
+	}
+	if !strings.Contains(err.Error(), "git worktree add") {
+		t.Errorf("error %q does not report the worktree add failure", err)
+	}
+	if strings.Contains(err.Error(), "could NOT be restored") {
+		t.Fatalf("restore itself failed: %v", err)
+	}
+
+	wantStashFile(t, repo, "tracked.txt", "user edit\n")
+	wantStashFile(t, repo, "untracked.txt", "user note\n")
+
+	// A successful restore must also consume the entry: leaving it behind
+	// would strand an orphan in the stash list that nothing ever pops.
+	if n := stashCount(t, repo); n != 0 {
+		t.Errorf("stash count = %d, want 0 (entry should be dropped after a successful apply)", n)
+	}
+	if mgr.Active() != 0 {
+		t.Errorf("Active() = %d, want 0 after a failed Create", mgr.Active())
+	}
+}
+
+// TestCreate_RestoreIgnoresDecoyStashEntry pins the by-message lookup. The
+// restore used to hardcode stash@{0}, so any stash pushed between Create's push
+// and its restore — by the user, an editor, or another agent — would be applied
+// instead, restoring someone else's work over the tree and leaving the user's
+// own entry behind.
+func TestCreate_RestoreIgnoresDecoyStashEntry(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	// Simulate an unrelated stash landing while Create is mid-flight: it is
+	// pushed after Create's own entry, so it becomes stash@{0} and Create's
+	// entry moves to stash@{1}.
+	mgr.gitRunner = func(dir string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "worktree" && args[1] == "add" {
+			writeStashFile(t, repo, "decoy.txt", "not the user's work\n")
+			if out, err := runGit(repo, "stash", "push", "-u", "-m", "decoy-entry"); err != nil {
+				t.Fatalf("pushing decoy stash: %v: %s", err, out)
+			}
+		}
+		return runGit(dir, args...)
+	}
+
+	if _, err := mgr.Create("agent-decoy", blockedName); err == nil {
+		t.Fatal("Create succeeded; expected git worktree add to fail")
+	}
+
+	wantStashFile(t, repo, "tracked.txt", "user edit\n")
+	wantStashFile(t, repo, "untracked.txt", "user note\n")
+
+	// The decoy must be untouched: still stashed, and its file still absent
+	// from the working tree.
+	if _, err := os.Stat(filepath.Join(repo, "decoy.txt")); err == nil {
+		t.Error("decoy.txt was applied to the working tree; the wrong stash entry was restored")
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Errorf("stash count = %d, want 1 (only the decoy should remain)", n)
+	}
+	if _, found := mgr.findStashByMessage("decoy-entry"); !found {
+		t.Error("decoy entry is gone from the stash list")
+	}
+}
+
+// TestCreate_RestoreFailureSurfacesBothCauses covers the worst case: the
+// worktree add failed *and* the stash could not be put back. The entry has to
+// survive, and the returned error has to name both the original failure and
+// the stash the user must recover by hand.
+func TestCreate_RestoreFailureSurfacesBothCauses(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	// Recreate the untracked file after Create stashed it away. `git stash
+	// apply` refuses to overwrite an existing untracked file, so the restore
+	// fails for a reason git itself produces rather than a faked error.
+	mgr.gitRunner = func(dir string, args ...string) (string, error) {
+		out, err := runGit(dir, args...)
+		if len(args) >= 2 && args[0] == "worktree" && args[1] == "add" {
+			writeStashFile(t, repo, "untracked.txt", "in the way\n")
+		}
+		return out, err
+	}
+
+	_, err := mgr.Create("agent-blocked", blockedName)
+	if err == nil {
+		t.Fatal("Create succeeded; expected git worktree add to fail")
+	}
+
+	// Neither cause may be swallowed.
+	if !strings.Contains(err.Error(), "git worktree add") {
+		t.Errorf("error %q lost the worktree add cause", err)
+	}
+	if !strings.Contains(err.Error(), "could NOT be restored") {
+		t.Errorf("error %q does not report that the restore failed", err)
+	}
+	if !strings.Contains(err.Error(), "git stash apply") {
+		t.Errorf("error %q lost the stash apply cause", err)
+	}
+	if !strings.Contains(err.Error(), "pi-go-worktree-agent-blocked-") {
+		t.Errorf("error %q does not name the stash entry the user has to recover", err)
+	}
+
+	// Both causes are wrapped, not just formatted: the worktree add failure is
+	// an *exec.ExitError and must still be reachable through the chain.
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("errors.As could not reach the git exit error in %v", err)
+	}
+
+	// The entry must still be there — that is the user's only copy.
+	if n := stashCount(t, repo); n != 1 {
+		t.Fatalf("stash count = %d, want 1 (a failed restore must not drop the entry)", n)
+	}
+	if list := stashGit(t, repo, "stash", "list"); !strings.Contains(list, "pi-go-worktree-agent-blocked-") {
+		t.Errorf("stash list %q does not hold Create's entry", list)
+	}
+}
+
+// TestCreate_KeepsStashOnSuccess covers the success path: the entry survives
+// Create so MergeBack or Cleanup can deal with it, and it is recorded by the
+// message they look it up with.
+func TestCreate_KeepsStashOnSuccess(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-ok"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = mgr.Cleanup("agent-ok") }()
+
+	if n := stashCount(t, repo); n != 1 {
+		t.Fatalf("stash count = %d, want 1 (stash must survive a successful Create)", n)
+	}
+
+	mgr.mu.Lock()
+	info := mgr.active["agent-ok"]
+	mgr.mu.Unlock()
+	if info.StashMsg == "" {
+		t.Fatal("StashMsg not recorded after a successful Create")
+	}
+	if _, found := mgr.findStashByMessage(info.StashMsg); !found {
+		t.Errorf("recorded StashMsg %q does not match any stash entry", info.StashMsg)
+	}
+
+	// The tree is clean, which is the point of stashing in the first place.
+	if _, err := os.Stat(filepath.Join(repo, "untracked.txt")); err == nil {
+		t.Error("untracked.txt still present; stash push did not clean the tree")
+	}
+}
+
+// TestMergeBack_AppliesOwnStashNotDecoy is the MergeBack half of the by-message
+// lookup: the same stash@{0} assumption meant a concurrent stash could be
+// applied in place of the one Create took.
+func TestMergeBack_AppliesOwnStashNotDecoy(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-merge-decoy"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = mgr.Cleanup("agent-merge-decoy") }()
+
+	// Someone else stashes while the agent is running.
+	writeStashFile(t, repo, "decoy.txt", "not the user's work\n")
+	stashGit(t, repo, "stash", "push", "-u", "-m", "decoy-entry")
+
+	if _, err := mgr.MergeBack("agent-merge-decoy"); err != nil {
+		t.Fatalf("MergeBack: %v", err)
+	}
+
+	wantStashFile(t, repo, "tracked.txt", "user edit\n")
+	wantStashFile(t, repo, "untracked.txt", "user note\n")
+	if _, err := os.Stat(filepath.Join(repo, "decoy.txt")); err == nil {
+		t.Error("decoy.txt was applied; MergeBack restored the wrong stash entry")
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Errorf("stash count = %d, want 1 (only the decoy should remain)", n)
+	}
+	if _, found := mgr.findStashByMessage("decoy-entry"); !found {
+		t.Error("decoy entry is gone from the stash list")
+	}
+}
+
+// TestPopStashByMessage_MissingEntry checks the explicit not-found path: with
+// no matching entry, popStashByMessage reports it rather than falling back to
+// whatever sits on top of the stash.
+func TestPopStashByMessage_MissingEntry(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	writeStashFile(t, repo, "someone-elses.txt", "unrelated\n")
+	stashGit(t, repo, "stash", "push", "-u", "-m", "unrelated-entry")
+
+	err := mgr.popStashByMessage("pi-go-worktree-never-pushed")
+	if err == nil {
+		t.Fatal("popStashByMessage succeeded with no matching entry")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error %q does not report a missing entry", err)
+	}
+
+	if n := stashCount(t, repo); n != 1 {
+		t.Errorf("stash count = %d, want 1 (the unrelated entry must be untouched)", n)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, "someone-elses.txt")); statErr == nil {
+		t.Error("the unrelated stash entry was applied")
+	}
+}
+
+// TestPopStashByMessage_ApplyFailureKeepsEntry checks that a failed apply
+// leaves the entry in the list, since that is the user's route back to the
+// content.
+func TestPopStashByMessage_ApplyFailureKeepsEntry(t *testing.T) {
+	repo := initTestRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	writeStashFile(t, repo, "note.txt", "stashed\n")
+	stashGit(t, repo, "stash", "push", "-u", "-m", "keep-me")
+
+	// An untracked file at the same path makes `git stash apply` bail out.
+	writeStashFile(t, repo, "note.txt", "in the way\n")
+
+	err := mgr.popStashByMessage("keep-me")
+	if err == nil {
+		t.Fatal("popStashByMessage succeeded despite the blocked apply")
+	}
+	if !strings.Contains(err.Error(), "git stash apply") {
+		t.Errorf("error %q does not report the apply failure", err)
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Errorf("stash count = %d, want 1 (a failed apply must not drop the entry)", n)
+	}
+}
+
+// TestCleanup_RestoresStashWhenMergeBackSkipped is the regression test for the
+// path that is reachable without anything going wrong in git: a run that ends
+// before MergeBack (a failed spawn, a shutdown mid-setup, a discarded result)
+// used to reach `stash drop` and delete the user's uncommitted work.
+func TestCleanup_RestoresStashWhenMergeBackSkipped(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-abandoned"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Fatalf("stash count after Create = %d, want 1", n)
+	}
+
+	// No MergeBack — straight to Cleanup, as orchestrator.go does on a spawn
+	// failure or a shutdown during setup.
+	if err := mgr.Cleanup("agent-abandoned"); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	wantStashFile(t, repo, "tracked.txt", "user edit\n")
+	wantStashFile(t, repo, "untracked.txt", "user note\n")
+	if n := stashCount(t, repo); n != 0 {
+		t.Errorf("stash count = %d, want 0 (entry should be dropped only after the apply succeeded)", n)
+	}
+}
+
+// TestCleanup_KeepsStashWhenRestoreFails checks the other half of the rule: if
+// Cleanup cannot put the work back, the entry stays and the failure is
+// reported rather than swallowed.
+func TestCleanup_KeepsStashWhenRestoreFails(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-blocked-cleanup"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Something recreates the untracked file while the agent runs, so the
+	// restore's `git stash apply` refuses to overwrite it.
+	writeStashFile(t, repo, "untracked.txt", "in the way\n")
+
+	err := mgr.Cleanup("agent-blocked-cleanup")
+	if err == nil {
+		t.Fatal("Cleanup succeeded despite the blocked restore")
+	}
+	if !strings.Contains(err.Error(), "restore stashed changes") {
+		t.Errorf("error %q does not report the failed restore", err)
+	}
+	if !strings.Contains(err.Error(), "pi-go-worktree-agent-blocked-cleanup-") {
+		t.Errorf("error %q does not name the stash entry the user has to recover", err)
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Errorf("stash count = %d, want 1 (a failed restore must not drop the entry)", n)
+	}
+}
+
+// TestCleanup_IgnoresDecoyStashEntry is the Cleanup half of the by-message
+// lookup: an unrelated entry sitting at stash@{0} must not be applied or
+// dropped.
+func TestCleanup_IgnoresDecoyStashEntry(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-cleanup-decoy"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	writeStashFile(t, repo, "decoy.txt", "not the user's work\n")
+	stashGit(t, repo, "stash", "push", "-u", "-m", "decoy-entry")
+
+	if err := mgr.Cleanup("agent-cleanup-decoy"); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	wantStashFile(t, repo, "tracked.txt", "user edit\n")
+	wantStashFile(t, repo, "untracked.txt", "user note\n")
+	if _, err := os.Stat(filepath.Join(repo, "decoy.txt")); err == nil {
+		t.Error("decoy.txt was applied; Cleanup restored the wrong stash entry")
+	}
+	if n := stashCount(t, repo); n != 1 {
+		t.Errorf("stash count = %d, want 1 (only the decoy should remain)", n)
+	}
+	if _, found := mgr.findStashByMessage("decoy-entry"); !found {
+		t.Error("decoy entry is gone from the stash list")
+	}
+}
+
+// TestCleanup_AfterMergeBackIsNoOp covers the ordinary two-step flow. MergeBack
+// has already restored and dropped the entry, so Cleanup finds nothing —
+// errStashEntryGone is expected there and must not surface as a cleanup error.
+func TestCleanup_AfterMergeBackIsNoOp(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-merge-then-clean"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := mgr.MergeBack("agent-merge-then-clean"); err != nil {
+		t.Fatalf("MergeBack: %v", err)
+	}
+	if err := mgr.Cleanup("agent-merge-then-clean"); err != nil {
+		t.Fatalf("Cleanup after MergeBack: %v", err)
+	}
+
+	wantStashFile(t, repo, "tracked.txt", "user edit\n")
+	wantStashFile(t, repo, "untracked.txt", "user note\n")
+	if n := stashCount(t, repo); n != 0 {
+		t.Errorf("stash count = %d, want 0", n)
+	}
+}
+
+// TestMergeBack_KeepsStashWhenApplyFails pins the fix to the path whose error
+// message used to be impossible to follow: it told the user to recover with
+// `git stash show` immediately after dropping the entry that command would
+// have shown.
+func TestMergeBack_KeepsStashWhenApplyFails(t *testing.T) {
+	repo := dirtyRepo(t)
+	mgr := NewWorktreeManager(repo)
+
+	if _, err := mgr.Create("agent-merge-blocked"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = mgr.Cleanup("agent-merge-blocked") }()
+
+	// Recreate the untracked file the stash holds, so the post-merge apply
+	// refuses to overwrite it.
+	writeStashFile(t, repo, "untracked.txt", "in the way\n")
+
+	_, err := mgr.MergeBack("agent-merge-blocked")
+	if err == nil {
+		t.Fatal("MergeBack succeeded despite the blocked stash apply")
+	}
+	if !strings.Contains(err.Error(), "git stash apply") {
+		t.Errorf("error %q does not report the apply failure", err)
+	}
+	if !strings.Contains(err.Error(), "still stashed as") {
+		t.Errorf("error %q does not tell the user the work is still stashed", err)
+	}
+
+	// The advice in that error must be followable: the entry is still there.
+	if n := stashCount(t, repo); n != 1 {
+		t.Fatalf("stash count = %d, want 1 (a failed apply must not drop the entry)", n)
+	}
+	if list := stashGit(t, repo, "stash", "list"); !strings.Contains(list, "pi-go-worktree-agent-merge-blocked-") {
+		t.Errorf("stash list %q no longer holds the entry the error points at", list)
+	}
+}

--- a/internal/subagent/worktree_test.go
+++ b/internal/subagent/worktree_test.go
@@ -712,7 +712,7 @@ func TestWorktree_FindStashByMessage(t *testing.T) {
 	mgr := NewWorktreeManager(repo)
 
 	// No stash present.
-	if _, found := mgr.findStashByMessage("anything"); found {
+	if _, _, found := mgr.findStashByMessage("anything"); found {
 		t.Error("findStashByMessage returned true with empty stash list")
 	}
 
@@ -726,7 +726,7 @@ func TestWorktree_FindStashByMessage(t *testing.T) {
 		t.Fatalf("stash push: %v: %s", err, out)
 	}
 
-	ref, found := mgr.findStashByMessage("unique-msg-12345")
+	ref, _, found := mgr.findStashByMessage("unique-msg-12345")
 	if !found {
 		t.Fatal("findStashByMessage did not find existing entry")
 	}
@@ -735,11 +735,11 @@ func TestWorktree_FindStashByMessage(t *testing.T) {
 	}
 
 	// Wrong message — not found.
-	if _, found := mgr.findStashByMessage("wrong-msg"); found {
+	if _, _, found := mgr.findStashByMessage("wrong-msg"); found {
 		t.Error("findStashByMessage returned true for non-matching message")
 	}
 	// Empty message — not found.
-	if _, found := mgr.findStashByMessage(""); found {
+	if _, _, found := mgr.findStashByMessage(""); found {
 		t.Error("findStashByMessage returned true for empty message")
 	}
 }


### PR DESCRIPTION
## The bug

`WorktreeManager.Create` stashes your uncommitted changes before `git worktree add`, because the add fails on a dirty tree. **Every path that later disposed of that stash entry was wrong**, in four distinct ways.

In all four, the comment described correct behaviour and the code did something else. That is how they survived review.

| # | Where | What it did |
|---|---|---|
| 1 | `Create` failure path | Commented *"Restore stashed changes on failure"* — ran `git stash drop`, which deletes **without applying** |
| 2 | `cleanupWorktree` | Dropped the entry outright |
| 3 | `MergeBack` apply-failure | Dropped it, then told the user to recover via `git stash show` |
| 4 | `popStashByMessage(msg)` | **Ignored `msg`**, operated on `stash@{0}` |

**#1** — `stash push -u` has already reverted your working tree, so after the drop your work exists only as a dangling commit until gc. Verified empirically in a throwaway repo, not inferred from reading.

**#2 is the worst in practice**, because it sits on *ordinary* paths rather than error paths. `orchestrator.go` calls `Cleanup` directly on spawn failure and on shutdown-during-setup — so a failed spawn with a dirty tree silently ate your changes. No error, no warning.

**#3** returned an error instructing the user to run `git stash show` against an entry it had just deleted. It also defeated `popStashByMessage`'s deliberate choice *not* to drop on apply failure "so the user can recover manually".

**#4 is worse than losing work — it applies the wrong work.** The doc claimed it "pops the most recent stash entry whose message matches", and `Create`'s doc claimed the unique message made the pop deterministic "even if other stash entries appear between Create and pop". Neither was implemented. With any unrelated entry on top — your own stash, an editor plugin's, a concurrent agent's — `MergeBack` applied **that** into your tree and then deleted it.

## The fix

One rule, stated once under *"The stash lifecycle"* and referenced from every site:

> An entry `Create` pushed may leave the stash list **only** after it has been successfully applied back to the working tree. Every other exit — a failed `worktree add`, a failed apply, a run abandoned before `MergeBack` — leaves the entry where the user can see it, and reports why.

`popStashByMessage` is now the only disposal path: resolve by message via the already-present `findStashByMessage`, apply, drop only on success. It never falls back to whatever is on top. Exactly one `git stash drop` remains in the file — the line after a successful apply, where the content is already back in the tree.

A vanished entry is reported as `errStashEntryGone`. `MergeBack` and `cleanupWorktree` filter it, because for them a missing entry is the expected state of the ordinary two-step flow. `Create` does not: it pushed the entry moments earlier and confirmed via the before/after count that it landed, so its absence is an anomaly the user must hear about.

`Create`'s failed-restore path discards neither cause — you learn why the worktree add failed **and** that your work is still stashed under a message you can recover with. Multi-`%w` rather than `errors.Join`, matching the existing "primary failed, fallback also failed" shape at `internal/atif/writer.go:188`, so `errors.As` still reaches the underlying `*exec.ExitError` through the combined error.

## Tests

13 tests in `internal/subagent/worktree_stash_test.go`, including **three decoy-stash tests** — an unrelated entry pushed *after* `Create`'s, so the decoy sits at `stash@{0}` and the agent's at `stash@{1}`. One per call site, because bug #4 was reachable from all three. Each asserts the user's content returns **and** that the decoy is neither applied nor dropped.

Against the old code all three fail with `tracked.txt = "committed\n", want "user edit\n"` — the decoy was applied instead.

Forcing `worktree add` to fail *after* the stash is taken is the fiddly part: occupying the target path doesn't work, because `claimExistingWorktree` prunes it first. The tests request a worktree name that survives `sanitizeWorktreeName` but violates git's ref-format rules. `TestSanitizeWorktreeName_KeepsBlockedName` pins that, so a future sanitizer change fails loudly instead of silently turning these into tests that assert nothing.

## Verification

- `go build ./...` clean
- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./internal/subagent/...` — **0 issues**
- `-race` clean on the stash tests at `-count=3`
- Coverage **88.5% → 89.4%**, measured back-to-back against a pristine checkout of this branch's fork point in a single run, with the two pre-existing timing-flaky spawner tests excluded

Note: `spawner_timeout_test.go`'s `TestSpawn_AbsoluteCapStillApplies` and `TestSpawn_SteadyOutputSurvivesInactivityWindow` are **pre-existing** flakes (a 700ms absolute cap raced against a 500ms inactivity window) and are currently failing more often than usual under load. Confirmed unrelated: they fail at the same rate on unmodified code.

## Caller note

Behaviour at `orchestrator.go`'s two `_ = Cleanup(agentID)` sites strictly improves — your work is now restored rather than deleted — and needs no caller change. But `Cleanup` can now return a restore error those two sites discard, so in the rare case the restore itself fails, the reason is silent there. Nothing is lost (the entry survives in the stash list by design). Logging it is a one-line follow-up, deliberately not bundled here.

## Related, not fixed here

A lifecycle audit found further data-loss paths in the same area, tracked separately — most seriously that `/run` prints *"Worktree preserved at: `<path>`"* and then force-deletes that worktree at session exit, with the work never committed. Those need a different fix shape (commit before destroy) and get their own PR.

https://claude.ai/code/session_011EA5xKa7i4BnC1TzWADXCE
