### PR TITLE
refactor: eliminate every function above cognitive complexity 20

### DIFF
--- a/internal/acp/server/adapter/complexity_cog_adapter_test.go
+++ b/internal/acp/server/adapter/complexity_cog_adapter_test.go
@@ -1,0 +1,213 @@
+package adapter
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// These tests pin formatArgsForDisplay exactly: which key wins, where each
+// truncation boundary falls, and what the map-iteration fallback emits. The
+// expectations were captured by running the same cases against the
+// pre-refactor implementation, so a passing run proves the flattening changed
+// no output.
+//
+// The fallback path iterates a Go map, so its ordering is deliberately not
+// asserted — only its contents and its three-item ceiling.
+
+func TestFormatArgsForDisplayPriorityKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"nil args", nil, ""},
+		{"empty args", map[string]any{}, ""},
+		{"path", map[string]any{"path": "/tmp/a.go"}, "/tmp/a.go"},
+		{"file_path", map[string]any{"file_path": "/tmp/b.go"}, "/tmp/b.go"},
+		{"command", map[string]any{"command": "git status"}, "git status"},
+		{"cmd", map[string]any{"cmd": "ls -la"}, "ls -la"},
+		{"prompt", map[string]any{"prompt": "explain"}, "explain"},
+		{"query", map[string]any{"query": "func main"}, "func main"},
+		{"pattern", map[string]any{"pattern": "TODO"}, "TODO"},
+		{"name", map[string]any{"name": "explore"}, "explore"},
+		{"url", map[string]any{"url": "https://x"}, "https://x"},
+		{"description", map[string]any{"description": "a task"}, "a task"},
+		{
+			name: "path outranks every later priority key",
+			args: map[string]any{"description": "d", "url": "u", "path": "p", "command": "c"},
+			want: "p",
+		},
+		{
+			name: "file_path outranks command when path is absent",
+			args: map[string]any{"command": "c", "file_path": "f"},
+			want: "f",
+		},
+		{
+			name: "command outranks cmd",
+			args: map[string]any{"cmd": "second", "command": "first"},
+			want: "first",
+		},
+		{
+			name: "an empty priority value is skipped for the next priority key",
+			args: map[string]any{"path": "", "command": "fallback-cmd"},
+			want: "fallback-cmd",
+		},
+		{
+			name: "a non-string priority value is skipped for the next priority key",
+			args: map[string]any{"path": 42, "command": "still-here"},
+			want: "still-here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatArgsForDisplay(tt.args); got != tt.want {
+				t.Errorf("formatArgsForDisplay = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatArgsForDisplayPriorityTruncationBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"49 bytes is untouched", strings.Repeat("a", 49), strings.Repeat("a", 49)},
+		{"50 bytes is untouched", strings.Repeat("a", 50), strings.Repeat("a", 50)},
+		{"51 bytes clips to 47 plus an ellipsis", strings.Repeat("a", 51), strings.Repeat("a", 47) + "..."},
+		{"a long value clips to the same 50-byte result", strings.Repeat("a", 400), strings.Repeat("a", 47) + "..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatArgsForDisplay(map[string]any{"path": tt.in})
+			if got != tt.want {
+				t.Errorf("formatArgsForDisplay len=%d = %q, want %q", len(tt.in), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatArgsForDisplayFallbackSingleKey(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "one non-priority string key becomes key=value",
+			args: map[string]any{"zz_custom": "hello"},
+			want: "zz_custom=hello",
+		},
+		{
+			name: "30 bytes is untouched",
+			args: map[string]any{"zz": strings.Repeat("b", 30)},
+			want: "zz=" + strings.Repeat("b", 30),
+		},
+		{
+			name: "31 bytes clips to 27 plus an ellipsis",
+			args: map[string]any{"zz": strings.Repeat("b", 31)},
+			want: "zz=" + strings.Repeat("b", 27) + "...",
+		},
+		{
+			name: "an empty value contributes nothing",
+			args: map[string]any{"zz": ""},
+			want: "",
+		},
+		{
+			name: "non-string values are skipped entirely",
+			args: map[string]any{"num": 42},
+			want: "",
+		},
+		{
+			name: "a nil value is skipped entirely",
+			args: map[string]any{"nothing": nil},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatArgsForDisplay(tt.args); got != tt.want {
+				t.Errorf("formatArgsForDisplay = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatArgsForDisplayFallbackJoinsUpToThree pins the shape of the
+// fallback join without depending on Go's randomized map ordering: three
+// entries produce exactly those three pairs, in some order, joined by ", ".
+func TestFormatArgsForDisplayFallbackJoinsUpToThree(t *testing.T) {
+	got := formatArgsForDisplay(map[string]any{"aa": "1", "bb": "2", "cc": "3"})
+	parts := strings.Split(got, ", ")
+	sort.Strings(parts)
+	want := []string{"aa=1", "bb=2", "cc=3"}
+	if len(parts) != len(want) {
+		t.Fatalf("formatArgsForDisplay = %q, want three pairs", got)
+	}
+	for i := range want {
+		if parts[i] != want[i] {
+			t.Fatalf("formatArgsForDisplay = %q, sorted parts %v, want %v", got, parts, want)
+		}
+	}
+}
+
+// TestFormatArgsForDisplayFallbackStopsAfterThreeEntries pins the ceiling: the
+// fallback visits at most three map entries, so it can never emit a fourth
+// pair however many keys are supplied.
+func TestFormatArgsForDisplayFallbackStopsAfterThreeEntries(t *testing.T) {
+	args := map[string]any{"aa": "1", "bb": "2", "cc": "3", "dd": "4", "ee": "5", "ff": "6"}
+	for i := 0; i < 20; i++ {
+		got := formatArgsForDisplay(args)
+		if n := len(strings.Split(got, ", ")); n > 3 {
+			t.Fatalf("formatArgsForDisplay = %q, emitted %d pairs, want at most 3", got, n)
+		}
+	}
+}
+
+// TestFormatArgsForDisplayFallbackCountsSkippedEntries pins a subtle
+// pre-existing property: the three-entry budget is spent on every visited map
+// entry, including non-string ones that emit nothing. With four non-string
+// entries and one string entry, the string may or may not be reached, so the
+// only invariant is that the result is either empty or exactly that one pair.
+func TestFormatArgsForDisplayFallbackCountsSkippedEntries(t *testing.T) {
+	args := map[string]any{"n1": 1, "n2": 2, "n3": 3, "n4": 4, "zz": "seen"}
+	for i := 0; i < 50; i++ {
+		got := formatArgsForDisplay(args)
+		if got != "" && got != "zz=seen" {
+			t.Fatalf("formatArgsForDisplay = %q, want %q or empty", got, "zz=seen")
+		}
+	}
+}
+
+// TestBuildTitleFallsBackThroughFormatArgs pins buildTitle's use of
+// formatArgsForDisplay: the summary is appended to the tool name whenever the
+// name-specific rule finds nothing.
+func TestBuildTitleFallsBackThroughFormatArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		args     map[string]any
+		want     string
+	}{
+		{"unknown tool with a priority key", "custom", map[string]any{"url": "https://x"}, "custom https://x"},
+		{"unknown tool with no args", "custom", nil, "custom"},
+		{"unknown tool with only non-string args", "custom", map[string]any{"n": 1}, "custom"},
+		{"bash without a command falls back to the summary", "bash", map[string]any{"url": "https://x"}, "bash https://x"},
+		{"read without a path falls back to the summary", "read", map[string]any{"url": "https://x"}, "read https://x"},
+		{"grep without a pattern falls back to the summary", "grep", map[string]any{"url": "https://x"}, "grep https://x"},
+		{"subagent without an agent falls back to the summary", "subagent", map[string]any{"url": "https://x"}, "subagent https://x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildTitle(tt.toolName, tt.args); got != tt.want {
+				t.Errorf("buildTitle = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/acp/server/adapter/toolcall.go
+++ b/internal/acp/server/adapter/toolcall.go
@@ -269,38 +269,59 @@ func formatArgsForDisplay(args map[string]any) string {
 	if args == nil {
 		return ""
 	}
+	if s := priorityArgValue(args); s != "" {
+		return s
+	}
+	return summarizeArgs(args)
+}
+
+// priorityArgValue returns the value of the first display-worthy key present
+// in args, truncated for display. Keys are tried in the order listed — the
+// most tool-identifying first — and a missing, non-string or empty value falls
+// through to the next key. Returns "" when no priority key yields a value.
+func priorityArgValue(args map[string]any) string {
 	// Keys to prioritize for display (most useful for tool visibility)
 	priorityKeys := []string{"path", "file_path", "command", "cmd", "prompt", "query", "pattern", "name", "url", "description"}
 
-	// First try to find a relevant key
 	for _, key := range priorityKeys {
-		if v, ok := args[key]; ok {
-			if s, ok := v.(string); ok && s != "" {
-				// Truncate long values
-				if len(s) > 50 {
-					s = s[:47] + "..."
-				}
-				return s
-			}
+		s, ok := args[key].(string)
+		if !ok || s == "" {
+			continue
 		}
+		// Truncate long values
+		return clipArg(s, 50, 47)
 	}
+	return ""
+}
 
-	// Fall back to first few keys from args
+// summarizeArgs is the fallback for arguments carrying no priority key: it
+// joins up to three "key=value" pairs. Map iteration order is random, so which
+// three entries are visited is not defined — and the budget is spent on every
+// entry visited, including non-string ones that contribute nothing.
+func summarizeArgs(args map[string]any) string {
 	var parts []string
 	i := 0
 	for k, v := range args {
 		if i >= 3 {
 			break
 		}
-		if s, ok := v.(string); ok && s != "" {
-			if len(s) > 30 {
-				s = s[:27] + "..."
-			}
-			parts = append(parts, fmt.Sprintf("%s=%s", k, s))
-		}
 		i++
+		s, ok := v.(string)
+		if !ok || s == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", k, clipArg(s, 30, 27)))
 	}
 	return strings.Join(parts, ", ")
+}
+
+// clipArg shortens s to keep bytes plus an ellipsis when it is longer than
+// limit bytes, and returns it unchanged otherwise.
+func clipArg(s string, limit, keep int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:keep] + "..."
 }
 
 // appendToParentLocked records line as nested content on the sub-agent parent

--- a/internal/agent/complexity_cog_agent_test.go
+++ b/internal/agent/complexity_cog_agent_test.go
@@ -1,0 +1,379 @@
+package agent
+
+import (
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// Retry timing is behavior, not decoration: how many attempts happen, how long
+// the pauses are, and which failures are replayed at all are all invisible to
+// an ordinary test. These pin them against the pre-refactor WithRetry so a
+// flattening cannot quietly change what pi-go does under provider failure.
+//
+// Nothing here sleeps for a real backoff schedule — every config uses
+// millisecond delays, and the one case that must observe a pause asks for a
+// window measured in tens of milliseconds.
+
+// cogProviderErr wraps a verbatim provider message. Provider text is prose — it
+// starts with a capital and ends with a full stop — which is what the
+// error-strings linter rejects at an errors.New call site, so it is built here
+// instead of inline.
+func cogProviderErr(msg string) error { return errors.New(msg) }
+
+func cogRetryEvent(text string) *session.Event {
+	return &session.Event{
+		LLMResponse: model.LLMResponse{
+			Content: genai.NewContentFromText(text, genai.RoleModel),
+		},
+	}
+}
+
+// cogAlwaysFailing returns a runFn that yields err on every attempt and counts
+// how many times it was started.
+func cogAlwaysFailing(calls *int, err error) func() iter.Seq2[*session.Event, error] {
+	return func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			*calls++
+			yield(nil, err)
+		}
+	}
+}
+
+// cogDrain consumes a sequence completely, returning the events and the last
+// error seen.
+func cogDrain(seq iter.Seq2[*session.Event, error]) ([]*session.Event, error) {
+	var events []*session.Event
+	var lastErr error
+	for ev, err := range seq {
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events, lastErr
+}
+
+// The attempt budget is MaxRetries retries *after* the initial attempt, so a
+// run that never clears is started MaxRetries+1 times. MaxRetries: 0 means one
+// attempt and no sleep at all.
+func TestWithRetryAttemptBudget(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxRetries int
+		wantCalls  int
+	}{
+		{"no retries means a single attempt", 0, 1},
+		{"one retry means two attempts", 1, 2},
+		{"three retries means four attempts", 3, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := RetryConfig{MaxRetries: tt.maxRetries, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+			calls := 0
+			_, lastErr := cogDrain(WithRetry(cfg, cogAlwaysFailing(&calls, errors.New("503 service unavailable"))))
+
+			if calls != tt.wantCalls {
+				t.Errorf("runFn started %d times, want %d", calls, tt.wantCalls)
+			}
+			if lastErr == nil {
+				t.Fatal("expected an exhaustion error")
+			}
+			if !strings.Contains(lastErr.Error(), "503 service unavailable") {
+				t.Errorf("exhaustion error lost the cause: %v", lastErr)
+			}
+			if !strings.Contains(lastErr.Error(), "transient error after") {
+				t.Errorf("exhaustion error changed shape: %v", lastErr)
+			}
+		})
+	}
+}
+
+// The retryable/terminal split is the whole point of the loop. A terminal error
+// is yielded verbatim on the first attempt; a transient one is replayed until
+// the budget runs out and then wrapped.
+func TestWithRetryErrorClassificationDrivesReplay(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantCalls int
+		wantWrap  bool
+	}{
+		{"rate limit is replayed", errors.New("429 Too Many Requests"), 3, true},
+		{"upstream 503 is replayed", errors.New("503 service unavailable"), 3, true},
+		{"connection reset is replayed", errors.New("connection reset by peer"), 3, true},
+		{"bad credentials are terminal", errors.New("invalid api key"), 1, false},
+		{"quota exhaustion is terminal", errors.New("429 Too Many Requests: you have reached your weekly usage limit"), 1, false},
+		{"an unrecognized failure is terminal", errors.New("something broke"), 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := RetryConfig{MaxRetries: 2, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+			calls := 0
+			_, lastErr := cogDrain(WithRetry(cfg, cogAlwaysFailing(&calls, tt.err)))
+
+			if calls != tt.wantCalls {
+				t.Errorf("runFn started %d times, want %d", calls, tt.wantCalls)
+			}
+			if lastErr == nil {
+				t.Fatal("expected an error to reach the consumer")
+			}
+			gotWrap := strings.Contains(lastErr.Error(), "transient error after")
+			if gotWrap != tt.wantWrap {
+				t.Errorf("wrapped = %v, want %v (err: %v)", gotWrap, tt.wantWrap, lastErr)
+			}
+			if !tt.wantWrap && !errors.Is(lastErr, tt.err) {
+				t.Errorf("terminal error was not passed through verbatim: %v", lastErr)
+			}
+		})
+	}
+}
+
+// A consumer that stops ranging must stop the whole thing: no further attempt,
+// no exhaustion error, and the inner run torn down at once.
+func TestWithRetryConsumerStopEndsEverything(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+	calls := 0
+	yielded := 0
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			for range 5 {
+				yielded++
+				if !yield(cogRetryEvent("chunk"), nil) {
+					return
+				}
+			}
+			yield(nil, errors.New("503 service unavailable"))
+		}
+	}
+
+	seen := 0
+	for range WithRetry(cfg, runFn) {
+		seen++
+		break
+	}
+
+	if calls != 1 {
+		t.Errorf("runFn started %d times after an early stop, want 1", calls)
+	}
+	if seen != 1 {
+		t.Errorf("consumer saw %d items, want 1", seen)
+	}
+	if yielded != 1 {
+		t.Errorf("runFn yielded %d times after the consumer stopped, want 1", yielded)
+	}
+}
+
+// Stopping while a terminal error is being delivered must also end the run —
+// that error travels through the same yield as an event.
+func TestWithRetryConsumerStopOnTerminalError(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+	calls := 0
+	afterYield := false
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			if !yield(nil, errors.New("invalid api key")) {
+				return
+			}
+			afterYield = true
+		}
+	}
+
+	for range WithRetry(cfg, runFn) {
+		break
+	}
+
+	if calls != 1 {
+		t.Errorf("runFn started %d times, want 1", calls)
+	}
+	if afterYield {
+		t.Error("runFn kept going after the consumer stopped")
+	}
+}
+
+// A yielded nil event is not a partial response: the run produced nothing the
+// consumer could act on, so it stays replayable.
+func TestWithRetryNilEventIsNotAPartialResponse(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 2, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+	calls := 0
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			if !yield(nil, nil) {
+				return
+			}
+			yield(nil, errors.New("503 service unavailable"))
+		}
+	}
+
+	_, lastErr := cogDrain(WithRetry(cfg, runFn))
+	if calls != 3 {
+		t.Errorf("runFn started %d times, want 3 — a nil event must not block replay", calls)
+	}
+	if lastErr == nil || !strings.Contains(lastErr.Error(), "transient error after 2 retries") {
+		t.Errorf("got %v, want the exhaustion error", lastErr)
+	}
+}
+
+// A real event already handed to the consumer makes the run unreplayable: tool
+// calls may have run, so the transient error is reported instead of retried.
+func TestWithRetryRealEventBlocksReplay(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+	calls := 0
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			if !yield(cogRetryEvent("partial"), nil) {
+				return
+			}
+			yield(nil, errors.New("503 service unavailable"))
+		}
+	}
+
+	events, lastErr := cogDrain(WithRetry(cfg, runFn))
+	if calls != 1 {
+		t.Errorf("runFn started %d times, want 1", calls)
+	}
+	if len(events) != 1 {
+		t.Errorf("consumer kept %d events, want 1", len(events))
+	}
+	if lastErr == nil || !strings.Contains(lastErr.Error(), "transient error after partial response (not retrying)") {
+		t.Errorf("got %v, want the partial-response error", lastErr)
+	}
+}
+
+// A successful run never sleeps and never repeats.
+func TestWithRetrySuccessDoesNotSleep(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: 5 * time.Second, MaxDelay: 5 * time.Second}
+	calls := 0
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			yield(cogRetryEvent("done"), nil)
+		}
+	}
+
+	start := time.Now()
+	events, lastErr := cogDrain(WithRetry(cfg, runFn))
+	elapsed := time.Since(start)
+
+	if calls != 1 {
+		t.Errorf("runFn started %d times, want 1", calls)
+	}
+	if lastErr != nil {
+		t.Errorf("unexpected error: %v", lastErr)
+	}
+	if len(events) != 1 {
+		t.Errorf("got %d events, want 1", len(events))
+	}
+	if elapsed > time.Second {
+		t.Errorf("a clean run slept for %v", elapsed)
+	}
+}
+
+// The pause between attempts comes from retry.Delay, and the failing error is
+// handed to it — a provider that names its own reopening window is obeyed
+// instead of the exponential schedule. InitialDelay here is 1ms, so an observed
+// pause of tens of milliseconds can only have come from the named window.
+func TestWithRetryObeysServerNamedWindow(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 1, InitialDelay: time.Millisecond, MaxDelay: time.Minute}
+	calls := 0
+	err := cogProviderErr("429 Too Many Requests: rate limit reached. Please retry in 60ms.")
+
+	start := time.Now()
+	_, lastErr := cogDrain(WithRetry(cfg, cogAlwaysFailing(&calls, err)))
+	elapsed := time.Since(start)
+
+	if calls != 2 {
+		t.Fatalf("runFn started %d times, want 2", calls)
+	}
+	if lastErr == nil {
+		t.Fatal("expected an exhaustion error")
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("waited %v; the server-named 60ms window was not applied", elapsed)
+	}
+}
+
+// MaxDelay caps a server-named window too. Without the cap this run would sleep
+// for a minute.
+func TestWithRetryMaxDelayCapsServerNamedWindow(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 1, InitialDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
+	calls := 0
+	err := cogProviderErr("429 Too Many Requests: rate limit reached. Please retry in 59.440629838s.")
+
+	start := time.Now()
+	_, lastErr := cogDrain(WithRetry(cfg, cogAlwaysFailing(&calls, err)))
+	elapsed := time.Since(start)
+
+	if calls != 2 {
+		t.Fatalf("runFn started %d times, want 2", calls)
+	}
+	if lastErr == nil {
+		t.Fatal("expected an exhaustion error")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("waited %v; MaxDelay did not cap the server-named window", elapsed)
+	}
+}
+
+// The last attempt reports rather than sleeps: with MaxRetries: 2 there are two
+// pauses, not three.
+func TestWithRetryDoesNotSleepAfterTheLastAttempt(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 2, InitialDelay: 30 * time.Millisecond, MaxDelay: 30 * time.Millisecond}
+	calls := 0
+
+	start := time.Now()
+	_, lastErr := cogDrain(WithRetry(cfg, cogAlwaysFailing(&calls, errors.New("503 service unavailable"))))
+	elapsed := time.Since(start)
+
+	if calls != 3 {
+		t.Fatalf("runFn started %d times, want 3", calls)
+	}
+	if lastErr == nil {
+		t.Fatal("expected an exhaustion error")
+	}
+	if elapsed < 45*time.Millisecond {
+		t.Errorf("waited %v; expected two 30ms pauses between three attempts", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("waited %v; expected no pause after the final attempt", elapsed)
+	}
+}
+
+// An empty run — no events, no error — completes without retrying.
+func TestWithRetryEmptyRunCompletes(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+	calls := 0
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(_ func(*session.Event, error) bool) { calls++ }
+	}
+
+	events, lastErr := cogDrain(WithRetry(cfg, runFn))
+	if calls != 1 {
+		t.Errorf("runFn started %d times, want 1", calls)
+	}
+	if lastErr != nil {
+		t.Errorf("unexpected error: %v", lastErr)
+	}
+	if len(events) != 0 {
+		t.Errorf("got %d events, want 0", len(events))
+	}
+}

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -41,40 +41,53 @@ func retryDelay(cfg RetryConfig, attempt int) time.Duration {
 // request without disturbing the turn around it.
 func WithRetry(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error]) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
-			var transientErr error
-			hadEvents := false
+		retryLoop(cfg, runFn, yield)
+	}
+}
 
-			for ev, err := range runFn() {
-				if err != nil && isTransient(err) {
-					transientErr = err
-					break
-				}
-				if !yield(ev, err) {
-					return
-				}
-				if ev != nil {
-					hadEvents = true
-				}
-			}
+// retryLoop runs runFn up to cfg.MaxRetries+1 times, sleeping between attempts.
+// It returns as soon as an attempt finishes without a transient error — which
+// includes the case where the consumer stopped ranging, since runAttempt stops
+// with no transient error then.
+func retryLoop(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error], yield func(*session.Event, error) bool) {
+	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
+		hadEvents, transientErr := runAttempt(runFn, yield)
 
-			if transientErr == nil {
-				return
-			}
+		if transientErr == nil {
+			return
+		}
 
-			if hadEvents {
-				// Already yielded partial results, cannot retry safely.
-				_ = yield(nil, fmt.Errorf("transient error after partial response (not retrying): %w", transientErr))
-				return
-			}
+		if hadEvents {
+			// Already yielded partial results, cannot retry safely.
+			_ = yield(nil, fmt.Errorf("transient error after partial response (not retrying): %w", transientErr))
+			return
+		}
 
-			if attempt < cfg.MaxRetries {
-				time.Sleep(retry.Delay(cfg, attempt, transientErr))
-				continue
-			}
+		if attempt < cfg.MaxRetries {
+			time.Sleep(retry.Delay(cfg, attempt, transientErr))
+			continue
+		}
 
-			// Exhausted retries.
-			_ = yield(nil, fmt.Errorf("transient error after %d retries: %w", cfg.MaxRetries, transientErr))
+		// Exhausted retries.
+		_ = yield(nil, fmt.Errorf("transient error after %d retries: %w", cfg.MaxRetries, transientErr))
+	}
+}
+
+// runAttempt forwards one run to the consumer. It reports the transient error
+// that cut the run short, if any, and whether a real event reached the consumer
+// — which is what makes a run unreplayable. A consumer that stops ranging ends
+// the attempt with no transient error, so the caller stops too.
+func runAttempt(runFn func() iter.Seq2[*session.Event, error], yield func(*session.Event, error) bool) (hadEvents bool, transientErr error) {
+	for ev, err := range runFn() {
+		if err != nil && isTransient(err) {
+			return hadEvents, err
+		}
+		if !yield(ev, err) {
+			return hadEvents, nil
+		}
+		if ev != nil {
+			hadEvents = true
 		}
 	}
+	return hadEvents, nil
 }

--- a/internal/atif/complexity_cog_atif_test.go
+++ b/internal/atif/complexity_cog_atif_test.go
@@ -1,0 +1,186 @@
+package atif
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// These tests pin the exact JSON shape ConvertEvent emits. ATIF steps are
+// written to disk as trajectory files and read back by external tooling, so a
+// change in emitted shape silently invalidates previously recorded
+// trajectories. Every golden below was captured by running the same cases
+// against the pre-refactor ConvertEvent, so a passing run proves the
+// flattening is a no-op rather than proving the new code agrees with itself.
+
+var cogRefTime = time.Date(2026, 4, 5, 10, 30, 0, 0, time.UTC)
+
+// cogEvent builds a session event with full control over the fields mapSource
+// consults: author, turn completion, finish reason and content role.
+func cogEvent(author string, turnComplete bool, finish genai.FinishReason, role string, parts ...*genai.Part) *session.Event {
+	ev := &session.Event{}
+	ev.Author = author
+	ev.Timestamp = cogRefTime
+	ev.TurnComplete = turnComplete
+	ev.FinishReason = finish
+	ev.Content = &genai.Content{Role: role, Parts: parts}
+	return ev
+}
+
+func TestConvertEventGoldenShape(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *session.Event
+		want  string
+	}{
+		{
+			name:  "user text becomes a plain string message",
+			event: cogEvent("user", false, "", "user", &genai.Part{Text: "Hello, world!"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"user","message":"Hello, world!"}]`,
+		},
+		{
+			name:  "model text maps to the agent source",
+			event: cogEvent("model", false, "", "model", &genai.Part{Text: "hi"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"hi"}]`,
+		},
+		{
+			name:  "a thought-only event yields no step",
+			event: cogEvent("model", false, "", "model", &genai.Part{Text: "think", Thought: true}),
+			want:  `null`,
+		},
+		{
+			name:  "an entirely empty part yields no step",
+			event: cogEvent("model", false, "", "model", &genai.Part{}),
+			want:  `null`,
+		},
+		{
+			name:  "two text parts become a content-part array",
+			event: cogEvent("model", false, "", "model", &genai.Part{Text: "a"}, &genai.Part{Text: "b"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]`,
+		},
+		{
+			name:  "a function call carries its arguments through",
+			event: cogEvent("model", false, "", "model", &genai.Part{FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"path": "/x"}}}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"","tool_calls":[{"tool_call_id":"c1","function_name":"read","arguments":{"path":"/x"}}]}]`,
+		},
+		{
+			name:  "nil call arguments become an empty object, never null",
+			event: cogEvent("model", false, "", "model", &genai.Part{FunctionCall: &genai.FunctionCall{ID: "c2", Name: "ls"}}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"","tool_calls":[{"tool_call_id":"c2","function_name":"ls","arguments":{}}]}]`,
+		},
+		{
+			name:  "a function response becomes an observation result",
+			event: cogEvent("user", false, "", "user", &genai.Part{FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"out": "ok"}}}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"user","message":"","observation":{"results":[{"source_call_id":"c1","content":{"out":"ok"}}]}}]`,
+		},
+		{
+			name:  "an id-less function response falls back to the function name",
+			event: cogEvent("user", false, "", "user", &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: "read", Response: map[string]any{"out": "ok"}}}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"user","message":"","observation":{"results":[{"source_call_id":"read","content":{"out":"ok"}}]}}]`,
+		},
+		{
+			name: "two responses share one observation, in part order",
+			event: cogEvent("user", false, "", "user",
+				&genai.Part{FunctionResponse: &genai.FunctionResponse{ID: "c1", Response: map[string]any{"a": float64(1)}}},
+				&genai.Part{FunctionResponse: &genai.FunctionResponse{ID: "c2", Response: map[string]any{"b": float64(2)}}}),
+			want: `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"user","message":"","observation":{"results":[{"source_call_id":"c1","content":{"a":1}},{"source_call_id":"c2","content":{"b":2}}]}}]`,
+		},
+		{
+			name: "text, thought, call and response in one event",
+			event: cogEvent("model", false, "", "model",
+				&genai.Part{Text: "doing it"},
+				&genai.Part{Text: "skip", Thought: true},
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "c9", Name: "bash", Args: map[string]any{"cmd": "ls"}}},
+				&genai.Part{FunctionResponse: &genai.FunctionResponse{ID: "c9", Response: map[string]any{"out": "f"}}}),
+			want: `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"doing it","tool_calls":[{"tool_call_id":"c9","function_name":"bash","arguments":{"cmd":"ls"}}],"observation":{"results":[{"source_call_id":"c9","content":{"out":"f"}}]}}]`,
+		},
+		{
+			name:  "an unknown author with a model content role is an agent",
+			event: cogEvent("pi-custom", false, "", "model", &genai.Part{Text: "x"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"x"}]`,
+		},
+		{
+			name:  "an unknown author completing on STOP with text is an agent",
+			event: cogEvent("weird", true, genai.FinishReason("STOP"), "", &genai.Part{Text: "final"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"final"}]`,
+		},
+		{
+			name:  "STOP with only thought text does not reach the agent fallback",
+			event: cogEvent("weird", true, genai.FinishReason("STOP"), "", &genai.Part{Text: "t", Thought: true}),
+			want:  `null`,
+		},
+		{
+			name:  "a non-STOP finish reason stays on the system source",
+			event: cogEvent("weird", true, genai.FinishReason("MAX_TOKENS"), "", &genai.Part{Text: "final"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"system","message":"final"}]`,
+		},
+		{
+			name:  "the assistant author maps to agent",
+			event: cogEvent("assistant", false, "", "", &genai.Part{Text: "a"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"a"}]`,
+		},
+		{
+			name:  "the agent author maps to agent",
+			event: cogEvent("agent", false, "", "", &genai.Part{Text: "a"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"a"}]`,
+		},
+		{
+			name:  "the pi author maps to agent",
+			event: cogEvent("pi", false, "", "", &genai.Part{Text: "a"}),
+			want:  `[{"step_id":7,"timestamp":"2026-04-05T10:30:00Z","source":"agent","message":"a"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(ConvertEvent(tt.event, 7))
+			if err != nil {
+				t.Fatalf("marshal steps: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("ConvertEvent JSON mismatch\n got: %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConvertEventNilInputs pins the three shapes that produce no step at all
+// before any part is inspected.
+func TestConvertEventNilInputs(t *testing.T) {
+	empty := &session.Event{}
+	emptyParts := &session.Event{}
+	emptyParts.Content = &genai.Content{Parts: []*genai.Part{}}
+
+	tests := []struct {
+		name  string
+		event *session.Event
+	}{
+		{"nil event", nil},
+		{"nil content", empty},
+		{"zero parts", emptyParts},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if steps := ConvertEvent(tt.event, 1); steps != nil {
+				t.Errorf("ConvertEvent = %v, want nil", steps)
+			}
+		})
+	}
+}
+
+// TestConvertEventStepIDIsTheStartingID pins that the returned step carries the
+// caller's starting step ID unchanged.
+func TestConvertEventStepIDIsTheStartingID(t *testing.T) {
+	for _, id := range []int{0, 1, 42} {
+		steps := ConvertEvent(cogEvent("user", false, "", "user", &genai.Part{Text: "x"}), id)
+		if len(steps) != 1 {
+			t.Fatalf("id %d: got %d steps, want 1", id, len(steps))
+		}
+		if steps[0].StepID != id {
+			t.Errorf("StepID = %d, want %d", steps[0].StepID, id)
+		}
+	}
+}

--- a/internal/atif/convert.go
+++ b/internal/atif/convert.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 )
 
 // ConvertEvent converts a session.Event into zero or more ATIF Steps.
@@ -26,33 +27,8 @@ func ConvertEvent(event *session.Event, stepID int) []Step {
 		if part.Text != "" && !part.Thought {
 			texts = append(texts, part.Text)
 		}
-
-		if part.FunctionCall != nil {
-			tc := ToolCall{
-				ToolCallID:   part.FunctionCall.ID,
-				FunctionName: part.FunctionCall.Name,
-				Arguments:    part.FunctionCall.Args,
-			}
-			if tc.Arguments == nil {
-				tc.Arguments = make(map[string]any)
-			}
-			step.ToolCalls = append(step.ToolCalls, tc)
-		}
-
-		if part.FunctionResponse != nil {
-			if step.Observation == nil {
-				step.Observation = &Observation{}
-			}
-			result := ObservationResult{
-				SourceCallID: part.FunctionResponse.ID,
-				Content:      part.FunctionResponse.Response,
-			}
-			// Fall back to Name if ID is empty.
-			if result.SourceCallID == "" {
-				result.SourceCallID = part.FunctionResponse.Name
-			}
-			step.Observation.Results = append(step.Observation.Results, result)
-		}
+		appendToolCall(&step, part.FunctionCall)
+		appendObservation(&step, part.FunctionResponse)
 	}
 
 	step.Message = buildMessage(texts)
@@ -63,6 +39,45 @@ func ConvertEvent(event *session.Event, stepID int) []Step {
 	}
 
 	return []Step{step}
+}
+
+// appendToolCall records a function call on the step. Nil calls are ignored,
+// and nil arguments become an empty map so the emitted JSON always carries an
+// object rather than null.
+func appendToolCall(step *Step, call *genai.FunctionCall) {
+	if call == nil {
+		return
+	}
+	tc := ToolCall{
+		ToolCallID:   call.ID,
+		FunctionName: call.Name,
+		Arguments:    call.Args,
+	}
+	if tc.Arguments == nil {
+		tc.Arguments = make(map[string]any)
+	}
+	step.ToolCalls = append(step.ToolCalls, tc)
+}
+
+// appendObservation records a function response on the step, creating the
+// observation on first use so steps without results keep it nil. Nil responses
+// are ignored.
+func appendObservation(step *Step, resp *genai.FunctionResponse) {
+	if resp == nil {
+		return
+	}
+	if step.Observation == nil {
+		step.Observation = &Observation{}
+	}
+	result := ObservationResult{
+		SourceCallID: resp.ID,
+		Content:      resp.Response,
+	}
+	// Fall back to Name if ID is empty.
+	if result.SourceCallID == "" {
+		result.SourceCallID = resp.Name
+	}
+	step.Observation.Results = append(step.Observation.Results, result)
 }
 
 // mapSource converts session event author to ATIF source.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -586,51 +586,90 @@ func PollDeviceToken(ctx context.Context, prov Provider, device *DeviceCodeRespo
 	if device == nil {
 		return nil, fmt.Errorf("nil device code response")
 	}
-	interval := device.Interval
-	if interval < 1 {
-		interval = 5
-	}
+	interval := deviceTokenInterval(device)
 	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	defer ticker.Stop()
 
-	var deadline time.Time
-	if device.ExpiresIn > 0 {
-		deadline = time.Now().Add(time.Duration(device.ExpiresIn) * time.Second)
-	}
+	deadline := deviceTokenDeadline(device)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return &Result{Provider: prov.Name, Err: ctx.Err()}, nil
 		case <-ticker.C:
-			if !deadline.IsZero() && time.Now().After(deadline) {
-				return &Result{Provider: prov.Name, Err: fmt.Errorf("device authorization timed out: device code expired")}, nil
+			res, slowDown := pollDeviceTokenOnce(ctx, prov, device, deadline)
+			if res != nil {
+				return res, nil
 			}
-			tok, err := requestDeviceToken(ctx, prov, device.DeviceCode)
-			if err != nil {
-				// Check for "authorization_pending" — keep polling.
-				if strings.Contains(err.Error(), "authorization_pending") {
-					continue
-				}
-				// "slow_down" — increase the interval (RFC 8628 §3.5) and keep
-				// polling; the bump is cumulative across repeated slow_down
-				// responses.
-				if strings.Contains(err.Error(), "slow_down") {
-					interval += 5
-					ticker.Reset(time.Duration(interval) * time.Second)
-					continue
-				}
-				return &Result{Provider: prov.Name, Err: err}, nil
+			if slowDown {
+				interval = slowDownInterval(interval, ticker)
 			}
-
-			apiKey := prov.TokenToKey(tok)
-			return &Result{
-				Provider: prov.Name,
-				APIKey:   apiKey,
-				EnvVar:   prov.EnvVar,
-			}, nil
 		}
 	}
+}
+
+// deviceTokenInterval is the polling period the device response asks for, in
+// seconds. RFC 8628 §3.2 makes interval optional; 5 seconds is the default the
+// spec prescribes, and it also guards against a server asking for zero.
+func deviceTokenInterval(device *DeviceCodeResponse) int {
+	if device.Interval < 1 {
+		return 5
+	}
+	return device.Interval
+}
+
+// deviceTokenDeadline is the instant the device code expires. A zero
+// expires_in means the code carries no expiry of its own, and the returned
+// zero time tells the poll loop to run until the context is done.
+func deviceTokenDeadline(device *DeviceCodeResponse) time.Time {
+	if device.ExpiresIn <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(time.Duration(device.ExpiresIn) * time.Second)
+}
+
+// pollTicker is the part of *time.Ticker the backoff needs. Naming it keeps
+// the interval arithmetic exercisable without waiting on a real tick.
+type pollTicker interface {
+	Reset(d time.Duration)
+}
+
+// slowDownInterval applies the RFC 8628 §3.5 backoff: each slow_down response
+// adds 5 seconds to the polling interval and retimes the ticker to match. The
+// bump is cumulative — repeated slow_down responses keep widening the gap.
+func slowDownInterval(interval int, ticker pollTicker) int {
+	interval += 5
+	ticker.Reset(time.Duration(interval) * time.Second)
+	return interval
+}
+
+// pollDeviceTokenOnce performs one token request. A non-nil Result ends the
+// poll — with the token on success, or with the reason in Result.Err. A nil
+// Result means keep polling, and slowDown reports whether the server asked for
+// a longer interval first.
+func pollDeviceTokenOnce(ctx context.Context, prov Provider, device *DeviceCodeResponse, deadline time.Time) (res *Result, slowDown bool) {
+	if !deadline.IsZero() && time.Now().After(deadline) {
+		return &Result{Provider: prov.Name, Err: fmt.Errorf("device authorization timed out: device code expired")}, false
+	}
+
+	tok, err := requestDeviceToken(ctx, prov, device.DeviceCode)
+	if err == nil {
+		return &Result{
+			Provider: prov.Name,
+			APIKey:   prov.TokenToKey(tok),
+			EnvVar:   prov.EnvVar,
+		}, false
+	}
+
+	// "authorization_pending" — keep polling.
+	if strings.Contains(err.Error(), "authorization_pending") {
+		return nil, false
+	}
+	// "slow_down" — keep polling on a longer interval (RFC 8628 §3.5).
+	if strings.Contains(err.Error(), "slow_down") {
+		return nil, true
+	}
+	return &Result{Provider: prov.Name, Err: err}, false
 }
 
 // --- Helpers ---

--- a/internal/auth/complexity_cog_auth_test.go
+++ b/internal/auth/complexity_cog_auth_test.go
@@ -1,0 +1,380 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Device-authorization polling has five terminal states — pending, slow_down,
+// expired, denied and success — and one piece of arithmetic, the cumulative
+// +5s backoff RFC 8628 §3.5 mandates. The pre-existing TestPollDeviceToken_SlowDown
+// proved only that polling continues past a slow_down and then succeeds; it
+// never asserted the interval bump. These tests pin both: the classification
+// of every server answer, and the backoff arithmetic itself.
+//
+// No test here waits out a real backoff interval. The arithmetic is pinned
+// through slowDownInterval with a recording ticker, and the classification
+// through pollDeviceTokenOnce, which performs exactly one request.
+
+// cogAuthProvider builds a provider whose token endpoint is the given URL and
+// whose key extraction is the identity on AccessToken.
+func cogAuthProvider(tokenURL string) Provider {
+	return Provider{
+		Name:       "cogtest",
+		EnvVar:     "COGTEST_KEY",
+		TokenURL:   tokenURL,
+		ClientID:   "client",
+		TokenToKey: func(tok *TokenResponse) string { return tok.AccessToken },
+	}
+}
+
+// cogAuthServer serves one JSON body per request, walking the list and
+// repeating the last entry once exhausted. status is the HTTP status used for
+// bodies carrying an "error" field.
+func cogAuthServer(t *testing.T, bodies ...map[string]any) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := bodies[min(calls, len(bodies)-1)]
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if _, isErr := body["error"]; isErr {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+// cogAuthTicker records every Reset it is given, standing in for the real
+// *time.Ticker so the backoff can be observed without waiting seconds for it.
+type cogAuthTicker struct {
+	resets []time.Duration
+}
+
+func (c *cogAuthTicker) Reset(d time.Duration) { c.resets = append(c.resets, d) }
+
+// TestSlowDownIntervalIsCumulative pins the arithmetic the old test left
+// unasserted: each slow_down adds exactly 5 seconds to the interval, the
+// ticker is retimed to the new interval every time, and the bumps accumulate
+// rather than resetting to a fixed backoff.
+func TestSlowDownIntervalIsCumulative(t *testing.T) {
+	ticker := &cogAuthTicker{}
+
+	interval := 1
+	var seen []int
+	for range 4 {
+		interval = slowDownInterval(interval, ticker)
+		seen = append(seen, interval)
+	}
+
+	wantIntervals := []int{6, 11, 16, 21}
+	if len(seen) != len(wantIntervals) {
+		t.Fatalf("got %d intervals, want %d", len(seen), len(wantIntervals))
+	}
+	for i, want := range wantIntervals {
+		if seen[i] != want {
+			t.Errorf("after %d slow_down responses interval = %d, want %d", i+1, seen[i], want)
+		}
+	}
+
+	wantResets := []time.Duration{6 * time.Second, 11 * time.Second, 16 * time.Second, 21 * time.Second}
+	if len(ticker.resets) != len(wantResets) {
+		t.Fatalf("ticker was reset %d times, want %d", len(ticker.resets), len(wantResets))
+	}
+	for i, want := range wantResets {
+		if ticker.resets[i] != want {
+			t.Errorf("reset %d = %v, want %v", i+1, ticker.resets[i], want)
+		}
+	}
+}
+
+// TestSlowDownIntervalFromDefault pins the bump against the default interval,
+// the value deviceTokenInterval supplies when the server names none.
+func TestSlowDownIntervalFromDefault(t *testing.T) {
+	ticker := &cogAuthTicker{}
+	if got := slowDownInterval(5, ticker); got != 10 {
+		t.Errorf("slowDownInterval(5) = %d, want 10", got)
+	}
+	if len(ticker.resets) != 1 || ticker.resets[0] != 10*time.Second {
+		t.Errorf("resets = %v, want one reset of 10s", ticker.resets)
+	}
+}
+
+// TestSlowDownIntervalAcceptsARealTicker pins that the seam is the real
+// ticker's own contract, not a test-only shape.
+func TestSlowDownIntervalAcceptsARealTicker(t *testing.T) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	if got := slowDownInterval(1, ticker); got != 6 {
+		t.Errorf("slowDownInterval(1) = %d, want 6", got)
+	}
+}
+
+func TestDeviceTokenInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"a negative interval falls back to the RFC default", -3, 5},
+		{"a zero interval falls back to the RFC default", 0, 5},
+		{"one second is honored", 1, 1},
+		{"the server's interval is honored", 7, 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deviceTokenInterval(&DeviceCodeResponse{Interval: tt.in}); got != tt.want {
+				t.Errorf("deviceTokenInterval(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeviceTokenDeadline(t *testing.T) {
+	t.Run("a zero expires_in means no deadline", func(t *testing.T) {
+		if got := deviceTokenDeadline(&DeviceCodeResponse{ExpiresIn: 0}); !got.IsZero() {
+			t.Errorf("deadline = %v, want the zero time", got)
+		}
+	})
+	t.Run("a negative expires_in means no deadline", func(t *testing.T) {
+		if got := deviceTokenDeadline(&DeviceCodeResponse{ExpiresIn: -1}); !got.IsZero() {
+			t.Errorf("deadline = %v, want the zero time", got)
+		}
+	})
+	t.Run("a positive expires_in lands that many seconds ahead", func(t *testing.T) {
+		before := time.Now()
+		got := deviceTokenDeadline(&DeviceCodeResponse{ExpiresIn: 600})
+		if got.Before(before.Add(599*time.Second)) || got.After(time.Now().Add(601*time.Second)) {
+			t.Errorf("deadline = %v, want roughly 600s after %v", got, before)
+		}
+	})
+}
+
+// TestPollDeviceTokenOnceStates pins each answer a device endpoint can give to
+// one poll: which ones end the flow, which ones continue it, and which one
+// asks for a longer interval.
+func TestPollDeviceTokenOnceStates(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         map[string]any
+		wantContinue bool // nil Result: keep polling
+		wantSlowDown bool
+		wantErrPart  string // substring of Result.Err, "" when the poll succeeded
+		wantKey      string
+	}{
+		{
+			name:         "authorization_pending keeps polling at the same interval",
+			body:         map[string]any{"error": "authorization_pending"},
+			wantContinue: true,
+		},
+		{
+			name:         "slow_down keeps polling and asks for a longer interval",
+			body:         map[string]any{"error": "slow_down"},
+			wantContinue: true,
+			wantSlowDown: true,
+		},
+		{
+			name:        "access_denied ends the flow with the server's reason",
+			body:        map[string]any{"error": "access_denied"},
+			wantErrPart: "access_denied",
+		},
+		{
+			name:        "expired_token ends the flow with the server's reason",
+			body:        map[string]any{"error": "expired_token"},
+			wantErrPart: "expired_token",
+		},
+		{
+			name:    "a token response ends the flow with the key",
+			body:    map[string]any{"access_token": "tok-123"},
+			wantKey: "tok-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, calls := cogAuthServer(t, tt.body)
+			res, slowDown := pollDeviceTokenOnce(context.Background(), cogAuthProvider(srv.URL), &DeviceCodeResponse{DeviceCode: "dc"}, time.Time{})
+
+			if *calls != 1 {
+				t.Errorf("made %d requests, want exactly 1", *calls)
+			}
+			if slowDown != tt.wantSlowDown {
+				t.Errorf("slowDown = %v, want %v", slowDown, tt.wantSlowDown)
+			}
+			if tt.wantContinue {
+				if res != nil {
+					t.Fatalf("Result = %+v, want nil so polling continues", res)
+				}
+				return
+			}
+			if res == nil {
+				t.Fatal("Result = nil, want a terminal result")
+			}
+			if res.Provider != "cogtest" {
+				t.Errorf("Provider = %q, want %q", res.Provider, "cogtest")
+			}
+			if tt.wantErrPart != "" {
+				if res.Err == nil || !strings.Contains(res.Err.Error(), tt.wantErrPart) {
+					t.Fatalf("Err = %v, want it to mention %q", res.Err, tt.wantErrPart)
+				}
+				return
+			}
+			if res.Err != nil {
+				t.Fatalf("Err = %v, want nil", res.Err)
+			}
+			if res.APIKey != tt.wantKey {
+				t.Errorf("APIKey = %q, want %q", res.APIKey, tt.wantKey)
+			}
+			if res.EnvVar != "COGTEST_KEY" {
+				t.Errorf("EnvVar = %q, want %q", res.EnvVar, "COGTEST_KEY")
+			}
+		})
+	}
+}
+
+// TestPollDeviceTokenOnceExpiredDeadline pins that a passed deadline is
+// checked before the request goes out — an expired code must not be polled
+// again.
+func TestPollDeviceTokenOnceExpiredDeadline(t *testing.T) {
+	srv, calls := cogAuthServer(t, map[string]any{"access_token": "never-read"})
+
+	res, slowDown := pollDeviceTokenOnce(
+		context.Background(),
+		cogAuthProvider(srv.URL),
+		&DeviceCodeResponse{DeviceCode: "dc"},
+		time.Now().Add(-time.Second),
+	)
+
+	if *calls != 0 {
+		t.Errorf("made %d requests past the deadline, want none", *calls)
+	}
+	if slowDown {
+		t.Error("slowDown = true, want false")
+	}
+	if res == nil || res.Err == nil {
+		t.Fatalf("Result = %+v, want a terminal expiry result", res)
+	}
+	if want := "device authorization timed out: device code expired"; res.Err.Error() != want {
+		t.Errorf("Err = %q, want %q", res.Err, want)
+	}
+	if res.APIKey != "" {
+		t.Errorf("APIKey = %q, want empty", res.APIKey)
+	}
+}
+
+// TestPollDeviceTokenOnceFutureDeadline pins the other side of the deadline
+// check: a deadline still ahead lets the request through.
+func TestPollDeviceTokenOnceFutureDeadline(t *testing.T) {
+	srv, calls := cogAuthServer(t, map[string]any{"access_token": "tok"})
+
+	res, _ := pollDeviceTokenOnce(
+		context.Background(),
+		cogAuthProvider(srv.URL),
+		&DeviceCodeResponse{DeviceCode: "dc"},
+		time.Now().Add(time.Hour),
+	)
+
+	if *calls != 1 {
+		t.Errorf("made %d requests, want 1", *calls)
+	}
+	if res == nil || res.APIKey != "tok" {
+		t.Fatalf("Result = %+v, want the token", res)
+	}
+}
+
+// TestPollDeviceTokenOnceTransportError pins that a request that never reaches
+// a server ends the flow rather than looping forever.
+func TestPollDeviceTokenOnceTransportError(t *testing.T) {
+	res, slowDown := pollDeviceTokenOnce(
+		context.Background(),
+		cogAuthProvider("http://127.0.0.1:1/token"),
+		&DeviceCodeResponse{DeviceCode: "dc"},
+		time.Time{},
+	)
+	if slowDown {
+		t.Error("slowDown = true, want false")
+	}
+	if res == nil || res.Err == nil {
+		t.Fatalf("Result = %+v, want a terminal error result", res)
+	}
+}
+
+// TestPollDeviceTokenTerminalStates drives the whole loop end to end, at a
+// one-second interval, so the states are pinned through the exported entry
+// point as well as through the helper. These cases run unchanged against the
+// pre-refactor implementation.
+func TestPollDeviceTokenTerminalStates(t *testing.T) {
+	t.Run("a nil device response is a caller error, not a Result", func(t *testing.T) {
+		res, err := PollDeviceToken(context.Background(), Provider{Name: "cogtest"}, nil)
+		if res != nil {
+			t.Errorf("Result = %+v, want nil", res)
+		}
+		if err == nil || err.Error() != "nil device code response" {
+			t.Fatalf("err = %v, want \"nil device code response\"", err)
+		}
+	})
+
+	t.Run("pending then a token yields the key", func(t *testing.T) {
+		srv, calls := cogAuthServer(t,
+			map[string]any{"error": "authorization_pending"},
+			map[string]any{"access_token": "tok-late"},
+		)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		res, err := PollDeviceToken(ctx, cogAuthProvider(srv.URL), &DeviceCodeResponse{DeviceCode: "dc", Interval: 1})
+		if err != nil {
+			t.Fatalf("PollDeviceToken: %v", err)
+		}
+		if res.Err != nil {
+			t.Fatalf("Result.Err = %v, want nil", res.Err)
+		}
+		if res.APIKey != "tok-late" {
+			t.Errorf("APIKey = %q, want %q", res.APIKey, "tok-late")
+		}
+		if *calls != 2 {
+			t.Errorf("made %d requests, want 2 (one pending, one success)", *calls)
+		}
+	})
+
+	t.Run("a denial ends the poll on the first tick", func(t *testing.T) {
+		srv, calls := cogAuthServer(t, map[string]any{"error": "access_denied"})
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		res, err := PollDeviceToken(ctx, cogAuthProvider(srv.URL), &DeviceCodeResponse{DeviceCode: "dc", Interval: 1})
+		if err != nil {
+			t.Fatalf("PollDeviceToken: %v", err)
+		}
+		if res.Err == nil || !strings.Contains(res.Err.Error(), "access_denied") {
+			t.Fatalf("Result.Err = %v, want it to mention access_denied", res.Err)
+		}
+		if *calls != 1 {
+			t.Errorf("made %d requests, want 1", *calls)
+		}
+	})
+
+	t.Run("a canceled context reports the context error", func(t *testing.T) {
+		srv, _ := cogAuthServer(t, map[string]any{"error": "authorization_pending"})
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		res, err := PollDeviceToken(ctx, cogAuthProvider(srv.URL), &DeviceCodeResponse{DeviceCode: "dc", Interval: 30})
+		if err != nil {
+			t.Fatalf("PollDeviceToken: %v", err)
+		}
+		if res.Err == nil || !strings.Contains(res.Err.Error(), "context deadline exceeded") {
+			t.Fatalf("Result.Err = %v, want the context deadline error", res.Err)
+		}
+		if res.Provider != "cogtest" {
+			t.Errorf("Provider = %q, want %q", res.Provider, "cogtest")
+		}
+	})
+}

--- a/internal/cli/complexity_cog_cli_test.go
+++ b/internal/cli/complexity_cog_cli_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/attest"
+)
+
+// These tests pin the exact bytes writeVerifyText produces — `pi verify` is a
+// security-reporting command, so the difference between "✓" and "✗", and the
+// no-attestation explanation that separates a locally built binary from a real
+// verification failure, are the output. Every golden below was captured by
+// running the same reports through the pre-refactor writeVerifyText, so a
+// passing run proves the flattening changed nothing a user sees.
+
+var cogVerifySignedAt = time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+
+// cogVerifyFullReport is a fully populated success: one provenance
+// attestation with every field set, and one SBOM attestation with ecosystems
+// and no signing time.
+func cogVerifyFullReport() verifyReport {
+	return verifyReport{
+		Path:     "/usr/local/bin/pi",
+		Digest:   "sha256:deadbeef",
+		Repo:     "dimetron/pi-go",
+		Verified: true,
+		Results: []*attest.Result{
+			{
+				PredicateType:  "https://slsa.dev/provenance/v1",
+				SignerIdentity: "signer-a",
+				SignedAt:       cogVerifySignedAt,
+				Provenance: &attest.Provenance{
+					Repository: "github.com/dimetron/pi-go",
+					Workflow:   ".github/workflows/release.yml",
+					Ref:        "refs/tags/v0.0.74",
+					Commit:     "4086645",
+					RunURL:     "https://github.com/dimetron/pi-go/actions/runs/1234",
+				},
+			},
+			{
+				PredicateType:  "https://spdx.dev/Document/v2.3",
+				SignerIdentity: "signer-b",
+				SBOM: &attest.SBOM{
+					Format:     "SPDX",
+					Version:    "2.3",
+					Packages:   192,
+					Ecosystems: map[string]int{"golang": 180, "github": 12},
+				},
+			},
+		},
+	}
+}
+
+func TestWriteVerifyTextGoldenOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		reports []verifyReport
+		want    string
+	}{
+		{
+			name:    "provenance and SBOM, every field populated",
+			reports: []verifyReport{cogVerifyFullReport()},
+			want: "/usr/local/bin/pi\n  sha256:deadbeef\n" +
+				"\n  ✓ build provenance\n" +
+				"      repository  github.com/dimetron/pi-go\n" +
+				"      workflow    .github/workflows/release.yml@refs/tags/v0.0.74\n" +
+				"      commit      4086645\n" +
+				"      run         https://github.com/dimetron/pi-go/actions/runs/1234\n" +
+				"      signer      signer-a\n" +
+				"      signed      2026-08-21T12:00:00Z\n" +
+				"\n  ✓ SBOM\n" +
+				"      format      SPDX 2.3\n" +
+				"      packages    192\n" +
+				"      ecosystems  golang 180, github 12\n" +
+				"      signer      signer-b\n",
+		},
+		{
+			name: "no attestation carries the locally-built explanation",
+			reports: []verifyReport{{
+				Path: "./pi", Digest: "sha256:abc", Repo: "dimetron/pi-go",
+				Error: "no attestations found", noAttestation: true,
+			}},
+			want: "./pi\n  sha256:abc\n" +
+				"\n  ✗ unverified: no attestations found\n" +
+				"\n    dimetron/pi-go holds no attestation for these bytes. A binary you\n" +
+				"    built yourself never has one, and neither does one from a\n" +
+				"    release made before the workflow started attesting.\n",
+		},
+		{
+			name: "a real verification failure gets no explanation block",
+			reports: []verifyReport{{
+				Path: "./pi", Digest: "sha256:abc", Repo: "dimetron/pi-go", Error: "boom",
+			}},
+			want: "./pi\n  sha256:abc\n\n  ✗ unverified: boom\n",
+		},
+		{
+			name:    "a missing digest line is omitted",
+			reports: []verifyReport{{Path: "./pi", Repo: "r", Error: "digest failed"}},
+			want:    "./pi\n\n  ✗ unverified: digest failed\n",
+		},
+		{
+			name: "a blank line separates consecutive targets",
+			reports: []verifyReport{
+				{Path: "a", Digest: "sha256:1", Repo: "r", Error: "e1"},
+				{Path: "b", Digest: "sha256:2", Repo: "r", Error: "e2"},
+			},
+			want: "a\n  sha256:1\n\n  ✗ unverified: e1\n" +
+				"\nb\n  sha256:2\n\n  ✗ unverified: e2\n",
+		},
+		{
+			name: "an attestation that is neither provenance nor SBOM prints its predicate type",
+			reports: []verifyReport{{
+				Path: "x", Digest: "sha256:9", Repo: "r", Verified: true,
+				Results: []*attest.Result{{
+					PredicateType:  "https://example.com/custom/v1",
+					SignerIdentity: "sid",
+					SignedAt:       cogVerifySignedAt,
+				}},
+			}},
+			want: "x\n  sha256:9\n\n  ✓ https://example.com/custom/v1\n" +
+				"      signer      sid\n" +
+				"      signed      2026-08-21T12:00:00Z\n",
+		},
+		{
+			name: "an SBOM without ecosystems omits that field, and a zero package count is still printed",
+			reports: []verifyReport{{
+				Path: "x", Digest: "sha256:9", Repo: "r", Verified: true,
+				Results: []*attest.Result{{
+					PredicateType: "p",
+					SBOM:          &attest.SBOM{Format: "SPDX", Packages: 0},
+				}},
+			}},
+			want: "x\n  sha256:9\n\n  ✓ SBOM\n      format      SPDX\n      packages    0\n",
+		},
+		{
+			name: "provenance with only a workflow prints one field",
+			reports: []verifyReport{{
+				Path: "x", Repo: "r", Verified: true,
+				Results: []*attest.Result{{PredicateType: "p", Provenance: &attest.Provenance{Workflow: "wf"}}},
+			}},
+			want: "x\n\n  ✓ build provenance\n      workflow    wf\n",
+		},
+		{
+			name: "provenance with only a ref prints the ref under the workflow label",
+			reports: []verifyReport{{
+				Path: "x", Repo: "r", Verified: true,
+				Results: []*attest.Result{{PredicateType: "p", Provenance: &attest.Provenance{Ref: "refs/heads/main"}}},
+			}},
+			want: "x\n\n  ✓ build provenance\n      workflow    refs/heads/main\n",
+		},
+		{
+			name:    "a verified report with no attestations prints only its header",
+			reports: []verifyReport{{Path: "x", Digest: "sha256:9", Repo: "r", Verified: true}},
+			want:    "x\n  sha256:9\n",
+		},
+		{
+			name:    "no reports produce no output",
+			reports: []verifyReport{},
+			want:    "",
+		},
+		{
+			name:    "a nil report slice produces no output",
+			reports: nil,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writeVerifyText(&buf, tt.reports)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("writeVerifyText output mismatch\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// cogVerifyFailingWriter fails every write, so the SBOM dump's I/O error path
+// can be exercised without a real broken pipe.
+type cogVerifyFailingWriter struct{}
+
+func (cogVerifyFailingWriter) Write([]byte) (int, error) { return 0, errors.New("disk full") }
+
+// TestWriteSBOMDocumentsPaths pins each outcome of the SBOM dump: the bytes it
+// writes on success, the two error paths, and the two ways a report can
+// contribute no document.
+func TestWriteSBOMDocumentsPaths(t *testing.T) {
+	sbomReport := func(pred string) verifyReport {
+		return verifyReport{
+			Path: "./pi", Repo: "r", Verified: true,
+			Results: []*attest.Result{{
+				PredicateType: "https://spdx.dev/Document/v2.3",
+				SBOM:          &attest.SBOM{Format: "SPDX", Version: "2.3"},
+				Predicate:     json.RawMessage(pred),
+			}},
+		}
+	}
+
+	t.Run("a valid predicate is re-indented and newline terminated", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := writeSBOMDocuments(&buf, []verifyReport{sbomReport(`{"a":1}`)}); err != nil {
+			t.Fatalf("writeSBOMDocuments: %v", err)
+		}
+		want := "{\n  \"a\": 1\n}\n"
+		if got := buf.String(); got != want {
+			t.Errorf("output = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("two reports each contribute their document", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := writeSBOMDocuments(&buf, []verifyReport{sbomReport(`{"a":1}`), sbomReport(`{"b":2}`)}); err != nil {
+			t.Fatalf("writeSBOMDocuments: %v", err)
+		}
+		want := "{\n  \"a\": 1\n}\n{\n  \"b\": 2\n}\n"
+		if got := buf.String(); got != want {
+			t.Errorf("output = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("an unverified report is refused before anything is written", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := writeSBOMDocuments(&buf, []verifyReport{{Path: "./pi", Error: "boom"}})
+		if err == nil || err.Error() != "./pi: boom" {
+			t.Fatalf("error = %v, want \"./pi: boom\"", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("wrote %q, want nothing", buf.String())
+		}
+	})
+
+	t.Run("an SBOM whose raw predicate was dropped contributes nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := writeSBOMDocuments(&buf, []verifyReport{sbomReport("")})
+		if err == nil || err.Error() != "no SBOM attestation found for the given artifacts" {
+			t.Fatalf("error = %v, want the no-SBOM error", err)
+		}
+	})
+
+	t.Run("a non-SBOM attestation contributes nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		report := verifyReport{Path: "./pi", Verified: true, Results: []*attest.Result{{
+			PredicateType: "https://slsa.dev/provenance/v1",
+			Provenance:    &attest.Provenance{Repository: "r"},
+			Predicate:     json.RawMessage(`{"a":1}`),
+		}}}
+		err := writeSBOMDocuments(&buf, []verifyReport{report})
+		if err == nil || err.Error() != "no SBOM attestation found for the given artifacts" {
+			t.Fatalf("error = %v, want the no-SBOM error", err)
+		}
+	})
+
+	t.Run("an unmarshalable predicate is reported as a formatting error", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := writeSBOMDocuments(&buf, []verifyReport{sbomReport(`{not json`)})
+		if err == nil || !strings.HasPrefix(err.Error(), "formatting SBOM: ") {
+			t.Fatalf("error = %v, want a formatting SBOM error", err)
+		}
+	})
+
+	t.Run("a write failure is returned unwrapped", func(t *testing.T) {
+		err := writeSBOMDocuments(cogVerifyFailingWriter{}, []verifyReport{sbomReport(`{"a":1}`)})
+		if err == nil || err.Error() != "disk full" {
+			t.Fatalf("error = %v, want \"disk full\"", err)
+		}
+	})
+}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -214,46 +214,59 @@ func writeVerifyText(out io.Writer, reports []verifyReport) {
 		if i > 0 {
 			fmt.Fprintln(out)
 		}
-		fmt.Fprintf(out, "%s\n", r.Path)
-		if r.Digest != "" {
-			fmt.Fprintf(out, "  %s\n", r.Digest)
-		}
+		writeVerifyReport(out, r)
+	}
+}
 
-		if !r.Verified {
-			fmt.Fprintf(out, "\n  ✗ unverified: %s\n", r.Error)
-			if r.noAttestation {
-				fmt.Fprintf(out, "\n    %s holds no attestation for these bytes. A binary you\n", r.Repo)
-				fmt.Fprintf(out, "    built yourself never has one, and neither does one from a\n")
-				fmt.Fprintf(out, "    release made before the workflow started attesting.\n")
-			}
-			continue
-		}
+// writeVerifyReport prints one target: its path and digest, then either the
+// reason it is unverified or the attestations that checked out.
+func writeVerifyReport(out io.Writer, r verifyReport) {
+	fmt.Fprintf(out, "%s\n", r.Path)
+	if r.Digest != "" {
+		fmt.Fprintf(out, "  %s\n", r.Digest)
+	}
 
-		for _, res := range r.Results {
-			switch {
-			case res.Provenance != nil:
-				p := res.Provenance
-				fmt.Fprintf(out, "\n  ✓ build provenance\n")
-				writeField(out, "repository", p.Repository)
-				writeField(out, "workflow", joinRef(p.Workflow, p.Ref))
-				writeField(out, "commit", p.Commit)
-				writeField(out, "run", p.RunURL)
-			case res.SBOM != nil:
-				s := res.SBOM
-				fmt.Fprintf(out, "\n  ✓ SBOM\n")
-				writeField(out, "format", strings.TrimSpace(s.Format+" "+s.Version))
-				writeField(out, "packages", fmt.Sprintf("%d", s.Packages))
-				if eco := s.EcosystemsSorted(); len(eco) > 0 {
-					writeField(out, "ecosystems", strings.Join(eco, ", "))
-				}
-			default:
-				fmt.Fprintf(out, "\n  ✓ %s\n", res.PredicateType)
-			}
-			writeField(out, "signer", res.SignerIdentity)
-			if !res.SignedAt.IsZero() {
-				writeField(out, "signed", res.SignedAt.UTC().Format(time.RFC3339))
-			}
+	if !r.Verified {
+		fmt.Fprintf(out, "\n  ✗ unverified: %s\n", r.Error)
+		if r.noAttestation {
+			fmt.Fprintf(out, "\n    %s holds no attestation for these bytes. A binary you\n", r.Repo)
+			fmt.Fprintf(out, "    built yourself never has one, and neither does one from a\n")
+			fmt.Fprintf(out, "    release made before the workflow started attesting.\n")
 		}
+		return
+	}
+
+	for _, res := range r.Results {
+		writeAttestation(out, res)
+	}
+}
+
+// writeAttestation prints one verified attestation: the detail block its
+// predicate type calls for, then the signer identity and signing time that
+// every predicate shares.
+func writeAttestation(out io.Writer, res *attest.Result) {
+	switch {
+	case res.Provenance != nil:
+		p := res.Provenance
+		fmt.Fprintf(out, "\n  ✓ build provenance\n")
+		writeField(out, "repository", p.Repository)
+		writeField(out, "workflow", joinRef(p.Workflow, p.Ref))
+		writeField(out, "commit", p.Commit)
+		writeField(out, "run", p.RunURL)
+	case res.SBOM != nil:
+		s := res.SBOM
+		fmt.Fprintf(out, "\n  ✓ SBOM\n")
+		writeField(out, "format", strings.TrimSpace(s.Format+" "+s.Version))
+		writeField(out, "packages", fmt.Sprintf("%d", s.Packages))
+		if eco := s.EcosystemsSorted(); len(eco) > 0 {
+			writeField(out, "ecosystems", strings.Join(eco, ", "))
+		}
+	default:
+		fmt.Fprintf(out, "\n  ✓ %s\n", res.PredicateType)
+	}
+	writeField(out, "signer", res.SignerIdentity)
+	if !res.SignedAt.IsZero() {
+		writeField(out, "signed", res.SignedAt.UTC().Format(time.RFC3339))
 	}
 }
 
@@ -284,24 +297,37 @@ func writeSBOMDocuments(out io.Writer, reports []verifyReport) error {
 		if !r.Verified {
 			return fmt.Errorf("%s: %s", r.Path, r.Error)
 		}
-		for _, res := range r.Results {
-			if res.SBOM == nil || len(res.Predicate) == 0 {
-				continue
-			}
-			buf, err := json.MarshalIndent(res.Predicate, "", "  ")
-			if err != nil {
-				return fmt.Errorf("formatting SBOM: %w", err)
-			}
-			if _, err := out.Write(append(buf, '\n')); err != nil {
-				return err
-			}
-			found = true
+		wrote, err := writeSBOMPredicates(out, r.Results)
+		if err != nil {
+			return err
 		}
+		found = found || wrote
 	}
 	if !found {
 		return errors.New("no SBOM attestation found for the given artifacts")
 	}
 	return nil
+}
+
+// writeSBOMPredicates writes the raw SBOM predicate of every SBOM attestation
+// in results, and reports whether it wrote any. Attestations that are not
+// SBOMs, and SBOM results whose raw predicate was not retained, are skipped.
+func writeSBOMPredicates(out io.Writer, results []*attest.Result) (bool, error) {
+	found := false
+	for _, res := range results {
+		if res.SBOM == nil || len(res.Predicate) == 0 {
+			continue
+		}
+		buf, err := json.MarshalIndent(res.Predicate, "", "  ")
+		if err != nil {
+			return found, fmt.Errorf("formatting SBOM: %w", err)
+		}
+		if _, err := out.Write(append(buf, '\n')); err != nil {
+			return found, err
+		}
+		found = true
+	}
+	return found, nil
 }
 
 // githubTokenFromEnv returns a token if one is around. The attestations

--- a/internal/codex/complexity_cog_codex_test.go
+++ b/internal/codex/complexity_cog_codex_test.go
@@ -1,0 +1,321 @@
+package codex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// loop's select arms were flattened into two helpers, startedResult and
+// exitedResult. Each arm decides one thing: whether the turn is over, and with
+// what RunResult. These tests pin every outcome of both helpers directly,
+// which the session-level tests could only reach through timing.
+
+// cogLoopSession returns a session wired to a fake app-server but with no loop
+// goroutine running, so the helpers can be called directly without racing the
+// session's own owner goroutine.
+func cogLoopSession(t *testing.T, threadID string) (*Session, *fakeServer) {
+	t.Helper()
+	fs := newFakeServer(t)
+	return newSession(fs.client, threadID), fs
+}
+
+func TestStartedResultOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		start      startResult
+		text       string
+		lastErr    string
+		wantDone   bool
+		wantStatus string
+		wantError  string
+		wantStop   string
+		wantResult string
+	}{
+		{
+			name:       "a failed turn/start ends the turn with the start error",
+			start:      startResult{err: errStartFailed},
+			text:       "partial answer",
+			wantDone:   true,
+			wantStatus: StatusError,
+			wantError:  "turn/start rejected",
+			wantResult: "partial answer",
+		},
+		{
+			name:     "a turn that is still in progress keeps the loop running",
+			start:    startResult{turn: &Turn{ID: "t1", Status: TurnInProgress}},
+			text:     "so far",
+			wantDone: false,
+		},
+		{
+			name:     "a start response with no turn keeps the loop running",
+			start:    startResult{},
+			wantDone: false,
+		},
+		{
+			name:       "a start response that is already completed ends the turn",
+			start:      startResult{turn: &Turn{ID: "t1", Status: TurnCompleted}},
+			text:       "the answer",
+			wantDone:   true,
+			wantStatus: StatusSuccess,
+			wantStop:   TurnCompleted,
+			wantResult: "the answer",
+		},
+		{
+			name:       "a start response that already failed ends the turn with the turn error",
+			start:      startResult{turn: &Turn{ID: "t1", Status: TurnFailed, Error: "model unavailable"}},
+			wantDone:   true,
+			wantStatus: StatusError,
+			wantError:  "model unavailable",
+			wantStop:   TurnFailed,
+		},
+		{
+			name:       "a failed turn with no error of its own falls back to the last reported error",
+			start:      startResult{turn: &Turn{ID: "t1", Status: TurnFailed}},
+			lastErr:    "rate limited",
+			wantDone:   true,
+			wantStatus: StatusError,
+			wantError:  "rate limited",
+			wantStop:   TurnFailed,
+		},
+		{
+			name:       "an interrupted start response ends the turn with a synthesized reason",
+			start:      startResult{turn: &Turn{ID: "t1", Status: TurnInterrupted}},
+			wantDone:   true,
+			wantStatus: StatusError,
+			wantError:  "codex turn interrupted",
+			wantStop:   TurnInterrupted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess, _ := cogLoopSession(t, "thr_1")
+
+			done, got := sess.startedResult(tt.start, tt.text, tt.lastErr)
+			if done != tt.wantDone {
+				t.Fatalf("done = %v, want %v", done, tt.wantDone)
+			}
+			if !tt.wantDone {
+				if got != (RunResult{}) {
+					t.Errorf("RunResult = %+v, want the zero value while the turn runs", got)
+				}
+				return
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.Error != tt.wantError {
+				t.Errorf("Error = %q, want %q", got.Error, tt.wantError)
+			}
+			if got.StopReason != tt.wantStop {
+				t.Errorf("StopReason = %q, want %q", got.StopReason, tt.wantStop)
+			}
+			if got.Result != tt.wantResult {
+				t.Errorf("Result = %q, want %q", got.Result, tt.wantResult)
+			}
+		})
+	}
+}
+
+// errStartFailed stands in for whatever turn/start rejection the app-server
+// reports; only its message reaches the RunResult.
+var errStartFailed = cogStartError("turn/start rejected")
+
+type cogStartError string
+
+func (e cogStartError) Error() string { return string(e) }
+
+// TestStartedResultKeepsSessionIDOnlyForTerminalTurns pins a pre-existing
+// asymmetry the flattening preserves: the start-error result carries no
+// session ID, while a result built from a terminal turn does.
+func TestStartedResultKeepsSessionIDOnlyForTerminalTurns(t *testing.T) {
+	sess, _ := cogLoopSession(t, "thr_9")
+
+	_, startErr := sess.startedResult(startResult{err: errStartFailed}, "", "")
+	if startErr.SessionID != "" {
+		t.Errorf("start-error SessionID = %q, want empty", startErr.SessionID)
+	}
+
+	_, completed := sess.startedResult(startResult{turn: &Turn{Status: TurnCompleted}}, "", "")
+	if completed.SessionID != "thr_9" {
+		t.Errorf("completed SessionID = %q, want %q", completed.SessionID, "thr_9")
+	}
+}
+
+// TestExitedResultCrashesWhenNothingIsBuffered pins the plain crash path: the
+// subprocess is gone and nothing terminal was queued behind the exit signal.
+func TestExitedResultCrashesWhenNothingIsBuffered(t *testing.T) {
+	sess, _ := cogLoopSession(t, "thr_1")
+
+	var text strings.Builder
+	text.WriteString("half an answer")
+	lastErr := ""
+
+	got := sess.exitedResult(&text, &lastErr)
+
+	if got.Status != StatusError {
+		t.Errorf("Status = %q, want %q", got.Status, StatusError)
+	}
+	if got.Error != "codex app-server exited before the turn completed" {
+		t.Errorf("Error = %q, want the plain crash message", got.Error)
+	}
+	if got.Result != "half an answer" {
+		t.Errorf("Result = %q, want the text accumulated so far", got.Result)
+	}
+	if got.SessionID != "thr_1" {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, "thr_1")
+	}
+}
+
+// TestExitedResultDrainsACompletionQueuedBehindTheExit pins the reason the
+// drain exists: a turn that finished just as the process went away must be
+// reported as that turn's outcome, not as a crash.
+func TestExitedResultDrainsACompletionQueuedBehindTheExit(t *testing.T) {
+	sess, fs := cogLoopSession(t, "thr_1")
+
+	cogQueueNotification(t, fs, NotifyTurnCompleted, TurnCompletedParams{
+		ThreadID: "thr_1",
+		Turn:     Turn{ID: "turn_1", Status: TurnCompleted},
+	})
+
+	var text strings.Builder
+	text.WriteString("the answer")
+	lastErr := ""
+
+	got := sess.exitedResult(&text, &lastErr)
+
+	if got.Status != StatusSuccess {
+		t.Errorf("Status = %q, want %q", got.Status, StatusSuccess)
+	}
+	if got.StopReason != TurnCompleted {
+		t.Errorf("StopReason = %q, want %q", got.StopReason, TurnCompleted)
+	}
+	if got.Result != "the answer" {
+		t.Errorf("Result = %q, want %q", got.Result, "the answer")
+	}
+	if got.Error != "" {
+		t.Errorf("Error = %q, want empty", got.Error)
+	}
+}
+
+// TestExitedResultFoldsADrainedErrorIntoTheCrashMessage pins the other half of
+// the drain: a non-terminal error notification queued behind the exit does not
+// end the turn, but it does explain the crash.
+func TestExitedResultFoldsADrainedErrorIntoTheCrashMessage(t *testing.T) {
+	sess, fs := cogLoopSession(t, "thr_1")
+
+	cogQueueNotification(t, fs, NotifyError, ErrorParams{
+		Error: RPCError{Message: "usage limit reached"},
+	})
+
+	var text strings.Builder
+	lastErr := ""
+
+	got := sess.exitedResult(&text, &lastErr)
+
+	if lastErr != "usage limit reached" {
+		t.Errorf("lastErr = %q, want it updated to the drained error", lastErr)
+	}
+	want := "codex app-server exited before the turn completed: usage limit reached"
+	if got.Error != want {
+		t.Errorf("Error = %q, want %q", got.Error, want)
+	}
+	if got.Status != StatusError {
+		t.Errorf("Status = %q, want %q", got.Status, StatusError)
+	}
+}
+
+// TestExitedResultIgnoresAChildThreadCompletion pins that the drain applies the
+// same thread filter the live path does: a child thread finishing is progress,
+// not the end of our turn.
+func TestExitedResultIgnoresAChildThreadCompletion(t *testing.T) {
+	sess, fs := cogLoopSession(t, "thr_parent")
+
+	cogQueueNotification(t, fs, NotifyTurnCompleted, TurnCompletedParams{
+		ThreadID: "thr_child",
+		Turn:     Turn{ID: "turn_child", Status: TurnCompleted},
+	})
+
+	var text strings.Builder
+	lastErr := ""
+
+	got := sess.exitedResult(&text, &lastErr)
+
+	if got.Status != StatusError {
+		t.Errorf("Status = %q, want %q — a child completion must not end the turn", got.Status, StatusError)
+	}
+	if got.Error != "codex app-server exited before the turn completed" {
+		t.Errorf("Error = %q, want the plain crash message", got.Error)
+	}
+}
+
+// cogQueueNotification places a notification directly on the client's
+// notification channel. Writing to the channel rather than through the fake
+// server's pipe keeps the test free of any race with the reader goroutine: the
+// notification is buffered before the drain starts, every time.
+func cogQueueNotification(t *testing.T, fs *fakeServer, method string, params any) {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal %s params: %v", method, err)
+	}
+	fs.client.notifCh <- JSONRPCNotification{Method: method, Params: raw}
+}
+
+// TestSessionTerminalStartResponseFinishesTheTurn drives the whole loop: a
+// turn/start response that already reports a terminal status must finish the
+// session, because no turn/completed notification will ever follow it. This
+// case runs unchanged against the pre-refactor loop.
+func TestSessionTerminalStartResponseFinishesTheTurn(t *testing.T) {
+	fs := newFakeServer(t)
+
+	type startedSession struct {
+		sess *Session
+		err  error
+	}
+	ch := make(chan startedSession, 1)
+	go func() {
+		sess, err := startSession(t.Context(), fs.client, SessionOpts{Prompt: "go"})
+		ch <- startedSession{sess, err}
+	}()
+
+	threadReq := fs.readRequest()
+	fs.respond(*threadReq.ID, ThreadStartResponse{Thread: Thread{ID: "thr_1"}})
+
+	res := <-ch
+	if res.err != nil {
+		t.Fatalf("startSession: %v", res.err)
+	}
+	t.Cleanup(func() { _ = fs.client.close() })
+
+	turnReq := fs.readRequest()
+	fs.respond(*turnReq.ID, TurnStartResponse{Turn: Turn{
+		ID:     "turn_1",
+		Status: TurnFailed,
+		Error:  "model unavailable",
+	}})
+
+	collect(t, res.sess)
+
+	select {
+	case <-res.sess.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("session did not finish on an already-terminal start response")
+	}
+
+	result := res.sess.Wait()
+	if result.Status != StatusError {
+		t.Errorf("Status = %q, want %q", result.Status, StatusError)
+	}
+	if result.StopReason != TurnFailed {
+		t.Errorf("StopReason = %q, want %q", result.StopReason, TurnFailed)
+	}
+	if result.Error != "model unavailable" {
+		t.Errorf("Error = %q, want %q", result.Error, "model unavailable")
+	}
+	if result.SessionID != "thr_1" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "thr_1")
+	}
+}

--- a/internal/codex/session.go
+++ b/internal/codex/session.go
@@ -256,20 +256,14 @@ func (s *Session) loop(ctx context.Context, started <-chan startResult) {
 	stderrLines := s.client.stderrLines()
 
 	for {
+		var (
+			done   bool
+			result RunResult
+		)
+
 		select {
 		case sr := <-started:
-			// turn/start failed — nothing will ever complete this turn.
-			if sr.err != nil {
-				s.finish(RunResult{Status: StatusError, Error: sr.err.Error(), Result: text.String()})
-				return
-			}
-			// The start response may already report a terminal status (the
-			// app-server protocol allows this); if so, no turn/completed
-			// notification will follow and we must not wait for one.
-			if sr.turn != nil && isTerminalTurnStatus(sr.turn.Status) {
-				s.finish(s.completedResult(*sr.turn, text.String(), lastErr))
-				return
-			}
+			done, result = s.startedResult(sr, text.String(), lastErr)
 
 		case line, ok := <-stderrLines:
 			if !ok {
@@ -287,46 +281,65 @@ func (s *Session) loop(ctx context.Context, started <-chan startResult) {
 				notifs = nil
 				continue
 			}
-			done, result := s.handleNotification(notif, &text, &lastErr)
-			if done {
-				s.finish(result)
-				return
-			}
+			done, result = s.handleNotification(notif, &text, &lastErr)
 
 		case <-s.client.closing:
 			// Cancel. Don't wait for the killed subprocess to hit EOF — the
 			// caller wants the session gone now.
-			s.finish(RunResult{
+			done, result = true, RunResult{
 				Status:     StatusError,
 				Error:      "codex turn canceled",
 				Result:     text.String(),
 				SessionID:  s.threadID,
 				StopReason: TurnInterrupted,
-			})
-			return
+			}
 
 		case <-s.client.exited:
-			// The subprocess is gone. Drain what is still buffered before
-			// concluding it crashed: a turn/completed (or the error that
-			// explains the exit) may already be queued behind this signal.
-			if done, result := s.drainRemaining(&text, &lastErr); done {
-				s.finish(result)
-				return
-			}
-			s.finish(s.crashResult(text.String(), lastErr))
-			return
+			done, result = true, s.exitedResult(&text, &lastErr)
 
 		case <-ctx.Done():
-			s.finish(RunResult{
+			done, result = true, RunResult{
 				Status:    StatusError,
 				Error:     ctx.Err().Error(),
 				Result:    text.String(),
 				SessionID: s.threadID,
 				Stderr:    s.client.stderrText(),
-			})
+			}
+		}
+
+		if done {
+			s.finish(result)
 			return
 		}
 	}
+}
+
+// startedResult translates the turn/start response into a terminal result. It
+// reports done=false while the turn is still running and a turn/completed
+// notification is still expected.
+func (s *Session) startedResult(sr startResult, text, lastErr string) (bool, RunResult) {
+	// turn/start failed — nothing will ever complete this turn.
+	if sr.err != nil {
+		return true, RunResult{Status: StatusError, Error: sr.err.Error(), Result: text}
+	}
+	// The start response may already report a terminal status (the app-server
+	// protocol allows this); if so, no turn/completed notification will follow
+	// and we must not wait for one.
+	if sr.turn != nil && isTerminalTurnStatus(sr.turn.Status) {
+		return true, s.completedResult(*sr.turn, text, lastErr)
+	}
+	return false, RunResult{}
+}
+
+// exitedResult concludes a turn whose subprocess is gone. What is still
+// buffered is drained first: a turn/completed (or the error that explains the
+// exit) may already be queued behind the exited signal, and only when nothing
+// terminal turns up is this reported as a crash.
+func (s *Session) exitedResult(text *strings.Builder, lastErr *string) RunResult {
+	if done, result := s.drainRemaining(text, lastErr); done {
+		return result
+	}
+	return s.crashResult(text.String(), *lastErr)
 }
 
 // drainRemaining consumes what is still buffered on the notification and

--- a/internal/eval/complexity_cog_eval_test.go
+++ b/internal/eval/complexity_cog_eval_test.go
@@ -1,0 +1,602 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/atif"
+)
+
+// The literals in this file were captured by running these exact fixtures
+// through the pre-refactor source (a `git archive HEAD` copy in a scratch
+// directory), so they pin the digest, prompt and metric output the judge and
+// the recorded eval reports depend on. A shift in shape or content would make
+// new runs non-comparable with old ones without failing anything, which is
+// precisely what these tests exist to prevent.
+
+// cogDigestFixture exercises every branch of one digest session: a nil entry,
+// an entry with no trajectory, a sized result, an error result, a call with no
+// result, a subagent-spawning result, an orphaned observation, over-long
+// arguments, and a session with no tool calls at all.
+func cogDigestFixture() []*LoadedTrajectory {
+	long := ""
+	for i := 0; i < 40; i++ {
+		long += "abcdefg-"
+	}
+	parent := &atif.Trajectory{
+		SessionID: "260809-0249-c53d2-7561f",
+		Agent:     atif.AgentInfo{Name: "pi-go", ModelName: "opus"},
+		Steps: []atif.Step{
+			{
+				StepID:    1,
+				Timestamp: "2026-08-22T10:00:00Z",
+				ToolCalls: []atif.ToolCall{
+					{ToolCallID: "c1", FunctionName: "bash", Arguments: map[string]any{"cmd": "ls"}},
+					{ToolCallID: "c2", FunctionName: "read", Arguments: map[string]any{"path": long}},
+					{ToolCallID: "c3", FunctionName: "grep"},
+					{ToolCallID: "c4", FunctionName: "subagent", Arguments: map[string]any{"task": "x"}},
+				},
+				Observation: &atif.Observation{Results: []atif.ObservationResult{
+					{SourceCallID: "c1", Content: "hello world"},
+					{SourceCallID: "c2", Content: "error: no such\nfile or\tdirectory"},
+					{SourceCallID: "", Content: "orphan"},
+					{SourceCallID: "c4", Content: map[string]any{"ok": true}, SubagentTrajectoryRef: "/s/child/trajectory.atif.json"},
+				}},
+			},
+			{StepID: 2, ToolCalls: []atif.ToolCall{{ToolCallID: "c5", FunctionName: "write"}}},
+		},
+	}
+	empty := &atif.Trajectory{SessionID: "sess-empty", Agent: atif.AgentInfo{Name: "worker"}}
+	return []*LoadedTrajectory{
+		nil,
+		{SessionID: "nil-traj"},
+		{SessionID: parent.SessionID, Traj: parent},
+		{SessionID: "sess-empty", Traj: empty},
+	}
+}
+
+// cogCappedFixture has seven calls spread over two steps, so a cap of five
+// stops mid-step and the remainder is reported as a count.
+func cogCappedFixture() []*LoadedTrajectory {
+	var first, second []atif.ToolCall
+	for i := 0; i < 3; i++ {
+		first = append(first, atif.ToolCall{ToolCallID: fmt.Sprintf("a%d", i), FunctionName: "bash"})
+	}
+	for i := 0; i < 4; i++ {
+		second = append(second, atif.ToolCall{ToolCallID: fmt.Sprintf("b%d", i), FunctionName: "read"})
+	}
+	t := &atif.Trajectory{
+		SessionID: "capped-session-id",
+		Agent:     atif.AgentInfo{Name: "pi-go"},
+		Steps: []atif.Step{
+			{StepID: 1, ToolCalls: first, Observation: &atif.Observation{Results: []atif.ObservationResult{{SourceCallID: "a0", Content: "ok"}}}},
+			{StepID: 2, ToolCalls: second},
+		},
+	}
+	return []*LoadedTrajectory{{SessionID: t.SessionID, Traj: t}}
+}
+
+// cogToolsFixture covers observed and unobserved calls, an error result, a
+// structured result, an orphaned observation, a call with no ID, duplicate
+// argument sets across sessions, a subagent call, and an unparseable step
+// timestamp (which must leave latency out of the average).
+func cogToolsFixture() []*LoadedTrajectory {
+	parent := &atif.Trajectory{
+		SessionID: "p",
+		Agent:     atif.AgentInfo{Name: "pi-go", ModelName: "m1"},
+		Steps: []atif.Step{
+			{
+				StepID:    1,
+				Timestamp: "2026-08-22T10:00:00Z",
+				ToolCalls: []atif.ToolCall{
+					{ToolCallID: "t1", FunctionName: "bash", Arguments: map[string]any{"cmd": "ls"}},
+					{ToolCallID: "t2", FunctionName: "bash", Arguments: map[string]any{"cmd": "ls"}},
+					{FunctionName: "read", Arguments: map[string]any{"p": "a"}},
+					{ToolCallID: "t4", FunctionName: "subagent"},
+				},
+			},
+			{
+				StepID:    2,
+				Timestamp: "2026-08-22T10:00:03Z",
+				Observation: &atif.Observation{Results: []atif.ObservationResult{
+					{SourceCallID: "t1", Content: "aaaa"},
+					{SourceCallID: "t2", Content: "error: boom"},
+					{SourceCallID: "unknown", Content: "x"},
+					{SourceCallID: "t4", Content: map[string]any{"k": "v"}, SubagentTrajectoryRef: "/s/c/trajectory.atif.json"},
+				}},
+			},
+			{
+				StepID:    3,
+				Timestamp: "bogus",
+				ToolCalls: []atif.ToolCall{{ToolCallID: "t5", FunctionName: "bash", Arguments: map[string]any{"cmd": "ls"}}},
+			},
+		},
+	}
+	child := &atif.Trajectory{
+		SessionID: "c",
+		Agent:     atif.AgentInfo{Name: "worker", ModelName: "m2"},
+		Steps: []atif.Step{
+			{
+				StepID:      1,
+				Timestamp:   "2026-08-22T10:00:01Z",
+				ToolCalls:   []atif.ToolCall{{ToolCallID: "u1", FunctionName: "read", Arguments: map[string]any{"p": "a"}}},
+				Observation: &atif.Observation{Results: []atif.ObservationResult{{SourceCallID: "u1", Content: "bb"}}},
+			},
+		},
+	}
+	return []*LoadedTrajectory{{SessionID: "p", Traj: parent}, {SessionID: "c", Traj: child}}
+}
+
+// cogChainFixture is a three-level chain where the leaf is referenced by both
+// the root and the middle session, so its depth must come from the deeper
+// parent rather than the first one visited.
+func cogChainFixture() []*LoadedTrajectory {
+	root := &atif.Trajectory{
+		SessionID: "root",
+		Agent:     atif.AgentInfo{Name: "pi-go", ModelName: "m1"},
+		Steps: []atif.Step{
+			{
+				StepID:    1,
+				Timestamp: "2026-08-22T10:00:00Z",
+				ToolCalls: []atif.ToolCall{{ToolCallID: "r1", FunctionName: "subagent"}},
+				Observation: &atif.Observation{Results: []atif.ObservationResult{
+					{SourceCallID: "r1", SubagentTrajectoryRef: "/s/mid/trajectory.atif.json"},
+					{SourceCallID: "r1", SubagentTrajectoryRef: "/s/leaf/trajectory.atif.json"},
+				}},
+			},
+			{StepID: 2, Timestamp: "2026-08-22T10:00:30Z"},
+		},
+	}
+	mid := &atif.Trajectory{
+		SessionID: "mid",
+		Agent:     atif.AgentInfo{Name: "mid-agent", ModelName: "m2"},
+		Steps: []atif.Step{
+			{
+				StepID:      1,
+				ToolCalls:   []atif.ToolCall{{ToolCallID: "m1", FunctionName: "subagent"}},
+				Observation: &atif.Observation{Results: []atif.ObservationResult{{SourceCallID: "m1", SubagentTrajectoryRef: "/s/leaf/trajectory.atif.json"}}},
+			},
+		},
+		ContinuedTrajectoryRef: "/s/prev/trajectory.atif.json",
+	}
+	leaf := &atif.Trajectory{
+		SessionID: "leaf",
+		Agent:     atif.AgentInfo{Name: "leaf-agent"},
+		Steps:     []atif.Step{{StepID: 1, Timestamp: "bad", ToolCalls: []atif.ToolCall{{ToolCallID: "l1", FunctionName: "bash"}}}},
+	}
+	return []*LoadedTrajectory{
+		{SessionID: "root", Traj: root},
+		{SessionID: "mid", Traj: mid},
+		{SessionID: "leaf", Traj: leaf},
+	}
+}
+
+// cogCycleFixture is two sessions that reference each other, which the depth
+// walk must survive rather than recurse forever on.
+func cogCycleFixture() []*LoadedTrajectory {
+	a := &atif.Trajectory{
+		SessionID: "a", Agent: atif.AgentInfo{Name: "A"},
+		Steps: []atif.Step{{StepID: 1, Observation: &atif.Observation{Results: []atif.ObservationResult{
+			{SourceCallID: "x", SubagentTrajectoryRef: "/s/b/trajectory.atif.json"},
+		}}}},
+	}
+	b := &atif.Trajectory{
+		SessionID: "b", Agent: atif.AgentInfo{Name: "B"},
+		Steps: []atif.Step{{StepID: 1, Observation: &atif.Observation{Results: []atif.ObservationResult{
+			{SourceCallID: "y", SubagentTrajectoryRef: "/s/a/trajectory.atif.json"},
+		}}}},
+	}
+	return []*LoadedTrajectory{{SessionID: "a", Traj: a}, {SessionID: "b", Traj: b}}
+}
+
+func cogJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestTrajectoryDigest_PinnedOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		loaded   []*LoadedTrajectory
+		maxCalls int
+		want     string
+	}{
+		{
+			name:     "every result shape, default cap",
+			loaded:   cogDigestFixture(),
+			maxCalls: 0,
+			want: "### session 260809-0249-… (agent pi-go)\n" +
+				"1. bash({\"cmd\":\"ls\"}) -> 11 bytes\n" +
+				"2. read({\"path\":\"abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg-abcdefg…) -> ERROR: error: no such file or directory\n" +
+				"3. grep() -> (no result)\n" +
+				"4. subagent({\"task\":\"x\"}) -> 11 bytes [spawned subagent]\n" +
+				"5. write() -> (no result)\n" +
+				"\n" +
+				"### session sess-empty (agent worker)\n" +
+				"(no tool calls)\n" +
+				"\n",
+		},
+		{
+			name:     "cap trips mid-step",
+			loaded:   cogCappedFixture(),
+			maxCalls: 5,
+			want: "### session capped-sessi… (agent pi-go)\n" +
+				"1. bash() -> 2 bytes\n" +
+				"2. bash() -> (no result)\n" +
+				"3. bash() -> (no result)\n" +
+				"4. read() -> (no result)\n" +
+				"5. read() -> (no result)\n" +
+				"... (2 more calls omitted)\n" +
+				"\n",
+		},
+		{name: "nothing loaded", loaded: nil, maxCalls: 10, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TrajectoryDigest(tt.loaded, tt.maxCalls); got != tt.want {
+				t.Errorf("TrajectoryDigest mismatch\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTrajectoryDigest_DefaultCapIsSixty pins the substitution the guard makes
+// for a non-positive cap, which is otherwise invisible in the output.
+func TestTrajectoryDigest_DefaultCapIsSixty(t *testing.T) {
+	var calls []atif.ToolCall
+	for i := 0; i < 65; i++ {
+		calls = append(calls, atif.ToolCall{ToolCallID: fmt.Sprintf("c%d", i), FunctionName: "bash"})
+	}
+	loaded := []*LoadedTrajectory{{SessionID: "s", Traj: &atif.Trajectory{SessionID: "s", Steps: []atif.Step{{ToolCalls: calls}}}}}
+
+	for _, maxCalls := range []int{0, -1} {
+		got := TrajectoryDigest(loaded, maxCalls)
+		if want := "60. bash() -> (no result)\n... (5 more calls omitted)\n"; !strings.Contains(got, want) {
+			t.Errorf("maxCalls=%d: want tail %q in\n%s", maxCalls, want, got)
+		}
+		if strings.Contains(got, "61. bash()") {
+			t.Errorf("maxCalls=%d: emitted a 61st call", maxCalls)
+		}
+	}
+}
+
+func TestComputeToolsMetrics_PinnedOutput(t *testing.T) {
+	want := `{
+  "total_calls": 6,
+  "total_results": 4,
+  "wasted": 2,
+  "duplicates": 3,
+  "nested_agent_calls": 1,
+  "by_tool": {
+    "bash": {
+      "calls": 3,
+      "results": 2,
+      "errors": 1,
+      "wasted": 1,
+      "duplicates": 2,
+      "avg_result_bytes": 7,
+      "avg_latency_ms": 3000
+    },
+    "read": {
+      "calls": 2,
+      "results": 1,
+      "errors": 0,
+      "wasted": 1,
+      "duplicates": 1,
+      "avg_result_bytes": 2,
+      "avg_latency_ms": 0
+    },
+    "subagent": {
+      "calls": 1,
+      "results": 1,
+      "errors": 0,
+      "wasted": 0,
+      "duplicates": 0,
+      "avg_result_bytes": 9,
+      "avg_latency_ms": 3000
+    }
+  }
+}`
+	if got := cogJSON(t, ComputeToolsMetrics(cogToolsFixture())); got != want {
+		t.Errorf("ComputeToolsMetrics mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestComputeToolsMetrics_StableAcrossRuns guards the ordering rebuild: the
+// same input must serialize identically every time, not merely be equal.
+func TestComputeToolsMetrics_StableAcrossRuns(t *testing.T) {
+	first := cogJSON(t, ComputeToolsMetrics(cogToolsFixture()))
+	for i := 0; i < 20; i++ {
+		if got := cogJSON(t, ComputeToolsMetrics(cogToolsFixture())); got != first {
+			t.Fatalf("run %d differs from run 0\n got: %s\nwant: %s", i, got, first)
+		}
+	}
+}
+
+func TestComputeToolsMetrics_Empty(t *testing.T) {
+	want := `{
+  "total_calls": 0,
+  "total_results": 0,
+  "wasted": 0,
+  "duplicates": 0,
+  "nested_agent_calls": 0,
+  "by_tool": {}
+}`
+	if got := cogJSON(t, ComputeToolsMetrics(nil)); got != want {
+		t.Errorf("ComputeToolsMetrics(nil) mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestComputeTrajectoryMetrics_PinnedOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		loaded []*LoadedTrajectory
+		want   string
+	}{
+		{
+			name:   "three-level chain, leaf reached from two depths",
+			loaded: cogChainFixture(),
+			want: `{
+  "sessions": [
+    {
+      "session_id": "root",
+      "agent_name": "pi-go",
+      "model": "m1",
+      "steps": 2,
+      "tool_calls": 1,
+      "subagent_refs": 2,
+      "depth": 0,
+      "started_at": "2026-08-22T10:00:00Z",
+      "duration": "30s"
+    },
+    {
+      "session_id": "mid",
+      "agent_name": "mid-agent",
+      "model": "m2",
+      "steps": 1,
+      "tool_calls": 1,
+      "subagent_refs": 1,
+      "depth": 1,
+      "continued_from": "/s/prev/trajectory.atif.json"
+    },
+    {
+      "session_id": "leaf",
+      "agent_name": "leaf-agent",
+      "model": "",
+      "steps": 1,
+      "tool_calls": 1,
+      "subagent_refs": 0,
+      "depth": 2
+    }
+  ],
+  "total_steps": 4,
+  "total_tool_calls": 3,
+  "nested_agent_calls": 3,
+  "max_depth": 2
+}`,
+		},
+		{
+			name:   "mutual reference does not hang",
+			loaded: cogCycleFixture(),
+			want: `{
+  "sessions": [
+    {
+      "session_id": "b",
+      "agent_name": "B",
+      "model": "",
+      "steps": 1,
+      "tool_calls": 0,
+      "subagent_refs": 1,
+      "depth": 1
+    },
+    {
+      "session_id": "a",
+      "agent_name": "A",
+      "model": "",
+      "steps": 1,
+      "tool_calls": 0,
+      "subagent_refs": 1,
+      "depth": 2
+    }
+  ],
+  "total_steps": 2,
+  "total_tool_calls": 0,
+  "nested_agent_calls": 2,
+  "max_depth": 2
+}`,
+		},
+		{
+			name:   "nothing loaded",
+			loaded: nil,
+			want: `{
+  "sessions": null,
+  "total_steps": 0,
+  "total_tool_calls": 0,
+  "nested_agent_calls": 0,
+  "max_depth": 0
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done := make(chan string, 1)
+			go func() { done <- cogJSON(t, ComputeTrajectoryMetrics(tt.loaded)) }()
+			select {
+			case got := <-done:
+				if got != tt.want {
+					t.Errorf("ComputeTrajectoryMetrics mismatch\n got: %s\nwant: %s", got, tt.want)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("ComputeTrajectoryMetrics did not return; the cycle guard regressed")
+			}
+		})
+	}
+}
+
+func cogReport() *RunReport {
+	return &RunReport{
+		Metadata: ReportMetadata{Spec: "spec.md", Mode: "parallel", Model: "opus", Timestamp: time.Unix(0, 0).UTC()},
+		Outcome: RunOutcome{
+			FinalPhase:  "failed",
+			Retries:     2,
+			GoldenPass:  false,
+			Reason:      "Verification failed:\n  gate build\n  gate test",
+			BaselineRef: "v1.2.3",
+			GateResults: []GateResult{
+				{Name: "build", Command: "go build ./...", Passed: true},
+				{Name: "test", Command: "go test ./...", Passed: false},
+			},
+			GoldenCheck: []GoldenFile{{Name: "add.go", Match: true}, {Name: "add_test.go", Match: false}},
+		},
+		Trajectory:  ComputeTrajectoryMetrics(cogChainFixture()),
+		Concurrency: ComputeConcurrencyMetrics(4, []ConcurrencySample{{Running: 1}, {Running: 3}}),
+		Tools:       ComputeToolsMetrics(cogToolsFixture()),
+	}
+}
+
+func TestBuildJudgePrompt_PinnedOutput(t *testing.T) {
+	want := "# Run under review\n\nSpec: spec.md (mode: parallel, model: opus)\n\n## Outcome\n\n" +
+		"- final phase: failed\n- retries: 2\n- golden artifacts match: false\n" +
+		"- matches baseline v1.2.3: false\n" +
+		"- gate \"build\" (go build ./...): passed=true\n" +
+		"- gate \"test\" (go test ./...): passed=false\n" +
+		"- golden mismatch: add_test.go\n" +
+		"- failure reason: Verification failed: gate build gate test\n" +
+		"\n## Trajectory\n\n- sessions: 3\n- total steps: 4\n- total tool calls: 3\n" +
+		"- nested agent calls: 3\n- max nesting depth: 2\n" +
+		"\n## Concurrency\n\n- pool budget: 4 (nested worker budget: 2)\n" +
+		"- max concurrent agents: 3\n- mean concurrent agents: 2.00\n" +
+		"- fraction of time with >1 running: 0.50\n" +
+		"\n## Tools\n\n- total calls: 6 (results: 4)\n- calls with no result: 2\n" +
+		"- duplicate calls (same tool, same arguments): 3\n" +
+		"\n| tool | calls | errors | wasted | duplicates | avg result bytes |\n" +
+		"|---|---|---|---|---|---|\n" +
+		"| bash | 3 | 1 | 1 | 2 | 7 |\n" +
+		"| read | 2 | 0 | 1 | 1 | 2 |\n" +
+		"| subagent | 1 | 0 | 0 | 0 | 9 |\n" +
+		"\n## Tool-call timeline\n\n" +
+		TrajectoryDigest(cogDigestFixture(), 0) + "\n"
+
+	if got := BuildJudgePrompt(cogReport(), TrajectoryDigest(cogDigestFixture(), 0)); got != want {
+		t.Errorf("BuildJudgePrompt mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestBuildJudgePrompt_NilReportAndBlankDigest(t *testing.T) {
+	if got, want := BuildJudgePrompt(nil, "  \n "), "# Run under review\n\n"; got != want {
+		t.Errorf("nil report: got %q, want %q", got, want)
+	}
+
+	want := "# Run under review\n\nSpec:  (mode: , model: )\n\n## Outcome\n\n" +
+		"- final phase: \n- retries: 0\n- golden artifacts match: false\n" +
+		"\n## Trajectory\n\n- sessions: 0\n- total steps: 0\n- total tool calls: 0\n" +
+		"- nested agent calls: 0\n- max nesting depth: 0\n" +
+		"\n## Concurrency\n\n- pool budget: 0 (nested worker budget: 0)\n" +
+		"- max concurrent agents: 0\n- mean concurrent agents: 0.00\n" +
+		"- fraction of time with >1 running: 0.00\n" +
+		"\n## Tools\n\n- total calls: 0 (results: 0)\n- calls with no result: 0\n" +
+		"- duplicate calls (same tool, same arguments): 0\n"
+	if got := BuildJudgePrompt(&RunReport{}, ""); got != want {
+		t.Errorf("empty report: got %q, want %q", got, want)
+	}
+}
+
+func TestParseJudgeVerdict_PinnedOutcomes(t *testing.T) {
+	tests := []cogVerdictCase{
+		{
+			name:        "stated verdict survives a clamped disqualifying score",
+			reply:       `{"verdict":"PASS ","scores":[{"dimension":"a","score":9},{"dimension":"b","score":-4}],"summary":"s"}`,
+			wantScores:  []int{5, 1},
+			wantOverall: 3,
+			wantVerdict: "pass",
+		},
+		{
+			name:        "fenced reply, a score of 1 forces fail",
+			reply:       "prose ```json\n{\"scores\":[{\"dimension\":\"a\",\"score\":1},{\"dimension\":\"b\",\"score\":5}]}\n``` tail",
+			wantScores:  []int{1, 5},
+			wantOverall: 3,
+			wantVerdict: "fail",
+		},
+		{
+			name:        "mean below three fails without any score of one",
+			reply:       `{"scores":[{"dimension":"a","score":2},{"dimension":"b","score":3}]}`,
+			wantScores:  []int{2, 3},
+			wantOverall: 2.5,
+			wantVerdict: "fail",
+		},
+		{
+			name:        "healthy scores derive a pass",
+			reply:       `{"scores":[{"dimension":"a","score":4},{"dimension":"b","score":5}]}`,
+			wantScores:  []int{4, 5},
+			wantOverall: 4.5,
+			wantVerdict: "pass",
+		},
+		{
+			name:        "unrecognized verdict is re-derived, not kept",
+			reply:       `{"verdict":"maybe","scores":[{"dimension":"a","score":3},{"dimension":"b","score":3}]}`,
+			wantScores:  []int{3, 3},
+			wantOverall: 3,
+			wantVerdict: "pass",
+		},
+		{name: "no object at all", reply: "no json here", wantErr: `judge reply contains no JSON object: "no json here"`},
+		{name: "object with no scores", reply: `{"scores":[]}`, wantErr: "judge reply has no scores"},
+		{
+			name:    "scores of the wrong type",
+			reply:   `{"scores": "oops"}`,
+			wantErr: "parse judge reply: json: cannot unmarshal string into Go struct field JudgeVerdict.scores of type []eval.JudgeScore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := ParseJudgeVerdict(tt.reply)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("err = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			checkVerdict(t, v, tt)
+		})
+	}
+}
+
+// cogVerdictCase is one reply and the verdict it must parse into.
+type cogVerdictCase struct {
+	name        string
+	reply       string
+	wantScores  []int
+	wantOverall float64
+	wantVerdict string
+	wantErr     string
+}
+
+func checkVerdict(t *testing.T, v JudgeVerdict, tt cogVerdictCase) {
+	t.Helper()
+	if len(v.Scores) != len(tt.wantScores) {
+		t.Fatalf("got %d scores, want %d", len(v.Scores), len(tt.wantScores))
+	}
+	for i, want := range tt.wantScores {
+		if v.Scores[i].Score != want {
+			t.Errorf("score %d = %d, want %d", i, v.Scores[i].Score, want)
+		}
+	}
+	if v.Overall != tt.wantOverall {
+		t.Errorf("overall = %v, want %v", v.Overall, tt.wantOverall)
+	}
+	if v.Verdict != tt.wantVerdict {
+		t.Errorf("verdict = %q, want %q", v.Verdict, tt.wantVerdict)
+	}
+}

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -118,53 +118,7 @@ func BuildJudgePrompt(r *RunReport, digest string) string {
 
 	b.WriteString("# Run under review\n\n")
 	if r != nil {
-		fmt.Fprintf(&b, "Spec: %s (mode: %s, model: %s)\n\n", r.Metadata.Spec, r.Metadata.Mode, r.Metadata.Model)
-
-		b.WriteString("## Outcome\n\n")
-		fmt.Fprintf(&b, "- final phase: %s\n", r.Outcome.FinalPhase)
-		fmt.Fprintf(&b, "- retries: %d\n", r.Outcome.Retries)
-		fmt.Fprintf(&b, "- golden artifacts match: %v\n", r.Outcome.GoldenPass)
-		if r.Outcome.BaselineRef != "" {
-			fmt.Fprintf(&b, "- matches baseline %s: %v\n", r.Outcome.BaselineRef, r.Outcome.BaselinePass)
-		}
-		for _, g := range r.Outcome.GateResults {
-			fmt.Fprintf(&b, "- gate %q (%s): passed=%v\n", g.Name, g.Command, g.Passed)
-		}
-		for _, g := range r.Outcome.GoldenCheck {
-			if !g.Match {
-				fmt.Fprintf(&b, "- golden mismatch: %s\n", g.Name)
-			}
-		}
-		if r.Outcome.Reason != "" {
-			fmt.Fprintf(&b, "- failure reason: %s\n", truncate(oneLine(r.Outcome.Reason), 600))
-		}
-
-		b.WriteString("\n## Trajectory\n\n")
-		fmt.Fprintf(&b, "- sessions: %d\n", len(r.Trajectory.Sessions))
-		fmt.Fprintf(&b, "- total steps: %d\n", r.Trajectory.TotalSteps)
-		fmt.Fprintf(&b, "- total tool calls: %d\n", r.Trajectory.TotalToolCalls)
-		fmt.Fprintf(&b, "- nested agent calls: %d\n", r.Trajectory.NestedAgentCalls)
-		fmt.Fprintf(&b, "- max nesting depth: %d\n", r.Trajectory.MaxDepth)
-
-		b.WriteString("\n## Concurrency\n\n")
-		fmt.Fprintf(&b, "- pool budget: %d (nested worker budget: %d)\n", r.Concurrency.PoolBudget, r.Concurrency.WorkerBudget)
-		fmt.Fprintf(&b, "- max concurrent agents: %d\n", r.Concurrency.MaxRunning)
-		fmt.Fprintf(&b, "- mean concurrent agents: %.2f\n", r.Concurrency.MeanRunning)
-		fmt.Fprintf(&b, "- fraction of time with >1 running: %.2f\n", r.Concurrency.ParallelOverlap)
-
-		b.WriteString("\n## Tools\n\n")
-		fmt.Fprintf(&b, "- total calls: %d (results: %d)\n", r.Tools.TotalCalls, r.Tools.TotalResults)
-		fmt.Fprintf(&b, "- calls with no result: %d\n", r.Tools.Wasted)
-		fmt.Fprintf(&b, "- duplicate calls (same tool, same arguments): %d\n", r.Tools.Duplicates)
-		if len(r.Tools.ByTool) > 0 {
-			b.WriteString("\n| tool | calls | errors | wasted | duplicates | avg result bytes |\n")
-			b.WriteString("|---|---|---|---|---|---|\n")
-			for _, name := range sortedKeys(r.Tools.ByTool) {
-				st := r.Tools.ByTool[name]
-				fmt.Fprintf(&b, "| %s | %d | %d | %d | %d | %d |\n",
-					name, st.Calls, st.Errors, st.Wasted, st.Duplicates, st.AvgResultBytes)
-			}
-		}
+		writeRunEvidence(&b, r)
 	}
 
 	if strings.TrimSpace(digest) != "" {
@@ -174,6 +128,58 @@ func BuildJudgePrompt(r *RunReport, digest string) string {
 	}
 
 	return b.String()
+}
+
+// writeRunEvidence renders the report's four sections — outcome, trajectory,
+// concurrency, tools — in the order the judge reads them.
+func writeRunEvidence(b *strings.Builder, r *RunReport) {
+	fmt.Fprintf(b, "Spec: %s (mode: %s, model: %s)\n\n", r.Metadata.Spec, r.Metadata.Mode, r.Metadata.Model)
+
+	b.WriteString("## Outcome\n\n")
+	fmt.Fprintf(b, "- final phase: %s\n", r.Outcome.FinalPhase)
+	fmt.Fprintf(b, "- retries: %d\n", r.Outcome.Retries)
+	fmt.Fprintf(b, "- golden artifacts match: %v\n", r.Outcome.GoldenPass)
+	if r.Outcome.BaselineRef != "" {
+		fmt.Fprintf(b, "- matches baseline %s: %v\n", r.Outcome.BaselineRef, r.Outcome.BaselinePass)
+	}
+	for _, g := range r.Outcome.GateResults {
+		fmt.Fprintf(b, "- gate %q (%s): passed=%v\n", g.Name, g.Command, g.Passed)
+	}
+	for _, g := range r.Outcome.GoldenCheck {
+		if !g.Match {
+			fmt.Fprintf(b, "- golden mismatch: %s\n", g.Name)
+		}
+	}
+	if r.Outcome.Reason != "" {
+		fmt.Fprintf(b, "- failure reason: %s\n", truncate(oneLine(r.Outcome.Reason), 600))
+	}
+
+	b.WriteString("\n## Trajectory\n\n")
+	fmt.Fprintf(b, "- sessions: %d\n", len(r.Trajectory.Sessions))
+	fmt.Fprintf(b, "- total steps: %d\n", r.Trajectory.TotalSteps)
+	fmt.Fprintf(b, "- total tool calls: %d\n", r.Trajectory.TotalToolCalls)
+	fmt.Fprintf(b, "- nested agent calls: %d\n", r.Trajectory.NestedAgentCalls)
+	fmt.Fprintf(b, "- max nesting depth: %d\n", r.Trajectory.MaxDepth)
+
+	b.WriteString("\n## Concurrency\n\n")
+	fmt.Fprintf(b, "- pool budget: %d (nested worker budget: %d)\n", r.Concurrency.PoolBudget, r.Concurrency.WorkerBudget)
+	fmt.Fprintf(b, "- max concurrent agents: %d\n", r.Concurrency.MaxRunning)
+	fmt.Fprintf(b, "- mean concurrent agents: %.2f\n", r.Concurrency.MeanRunning)
+	fmt.Fprintf(b, "- fraction of time with >1 running: %.2f\n", r.Concurrency.ParallelOverlap)
+
+	b.WriteString("\n## Tools\n\n")
+	fmt.Fprintf(b, "- total calls: %d (results: %d)\n", r.Tools.TotalCalls, r.Tools.TotalResults)
+	fmt.Fprintf(b, "- calls with no result: %d\n", r.Tools.Wasted)
+	fmt.Fprintf(b, "- duplicate calls (same tool, same arguments): %d\n", r.Tools.Duplicates)
+	if len(r.Tools.ByTool) > 0 {
+		b.WriteString("\n| tool | calls | errors | wasted | duplicates | avg result bytes |\n")
+		b.WriteString("|---|---|---|---|---|---|\n")
+		for _, name := range sortedKeys(r.Tools.ByTool) {
+			st := r.Tools.ByTool[name]
+			fmt.Fprintf(b, "| %s | %d | %d | %d | %d | %d |\n",
+				name, st.Calls, st.Errors, st.Wasted, st.Duplicates, st.AvgResultBytes)
+		}
+	}
 }
 
 // ParseJudgeVerdict reads the model's reply into a verdict. Models routinely
@@ -193,38 +199,48 @@ func ParseJudgeVerdict(reply string) (JudgeVerdict, error) {
 		return JudgeVerdict{}, fmt.Errorf("judge reply has no scores")
 	}
 
-	total := 0
-	for i, s := range v.Scores {
-		// Clamp rather than reject: an out-of-range score is still a usable
-		// signal, and losing the whole verdict over one bad number is worse.
-		if s.Score < 1 {
-			v.Scores[i].Score = 1
-		}
-		if s.Score > 5 {
-			v.Scores[i].Score = 5
-		}
-		total += v.Scores[i].Score
-	}
-	v.Overall = float64(total) / float64(len(v.Scores))
-
-	switch strings.ToLower(strings.TrimSpace(v.Verdict)) {
-	case "pass", "fail":
-		v.Verdict = strings.ToLower(strings.TrimSpace(v.Verdict))
-	default:
-		// Derive a verdict the model failed to state, so the field is always
-		// meaningful: any 1 is disqualifying, otherwise a mean of 3 passes.
-		v.Verdict = "pass"
-		for _, s := range v.Scores {
-			if s.Score <= 1 {
-				v.Verdict = "fail"
-			}
-		}
-		if v.Overall < 3 {
-			v.Verdict = "fail"
-		}
-	}
+	v.Overall = float64(clampScores(v.Scores)) / float64(len(v.Scores))
+	v.Verdict = normalizeVerdict(v.Verdict, v.Scores, v.Overall)
 
 	return v, nil
+}
+
+// clampScores pins every score into 1..5 in place and returns their total.
+// Clamping rather than rejecting keeps the verdict usable: an out-of-range
+// score is still a signal, and losing the whole grade over one bad number is
+// worse.
+func clampScores(scores []JudgeScore) int {
+	total := 0
+	for i, s := range scores {
+		switch {
+		case s.Score < 1:
+			scores[i].Score = 1
+		case s.Score > 5:
+			scores[i].Score = 5
+		}
+		total += scores[i].Score
+	}
+	return total
+}
+
+// normalizeVerdict lowercases a stated pass/fail. When the model failed to
+// state one, it is derived so the field is always meaningful: any score of 1
+// is disqualifying, otherwise a mean of 3 passes.
+func normalizeVerdict(stated string, scores []JudgeScore, overall float64) string {
+	switch v := strings.ToLower(strings.TrimSpace(stated)); v {
+	case "pass", "fail":
+		return v
+	}
+
+	if overall < 3 {
+		return "fail"
+	}
+	for _, s := range scores {
+		if s.Score <= 1 {
+			return "fail"
+		}
+	}
+	return "pass"
 }
 
 // TrajectoryDigest condenses the loaded trajectories into the timeline the
@@ -242,47 +258,55 @@ func TrajectoryDigest(loaded []*LoadedTrajectory, maxCallsPerSession int) string
 		if lt == nil || lt.Traj == nil {
 			continue
 		}
-		t := lt.Traj
-		fmt.Fprintf(&b, "### session %s (agent %s)\n", shortID(t.SessionID), t.Agent.Name)
-
-		results := resultsBySourceCall(lt)
-		n := 0
-		truncated := false
-		for _, step := range t.Steps {
-			for _, tc := range step.ToolCalls {
-				if n >= maxCallsPerSession {
-					truncated = true
-					break
-				}
-				n++
-				fmt.Fprintf(&b, "%d. %s(%s)", n, tc.FunctionName, truncate(canonicalArgs(tc.Arguments), 160))
-				if res, ok := results[tc.ToolCallID]; ok {
-					if looksLikeError(res.Content) {
-						fmt.Fprintf(&b, " -> ERROR: %s", truncate(oneLine(contentText(res.Content)), 160))
-					} else {
-						fmt.Fprintf(&b, " -> %d bytes", contentBytes(res.Content))
-					}
-					if res.SubagentTrajectoryRef != "" {
-						b.WriteString(" [spawned subagent]")
-					}
-				} else {
-					b.WriteString(" -> (no result)")
-				}
-				b.WriteString("\n")
-			}
-			if truncated {
-				break
-			}
-		}
-		if truncated {
-			fmt.Fprintf(&b, "... (%d more calls omitted)\n", countToolCalls(t)-n)
-		}
-		if n == 0 {
-			b.WriteString("(no tool calls)\n")
-		}
-		b.WriteString("\n")
+		digestSession(&b, lt, maxCallsPerSession)
 	}
 	return b.String()
+}
+
+// digestSession writes one session's block of the digest: a header line, then
+// one line per tool call up to maxCalls, then a blank separator line. Hitting
+// the cap replaces the remaining lines with a count of what was dropped.
+func digestSession(b *strings.Builder, lt *LoadedTrajectory, maxCalls int) {
+	t := lt.Traj
+	fmt.Fprintf(b, "### session %s (agent %s)\n", shortID(t.SessionID), t.Agent.Name)
+
+	results := resultsBySourceCall(lt)
+	n := 0
+	for _, step := range t.Steps {
+		for _, tc := range step.ToolCalls {
+			if n >= maxCalls {
+				fmt.Fprintf(b, "... (%d more calls omitted)\n", countToolCalls(t)-n)
+				b.WriteString("\n")
+				return
+			}
+			n++
+			fmt.Fprintf(b, "%d. %s(%s)", n, tc.FunctionName, truncate(canonicalArgs(tc.Arguments), 160))
+			res, ok := results[tc.ToolCallID]
+			writeCallOutcome(b, res, ok)
+		}
+	}
+	if n == 0 {
+		b.WriteString("(no tool calls)\n")
+	}
+	b.WriteString("\n")
+}
+
+// writeCallOutcome appends the result half of a tool-call line: the failure
+// marker and message, the result size, or the absence of a result altogether.
+func writeCallOutcome(b *strings.Builder, res atifResult, ok bool) {
+	if !ok {
+		b.WriteString(" -> (no result)\n")
+		return
+	}
+	if looksLikeError(res.Content) {
+		fmt.Fprintf(b, " -> ERROR: %s", truncate(oneLine(contentText(res.Content)), 160))
+	} else {
+		fmt.Fprintf(b, " -> %d bytes", contentBytes(res.Content))
+	}
+	if res.SubagentTrajectoryRef != "" {
+		b.WriteString(" [spawned subagent]")
+	}
+	b.WriteString("\n")
 }
 
 // resultsBySourceCall indexes a trajectory's observation results by the tool

--- a/internal/eval/metrics.go
+++ b/internal/eval/metrics.go
@@ -214,56 +214,22 @@ func LoadTrajectories(sessionsDir string) ([]*LoadedTrajectory, error) {
 func ComputeTrajectoryMetrics(loaded []*LoadedTrajectory) TrajectoryMetrics {
 	m := TrajectoryMetrics{}
 
-	byID := make(map[string]*LoadedTrajectory, len(loaded))
-	for _, lt := range loaded {
-		byID[lt.SessionID] = lt
-	}
-
-	// childRefs[sessionID] → set of child session IDs referenced from its
-	// observations. parentOf[child] → count of parents, for root detection.
 	childRefs := make(map[string]map[string]bool)
-	parentOf := make(map[string]int)
 	for _, lt := range loaded {
 		refs := subagentRefs(lt.Traj)
 		if len(refs) > 0 {
 			childRefs[lt.SessionID] = refs
-			for child := range refs {
-				parentOf[child]++
-			}
 		}
 		m.NestedAgentCalls += len(refs)
 	}
 
-	// Roots are sessions nobody references. Depth is memoized DFS:
-	// depth(child) = 1 + max(depth(parent)).
-	depth := make(map[string]int, len(loaded))
-	var depthOf func(id string, stack map[string]bool) int
-	depthOf = func(id string, stack map[string]bool) int {
-		if d, ok := depth[id]; ok {
-			return d
-		}
-		if stack[id] { // cycle guard — should not happen, but never recurse forever
-			return 0
-		}
-		stack[id] = true
-		best := 0
-		for parent := range parentsOf(id, loaded, childRefs) {
-			if d := depthOf(parent, stack) + 1; d > best {
-				best = d
-			}
-		}
-		delete(stack, id)
-		depth[id] = best
-		return best
-	}
+	depths := sessionDepths(loaded, childRefs)
 
 	for _, lt := range loaded {
 		t := lt.Traj
 		toolCalls := countToolCalls(t)
-		refs := len(subagentRefs(t))
-		d := depthOf(lt.SessionID, map[string]bool{})
-
 		started, duration := stepSpan(t)
+		d := depths[lt.SessionID]
 
 		m.Sessions = append(m.Sessions, SessionSummary{
 			SessionID:     lt.SessionID,
@@ -271,7 +237,7 @@ func ComputeTrajectoryMetrics(loaded []*LoadedTrajectory) TrajectoryMetrics {
 			Model:         t.Agent.ModelName,
 			Steps:         len(t.Steps),
 			ToolCalls:     toolCalls,
-			SubagentRefs:  refs,
+			SubagentRefs:  len(subagentRefs(t)),
 			Depth:         d,
 			StartedAt:     started,
 			Duration:      duration,
@@ -294,6 +260,50 @@ func ComputeTrajectoryMetrics(loaded []*LoadedTrajectory) TrajectoryMetrics {
 	})
 
 	return m
+}
+
+// sessionDepths resolves every session's nesting depth from the child-ref
+// graph. Roots are sessions nobody references; depth is a memoized DFS over
+// parents, depth(child) = 1 + max(depth(parent)).
+func sessionDepths(loaded []*LoadedTrajectory, childRefs map[string]map[string]bool) map[string]int {
+	depth := make(map[string]int, len(loaded))
+	var depthOf func(id string, stack map[string]bool) int
+	depthOf = func(id string, stack map[string]bool) int {
+		if d, ok := depth[id]; ok {
+			return d
+		}
+		if stack[id] { // cycle guard — should not happen, but never recurse forever
+			return 0
+		}
+		stack[id] = true
+		best := maxParentDepth(id, loaded, childRefs, stack, depthOf)
+		delete(stack, id)
+		depth[id] = best
+		return best
+	}
+
+	for _, lt := range loaded {
+		depthOf(lt.SessionID, map[string]bool{})
+	}
+	return depth
+}
+
+// maxParentDepth returns one more than the deepest parent of id, or 0 when id
+// has no parents. Split out of the DFS so the recursion stays flat.
+func maxParentDepth(
+	id string,
+	loaded []*LoadedTrajectory,
+	childRefs map[string]map[string]bool,
+	stack map[string]bool,
+	depthOf func(string, map[string]bool) int,
+) int {
+	best := 0
+	for parent := range parentsOf(id, loaded, childRefs) {
+		if d := depthOf(parent, stack) + 1; d > best {
+			best = d
+		}
+	}
+	return best
 }
 
 // parentsOf returns the session IDs that directly reference id as a subagent.
@@ -421,33 +431,8 @@ func ComputeToolsMetrics(loaded []*LoadedTrajectory) ToolsMetrics {
 	m := ToolsMetrics{ByTool: make(map[string]ToolStats)}
 
 	for _, lt := range loaded {
-		records := pairCalls(lt.Traj)
-		for id, rec := range records {
-			st := m.ByTool[rec.fn]
-			st.Calls++
-			if rec.observed {
-				st.Results++
-				if rec.isError {
-					st.Errors++
-				}
-				st.AvgResultBytes += rec.obsBytes
-				if !rec.stepTS.IsZero() && !rec.obsStepTS.IsZero() {
-					st.AvgLatencyMs += int(rec.obsStepTS.Sub(rec.stepTS).Milliseconds())
-				}
-			} else {
-				st.Wasted++
-			}
-			m.ByTool[rec.fn] = st
-			m.TotalCalls++
-			if rec.observed {
-				m.TotalResults++
-			} else {
-				m.Wasted++
-			}
-			if rec.fn == "subagent" {
-				m.NestedAgentCalls++
-			}
-			_ = id
+		for _, rec := range pairCalls(lt.Traj) {
+			m.recordCall(rec)
 		}
 	}
 
@@ -463,19 +448,47 @@ func ComputeToolsMetrics(loaded []*LoadedTrajectory) ToolsMetrics {
 		m.Duplicates += st.Duplicates
 	}
 
-	// Deterministic tool ordering.
-	sorted := make([]string, 0, len(m.ByTool))
-	for name := range m.ByTool {
-		sorted = append(sorted, name)
-	}
-	sort.Strings(sorted)
-	ordered := make(map[string]ToolStats, len(sorted))
-	for _, name := range sorted {
-		ordered[name] = m.ByTool[name]
-	}
-	m.ByTool = ordered
-
+	m.ByTool = orderedTools(m.ByTool)
 	return m
+}
+
+// recordCall folds one paired call into the run totals and its tool's stats.
+// The byte and latency averages are accumulated as sums here and divided by
+// the result count once every call has been seen.
+func (m *ToolsMetrics) recordCall(rec *callRecord) {
+	st := m.ByTool[rec.fn]
+	st.Calls++
+	if rec.observed {
+		st.Results++
+		if rec.isError {
+			st.Errors++
+		}
+		st.AvgResultBytes += rec.obsBytes
+		if !rec.stepTS.IsZero() && !rec.obsStepTS.IsZero() {
+			st.AvgLatencyMs += int(rec.obsStepTS.Sub(rec.stepTS).Milliseconds())
+		}
+		m.TotalResults++
+	} else {
+		st.Wasted++
+		m.Wasted++
+	}
+	m.ByTool[rec.fn] = st
+
+	m.TotalCalls++
+	if rec.fn == "subagent" {
+		m.NestedAgentCalls++
+	}
+}
+
+// orderedTools rebuilds the per-tool map in sorted key order, so the report is
+// stable across runs rather than reflecting map iteration order.
+func orderedTools(byTool map[string]ToolStats) map[string]ToolStats {
+	names := sortedKeys(byTool)
+	ordered := make(map[string]ToolStats, len(names))
+	for _, name := range names {
+		ordered[name] = byTool[name]
+	}
+	return ordered
 }
 
 // pairCalls walks a trajectory's steps in order, recording each tool call and

--- a/internal/extension/complexity_cog_extension_test.go
+++ b/internal/extension/complexity_cog_extension_test.go
@@ -1,0 +1,660 @@
+package extension
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+// These tests pin the branch structure of BuildReadImageCallback,
+// parseSkillContent and LoadBundledSkills before those functions were
+// flattened for cognitive complexity. Every skip, fallback and boundary the
+// original nesting encoded gets a case here, so the refactor is provably a
+// no-op rather than a rewrite that merely agrees with itself.
+
+// cogSandbox returns a sandbox rooted at a fresh temp dir.
+func cogSandbox(t *testing.T) *tools.Sandbox {
+	t.Helper()
+	sb, err := tools.NewSandbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { sb.Close() })
+	return sb
+}
+
+// cogPNGBytes returns the bytes of a small 2x1 PNG.
+func cogPNGBytes(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 1))
+	img.Set(0, 0, color.RGBA{G: 255, A: 255})
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// cogWriteImage writes a PNG into the sandbox and returns its absolute path.
+func cogWriteImage(t *testing.T, sb *tools.Sandbox, name string) string {
+	t.Helper()
+	path := filepath.Join(sb.Dir(), name)
+	if err := os.WriteFile(path, cogPNGBytes(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// cogRespPart builds a FunctionResponse part with the given tool name and
+// response map.
+func cogRespPart(name string, resp map[string]any) *genai.Part {
+	return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: name, Response: resp}}
+}
+
+// cogInlineCount counts the InlineData parts on a Content.
+func cogInlineCount(c *genai.Content) int {
+	n := 0
+	for _, p := range c.Parts {
+		if p != nil && p.InlineData != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// TestReadImageCallback_SkipsEverythingButReadImageResults walks the skip
+// ladder the callback encodes: nil request, nil sandbox, nil Content, nil
+// part, a part with no FunctionResponse, a FunctionResponse from another
+// tool, and a read_image response whose "path" is missing, non-string or
+// empty. None of these may produce an InlineData part, and none may panic.
+func TestReadImageCallback_SkipsEverythingButReadImageResults(t *testing.T) {
+	sb := cogSandbox(t)
+
+	t.Run("nil request", func(t *testing.T) {
+		resp, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, nil)
+		if resp != nil || err != nil {
+			t.Fatalf("callback(nil req) = %v, %v; want nil, nil", resp, err)
+		}
+	})
+
+	t.Run("nil sandbox leaves parts untouched", func(t *testing.T) {
+		content := &genai.Content{
+			Role:  "user",
+			Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": "shot.png"})},
+		}
+		req := &model.LLMRequest{Contents: []*genai.Content{content}}
+		if _, err := BuildReadImageCallback(nil)(&mockReadonlyContext{}, req); err != nil {
+			t.Fatalf("callback: %v", err)
+		}
+		if len(content.Parts) != 1 {
+			t.Fatalf("parts = %d, want 1 (nil sandbox must not inject)", len(content.Parts))
+		}
+	})
+
+	skipCases := []struct {
+		name string
+		part *genai.Part
+	}{
+		{"nil part", nil},
+		{"text part", &genai.Part{Text: "hello"}},
+		{"empty part", &genai.Part{}},
+		{"other tool", cogRespPart("read", map[string]any{"path": "shot.png"})},
+		{"no path key", cogRespPart(readImageToolName, map[string]any{"size": 12})},
+		{"non-string path", cogRespPart(readImageToolName, map[string]any{"path": 42})},
+		{"empty path", cogRespPart(readImageToolName, map[string]any{"path": ""})},
+		{"nil response map", &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: readImageToolName}}},
+	}
+	for _, tc := range skipCases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := &genai.Content{Role: "user", Parts: []*genai.Part{tc.part}}
+			req := &model.LLMRequest{Contents: []*genai.Content{nil, content}}
+			if _, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, req); err != nil {
+				t.Fatalf("callback: %v", err)
+			}
+			if got := len(content.Parts); got != 1 {
+				t.Fatalf("parts = %d, want 1 (nothing should have been injected)", got)
+			}
+			if n := cogInlineCount(content); n != 0 {
+				t.Fatalf("inline parts = %d, want 0", n)
+			}
+		})
+	}
+}
+
+// TestReadImageCallback_UnreadablePathIsWarnedNotFatal pins that a read
+// failure only skips that one part: the callback still returns nil, nil and
+// still injects the image for a sibling part that does resolve.
+func TestReadImageCallback_UnreadablePathIsWarnedNotFatal(t *testing.T) {
+	sb := cogSandbox(t)
+	good := cogWriteImage(t, sb, "good.png")
+
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			cogRespPart(readImageToolName, map[string]any{"path": filepath.Join(sb.Dir(), "missing.png")}),
+			cogRespPart(readImageToolName, map[string]any{"path": good}),
+		},
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{content}}
+
+	resp, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, req)
+	if resp != nil || err != nil {
+		t.Fatalf("callback = %v, %v; want nil, nil", resp, err)
+	}
+	if got := len(content.Parts); got != 3 {
+		t.Fatalf("parts = %d, want 3 (2 responses + 1 injected image)", got)
+	}
+	if n := cogInlineCount(content); n != 1 {
+		t.Fatalf("inline parts = %d, want 1 (only the readable path)", n)
+	}
+	if got := content.Parts[2].InlineData.MIMEType; got != "image/png" {
+		t.Errorf("MIMEType = %q, want image/png", got)
+	}
+}
+
+// TestReadImageCallback_AppendsPerContentInOrder pins that images are appended
+// to the Content that carried the response — not pooled onto the first one —
+// and that two responses on one Content append in the order they appear.
+func TestReadImageCallback_AppendsPerContentInOrder(t *testing.T) {
+	sb := cogSandbox(t)
+	first := cogWriteImage(t, sb, "first.png")
+	second := cogWriteImage(t, sb, "second.png")
+	other := cogWriteImage(t, sb, "other.png")
+
+	// Make the payloads distinguishable by size.
+	if err := os.WriteFile(second, append(cogPNGBytes(t), make([]byte, 64)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	contentA := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			cogRespPart(readImageToolName, map[string]any{"path": first}),
+			{Text: "between"},
+			cogRespPart(readImageToolName, map[string]any{"path": second}),
+		},
+	}
+	contentB := &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": other})},
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{contentA, contentB}}
+
+	if _, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, req); err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+
+	if got := len(contentA.Parts); got != 5 {
+		t.Fatalf("contentA parts = %d, want 5", got)
+	}
+	firstBytes, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBytes, err := os.ReadFile(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(contentA.Parts[3].InlineData.Data, firstBytes) {
+		t.Error("contentA.Parts[3] is not the first image: injection order changed")
+	}
+	if !bytes.Equal(contentA.Parts[4].InlineData.Data, secondBytes) {
+		t.Error("contentA.Parts[4] is not the second image: injection order changed")
+	}
+	if got := len(contentB.Parts); got != 2 {
+		t.Fatalf("contentB parts = %d, want 2 (its own image, not contentA's)", got)
+	}
+	if cogInlineCount(contentB) != 1 {
+		t.Error("contentB did not receive its own inline image")
+	}
+}
+
+// TestParseSkillContent_Boundaries pins the frontmatter state machine: when
+// the delimiter opens and closes it, what counts as a frontmatter line, how
+// "tools" is split, and which lines land in the body.
+func TestParseSkillContent_Boundaries(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		defName  string
+		wantName string
+		wantDesc string
+		wantTool []string
+		wantBody string
+	}{
+		{
+			name:     "no frontmatter at all",
+			content:  "just a body\nsecond line\n",
+			defName:  "fallback",
+			wantName: "fallback",
+			wantBody: "just a body\nsecond line",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			defName:  "fallback",
+			wantName: "fallback",
+			wantBody: "",
+		},
+		{
+			name:     "full frontmatter overrides default name",
+			content:  "---\nname: real-name\ndescription: does a thing\ntools: read, write\n---\nBody here.\n",
+			defName:  "fallback",
+			wantName: "real-name",
+			wantDesc: "does a thing",
+			wantTool: []string{"read", "write"},
+			wantBody: "Body here.",
+		},
+		{
+			name:     "indented delimiter still opens frontmatter",
+			content:  "   ---   \nname: trimmed\n---\nbody\n",
+			defName:  "fallback",
+			wantName: "trimmed",
+			wantBody: "body",
+		},
+		{
+			name:     "unknown keys and colonless lines are ignored",
+			content:  "---\nname: keeper\nno-colon-here\nunknown: value\n---\nbody\n",
+			defName:  "fallback",
+			wantName: "keeper",
+			wantBody: "body",
+		},
+		{
+			name:     "tools drops empty entries and trims each",
+			content:  "---\ntools:  read , , write ,\n---\n",
+			defName:  "fallback",
+			wantName: "fallback",
+			wantTool: []string{"read", "write"},
+			wantBody: "",
+		},
+		{
+			name:     "empty tools value yields no tools",
+			content:  "---\ntools:\n---\nbody\n",
+			defName:  "fallback",
+			wantName: "fallback",
+			wantBody: "body",
+		},
+		{
+			name:     "value keeps colons after the first",
+			content:  "---\ndescription: see http://example.com/x\n---\n",
+			defName:  "fallback",
+			wantName: "fallback",
+			wantDesc: "see http://example.com/x",
+			wantBody: "",
+		},
+		{
+			name:     "a later --- is body, not a new frontmatter block",
+			content:  "---\nname: once\n---\nbefore\n---\nafter: not-frontmatter\n",
+			defName:  "fallback",
+			wantName: "once",
+			wantBody: "before\n---\nafter: not-frontmatter",
+		},
+		{
+			name:     "unterminated frontmatter consumes the whole file",
+			content:  "---\nname: swallowed\ndescription: everything\nbody line\n",
+			defName:  "fallback",
+			wantName: "swallowed",
+			wantDesc: "everything",
+			wantBody: "",
+		},
+		{
+			name:     "body-only lines before an opening delimiter are body",
+			content:  "preamble\n---\nname: late\n---\ntail\n",
+			defName:  "fallback",
+			wantName: "late",
+			wantBody: "preamble\ntail",
+		},
+		{
+			name:     "empty frontmatter block leaves defaults",
+			content:  "---\n---\nbody\n",
+			defName:  "fallback",
+			wantName: "fallback",
+			wantBody: "body",
+		},
+		{
+			name:     "body whitespace is trimmed at both ends",
+			content:  "---\nname: n\n---\n\n\n  padded  \n\n",
+			defName:  "fallback",
+			wantName: "n",
+			wantBody: "padded",
+		},
+		{
+			name:     "empty name value clears the default",
+			content:  "---\nname:\n---\nbody\n",
+			defName:  "fallback",
+			wantName: "",
+			wantBody: "body",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			skill, body, err := parseSkillContent(tc.content, tc.defName)
+			if err != nil {
+				t.Fatalf("parseSkillContent: %v", err)
+			}
+			if skill.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", skill.Name, tc.wantName)
+			}
+			if skill.Description != tc.wantDesc {
+				t.Errorf("Description = %q, want %q", skill.Description, tc.wantDesc)
+			}
+			if body != tc.wantBody {
+				t.Errorf("body = %q, want %q", body, tc.wantBody)
+			}
+			if len(skill.Tools) != len(tc.wantTool) {
+				t.Fatalf("Tools = %v, want %v", skill.Tools, tc.wantTool)
+			}
+			for i, want := range tc.wantTool {
+				if skill.Tools[i] != want {
+					t.Errorf("Tools[%d] = %q, want %q", i, skill.Tools[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseSkillContent_ScannerErrorSurfaces pins that a line longer than
+// bufio.Scanner's buffer is reported as an error rather than silently
+// truncating the skill.
+func TestParseSkillContent_ScannerErrorSurfaces(t *testing.T) {
+	huge := strings.Repeat("x", 128*1024)
+	_, _, err := parseSkillContent(huge, "big")
+	if err == nil {
+		t.Fatal("expected a scanner error for an over-long line, got nil")
+	}
+}
+
+// TestLoadBundledSkills_ShapeOfEveryEntry pins the invariants the walk
+// enforces: only files under a skill subdirectory are collected, each is
+// filed under that subdirectory's name, and RelPath is the full embedded
+// path with content attached.
+func TestLoadBundledSkills_ShapeOfEveryEntry(t *testing.T) {
+	got, err := LoadBundledSkills()
+	if err != nil {
+		t.Fatalf("LoadBundledSkills: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one bundled skill")
+	}
+	for skillName, files := range got {
+		if skillName == "" {
+			t.Error("bundled skill has an empty name")
+		}
+		if strings.Contains(skillName, "/") {
+			t.Errorf("skill name %q contains a slash: only the first path segment is the name", skillName)
+		}
+		if len(files) == 0 {
+			t.Errorf("skill %q has no files", skillName)
+		}
+		cogCheckBundledFiles(t, skillName, files)
+	}
+}
+
+// cogCheckBundledFiles asserts every file of one bundled skill is filed under
+// that skill, carries its full embedded path, and has content.
+func cogCheckBundledFiles(t *testing.T, skillName string, files []BundledSkillFile) {
+	t.Helper()
+	wantPrefix := "bundled_skills/" + skillName + "/"
+	for _, f := range files {
+		if f.SkillName != skillName {
+			t.Errorf("file %q filed under %q but SkillName = %q", f.RelPath, skillName, f.SkillName)
+		}
+		if !strings.HasPrefix(f.RelPath, wantPrefix) {
+			t.Errorf("RelPath = %q, want prefix %q", f.RelPath, wantPrefix)
+		}
+		if len(f.Content) == 0 {
+			t.Errorf("file %q has empty content", f.RelPath)
+		}
+	}
+}
+
+// TestLoadBundledSkills_Deterministic pins that repeated calls produce the
+// same skill set and the same per-skill file counts — the walk keeps no
+// state between calls.
+func TestLoadBundledSkills_Deterministic(t *testing.T) {
+	first, err := LoadBundledSkills()
+	if err != nil {
+		t.Fatalf("LoadBundledSkills: %v", err)
+	}
+	second, err := LoadBundledSkills()
+	if err != nil {
+		t.Fatalf("LoadBundledSkills: %v", err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("skill count = %d then %d", len(first), len(second))
+	}
+	for name, files := range first {
+		other, ok := second[name]
+		if !ok {
+			t.Errorf("skill %q missing from second call", name)
+			continue
+		}
+		if len(files) != len(other) {
+			t.Errorf("skill %q file count = %d then %d", name, len(files), len(other))
+		}
+	}
+}
+
+// TestLoadSkillBody_ErrorLadder pins each early return LoadSkillBody makes
+// before it reaches the disk.
+func TestLoadSkillBody_ErrorLadder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(path, []byte("---\nname: on-disk\n---\nthe body\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := []Skill{
+		{Name: "missing-body-path", Source: "user"},
+		{Name: "preloaded", Source: "user", Instruction: "already here"},
+		{Name: "cog-bundled-cached", Source: "bundled"},
+		{Name: "cog-bundled-uncached", Source: "bundled"},
+		{Name: "on-disk", Source: "user", BodyPath: path},
+		{Name: "unreadable", Source: "user", BodyPath: filepath.Join(dir, "nope", "SKILL.md")},
+	}
+	bundledBodyCache.Store("cog-bundled-cached", "cached bundled body")
+	t.Cleanup(func() { bundledBodyCache.Delete("cog-bundled-cached") })
+
+	t.Run("unknown skill", func(t *testing.T) {
+		if _, err := LoadSkillBody(skills, "nope"); err == nil {
+			t.Fatal("expected an error for an unknown skill")
+		}
+	})
+	t.Run("preloaded instruction wins", func(t *testing.T) {
+		got, err := LoadSkillBody(skills, "preloaded")
+		if err != nil || got != "already here" {
+			t.Fatalf("LoadSkillBody = %q, %v; want %q, nil", got, err, "already here")
+		}
+	})
+	t.Run("bundled cached body", func(t *testing.T) {
+		got, err := LoadSkillBody(skills, "cog-bundled-cached")
+		if err != nil || got != "cached bundled body" {
+			t.Fatalf("LoadSkillBody = %q, %v", got, err)
+		}
+	})
+	t.Run("bundled without cache errors", func(t *testing.T) {
+		if _, err := LoadSkillBody(skills, "cog-bundled-uncached"); err == nil {
+			t.Fatal("expected an error for a bundled skill with no cached body")
+		}
+	})
+	t.Run("no body path errors", func(t *testing.T) {
+		if _, err := LoadSkillBody(skills, "missing-body-path"); err == nil {
+			t.Fatal("expected an error for a skill with no BodyPath")
+		}
+	})
+	t.Run("unreadable body path errors", func(t *testing.T) {
+		if _, err := LoadSkillBody(skills, "unreadable"); err == nil {
+			t.Fatal("expected an error for an unreadable BodyPath")
+		}
+	})
+	t.Run("reads and then caches by path", func(t *testing.T) {
+		got, err := LoadSkillBody(skills, "on-disk")
+		if err != nil || got != "the body" {
+			t.Fatalf("LoadSkillBody = %q, %v; want %q, nil", got, err, "the body")
+		}
+		// Delete the file: a second call must be served from the cache.
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { fileBodyCache.Delete(path) })
+		again, err := LoadSkillBody(skills, "on-disk")
+		if err != nil || again != "the body" {
+			t.Fatalf("cached LoadSkillBody = %q, %v; want %q, nil", again, err, "the body")
+		}
+		if size, ok := SkillBodySize(skills, "on-disk"); !ok || size != len("the body") {
+			t.Fatalf("SkillBodySize = %d, %v; want %d, true", size, ok, len("the body"))
+		}
+	})
+}
+
+// TestSkillBodySize_UnloadedReportsFalse pins that SkillBodySize never
+// triggers I/O: an unloaded skill reports (0, false) rather than reading.
+func TestSkillBodySize_UnloadedReportsFalse(t *testing.T) {
+	skills := []Skill{
+		{Name: "preloaded", Instruction: "abcd"},
+		{Name: "cog-size-uncached", Source: "bundled"},
+		{Name: "no-path", Source: "user"},
+		{Name: "unread", Source: "user", BodyPath: filepath.Join(t.TempDir(), "SKILL.md")},
+	}
+	cases := []struct {
+		name     string
+		wantSize int
+		wantOK   bool
+	}{
+		{"nope", 0, false},
+		{"preloaded", 4, true},
+		{"cog-size-uncached", 0, false},
+		{"no-path", 0, false},
+		{"unread", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, ok := SkillBodySize(skills, tc.name)
+			if size != tc.wantSize || ok != tc.wantOK {
+				t.Errorf("SkillBodySize(%q) = %d, %v; want %d, %v", tc.name, size, ok, tc.wantSize, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestBundledSkillName_PathBoundaries pins the path shapes that carry no skill
+// name. The real embed fs cannot produce them — the walk is rooted at
+// "bundled_skills" and every entry is nested — but the guards are what keeps a
+// stray path from being filed under an empty skill name.
+func TestBundledSkillName_PathBoundaries(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"bundled_skills/agents-md/SKILL.md", "agents-md", true},
+		{"bundled_skills/agents-md/refs/extra.md", "agents-md", true},
+		{"bundled_skills/agents-md/", "agents-md", true},
+		{"bundled_skills/loose.md", "", false},
+		{"bundled_skills/", "", false},
+		{"bundled_skills", "", false},
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			got, ok := bundledSkillName(tc.path)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("bundledSkillName(%q) = %q, %v; want %q, %v", tc.path, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestReadImagePath_Ladder pins, on the helper directly, the same skip ladder
+// TestReadImageCallback_SkipsEverythingButReadImageResults checks end to end.
+func TestReadImagePath_Ladder(t *testing.T) {
+	tests := []struct {
+		name string
+		part *genai.Part
+		want string
+		ok   bool
+	}{
+		{"nil part", nil, "", false},
+		{"text part", &genai.Part{Text: "hi"}, "", false},
+		{"other tool", cogRespPart("read", map[string]any{"path": "/a.png"}), "", false},
+		{"nil response map", &genai.Part{
+			FunctionResponse: &genai.FunctionResponse{Name: readImageToolName},
+		}, "", false},
+		{"missing path", cogRespPart(readImageToolName, map[string]any{"size": 1}), "", false},
+		{"non-string path", cogRespPart(readImageToolName, map[string]any{"path": 1}), "", false},
+		{"empty path", cogRespPart(readImageToolName, map[string]any{"path": ""}), "", false},
+		{"good path", cogRespPart(readImageToolName, map[string]any{"path": "/a.png"}), "/a.png", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := readImagePath(tc.part)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("readImagePath = %q, %v; want %q, %v", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestSplitSkillTools_TrimAndDrop pins the "tools:" splitting rules on the
+// helper directly, including the all-empty case that must yield no slice at
+// all rather than a slice of empty strings.
+func TestSplitSkillTools_TrimAndDrop(t *testing.T) {
+	tests := []struct {
+		value string
+		want  []string
+	}{
+		{"", nil},
+		{",", nil},
+		{"   ,  ,  ", nil},
+		{"read", []string{"read"}},
+		{" read , write ", []string{"read", "write"}},
+		{"read,,write,", []string{"read", "write"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			got := splitSkillTools(tc.value)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitSkillTools(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+			for i, want := range tc.want {
+				if got[i] != want {
+					t.Errorf("[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestAppendOrOverrideSkill_IndexBookkeeping pins that an override replaces in
+// place — keeping load order stable — while a new name is appended and its
+// index recorded for a later override to find.
+func TestAppendOrOverrideSkill_IndexBookkeeping(t *testing.T) {
+	seen := map[string]int{}
+	skills := appendOrOverrideSkill(nil, seen, Skill{Name: "a", Source: "bundled"})
+	skills = appendOrOverrideSkill(skills, seen, Skill{Name: "b", Source: "bundled"})
+	skills = appendOrOverrideSkill(skills, seen, Skill{Name: "a", Source: "project"})
+
+	if len(skills) != 2 {
+		t.Fatalf("len(skills) = %d, want 2 — an override must not append", len(skills))
+	}
+	if skills[0].Name != "a" || skills[0].Source != "project" {
+		t.Errorf("skills[0] = %+v, want a/project replaced in place", skills[0])
+	}
+	if skills[1].Name != "b" {
+		t.Errorf("skills[1] = %+v, want b to keep its slot", skills[1])
+	}
+	if seen["a"] != 0 || seen["b"] != 1 {
+		t.Errorf("seen = %v, want a:0 b:1", seen)
+	}
+}

--- a/internal/extension/embed_skills.go
+++ b/internal/extension/embed_skills.go
@@ -3,6 +3,7 @@ package extension
 import (
 	"embed"
 	"io/fs"
+	"strings"
 )
 
 // bundledSkillsFS embeds all skills in the bundled_skills directory.
@@ -25,46 +26,58 @@ func LoadBundledSkills() (map[string][]BundledSkillFile, error) {
 	skillFiles := make(map[string]map[string][]byte) // skillName → relPath → content
 
 	err := fs.WalkDir(bundledSkillsFS, "bundled_skills", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil //nolint:nilerr // skip inaccessible entries — embedded fs may have restricted files
-		}
-		if d.IsDir() {
-			return nil
-		}
-		// path is like "bundled_skills/agents-md/SKILL.md"
-		// Extract skill name: "bundled_skills/" = 15 chars
-		if len(path) <= 15 {
-			return nil
-		}
-		rest := path[15:] // "agents-md/SKILL.md"
-		slashIdx := -1
-		for i := 0; i < len(rest); i++ {
-			if rest[i] == '/' {
-				slashIdx = i
-				break
-			}
-		}
-		if slashIdx < 0 {
-			return nil // no subdir, skip
-		}
-		skillName := rest[:slashIdx]
-
-		content, err := fs.ReadFile(bundledSkillsFS, path)
-		if err != nil {
-			return nil //nolint:nilerr // skip files that fail to read — not fatal
-		}
-
-		if skillFiles[skillName] == nil {
-			skillFiles[skillName] = make(map[string][]byte)
-		}
-		skillFiles[skillName][path] = content
+		collectBundledSkillFile(skillFiles, path, d, err)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert to the result type.
+	return groupBundledSkillFiles(skillFiles), nil
+}
+
+// collectBundledSkillFile records one walked entry under its skill name.
+// Everything that is not a readable file inside a skill subdirectory is
+// skipped rather than reported: an inaccessible entry, a directory, a path
+// with no skill subdirectory, and a file that fails to read are all
+// non-fatal — a single bad entry must not cost the binary every other skill.
+func collectBundledSkillFile(skillFiles map[string]map[string][]byte, path string, d fs.DirEntry, err error) {
+	if err != nil || d.IsDir() {
+		return
+	}
+	skillName, ok := bundledSkillName(path)
+	if !ok {
+		return
+	}
+	content, readErr := fs.ReadFile(bundledSkillsFS, path)
+	if readErr != nil {
+		return
+	}
+	if skillFiles[skillName] == nil {
+		skillFiles[skillName] = make(map[string][]byte)
+	}
+	skillFiles[skillName][path] = content
+}
+
+// bundledSkillName extracts the skill directory name from an embedded path
+// like "bundled_skills/agents-md/SKILL.md". A path with nothing after the
+// prefix, or with no subdirectory under it, belongs to no skill.
+func bundledSkillName(path string) (string, bool) {
+	const prefix = "bundled_skills/"
+	if len(path) <= len(prefix) {
+		return "", false
+	}
+	rest := path[len(prefix):] // "agents-md/SKILL.md"
+	slashIdx := strings.IndexByte(rest, '/')
+	if slashIdx < 0 {
+		return "", false // no subdir, skip
+	}
+	return rest[:slashIdx], true
+}
+
+// groupBundledSkillFiles flattens the per-skill path→content map into the
+// public result type.
+func groupBundledSkillFiles(skillFiles map[string]map[string][]byte) map[string][]BundledSkillFile {
 	result := make(map[string][]BundledSkillFile)
 	for skillName, files := range skillFiles {
 		var sorted []BundledSkillFile
@@ -77,5 +90,5 @@ func LoadBundledSkills() (map[string][]BundledSkillFile, error) {
 		}
 		result[skillName] = sorted
 	}
-	return result, nil
+	return result
 }

--- a/internal/extension/read_image.go
+++ b/internal/extension/read_image.go
@@ -27,40 +27,65 @@ const readImageToolName = "read_image"
 // forward InlineData (Gemini via ADK-native model) see the image; others simply
 // ignore it and fall back to the textual path.
 func BuildReadImageCallback(sb *tools.Sandbox) llmagent.BeforeModelCallback {
-	return func(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
-		if req == nil || sb == nil {
-			return nil, nil
-		}
-		for _, content := range req.Contents {
-			if content == nil {
-				continue
-			}
-			// A read_image FunctionResponse is a user-turn part. We append the
-			// image part to the same Content after the FunctionResponse so the
-			// model sees path+metadata and the image together in one turn.
-			for _, part := range content.Parts {
-				if part == nil || part.FunctionResponse == nil {
-					continue
-				}
-				fr := part.FunctionResponse
-				if fr.Name != readImageToolName {
-					continue
-				}
-				path, ok := fr.Response["path"].(string)
-				if !ok || path == "" {
-					continue
-				}
-				data, err := sb.ReadFile(path)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "pi-go: warning: read_image callback could not read %q: %v\n", path, err)
-					continue
-				}
-				mime := detectImageMIMEType(data, path)
-				content.Parts = append(content.Parts, genai.NewPartFromBytes(data, mime))
-			}
-		}
+	return func(_ agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
+		injectReadImageParts(sb, req)
 		return nil, nil
 	}
+}
+
+// injectReadImageParts appends the image bytes behind each read_image result
+// to the Content that carried the result. A nil request or sandbox is a no-op.
+func injectReadImageParts(sb *tools.Sandbox, req *model.LLMRequest) {
+	if req == nil || sb == nil {
+		return
+	}
+	for _, content := range req.Contents {
+		if content == nil {
+			continue
+		}
+		// A read_image FunctionResponse is a user-turn part. We append the
+		// image parts to the same Content after the FunctionResponse so the
+		// model sees path+metadata and the image together in one turn.
+		content.Parts = append(content.Parts, readImageParts(sb, content.Parts)...)
+	}
+}
+
+// readImageParts reads the file behind every read_image FunctionResponse in
+// parts and returns the inline image parts to append, in the order the
+// responses appear. A file that cannot be read is warned about and skipped —
+// the textual path result still stands on its own.
+func readImageParts(sb *tools.Sandbox, parts []*genai.Part) []*genai.Part {
+	var out []*genai.Part
+	for _, part := range parts {
+		path, ok := readImagePath(part)
+		if !ok {
+			continue
+		}
+		data, err := sb.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pi-go: warning: read_image callback could not read %q: %v\n", path, err)
+			continue
+		}
+		out = append(out, genai.NewPartFromBytes(data, detectImageMIMEType(data, path)))
+	}
+	return out
+}
+
+// readImagePath returns the path a read_image FunctionResponse reported, and
+// whether part is such a response at all.
+func readImagePath(part *genai.Part) (string, bool) {
+	if part == nil || part.FunctionResponse == nil {
+		return "", false
+	}
+	fr := part.FunctionResponse
+	if fr.Name != readImageToolName {
+		return "", false
+	}
+	path, ok := fr.Response["path"].(string)
+	if !ok || path == "" {
+		return "", false
+	}
+	return path, true
 }
 
 // detectImageMIMEType sniffs an image's MIME type from its bytes, falling back

--- a/internal/extension/skills.go
+++ b/internal/extension/skills.go
@@ -144,6 +144,12 @@ func appendDirSkills(skills []Skill, seen map[string]int, blocked *[]string, opt
 		return nil, fmt.Errorf("reading skills dir %s: %w", dir, err)
 	}
 
+	// Determine source based on whether the path is absolute.
+	source := "user"
+	if !filepath.IsAbs(dir) {
+		source = "project"
+	}
+
 	for _, skillInfo := range skillCandidates(dir, entries) {
 		if _, err := os.Stat(skillInfo.path); err != nil {
 			continue
@@ -162,21 +168,22 @@ func appendDirSkills(skills []Skill, seen map[string]int, blocked *[]string, opt
 		if skill.Name == "" {
 			skill.Name = skillInfo.defaultName
 		}
-		// Determine source based on whether the path is absolute.
-		source := "user"
-		if !filepath.IsAbs(dir) {
-			source = "project"
-		}
 		skill.Source = source
-		if idx, ok := seen[skill.Name]; ok {
-			// Override with project/user-level skill.
-			skills[idx] = skill
-		} else {
-			seen[skill.Name] = len(skills)
-			skills = append(skills, skill)
-		}
+		skills = appendOrOverrideSkill(skills, seen, skill)
 	}
 	return skills, nil
+}
+
+// appendOrOverrideSkill replaces a same-named skill loaded earlier — that is
+// how a project or user skill overrides a bundled one — or appends the skill
+// and records its index in seen.
+func appendOrOverrideSkill(skills []Skill, seen map[string]int, skill Skill) []Skill {
+	if idx, ok := seen[skill.Name]; ok {
+		skills[idx] = skill
+		return skills
+	}
+	seen[skill.Name] = len(skills)
+	return append(skills, skill)
 }
 
 // skillCandidates lists the SKILL.md files to consider under dir: the
@@ -265,44 +272,52 @@ func parseSkillContent(content, skillName string) (Skill, string, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		trimmed := strings.TrimSpace(line)
 
-		if trimmed == "---" && !frontmatterDone {
-			if !inFrontmatter {
-				inFrontmatter = true
-				continue
-			}
-			// End of frontmatter.
-			inFrontmatter = false
-			frontmatterDone = true
+		// The first "---" opens the frontmatter and the second closes it for
+		// good; a later one is ordinary body text.
+		if !frontmatterDone && strings.TrimSpace(line) == "---" {
+			inFrontmatter = !inFrontmatter
+			frontmatterDone = !inFrontmatter
 			continue
 		}
-
-		if inFrontmatter {
-			key, value, ok := parseFrontmatterLine(line)
-			if !ok {
-				continue
-			}
-			switch key {
-			case "name":
-				skill.Name = value
-			case "description":
-				skill.Description = value
-			case "tools":
-				for _, t := range strings.Split(value, ",") {
-					t = strings.TrimSpace(t)
-					if t != "" {
-						skill.Tools = append(skill.Tools, t)
-					}
-				}
-			}
-		} else {
+		if !inFrontmatter {
 			body.WriteString(line)
 			body.WriteString("\n")
+			continue
 		}
+		applyFrontmatterLine(&skill, line)
 	}
 
 	return skill, strings.TrimSpace(body.String()), scanner.Err()
+}
+
+// applyFrontmatterLine records one recognized "key: value" frontmatter line on
+// skill. Lines with no colon, and keys the format does not define, are ignored.
+func applyFrontmatterLine(skill *Skill, line string) {
+	key, value, ok := parseFrontmatterLine(line)
+	if !ok {
+		return
+	}
+	switch key {
+	case "name":
+		skill.Name = value
+	case "description":
+		skill.Description = value
+	case "tools":
+		skill.Tools = append(skill.Tools, splitSkillTools(value)...)
+	}
+}
+
+// splitSkillTools splits a comma-separated "tools:" value, trimming each entry
+// and dropping the empty ones a trailing or doubled comma leaves behind.
+func splitSkillTools(value string) []string {
+	var tools []string
+	for _, t := range strings.Split(value, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			tools = append(tools, t)
+		}
+	}
+	return tools
 }
 
 // parseFrontmatterLine parses "key: value" from a frontmatter line.

--- a/internal/jsonrpc/complexity_cog_jsonrpc_test.go
+++ b/internal/jsonrpc/complexity_cog_jsonrpc_test.go
@@ -1,0 +1,461 @@
+package jsonrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"regexp"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+)
+
+// handlePrompt is the whole wire contract for the "prompt" method: an
+// acknowledgement carrying the session id, then a JSONL event stream. The
+// literals below are the exact bytes the pre-refactor handler wrote, captured
+// by running these same cases against it before any edit, with only the random
+// session id normalized. A change in event order, in which parts produce
+// events, or in a single JSON field name fails here.
+
+// cogScriptedLLM drives the agent through a fixed sequence of responses, one
+// per turn. A turn that runs off the end repeats the last response.
+type cogScriptedLLM struct {
+	turns []*genai.Content
+	n     int
+}
+
+func (m *cogScriptedLLM) Name() string { return "cog-scripted" }
+
+func (m *cogScriptedLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		i := min(m.n, len(m.turns)-1)
+		m.n++
+		yield(&model.LLMResponse{Content: m.turns[i]}, nil)
+	}
+}
+
+// cogFailingLLM fails the stream, which reaches handlePrompt as an iteration
+// error rather than an event.
+type cogFailingLLM struct{ err error }
+
+func (m *cogFailingLLM) Name() string { return "cog-failing" }
+
+func (m *cogFailingLLM) GenerateContent(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) { yield(nil, m.err) }
+}
+
+func cogServer(t *testing.T, llm model.LLM) *Server {
+	t.Helper()
+	ag, err := agent.New(agent.Config{Model: llm, Instruction: "Test agent"})
+	if err != nil {
+		t.Fatalf("creating agent: %v", err)
+	}
+	return NewServer(Config{Agent: ag})
+}
+
+var cogSessionIDRe = regexp.MustCompile(`"session_id":"[0-9a-f-]{36}"`)
+
+// cogPrompt runs one prompt request against an in-memory encoder and returns
+// the JSONL the handler wrote, with the generated session id normalized so the
+// bytes can be compared literally.
+func cogPrompt(t *testing.T, s *Server, params string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	req := Request{JSONRPC: "2.0", Method: "prompt", Params: json.RawMessage(params), ID: 1}
+	s.handlePrompt(context.Background(), nil, enc, req)
+	return cogSessionIDRe.ReplaceAllString(buf.String(), `"session_id":"SESSION"`)
+}
+
+func cogAssertStream(t *testing.T, got string, want []string) {
+	t.Helper()
+	wantStr := strings.Join(want, "\n") + "\n"
+	if got != wantStr {
+		t.Errorf("stream mismatch\n got:\n%s\nwant:\n%s", got, wantStr)
+	}
+}
+
+// A plain text answer: acknowledgement, one message_start, one delta per part,
+// message_end.
+func TestHandlePromptTextStream(t *testing.T) {
+	s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+		genai.NewContentFromText("Hello from RPC!", genai.RoleModel),
+	}})
+
+	cogAssertStream(t, cogPrompt(t, s, `{"text":"hello"}`), []string{
+		`{"jsonrpc":"2.0","result":{"session_id":"SESSION"},"id":1}`,
+		`{"type":"message_start","agent":"pi","role":"model"}`,
+		`{"type":"text_delta","agent":"pi","delta":"Hello from RPC!"}`,
+		`{"type":"message_end"}`,
+	})
+}
+
+// A tool round trip. message_start appears once even though the agent produces
+// several events, the call carries its arguments, and the result is the
+// marshaled response string.
+func TestHandlePromptToolCallStream(t *testing.T) {
+	s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+		{Role: genai.RoleModel, Parts: []*genai.Part{
+			{Text: "calling"},
+			{FunctionCall: &genai.FunctionCall{Name: "search", Args: map[string]any{"q": "x", "n": 2}}},
+		}},
+		genai.NewContentFromText("done", genai.RoleModel),
+	}})
+
+	got := cogPrompt(t, s, `{"text":"go"}`)
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+
+	if len(lines) != 7 {
+		t.Fatalf("got %d lines, want 7:\n%s", len(lines), got)
+	}
+	if lines[0] != `{"jsonrpc":"2.0","result":{"session_id":"SESSION"},"id":1}` {
+		t.Errorf("ack = %s", lines[0])
+	}
+	if lines[1] != `{"type":"message_start","agent":"pi","role":"model"}` {
+		t.Errorf("message_start = %s", lines[1])
+	}
+	if lines[2] != `{"type":"text_delta","agent":"pi","delta":"calling"}` {
+		t.Errorf("text_delta = %s", lines[2])
+	}
+	if lines[3] != `{"type":"tool_call","agent":"pi","tool_name":"search","tool_input":{"n":2,"q":"x"}}` {
+		t.Errorf("tool_call = %s", lines[3])
+	}
+	// The tool does not exist, so the agent's own not-found report comes back
+	// as the result payload. Only its envelope is pinned; the prose is the
+	// agent's, not this handler's.
+	if !strings.HasPrefix(lines[4], `{"type":"tool_result","agent":"pi","content":"{\"error\":\"tool 'search' not found.`) {
+		t.Errorf("tool_result = %s", lines[4])
+	}
+	if !strings.HasSuffix(lines[4], `","tool_name":"search"}`) {
+		t.Errorf("tool_result envelope = %s", lines[4])
+	}
+	if lines[5] != `{"type":"text_delta","agent":"pi","delta":"done"}` {
+		t.Errorf("trailing text_delta = %s", lines[5])
+	}
+	if lines[6] != `{"type":"message_end"}` {
+		t.Errorf("message_end = %s", lines[6])
+	}
+	if strings.Count(got, `"type":"message_start"`) != 1 {
+		t.Errorf("message_start appeared %d times, want 1", strings.Count(got, `"type":"message_start"`))
+	}
+}
+
+// A part carrying none of text, a call or a response produces no event at all.
+func TestHandlePromptEmptyPartProducesNothing(t *testing.T) {
+	s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+		{Role: genai.RoleModel, Parts: []*genai.Part{{}, {Text: "after"}, {}}},
+	}})
+
+	cogAssertStream(t, cogPrompt(t, s, `{"text":"hello"}`), []string{
+		`{"jsonrpc":"2.0","result":{"session_id":"SESSION"},"id":1}`,
+		`{"type":"message_start","agent":"pi","role":"model"}`,
+		`{"type":"text_delta","agent":"pi","delta":"after"}`,
+		`{"type":"message_end"}`,
+	})
+}
+
+// A stream failure ends the loop: one error event, then message_end. The
+// acknowledgement has already gone out, so the client still learns the session.
+func TestHandlePromptStreamErrorStopsTheLoop(t *testing.T) {
+	s := cogServer(t, &cogFailingLLM{err: errors.New("model exploded")})
+
+	got := cogPrompt(t, s, `{"text":"hello"}`)
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3:\n%s", len(lines), got)
+	}
+	if lines[0] != `{"jsonrpc":"2.0","result":{"session_id":"SESSION"},"id":1}` {
+		t.Errorf("ack = %s", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], `{"type":"error","content":"`) || !strings.Contains(lines[1], "model exploded") {
+		t.Errorf("error event = %s", lines[1])
+	}
+	if lines[2] != `{"type":"message_end"}` {
+		t.Errorf("message_end = %s", lines[2])
+	}
+}
+
+// The rejection paths write a JSON-RPC error and no events at all — not even
+// message_end, because the agent is never run.
+func TestHandlePromptRejections(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{
+			name:   "params that are not an object",
+			params: `"nope"`,
+			want:   `{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid params: json: cannot unmarshal string into Go value of type jsonrpc.PromptParams"},"id":1}`,
+		},
+		{
+			name:   "params with the wrong type for text",
+			params: `{"text":7}`,
+			want:   `{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid params: json: cannot unmarshal number into Go struct field PromptParams.text of type string"},"id":1}`,
+		},
+		{
+			name:   "an empty text",
+			params: `{"text":""}`,
+			want:   `{"jsonrpc":"2.0","error":{"code":-32602,"message":"params.text is required"},"id":1}`,
+		},
+		{
+			name:   "a missing text",
+			params: `{"session_id":"s1"}`,
+			want:   `{"jsonrpc":"2.0","error":{"code":-32602,"message":"params.text is required"},"id":1}`,
+		},
+		{
+			name:   "text absent but session present is still rejected",
+			params: `{}`,
+			want:   `{"jsonrpc":"2.0","error":{"code":-32602,"message":"params.text is required"},"id":1}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+				genai.NewContentFromText("unreached", genai.RoleModel),
+			}})
+			cogAssertStream(t, cogPrompt(t, s, tt.params), []string{tt.want})
+		})
+	}
+}
+
+// An empty params field is decoded as a nil RawMessage, which is a decode
+// failure rather than an empty object.
+func TestHandlePromptNilParams(t *testing.T) {
+	s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+		genai.NewContentFromText("unreached", genai.RoleModel),
+	}})
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	s.handlePrompt(context.Background(), nil, enc, Request{JSONRPC: "2.0", Method: "prompt", ID: 1})
+
+	got := buf.String()
+	if !strings.HasPrefix(got, `{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid params: `) {
+		t.Errorf("got %s, want an invalid-params error", got)
+	}
+	if strings.Contains(got, "message_end") {
+		t.Error("the agent ran despite unusable params")
+	}
+}
+
+// A client-supplied session id is used as given and echoed back; no session is
+// created for it.
+func TestHandlePromptHonorsSuppliedSessionID(t *testing.T) {
+	s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+		genai.NewContentFromText("hi", genai.RoleModel),
+	}})
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	req := Request{JSONRPC: "2.0", Method: "prompt", Params: json.RawMessage(`{"text":"hello","session_id":"caller-supplied"}`), ID: 42}
+	s.handlePrompt(context.Background(), nil, enc, req)
+
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if lines[0] != `{"jsonrpc":"2.0","result":{"session_id":"caller-supplied"},"id":42}` {
+		t.Errorf("ack = %s", lines[0])
+	}
+	if lines[len(lines)-1] != `{"type":"message_end"}` {
+		t.Errorf("last line = %s, want message_end", lines[len(lines)-1])
+	}
+}
+
+// The request ID is echoed verbatim, including the JSON-native shapes a client
+// may use for it.
+func TestHandlePromptEchoesRequestID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   any
+		want string
+	}{
+		{"a number", 7, `"id":7`},
+		{"a string", "abc", `"id":"abc"`},
+		{"null", nil, `"id":null`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+				genai.NewContentFromText("hi", genai.RoleModel),
+			}})
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			req := Request{JSONRPC: "2.0", Method: "prompt", Params: json.RawMessage(`{"text":"x"}`), ID: tt.id}
+			s.handlePrompt(context.Background(), nil, enc, req)
+
+			if !strings.Contains(strings.Split(buf.String(), "\n")[0], tt.want) {
+				t.Errorf("ack = %s, want it to carry %s", strings.Split(buf.String(), "\n")[0], tt.want)
+			}
+		})
+	}
+}
+
+// Two prompts arriving on separate connections run one after the other: runMu
+// is held for a whole stream, so neither run is interleaved with the other.
+//
+// Each connection gets its own encoder in handleConn, and handleConn dispatches
+// a connection's requests sequentially, so two handlePrompt calls never share an
+// encoder in production. This test models that: one buffer and one encoder per
+// simulated connection. Sharing a single encoder across both goroutines would
+// race on the acknowledgement write, which handlePrompt performs before
+// streamRun takes runMu -- a race the server itself cannot reach.
+func TestHandlePromptStreamsAreNotInterleaved(t *testing.T) {
+	s := cogServer(t, &cogScriptedLLM{turns: []*genai.Content{
+		genai.NewContentFromText("one", genai.RoleModel),
+	}})
+
+	bufs := make([]bytes.Buffer, 2)
+	done := make(chan struct{}, len(bufs))
+	for i := range bufs {
+		go func() {
+			s.handlePrompt(context.Background(), nil, json.NewEncoder(&bufs[i]), Request{
+				JSONRPC: "2.0", Method: "prompt",
+				Params: json.RawMessage(`{"text":"hello"}`), ID: 1,
+			})
+			done <- struct{}{}
+		}()
+	}
+	for range bufs {
+		<-done
+	}
+
+	// Each connection sees its own complete, self-contained stream: the
+	// acknowledgement followed by exactly one run's events, in order.
+	for i := range bufs {
+		got := cogSessionIDRe.ReplaceAllString(bufs[i].String(), `"session_id":"SESSION"`)
+		lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+		if len(lines) != 4 {
+			t.Errorf("connection %d: got %d lines, want 4:\n%s", i, len(lines), got)
+			continue
+		}
+		want := []string{
+			`{"jsonrpc":"2.0","result":{"session_id":"SESSION"},"id":1}`,
+			`{"type":"message_start","agent":"pi","role":"model"}`,
+			`{"type":"text_delta","agent":"pi","delta":"one"}`,
+			`{"type":"message_end"}`,
+		}
+		for j, w := range want {
+			if lines[j] != w {
+				t.Errorf("connection %d line %d = %s, want %s", i, j, lines[j], w)
+			}
+		}
+	}
+}
+
+// encodePart carries the per-part mapping that the stream loop used to hold
+// inline. These drive it directly, which is the only way to reach the
+// marshal-failure fallback: a response the agent produces always marshals.
+func TestEncodePart(t *testing.T) {
+	tests := []struct {
+		name string
+		part *genai.Part
+		want []string
+	}{
+		{
+			name: "text becomes one delta",
+			part: &genai.Part{Text: "hello"},
+			want: []string{`{"type":"text_delta","agent":"pi","delta":"hello"}`},
+		},
+		{
+			name: "an empty part produces nothing",
+			part: &genai.Part{},
+			want: nil,
+		},
+		{
+			name: "a call carries its name and arguments",
+			part: &genai.Part{FunctionCall: &genai.FunctionCall{Name: "search", Args: map[string]any{"q": "x", "n": 2}}},
+			want: []string{`{"type":"tool_call","agent":"pi","tool_name":"search","tool_input":{"n":2,"q":"x"}}`},
+		},
+		{
+			// Args is a nil map inside an any field, which omitempty does not
+			// drop, so the null reaches the client.
+			name: "a call with no arguments still sends a null tool_input",
+			part: &genai.Part{FunctionCall: &genai.FunctionCall{Name: "ping"}},
+			want: []string{`{"type":"tool_call","agent":"pi","tool_name":"ping","tool_input":null}`},
+		},
+		{
+			name: "a response is marshaled into content",
+			part: &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: "search", Response: map[string]any{"n": 1}}},
+			want: []string{`{"type":"tool_result","agent":"pi","content":"{\"n\":1}","tool_name":"search"}`},
+		},
+		{
+			name: "a nil response marshals to null",
+			part: &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: "search"}},
+			want: []string{`{"type":"tool_result","agent":"pi","content":"null","tool_name":"search"}`},
+		},
+		{
+			name: "all three shapes emit in order",
+			part: &genai.Part{
+				Text:             "t",
+				FunctionCall:     &genai.FunctionCall{Name: "c"},
+				FunctionResponse: &genai.FunctionResponse{Name: "r", Response: map[string]any{"ok": true}},
+			},
+			want: []string{
+				`{"type":"text_delta","agent":"pi","delta":"t"}`,
+				`{"type":"tool_call","agent":"pi","tool_name":"c","tool_input":null}`,
+				`{"type":"tool_result","agent":"pi","content":"{\"ok\":true}","tool_name":"r"}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			encodePart(json.NewEncoder(&buf), "pi", tt.part)
+
+			got := buf.String()
+			wantStr := ""
+			if len(tt.want) > 0 {
+				wantStr = strings.Join(tt.want, "\n") + "\n"
+			}
+			if got != wantStr {
+				t.Errorf("encodePart\n got: %q\nwant: %q", got, wantStr)
+			}
+		})
+	}
+}
+
+// A response that will not marshal falls back to its Go rendering rather than
+// dropping the tool_result event entirely.
+func TestEncodePartUnmarshalableResponse(t *testing.T) {
+	part := &genai.Part{FunctionResponse: &genai.FunctionResponse{
+		Name:     "broken",
+		Response: map[string]any{"ch": make(chan int)},
+	}}
+
+	var buf bytes.Buffer
+	encodePart(json.NewEncoder(&buf), "pi", part)
+
+	var ev Event
+	if err := json.Unmarshal(buf.Bytes(), &ev); err != nil {
+		t.Fatalf("decoding the event: %v (raw: %s)", err, buf.String())
+	}
+	if ev.Type != "tool_result" {
+		t.Errorf("type = %q, want tool_result", ev.Type)
+	}
+	if ev.ToolName != "broken" {
+		t.Errorf("tool_name = %q, want broken", ev.ToolName)
+	}
+	if !strings.HasPrefix(ev.Content, "map[ch:0x") {
+		t.Errorf("content = %q, want the Go rendering of the map", ev.Content)
+	}
+}
+
+// writeError is the single shape every rejection uses.
+func TestWriteError(t *testing.T) {
+	var buf bytes.Buffer
+	writeError(json.NewEncoder(&buf), "req-9", -32000, "creating session: disk full")
+
+	want := `{"jsonrpc":"2.0","error":{"code":-32000,"message":"creating session: disk full"},"id":"req-9"}` + "\n"
+	if buf.String() != want {
+		t.Errorf("writeError\n got: %s\nwant: %s", buf.String(), want)
+	}
+}

--- a/internal/jsonrpc/rpc.go
+++ b/internal/jsonrpc/rpc.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"syscall"
 
+	"google.golang.org/genai"
+
 	"github.com/dimetron/pi-go/internal/agent"
 )
 
@@ -174,38 +176,9 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 
 // handlePrompt processes a prompt request by running the agent and streaming events.
 func (s *Server) handlePrompt(ctx context.Context, _ net.Conn, enc *json.Encoder, req Request) {
-	var params PromptParams
-	if err := json.Unmarshal(req.Params, &params); err != nil {
-		_ = enc.Encode(Response{
-			JSONRPC: "2.0",
-			Error:   &Error{Code: -32602, Message: "invalid params: " + err.Error()},
-			ID:      req.ID,
-		})
+	params, sessionID, ok := s.resolvePrompt(ctx, enc, req)
+	if !ok {
 		return
-	}
-
-	if params.Text == "" {
-		_ = enc.Encode(Response{
-			JSONRPC: "2.0",
-			Error:   &Error{Code: -32602, Message: "params.text is required"},
-			ID:      req.ID,
-		})
-		return
-	}
-
-	// Create a session if not provided.
-	sessionID := params.SessionID
-	if sessionID == "" {
-		var err error
-		sessionID, _, err = s.agent.CreateSession(ctx)
-		if err != nil {
-			_ = enc.Encode(Response{
-				JSONRPC: "2.0",
-				Error:   &Error{Code: -32000, Message: "creating session: " + err.Error()},
-				ID:      req.ID,
-			})
-			return
-		}
 	}
 
 	// Send initial response with session ID to acknowledge the request.
@@ -215,6 +188,40 @@ func (s *Server) handlePrompt(ctx context.Context, _ net.Conn, enc *json.Encoder
 		ID:      req.ID,
 	})
 
+	s.streamRun(ctx, enc, sessionID, params.Text)
+}
+
+// resolvePrompt validates the request and settles which session it runs in,
+// creating one when the client did not name it. It writes the JSON-RPC error
+// response and reports ok=false when the request cannot be served, so the
+// caller has nothing left to do.
+func (s *Server) resolvePrompt(ctx context.Context, enc *json.Encoder, req Request) (params PromptParams, sessionID string, ok bool) {
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeError(enc, req.ID, -32602, "invalid params: "+err.Error())
+		return params, "", false
+	}
+
+	if params.Text == "" {
+		writeError(enc, req.ID, -32602, "params.text is required")
+		return params, "", false
+	}
+
+	// Create a session if not provided.
+	if params.SessionID != "" {
+		return params, params.SessionID, true
+	}
+
+	sessionID, _, err := s.agent.CreateSession(ctx)
+	if err != nil {
+		writeError(enc, req.ID, -32000, "creating session: "+err.Error())
+		return params, "", false
+	}
+	return params, sessionID, true
+}
+
+// streamRun runs the agent and writes its events as JSONL, closing with
+// message_end.
+func (s *Server) streamRun(ctx context.Context, enc *json.Encoder, sessionID, text string) {
 	// Stream JSONL events (same schema as JSON mode).
 	started := false
 
@@ -225,7 +232,7 @@ func (s *Server) handlePrompt(ctx context.Context, _ net.Conn, enc *json.Encoder
 	// re-introduce the data race.
 	s.runMu.Lock()
 	defer s.runMu.Unlock()
-	for ev, err := range s.agent.Run(ctx, sessionID, params.Text) {
+	for ev, err := range s.agent.Run(ctx, sessionID, text) {
 		if err != nil {
 			_ = enc.Encode(Event{Type: "error", Content: err.Error()})
 			break
@@ -244,48 +251,64 @@ func (s *Server) handlePrompt(ctx context.Context, _ net.Conn, enc *json.Encoder
 		}
 
 		for _, part := range ev.Content.Parts {
-			if part.Text != "" {
-				_ = enc.Encode(Event{
-					Type:  "text_delta",
-					Agent: ev.Author,
-					Delta: part.Text,
-				})
-			}
-			if part.FunctionCall != nil {
-				_ = enc.Encode(Event{
-					Type:      "tool_call",
-					Agent:     ev.Author,
-					ToolName:  part.FunctionCall.Name,
-					ToolInput: part.FunctionCall.Args,
-				})
-			}
-			if part.FunctionResponse != nil {
-				respJSON, err := json.Marshal(part.FunctionResponse.Response)
-				if err != nil {
-					respJSON = []byte(fmt.Sprintf("%v", part.FunctionResponse.Response))
-				}
-				_ = enc.Encode(Event{
-					Type:     "tool_result",
-					Agent:    ev.Author,
-					ToolName: part.FunctionResponse.Name,
-					Content:  string(respJSON),
-				})
-			}
+			encodePart(enc, ev.Author, part)
 		}
 	}
 
 	_ = enc.Encode(Event{Type: "message_end"})
 }
 
+// encodePart writes the events one content part carries. A part may carry text,
+// a tool call and a tool result at once, so each is checked in turn; a part
+// carrying none of them produces nothing.
+func encodePart(enc *json.Encoder, author string, part *genai.Part) {
+	if part.Text != "" {
+		_ = enc.Encode(Event{
+			Type:  "text_delta",
+			Agent: author,
+			Delta: part.Text,
+		})
+	}
+	if part.FunctionCall != nil {
+		_ = enc.Encode(Event{
+			Type:      "tool_call",
+			Agent:     author,
+			ToolName:  part.FunctionCall.Name,
+			ToolInput: part.FunctionCall.Args,
+		})
+	}
+	if part.FunctionResponse == nil {
+		return
+	}
+
+	// A response that will not marshal is still worth reporting, so fall back
+	// to its Go rendering rather than dropping the event.
+	respJSON, err := json.Marshal(part.FunctionResponse.Response)
+	if err != nil {
+		respJSON = []byte(fmt.Sprintf("%v", part.FunctionResponse.Response))
+	}
+	_ = enc.Encode(Event{
+		Type:     "tool_result",
+		Agent:    author,
+		ToolName: part.FunctionResponse.Name,
+		Content:  string(respJSON),
+	})
+}
+
+// writeError sends a JSON-RPC error response.
+func writeError(enc *json.Encoder, id any, code int, message string) {
+	_ = enc.Encode(Response{
+		JSONRPC: "2.0",
+		Error:   &Error{Code: code, Message: message},
+		ID:      id,
+	})
+}
+
 // handleSessionCreate creates a new session and returns the ID.
 func (s *Server) handleSessionCreate(ctx context.Context, enc *json.Encoder, req Request) {
 	sessionID, _, err := s.agent.CreateSession(ctx)
 	if err != nil {
-		_ = enc.Encode(Response{
-			JSONRPC: "2.0",
-			Error:   &Error{Code: -32000, Message: "creating session: " + err.Error()},
-			ID:      req.ID,
-		})
+		writeError(enc, req.ID, -32000, "creating session: "+err.Error())
 		return
 	}
 

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -221,17 +221,7 @@ func (c *Client) writeMessage(msg any) error {
 // readLoop reads Content-Length framed JSON-RPC messages from stdout.
 func (c *Client) readLoop() {
 	defer func() {
-		// Fail all pending requests.
-		c.pendMu.Lock()
-		for id, ch := range c.pending {
-			ch <- &Response{
-				JSONRPC: "2.0",
-				ID:      &id,
-				Error:   &ResponseError{Code: -1, Message: "server exited"},
-			}
-			delete(c.pending, id)
-		}
-		c.pendMu.Unlock()
+		c.failPending()
 
 		select {
 		case <-c.done:
@@ -242,25 +232,10 @@ func (c *Client) readLoop() {
 
 	reader := bufio.NewReader(c.stdout)
 	for {
-		// Read headers until empty line.
-		contentLength := -1
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return
-			}
-			line = strings.TrimRight(line, "\r\n")
-			if line == "" {
-				break // end of headers
-			}
-			if val, ok := strings.CutPrefix(line, "Content-Length: "); ok {
-				n, err := strconv.Atoi(val)
-				if err == nil {
-					contentLength = n
-				}
-			}
+		contentLength, err := readFrameLength(reader)
+		if err != nil {
+			return
 		}
-
 		if contentLength < 0 {
 			continue
 		}
@@ -272,6 +247,47 @@ func (c *Client) readLoop() {
 		}
 
 		c.handleMessage(body)
+	}
+}
+
+// failPending answers every in-flight request with a "server exited" error and
+// empties the pending map. It is the reader goroutine's last act, so a caller
+// blocked in Request is never left waiting for a server that is gone.
+func (c *Client) failPending() {
+	c.pendMu.Lock()
+	for id, ch := range c.pending {
+		ch <- &Response{
+			JSONRPC: "2.0",
+			ID:      &id,
+			Error:   &ResponseError{Code: -1, Message: "server exited"},
+		}
+		delete(c.pending, id)
+	}
+	c.pendMu.Unlock()
+}
+
+// readFrameLength consumes one header block, up to and including the blank line
+// that ends it, and returns the Content-Length it declared. It returns -1 when
+// the block carried no parsable Content-Length, which tells the caller to drop
+// the frame; a read failure ends the reader.
+func readFrameLength(reader *bufio.Reader) (int, error) {
+	contentLength := -1
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return 0, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			return contentLength, nil // end of headers
+		}
+		val, ok := strings.CutPrefix(line, "Content-Length: ")
+		if !ok {
+			continue
+		}
+		if n, err := strconv.Atoi(val); err == nil {
+			contentLength = n
+		}
 	}
 }
 

--- a/internal/lsp/complexity_cog_lsp_test.go
+++ b/internal/lsp/complexity_cog_lsp_test.go
@@ -1,0 +1,325 @@
+package lsp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+)
+
+// readLoop is a goroutine: every one of its exits has to close c.done and fail
+// the pending requests, or a caller waits forever. These tests drive it through
+// a pipe so each framing decision and each exit path can be observed directly,
+// and they are pinned against the pre-refactor loop.
+
+// cogReaderClient wires a bare Client to a pipe and starts its reader. Only the
+// fields readLoop touches are populated: cmd and stdin stay nil so a test that
+// strays outside the reader fails loudly.
+func cogReaderClient(t *testing.T) (*Client, *io.PipeWriter) {
+	t.Helper()
+	pr, pw := io.Pipe()
+	c := &Client{
+		stdout:  pr,
+		pending: make(map[int]chan *Response),
+		done:    make(chan struct{}),
+	}
+	go c.readLoop()
+	t.Cleanup(func() { _ = pw.Close() })
+	return c, pw
+}
+
+// cogPend registers a pending response channel the way Request does.
+func cogPend(c *Client, id int) chan *Response {
+	ch := make(chan *Response, 1)
+	c.pendMu.Lock()
+	c.pending[id] = ch
+	c.pendMu.Unlock()
+	return ch
+}
+
+func cogFrame(body string) string {
+	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)
+}
+
+func cogAwaitResponse(t *testing.T, ch chan *Response) *Response {
+	t.Helper()
+	select {
+	case resp := <-ch:
+		return resp
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a response")
+		return nil
+	}
+}
+
+func cogAwaitDone(t *testing.T, c *Client) {
+	t.Helper()
+	select {
+	case <-c.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not close done")
+	}
+}
+
+// The framing cases. Each writes a stream to the reader and expects the id of
+// the single response that survives it; a header set the reader rejects must
+// drop its frame without disturbing the frame that follows.
+func TestReadLoopFraming(t *testing.T) {
+	body1 := `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`
+
+	tests := []struct {
+		name   string
+		stream string
+	}{
+		{
+			name:   "a plain frame",
+			stream: cogFrame(body1),
+		},
+		{
+			name:   "unknown headers are ignored",
+			stream: fmt.Sprintf("Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: %d\r\n\r\n%s", len(body1), body1),
+		},
+		{
+			name:   "bare LF line endings are accepted",
+			stream: fmt.Sprintf("Content-Length: %d\n\n%s", len(body1), body1),
+		},
+		{
+			name: "a frame with no Content-Length is dropped",
+			// An empty header block ends the headers immediately, leaving no
+			// length; the reader skips to the next frame.
+			stream: "\r\n" + cogFrame(body1),
+		},
+		{
+			name:   "an unparsable Content-Length is ignored and drops the frame",
+			stream: "Content-Length: not-a-number\r\n\r\n" + cogFrame(body1),
+		},
+		{
+			name: "a repeated Content-Length keeps the last valid value",
+			// The first value is wrong; the second is right, and the frame is
+			// read with it.
+			stream: fmt.Sprintf("Content-Length: 9999\r\nContent-Length: %d\r\n\r\n%s", len(body1), body1),
+		},
+		{
+			name: "a trailing unparsable Content-Length does not clear the good one",
+			stream: fmt.Sprintf("Content-Length: %d\r\nContent-Length: xyz\r\n\r\n%s",
+				len(body1), body1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, pw := cogReaderClient(t)
+			ch := cogPend(c, 1)
+
+			go func() { _, _ = io.WriteString(pw, tt.stream) }()
+
+			resp := cogAwaitResponse(t, ch)
+			if resp.ID == nil || *resp.ID != 1 {
+				t.Fatalf("response ID = %v, want 1", resp.ID)
+			}
+			if resp.Error != nil {
+				t.Errorf("unexpected error: %v", resp.Error)
+			}
+			if string(resp.Result) != `{"ok":true}` {
+				t.Errorf("result = %s, want {\"ok\":true}", resp.Result)
+			}
+		})
+	}
+}
+
+// Back-to-back frames on one stream are all delivered, in order.
+func TestReadLoopConsecutiveFrames(t *testing.T) {
+	c, pw := cogReaderClient(t)
+	chans := map[int]chan *Response{}
+	for id := 1; id <= 3; id++ {
+		chans[id] = cogPend(c, id)
+	}
+
+	go func() {
+		for id := 1; id <= 3; id++ {
+			_, _ = io.WriteString(pw, cogFrame(fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":%d}`, id, id*10)))
+		}
+	}()
+
+	for id := 1; id <= 3; id++ {
+		resp := cogAwaitResponse(t, chans[id])
+		if string(resp.Result) != fmt.Sprintf("%d", id*10) {
+			t.Errorf("id %d: result = %s, want %d", id, resp.Result, id*10)
+		}
+	}
+}
+
+// A server notification reaches the handler from inside the reader goroutine.
+func TestReadLoopDeliversNotification(t *testing.T) {
+	c, pw := cogReaderClient(t)
+
+	type got struct {
+		method string
+		params string
+	}
+	seen := make(chan got, 1)
+	c.NotificationHandler = func(method string, params json.RawMessage) {
+		seen <- got{method: method, params: string(params)}
+	}
+
+	body := `{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///a.go"}}`
+	go func() { _, _ = io.WriteString(pw, cogFrame(body)) }()
+
+	select {
+	case g := <-seen:
+		if g.method != "textDocument/publishDiagnostics" {
+			t.Errorf("method = %q", g.method)
+		}
+		if g.params != `{"uri":"file:///a.go"}` {
+			t.Errorf("params = %s", g.params)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification never arrived")
+	}
+}
+
+// Every exit path has to do the same two things: answer the in-flight requests
+// with "server exited" and close done.
+func TestReadLoopExitPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		// write produces the stream, then ends it. Returning without closing
+		// is not an option — the reader only exits on a read failure.
+		write func(pw *io.PipeWriter)
+	}{
+		{
+			name: "the stream ends between frames",
+			write: func(pw *io.PipeWriter) {
+				_ = pw.Close()
+			},
+		},
+		{
+			name: "the stream ends mid-header",
+			write: func(pw *io.PipeWriter) {
+				_, _ = io.WriteString(pw, "Content-Length: 4")
+				_ = pw.Close()
+			},
+		},
+		{
+			name: "the stream ends before the body arrives",
+			write: func(pw *io.PipeWriter) {
+				_, _ = io.WriteString(pw, "Content-Length: 40\r\n\r\n")
+				_ = pw.Close()
+			},
+		},
+		{
+			name: "the body is truncated",
+			write: func(pw *io.PipeWriter) {
+				_, _ = io.WriteString(pw, "Content-Length: 40\r\n\r\n{\"id\":1}")
+				_ = pw.Close()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, pw := cogReaderClient(t)
+			ch := cogPend(c, 7)
+
+			go tt.write(pw)
+
+			resp := cogAwaitResponse(t, ch)
+			if resp.Error == nil {
+				t.Fatalf("got %+v, want a server-exited error", resp)
+			}
+			if resp.Error.Code != -1 || resp.Error.Message != "server exited" {
+				t.Errorf("error = %+v, want code -1 \"server exited\"", resp.Error)
+			}
+			if resp.ID == nil || *resp.ID != 7 {
+				t.Errorf("error response ID = %v, want 7", resp.ID)
+			}
+			if resp.JSONRPC != "2.0" {
+				t.Errorf("error response JSONRPC = %q, want \"2.0\"", resp.JSONRPC)
+			}
+
+			cogAwaitDone(t, c)
+
+			c.pendMu.Lock()
+			left := len(c.pending)
+			c.pendMu.Unlock()
+			if left != 0 {
+				t.Errorf("%d pending entries left behind", left)
+			}
+		})
+	}
+}
+
+// Every waiter is answered, not just the first, and each gets its own ID.
+func TestReadLoopFailsAllPendingOnExit(t *testing.T) {
+	c, pw := cogReaderClient(t)
+
+	chans := map[int]chan *Response{}
+	for id := 1; id <= 5; id++ {
+		chans[id] = cogPend(c, id)
+	}
+
+	_ = pw.Close()
+	cogAwaitDone(t, c)
+
+	for id, ch := range chans {
+		resp := cogAwaitResponse(t, ch)
+		if resp.ID == nil || *resp.ID != id {
+			t.Errorf("waiter %d got ID %v", id, resp.ID)
+		}
+		if resp.Error == nil || resp.Error.Message != "server exited" {
+			t.Errorf("waiter %d got %+v, want the server-exited error", id, resp.Error)
+		}
+	}
+}
+
+// A response nobody is waiting for is discarded rather than blocking the
+// reader, and the reader keeps going.
+func TestReadLoopUnmatchedResponseDoesNotStall(t *testing.T) {
+	c, pw := cogReaderClient(t)
+	ch := cogPend(c, 2)
+
+	go func() {
+		_, _ = io.WriteString(pw, cogFrame(`{"jsonrpc":"2.0","id":99,"result":1}`))
+		_, _ = io.WriteString(pw, cogFrame(`{"jsonrpc":"2.0","id":2,"result":2}`))
+	}()
+
+	resp := cogAwaitResponse(t, ch)
+	if string(resp.Result) != "2" {
+		t.Errorf("result = %s, want 2", resp.Result)
+	}
+}
+
+// Malformed JSON inside a correctly framed body is dropped without killing the
+// reader.
+func TestReadLoopSurvivesMalformedBody(t *testing.T) {
+	c, pw := cogReaderClient(t)
+	ch := cogPend(c, 3)
+
+	go func() {
+		_, _ = io.WriteString(pw, cogFrame(`{not json`))
+		_, _ = io.WriteString(pw, cogFrame(`{"jsonrpc":"2.0","id":3,"result":"after"}`))
+	}()
+
+	resp := cogAwaitResponse(t, ch)
+	if string(resp.Result) != `"after"` {
+		t.Errorf("result = %s, want \"after\"", resp.Result)
+	}
+}
+
+// A zero-length body is a valid frame; it decodes to an empty message that is
+// neither a response nor a notification, and the reader moves on.
+func TestReadLoopZeroLengthBody(t *testing.T) {
+	c, pw := cogReaderClient(t)
+	ch := cogPend(c, 4)
+
+	go func() {
+		_, _ = io.WriteString(pw, "Content-Length: 0\r\n\r\n")
+		_, _ = io.WriteString(pw, cogFrame(`{"jsonrpc":"2.0","id":4,"result":"ok"}`))
+	}()
+
+	resp := cogAwaitResponse(t, ch)
+	if string(resp.Result) != `"ok"` {
+		t.Errorf("result = %s, want \"ok\"", resp.Result)
+	}
+}

--- a/internal/palace/complexity_cog_palace_test.go
+++ b/internal/palace/complexity_cog_palace_test.go
@@ -1,0 +1,309 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// cogInsertDrawers inserts one drawer per (wing, room) entry, repeated `count`
+// times so drawer counts — which drive the result ordering — are controllable.
+func cogInsertDrawers(t *testing.T, store *SQLitePalaceStore, rows []cogDrawerRow) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	n := 0
+	for _, r := range rows {
+		for range max(r.count, 1) {
+			n++
+			d := &Drawer{
+				ID:        fmt.Sprintf("cog-%d", n),
+				Wing:      r.wing,
+				Room:      r.room,
+				Content:   fmt.Sprintf("content %d", n),
+				CreatedAt: now,
+			}
+			if err := store.InsertDrawer(ctx, d); err != nil {
+				t.Fatalf("insert %s: %v", d.ID, err)
+			}
+		}
+	}
+}
+
+type cogDrawerRow struct {
+	wing  string
+	room  string
+	count int
+}
+
+// cogFailingStore fails every ListDrawers, which is the only store call
+// Traverse makes. The embedded interface is nil on purpose: any other call
+// would panic and so prove the test was measuring something else.
+type cogFailingStore struct {
+	PalaceStore
+	err error
+}
+
+func (s cogFailingStore) ListDrawers(_ context.Context, _ DrawerFilter) ([]*Drawer, error) {
+	return nil, s.err
+}
+
+// cogHopsByRoom indexes a traversal by room so assertions do not depend on the
+// ordering of ties, which map iteration makes nondeterministic.
+func cogHopsByRoom(results []TraverseResult) map[string]int {
+	hops := make(map[string]int, len(results))
+	for _, r := range results {
+		hops[r.Room] = r.Hops
+	}
+	return hops
+}
+
+// A chain of wings, each overlapping the next by one room, gives every room a
+// single unambiguous hop distance from "start":
+//
+//	w1: start, m     w2: m, n     w3: n, p     w4: p, q
+func cogChainFixture(t *testing.T, store *SQLitePalaceStore) {
+	t.Helper()
+	cogInsertDrawers(t, store, []cogDrawerRow{
+		{"w1", "start", 1}, {"w1", "m", 1},
+		{"w2", "m", 1}, {"w2", "n", 1},
+		{"w3", "n", 1}, {"w3", "p", 1},
+		{"w4", "p", 1}, {"w4", "q", 1},
+	})
+}
+
+// maxHops is what stops the BFS, and the pre-refactor code substitutes 2 for
+// any non-positive value. Each case pins exactly which rooms of the chain come
+// back, so a changed loop bound cannot pass unnoticed.
+func TestGraphTraverseHopBoundary(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxHops  int
+		wantHops map[string]int
+	}{
+		{"zero means two hops", 0, map[string]int{"start": 0, "m": 1, "n": 2}},
+		{"negative means two hops", -5, map[string]int{"start": 0, "m": 1, "n": 2}},
+		{"one hop stops at the first ring", 1, map[string]int{"start": 0, "m": 1}},
+		{"two hops", 2, map[string]int{"start": 0, "m": 1, "n": 2}},
+		{"three hops", 3, map[string]int{"start": 0, "m": 1, "n": 2, "p": 3}},
+		{"four hops reaches the whole chain", 4, map[string]int{"start": 0, "m": 1, "n": 2, "p": 3, "q": 4}},
+		{"more hops than the chain is long adds nothing", 9, map[string]int{"start": 0, "m": 1, "n": 2, "p": 3, "q": 4}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore(t)
+			cogChainFixture(t, store)
+
+			results, err := NewGraph(store).Traverse(context.Background(), "start", tt.maxHops)
+			if err != nil {
+				t.Fatalf("Traverse: %v", err)
+			}
+
+			got := cogHopsByRoom(results)
+			if len(got) != len(tt.wantHops) {
+				t.Fatalf("reached %v, want %v", got, tt.wantHops)
+			}
+			for room, want := range tt.wantHops {
+				if h, ok := got[room]; !ok || h != want {
+					t.Errorf("room %q: hops = %d (present: %v), want %d", room, h, ok, want)
+				}
+			}
+		})
+	}
+}
+
+// The start room is always first, carries hop 0, and reports its own wings and
+// drawer count rather than a neighbor's.
+func TestGraphTraverseStartRoomLeadsTheResults(t *testing.T) {
+	store := newTestStore(t)
+	cogInsertDrawers(t, store, []cogDrawerRow{
+		{"w1", "start", 3},
+		{"w2", "start", 2},
+		{"w1", "other", 1},
+	})
+
+	results, err := NewGraph(store).Traverse(context.Background(), "start", 2)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("no results")
+	}
+
+	first := results[0]
+	if first.Room != "start" {
+		t.Errorf("results[0].Room = %q, want \"start\"", first.Room)
+	}
+	if first.Hops != 0 {
+		t.Errorf("results[0].Hops = %d, want 0", first.Hops)
+	}
+	if first.DrawerCount != 5 {
+		t.Errorf("results[0].DrawerCount = %d, want 5", first.DrawerCount)
+	}
+	if len(first.Wings) != 2 || first.Wings[0] != "w1" || first.Wings[1] != "w2" {
+		t.Errorf("results[0].Wings = %v, want [w1 w2] sorted", first.Wings)
+	}
+
+	for _, r := range results[1:] {
+		if r.Room == "start" {
+			t.Error("the start room appeared twice")
+		}
+	}
+}
+
+// Ordering is (hops ASC, drawer count DESC). The two rings here have distinct
+// drawer counts so there are no ties to make the comparison nondeterministic.
+func TestGraphTraverseResultOrdering(t *testing.T) {
+	store := newTestStore(t)
+	cogInsertDrawers(t, store, []cogDrawerRow{
+		// Ring one, in the same wing as the start room.
+		{"w1", "start", 1},
+		{"w1", "near-big", 5},
+		{"w1", "near-mid", 3},
+		{"w1", "near-small", 1},
+		// Ring two, reachable only through near-big's second wing.
+		{"w2", "near-big", 1},
+		{"w2", "far-big", 4},
+		{"w2", "far-small", 2},
+	})
+
+	results, err := NewGraph(store).Traverse(context.Background(), "start", 2)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+
+	want := []string{"start", "near-big", "near-mid", "near-small", "far-big", "far-small"}
+	if len(results) != len(want) {
+		t.Fatalf("got %d results, want %d: %+v", len(results), len(want), results)
+	}
+	for i, room := range want {
+		if results[i].Room != room {
+			t.Errorf("results[%d].Room = %q, want %q (full order: %v)", i, results[i].Room, room, cogRoomOrder(results))
+		}
+	}
+	if results[1].Hops != 1 || results[4].Hops != 2 {
+		t.Errorf("hop ordering broke: %v", cogRoomOrder(results))
+	}
+}
+
+func cogRoomOrder(results []TraverseResult) []string {
+	rooms := make([]string, 0, len(results))
+	for _, r := range results {
+		rooms = append(rooms, r.Room)
+	}
+	return rooms
+}
+
+// Neighbors are capped at 50, and the cap is applied to the neighbors only —
+// the start room is prepended afterwards, so a full traversal returns 51.
+func TestGraphTraverseCapsNeighborsAtFifty(t *testing.T) {
+	store := newTestStore(t)
+	rows := []cogDrawerRow{{"w1", "start", 1}}
+	for i := range 60 {
+		rows = append(rows, cogDrawerRow{"w1", fmt.Sprintf("room-%02d", i), 1})
+	}
+	cogInsertDrawers(t, store, rows)
+
+	results, err := NewGraph(store).Traverse(context.Background(), "start", 2)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+	if len(results) != 51 {
+		t.Fatalf("got %d results, want 51 (50 neighbors plus the start room)", len(results))
+	}
+	if results[0].Room != "start" {
+		t.Errorf("results[0].Room = %q, want \"start\"", results[0].Room)
+	}
+	for _, r := range results[1:] {
+		if r.Hops != 1 {
+			t.Errorf("room %q: hops = %d, want 1", r.Room, r.Hops)
+		}
+	}
+}
+
+// A room already reached keeps the hop count it was first given; a later,
+// longer path to it must not overwrite that.
+func TestGraphTraverseKeepsTheShortestHop(t *testing.T) {
+	store := newTestStore(t)
+	cogInsertDrawers(t, store, []cogDrawerRow{
+		// "target" sits one hop away through w1 and would also be found two
+		// hops away through the w2/w3 detour.
+		{"w1", "start", 1}, {"w1", "target", 1},
+		{"w2", "start", 1}, {"w2", "detour", 1},
+		{"w3", "detour", 1}, {"w3", "target", 1},
+	})
+
+	results, err := NewGraph(store).Traverse(context.Background(), "start", 3)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+
+	got := cogHopsByRoom(results)
+	if got["target"] != 1 {
+		t.Errorf("target hops = %d, want 1 — the shorter path must win", got["target"])
+	}
+	if got["detour"] != 1 {
+		t.Errorf("detour hops = %d, want 1", got["detour"])
+	}
+}
+
+// An isolated start room yields only itself.
+func TestGraphTraverseIsolatedStartRoom(t *testing.T) {
+	store := newTestStore(t)
+	cogInsertDrawers(t, store, []cogDrawerRow{
+		{"w1", "start", 2},
+		{"w2", "elsewhere", 1},
+	})
+
+	results, err := NewGraph(store).Traverse(context.Background(), "start", 3)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1: %v", len(results), cogRoomOrder(results))
+	}
+	if results[0].Room != "start" || results[0].Hops != 0 || results[0].DrawerCount != 2 {
+		t.Errorf("results[0] = %+v, want the start room at hop 0 with 2 drawers", results[0])
+	}
+}
+
+// A store failure surfaces unchanged, before any traversal happens.
+func TestGraphTraverseStoreError(t *testing.T) {
+	wantErr := errors.New("store is down")
+	g := NewGraph(cogFailingStore{err: wantErr})
+
+	results, err := g.Traverse(context.Background(), "start", 2)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Traverse error = %v, want %v", err, wantErr)
+	}
+	if results != nil {
+		t.Errorf("Traverse results = %v, want nil on error", results)
+	}
+}
+
+// The "general" room is excluded from the graph entirely, so it is never a
+// start room and never a neighbor.
+func TestGraphTraverseExcludesGeneralRoom(t *testing.T) {
+	store := newTestStore(t)
+	cogInsertDrawers(t, store, []cogDrawerRow{
+		{"w1", "start", 1},
+		{"w1", "general", 4},
+		{"w1", "real", 1},
+	})
+
+	results, err := NewGraph(store).Traverse(context.Background(), "start", 2)
+	if err != nil {
+		t.Fatalf("Traverse: %v", err)
+	}
+	for _, r := range results {
+		if r.Room == "general" {
+			t.Error("the general room leaked into the traversal")
+		}
+	}
+	if got := cogRoomOrder(results); len(got) != 2 {
+		t.Errorf("rooms = %v, want just start and real", got)
+	}
+}

--- a/internal/palace/graph.go
+++ b/internal/palace/graph.go
@@ -87,22 +87,46 @@ func (g *Graph) Traverse(ctx context.Context, startRoom string, maxHops int) ([]
 	frontier := []string{startRoom}
 
 	for hop := 1; hop <= maxHops && len(frontier) > 0; hop++ {
-		var next []string
-		for _, room := range frontier {
-			node := nodes[room]
-			for wing := range node.wings {
-				for _, neighbor := range wingRooms(nodes, wing) {
-					if _, seen := visited[neighbor]; !seen {
-						visited[neighbor] = hop
-						next = append(next, neighbor)
-					}
-				}
-			}
-		}
-		frontier = next
+		frontier = expandFrontier(nodes, frontier, visited, hop)
 	}
 
-	// Build results (exclude start room itself).
+	results := traverseResults(nodes, visited, startRoom)
+
+	// Include start room info at position 0 for context.
+	startResult := TraverseResult{
+		Room:        startRoom,
+		Wings:       sortedKeys(start.wings),
+		DrawerCount: start.count,
+		Hops:        0,
+	}
+	return append([]TraverseResult{startResult}, results...), nil
+}
+
+// expandFrontier walks one BFS ring outward: every room sharing a wing with a
+// frontier room and not yet visited is recorded at this hop and becomes the
+// next frontier. A room already visited keeps the hop it was first given, so
+// the shortest path wins.
+func expandFrontier(nodes map[string]*graphNode, frontier []string, visited map[string]int, hop int) []string {
+	var next []string
+	for _, room := range frontier {
+		node := nodes[room]
+		for wing := range node.wings {
+			for _, neighbor := range wingRooms(nodes, wing) {
+				if _, seen := visited[neighbor]; seen {
+					continue
+				}
+				visited[neighbor] = hop
+				next = append(next, neighbor)
+			}
+		}
+	}
+	return next
+}
+
+// traverseResults turns the visited set into results sorted by
+// (hops ASC, drawer count DESC) and capped at 50. The start room is excluded;
+// the caller prepends it.
+func traverseResults(nodes map[string]*graphNode, visited map[string]int, startRoom string) []TraverseResult {
 	results := make([]TraverseResult, 0, len(visited)-1)
 	for room, hops := range visited {
 		if room == startRoom {
@@ -127,15 +151,7 @@ func (g *Graph) Traverse(ctx context.Context, startRoom string, maxHops int) ([]
 	if len(results) > 50 {
 		results = results[:50]
 	}
-
-	// Include start room info at position 0 for context.
-	startResult := TraverseResult{
-		Room:        startRoom,
-		Wings:       sortedKeys(start.wings),
-		DrawerCount: start.count,
-		Hops:        0,
-	}
-	return append([]TraverseResult{startResult}, results...), nil
+	return results
 }
 
 // suggestRooms returns approximate matches when startRoom is not found.

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -109,71 +109,91 @@ func isAnthropicOAuthToken(apiKey string) bool {
 
 func (m *anthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		messages, systemPrompt := antContentsToMessages(req.Contents, req.Config)
+		m.generate(ctx, req, stream, yield)
+	}
+}
 
-		modelName := m.modelName
-		if req.Model != "" && req.Model != "anthropic" {
-			modelName = req.Model
-		}
-		if modelName == "" || modelName == "anthropic" {
-			modelName = "claude-sonnet-5"
-		}
+// generate runs one request against whichever Anthropic surface the model is
+// configured for. It lives outside the iterator closure so the routing reads at
+// the top level rather than one nesting level down.
+func (m *anthropicModel) generate(ctx context.Context, req *model.LLMRequest, stream bool, yield func(*model.LLMResponse, error) bool) {
+	messages, systemPrompt := antContentsToMessages(req.Contents, req.Config)
+	modelName := antResolveModelName(m.modelName, req.Model)
 
-		maxTokens := defaultMaxTokens
-		thinkingCfg := antThinkingConfig(m.thinkingLevel)
-		if thinkingCfg != nil {
-			// Thinking requires higher max_tokens to accommodate the thinking budget.
-			maxTokens = 16384
-		}
+	maxTokens := defaultMaxTokens
+	thinkingCfg := antThinkingConfig(m.thinkingLevel)
+	if thinkingCfg != nil {
+		// Thinking requires higher max_tokens to accommodate the thinking budget.
+		maxTokens = 16384
+	}
 
-		// Route to advisor-aware or standard implementation.
-		if m.advisorModel != "" {
-			thinkingCfgBeta := antThinkingConfigBeta(m.thinkingLevel)
-			params := m.buildBetaParams(modelName, messages, systemPrompt, maxTokens, thinkingCfgBeta, req.Config)
-			if stream {
-				retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
-					antRunStreamingBeta(ctx, &m.betaClient, params, y)
-				})
-			} else {
-				antRunNonStreamingBeta(ctx, &m.betaClient, params, yield)
-			}
+	// Route to advisor-aware or standard implementation.
+	if m.advisorModel != "" {
+		thinkingCfgBeta := antThinkingConfigBeta(m.thinkingLevel)
+		params := m.buildBetaParams(modelName, messages, systemPrompt, maxTokens, thinkingCfgBeta, req.Config)
+		if !stream {
+			antRunNonStreamingBeta(ctx, &m.betaClient, params, yield)
 			return
 		}
+		retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+			antRunStreamingBeta(ctx, &m.betaClient, params, y)
+		})
+		return
+	}
 
-		params := anthropic.MessageNewParams{
-			Model:     modelName,
-			Messages:  messages,
-			MaxTokens: maxTokens,
-		}
+	params := m.buildParams(modelName, messages, systemPrompt, maxTokens, thinkingCfg, req.Config)
+	if !stream {
+		antRunNonStreaming(ctx, &m.client, params, yield)
+		return
+	}
+	retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+		antRunStreaming(ctx, &m.client, params, y)
+	})
+}
 
-		if thinkingCfg != nil {
-			params.Thinking = *thinkingCfg
-		}
+// antResolveModelName picks the model one request runs against: the request's
+// own override when it names a concrete model, else the configured default,
+// else the built-in fallback. "anthropic" is the provider alias, not a model.
+func antResolveModelName(configured, requested string) string {
+	modelName := configured
+	if requested != "" && requested != "anthropic" {
+		modelName = requested
+	}
+	if modelName == "" || modelName == "anthropic" {
+		return "claude-sonnet-5"
+	}
+	return modelName
+}
 
-		if systemPrompt != "" {
-			params.System = []anthropic.TextBlockParam{
-				{Text: systemPrompt},
-			}
-		}
+// buildParams constructs MessageNewParams for the standard (non-advisor) path.
+func (m *anthropicModel) buildParams(modelName string, messages []anthropic.MessageParam, systemPrompt string, maxTokens int64, thinkingCfg *anthropic.ThinkingConfigParamUnion, config *genai.GenerateContentConfig) anthropic.MessageNewParams {
+	params := anthropic.MessageNewParams{
+		Model:     modelName,
+		Messages:  messages,
+		MaxTokens: maxTokens,
+	}
 
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = antGenaiToolsToAnthropic(req.Config.Tools)
-		}
+	if thinkingCfg != nil {
+		params.Thinking = *thinkingCfg
+	}
 
-		// Stamp cache_control markers on the request unless the user opted
-		// out. This is the last wire step so all sections are final.
-		if !m.disablePromptCaching {
-			applyAnthropicCacheControl(&params)
-		}
-
-		if stream {
-			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
-				antRunStreaming(ctx, &m.client, params, y)
-			})
-		} else {
-			antRunNonStreaming(ctx, &m.client, params, yield)
+	if systemPrompt != "" {
+		params.System = []anthropic.TextBlockParam{
+			{Text: systemPrompt},
 		}
 	}
+
+	if config != nil && len(config.Tools) > 0 {
+		params.Tools = antGenaiToolsToAnthropic(config.Tools)
+	}
+
+	// Stamp cache_control markers on the request unless the user opted
+	// out. This is the last wire step so all sections are final.
+	if !m.disablePromptCaching {
+		applyAnthropicCacheControl(&params)
+	}
+
+	return params
 }
 
 // buildBetaParams constructs BetaMessageNewParams for advisor tool support.
@@ -257,41 +277,82 @@ func convertContentBlockToBeta(c anthropic.ContentBlockParamUnion) anthropic.Bet
 	return anthropic.NewBetaTextBlock("")
 }
 
-// antGenaiToolsToBetaAnthropic converts genai tools to Anthropic beta tool format.
-func antGenaiToolsToBetaAnthropic(tools []*genai.Tool) []anthropic.BetaToolUnionParam {
-	var out []anthropic.BetaToolUnionParam
+// antToolSchema is one genai function declaration reduced to the fields both
+// the standard and the beta Anthropic tool formats are built from. The two
+// formats emit byte-identical JSON; only the Go wrapper types differ, so the
+// flattening and schema-reading below is shared and each converter is a thin
+// adapter over it.
+type antToolSchema struct {
+	name        string
+	description string
+	properties  map[string]any
+	required    []string
+}
+
+// antToolSchemas flattens genai tools into one entry per usable function
+// declaration, skipping nil tools and nil declarations. A tool with no
+// declarations needs no guard: ranging a nil slice yields nothing.
+func antToolSchemas(tools []*genai.Tool) []antToolSchema {
+	var out []antToolSchema
 	for _, t := range tools {
-		if t == nil || t.FunctionDeclarations == nil {
+		if t == nil {
 			continue
 		}
 		for _, fd := range t.FunctionDeclarations {
 			if fd == nil {
 				continue
 			}
-			inputSchema := anthropic.BetaToolInputSchemaParam{
-				Properties: make(map[string]any),
-			}
-			if m := schemaToMap(fd.ParametersJsonSchema); m != nil {
-				if props, ok := m["properties"].(map[string]any); ok {
-					inputSchema.Properties = props
-				}
-				if required, ok := m["required"].([]any); ok {
-					reqStrings := make([]string, 0, len(required))
-					for _, r := range required {
-						if s, ok := r.(string); ok {
-							reqStrings = append(reqStrings, s)
-						}
-					}
-					inputSchema.Required = reqStrings
-				}
-			}
-			tool := anthropic.BetaToolParam{
-				Name:        fd.Name,
-				Description: anthropic.String(fd.Description),
-				InputSchema: inputSchema,
-			}
-			out = append(out, anthropic.BetaToolUnionParam{OfTool: &tool})
+			properties, required := antSchemaFields(fd.ParametersJsonSchema)
+			out = append(out, antToolSchema{
+				name:        fd.Name,
+				description: fd.Description,
+				properties:  properties,
+				required:    required,
+			})
 		}
+	}
+	return out
+}
+
+// antSchemaFields reads the "properties" and "required" members out of a genai
+// parameter schema.
+//
+// Properties defaults to an empty (never nil) map so a tool with no parameters
+// still advertises an object schema; Anthropic passes the property map through
+// verbatim, which is why this half is not shared with the Ollama converter —
+// that one flattens each property into a typed ollamaapi.ToolProperty.
+//
+// Required comes from jsonSchemaRequiredNames, shared with the Ollama
+// converter. Its nil-versus-empty distinction is load bearing here:
+// ToolInputSchemaParam.Required is tagged `omitzero`, so nil omits the key
+// while a non-nil empty slice emits "required": []. A schema whose required
+// list is absent or is not a JSON array omits the key; one that is an array
+// with no usable string entries emits an empty array.
+func antSchemaFields(parametersJSONSchema any) (map[string]any, []string) {
+	properties := make(map[string]any)
+	schema := schemaToMap(parametersJSONSchema)
+	if schema == nil {
+		return properties, nil
+	}
+	if props, ok := schema["properties"].(map[string]any); ok {
+		properties = props
+	}
+	return properties, jsonSchemaRequiredNames(schema["required"])
+}
+
+// antGenaiToolsToBetaAnthropic converts genai tools to Anthropic beta tool format.
+func antGenaiToolsToBetaAnthropic(tools []*genai.Tool) []anthropic.BetaToolUnionParam {
+	var out []anthropic.BetaToolUnionParam
+	for _, s := range antToolSchemas(tools) {
+		tool := anthropic.BetaToolParam{
+			Name:        s.name,
+			Description: anthropic.String(s.description),
+			InputSchema: anthropic.BetaToolInputSchemaParam{
+				Properties: s.properties,
+				Required:   s.required,
+			},
+		}
+		out = append(out, anthropic.BetaToolUnionParam{OfTool: &tool})
 	}
 	return out
 }
@@ -397,40 +458,20 @@ func antTextMessage(role, text string) anthropic.MessageParam {
 	}
 }
 
+// antGenaiToolsToAnthropic converts genai tools to the standard Anthropic tool
+// format. Same shared core as antGenaiToolsToBetaAnthropic, different wrapper.
 func antGenaiToolsToAnthropic(tools []*genai.Tool) []anthropic.ToolUnionParam {
 	var out []anthropic.ToolUnionParam
-	for _, t := range tools {
-		if t == nil || t.FunctionDeclarations == nil {
-			continue
+	for _, s := range antToolSchemas(tools) {
+		tool := anthropic.ToolParam{
+			Name:        s.name,
+			Description: anthropic.String(s.description),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: s.properties,
+				Required:   s.required,
+			},
 		}
-		for _, fd := range t.FunctionDeclarations {
-			if fd == nil {
-				continue
-			}
-			inputSchema := anthropic.ToolInputSchemaParam{
-				Properties: make(map[string]any),
-			}
-			if m := schemaToMap(fd.ParametersJsonSchema); m != nil {
-				if props, ok := m["properties"].(map[string]any); ok {
-					inputSchema.Properties = props
-				}
-				if required, ok := m["required"].([]any); ok {
-					reqStrings := make([]string, 0, len(required))
-					for _, r := range required {
-						if s, ok := r.(string); ok {
-							reqStrings = append(reqStrings, s)
-						}
-					}
-					inputSchema.Required = reqStrings
-				}
-			}
-			tool := anthropic.ToolParam{
-				Name:        fd.Name,
-				Description: anthropic.String(fd.Description),
-				InputSchema: inputSchema,
-			}
-			out = append(out, anthropic.ToolUnionParam{OfTool: &tool})
-		}
+		out = append(out, anthropic.ToolUnionParam{OfTool: &tool})
 	}
 	return out
 }
@@ -567,32 +608,34 @@ func antHandleContentBlockDelta(e anthropic.ContentBlockDeltaEvent, state *antSt
 	delta := e.Delta
 	switch delta.Type {
 	case "text_delta":
-		if textDelta, ok := delta.AsAny().(anthropic.TextDelta); ok {
-			state.text += textDelta.Text
-			if !yield(&model.LLMResponse{
-				Partial:      true,
-				TurnComplete: false,
-				Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
-			}, nil) {
-				return false
-			}
+		textDelta, ok := delta.AsAny().(anthropic.TextDelta)
+		if !ok {
+			return true
 		}
+		state.text += textDelta.Text
+		return yield(&model.LLMResponse{
+			Partial:      true,
+			TurnComplete: false,
+			Content:      &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: textDelta.Text}}},
+		}, nil)
 	case "thinking_delta":
-		if thinkingDelta, ok := delta.AsAny().(anthropic.ThinkingDelta); ok {
-			if !yield(&model.LLMResponse{
-				Partial:      true,
-				TurnComplete: false,
-				Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
-			}, nil) {
-				return false
-			}
+		thinkingDelta, ok := delta.AsAny().(anthropic.ThinkingDelta)
+		if !ok {
+			return true
 		}
+		return yield(&model.LLMResponse{
+			Partial:      true,
+			TurnComplete: false,
+			Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: thinkingDelta.Thinking}}},
+		}, nil)
 	case "input_json_delta":
-		if jsonDelta, ok := delta.AsAny().(anthropic.InputJSONDelta); ok {
-			if block, exists := state.toolUse[idx]; exists {
-				block.inputJSON += jsonDelta.PartialJSON
-				state.toolUse[idx] = block
-			}
+		jsonDelta, ok := delta.AsAny().(anthropic.InputJSONDelta)
+		if !ok {
+			return true
+		}
+		if block, exists := state.toolUse[idx]; exists {
+			block.inputJSON += jsonDelta.PartialJSON
+			state.toolUse[idx] = block
 		}
 	}
 	return true
@@ -786,34 +829,8 @@ func antRunNonStreamingBeta(ctx context.Context, client *anthropic.BetaService, 
 
 	parts := make([]*genai.Part, 0, len(message.Content))
 	for _, block := range message.Content {
-		switch block.Type {
-		case "text":
-			textBlock := block.Text
-			if textBlock != "" {
-				parts = append(parts, &genai.Part{Text: textBlock})
-			}
-		case "thinking":
-			thinkingBlock := block.Thinking
-			if thinkingBlock != "" {
-				parts = append(parts, &genai.Part{Text: thinkingBlock})
-			}
-		case "tool_use":
-			id := block.ID
-			name := block.Name
-			var args map[string]any
-			if block.Input != nil {
-				_ = json.Unmarshal(block.Input, &args)
-			}
-			if name != "" || id != "" {
-				p := genai.NewPartFromFunctionCall(name, args)
-				p.FunctionCall.ID = id
-				parts = append(parts, p)
-			}
-		case "advisor_tool_result":
-			advText := extractBetaAdvisorResultText(block)
-			if advText != "" {
-				parts = append(parts, &genai.Part{Text: advText})
-			}
+		if p := antBetaBlockToPart(block); p != nil {
+			parts = append(parts, p)
 		}
 	}
 
@@ -832,6 +849,45 @@ func antRunNonStreamingBeta(ctx context.Context, client *anthropic.BetaService, 
 		UsageMetadata: usage,
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: parts},
 	}, nil)
+}
+
+// antBetaBlockToPart converts one non-streaming beta content block into the
+// genai part it contributes, or nil when the block carries nothing to emit —
+// an empty text/thinking/advisor payload, or a block type this path ignores.
+func antBetaBlockToPart(block anthropic.BetaContentBlockUnion) *genai.Part {
+	switch block.Type {
+	case "text":
+		if block.Text != "" {
+			return &genai.Part{Text: block.Text}
+		}
+	case "thinking":
+		if block.Thinking != "" {
+			return &genai.Part{Text: block.Thinking}
+		}
+	case "tool_use":
+		return antBetaToolUsePart(block)
+	case "advisor_tool_result":
+		if advText := extractBetaAdvisorResultText(block); advText != "" {
+			return &genai.Part{Text: advText}
+		}
+	}
+	return nil
+}
+
+// antBetaToolUsePart renders a beta tool_use block as a function-call part.
+// A block that identifies no tool at all is dropped; absent input leaves the
+// arguments nil rather than an empty map.
+func antBetaToolUsePart(block anthropic.BetaContentBlockUnion) *genai.Part {
+	if block.Name == "" && block.ID == "" {
+		return nil
+	}
+	var args map[string]any
+	if block.Input != nil {
+		_ = json.Unmarshal(block.Input, &args)
+	}
+	p := genai.NewPartFromFunctionCall(block.Name, args)
+	p.FunctionCall.ID = block.ID
+	return p
 }
 
 // extractAdvisorResultText extracts the advisor result text from an advisor_tool_result block.

--- a/internal/provider/complexity_cog_provider_a_test.go
+++ b/internal/provider/complexity_cog_provider_a_test.go
@@ -1,0 +1,1702 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// Goldens pinning the wire output of the Ollama and xAI translation layers.
+//
+// Every `want` literal in this file was captured by running these same cases
+// against the pre-refactor source, so a mismatch means the refactor changed what
+// pi sends to a model server — not that the new code disagrees with itself.
+//
+// Comparisons run over a canonical form (see cogPACanon) because
+// ollamaapi.ToolPropertiesMap preserves insertion order and insertion happens
+// while ranging a Go map: the emitted property order is already
+// nondeterministic, and pinning it would only make the tests flake.
+
+// cogPACanon renders any value as indented JSON with object keys sorted, by
+// round-tripping through `any` so every object becomes a map[string]any (which
+// encoding/json emits in sorted-key order). Array order is preserved.
+func cogPACanon(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var generic any
+	if err := json.Unmarshal(b, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	out, err := json.MarshalIndent(generic, "", "  ")
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	return string(out)
+}
+
+// cogPAGolden compares a value against the golden recorded for this test under
+// key (the test name, plus a suffix when one test pins more than one value).
+// A missing golden prints the captured value in a form that can be pasted back
+// into cogPAGoldens, which is how every literal below was produced.
+func cogPAGolden(t *testing.T, key string, got any) {
+	t.Helper()
+	name := t.Name()
+	if key != "" {
+		name += "#" + key
+	}
+	g := cogPACanon(t, got)
+	want, ok := cogPAGoldens[name]
+	if !ok {
+		t.Errorf("no golden recorded\n<<<CAPTURE %s\n%s\nCAPTURE>>>", name, g)
+		return
+	}
+	if g != want {
+		t.Errorf("golden %s mismatch\n--- got ---\n%s\n--- want ---\n%s", name, g, want)
+	}
+}
+
+// cogPAGoldens holds the expected wire output, captured from the pre-refactor
+// source. See the file comment.
+var cogPAGoldens = map[string]string{
+	"TestCogPAOllamaChatRequestGoldens/PI_OLLAMA_NUM_PREDICT_of_zero_removes_options_entirely": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": null,
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/PI_OLLAMA_NUM_PREDICT_overrides_the_default_cap": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 128
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/an_assistant_tool_call_round_trip": `{
+  "messages": [
+    {
+      "content": "read it",
+      "role": "user"
+    },
+    {
+      "content": "sure",
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "arguments": {
+              "path": "/tmp/x"
+            },
+            "index": 0,
+            "name": "read"
+          },
+          "id": "c1"
+        }
+      ]
+    },
+    {
+      "content": "contents",
+      "role": "tool",
+      "tool_call_id": "c1"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/an_empty_tool_list_leaves_tools_off_the_wire": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/an_unparseable_num_predict_falls_back_to_the_default": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/no_contents_falls_back_to_a_Hello_turn": `{
+  "messages": [
+    {
+      "content": "Hello",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/nothink_applies_to_the_per-request_model_too": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "gemma-nothink",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false,
+  "think": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/nothink_model_forces_think_off_even_at_level_high": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "qwen3-NoThink:8b",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false,
+  "think": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/per-request_model_overrides_the_instance_model": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "qwen3:8b",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/plain_user_turn": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/sampling_knobs_join_num_predict_in_options": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "frequency_penalty": 0.25,
+    "num_predict": 16384,
+    "presence_penalty": 0.5,
+    "repeat_last_n": 256,
+    "repeat_penalty": 1.3
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/sampling_knobs_survive_an_uncapped_num_predict": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "repeat_penalty": 1.3
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/system_instruction_is_prepended_as_a_system_message": `{
+  "messages": [
+    {
+      "content": "be terse",
+      "role": "system"
+    },
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/thinking_level_high": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false,
+  "think": "high"
+}`,
+	"TestCogPAOllamaChatRequestGoldens/thinking_level_none_sends_an_explicit_false": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false,
+  "think": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/tools_are_converted_onto_the_request": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false,
+  "tools": [
+    {
+      "function": {
+        "description": "read a file",
+        "name": "read",
+        "parameters": {
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}`,
+	"TestCogPAOllamaChatRequestGoldens/unparseable_sampling_knobs_are_ignored": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaChatRequestGoldens/unrecognized_thinking_level_omits_think": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "stream": false
+}`,
+	"TestCogPAOllamaStreamingRequestGolden#request": `{
+  "messages": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "llama3",
+  "options": {
+    "num_predict": 16384
+  },
+  "think": "low"
+}`,
+	"TestCogPAOllamaStreamingRequestGolden#text": `[
+  "ok",
+  "ok"
+]`,
+	"TestCogPAOllamaToolsGoldens/array_property_drops_its_items_schema": `[
+  {
+    "function": {
+      "name": "batch",
+      "parameters": {
+        "properties": {
+          "paths": {
+            "description": "files",
+            "type": "array"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/declaration_with_no_parameters": `[
+  {
+    "function": {
+      "description": "current time",
+      "name": "now",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/empty_object_schema": `[
+  {
+    "function": {
+      "name": "ping",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/empty_required_list": `[
+  {
+    "function": {
+      "name": "emptyreq",
+      "parameters": {
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/enum_property": `[
+  {
+    "function": {
+      "name": "mode",
+      "parameters": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "read",
+              "write",
+              "append"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/nested_object_property_drops_its_sub-properties": `[
+  {
+    "function": {
+      "name": "config",
+      "parameters": {
+        "properties": {
+          "opts": {
+            "description": "options",
+            "type": "object"
+          }
+        },
+        "required": [
+          "opts"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/nil_declaration_inside_a_tool_is_skipped": `null`,
+	"TestCogPAOllamaToolsGoldens/nil_tool_entry_is_skipped":                `null`,
+	"TestCogPAOllamaToolsGoldens/nil_tool_slice":                           `null`,
+	"TestCogPAOllamaToolsGoldens/non-string_entries_in_required_are_dropped": `[
+  {
+    "function": {
+      "name": "mixed",
+      "parameters": {
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/optional_field_is_not_listed_as_required": `[
+  {
+    "function": {
+      "name": "grep",
+      "parameters": {
+        "properties": {
+          "limit": {
+            "description": "max hits",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/properties_that_is_not_a_map_is_ignored": `[
+  {
+    "function": {
+      "name": "badprops",
+      "parameters": {
+        "properties": {},
+        "required": [
+          "a"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/property_that_is_not_an_object_yields_a_bare_property": `[
+  {
+    "function": {
+      "name": "odd",
+      "parameters": {
+        "properties": {
+          "weird": {}
+        },
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/required_that_is_not_a_list_is_ignored": `[
+  {
+    "function": {
+      "name": "badreq",
+      "parameters": {
+        "properties": {
+          "a": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/schema_that_is_not_an_object_at_all": `[
+  {
+    "function": {
+      "name": "scalar",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/several_declarations_across_several_tools": `[
+  {
+    "function": {
+      "name": "first",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
+      "description": "two",
+      "name": "second",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
+      "name": "third",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/single_required_string_field": `[
+  {
+    "function": {
+      "description": "read a file",
+      "name": "read",
+      "parameters": {
+        "properties": {
+          "path": {
+            "description": "absolute path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAOllamaToolsGoldens/tool_with_nil_declarations_is_skipped": `null`,
+	"TestCogPAOllamaToolsGoldens/typed_jsonschema.Schema_is_marshaled_through_JSON": `[
+  {
+    "function": {
+      "description": "typed schema",
+      "name": "typed",
+      "parameters": {
+        "properties": {
+          "path": {
+            "description": "file to read",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  }
+]`,
+	"TestCogPAXAIInputConversionError": `[
+  "xAI Responses API failed: Post \"http://127.0.0.1:1/responses\": dial tcp 127.0.0.1:1: connect: connection refused"
+]`,
+	"TestCogPAXAINilRequest": `[
+  "xAI responses: nil LLM request"
+]`,
+	"TestCogPAXAIRequestGoldens/an_empty_tool_list_leaves_tools_off_the_wire": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.6",
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/function_declarations_reach_the_tools_field": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.6",
+  "store": false,
+  "tools": [
+    {
+      "description": "read a file",
+      "name": "read",
+      "parameters": {
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    }
+  ]
+}`,
+	"TestCogPAXAIRequestGoldens/level_none_maps_to_low": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.6",
+  "reasoning": {
+    "effort": "low"
+  },
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/non-reasoning_model_never_gets_reasoning": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.20-0309-non-reasoning",
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/per-request_model_gates_reasoning": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.20-0309-non-reasoning",
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/per-request_model_overrides_the_instance_model": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.7",
+  "reasoning": {
+    "effort": "high"
+  },
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/plain_user_turn_with_no_reasoning_level": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.6",
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/reasoning_effort_medium": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.6",
+  "reasoning": {
+    "effort": "medium"
+  },
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/system_instruction_becomes_instructions": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "instructions": "be terse",
+  "model": "grok-4.6",
+  "store": false
+}`,
+	"TestCogPAXAIRequestGoldens/unrecognized_level_omits_reasoning": `{
+  "input": [
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "grok-4.6",
+  "store": false
+}`,
+	"TestCogPAXAIServerSideToolsGolden": `[
+  {
+    "type": "web_search"
+  },
+  {
+    "type": "x_search"
+  },
+  {
+    "type": "code_interpreter"
+  }
+]`,
+}
+
+// cogPATools wraps function declarations in the single-tool shape genai uses.
+func cogPATools(fds ...*genai.FunctionDeclaration) []*genai.Tool {
+	return []*genai.Tool{{FunctionDeclarations: fds}}
+}
+
+// ---------------------------------------------------------------------------
+// ollamaGenaiToolsToOllama
+// ---------------------------------------------------------------------------
+
+func TestCogPAOllamaToolsGoldens(t *testing.T) {
+	typed := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"path": {Type: "string", Description: "file to read"},
+		},
+		Required: []string{"path"},
+	}
+
+	tests := []struct {
+		name  string
+		tools []*genai.Tool
+	}{
+		{
+			name:  "nil tool slice",
+			tools: nil,
+		},
+		{
+			name:  "nil tool entry is skipped",
+			tools: []*genai.Tool{nil},
+		},
+		{
+			name:  "tool with nil declarations is skipped",
+			tools: []*genai.Tool{{FunctionDeclarations: nil}},
+		},
+		{
+			name:  "nil declaration inside a tool is skipped",
+			tools: cogPATools(nil),
+		},
+		{
+			name:  "declaration with no parameters",
+			tools: cogPATools(&genai.FunctionDeclaration{Name: "now", Description: "current time"}),
+		},
+		{
+			name: "empty object schema",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name:                 "ping",
+				ParametersJsonSchema: map[string]any{"type": "object"},
+			}),
+		},
+		{
+			name: "single required string field",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name:        "read",
+				Description: "read a file",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"path": map[string]any{"type": "string", "description": "absolute path"},
+					},
+					"required": []any{"path"},
+				},
+			}),
+		},
+		{
+			name: "optional field is not listed as required",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "grep",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"limit": map[string]any{"type": "integer", "description": "max hits"},
+					},
+				},
+			}),
+		},
+		{
+			name: "enum property",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "mode",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"kind": map[string]any{
+							"type": "string",
+							"enum": []any{"read", "write", "append"},
+						},
+					},
+					"required": []any{"kind"},
+				},
+			}),
+		},
+		{
+			name: "array property drops its items schema",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "batch",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"paths": map[string]any{
+							"type":        "array",
+							"description": "files",
+							"items":       map[string]any{"type": "string"},
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "nested object property drops its sub-properties",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "config",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"opts": map[string]any{
+							"type":        "object",
+							"description": "options",
+							"properties": map[string]any{
+								"deep": map[string]any{"type": "boolean"},
+							},
+							"required": []any{"deep"},
+						},
+					},
+					"required": []any{"opts"},
+				},
+			}),
+		},
+		{
+			name: "property that is not an object yields a bare property",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "odd",
+				ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"weird": "not-a-schema"},
+				},
+			}),
+		},
+		{
+			name: "non-string entries in required are dropped",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "mixed",
+				ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   []any{"a", 7, nil, true},
+				},
+			}),
+		},
+		{
+			name: "required that is not a list is ignored",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "badreq",
+				ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   "a",
+				},
+			}),
+		},
+		{
+			name: "empty required list",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "emptyreq",
+				ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   []any{},
+				},
+			}),
+		},
+		{
+			name: "properties that is not a map is ignored",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name: "badprops",
+				ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": []any{"a"},
+					"required":   []any{"a"},
+				},
+			}),
+		},
+		{
+			name: "schema that is not an object at all",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name:                 "scalar",
+				ParametersJsonSchema: 42,
+			}),
+		},
+		{
+			name: "typed jsonschema.Schema is marshaled through JSON",
+			tools: cogPATools(&genai.FunctionDeclaration{
+				Name:                 "typed",
+				Description:          "typed schema",
+				ParametersJsonSchema: typed,
+			}),
+		},
+		{
+			name: "several declarations across several tools",
+			tools: []*genai.Tool{
+				{FunctionDeclarations: []*genai.FunctionDeclaration{
+					{Name: "first"},
+					nil,
+					{Name: "second", Description: "two"},
+				}},
+				nil,
+				{FunctionDeclarations: []*genai.FunctionDeclaration{{Name: "third"}}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cogPAGolden(t, "", ollamaGenaiToolsToOllama(tc.tools))
+		})
+	}
+}
+
+// TestCogPAOllamaToolsRequiredIsNilNotEmpty pins the distinction the golden's
+// JSON cannot show: Required stays a nil slice when the schema carries no
+// usable required list, rather than becoming an empty non-nil slice.
+func TestCogPAOllamaToolsRequiredIsNilNotEmpty(t *testing.T) {
+	cases := map[string]any{
+		"absent":     map[string]any{"type": "object"},
+		"empty list": map[string]any{"type": "object", "required": []any{}},
+		"wrong type": map[string]any{"type": "object", "required": "a"},
+		"no strings": map[string]any{"type": "object", "required": []any{1, 2}},
+		"nil schema": nil,
+	}
+	for name, schema := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := ollamaGenaiToolsToOllama(cogPATools(&genai.FunctionDeclaration{
+				Name:                 "f",
+				ParametersJsonSchema: schema,
+			}))
+			if len(out) != 1 {
+				t.Fatalf("len(out) = %d, want 1", len(out))
+			}
+			if got := out[0].Function.Parameters.Required; got != nil {
+				t.Errorf("Required = %#v, want nil", got)
+			}
+			if out[0].Function.Parameters.Properties == nil {
+				t.Error("Properties map must always be allocated")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (*ollamaModel).GenerateContent — the request that reaches /api/chat
+// ---------------------------------------------------------------------------
+
+// cogPAOllamaCapture serves one non-streaming chat reply and records the request
+// body that produced it.
+func cogPAOllamaCapture(t *testing.T, body *map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, body)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":             "m",
+			"message":           map[string]any{"role": "assistant", "content": "ok"},
+			"done":              true,
+			"done_reason":       "stop",
+			"prompt_eval_count": 3,
+			"eval_count":        4,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// cogPAClearOllamaEnv unsets every knob ollamaChatRequest reads so a golden does
+// not depend on the ambient environment.
+func cogPAClearOllamaEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"PI_OLLAMA_NUM_PREDICT",
+		"PI_OLLAMA_REPEAT_PENALTY",
+		"PI_OLLAMA_REPEAT_LAST_N",
+		"PI_OLLAMA_PRESENCE_PENALTY",
+		"PI_OLLAMA_FREQUENCY_PENALTY",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestCogPAOllamaChatRequestGoldens(t *testing.T) {
+	toolReq := cogPATools(&genai.FunctionDeclaration{
+		Name:        "read",
+		Description: "read a file",
+		ParametersJsonSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"path": map[string]any{"type": "string"}},
+			"required":   []any{"path"},
+		},
+	})
+
+	tests := []struct {
+		name     string
+		model    string
+		thinking string
+		env      map[string]string
+		req      *model.LLMRequest
+	}{
+		{
+			name:  "plain user turn",
+			model: "llama3",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "no contents falls back to a Hello turn",
+			model: "llama3",
+			req:   &model.LLMRequest{},
+		},
+		{
+			name:  "system instruction is prepended as a system message",
+			model: "llama3",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+				Config: &genai.GenerateContentConfig{
+					SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "be terse"}}},
+				},
+			},
+		},
+		{
+			name:  "per-request model overrides the instance model",
+			model: "llama3",
+			req: &model.LLMRequest{
+				Model:    "qwen3:8b",
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "thinking level high",
+			model:    "llama3",
+			thinking: "high",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "thinking level none sends an explicit false",
+			model:    "llama3",
+			thinking: "none",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "unrecognized thinking level omits think",
+			model:    "llama3",
+			thinking: "turbo",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "nothink model forces think off even at level high",
+			model:    "qwen3-NoThink:8b",
+			thinking: "high",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "nothink applies to the per-request model too",
+			model:    "llama3",
+			thinking: "medium",
+			req: &model.LLMRequest{
+				Model:    "gemma-nothink",
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "PI_OLLAMA_NUM_PREDICT overrides the default cap",
+			model: "llama3",
+			env:   map[string]string{"PI_OLLAMA_NUM_PREDICT": "128"},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "PI_OLLAMA_NUM_PREDICT of zero removes options entirely",
+			model: "llama3",
+			env:   map[string]string{"PI_OLLAMA_NUM_PREDICT": "0"},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "an unparseable num_predict falls back to the default",
+			model: "llama3",
+			env:   map[string]string{"PI_OLLAMA_NUM_PREDICT": "lots"},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "sampling knobs join num_predict in options",
+			model: "llama3",
+			env: map[string]string{
+				"PI_OLLAMA_REPEAT_PENALTY":    "1.3",
+				"PI_OLLAMA_REPEAT_LAST_N":     "256",
+				"PI_OLLAMA_PRESENCE_PENALTY":  "0.5",
+				"PI_OLLAMA_FREQUENCY_PENALTY": "0.25",
+			},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "sampling knobs survive an uncapped num_predict",
+			model: "llama3",
+			env: map[string]string{
+				"PI_OLLAMA_NUM_PREDICT":    "-1",
+				"PI_OLLAMA_REPEAT_PENALTY": "1.3",
+			},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "unparseable sampling knobs are ignored",
+			model: "llama3",
+			env: map[string]string{
+				"PI_OLLAMA_REPEAT_PENALTY": "high",
+				"PI_OLLAMA_REPEAT_LAST_N":  "many",
+			},
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "tools are converted onto the request",
+			model: "llama3",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+				Config:   &genai.GenerateContentConfig{Tools: toolReq},
+			},
+		},
+		{
+			name:  "an empty tool list leaves tools off the wire",
+			model: "llama3",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+				Config:   &genai.GenerateContentConfig{Tools: []*genai.Tool{}},
+			},
+		},
+		{
+			name:  "an assistant tool call round trip",
+			model: "llama3",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{
+					{Role: "user", Parts: []*genai.Part{{Text: "read it"}}},
+					{Role: "model", Parts: []*genai.Part{
+						{Text: "sure"},
+						{FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"path": "/tmp/x"}}},
+					}},
+					{Role: "user", Parts: []*genai.Part{
+						{FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"result": "contents"}}},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cogPAClearOllamaEnv(t)
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			var body map[string]any
+			srv := cogPAOllamaCapture(t, &body)
+			llm, err := NewOllama(context.Background(), tc.model, "", srv.URL, tc.thinking, nil)
+			if err != nil {
+				t.Fatalf("NewOllama: %v", err)
+			}
+			for _, err := range llm.GenerateContent(context.Background(), tc.req, false) {
+				if err != nil {
+					t.Fatalf("GenerateContent: %v", err)
+				}
+			}
+			cogPAGolden(t, "", body)
+		})
+	}
+}
+
+// TestCogPAOllamaStreamingRequestGolden pins the streaming branch of
+// GenerateContent, which differs from the non-streaming one only in the stream
+// flag it sends.
+func TestCogPAOllamaStreamingRequestGolden(t *testing.T) {
+	cogPAClearOllamaEnv(t)
+	var body map[string]any
+	srv := cogPAOllamaCapture(t, &body)
+	llm, err := NewOllama(context.Background(), "llama3", "", srv.URL, "low", nil)
+	if err != nil {
+		t.Fatalf("NewOllama: %v", err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+	}
+	var texts []string
+	for resp, err := range llm.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if resp != nil && resp.Content != nil {
+			for _, p := range resp.Content.Parts {
+				texts = append(texts, p.Text)
+			}
+		}
+	}
+	cogPAGolden(t, "request", body)
+	cogPAGolden(t, "text", texts)
+}
+
+// ---------------------------------------------------------------------------
+// (*xaiModel).GenerateContent — the request that reaches /responses
+// ---------------------------------------------------------------------------
+
+func cogPAXAICapture(t *testing.T, body *map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     "resp_x",
+			"object": "response",
+			"status": "completed",
+			"model":  "grok-4.6",
+			"output": []map[string]any{{
+				"type":   "message",
+				"id":     "msg_x",
+				"role":   "assistant",
+				"status": "completed",
+				"content": []map[string]any{{
+					"type":        "output_text",
+					"text":        "hello",
+					"annotations": []any{},
+				}},
+			}},
+			"usage": map[string]any{"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCogPAXAIRequestGoldens(t *testing.T) {
+	tools := cogPATools(&genai.FunctionDeclaration{
+		Name:        "read",
+		Description: "read a file",
+		ParametersJsonSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"path": map[string]any{"type": "string"}},
+			"required":   []any{"path"},
+		},
+	})
+
+	tests := []struct {
+		name     string
+		model    string
+		thinking string
+		req      *model.LLMRequest
+	}{
+		{
+			name:  "plain user turn with no reasoning level",
+			model: "grok-4.6",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "reasoning effort medium",
+			model:    "grok-4.6",
+			thinking: "medium",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "level none maps to low",
+			model:    "grok-4.6",
+			thinking: "none",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "unrecognized level omits reasoning",
+			model:    "grok-4.6",
+			thinking: "turbo",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "non-reasoning model never gets reasoning",
+			model:    "grok-4.20-0309-non-reasoning",
+			thinking: "high",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "per-request model gates reasoning",
+			model:    "grok-4.6",
+			thinking: "high",
+			req: &model.LLMRequest{
+				Model:    "grok-4.20-0309-non-reasoning",
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:     "per-request model overrides the instance model",
+			model:    "grok-4.6",
+			thinking: "high",
+			req: &model.LLMRequest{
+				Model:    "grok-4.7",
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+			},
+		},
+		{
+			name:  "system instruction becomes instructions",
+			model: "grok-4.6",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+				Config: &genai.GenerateContentConfig{
+					SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "be terse"}}},
+				},
+			},
+		},
+		{
+			name:  "function declarations reach the tools field",
+			model: "grok-4.6",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+				Config:   &genai.GenerateContentConfig{Tools: tools},
+			},
+		},
+		{
+			name:  "an empty tool list leaves tools off the wire",
+			model: "grok-4.6",
+			req: &model.LLMRequest{
+				Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+				Config:   &genai.GenerateContentConfig{Tools: []*genai.Tool{}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PI_XAI_TOOLS", "")
+			var body map[string]any
+			srv := cogPAXAICapture(t, &body)
+			llm, err := NewXAI(context.Background(), tc.model, "k", srv.URL, tc.thinking, nil)
+			if err != nil {
+				t.Fatalf("NewXAI: %v", err)
+			}
+			for _, err := range llm.GenerateContent(context.Background(), tc.req, false) {
+				if err != nil {
+					t.Fatalf("GenerateContent: %v", err)
+				}
+			}
+			cogPAGolden(t, "", body)
+		})
+	}
+}
+
+// TestCogPAXAIServerSideToolsGolden pins the opt-in that appends xAI's built-in
+// tools alongside the caller's function declarations.
+func TestCogPAXAIServerSideToolsGolden(t *testing.T) {
+	t.Setenv("PI_XAI_TOOLS", "")
+	var body map[string]any
+	srv := cogPAXAICapture(t, &body)
+	llm, err := NewXAI(context.Background(), "grok-4.6", "k", srv.URL, "", &LLMOptions{EnableXAITools: true})
+	if err != nil {
+		t.Fatalf("NewXAI: %v", err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+	}
+	for _, err := range llm.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+	}
+	cogPAGolden(t, "", body["tools"])
+}
+
+// TestCogPAXAINilRequest pins the nil-request guard, which yields an error and
+// never reaches the network.
+func TestCogPAXAINilRequest(t *testing.T) {
+	llm, err := NewXAI(context.Background(), "grok-4.6", "k", "http://127.0.0.1:1", "", nil)
+	if err != nil {
+		t.Fatalf("NewXAI: %v", err)
+	}
+	var errs []string
+	for resp, err := range llm.GenerateContent(context.Background(), nil, false) {
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+		if resp != nil {
+			t.Errorf("unexpected response %+v", resp)
+		}
+	}
+	cogPAGolden(t, "", errs)
+}
+
+// TestCogPAXAIInputConversionError pins the wrapping of an input-conversion
+// failure, which happens before any request is built.
+func TestCogPAXAIInputConversionError(t *testing.T) {
+	llm, err := NewXAI(context.Background(), "grok-4.6", "k", "http://127.0.0.1:1", "", nil)
+	if err != nil {
+		t.Fatalf("NewXAI: %v", err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{
+			Role:  "user",
+			Parts: []*genai.Part{{InlineData: &genai.Blob{MIMEType: "application/x-unsupported", Data: []byte("x")}}},
+		}},
+	}
+	var errs []string
+	for _, err := range llm.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	cogPAGolden(t, "", errs)
+}
+
+// TestCogPAXAISendErrorShapes pins how a transport failure is reported: as a
+// yielded error in the non-streaming path and as a STREAM_ERROR response in the
+// streaming one.
+func TestCogPAXAISendErrorShapes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	llm, err := NewXAI(context.Background(), "grok-4.6", "k", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewXAI: %v", err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+	}
+
+	var sawErr bool
+	for _, err := range llm.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Error("non-streaming failure must yield an error")
+	}
+
+	var codes []string
+	for resp := range llm.GenerateContent(context.Background(), req, true) {
+		if resp != nil && resp.ErrorCode != "" {
+			codes = append(codes, resp.ErrorCode)
+		}
+	}
+	if len(codes) == 0 || codes[len(codes)-1] != "STREAM_ERROR" {
+		t.Errorf("streaming failure codes = %v, want a trailing STREAM_ERROR", codes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OllamaContextWindowSize
+// ---------------------------------------------------------------------------
+
+// cogPAShowServer serves one /api/show reply built from the given parameters
+// block and model_info map.
+func cogPAShowServer(t *testing.T, parameters string, modelInfo map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"parameters": parameters,
+			"model_info": modelInfo,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCogPAOllamaContextWindowSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		modelInfo  map[string]any
+		want       int64
+	}{
+		{
+			name:       "num_ctx parameter is used",
+			parameters: "stop \"<eot>\"\nnum_ctx 32768\ntemperature 0.7",
+			want:       32768,
+		},
+		{
+			name:       "num_ctx beats the native context length",
+			parameters: "num_ctx 8192",
+			modelInfo:  map[string]any{"llama.context_length": 131072},
+			want:       8192,
+		},
+		{
+			name:       "a zero num_ctx is returned rather than falling through",
+			parameters: "num_ctx 0",
+			modelInfo:  map[string]any{"llama.context_length": 131072},
+			want:       0,
+		},
+		{
+			name:       "an unparseable num_ctx falls through to model_info",
+			parameters: "num_ctx lots",
+			modelInfo:  map[string]any{"llama.context_length": 4096},
+			want:       4096,
+		},
+		{
+			name:       "a num_ctx line with extra fields is ignored",
+			parameters: "num_ctx 4096 extra",
+			modelInfo:  map[string]any{"llama.context_length": 2048},
+			want:       2048,
+		},
+		{
+			name:       "a later num_ctx is reached when an earlier one is unparseable",
+			parameters: "num_ctx x\nnum_ctx 1234",
+			want:       1234,
+		},
+		{
+			name:      "native context length from model_info",
+			modelInfo: map[string]any{"qwen3.context_length": 262144},
+			want:      262144,
+		},
+		{
+			name:      "a key that does not end in .context_length is ignored",
+			modelInfo: map[string]any{"qwen3.context_length_hint": 999},
+			want:      0,
+		},
+		{
+			name:      "a non-numeric context_length yields zero",
+			modelInfo: map[string]any{"qwen3.context_length": "big"},
+			want:      0,
+		},
+		{
+			name: "nothing to go on yields zero",
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := cogPAShowServer(t, tc.parameters, tc.modelInfo)
+			if got := OllamaContextWindowSize(context.Background(), srv.URL, "m"); got != tc.want {
+				t.Errorf("OllamaContextWindowSize = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCogPAOllamaContextWindowSizeFailures(t *testing.T) {
+	t.Run("unparseable base URL", func(t *testing.T) {
+		if got := OllamaContextWindowSize(context.Background(), "http://[::1", "m"); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+	t.Run("server error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		if got := OllamaContextWindowSize(context.Background(), srv.URL, "m"); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+}
+
+// TestCogPAOllamaNativeContextLengthIntegerValues covers the integer arms of the
+// model_info type switch. They are unreachable through the HTTP path above,
+// where every number arrives decoded as a float64, so they are exercised
+// directly instead of through OllamaContextWindowSize.
+func TestCogPAOllamaNativeContextLengthIntegerValues(t *testing.T) {
+	tests := []struct {
+		name string
+		info map[string]any
+		want int64
+	}{
+		{name: "int64", info: map[string]any{"a.context_length": int64(65536)}, want: 65536},
+		{name: "int", info: map[string]any{"a.context_length": 4096}, want: 4096},
+		{name: "float64", info: map[string]any{"a.context_length": float64(8192)}, want: 8192},
+		{name: "unusable type", info: map[string]any{"a.context_length": []int{1}}, want: 0},
+		{name: "no matching key", info: map[string]any{"a.embedding_length": 1}, want: 0},
+		{name: "empty", info: nil, want: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ollamaNativeContextLength(tc.info); got != tc.want {
+				t.Errorf("ollamaNativeContextLength = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/complexity_cog_provider_b_test.go
+++ b/internal/provider/complexity_cog_provider_b_test.go
@@ -1,0 +1,892 @@
+package provider
+
+// Goldens pinning the Anthropic translation layer across the cognitive-
+// complexity refactor of anthropic.go.
+//
+// Every literal in this file was captured by running the cases against the
+// PRE-refactor source (extracted with `git archive HEAD` into a scratch tree),
+// not by reading back the refactored code. They therefore assert that the
+// refactor is a no-op rather than that the new code agrees with itself.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// ---------------------------------------------------------------------------
+// Tool schema conversion: antToolSchemas / antSchemaFields and the two
+// converters built on them.
+// ---------------------------------------------------------------------------
+
+type cogBToolCase struct {
+	name  string
+	tools []*genai.Tool
+	// want is the exact JSON the emitted tool list marshals to. The standard
+	// and beta converters emit byte-identical wire schemas, so one literal
+	// serves both; the test asserts that equality explicitly.
+	want string
+}
+
+func cogBToolCases() []cogBToolCase {
+	typed := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"path":      {Type: "string", Description: "file path"},
+			"max_lines": {Type: "integer"},
+		},
+		Required: []string{"path"},
+	}
+
+	return []cogBToolCase{
+		{name: "nil tools slice", tools: nil, want: `null`},
+		{name: "empty tools slice", tools: []*genai.Tool{}, want: `null`},
+		{name: "nil tool entry", tools: []*genai.Tool{nil}, want: `null`},
+		{name: "nil function declarations", tools: []*genai.Tool{{}}, want: `null`},
+		{
+			name:  "empty function declarations",
+			tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{}}},
+			want:  `null`,
+		},
+		{
+			name:  "nil declaration entry",
+			tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{nil}}},
+			want:  `null`,
+		},
+		{
+			name: "no parameters yields empty object schema",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "ping", Description: "no args",
+			}),
+			want: `[{"input_schema":{"properties":{},"type":"object"},"name":"ping","description":"no args"}]`,
+		},
+		{
+			name:  "empty description is still emitted",
+			tools: cogBTools(&genai.FunctionDeclaration{Name: "bare"}),
+			want:  `[{"input_schema":{"properties":{},"type":"object"},"name":"bare","description":""}]`,
+		},
+		{
+			name: "required and optional properties",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name:        "read_file",
+				Description: "Read a file",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"path":   map[string]any{"type": "string", "description": "file path"},
+						"offset": map[string]any{"type": "integer"},
+					},
+					"required": []any{"path"},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"offset":{"type":"integer"},"path":{"description":"file path","type":"string"}},"required":["path"],"type":"object"},"name":"read_file","description":"Read a file"}]`,
+		},
+		{
+			name: "properties without required omits required",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "opt_only",
+				ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"q": map[string]any{"type": "string"}},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"q":{"type":"string"}},"type":"object"},"name":"opt_only","description":""}]`,
+		},
+		{
+			// An empty JSON array is distinct from an absent one: it emits
+			// "required":[] where an absent key emits nothing at all.
+			name: "empty required array survives as empty array",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "req_empty",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"q": map[string]any{"type": "string"}},
+					"required":   []any{},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"q":{"type":"string"}},"required":[],"type":"object"},"name":"req_empty","description":""}]`,
+		},
+		{
+			name: "non-string required entries are dropped",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "req_mixed",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   []any{"a", 42, nil, "b", true},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"a":{"type":"string"}},"required":["a","b"],"type":"object"},"name":"req_mixed","description":""}]`,
+		},
+		{
+			// An array carrying no usable string entries still emits an empty
+			// array, not an absent key. This is the case that decides whether
+			// the required-list reader can be shared with the Ollama
+			// converter: ToolInputSchemaParam.Required is `omitzero`, so a nil
+			// slice and a non-nil empty slice are different on the wire.
+			name: "required with only non-string entries emits empty array",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "req_junk",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   []any{42, nil, true, 3.5},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"a":{"type":"string"}},"required":[],"type":"object"},"name":"req_junk","description":""}]`,
+		},
+		{
+			name: "required as a bare string is ignored",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "req_str",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   "a",
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"a":{"type":"string"}},"type":"object"},"name":"req_str","description":""}]`,
+		},
+		{
+			name: "required as a map is ignored",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "req_map",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   map[string]any{"a": true},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"a":{"type":"string"}},"type":"object"},"name":"req_map","description":""}]`,
+		},
+		{
+			// A []string (rather than []any) fails the assertion, so required
+			// is dropped entirely. Preserved quirk, pinned deliberately.
+			name: "required as []string is ignored",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "req_strings",
+				ParametersJsonSchema: map[string]any{
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+					"required":   []string{"a"},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"a":{"type":"string"}},"type":"object"},"name":"req_strings","description":""}]`,
+		},
+		{
+			name: "non-map properties fall back to empty object",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "weird",
+				ParametersJsonSchema: map[string]any{
+					"properties": "not-a-map",
+					"required":   []any{"a"},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{},"required":["a"],"type":"object"},"name":"weird","description":""}]`,
+		},
+		{
+			name: "empty schema map",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "empty_schema", ParametersJsonSchema: map[string]any{},
+			}),
+			want: `[{"input_schema":{"properties":{},"type":"object"},"name":"empty_schema","description":""}]`,
+		},
+		{
+			// schemaToMap returns nil when the value cannot be marshaled.
+			name: "unmarshalable schema falls back to empty object",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "bad_schema", ParametersJsonSchema: make(chan int),
+			}),
+			want: `[{"input_schema":{"properties":{},"type":"object"},"name":"bad_schema","description":""}]`,
+		},
+		{
+			name: "scalar schema falls back to empty object",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "scalar_schema", ParametersJsonSchema: "just-a-string",
+			}),
+			want: `[{"input_schema":{"properties":{},"type":"object"},"name":"scalar_schema","description":""}]`,
+		},
+		{
+			name: "nested object properties pass through verbatim",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name:        "nested",
+				Description: "nested object properties",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"filter": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"since": map[string]any{"type": "string"},
+								"limit": map[string]any{"type": "integer"},
+							},
+							"required": []any{"since"},
+						},
+					},
+					"required": []any{"filter"},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"filter":{"properties":{"limit":{"type":"integer"},"since":{"type":"string"}},"required":["since"],"type":"object"}},"required":["filter"],"type":"object"},"name":"nested","description":"nested object properties"}]`,
+		},
+		{
+			name: "arrays and enums pass through verbatim",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name:        "arr_enum",
+				Description: "arrays and enums",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"tags": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+						"mode": map[string]any{
+							"type": "string",
+							"enum": []any{"fast", "slow"},
+						},
+					},
+					"required": []any{"tags", "mode"},
+				},
+			}),
+			want: `[{"input_schema":{"properties":{"mode":{"enum":["fast","slow"],"type":"string"},"tags":{"items":{"type":"string"},"type":"array"}},"required":["tags","mode"],"type":"object"},"name":"arr_enum","description":"arrays and enums"}]`,
+		},
+		{
+			// The tools registry hands over a typed *jsonschema.Schema, which
+			// only survives via schemaToMap's marshal round trip.
+			name: "typed jsonschema.Schema",
+			tools: cogBTools(&genai.FunctionDeclaration{
+				Name: "typed", Description: "typed schema", ParametersJsonSchema: typed,
+			}),
+			want: `[{"input_schema":{"properties":{"max_lines":{"type":"integer"},"path":{"description":"file path","type":"string"}},"required":["path"],"type":"object"},"name":"typed","description":"typed schema"}]`,
+		},
+		{
+			name: "multiple tools and declarations keep source order",
+			tools: []*genai.Tool{
+				{FunctionDeclarations: []*genai.FunctionDeclaration{
+					{Name: "first"},
+					nil,
+					{Name: "second", ParametersJsonSchema: map[string]any{
+						"properties": map[string]any{"x": map[string]any{"type": "number"}},
+						"required":   []any{"x"},
+					}},
+				}},
+				nil,
+				{FunctionDeclarations: nil},
+				{FunctionDeclarations: []*genai.FunctionDeclaration{
+					{Name: "third", Description: "third tool"},
+				}},
+			},
+			want: `[{"input_schema":{"properties":{},"type":"object"},"name":"first","description":""},{"input_schema":{"properties":{"x":{"type":"number"}},"required":["x"],"type":"object"},"name":"second","description":""},{"input_schema":{"properties":{},"type":"object"},"name":"third","description":"third tool"}]`,
+		},
+	}
+}
+
+func cogBTools(decls ...*genai.FunctionDeclaration) []*genai.Tool {
+	return []*genai.Tool{{FunctionDeclarations: decls}}
+}
+
+func cogBMarshal(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestCogProviderBToolConverterGoldens(t *testing.T) {
+	for _, tc := range cogBToolCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStd := cogBMarshal(t, antGenaiToolsToAnthropic(tc.tools))
+			if gotStd != tc.want {
+				t.Errorf("antGenaiToolsToAnthropic:\n got %s\nwant %s", gotStd, tc.want)
+			}
+			gotBeta := cogBMarshal(t, antGenaiToolsToBetaAnthropic(tc.tools))
+			if gotBeta != tc.want {
+				t.Errorf("antGenaiToolsToBetaAnthropic:\n got %s\nwant %s", gotBeta, tc.want)
+			}
+			// The shared core is only legitimate if the two formats really do
+			// emit the same wire schema for every declaration shape.
+			if gotStd != gotBeta {
+				t.Errorf("standard and beta schemas diverge:\n std  %s\n beta %s", gotStd, gotBeta)
+			}
+		})
+	}
+}
+
+// TestCogProviderBSchemaFields pins the nil-versus-empty distinctions that the
+// marshaled goldens above cannot see: Properties is never nil, and Required is
+// nil only when the schema carries no JSON array.
+func TestCogProviderBSchemaFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		schema       any
+		wantProps    map[string]any
+		wantRequired []string
+		wantReqNil   bool
+	}{
+		{
+			name: "nil schema", schema: nil,
+			wantProps: map[string]any{}, wantReqNil: true,
+		},
+		{
+			name: "unreadable schema", schema: make(chan int),
+			wantProps: map[string]any{}, wantReqNil: true,
+		},
+		{
+			name:      "required absent",
+			schema:    map[string]any{"properties": map[string]any{"a": "x"}},
+			wantProps: map[string]any{"a": "x"}, wantReqNil: true,
+		},
+		{
+			name:      "required empty array is non-nil",
+			schema:    map[string]any{"required": []any{}},
+			wantProps: map[string]any{}, wantRequired: []string{},
+		},
+		{
+			name:      "required filters non-strings",
+			schema:    map[string]any{"required": []any{"a", 1, "b"}},
+			wantProps: map[string]any{}, wantRequired: []string{"a", "b"},
+		},
+		{
+			// Non-nil but empty: emits "required": [] rather than omitting it.
+			name:      "required with only non-strings is non-nil empty",
+			schema:    map[string]any{"required": []any{1, true}},
+			wantProps: map[string]any{}, wantRequired: []string{},
+		},
+		{
+			name:      "required as a bare string is nil",
+			schema:    map[string]any{"required": "a"},
+			wantProps: map[string]any{}, wantReqNil: true,
+		},
+		{
+			name:      "required as []string is nil",
+			schema:    map[string]any{"required": []string{"a"}},
+			wantProps: map[string]any{}, wantReqNil: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			props, required := antSchemaFields(tc.schema)
+			if props == nil {
+				t.Fatal("properties must never be nil")
+			}
+			if got := cogBMarshal(t, props); got != cogBMarshal(t, tc.wantProps) {
+				t.Errorf("properties = %s, want %s", got, cogBMarshal(t, tc.wantProps))
+			}
+			if tc.wantReqNil {
+				if required != nil {
+					t.Errorf("required = %v, want nil", required)
+				}
+				return
+			}
+			if required == nil {
+				t.Fatal("required = nil, want non-nil")
+			}
+			if got := cogBMarshal(t, required); got != cogBMarshal(t, tc.wantRequired) {
+				t.Errorf("required = %s, want %s", got, cogBMarshal(t, tc.wantRequired))
+			}
+		})
+	}
+}
+
+// TestCogProviderBToolSchemas pins the flattening step on its own: which
+// declarations survive, in which order.
+func TestCogProviderBToolSchemas(t *testing.T) {
+	got := antToolSchemas([]*genai.Tool{
+		nil,
+		{FunctionDeclarations: nil},
+		{FunctionDeclarations: []*genai.FunctionDeclaration{}},
+		{FunctionDeclarations: []*genai.FunctionDeclaration{nil, {Name: "a"}, nil, {Name: "b"}}},
+		{FunctionDeclarations: []*genai.FunctionDeclaration{{Name: "c", Description: "third"}}},
+	})
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (%+v)", len(got), got)
+	}
+	wantNames := []string{"a", "b", "c"}
+	for i, want := range wantNames {
+		if got[i].name != want {
+			t.Errorf("[%d].name = %q, want %q", i, got[i].name, want)
+		}
+	}
+	if got[2].description != "third" {
+		t.Errorf("[2].description = %q, want %q", got[2].description, "third")
+	}
+	if antToolSchemas(nil) != nil {
+		t.Error("antToolSchemas(nil) must be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model-name resolution
+// ---------------------------------------------------------------------------
+
+func TestCogProviderBResolveModelName(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		requested  string
+		want       string
+	}{
+		{"configured only", "claude-sonnet-4-6", "", "claude-sonnet-4-6"},
+		{"request overrides", "claude-sonnet-4-6", "claude-opus-4-7", "claude-opus-4-7"},
+		{"provider alias request keeps configured", "claude-sonnet-4-6", "anthropic", "claude-sonnet-4-6"},
+		{"both empty falls back", "", "", "claude-sonnet-5"},
+		{"both alias falls back", "anthropic", "anthropic", "claude-sonnet-5"},
+		{"empty configured with alias request falls back", "", "anthropic", "claude-sonnet-5"},
+		{"empty configured with real request", "", "claude-opus-4-7", "claude-opus-4-7"},
+		{"alias configured with real request", "anthropic", "claude-opus-4-7", "claude-opus-4-7"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := antResolveModelName(tc.configured, tc.requested); got != tc.want {
+				t.Errorf("antResolveModelName(%q, %q) = %q, want %q",
+					tc.configured, tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Outgoing request bodies: buildParams / buildBetaParams as reached through
+// GenerateContent's routing.
+// ---------------------------------------------------------------------------
+
+func cogBCaptureRequest(t *testing.T, modelName, reqModel, thinking string, opts *LLMOptions, config *genai.GenerateContentConfig) string {
+	t.Helper()
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "m", "type": "message", "role": "assistant", "model": "x",
+			"content":     []map[string]any{{"type": "text", "text": "ok"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	llm, err := NewAnthropic(ctx, modelName, "sk-test", srv.URL, thinking, opts)
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	req := &model.LLMRequest{
+		Model:    reqModel,
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+		Config:   config,
+	}
+	for _, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+	}
+	// Re-marshal through map[string]any so key order is canonical.
+	var m map[string]any
+	if err := json.Unmarshal(captured, &m); err != nil {
+		t.Fatalf("unmarshal request body: %v (%s)", err, captured)
+	}
+	return cogBMarshal(t, m)
+}
+
+func TestCogProviderBRequestBodyGoldens(t *testing.T) {
+	toolsCfg := func() *genai.GenerateContentConfig {
+		return &genai.GenerateContentConfig{
+			SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "be brief"}}},
+			Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "read_file", Description: "Read a file", ParametersJsonSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"path": map[string]any{"type": "string"}},
+					"required":   []any{"path"},
+				}},
+			}}},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		modelName  string
+		reqModel   string
+		thinking   string
+		opts       *LLMOptions
+		config     *genai.GenerateContentConfig
+		wantBody   string
+		wantCached bool
+	}{
+		{
+			name: "plain request", modelName: "claude-sonnet-4-6", thinking: "none",
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6"}`,
+		},
+		{
+			name: "request model override", modelName: "claude-sonnet-4-6", reqModel: "claude-opus-4-7", thinking: "none",
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-opus-4-7"}`,
+		},
+		{
+			name: "provider alias in request", modelName: "claude-sonnet-4-6", reqModel: "anthropic", thinking: "none",
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6"}`,
+		},
+		{
+			name: "empty model falls back", modelName: "", thinking: "none",
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-5"}`,
+		},
+		{
+			name: "alias model falls back", modelName: "anthropic", reqModel: "anthropic", thinking: "none",
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-5"}`,
+		},
+		{
+			// Thinking raises max_tokens to 16384 and adds the adaptive block.
+			name: "thinking high", modelName: "claude-sonnet-4-6", thinking: "high",
+			wantBody: `{"max_tokens":16384,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","thinking":{"display":"summarized","type":"adaptive"}}`,
+		},
+		{
+			name: "unrecognized thinking level is off", modelName: "claude-sonnet-4-6", thinking: "bogus",
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6"}`,
+		},
+		{
+			name: "system prompt and tools", modelName: "claude-sonnet-4-6", thinking: "none", config: toolsCfg(),
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"cache_control":{"type":"ephemeral"},"text":"be brief","type":"text"}],"tools":[{"cache_control":{"type":"ephemeral"},"description":"Read a file","input_schema":{"properties":{"path":{"type":"string"}},"required":["path"],"type":"object"},"name":"read_file"}]}`,
+		},
+		{
+			name: "prompt caching disabled", modelName: "claude-sonnet-4-6", thinking: "none",
+			opts: &LLMOptions{DisablePromptCaching: true}, config: toolsCfg(),
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"be brief","type":"text"}],"tools":[{"description":"Read a file","input_schema":{"properties":{"path":{"type":"string"}},"required":["path"],"type":"object"},"name":"read_file"}]}`,
+		},
+		{
+			// An empty Tools slice must not produce a "tools" key.
+			name: "empty tools slice", modelName: "claude-sonnet-4-6", thinking: "none",
+			config:   &genai.GenerateContentConfig{Tools: []*genai.Tool{}},
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6"}`,
+		},
+		{
+			// Advisor path: the advisor tool leads the Tools slice and the
+			// converted genai tools follow it.
+			name: "beta advisor with thinking and caching", modelName: "claude-sonnet-4-6", thinking: "high",
+			opts:     &LLMOptions{AdvisorModel: "claude-opus-4-7", AdvisorMaxUses: 3, AdvisorCaching: true},
+			config:   toolsCfg(),
+			wantBody: `{"max_tokens":16384,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"cache_control":{"type":"ephemeral"},"text":"be brief","type":"text"}],"thinking":{"display":"summarized","type":"adaptive"},"tools":[{"caching":{"type":"ephemeral"},"max_uses":3,"model":"claude-opus-4-7","name":"advisor","type":"advisor_20260301"},{"cache_control":{"type":"ephemeral"},"description":"Read a file","input_schema":{"properties":{"path":{"type":"string"}},"required":["path"],"type":"object"},"name":"read_file"}]}`,
+		},
+		{
+			name: "beta advisor without caching", modelName: "claude-sonnet-4-6", thinking: "none",
+			opts:     &LLMOptions{AdvisorModel: "claude-opus-4-7", DisablePromptCaching: true},
+			config:   toolsCfg(),
+			wantBody: `{"max_tokens":8192,"messages":[{"content":[{"text":"hi","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"be brief","type":"text"}],"tools":[{"model":"claude-opus-4-7","name":"advisor","type":"advisor_20260301"},{"description":"Read a file","input_schema":{"properties":{"path":{"type":"string"}},"required":["path"],"type":"object"},"name":"read_file"}]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cogBCaptureRequest(t, tc.modelName, tc.reqModel, tc.thinking, tc.opts, tc.config)
+			if got != tc.wantBody {
+				t.Errorf("request body:\n got %s\nwant %s", got, tc.wantBody)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// antRunNonStreamingBeta: block -> part conversion
+// ---------------------------------------------------------------------------
+
+type cogBPart struct {
+	Text   string         `json:"text,omitempty"`
+	FCName string         `json:"fc_name,omitempty"`
+	FCID   string         `json:"fc_id,omitempty"`
+	FCArgs map[string]any `json:"fc_args,omitempty"`
+	FCNil  bool           `json:"fc_nil_args,omitempty"`
+}
+
+func cogBParts(parts []*genai.Part) []cogBPart {
+	out := make([]cogBPart, 0, len(parts))
+	for _, p := range parts {
+		g := cogBPart{Text: p.Text}
+		if p.FunctionCall != nil {
+			g.FCName = p.FunctionCall.Name
+			g.FCID = p.FunctionCall.ID
+			g.FCArgs = p.FunctionCall.Args
+			g.FCNil = p.FunctionCall.Args == nil
+		}
+		out = append(out, g)
+	}
+	return out
+}
+
+// TestCogProviderBBetaNonStreamingGolden drives every beta content-block shape
+// through antRunNonStreamingBeta in one response: empty text and thinking are
+// dropped, a tool_use identifying no tool is dropped, absent tool input leaves
+// nil arguments, a redacted advisor result becomes its placeholder string, an
+// empty advisor result is dropped, and an unhandled block type contributes
+// nothing. Order is preserved.
+func TestCogProviderBBetaNonStreamingGolden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_golden", "type": "message", "role": "assistant", "model": "claude-sonnet-4-6",
+			"content": []map[string]any{
+				{"type": "text", "text": "hello"},
+				{"type": "text", "text": ""},
+				{"type": "thinking", "thinking": "reasoning"},
+				{"type": "thinking", "thinking": ""},
+				{"type": "tool_use", "id": "toolu_1", "name": "bash", "input": map[string]any{"command": "ls"}},
+				{"type": "tool_use", "id": "toolu_2", "name": "noargs"},
+				{"type": "tool_use", "id": "toolu_3", "name": "nested", "input": map[string]any{
+					"filter": map[string]any{"since": "yesterday", "limit": 3},
+					"tags":   []any{"a", "b"},
+				}},
+				{"type": "advisor_tool_result", "tool_use_id": "advtool_1",
+					"content": map[string]any{"type": "advisor_result", "text": "advice payload"}},
+				{"type": "advisor_tool_result", "tool_use_id": "advtool_2",
+					"content": map[string]any{"type": "advisor_redacted_result", "encrypted_content": "zzz"}},
+				{"type": "advisor_tool_result", "tool_use_id": "advtool_3",
+					"content": map[string]any{"type": "advisor_result", "text": ""}},
+				{"type": "tool_use", "id": "", "name": "", "input": map[string]any{"x": 1}},
+				{"type": "server_tool_use", "id": "srv_1", "name": "web_search"},
+				{"type": "text", "text": "tail"},
+			},
+			"stop_reason": "tool_use",
+			"usage": map[string]any{
+				"input_tokens": 13, "output_tokens": 29,
+				"cache_read_input_tokens": 5, "cache_creation_input_tokens": 2,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	llm, err := NewAnthropic(ctx, "claude-sonnet-4-6", "sk-test", srv.URL, "none",
+		&LLMOptions{AdvisorModel: "claude-opus-4-7"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+
+	var last *model.LLMResponse
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		last = resp
+	}
+	if last == nil || last.Content == nil {
+		t.Fatal("no response")
+	}
+
+	const wantParts = `[{"text":"hello"},{"text":"reasoning"},{"fc_name":"bash","fc_id":"toolu_1","fc_args":{"command":"ls"}},{"fc_name":"noargs","fc_id":"toolu_2","fc_nil_args":true},{"fc_name":"nested","fc_id":"toolu_3","fc_args":{"filter":{"limit":3,"since":"yesterday"},"tags":["a","b"]}},{"text":"advice payload"},{"text":"[advisor result encrypted; will be decrypted on next turn]"},{"text":"tail"}]`
+	if got := cogBMarshal(t, cogBParts(last.Content.Parts)); got != wantParts {
+		t.Errorf("parts:\n got %s\nwant %s", got, wantParts)
+	}
+
+	// Note: the beta path reports raw input_tokens; it does not fold the cache
+	// counters into the prompt count the way the streaming path does.
+	const wantUsage = `{"cachedContentTokenCount":5,"candidatesTokenCount":29,"promptTokenCount":13}`
+	if got := cogBMarshal(t, last.UsageMetadata); got != wantUsage {
+		t.Errorf("usage:\n got %s\nwant %s", got, wantUsage)
+	}
+	if last.FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason = %v, want STOP", last.FinishReason)
+	}
+	if last.Partial || !last.TurnComplete || last.Content.Role != "model" {
+		t.Errorf("partial=%v turn=%v role=%q, want false/true/model",
+			last.Partial, last.TurnComplete, last.Content.Role)
+	}
+}
+
+// TestCogProviderBBetaNonStreamingError pins the early return when the API
+// call fails: one error and no response.
+func TestCogProviderBBetaNonStreamingError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"nope"}}`))
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	llm, err := NewAnthropic(ctx, "claude-sonnet-4-6", "sk-test", srv.URL, "none",
+		&LLMOptions{AdvisorModel: "claude-opus-4-7"})
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+
+	var errCount, respCount int
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			errCount++
+		}
+		if resp != nil {
+			respCount++
+		}
+	}
+	if errCount != 1 || respCount != 0 {
+		t.Errorf("errCount=%d respCount=%d, want 1/0", errCount, respCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// antHandleContentBlockDelta, via the standard streaming path
+// ---------------------------------------------------------------------------
+
+// TestCogProviderBStandardStreamingGolden pins the full yielded sequence of the
+// standard streaming path: text deltas accumulate into the final text, a
+// thinking delta is yielded under the "thinking" role, a signature_delta is
+// ignored, an input_json_delta for an index with no tool_use header is dropped,
+// and the final usage folds the cache counters into the prompt count.
+func TestCogProviderBStandardStreamingGolden(t *testing.T) {
+	events := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"message_start", map[string]any{"type": "message_start", "message": map[string]any{
+			"id": "msg_s", "type": "message", "role": "assistant", "model": "m",
+			"content": []any{}, "stop_reason": nil,
+			"usage": map[string]any{"input_tokens": 7, "output_tokens": 0,
+				"cache_read_input_tokens": 3, "cache_creation_input_tokens": 1},
+		}}},
+		{"content_block_start", map[string]any{"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 0,
+			"delta": map[string]any{"type": "text_delta", "text": "Hel"}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 0,
+			"delta": map[string]any{"type": "text_delta", "text": "lo"}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 0,
+			"delta": map[string]any{"type": "thinking_delta", "thinking": "hmm"}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 0,
+			"delta": map[string]any{"type": "signature_delta", "signature": "sig"}}},
+		{"content_block_stop", map[string]any{"type": "content_block_stop", "index": 0}},
+		{"content_block_start", map[string]any{"type": "content_block_start", "index": 1,
+			"content_block": map[string]any{"type": "tool_use", "id": "toolu_9", "name": "bash",
+				"input": map[string]any{}}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 1,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": `{"cmd":`}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 1,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": `"ls"}`}}},
+		{"content_block_delta", map[string]any{"type": "content_block_delta", "index": 5,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": `{"orphan":1}`}}},
+		{"content_block_stop", map[string]any{"type": "content_block_stop", "index": 1}},
+		{"message_delta", map[string]any{"type": "message_delta",
+			"delta": map[string]any{"stop_reason": "tool_use"},
+			"usage": map[string]any{"output_tokens": 42, "cache_read_input_tokens": 9,
+				"cache_creation_input_tokens": 0}}},
+		{"message_stop", map[string]any{"type": "message_stop"}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		for _, e := range events {
+			b, err := json.Marshal(e.payload)
+			if err != nil {
+				return
+			}
+			if _, err := w.Write([]byte("event: " + e.name + "\ndata: " + string(b) + "\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	llm, err := NewAnthropic(ctx, "claude-sonnet-4-6", "sk-test", srv.URL, "none", nil)
+	if err != nil {
+		t.Fatalf("NewAnthropic: %v", err)
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+
+	type rec struct {
+		Role    string     `json:"role"`
+		Partial bool       `json:"partial"`
+		Turn    bool       `json:"turn"`
+		Finish  string     `json:"finish,omitempty"`
+		Parts   []cogBPart `json:"parts"`
+		Usage   any        `json:"usage,omitempty"`
+	}
+	var got []rec
+	for resp, err := range llm.GenerateContent(ctx, req, true) {
+		if err != nil {
+			t.Fatalf("stream: %v", err)
+		}
+		r := rec{Partial: resp.Partial, Turn: resp.TurnComplete, Finish: string(resp.FinishReason)}
+		if resp.Content != nil {
+			r.Role = resp.Content.Role
+			r.Parts = cogBParts(resp.Content.Parts)
+		}
+		if resp.UsageMetadata != nil {
+			r.Usage = resp.UsageMetadata
+		}
+		got = append(got, r)
+	}
+
+	const want = `[{"role":"model","partial":true,"turn":false,"parts":[{"text":"Hel"}]},{"role":"model","partial":true,"turn":false,"parts":[{"text":"lo"}]},{"role":"thinking","partial":true,"turn":false,"parts":[{"text":"hmm"}]},{"role":"model","partial":false,"turn":true,"finish":"STOP","parts":[{"text":"Hello"},{"fc_name":"bash","fc_id":"toolu_9","fc_args":{"cmd":"ls"}}],"usage":{"cachedContentTokenCount":9,"candidatesTokenCount":42,"promptTokenCount":17}}]`
+	if g := cogBMarshal(t, got); g != want {
+		t.Errorf("stream sequence:\n got %s\nwant %s", g, want)
+	}
+}
+
+// TestCogProviderBStreamingStopsOnConsumerBreak pins the early-exit path of
+// antHandleContentBlockDelta: once the consumer stops reading, no further
+// events are yielded.
+func TestCogProviderBStreamingStopsOnConsumerBreak(t *testing.T) {
+	for _, deltaType := range []string{"text_delta", "thinking_delta"} {
+		t.Run(deltaType, func(t *testing.T) {
+			delta := map[string]any{"type": deltaType}
+			if deltaType == "text_delta" {
+				delta["text"] = "a"
+			} else {
+				delta["thinking"] = "a"
+			}
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					return
+				}
+				for range 3 {
+					b, err := json.Marshal(map[string]any{
+						"type": "content_block_delta", "index": 0, "delta": delta,
+					})
+					if err != nil {
+						return
+					}
+					if _, err := w.Write([]byte("event: content_block_delta\ndata: " + string(b) + "\n\n")); err != nil {
+						return
+					}
+					flusher.Flush()
+				}
+			}))
+			defer srv.Close()
+
+			ctx := context.Background()
+			llm, err := NewAnthropic(ctx, "claude-sonnet-4-6", "sk-test", srv.URL, "none", nil)
+			if err != nil {
+				t.Fatalf("NewAnthropic: %v", err)
+			}
+			req := &model.LLMRequest{Contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+			}}
+
+			n := 0
+			for range llm.GenerateContent(ctx, req, true) {
+				n++
+				break
+			}
+			if n != 1 {
+				t.Errorf("yielded %d responses after break, want 1", n)
+			}
+		})
+	}
+}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -133,70 +133,80 @@ func (m *ollamaModel) Name() string { return m.modelName }
 
 func (m *ollamaModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		messages, systemPrompt := ollamaContentsToMessages(req.Contents, req.Config)
+		chatReq := m.buildChatRequest(req)
 
-		// Prepend system message if present.
-		if systemPrompt != "" {
-			messages = append([]ollamaapi.Message{{Role: "system", Content: systemPrompt}}, messages...)
-		}
-
-		modelName := m.modelName
-		if req.Model != "" {
-			modelName = req.Model
-		}
-
-		chatReq := &ollamaapi.ChatRequest{
-			Model:    modelName,
-			Messages: messages,
-		}
-
-		if n := ollamaNumPredict(); n > 0 {
-			if chatReq.Options == nil {
-				chatReq.Options = map[string]any{}
-			}
-			chatReq.Options["num_predict"] = n
-		}
-
-		if sampling := ollamaSamplingOptions(); len(sampling) > 0 {
-			if chatReq.Options == nil {
-				chatReq.Options = map[string]any{}
-			}
-			for k, v := range sampling {
-				chatReq.Options[k] = v
-			}
-		}
-
-		// No num_ctx for cloud models. api.ollama.com already serves each model
-		// at its native window, and sending a fixed value caps it instead of
-		// raising it: deepseek-v4-flash:0731-cloud has 1M, so the 256K that
-		// used to be set here would have thrown away three quarters of it.
-		//
-		// The old test also only matched ":cloud", never the ":<size>-cloud"
-		// form that most of the cloud catalog uses, so it silently did nothing
-		// for those models — the routing checks in config.go and provider.go
-		// accept both suffixes.
-
-		// Configure thinking. nothink models must not have thinking forced on.
-		if strings.Contains(strings.ToLower(modelName), "nothink") {
-			chatReq.Think = &ollamaapi.ThinkValue{Value: false}
-		} else if thinkCfg := ollamaThinkingConfig(m.thinkingLevel); thinkCfg != nil {
-			chatReq.Think = thinkCfg
-		}
-
-		// Convert tools.
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			chatReq.Tools = ollamaGenaiToolsToOllama(req.Config.Tools)
-		}
-
-		if stream {
-			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
-				ollamaRunStreaming(ctx, m.client, chatReq, y)
-			})
-		} else {
+		if !stream {
 			chatReq.Stream = new(false)
 			ollamaRunNonStreaming(ctx, m.client, chatReq, yield)
+			return
 		}
+
+		retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
+			ollamaRunStreaming(ctx, m.client, chatReq, y)
+		})
 	}
+}
+
+// buildChatRequest assembles the /api/chat request for one turn.
+//
+// No num_ctx is set, for cloud models or any other. api.ollama.com already
+// serves each model at its native window, and sending a fixed value caps it
+// instead of raising it: deepseek-v4-flash:0731-cloud has 1M, so the 256K that
+// used to be set here would have thrown away three quarters of it.
+//
+// The old test also only matched ":cloud", never the ":<size>-cloud" form that
+// most of the cloud catalog uses, so it silently did nothing for those models —
+// the routing checks in config.go and provider.go accept both suffixes.
+func (m *ollamaModel) buildChatRequest(req *model.LLMRequest) *ollamaapi.ChatRequest {
+	messages, systemPrompt := ollamaContentsToMessages(req.Contents, req.Config)
+
+	// Prepend system message if present.
+	if systemPrompt != "" {
+		messages = append([]ollamaapi.Message{{Role: "system", Content: systemPrompt}}, messages...)
+	}
+
+	modelName := m.modelName
+	if req.Model != "" {
+		modelName = req.Model
+	}
+
+	chatReq := &ollamaapi.ChatRequest{
+		Model:    modelName,
+		Messages: messages,
+		Options:  ollamaChatOptions(),
+		Think:    ollamaThinkValue(modelName, m.thinkingLevel),
+	}
+
+	// Convert tools.
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		chatReq.Tools = ollamaGenaiToolsToOllama(req.Config.Tools)
+	}
+
+	return chatReq
+}
+
+// ollamaChatOptions collects the per-request entries of the Ollama options map,
+// returning nil when none apply so the field stays absent and the server's own
+// defaults hold.
+func ollamaChatOptions() map[string]any {
+	opts := ollamaSamplingOptions()
+	if n := ollamaNumPredict(); n > 0 {
+		opts["num_predict"] = n
+	}
+	if len(opts) == 0 {
+		return nil
+	}
+	return opts
+}
+
+// ollamaThinkValue resolves the think field for one request. nothink models must
+// not have thinking forced on, whichever level the session is running at; a nil
+// result leaves the field off so the model's own default applies.
+func ollamaThinkValue(modelName, thinkingLevel string) *ollamaapi.ThinkValue {
+	if strings.Contains(strings.ToLower(modelName), "nothink") {
+		return &ollamaapi.ThinkValue{Value: false}
+	}
+	return ollamaThinkingConfig(thinkingLevel)
 }
 
 // ollamaThinkingConfig maps a thinking level string to Ollama ThinkValue.
@@ -416,45 +426,64 @@ func ollamaTextMessage(role, text string) ollamaapi.Message {
 func ollamaGenaiToolsToOllama(tools []*genai.Tool) ollamaapi.Tools {
 	var out ollamaapi.Tools
 	for _, t := range tools {
-		if t == nil || t.FunctionDeclarations == nil {
+		if t == nil {
 			continue
 		}
 		for _, fd := range t.FunctionDeclarations {
 			if fd == nil {
 				continue
 			}
-			params := ollamaapi.ToolFunctionParameters{
-				Type:       "object",
-				Properties: ollamaapi.NewToolPropertiesMap(),
-			}
-
-			if m := schemaToMap(fd.ParametersJsonSchema); m != nil {
-				if props, ok := m["properties"].(map[string]any); ok {
-					for name, propRaw := range props {
-						prop := convertToToolProperty(propRaw)
-						params.Properties.Set(name, prop)
-					}
-				}
-				if required, ok := m["required"].([]any); ok {
-					for _, r := range required {
-						if s, ok := r.(string); ok {
-							params.Required = append(params.Required, s)
-						}
-					}
-				}
-			}
-
 			out = append(out, ollamaapi.Tool{
 				Type: "function",
 				Function: ollamaapi.ToolFunction{
 					Name:        fd.Name,
 					Description: fd.Description,
-					Parameters:  params,
+					Parameters:  ollamaToolParameters(fd.ParametersJsonSchema),
 				},
 			})
 		}
 	}
 	return out
+}
+
+// ollamaToolParameters renders one declaration's JSON schema as Ollama's
+// parameter object. The Properties map is always allocated, even for a
+// declaration that takes no arguments, and Required is left nil unless the
+// schema carries a list with at least one string in it.
+func ollamaToolParameters(rawSchema any) ollamaapi.ToolFunctionParameters {
+	params := ollamaapi.ToolFunctionParameters{
+		Type:       "object",
+		Properties: ollamaapi.NewToolPropertiesMap(),
+	}
+	m := schemaToMap(rawSchema)
+	if m == nil {
+		return params
+	}
+	if props, ok := m["properties"].(map[string]any); ok {
+		for name, propRaw := range props {
+			params.Properties.Set(name, convertToToolProperty(propRaw))
+		}
+	}
+	params.Required = append(params.Required, jsonSchemaRequiredNames(m["required"])...)
+	return params
+}
+
+// jsonSchemaRequiredNames reads the string entries of a JSON schema "required"
+// list. Anything that is not a list, and any entry in it that is not a string,
+// is dropped: the schema reaches here as `any` and a malformed one must not
+// take down the request that carries it.
+func jsonSchemaRequiredNames(raw any) []string {
+	list, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(list))
+	for _, r := range list {
+		if s, ok := r.(string); ok {
+			names = append(names, s)
+		}
+	}
+	return names
 }
 
 // schemaToMap normalizes a genai FunctionDeclaration.ParametersJsonSchema (typed
@@ -756,30 +785,49 @@ func OllamaContextWindowSize(ctx context.Context, baseURL, modelName string) int
 		return 0
 	}
 
-	// Parameters is a newline-separated list of "key value" pairs.
 	// num_ctx takes precedence as it reflects the configured context window.
-	for _, line := range strings.Split(resp.Parameters, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) == 2 && fields[0] == "num_ctx" {
-			if n, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
-				return n
-			}
-		}
+	if n, ok := ollamaNumCtxParameter(resp.Parameters); ok {
+		return n
 	}
 
 	// Fall back to the model's native context length from ModelInfo.
-	for key, val := range resp.ModelInfo {
-		if strings.HasSuffix(key, ".context_length") {
-			switch v := val.(type) {
-			case float64:
-				return int64(v)
-			case int64:
-				return v
-			case int:
-				return int64(v)
-			}
+	return ollamaNativeContextLength(resp.ModelInfo)
+}
+
+// ollamaNumCtxParameter reads num_ctx out of a /api/show parameters block, which
+// is a newline-separated list of "key value" pairs. The second return says
+// whether a value was found at all, so a configured num_ctx of 0 is reported as
+// itself rather than falling through to the native context length.
+func ollamaNumCtxParameter(parameters string) (int64, bool) {
+	for _, line := range strings.Split(parameters, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != "num_ctx" {
+			continue
+		}
+		if n, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
+			return n, true
 		}
 	}
+	return 0, false
+}
 
+// ollamaNativeContextLength reads the model's native context length out of a
+// /api/show model_info map, returning 0 when no key carries one. A value that
+// arrived over HTTP is always a float64; the integer cases are here for a map
+// built in process.
+func ollamaNativeContextLength(modelInfo map[string]any) int64 {
+	for key, val := range modelInfo {
+		if !strings.HasSuffix(key, ".context_length") {
+			continue
+		}
+		switch v := val.(type) {
+		case float64:
+			return int64(v)
+		case int64:
+			return v
+		case int:
+			return int64(v)
+		}
+	}
 	return 0
 }

--- a/internal/provider/xai.go
+++ b/internal/provider/xai.go
@@ -92,61 +92,80 @@ func (m *xaiModel) GenerateContent(ctx context.Context, req *model.LLMRequest, s
 			_ = yield(nil, fmt.Errorf("xAI responses: nil LLM request"))
 			return
 		}
-		input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
+		params, err := m.buildXAIResponsesParams(req)
 		if err != nil {
-			_ = yield(nil, fmt.Errorf("xAI responses input: %w", err))
+			_ = yield(nil, err)
 			return
 		}
 
-		modelName := req.Model
-		if modelName == "" {
-			modelName = m.modelName
-		}
-
-		params := responses.ResponseNewParams{
-			Model: modelName,
-			Input: input,
-			// Match the OpenAI Responses default: do not persist the turn
-			// server-side. Multi-turn continues via the full conversation
-			// replayed in params.Input.
-			Store: param.NewOpt(false),
-		}
-		if instructions != "" {
-			params.Instructions = param.NewOpt(instructions)
-		}
-
-		tools := xaiRequestTools(req, m.enableXAITools)
-		if len(tools) > 0 {
-			params.Tools = tools
-		}
-
-		if m.reasoningEffort != "" && xaiModelReasons(modelName) {
-			params.Reasoning = shared.ReasoningParam{Effort: m.reasoningEffort}
-		}
-
+		// send performs the request once. It takes its own yield so retryStream
+		// can re-run it across attempts.
 		send := func(y func(*model.LLMResponse, error) bool) {
-			var sendErr error
-			if stream {
-				_, sendErr = m.runResponsesStreaming(ctx, params, y)
-			} else {
-				_, sendErr = m.runResponsesNonStreaming(ctx, params, y)
-			}
-			if sendErr == nil {
-				return
-			}
-			if stream {
-				_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: sendErr.Error()}, nil)
-				return
-			}
-			_ = y(nil, fmt.Errorf("xAI Responses API failed: %w", sendErr))
+			m.sendXAIResponses(ctx, params, stream, y)
 		}
 
-		if stream {
-			retryStream(ctx, streamRetryConfig(), yield, send)
-		} else {
+		if !stream {
 			send(yield)
+			return
 		}
+		retryStream(ctx, streamRetryConfig(), yield, send)
 	}
+}
+
+// buildXAIResponsesParams assembles the Responses request for one turn.
+func (m *xaiModel) buildXAIResponsesParams(req *model.LLMRequest) (responses.ResponseNewParams, error) {
+	input, instructions, err := oaiContentsToResponsesInput(req.Contents, req.Config)
+	if err != nil {
+		return responses.ResponseNewParams{}, fmt.Errorf("xAI responses input: %w", err)
+	}
+
+	modelName := req.Model
+	if modelName == "" {
+		modelName = m.modelName
+	}
+
+	params := responses.ResponseNewParams{
+		Model: modelName,
+		Input: input,
+		// Match the OpenAI Responses default: do not persist the turn
+		// server-side. Multi-turn continues via the full conversation
+		// replayed in params.Input.
+		Store: param.NewOpt(false),
+	}
+	if instructions != "" {
+		params.Instructions = param.NewOpt(instructions)
+	}
+	if tools := xaiRequestTools(req, m.enableXAITools); len(tools) > 0 {
+		params.Tools = tools
+	}
+	if m.reasoningEffort != "" && xaiModelReasons(modelName) {
+		params.Reasoning = shared.ReasoningParam{Effort: m.reasoningEffort}
+	}
+	return params, nil
+}
+
+// sendXAIResponses runs one Responses request and reports a failure in the shape
+// the caller's mode expects: a STREAM_ERROR response while streaming, so the
+// turn ends cleanly, and a yielded error otherwise.
+//
+// The name keeps it distinct from the embedded openaiModel's sendResponses,
+// which it does not replace: that one also recovers from a rejected
+// previous_response_id, and xAI requests never carry one.
+func (m *xaiModel) sendXAIResponses(ctx context.Context, params responses.ResponseNewParams, stream bool, y func(*model.LLMResponse, error) bool) {
+	var err error
+	if stream {
+		_, err = m.runResponsesStreaming(ctx, params, y)
+	} else {
+		_, err = m.runResponsesNonStreaming(ctx, params, y)
+	}
+	if err == nil {
+		return
+	}
+	if stream {
+		_ = y(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+		return
+	}
+	_ = y(nil, fmt.Errorf("xAI Responses API failed: %w", err))
 }
 
 // xaiRequestTools is the function declarations from the ADK request plus

--- a/internal/session/compaction.go
+++ b/internal/session/compaction.go
@@ -164,43 +164,65 @@ const SummaryPrefix = "Another language model started to solve this problem and 
 // budget with no way to recover.
 func LLMSummarizer(ctx context.Context, llm llmmodel.LLM) Summarizer {
 	return func(events []*session.Event) (string, error) {
-		if llm == nil {
-			return SimpleSummarizer(events)
-		}
-		transcript := renderTranscript(events)
-		if strings.TrimSpace(transcript) == "" {
-			return SimpleSummarizer(events)
-		}
+		return summarizeWithLLM(ctx, llm, events)
+	}
+}
 
-		req := &llmmodel.LLMRequest{
-			Contents: []*genai.Content{
-				genai.NewContentFromText(transcript, genai.RoleUser),
-			},
-			Config: &genai.GenerateContentConfig{
-				SystemInstruction: genai.NewContentFromText(SummarizationPrompt, genai.RoleUser),
-			},
-		}
+// summarizeWithLLM is the body of the Summarizer LLMSummarizer returns. It
+// never fails: a model error or an empty answer degrades to a placeholder so
+// the caller still reclaims the context.
+func summarizeWithLLM(ctx context.Context, llm llmmodel.LLM, events []*session.Event) (string, error) {
+	if llm == nil {
+		return SimpleSummarizer(events)
+	}
+	transcript := renderTranscript(events)
+	if strings.TrimSpace(transcript) == "" {
+		return SimpleSummarizer(events)
+	}
 
-		var b strings.Builder
-		for resp, err := range llm.GenerateContent(ctx, req, false) {
-			if err != nil {
-				return degradedSummary(events, err), nil
-			}
-			if resp == nil || resp.Content == nil {
-				continue
-			}
-			for _, part := range resp.Content.Parts {
-				if part.Text != "" {
-					b.WriteString(part.Text)
-				}
-			}
-		}
+	summary, err := generateSummaryText(ctx, llm, transcript)
+	if err != nil {
+		return degradedSummary(events, err), nil
+	}
+	if summary == "" {
+		return degradedSummary(events, nil), nil
+	}
+	return summary, nil
+}
 
-		out := strings.TrimSpace(b.String())
-		if out == "" {
-			return degradedSummary(events, nil), nil
+// generateSummaryText asks the model to summarize the transcript and joins the
+// text of every part it streams back. A partial answer interrupted by an error
+// is discarded rather than returned: half a handoff summary reads as complete
+// to the resuming model.
+func generateSummaryText(ctx context.Context, llm llmmodel.LLM, transcript string) (string, error) {
+	req := &llmmodel.LLMRequest{
+		Contents: []*genai.Content{
+			genai.NewContentFromText(transcript, genai.RoleUser),
+		},
+		Config: &genai.GenerateContentConfig{
+			SystemInstruction: genai.NewContentFromText(SummarizationPrompt, genai.RoleUser),
+		},
+	}
+
+	var b strings.Builder
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			return "", err
 		}
-		return out, nil
+		if resp == nil || resp.Content == nil {
+			continue
+		}
+		appendPartText(&b, resp.Content.Parts)
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+// appendPartText writes the text of every part to b, in order.
+func appendPartText(b *strings.Builder, parts []*genai.Part) {
+	for _, part := range parts {
+		if part.Text != "" {
+			b.WriteString(part.Text)
+		}
 	}
 }
 
@@ -272,22 +294,30 @@ func filesTouched(events []*session.Event) []string {
 			continue
 		}
 		for _, part := range ev.Content.Parts {
-			if part.FunctionCall == nil {
-				continue
-			}
-			for _, key := range []string{"file_path", "path", "filePath"} {
-				v, ok := part.FunctionCall.Args[key]
-				if !ok {
-					continue
-				}
-				s, isStr := v.(string)
-				if !isStr || s == "" || seen[s] {
-					continue
-				}
-				seen[s] = true
-				out = append(out, s)
-			}
+			out = appendCallFilePaths(out, seen, part)
 		}
+	}
+	return out
+}
+
+// filePathArgKeys are the tool-call argument names that name a file, in the
+// order they are collected.
+var filePathArgKeys = []string{"file_path", "path", "filePath"}
+
+// appendCallFilePaths appends the not-yet-seen paths named by part's
+// function-call arguments, marking each one in seen. Non-string and empty
+// values carry no trail, so they are skipped.
+func appendCallFilePaths(out []string, seen map[string]bool, part *genai.Part) []string {
+	if part.FunctionCall == nil {
+		return out
+	}
+	for _, key := range filePathArgKeys {
+		s, isStr := part.FunctionCall.Args[key].(string)
+		if !isStr || s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
 	}
 	return out
 }

--- a/internal/session/compaction_shed.go
+++ b/internal/session/compaction_shed.go
@@ -66,40 +66,62 @@ func ShedSupersededToolResultsWithDedup(
 		return events, res
 	}
 
-	// Index every FunctionCall by its ID so a FunctionResponse can look up the
-	// args it was answering. Without this, the read tool's response (which only
-	// carries content/total_lines/truncated, not file_path) would key on
-	// nothing and two unrelated reads would collapse.
-	callsByID := indexFunctionCalls(events)
+	pass := &shedPass{
+		seen: make(map[string]bool),
+		// Index every FunctionCall by its ID so a FunctionResponse can look up
+		// the args it was answering. Without this, the read tool's response
+		// (which only carries content/total_lines/truncated, not file_path)
+		// would key on nothing and two unrelated reads would collapse.
+		callsByID:     indexFunctionCalls(events),
+		dedupPointers: dedupPointers,
+		res:           res,
+	}
 
 	// Walk backwards so the first sighting of a (tool, args) key is the newest
 	// call — the one worth keeping.
-	seen := make(map[string]bool)
 	for i := cutoff - 1; i >= 0; i-- {
 		ev := events[i]
 		if ev == nil || ev.Content == nil {
 			continue
 		}
-		for _, part := range ev.Content.Parts {
-			fr := part.FunctionResponse
-			if fr == nil || fr.Response == nil {
-				continue
-			}
-			if isDedupPointer(fr, dedupPointers) {
-				continue
-			}
-			key := fr.Name + "\x00" + responseTargetKey(fr, callsByID)
-			if !seen[key] {
-				seen[key] = true
-				continue
-			}
-			if n := shedResponsePayload(fr); n > 0 {
-				res.ResultsShed++
-				res.BytesReclaimed += n
-			}
+		pass.shedParts(ev.Content.Parts)
+	}
+	return events, pass.res
+}
+
+// shedPass is the state one backwards shedding walk carries: the (tool, target)
+// keys already sighted — the first sighting is the newest and is kept — the
+// call index responses are keyed through, the deduper's pointer set, and the
+// running tally.
+type shedPass struct {
+	seen          map[string]bool
+	callsByID     map[string]*genai.FunctionCall
+	dedupPointers map[string]bool
+	res           ShedResult
+}
+
+// shedParts sheds the superseded tool results among one event's parts. A part
+// that is not a tool result, and one holding a dedup pointer rather than a
+// payload of its own, are both out of scope.
+func (p *shedPass) shedParts(parts []*genai.Part) {
+	for _, part := range parts {
+		fr := part.FunctionResponse
+		if fr == nil || fr.Response == nil {
+			continue
+		}
+		if isDedupPointer(fr, p.dedupPointers) {
+			continue
+		}
+		key := fr.Name + "\x00" + responseTargetKey(fr, p.callsByID)
+		if !p.seen[key] {
+			p.seen[key] = true
+			continue
+		}
+		if n := shedResponsePayload(fr); n > 0 {
+			p.res.ResultsShed++
+			p.res.BytesReclaimed += n
 		}
 	}
-	return events, res
 }
 
 // indexFunctionCalls walks the events once and records every FunctionCall by
@@ -111,22 +133,28 @@ func indexFunctionCalls(events []*session.Event) map[string]*genai.FunctionCall 
 		if ev == nil || ev.Content == nil {
 			continue
 		}
-		for _, part := range ev.Content.Parts {
-			if part == nil || part.FunctionCall == nil {
-				continue
-			}
-			fc := part.FunctionCall
-			if fc.ID == "" {
-				continue
-			}
-			// Keep the first sighting — a second FunctionCall with the same ID
-			// is a duplicate, and the first is the authoritative pair partner.
-			if _, dup := out[fc.ID]; !dup {
-				out[fc.ID] = fc
-			}
-		}
+		indexPartCalls(out, ev.Content.Parts)
 	}
 	return out
+}
+
+// indexPartCalls records each part's FunctionCall in out under its ID. Calls
+// with no ID cannot be paired with a response, so they are skipped.
+func indexPartCalls(out map[string]*genai.FunctionCall, parts []*genai.Part) {
+	for _, part := range parts {
+		if part == nil || part.FunctionCall == nil {
+			continue
+		}
+		fc := part.FunctionCall
+		if fc.ID == "" {
+			continue
+		}
+		// Keep the first sighting — a second FunctionCall with the same ID
+		// is a duplicate, and the first is the authoritative pair partner.
+		if _, dup := out[fc.ID]; !dup {
+			out[fc.ID] = fc
+		}
+	}
 }
 
 // isDedupPointer reports whether the response's primary field is a dedup

--- a/internal/session/complexity_cog_session_test.go
+++ b/internal/session/complexity_cog_session_test.go
@@ -1,0 +1,574 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+
+	adkmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// These tests pin the branch structure of ShedSupersededToolResultsWithDedup,
+// LLMSummarizer, filesTouched and indexFunctionCalls before those functions
+// were flattened for cognitive complexity.
+//
+// Shedding deserves the detail: it decides which tool results are dropped
+// before a session is sent to the model, and both failure modes are silent at
+// the call site — shedding too little bloats the context, shedding too much
+// discards a result the model still needed. Every skip, cutoff and tally the
+// original nesting encoded therefore gets a case here.
+
+// --- builders ---------------------------------------------------------------
+
+// cogEvent wraps explicit parts in a user-role event.
+func cogEvent(parts ...*genai.Part) *session.Event {
+	ev := &session.Event{Author: "tool"}
+	ev.Content = &genai.Content{Role: string(genai.RoleUser), Parts: parts}
+	return ev
+}
+
+// cogCallPart builds a FunctionCall part.
+func cogCallPart(id, name string, args map[string]any) *genai.Part {
+	return &genai.Part{FunctionCall: &genai.FunctionCall{ID: id, Name: name, Args: args}}
+}
+
+// cogRespPart builds a FunctionResponse part.
+func cogRespPart(id, name string, resp map[string]any) *genai.Part {
+	return &genai.Part{FunctionResponse: &genai.FunctionResponse{ID: id, Name: name, Response: resp}}
+}
+
+// cogBody returns a payload comfortably above shedMinBytes so it is a shed
+// candidate, tagged so tests can tell two payloads apart.
+func cogBody(tag string) string {
+	return tag + strings.Repeat("z", shedMinBytes*2)
+}
+
+// cogContent reads back the "content" field of a response part.
+func cogContent(ev *session.Event, part int) string {
+	s, _ := ev.Content.Parts[part].FunctionResponse.Response["content"].(string)
+	return s
+}
+
+// --- shedding ---------------------------------------------------------------
+
+// TestShedWithDedup_NoOpBoundaries pins every early return: an empty or nil
+// event slice, and a keepRecent that protects the whole conversation. In all
+// of them the input slice comes back unchanged and nothing is tallied.
+func TestShedWithDedup_NoOpBoundaries(t *testing.T) {
+	body := cogBody("a")
+	full := []*session.Event{
+		cogEvent(cogRespPart("c1", "read", map[string]any{"content": body})),
+		cogEvent(cogRespPart("c2", "read", map[string]any{"content": body})),
+	}
+
+	tests := []struct {
+		name        string
+		events      []*session.Event
+		keepRecent  int
+		wantScanned int
+	}{
+		{"nil events", nil, 0, 0},
+		{"empty events", []*session.Event{}, 5, 0},
+		{"keepRecent equals length", full, 2, 2},
+		{"keepRecent exceeds length", full, 99, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, res := ShedSupersededToolResultsWithDedup(tc.events, tc.keepRecent, nil)
+			if len(out) != len(tc.events) {
+				t.Fatalf("len(out) = %d, want %d", len(out), len(tc.events))
+			}
+			if res.EventsScanned != tc.wantScanned {
+				t.Errorf("EventsScanned = %d, want %d", res.EventsScanned, tc.wantScanned)
+			}
+			if res.ResultsShed != 0 || res.BytesReclaimed != 0 {
+				t.Errorf("ResultsShed/BytesReclaimed = %d/%d, want 0/0", res.ResultsShed, res.BytesReclaimed)
+			}
+		})
+	}
+	// The protected events must still hold their full payloads.
+	for i := range full {
+		if cogContent(full[i], 0) != body {
+			t.Errorf("event %d was shed despite being inside the protected tail", i)
+		}
+	}
+}
+
+// TestShedWithDedup_NegativeKeepRecentClampsToZero pins that a negative
+// keepRecent is treated as zero rather than shortening the window (a negative
+// cutoff would silently protect the whole conversation).
+func TestShedWithDedup_NegativeKeepRecentClampsToZero(t *testing.T) {
+	body := cogBody("b")
+	events := []*session.Event{
+		cogEvent(cogRespPart("c1", "read", map[string]any{"file_path": "/a.go", "content": body})),
+		cogEvent(cogRespPart("c2", "read", map[string]any{"file_path": "/a.go", "content": body})),
+	}
+	_, res := ShedSupersededToolResultsWithDedup(events, -7, nil)
+	if res.ResultsShed != 1 {
+		t.Fatalf("ResultsShed = %d, want 1 — negative keepRecent must behave as 0", res.ResultsShed)
+	}
+	if cogContent(events[1], 0) != body {
+		t.Error("the newest result must survive in full")
+	}
+	if cogContent(events[0], 0) == body {
+		t.Error("the superseded result should have been shed")
+	}
+}
+
+// TestShedWithDedup_SkipsNonCandidateParts pins the skip ladder inside the
+// walk: a nil event, an event with nil Content, a text part, a function-call
+// part, and a response with a nil Response map are all stepped over without
+// stopping the pass — the real superseded result later in the slice is still
+// shed.
+func TestShedWithDedup_SkipsNonCandidateParts(t *testing.T) {
+	body := cogBody("c")
+	nilContent := &session.Event{Author: "pi"}
+	events := []*session.Event{
+		nil,
+		nilContent,
+		cogEvent(&genai.Part{Text: "thinking out loud"}),
+		cogEvent(cogCallPart("cx", "read", map[string]any{"file_path": "/unpaired.go"})),
+		cogEvent(&genai.Part{FunctionResponse: &genai.FunctionResponse{ID: "c9", Name: "read"}}),
+		cogEvent(cogRespPart("c1", "read", map[string]any{"file_path": "/a.go", "content": body})),
+		cogEvent(cogRespPart("c2", "read", map[string]any{"file_path": "/a.go", "content": body})),
+	}
+
+	out, res := ShedSupersededToolResultsWithDedup(events, 0, nil)
+	if len(out) != len(events) {
+		t.Fatalf("len(out) = %d, want %d — shedding must not reshape the slice", len(out), len(events))
+	}
+	if res.EventsScanned != len(events) {
+		t.Errorf("EventsScanned = %d, want %d", res.EventsScanned, len(events))
+	}
+	if res.ResultsShed != 1 {
+		t.Fatalf("ResultsShed = %d, want 1", res.ResultsShed)
+	}
+	if res.BytesReclaimed != len(body) {
+		t.Errorf("BytesReclaimed = %d, want %d", res.BytesReclaimed, len(body))
+	}
+	if cogContent(events[6], 0) != body {
+		t.Error("the newest result must survive in full")
+	}
+	if got := cogContent(events[5], 0); got == body || !strings.Contains(got, "superseded") {
+		t.Errorf("older result = %q, want a superseded stub", got)
+	}
+}
+
+// TestShedWithDedup_ShedsEveryOlderResultOnOneTarget pins the tally across
+// more than one shed: with three reads of the same file only the newest
+// survives, and BytesReclaimed is the sum of both dropped payloads.
+func TestShedWithDedup_ShedsEveryOlderResultOnOneTarget(t *testing.T) {
+	first, second, third := cogBody("1"), cogBody("22"), cogBody("333")
+	events := []*session.Event{
+		cogEvent(cogRespPart("c1", "read", map[string]any{"file_path": "/a.go", "content": first})),
+		cogEvent(cogRespPart("c2", "read", map[string]any{"file_path": "/a.go", "content": second})),
+		cogEvent(cogRespPart("c3", "read", map[string]any{"file_path": "/a.go", "content": third})),
+	}
+
+	_, res := ShedSupersededToolResultsWithDedup(events, 0, nil)
+	if res.ResultsShed != 2 {
+		t.Fatalf("ResultsShed = %d, want 2", res.ResultsShed)
+	}
+	if want := len(first) + len(second); res.BytesReclaimed != want {
+		t.Errorf("BytesReclaimed = %d, want %d (both dropped payloads)", res.BytesReclaimed, want)
+	}
+	if cogContent(events[2], 0) != third {
+		t.Error("the newest result must survive in full")
+	}
+}
+
+// TestShedWithDedup_ShedsBothPartsOfOneEvent pins that the inner part loop
+// keeps going after the first candidate: two superseded results carried by a
+// single event are both shed.
+func TestShedWithDedup_ShedsBothPartsOfOneEvent(t *testing.T) {
+	bodyA, bodyB := cogBody("A"), cogBody("B")
+	events := []*session.Event{
+		cogEvent(
+			cogRespPart("c1", "read", map[string]any{"file_path": "/a.go", "content": bodyA}),
+			cogRespPart("c2", "read", map[string]any{"file_path": "/b.go", "content": bodyB}),
+		),
+		cogEvent(
+			cogRespPart("c3", "read", map[string]any{"file_path": "/a.go", "content": bodyA}),
+			cogRespPart("c4", "read", map[string]any{"file_path": "/b.go", "content": bodyB}),
+		),
+	}
+
+	_, res := ShedSupersededToolResultsWithDedup(events, 0, nil)
+	if res.ResultsShed != 2 {
+		t.Fatalf("ResultsShed = %d, want 2 — both parts of the older event are superseded", res.ResultsShed)
+	}
+	if cogContent(events[0], 0) == bodyA || cogContent(events[0], 1) == bodyB {
+		t.Error("both older payloads should have been shed")
+	}
+	if cogContent(events[1], 0) != bodyA || cogContent(events[1], 1) != bodyB {
+		t.Error("both newer payloads must survive in full")
+	}
+}
+
+// TestShedWithDedup_KeepsFirstSeenPerToolName pins that the (tool, target)
+// key includes the tool name: the same path read by two different tools is
+// two targets, not one.
+func TestShedWithDedup_KeepsFirstSeenPerToolName(t *testing.T) {
+	body := cogBody("d")
+	events := []*session.Event{
+		cogEvent(cogRespPart("c1", "read", map[string]any{"file_path": "/a.go", "content": body})),
+		cogEvent(cogRespPart("c2", "grep", map[string]any{"file_path": "/a.go", "content": body})),
+	}
+	if _, res := ShedSupersededToolResultsWithDedup(events, 0, nil); res.ResultsShed != 0 {
+		t.Fatalf("ResultsShed = %d, want 0 — different tools are different targets", res.ResultsShed)
+	}
+}
+
+// TestShedWithDedup_EmptyPointerSetBehavesLikeNil pins that passing an empty
+// (rather than nil) dedup set does not change what is shed.
+func TestShedWithDedup_EmptyPointerSetBehavesLikeNil(t *testing.T) {
+	body := cogBody("e")
+	build := func() []*session.Event {
+		return []*session.Event{
+			cogEvent(cogRespPart("c1", "read", map[string]any{"file_path": "/a.go", "content": body})),
+			cogEvent(cogRespPart("c2", "read", map[string]any{"file_path": "/a.go", "content": body})),
+		}
+	}
+	_, withNil := ShedSupersededToolResultsWithDedup(build(), 0, nil)
+	_, withEmpty := ShedSupersededToolResultsWithDedup(build(), 0, map[string]bool{})
+	if withNil != withEmpty {
+		t.Errorf("nil set gave %+v, empty set gave %+v", withNil, withEmpty)
+	}
+}
+
+// TestIsDedupPointer_FieldLadder pins which response fields are inspected for
+// a deduper pointer and which value shapes are ignored.
+func TestIsDedupPointer_FieldLadder(t *testing.T) {
+	const pointer = "[identical to an earlier result]"
+	set := map[string]bool{pointer: true}
+
+	tests := []struct {
+		name string
+		resp map[string]any
+		set  map[string]bool
+		want bool
+	}{
+		{"nil pointer set", map[string]any{"content": pointer}, nil, false},
+		{"empty pointer set", map[string]any{"content": pointer}, map[string]bool{}, false},
+		{"content field", map[string]any{"content": pointer}, set, true},
+		{"stdout field", map[string]any{"stdout": pointer}, set, true},
+		{"output field", map[string]any{"output": pointer}, set, true},
+		{"result field", map[string]any{"result": pointer}, set, true},
+		{"unwatched field", map[string]any{"diff": pointer}, set, false},
+		{"non-string value", map[string]any{"content": 42}, set, false},
+		{"unrelated string", map[string]any{"content": "something else"}, set, false},
+		{"empty response map", map[string]any{}, set, false},
+		{"later field matches", map[string]any{"content": "no", "result": pointer}, set, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fr := &genai.FunctionResponse{Name: "read", Response: tc.resp}
+			if got := isDedupPointer(fr, tc.set); got != tc.want {
+				t.Errorf("isDedupPointer = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("nil response", func(t *testing.T) {
+		if isDedupPointer(nil, set) {
+			t.Error("isDedupPointer(nil) = true, want false")
+		}
+		if isDedupPointer(&genai.FunctionResponse{Name: "read"}, set) {
+			t.Error("isDedupPointer on a nil Response map = true, want false")
+		}
+	})
+}
+
+// --- call indexing -----------------------------------------------------------
+
+// TestIndexFunctionCalls_SkipsAndFirstWins pins that the index skips nil
+// events, nil Content, nil parts, non-call parts and empty IDs, and that the
+// first sighting of a duplicate ID is the one kept.
+func TestIndexFunctionCalls_SkipsAndFirstWins(t *testing.T) {
+	events := []*session.Event{
+		nil,
+		{Author: "pi"}, // nil Content
+		cogEvent(nil),
+		cogEvent(&genai.Part{Text: "no call here"}),
+		cogEvent(cogRespPart("r1", "read", map[string]any{"content": "x"})),
+		cogEvent(cogCallPart("", "read", map[string]any{"file_path": "/anon.go"})),
+		cogEvent(cogCallPart("dup", "read", map[string]any{"file_path": "/first.go"})),
+		cogEvent(cogCallPart("dup", "read", map[string]any{"file_path": "/second.go"})),
+		cogEvent(cogCallPart("solo", "grep", map[string]any{"pattern": "TODO"})),
+	}
+
+	got := indexFunctionCalls(events)
+	if len(got) != 2 {
+		t.Fatalf("index size = %d, want 2 (dup + solo)", len(got))
+	}
+	if _, ok := got[""]; ok {
+		t.Error("an empty call ID must not be indexed")
+	}
+	if fc := got["dup"]; fc == nil || fc.Args["file_path"] != "/first.go" {
+		t.Errorf("dup resolved to %v, want the first sighting (/first.go)", fc)
+	}
+	if fc := got["solo"]; fc == nil || fc.Name != "grep" {
+		t.Errorf("solo resolved to %v, want the grep call", fc)
+	}
+}
+
+// --- filesTouched -------------------------------------------------------------
+
+// TestFilesTouched_KeyLadderAndDedup pins which call-argument keys contribute
+// a path, in what order, and which values are ignored.
+func TestFilesTouched_KeyLadderAndDedup(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []*session.Event
+		want   []string
+	}{
+		{"nil events", nil, nil},
+		{"nil event and nil content", []*session.Event{nil, {Author: "pi"}}, nil},
+		{"no function call parts", []*session.Event{cogEvent(&genai.Part{Text: "hi"})}, nil},
+		{
+			"response parts contribute nothing",
+			[]*session.Event{cogEvent(cogRespPart("r", "read", map[string]any{"file_path": "/a.go"}))},
+			nil,
+		},
+		{
+			"no recognized key",
+			[]*session.Event{cogEvent(cogCallPart("c", "bash", map[string]any{"command": "ls"}))},
+			nil,
+		},
+		{
+			"nil args map",
+			[]*session.Event{cogEvent(cogCallPart("c", "read", nil))},
+			nil,
+		},
+		{
+			"file_path",
+			[]*session.Event{cogEvent(cogCallPart("c", "read", map[string]any{"file_path": "/a.go"}))},
+			[]string{"/a.go"},
+		},
+		{
+			"path",
+			[]*session.Event{cogEvent(cogCallPart("c", "read", map[string]any{"path": "/b.go"}))},
+			[]string{"/b.go"},
+		},
+		{
+			"filePath",
+			[]*session.Event{cogEvent(cogCallPart("c", "read", map[string]any{"filePath": "/c.go"}))},
+			[]string{"/c.go"},
+		},
+		{
+			"all three keys are collected in ladder order",
+			[]*session.Event{cogEvent(cogCallPart("c", "read", map[string]any{
+				"filePath": "/third.go", "path": "/second.go", "file_path": "/first.go",
+			}))},
+			[]string{"/first.go", "/second.go", "/third.go"},
+		},
+		{
+			"non-string and empty values are ignored",
+			[]*session.Event{cogEvent(cogCallPart("c", "read", map[string]any{
+				"file_path": 42, "path": "", "filePath": "/kept.go",
+			}))},
+			[]string{"/kept.go"},
+		},
+		{
+			"repeats across events are deduped, first order wins",
+			[]*session.Event{
+				cogEvent(cogCallPart("c1", "read", map[string]any{"file_path": "/a.go"})),
+				cogEvent(cogCallPart("c2", "read", map[string]any{"file_path": "/b.go"})),
+				cogEvent(cogCallPart("c3", "read", map[string]any{"file_path": "/a.go"})),
+			},
+			[]string{"/a.go", "/b.go"},
+		},
+		{
+			"two call parts on one event",
+			[]*session.Event{cogEvent(
+				cogCallPart("c1", "read", map[string]any{"file_path": "/a.go"}),
+				cogCallPart("c2", "read", map[string]any{"file_path": "/b.go"}),
+			)},
+			[]string{"/a.go", "/b.go"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filesTouched(tc.events)
+			if len(got) != len(tc.want) {
+				t.Fatalf("filesTouched = %v, want %v", got, tc.want)
+			}
+			for i, want := range tc.want {
+				if got[i] != want {
+					t.Errorf("filesTouched[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestDegradedSummary_ListsTouchedFiles pins the one caller of filesTouched:
+// a degraded summary must still leave the next model a trail to follow.
+func TestDegradedSummary_ListsTouchedFiles(t *testing.T) {
+	events := []*session.Event{
+		cogEvent(cogCallPart("c1", "read", map[string]any{"file_path": "/x.go"})),
+		cogEvent(cogCallPart("c2", "read", map[string]any{"path": "/y.go"})),
+	}
+	got := degradedSummary(events, errors.New("boom"))
+	for _, want := range []string{"/x.go", "/y.go", "boom", "Files touched before compaction"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("degradedSummary missing %q; got:\n%s", want, got)
+		}
+	}
+
+	// With no calls at all the file list is omitted entirely.
+	bare := degradedSummary([]*session.Event{cogEvent(&genai.Part{Text: "hi"})}, nil)
+	if strings.Contains(bare, "Files touched") {
+		t.Errorf("degradedSummary listed files when none were touched:\n%s", bare)
+	}
+	if strings.Contains(bare, "Summarizer error") {
+		t.Errorf("degradedSummary reported an error when none was given:\n%s", bare)
+	}
+}
+
+// --- LLMSummarizer ------------------------------------------------------------
+
+// cogScriptLLM is an in-process LLM that yields a fixed script of
+// (response, error) steps. It never touches the network, so these tests behave
+// identically with and without credentials in the environment.
+type cogScriptLLM struct {
+	steps  []cogStep
+	called int
+}
+
+type cogStep struct {
+	resp *adkmodel.LLMResponse
+	err  error
+}
+
+func (m *cogScriptLLM) Name() string { return "cog-script-model" }
+
+func (m *cogScriptLLM) GenerateContent(
+	_ context.Context, _ *adkmodel.LLMRequest, _ bool,
+) iter.Seq2[*adkmodel.LLMResponse, error] {
+	m.called++
+	return func(yield func(*adkmodel.LLMResponse, error) bool) {
+		for _, s := range m.steps {
+			if !yield(s.resp, s.err) {
+				return
+			}
+		}
+	}
+}
+
+// cogMultiPart builds a response whose Content carries several parts, so the
+// concatenation loop is exercised with text and non-text parts mixed.
+func cogMultiPart(texts ...string) *adkmodel.LLMResponse {
+	parts := make([]*genai.Part, 0, len(texts))
+	for _, s := range texts {
+		parts = append(parts, &genai.Part{Text: s})
+	}
+	return &adkmodel.LLMResponse{Content: &genai.Content{Role: string(genai.RoleModel), Parts: parts}}
+}
+
+// TestLLMSummarizer_StreamAssembly pins how the streamed response is turned
+// into a summary: text parts concatenate across parts and across responses,
+// empty-text parts contribute nothing, and a nil response or nil Content is
+// skipped rather than ending the stream.
+func TestLLMSummarizer_StreamAssembly(t *testing.T) {
+	events := []*session.Event{textEvent("user", "user", "please summarize")}
+
+	llm := &cogScriptLLM{steps: []cogStep{
+		{resp: nil},
+		{resp: &adkmodel.LLMResponse{}}, // nil Content
+		{resp: cogMultiPart("Alpha ", "", "Beta")},
+		{resp: cogMultiPart(" Gamma")},
+	}}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("summarizer: %v", err)
+	}
+	if got != "Alpha Beta Gamma" {
+		t.Errorf("summary = %q, want %q", got, "Alpha Beta Gamma")
+	}
+	if llm.called != 1 {
+		t.Errorf("GenerateContent called %d times, want 1", llm.called)
+	}
+}
+
+// TestLLMSummarizer_ErrorMidStreamDiscardsPartialText pins that an error
+// arriving after usable text still degrades: a half-written handoff summary
+// would read as complete to the resuming model, which is worse than an
+// explicit statement that detail was lost.
+func TestLLMSummarizer_ErrorMidStreamDiscardsPartialText(t *testing.T) {
+	events := []*session.Event{
+		textEvent("user", "user", "please summarize"),
+		cogEvent(cogCallPart("c1", "read", map[string]any{"file_path": "/trail.go"})),
+	}
+	llm := &cogScriptLLM{steps: []cogStep{
+		{resp: cogMultiPart("half a summary")},
+		{err: errors.New("stream broke")},
+		{resp: cogMultiPart("never reached")},
+	}}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("summarizer must not fail the compaction: %v", err)
+	}
+	if strings.Contains(got, "half a summary") {
+		t.Errorf("partial text leaked into the degraded summary:\n%s", got)
+	}
+	for _, want := range []string{"Compaction summary unavailable", "stream broke", "/trail.go"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("degraded summary missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// TestLLMSummarizer_WhitespaceOnlyOutputDegrades pins that a response made
+// only of whitespace counts as empty, not as a summary.
+func TestLLMSummarizer_WhitespaceOnlyOutputDegrades(t *testing.T) {
+	events := []*session.Event{textEvent("user", "user", "please summarize")}
+	llm := &cogScriptLLM{steps: []cogStep{{resp: cogMultiPart("   \n\t  ")}}}
+
+	got, err := LLMSummarizer(context.Background(), llm)(events)
+	if err != nil {
+		t.Fatalf("summarizer: %v", err)
+	}
+	if !strings.Contains(got, "Compaction summary unavailable") {
+		t.Errorf("whitespace-only output was accepted as a summary:\n%s", got)
+	}
+	if strings.Contains(got, "Summarizer error") {
+		t.Errorf("an empty (not failed) response must not report an error:\n%s", got)
+	}
+}
+
+// TestLLMSummarizer_SkipsModelForEmptyTranscript pins that the transcript
+// guard runs before the call: events with nothing renderable never reach the
+// model at all.
+func TestLLMSummarizer_SkipsModelForEmptyTranscript(t *testing.T) {
+	llm := &cogScriptLLM{steps: []cogStep{{resp: cogMultiPart("should not be used")}}}
+
+	for _, tc := range []struct {
+		name   string
+		events []*session.Event
+	}{
+		{"no events", nil},
+		{"nil content only", []*session.Event{{Author: "pi"}}},
+		{"empty text part", []*session.Event{cogEvent(&genai.Part{Text: ""})}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LLMSummarizer(context.Background(), llm)(tc.events)
+			if err != nil {
+				t.Fatalf("summarizer: %v", err)
+			}
+			if strings.Contains(got, "should not be used") {
+				t.Error("the model was consulted for an empty transcript")
+			}
+		})
+	}
+	if llm.called != 0 {
+		t.Errorf("GenerateContent called %d times, want 0", llm.called)
+	}
+}

--- a/internal/subagent/complexity_cog_spawnretry_test.go
+++ b/internal/subagent/complexity_cog_spawnretry_test.go
@@ -1,0 +1,484 @@
+package subagent
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sharedacp "github.com/dimetron/pi-go/internal/acp"
+)
+
+// These tests pin the retry behavior of (*Orchestrator).SpawnWithRetry before
+// it was flattened for cognitive complexity: how many attempts run, which
+// agent statuses count as retryable, that retries carry no backoff, what a
+// canceled context does mid-sequence, and what is left on the returned event
+// stream. They were written and run against the unrefactored function first,
+// so the literals below are recordings of the original behavior rather than
+// agreement with the new code.
+
+// acpAttemptRecorder counts how many times the ACP session factory was asked
+// for a session, which is one call per SpawnWithRetry attempt that reaches
+// dispatchACP.
+type acpAttemptRecorder struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (r *acpAttemptRecorder) next() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := r.count
+	r.count++
+	return n
+}
+
+func (r *acpAttemptRecorder) total() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.count
+}
+
+// installACPAttempts routes every ACP spawn through start, handing it the
+// zero-based attempt number so a test can script a different outcome per
+// attempt.
+func installACPAttempts(t *testing.T, rec *acpAttemptRecorder, start func(attempt int) (acpSession, error)) {
+	t.Helper()
+	prev := startACPSessionFn
+	startACPSessionFn = func(_ context.Context, _, _ string, _ SpawnOpts) (acpSession, error) {
+		return start(rec.next())
+	}
+	t.Cleanup(func() { startACPSessionFn = prev })
+}
+
+// forceRunningAgentStatus waits for the orchestrator to register a running
+// agent and overwrites its status, returning the agent id.
+//
+// SpawnWithRetry samples the tracked status the moment it sees a terminal
+// event, while forwardAgentEvents only writes that status after the process
+// stream closes. Setting the status before the terminal event is emitted is
+// what makes the crash branch deterministic instead of a scheduling race.
+func forceRunningAgentStatus(t *testing.T, o *Orchestrator, status string) string {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		o.mu.Lock()
+		for id, st := range o.agents {
+			if st.Status == "running" {
+				st.Status = status
+				o.mu.Unlock()
+				return id
+			}
+		}
+		o.mu.Unlock()
+		time.Sleep(time.Millisecond)
+	}
+	t.Errorf("no running agent registered within 3s")
+	return ""
+}
+
+// drainEventTypes reads an event stream to close and returns the types seen.
+func drainEventTypes(events <-chan Event) []string {
+	var types []string
+	for ev := range events {
+		types = append(types, ev.Type)
+	}
+	return types
+}
+
+func containsType(types []string, want string) bool {
+	for _, ty := range types {
+		if ty == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSpawnWithRetry_AttemptCountPinned pins the attempt arithmetic when every
+// spawn fails: MaxRetries is clamped to [0,3], the first try is not counted as
+// a retry, and the reported count is retries+1.
+func TestSpawnWithRetry_AttemptCountPinned(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxRetries int
+		wantSpawns int
+		wantErr    string
+	}{
+		{"negative clamps to zero", -1, 1, "spawn failed after 1 attempts"},
+		{"zero is a single attempt", 0, 1, "spawn failed after 1 attempts"},
+		{"one retry is two attempts", 1, 2, "spawn failed after 2 attempts"},
+		{"three retries is four attempts", 3, 4, "spawn failed after 4 attempts"},
+		{"above max clamps to three", 10, 4, "spawn failed after 4 attempts"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &acpAttemptRecorder{}
+			installACPAttempts(t, rec, func(int) (acpSession, error) {
+				return nil, stubError("start refused")
+			})
+
+			orch := NewOrchestrator(testConfig(), "", nil)
+			defer orch.Shutdown()
+
+			events, agentID, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+				Agent:      AgentConfig{Name: "claude", Role: "smol"},
+				Prompt:     "hi",
+				MaxRetries: tc.maxRetries,
+			})
+			if err == nil {
+				t.Fatal("expected a spawn failure")
+			}
+			if got := err.Error(); !strings.Contains(got, tc.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", got, tc.wantErr)
+			}
+			if !errors.Is(err, stubError("start refused")) {
+				t.Errorf("error %v does not wrap the underlying spawn error", err)
+			}
+			if events != nil {
+				t.Error("expected a nil event stream on total spawn failure")
+			}
+			if agentID != "" {
+				t.Errorf("agentID = %q, want empty on total spawn failure", agentID)
+			}
+			if got := rec.total(); got != tc.wantSpawns {
+				t.Errorf("spawn attempts = %d, want %d", got, tc.wantSpawns)
+			}
+		})
+	}
+}
+
+// TestSpawnWithRetry_NoBackoffBetweenAttempts pins that the retry loop
+// re-spawns immediately. There is no sleep and no backoff schedule, so four
+// failing attempts finish essentially instantly; a flattening that introduced
+// a delay would show up here.
+func TestSpawnWithRetry_NoBackoffBetweenAttempts(t *testing.T) {
+	rec := &acpAttemptRecorder{}
+	installACPAttempts(t, rec, func(int) (acpSession, error) {
+		return nil, stubError("start refused")
+	})
+
+	orch := NewOrchestrator(testConfig(), "", nil)
+	defer orch.Shutdown()
+
+	start := time.Now()
+	_, _, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+		Agent:      AgentConfig{Name: "claude", Role: "smol"},
+		Prompt:     "hi",
+		MaxRetries: 3,
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a spawn failure")
+	}
+	if rec.total() != 4 {
+		t.Fatalf("spawn attempts = %d, want 4", rec.total())
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("four attempts took %s; the loop retries with no backoff and should be near-instant", elapsed)
+	}
+}
+
+// TestSpawnWithRetry_StatusClassification pins which tracked statuses count as
+// a crash worth re-spawning. Only "failed" and "killed" retry; every other
+// terminal status is handed back to the caller as a success.
+func TestSpawnWithRetry_StatusClassification(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		wantSpawns int
+	}{
+		{"failed retries", "failed", 2},
+		{"killed retries", "killed", 2},
+		{"canceled does not retry", "canceled", 1},
+		{"completed does not retry", "completed", 1},
+		{"timeout does not retry", "timeout", 1},
+		{"unrecognized status does not retry", "running-observed", 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orch := NewOrchestrator(testConfig(), "", nil)
+			defer orch.Shutdown()
+
+			var (
+				idMu    sync.Mutex
+				firstID string
+			)
+			rec := &acpAttemptRecorder{}
+			installACPAttempts(t, rec, func(attempt int) (acpSession, error) {
+				sess := newFakeACPSession()
+				go func() {
+					if attempt == 0 {
+						id := forceRunningAgentStatus(t, orch, tc.status)
+						idMu.Lock()
+						firstID = id
+						idMu.Unlock()
+						sess.events <- sharedacp.Event{Type: sharedacp.EventTypeError, Error: "boom", SessionID: "s"}
+						sess.finish(sharedacp.RunResult{Status: sharedacp.StatusError, Error: "boom", SessionID: "s"})
+						return
+					}
+					sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "ok", SessionID: "s"}
+					sess.finish(sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: "ok", SessionID: "s"})
+				}()
+				return sess, nil
+			})
+
+			events, agentID, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+				Agent:      AgentConfig{Name: "claude", Role: "smol"},
+				Prompt:     "hi",
+				MaxRetries: 1,
+			})
+			if err != nil {
+				t.Fatalf("SpawnWithRetry: %v", err)
+			}
+			if events == nil {
+				t.Fatal("expected a non-nil event stream")
+			}
+			if got := rec.total(); got != tc.wantSpawns {
+				t.Errorf("spawn attempts = %d, want %d", got, tc.wantSpawns)
+			}
+
+			idMu.Lock()
+			first := firstID
+			idMu.Unlock()
+			if tc.wantSpawns == 1 && agentID != first {
+				t.Errorf("agentID = %q, want the first agent %q", agentID, first)
+			}
+			if tc.wantSpawns == 2 && agentID == first {
+				t.Errorf("agentID = %q, want a different agent than the crashed %q", agentID, first)
+			}
+
+			drainEventTypes(events)
+		})
+	}
+}
+
+// TestSpawnWithRetry_CrashOnEveryAttempt pins the exhausted-retry failure: the
+// error names the agent and the attempt count, the event stream comes back
+// nil, and the agent id of the last attempt is still returned alongside it.
+func TestSpawnWithRetry_CrashOnEveryAttempt(t *testing.T) {
+	orch := NewOrchestrator(testConfig(), "", nil)
+	defer orch.Shutdown()
+
+	var (
+		idMu sync.Mutex
+		ids  []string
+	)
+	rec := &acpAttemptRecorder{}
+	installACPAttempts(t, rec, func(int) (acpSession, error) {
+		sess := newFakeACPSession()
+		go func() {
+			id := forceRunningAgentStatus(t, orch, "failed")
+			idMu.Lock()
+			ids = append(ids, id)
+			idMu.Unlock()
+			sess.events <- sharedacp.Event{Type: sharedacp.EventTypeError, Error: "boom", SessionID: "s"}
+			sess.finish(sharedacp.RunResult{Status: sharedacp.StatusError, Error: "boom", SessionID: "s"})
+		}()
+		return sess, nil
+	})
+
+	events, agentID, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+		Agent:      AgentConfig{Name: "claude", Role: "smol"},
+		Prompt:     "hi",
+		MaxRetries: 2,
+	})
+	if err == nil {
+		t.Fatal("expected a crash error after every attempt failed")
+	}
+	if events != nil {
+		t.Error("expected a nil event stream when the retries are exhausted")
+	}
+	if rec.total() != 3 {
+		t.Errorf("spawn attempts = %d, want 3", rec.total())
+	}
+
+	idMu.Lock()
+	got := append([]string(nil), ids...)
+	idMu.Unlock()
+	if len(got) != 3 {
+		t.Fatalf("tracked %d agents, want 3", len(got))
+	}
+	if agentID != got[2] {
+		t.Errorf("agentID = %q, want the last attempt's agent %q", agentID, got[2])
+	}
+	want := "subagent " + got[2] + " crashed after 3 attempts"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestSpawnWithRetry_SilentStreamRetriesThenSucceeds pins the third outcome of
+// an attempt: the stream closes without ever emitting message_end or error.
+// That is treated as retryable, and once the attempts run out the last stream
+// is handed back with a nil error rather than a crash error.
+//
+// `true` exits immediately with no JSONL output, so the only event the
+// forwarder produces is the synthesized run_done — which is neither of the two
+// types the retry loop waits for.
+func TestSpawnWithRetry_SilentStreamRetriesThenSucceeds(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("no `true` binary on PATH: %v", err)
+	}
+
+	orch := NewOrchestrator(testConfig(), "", nil)
+	defer orch.Shutdown()
+	orch.SetPiBinary(truePath)
+
+	events, agentID, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+		Agent:      AgentConfig{Name: "explore", Role: "smol"},
+		Prompt:     "hi",
+		MaxRetries: 2,
+	})
+	if err != nil {
+		t.Fatalf("SpawnWithRetry: %v", err)
+	}
+	if agentID == "" {
+		t.Fatal("expected a non-empty agent id")
+	}
+	if events == nil {
+		t.Fatal("expected a non-nil event stream")
+	}
+
+	orch.mu.Lock()
+	spawned := len(orch.agents)
+	orch.mu.Unlock()
+	if spawned != 3 {
+		t.Errorf("registered agents = %d, want 3 (a silent stream is retried)", spawned)
+	}
+
+	drainEventTypes(events)
+}
+
+// TestSpawnWithRetry_ZeroRetriesLeavesStreamUndrained pins the difference the
+// maxRetries==0 shortcut makes to the caller: with no retries configured the
+// stream is returned untouched, so the caller still sees message_end. With
+// retries configured the loop consumes events up to and including the terminal
+// one, and the caller never sees it.
+func TestSpawnWithRetry_ZeroRetriesLeavesStreamUndrained(t *testing.T) {
+	cases := []struct {
+		name            string
+		maxRetries      int
+		wantMessageEnd  bool
+		wantSpawnCalls  int
+		wantRunDoneLast bool
+	}{
+		{"zero retries hands back an undrained stream", 0, true, 1, true},
+		{"retries consume the terminal event", 1, false, 1, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &acpAttemptRecorder{}
+			installACPAttempts(t, rec, func(int) (acpSession, error) {
+				sess := newFakeACPSession()
+				go func() {
+					sess.events <- sharedacp.Event{Type: sharedacp.EventTypeMessage, Content: "ok", SessionID: "s"}
+					sess.finish(sharedacp.RunResult{Status: sharedacp.StatusSuccess, Result: "ok", SessionID: "s"})
+				}()
+				return sess, nil
+			})
+
+			orch := NewOrchestrator(testConfig(), "", nil)
+			defer orch.Shutdown()
+
+			events, agentID, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+				Agent:      AgentConfig{Name: "claude", Role: "smol"},
+				Prompt:     "hi",
+				MaxRetries: tc.maxRetries,
+			})
+			if err != nil {
+				t.Fatalf("SpawnWithRetry: %v", err)
+			}
+			if agentID == "" {
+				t.Fatal("expected a non-empty agent id")
+			}
+			if got := rec.total(); got != tc.wantSpawnCalls {
+				t.Errorf("spawn attempts = %d, want %d", got, tc.wantSpawnCalls)
+			}
+
+			types := drainEventTypes(events)
+			if got := containsType(types, "message_end"); got != tc.wantMessageEnd {
+				t.Errorf("caller saw message_end = %v, want %v (events: %v)", got, tc.wantMessageEnd, types)
+			}
+			if tc.wantRunDoneLast {
+				if len(types) == 0 || types[len(types)-1] != "run_done" {
+					t.Errorf("last event = %v, want run_done", types)
+				}
+			}
+		})
+	}
+}
+
+// TestSpawnWithRetry_CanceledContextDoesNotShortCircuit pins what a context
+// canceled partway through the retry sequence does: nothing special. The loop
+// keeps re-spawning until the attempts run out, and each remaining attempt
+// fails at spawn, so the caller gets the spawn-failure error naming the full
+// attempt count rather than an early context error.
+func TestSpawnWithRetry_CanceledContextDoesNotShortCircuit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch := NewOrchestrator(testConfig(), "", nil)
+	defer orch.Shutdown()
+
+	rec := &acpAttemptRecorder{}
+	installACPAttempts(t, rec, func(attempt int) (acpSession, error) {
+		if attempt > 0 {
+			return nil, stubError("session start refused after cancel")
+		}
+		sess := newFakeACPSession()
+		go func() {
+			forceRunningAgentStatus(t, orch, "failed")
+			cancel() // cancel between the first crash and the first retry
+			sess.events <- sharedacp.Event{Type: sharedacp.EventTypeError, Error: "boom", SessionID: "s"}
+			sess.finish(sharedacp.RunResult{Status: sharedacp.StatusError, Error: "boom", SessionID: "s"})
+		}()
+		return sess, nil
+	})
+
+	events, agentID, err := orch.SpawnWithRetry(ctx, SpawnInput{
+		Agent:      AgentConfig{Name: "claude", Role: "smol"},
+		Prompt:     "hi",
+		MaxRetries: 2,
+	})
+	if err == nil {
+		t.Fatal("expected an error once the context was canceled")
+	}
+	if !strings.Contains(err.Error(), "spawn failed after 3 attempts") {
+		t.Errorf("error = %q, want it to report all 3 attempts", err.Error())
+	}
+	if events != nil || agentID != "" {
+		t.Errorf("events = %v, agentID = %q; want nil and empty", events, agentID)
+	}
+}
+
+// TestSpawnWithRetry_ShutdownOrchestratorFailsEveryAttempt pins that a
+// shut-down orchestrator is not a special case either: Spawn rejects every
+// attempt and the loop still burns through the full budget.
+func TestSpawnWithRetry_ShutdownOrchestratorFailsEveryAttempt(t *testing.T) {
+	orch := NewOrchestrator(testConfig(), "", nil)
+	orch.Shutdown()
+
+	_, _, err := orch.SpawnWithRetry(context.Background(), SpawnInput{
+		Agent:      AgentConfig{Name: "claude", Role: "smol"},
+		Prompt:     "hi",
+		MaxRetries: 3,
+	})
+	if err == nil {
+		t.Fatal("expected an error from a shut-down orchestrator")
+	}
+	if !strings.Contains(err.Error(), "spawn failed after 4 attempts") {
+		t.Errorf("error = %q, want it to report all 4 attempts", err.Error())
+	}
+	if !strings.Contains(err.Error(), "orchestrator is shut down") {
+		t.Errorf("error = %q, want the underlying shutdown error", err.Error())
+	}
+}

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -311,69 +311,104 @@ func (o *Orchestrator) LookupAgent(name string) (AgentConfig, error) {
 // It monitors the subagent and re-spawns if the subagent crashes with status "failed" or "killed".
 // Returns the final events channel, agentID, and error (nil on success).
 func (o *Orchestrator) SpawnWithRetry(ctx context.Context, input SpawnInput) (<-chan Event, string, error) {
-	maxRetries := input.MaxRetries
-	if maxRetries < 0 {
-		maxRetries = 0
-	}
-	if maxRetries > 3 {
-		maxRetries = 3
-	}
+	maxRetries := clampRetries(input.MaxRetries)
 
 	var lastErr error
 	var finalAgentID string
 	var finalEvents <-chan Event
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// The first try is attempt 0, so the last one is attempt == maxRetries
+		// and the count reported in errors is attempt+1.
+		lastAttempt := attempt == maxRetries
+
 		events, agentID, err := o.Spawn(ctx, input)
-		if err != nil {
-			lastErr = err
+		switch {
+		case err != nil && lastAttempt:
+			return nil, "", fmt.Errorf("spawn failed after %d attempts: %w", attempt+1, err)
+		case err != nil:
 			// On spawn error, retry if we have attempts left.
-			if attempt < maxRetries {
-				continue
-			}
-			return nil, "", fmt.Errorf("spawn failed after %d attempts: %w", attempt+1, lastErr)
+			lastErr = err
+			continue
 		}
 
 		finalAgentID = agentID
 		finalEvents = events
 
-		// If no retries configured, return immediately.
+		// If no retries configured, return immediately — the caller gets the
+		// stream undrained.
 		if maxRetries == 0 {
 			return finalEvents, finalAgentID, nil
 		}
 
-		// Wait for the subagent to complete and check status.
-		var status string
-		for ev := range events {
-			// Forward events to caller (consume the channel).
-			if ev.Type == "message_end" || ev.Type == "error" {
-				// Check agent state.
-				o.mu.Lock()
-				state := o.agents[agentID]
-				if state != nil {
-					status = state.Status
-				}
-				o.mu.Unlock()
-
-				if status == "failed" || status == "killed" {
-					// Crash detected — retry if we have attempts left.
-					if attempt < maxRetries {
-						break
-					}
-					return nil, agentID, fmt.Errorf("subagent %s crashed after %d attempts", agentID, attempt+1)
-				}
-				return finalEvents, finalAgentID, nil
-			}
+		// Wait for the subagent to reach a terminal event and check status.
+		switch outcome := o.awaitAttemptOutcome(events, agentID); {
+		case outcome == attemptHealthy, outcome == attemptSilent && lastAttempt:
+			return finalEvents, finalAgentID, nil
+		case lastAttempt:
+			return nil, agentID, fmt.Errorf("subagent %s crashed after %d attempts", agentID, attempt+1)
 		}
-
-		// If we broke out of the loop for retry, continue to next attempt.
-		if attempt < maxRetries {
-			continue
-		}
-		return finalEvents, finalAgentID, nil
+		// Crashed or silent with attempts left: re-spawn.
 	}
 
 	return finalEvents, finalAgentID, lastErr
+}
+
+// clampRetries pins a requested retry budget to the supported range: never
+// negative, never more than three re-spawns.
+func clampRetries(maxRetries int) int {
+	if maxRetries < 0 {
+		return 0
+	}
+	if maxRetries > 3 {
+		return 3
+	}
+	return maxRetries
+}
+
+// attemptOutcome is how one SpawnWithRetry attempt ended, as observed on the
+// agent's event stream.
+type attemptOutcome int
+
+const (
+	// attemptHealthy: a terminal event arrived and the agent was not in a
+	// crashed state — the stream belongs to the caller now.
+	attemptHealthy attemptOutcome = iota
+	// attemptCrashed: a terminal event arrived while the agent was tracked as
+	// "failed" or "killed".
+	attemptCrashed
+	// attemptSilent: the stream closed without ever producing a terminal event.
+	attemptSilent
+)
+
+// awaitAttemptOutcome consumes events until the first terminal one
+// ("message_end" or "error") and reports how the attempt ended. Events before
+// that are dropped, which is why the maxRetries==0 shortcut in SpawnWithRetry
+// skips this entirely.
+func (o *Orchestrator) awaitAttemptOutcome(events <-chan Event, agentID string) attemptOutcome {
+	for ev := range events {
+		if ev.Type != "message_end" && ev.Type != "error" {
+			continue
+		}
+		if o.agentCrashed(agentID) {
+			return attemptCrashed
+		}
+		return attemptHealthy
+	}
+	return attemptSilent
+}
+
+// agentCrashed reports whether the tracked agent is in a state worth
+// re-spawning. An agent that has already been evicted from the map is not
+// treated as crashed.
+func (o *Orchestrator) agentCrashed(agentID string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	state := o.agents[agentID]
+	if state == nil {
+		return false
+	}
+	return state.Status == "failed" || state.Status == "killed"
 }
 
 // Spawn starts a new subagent and returns an event channel.

--- a/internal/tools/a2a.go
+++ b/internal/tools/a2a.go
@@ -184,40 +184,47 @@ func (c *ClientCache) sendStreamingMessage(ctx context.Context, client *a2aclien
 		if err != nil {
 			return sb.String(), fmt.Errorf("streaming error: %w", err)
 		}
-
-		switch e := event.(type) {
-		case *a2a.Message:
-			// Terminal message with result
-			for _, part := range e.Parts {
-				if text := part.Text(); text != "" {
-					sb.WriteString(text)
-				}
-			}
+		if appendStreamEvent(&sb, event) {
 			return sb.String(), nil
-
-		case *a2a.Task:
-			// Terminal task (non-streaming completion)
-			result := extractTaskResult(e)
-			sb.WriteString(result)
-			return sb.String(), nil
-
-		case *a2a.TaskStatusUpdateEvent:
-			// State change updates - check for terminal state
-			if e.Status.State.Terminal() {
-				return sb.String(), nil
-			}
-
-		case *a2a.TaskArtifactUpdateEvent:
-			// Extract text from artifact parts
-			for _, part := range e.Artifact.Parts {
-				if text := part.Text(); text != "" {
-					sb.WriteString(text)
-				}
-			}
 		}
 	}
 
 	return sb.String(), nil
+}
+
+// appendStreamEvent writes any text carried by a streaming event to sb and
+// reports whether the event ends the stream.
+func appendStreamEvent(sb *strings.Builder, event a2a.Event) bool {
+	switch e := event.(type) {
+	case *a2a.Message:
+		// Terminal message with result
+		appendPartsText(sb, e.Parts)
+		return true
+
+	case *a2a.Task:
+		// Terminal task (non-streaming completion)
+		sb.WriteString(extractTaskResult(e))
+		return true
+
+	case *a2a.TaskStatusUpdateEvent:
+		// State change updates - check for terminal state
+		return e.Status.State.Terminal()
+
+	case *a2a.TaskArtifactUpdateEvent:
+		// Extract text from artifact parts
+		appendPartsText(sb, e.Artifact.Parts)
+	}
+
+	return false
+}
+
+// appendPartsText writes the text of every non-empty content part to sb.
+func appendPartsText(sb *strings.Builder, parts a2a.ContentParts) {
+	for _, part := range parts {
+		if text := part.Text(); text != "" {
+			sb.WriteString(text)
+		}
+	}
 }
 
 // extractSendMessageResult extracts text from a SendMessageResult (either *a2a.Task or *a2a.Message).
@@ -238,11 +245,7 @@ func extractMessageText(msg *a2a.Message) string {
 		return ""
 	}
 	var sb strings.Builder
-	for _, part := range msg.Parts {
-		if text := part.Text(); text != "" {
-			sb.WriteString(text)
-		}
-	}
+	appendPartsText(&sb, msg.Parts)
 	return sb.String()
 }
 

--- a/internal/tools/compactor_read.go
+++ b/internal/tools/compactor_read.go
@@ -64,48 +64,12 @@ func filterSourceCode(s string, level string) (string, bool) {
 		return s, false // not worth filtering short files
 	}
 
+	f := sourceLineFilter{level: level}
 	var filtered []string
-	inBlockComment := false
-	consecutiveBlanks := 0
-
 	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		// Track block comments
-		if strings.Contains(trimmed, "/*") {
-			inBlockComment = true
+		if f.keep(line) {
+			filtered = append(filtered, line)
 		}
-		if inBlockComment {
-			if strings.Contains(trimmed, "*/") {
-				inBlockComment = false
-			}
-			if level == "aggressive" {
-				continue
-			}
-		}
-
-		// Skip line comments in aggressive mode
-		if level == "aggressive" && (strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")) {
-			continue
-		}
-
-		// Minimal: only strip doc comments (multi-line // blocks)
-		if level == "minimal" && strings.HasPrefix(trimmed, "//") {
-			// Keep single inline comments, skip doc blocks
-			continue
-		}
-
-		// Collapse blank line runs
-		if trimmed == "" {
-			consecutiveBlanks++
-			if consecutiveBlanks <= 1 {
-				filtered = append(filtered, line)
-			}
-			continue
-		}
-		consecutiveBlanks = 0
-
-		filtered = append(filtered, line)
 	}
 
 	if len(filtered) >= len(lines) {
@@ -113,4 +77,58 @@ func filterSourceCode(s string, level string) (string, bool) {
 	}
 
 	return strings.Join(filtered, "\n"), true
+}
+
+// sourceLineFilter carries the line-by-line state filterSourceCode threads
+// through a file: whether the scan is inside a /* */ block, and how many blank
+// lines have run consecutively.
+type sourceLineFilter struct {
+	level             string
+	inBlockComment    bool
+	consecutiveBlanks int
+}
+
+// keep reports whether line survives filtering, advancing the filter state.
+func (f *sourceLineFilter) keep(line string) bool {
+	trimmed := strings.TrimSpace(line)
+
+	if f.dropsComment(trimmed) {
+		return false
+	}
+
+	// Collapse blank line runs
+	if trimmed == "" {
+		f.consecutiveBlanks++
+		return f.consecutiveBlanks <= 1
+	}
+	f.consecutiveBlanks = 0
+
+	return true
+}
+
+// dropsComment advances the block-comment state for trimmed and reports whether
+// the configured level strips it as a comment.
+func (f *sourceLineFilter) dropsComment(trimmed string) bool {
+	// Track block comments
+	if strings.Contains(trimmed, "/*") {
+		f.inBlockComment = true
+	}
+	if f.inBlockComment {
+		if strings.Contains(trimmed, "*/") {
+			f.inBlockComment = false
+		}
+		// Skip block comment bodies in aggressive mode
+		if f.level == "aggressive" {
+			return true
+		}
+	}
+
+	// Skip line comments in aggressive mode
+	if f.level == "aggressive" && (strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")) {
+		return true
+	}
+
+	// Minimal: only strip doc comments (multi-line // blocks), keeping single
+	// inline comments.
+	return f.level == "minimal" && strings.HasPrefix(trimmed, "//")
 }

--- a/internal/tools/compactor_search.go
+++ b/internal/tools/compactor_search.go
@@ -82,26 +82,7 @@ func groupSearchOutput(s string, cfg CompactorConfig) (string, bool) {
 		return s, false
 	}
 
-	// Group lines by file prefix (file:line:content pattern)
-	byFile := make(map[string][]string)
-	var fileOrder []string
-
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-		// Parse file:line:content or file:content patterns
-		idx := strings.Index(line, ":")
-		if idx < 0 {
-			continue
-		}
-		file := line[:idx]
-		if _, seen := byFile[file]; !seen {
-			fileOrder = append(fileOrder, file)
-		}
-		byFile[file] = append(byFile[file], line)
-	}
-
+	byFile, fileOrder := groupSearchLinesByFile(lines)
 	if len(byFile) == 0 {
 		return s, false
 	}
@@ -109,29 +90,7 @@ func groupSearchOutput(s string, cfg CompactorConfig) (string, bool) {
 	var b strings.Builder
 	totalShown := 0
 	for _, file := range fileOrder {
-		matches := byFile[file]
-		fmt.Fprintf(&b, "%s (%d matches):\n", file, len(matches))
-		shown := 0
-		for _, m := range matches {
-			if totalShown >= cfg.MaxSearchTotal {
-				break
-			}
-			if shown >= cfg.MaxSearchPerFile {
-				fmt.Fprintf(&b, "  ... and %d more matches\n", len(matches)-shown)
-				break
-			}
-			// Strip file prefix for cleaner output
-			if idx := strings.Index(m, ":"); idx >= 0 {
-				b.WriteString("  ")
-				b.WriteString(m[idx+1:])
-			} else {
-				b.WriteString("  ")
-				b.WriteString(m)
-			}
-			b.WriteString("\n")
-			shown++
-			totalShown++
-		}
+		totalShown = writeSearchFileGroup(&b, file, byFile[file], totalShown, cfg)
 		if totalShown >= cfg.MaxSearchTotal {
 			fmt.Fprintf(&b, "\n... (%d total matches shown, limited to %d)\n",
 				totalShown, cfg.MaxSearchTotal)
@@ -144,4 +103,63 @@ func groupSearchOutput(s string, cfg CompactorConfig) (string, bool) {
 		return s, false
 	}
 	return result, true
+}
+
+// groupSearchLinesByFile buckets search result lines by their file prefix
+// (the file:line:content or file:content pattern), returning the buckets and
+// the order in which the files were first seen. Lines that are empty or carry
+// no colon are dropped.
+func groupSearchLinesByFile(lines []string) (map[string][]string, []string) {
+	byFile := make(map[string][]string)
+	var fileOrder []string
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx < 0 {
+			continue
+		}
+		file := line[:idx]
+		if _, seen := byFile[file]; !seen {
+			fileOrder = append(fileOrder, file)
+		}
+		byFile[file] = append(byFile[file], line)
+	}
+
+	return byFile, fileOrder
+}
+
+// writeSearchFileGroup writes one file's header and matches to b, honoring the
+// per-file and running limits, and returns the updated running total.
+func writeSearchFileGroup(b *strings.Builder, file string, matches []string, totalShown int, cfg CompactorConfig) int {
+	fmt.Fprintf(b, "%s (%d matches):\n", file, len(matches))
+
+	shown := 0
+	for _, m := range matches {
+		if totalShown >= cfg.MaxSearchTotal {
+			break
+		}
+		if shown >= cfg.MaxSearchPerFile {
+			fmt.Fprintf(b, "  ... and %d more matches\n", len(matches)-shown)
+			break
+		}
+		b.WriteString("  ")
+		b.WriteString(stripSearchLinePrefix(m))
+		b.WriteString("\n")
+		shown++
+		totalShown++
+	}
+
+	return totalShown
+}
+
+// stripSearchLinePrefix drops the leading file: prefix from a match line for
+// cleaner grouped output, returning the line unchanged when it has no colon.
+func stripSearchLinePrefix(m string) string {
+	if idx := strings.Index(m, ":"); idx >= 0 {
+		return m[idx+1:]
+	}
+	return m
 }

--- a/internal/tools/complexity_cog_tools_a_test.go
+++ b/internal/tools/complexity_cog_tools_a_test.go
@@ -1,0 +1,834 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// Tests pinning the behavior of find.go, session_sweep.go and subagent.go
+// across the cognitive-complexity flattening of findHandler,
+// accumulateSweepFile, parallelModeHandler, chainModeHandler and
+// singleModeHandler.
+//
+// Every "golden" literal below was captured by running these same inputs
+// against the unmodified source at HEAD (extracted with `git archive` into a
+// scratch tree) before any edit, so the tests prove the refactor is a no-op
+// rather than proving the new code agrees with itself.
+
+// cogATree builds the fixture tree the find goldens were captured against:
+// a .gitignore, always-skipped directories, a hidden directory, and the two
+// dot-directories find deliberately does NOT skip.
+func cogATree(t *testing.T) *Sandbox {
+	t.Helper()
+	dir := t.TempDir()
+	sb := testSandbox(t, dir)
+	mk := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	mk(".gitignore", "ignored.go\nbuild/\n")
+	mk("main.go", "package main")
+	mk("readme.md", "# hi")
+	mk("ignored.go", "package ignored")
+	mk("build/out.go", "package build")
+	mk("src/app.go", "package app")
+	mk("src/app_test.go", "package app")
+	mk("src/deep/nested/thing.go", "package nested")
+	mk("node_modules/pkg/index.go", "package pkg")
+	mk("vendor/v/v.go", "package v")
+	mk("__pycache__/x.go", "package x")
+	mk(".hidden/h.go", "package h")
+	mk(".claude/agent.go", "package agent")
+	mk(".pi-go/tasks/t.go", "package t")
+	return sb
+}
+
+func TestCogAFindHandlerGolden(t *testing.T) {
+	sb := cogATree(t)
+
+	tests := []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{
+			// Bare name pattern: matched against the file name, so it reaches
+			// every depth. .claude and .pi-go survive; .hidden, node_modules,
+			// vendor, __pycache__ and the gitignored build/ and ignored.go do not.
+			name:    "name pattern reaches every depth",
+			pattern: "*.go",
+			want: []string{
+				".claude/agent.go", ".pi-go/tasks/t.go", "main.go",
+				"src/app.go", "src/app_test.go", "src/deep/nested/thing.go",
+			},
+		},
+		{
+			name:    "leading doublestar is stripped and behaves the same",
+			pattern: "**/*.go",
+			want: []string{
+				".claude/agent.go", ".pi-go/tasks/t.go", "main.go",
+				"src/app.go", "src/app_test.go", "src/deep/nested/thing.go",
+			},
+		},
+		{
+			// Interior "**" takes the doublestar path: prefix must match, then
+			// the suffix is matched against the base name.
+			name:    "interior doublestar anchors on the prefix",
+			pattern: "src/**/*.go",
+			want:    []string{"src/app.go", "src/app_test.go", "src/deep/nested/thing.go"},
+		},
+		{
+			name:    "suffix pattern",
+			pattern: "**/*_test.go",
+			want:    []string{"src/app_test.go"},
+		},
+		{
+			// No "**": matches the path relative to the walk root, one segment
+			// deep only — src/deep/nested/thing.go is not a hit.
+			name:    "relative path pattern is not recursive",
+			pattern: "src/*.go",
+			want:    []string{"src/app.go", "src/app_test.go"},
+		},
+		{
+			name:    "star matches every surviving file",
+			pattern: "*",
+			want: []string{
+				".claude/agent.go", ".pi-go/tasks/t.go", "main.go", "readme.md",
+				"src/app.go", "src/app_test.go", "src/deep/nested/thing.go",
+			},
+		},
+		{
+			// "**/" normalizes to "", and matchDoublestar's empty suffix
+			// returns true — so an empty pattern matches everything.
+			name:    "trailing-slash doublestar matches everything",
+			pattern: "**/",
+			want: []string{
+				".claude/agent.go", ".pi-go/tasks/t.go", "main.go", "readme.md",
+				"src/app.go", "src/app_test.go", "src/deep/nested/thing.go",
+			},
+		},
+		{
+			name:    "doublestar prefix that matches no directory",
+			pattern: "nope/**/*.go",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := findHandler(sb, FindInput{Pattern: tt.pattern, Path: "."})
+			if err != nil {
+				t.Fatalf("findHandler(%q): %v", tt.pattern, err)
+			}
+			if !reflect.DeepEqual(out.Files, tt.want) {
+				t.Errorf("files = %v, want %v", out.Files, tt.want)
+			}
+			if out.TotalFiles != len(tt.want) {
+				t.Errorf("total_files = %d, want %d", out.TotalFiles, len(tt.want))
+			}
+			if out.Truncated {
+				t.Error("truncated = true, want false")
+			}
+		})
+	}
+}
+
+func TestCogAFindHandlerDefaultPath(t *testing.T) {
+	sb := cogATree(t)
+	out, err := findHandler(sb, FindInput{Pattern: "*.md"})
+	if err != nil {
+		t.Fatalf("findHandler: %v", err)
+	}
+	if !reflect.DeepEqual(out.Files, []string{"readme.md"}) {
+		t.Errorf("files = %v, want [readme.md] — an empty path must default to \".\"", out.Files)
+	}
+}
+
+func TestCogAFindHandlerErrors(t *testing.T) {
+	sb := cogATree(t)
+
+	if _, err := findHandler(sb, FindInput{Pattern: ""}); err == nil {
+		t.Error("empty pattern returned no error")
+	} else if err.Error() != "pattern is required" {
+		t.Errorf("error = %q, want %q", err.Error(), "pattern is required")
+	}
+
+	if _, err := findHandler(sb, FindInput{Pattern: "*.go", Path: "../escape"}); err == nil {
+		t.Error("a path outside the sandbox returned no error")
+	} else if !strings.Contains(err.Error(), "escapes sandbox root") {
+		t.Errorf("error = %q, want a sandbox-escape error", err.Error())
+	}
+}
+
+// TestCogAFindHandlerTruncates pins the cap: results stop at maxFindResults
+// but the total keeps counting, and Truncated flips.
+func TestCogAFindHandlerTruncates(t *testing.T) {
+	dir := t.TempDir()
+	sb := testSandbox(t, dir)
+	const extra = 7
+	for i := 0; i < maxFindResults+extra; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("f%04d.go", i))
+		if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	out, err := findHandler(sb, FindInput{Pattern: "*.go", Path: "."})
+	if err != nil {
+		t.Fatalf("findHandler: %v", err)
+	}
+	if len(out.Files) != maxFindResults {
+		t.Errorf("files = %d, want %d", len(out.Files), maxFindResults)
+	}
+	if out.TotalFiles != maxFindResults+extra {
+		t.Errorf("total_files = %d, want %d", out.TotalFiles, maxFindResults+extra)
+	}
+	if !out.Truncated {
+		t.Error("truncated = false, want true")
+	}
+	if out.Files[0] != "f0000.go" || out.Files[len(out.Files)-1] != "f0499.go" {
+		t.Errorf("kept window = %s..%s, want f0000.go..f0499.go", out.Files[0], out.Files[len(out.Files)-1])
+	}
+}
+
+// TestCogAFindWalkMatches exercises the three-way match ladder directly:
+// name, then path relative to the root, then doublestar.
+func TestCogAFindWalkMatches(t *testing.T) {
+	tests := []struct {
+		name        string
+		root        string
+		pattern     string
+		filePattern string
+		path        string
+		base        string
+		want        bool
+	}{
+		{"name match wins first", ".", "*.go", "*.go", "src/a.go", "a.go", true},
+		{"relative path match", ".", "src/*.go", "src/*.go", "src/a.go", "a.go", true},
+		{"doublestar fallback", ".", "src/**/*.go", "src/**/*.go", "src/deep/a.go", "a.go", true},
+		{"doublestar prefix mismatch", ".", "other/**/*.go", "other/**/*.go", "src/deep/a.go", "a.go", false},
+		{"no match at all", ".", "*.rs", "*.rs", "src/a.go", "a.go", false},
+		{
+			// filepath.Rel fails for an absolute root against a relative path;
+			// the ladder stops there rather than falling through to doublestar.
+			name: "unrelatable path stops the ladder", root: "/abs/root",
+			pattern: "**/*.go", filePattern: "*.go", path: "relative/a.txt", base: "a.txt", want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &findWalk{root: tt.root, pattern: tt.pattern, filePattern: tt.filePattern}
+			if got := w.matches(tt.path, tt.base); got != tt.want {
+				t.Errorf("matches(%q, %q) = %v, want %v", tt.path, tt.base, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCogAFindWalkVisit pins the callback's four exits: walk error, directory
+// pruning, gitignored file, and a recorded hit.
+func TestCogAFindWalkVisit(t *testing.T) {
+	patterns := []GitignorePattern{{pattern: "*.log"}}
+
+	t.Run("walk error is swallowed", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*", filePattern: "*"}
+		if err := w.visit("x", fakeDirEntry{name: "x"}, os.ErrPermission); err != nil {
+			t.Fatalf("visit returned %v, want nil", err)
+		}
+		if w.total != 0 {
+			t.Errorf("total = %d, want 0", w.total)
+		}
+	})
+
+	t.Run("always-skipped dir prunes", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*", filePattern: "*"}
+		got := w.visit("node_modules", fakeDirEntry{name: "node_modules", isDir: true}, nil)
+		if !errors.Is(got, filepath.SkipDir) {
+			t.Fatalf("visit = %v, want SkipDir", got)
+		}
+	})
+
+	t.Run("gitignored dir prunes", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*", filePattern: "*", patterns: []GitignorePattern{{pattern: "build", isDir: true}}}
+		got := w.visit("build", fakeDirEntry{name: "build", isDir: true}, nil)
+		if !errors.Is(got, filepath.SkipDir) {
+			t.Fatalf("visit = %v, want SkipDir", got)
+		}
+	})
+
+	t.Run("ordinary dir descends", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*", filePattern: "*"}
+		if got := w.visit("src", fakeDirEntry{name: "src", isDir: true}, nil); got != nil {
+			t.Fatalf("visit = %v, want nil", got)
+		}
+	})
+
+	t.Run("gitignored file is dropped", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*", filePattern: "*", patterns: patterns}
+		if got := w.visit("app.log", fakeDirEntry{name: "app.log"}, nil); got != nil {
+			t.Fatalf("visit = %v, want nil", got)
+		}
+		if w.total != 0 {
+			t.Errorf("total = %d, want 0 — a gitignored file must not be counted", w.total)
+		}
+	})
+
+	t.Run("non-matching file is dropped", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*.rs", filePattern: "*.rs"}
+		_ = w.visit("main.go", fakeDirEntry{name: "main.go"}, nil)
+		if w.total != 0 {
+			t.Errorf("total = %d, want 0", w.total)
+		}
+	})
+
+	t.Run("hit is counted and kept", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*.go", filePattern: "*.go"}
+		_ = w.visit("main.go", fakeDirEntry{name: "main.go"}, nil)
+		if w.total != 1 || !reflect.DeepEqual(w.files, []string{"main.go"}) {
+			t.Errorf("total = %d files = %v, want 1 [main.go]", w.total, w.files)
+		}
+	})
+
+	t.Run("past the cap the total still climbs", func(t *testing.T) {
+		w := &findWalk{root: ".", pattern: "*.go", filePattern: "*.go"}
+		w.files = make([]string, maxFindResults)
+		_ = w.visit("main.go", fakeDirEntry{name: "main.go"}, nil)
+		if w.total != 1 {
+			t.Errorf("total = %d, want 1", w.total)
+		}
+		if len(w.files) != maxFindResults {
+			t.Errorf("files = %d, want %d — the cap must hold", len(w.files), maxFindResults)
+		}
+	})
+}
+
+// cogASweepLines is the fixture the sweep goldens were captured against: a
+// tool call with usage, a malformed line, a part carrying both a call and a
+// response, an oversize duplicate, two identical error responses, a
+// loop-guard abort, and an unrelated error.
+func cogASweepLines(big string) []string {
+	return []string{
+		`{"content":{"parts":[{"functionCall":{"name":"read"}}]},"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":20}}`,
+		`not json at all`,
+		`{"content":{"parts":[{"functionCall":{"name":"read"},"functionResponse":{"name":"read","response":{"content":"` + big + `"}}}]}}`,
+		`{"content":{"parts":[{"functionResponse":{"name":"read","response":{"content":"` + big + `"}}}]}}`,
+		`{"content":{"parts":[{"functionResponse":{"name":"grep","response":{"error":"boom"}}}]},"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":3}}`,
+		`{"content":{"parts":[]},"errorMessage":"agent loop aborted: identical tool call \"read\" repeated 10 times"}`,
+		`{"errorMessage":"provider timed out"}`,
+		`{"content":{"parts":[{"functionResponse":{"name":"grep","response":{"error":"boom"}}}]}}`,
+	}
+}
+
+// TestCogAAccumulateSweepFileGolden pins every counter accumulateSweepFile
+// maintains, with the exact totals the pre-refactor code produced.
+func TestCogAAccumulateSweepFileGolden(t *testing.T) {
+	root := t.TempDir()
+	big := strings.Repeat("z", oversizeChars+10)
+	writeEvents(t, root, "cog-a", cogASweepLines(big)...)
+
+	totals := newSweepTotals()
+	accumulateSweepFile(totals, filepath.Join(root, "cog-a", "events.jsonl"))
+
+	// Usage is summed across events; the malformed line contributes nothing.
+	if totals.PromptTokens != 107 || totals.OutputTokens != 23 {
+		t.Errorf("usage = %d/%d, want 107/23", totals.PromptTokens, totals.OutputTokens)
+	}
+	// Two 24024-byte read results plus two 16-byte grep results.
+	if totals.ToolBytes != 48080 {
+		t.Errorf("ToolBytes = %d, want 48080", totals.ToolBytes)
+	}
+	// The repeat of each body: one read (24024) and one grep (16).
+	if totals.DupBytes != 24040 {
+		t.Errorf("DupBytes = %d, want 24040", totals.DupBytes)
+	}
+
+	read := totals.tool("read")
+	if read.Calls != 2 || read.Errors != 0 || read.Bytes != 48048 || read.Oversized != 48 {
+		t.Errorf("read = %+v, want calls 2 errors 0 bytes 48048 oversized 48", *read)
+	}
+	grep := totals.tool("grep")
+	if grep.Calls != 0 || grep.Errors != 2 || grep.Bytes != 32 || grep.Oversized != 0 {
+		t.Errorf("grep = %+v, want calls 0 errors 2 bytes 32 oversized 0", *grep)
+	}
+
+	wantAborts := map[string]int{`identical tool call "read" repeated 10 times`: 1}
+	if !reflect.DeepEqual(totals.Aborts, wantAborts) {
+		t.Errorf("Aborts = %v, want %v — an unrelated error must not be counted", totals.Aborts, wantAborts)
+	}
+	if n := totalAborts(totals); n != 1 {
+		t.Errorf("totalAborts = %d, want 1", n)
+	}
+}
+
+// TestCogAAccumulateSweepEvent covers the per-event fold in isolation: the
+// branches an event can skip.
+func TestCogAAccumulateSweepEvent(t *testing.T) {
+	t.Run("no usage, no abort, no parts", func(t *testing.T) {
+		totals := newSweepTotals()
+		accumulateSweepEvent(totals, map[string]bool{}, sweepEvent{ErrorMessage: "provider timed out"})
+		if totals.PromptTokens != 0 || len(totals.Aborts) != 0 || len(totals.Tools) != 0 {
+			t.Errorf("totals = %+v, want all zero", *totals)
+		}
+	})
+
+	t.Run("call without response counts a call only", func(t *testing.T) {
+		totals := newSweepTotals()
+		ev := sweepEvent{}
+		ev.Content.Parts = []sweepPart{{FunctionCall: &sweepFunctionCall{Name: "bash"}}}
+		accumulateSweepEvent(totals, map[string]bool{}, ev)
+		if totals.tool("bash").Calls != 1 {
+			t.Errorf("calls = %d, want 1", totals.tool("bash").Calls)
+		}
+		if totals.ToolBytes != 0 {
+			t.Errorf("ToolBytes = %d, want 0 — a call carries no result bytes", totals.ToolBytes)
+		}
+	})
+
+	t.Run("usage and abort are both folded", func(t *testing.T) {
+		totals := newSweepTotals()
+		ev := sweepEvent{
+			UsageMetadata: &sweepUsage{PromptTokenCount: 5, CandidatesTokenCount: 6},
+			ErrorMessage:  "agent loop aborted: stuck",
+		}
+		accumulateSweepEvent(totals, map[string]bool{}, ev)
+		if totals.PromptTokens != 5 || totals.OutputTokens != 6 {
+			t.Errorf("usage = %d/%d, want 5/6", totals.PromptTokens, totals.OutputTokens)
+		}
+		if totals.Aborts["stuck"] != 1 {
+			t.Errorf("Aborts = %v, want {stuck: 1}", totals.Aborts)
+		}
+	})
+}
+
+// TestCogAAccumulateSweepResponse pins the per-result accounting: volume, the
+// error marker, the oversize excess, and first-seen versus duplicate.
+func TestCogAAccumulateSweepResponse(t *testing.T) {
+	oversize := `{"x":"` + strings.Repeat("z", oversizeChars) + `"}`
+
+	tests := []struct {
+		name          string
+		body          string
+		seenAlready   bool
+		wantErrors    int
+		wantOversized int
+		wantDup       int
+	}{
+		{"plain result", `{"content":"ok"}`, false, 0, 0, 0},
+		{"error marker counts an error", `{"error":"boom"}`, false, 1, 0, 0},
+		{"oversize counts only the excess", oversize, false, 0, len(oversize) - oversizeChars, 0},
+		{"first sighting is not a duplicate", `{"content":"ok"}`, false, 0, 0, 0},
+		{"second sighting is a duplicate", `{"content":"ok"}`, true, 0, 0, len(`{"content":"ok"}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			totals := newSweepTotals()
+			seen := map[string]bool{}
+			if tt.seenAlready {
+				seen[tt.body] = true
+			}
+			accumulateSweepResponse(totals, seen, &sweepFunctionResponse{Name: "read", Response: []byte(tt.body)})
+
+			u := totals.tool("read")
+			if u.Bytes != len(tt.body) || totals.ToolBytes != len(tt.body) {
+				t.Errorf("bytes = %d/%d, want %d", u.Bytes, totals.ToolBytes, len(tt.body))
+			}
+			if u.Errors != tt.wantErrors {
+				t.Errorf("errors = %d, want %d", u.Errors, tt.wantErrors)
+			}
+			if u.Oversized != tt.wantOversized {
+				t.Errorf("oversized = %d, want %d", u.Oversized, tt.wantOversized)
+			}
+			if totals.DupBytes != tt.wantDup {
+				t.Errorf("DupBytes = %d, want %d", totals.DupBytes, tt.wantDup)
+			}
+			if !seen[tt.body] {
+				t.Error("body was not recorded as seen")
+			}
+		})
+	}
+}
+
+// --- subagent pipeline ---
+
+// TestCogASubagentPipelineLimits pins the over-limit output for both
+// multi-agent modes, including the two differently-worded messages.
+func TestCogASubagentPipelineLimits(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore")
+
+	t.Run("parallel", func(t *testing.T) {
+		tasks := make([]TaskItem, maxParallelTasks+1)
+		for i := range tasks {
+			tasks[i] = TaskItem{Agent: "explore", Task: "t"}
+		}
+		out, err := subagentHandler(nil, orch, SubagentInput{Tasks: tasks}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Mode != "parallel" {
+			t.Errorf("mode = %q, want parallel", out.Mode)
+		}
+		if out.Summary != "too many parallel tasks: 9 (max 8)" {
+			t.Errorf("summary = %q", out.Summary)
+		}
+		if len(out.Results) != 1 {
+			t.Fatalf("results = %d, want 1", len(out.Results))
+		}
+		r := out.Results[0]
+		if r.Agent != "parallel" || r.Status != "failed" {
+			t.Errorf("result = %+v, want agent parallel status failed", r)
+		}
+		if r.Error != "too many parallel tasks: 9 exceeds maximum of 8" {
+			t.Errorf("error = %q", r.Error)
+		}
+		if r.Duration == "" {
+			t.Error("result carries no duration")
+		}
+	})
+
+	t.Run("chain", func(t *testing.T) {
+		steps := make([]ChainItem, maxChainSteps+1)
+		for i := range steps {
+			steps[i] = ChainItem{Agent: "explore", Task: "t"}
+		}
+		out, err := subagentHandler(nil, orch, SubagentInput{Chain: steps}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out.Mode != "chain" {
+			t.Errorf("mode = %q, want chain", out.Mode)
+		}
+		if out.Summary != "too many chain steps: 9 (max 8)" {
+			t.Errorf("summary = %q", out.Summary)
+		}
+		if len(out.Results) != 1 {
+			t.Fatalf("results = %d, want 1", len(out.Results))
+		}
+		r := out.Results[0]
+		if r.Agent != "chain" || r.Status != "failed" {
+			t.Errorf("result = %+v, want agent chain status failed", r)
+		}
+		if r.Error != "too many chain steps: 9 exceeds maximum of 8" {
+			t.Errorf("error = %q", r.Error)
+		}
+	})
+}
+
+// TestCogASubagentUnknownAgentStopsBeforeSpawning pins that validation runs
+// over the whole batch up front: an unknown agent in the second slot fails
+// the call, and the report names that agent, not the first.
+func TestCogASubagentUnknownAgentStopsBeforeSpawning(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore", "review")
+
+	check := func(t *testing.T, out SubagentOutput, wantMode string) {
+		t.Helper()
+		if out.Mode != wantMode {
+			t.Errorf("mode = %q, want %q", out.Mode, wantMode)
+		}
+		if out.Summary != `validation failed: unknown agent "ghost"` {
+			t.Errorf("summary = %q", out.Summary)
+		}
+		if len(out.Results) != 1 {
+			t.Fatalf("results = %d, want 1 — validation reports the offender only", len(out.Results))
+		}
+		r := out.Results[0]
+		if r.Agent != "ghost" || r.Status != "failed" {
+			t.Errorf("result = %+v, want agent ghost status failed", r)
+		}
+		// The available-agent list is map-ordered, so pin the prefix only.
+		if !strings.HasPrefix(r.Error, `unknown agent "ghost"`) {
+			t.Errorf("error = %q, want it to start with `unknown agent \"ghost\"`", r.Error)
+		}
+	}
+
+	t.Run("parallel", func(t *testing.T) {
+		out, err := subagentHandler(nil, orch, SubagentInput{Tasks: []TaskItem{
+			{Agent: "explore", Task: "a"}, {Agent: "ghost", Task: "b"},
+		}}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		check(t, out, "parallel")
+	})
+
+	t.Run("chain", func(t *testing.T) {
+		out, err := subagentHandler(nil, orch, SubagentInput{Chain: []ChainItem{
+			{Agent: "explore", Task: "a"}, {Agent: "ghost", Task: "b"},
+		}}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		check(t, out, "chain")
+	})
+}
+
+// TestCogACheckSubagentPipelineAccepts pins the pass-through: a call within
+// the limit whose agents all exist reports ok and an empty output.
+func TestCogACheckSubagentPipelineAccepts(t *testing.T) {
+	orch := noRoleOrchestrator(t, "explore")
+	spec := subagentPipelineSpec{Mode: "parallel", Noun: "parallel tasks", Limit: maxParallelTasks}
+
+	out, ok := checkSubagentPipeline(orch, spec, []subagentTask{{Agent: "explore", Task: "a"}}, time.Now())
+	if !ok {
+		t.Fatalf("ok = false, want true (out = %+v)", out)
+	}
+	if !reflect.DeepEqual(out, SubagentOutput{}) {
+		t.Errorf("out = %+v, want the zero output", out)
+	}
+
+	// An empty batch is under the limit and names no agent: also fine.
+	if _, ok := checkSubagentPipeline(orch, spec, nil, time.Now()); !ok {
+		t.Error("an empty batch was rejected")
+	}
+}
+
+// TestCogASubagentSpawnFailureGolden pins how each mode reports a spawn that
+// never starts: parallel runs every task and reports each one, chain stops at
+// the step that failed.
+func TestCogASubagentSpawnFailureGolden(t *testing.T) {
+	t.Run("parallel reports every task", func(t *testing.T) {
+		orch := noRoleOrchestrator(t, "explore", "review")
+		out, err := subagentHandler(nil, orch, SubagentInput{Tasks: []TaskItem{
+			{Agent: "explore", Task: "a"}, {Agent: "review", Task: "b"},
+		}}, nil)
+		if err != nil {
+			t.Fatalf("a spawn failure must be reported, not returned: %v", err)
+		}
+		if len(out.Results) != 2 {
+			t.Fatalf("results = %d, want 2", len(out.Results))
+		}
+		for i, want := range []string{"explore", "review"} {
+			r := out.Results[i]
+			if r.Agent != want {
+				t.Errorf("results[%d].Agent = %q, want %q — order follows the input", i, r.Agent, want)
+			}
+			if r.Status != "failed" || r.Error == "" {
+				t.Errorf("results[%d] = %+v, want a failed result carrying an error", i, r)
+			}
+			if r.AgentID != "" {
+				t.Errorf("results[%d].AgentID = %q, want empty — nothing spawned", i, r.AgentID)
+			}
+		}
+		if !strings.HasPrefix(out.Summary, "parallel: 0/2 completed, 2 failed in ") {
+			t.Errorf("summary = %q", out.Summary)
+		}
+	})
+
+	t.Run("chain stops at the failed step", func(t *testing.T) {
+		orch := noRoleOrchestrator(t, "explore", "review")
+		out, err := subagentHandler(nil, orch, SubagentInput{Chain: []ChainItem{
+			{Agent: "explore", Task: "a"}, {Agent: "review", Task: "b {previous}"},
+		}}, nil)
+		if err != nil {
+			t.Fatalf("a spawn failure must be reported, not returned: %v", err)
+		}
+		if len(out.Results) != 1 {
+			t.Fatalf("results = %d, want 1 — the chain must not run step 2", len(out.Results))
+		}
+		r := out.Results[0]
+		if r.Agent != "explore" || r.Status != "failed" || r.Error == "" {
+			t.Errorf("result = %+v, want a failed explore result carrying an error", r)
+		}
+		if !strings.HasPrefix(out.Summary, "chain: stopped at step 1/2 in ") {
+			t.Errorf("summary = %q", out.Summary)
+		}
+	})
+}
+
+// cogAEventChan feeds a closed channel of events, standing in for a live
+// agent so the forwarding loops can be exercised without spawning one.
+func cogAEventChan(evs ...subagent.Event) <-chan subagent.Event {
+	ch := make(chan subagent.Event, len(evs))
+	for _, ev := range evs {
+		ch <- ev
+	}
+	close(ch)
+	return ch
+}
+
+// TestCogAForwardSubagentEvents covers the loop parallel and chain share:
+// text accumulation, the error path with its content fallback, session-id
+// capture, and the event metadata stamped on every forwarded event.
+func TestCogAForwardSubagentEvents(t *testing.T) {
+	meta := subagentStepMeta{PipelineID: "pipe-1", Mode: "parallel", Step: 2, Total: 3}
+
+	t.Run("text is accumulated and metadata stamped", func(t *testing.T) {
+		var seen []SubagentEvent
+		text, status, errMsg, sessID := forwardSubagentEvents(
+			cogAEventChan(
+				subagent.Event{Type: "message_start", SessionID: "sess-1"},
+				subagent.Event{Type: "text_delta", Content: "hello "},
+				subagent.Event{Type: "text_delta", Content: "world"},
+			),
+			func(ev SubagentEvent) { seen = append(seen, ev) },
+			"agent-7", meta,
+		)
+		if text != "hello world" {
+			t.Errorf("text = %q, want %q", text, "hello world")
+		}
+		if status != "completed" || errMsg != "" {
+			t.Errorf("status/err = %q/%q, want completed/empty", status, errMsg)
+		}
+		if sessID != "sess-1" {
+			t.Errorf("sessID = %q, want sess-1", sessID)
+		}
+		if len(seen) != 3 {
+			t.Fatalf("forwarded %d events, want 3", len(seen))
+		}
+		for i, ev := range seen {
+			if ev.AgentID != "agent-7" || ev.PipelineID != "pipe-1" || ev.Mode != "parallel" || ev.Step != 2 || ev.Total != 3 {
+				t.Errorf("event %d = %+v, want the step metadata stamped on it", i, ev)
+			}
+		}
+	})
+
+	t.Run("error sets the status and fills empty content", func(t *testing.T) {
+		var seen []SubagentEvent
+		_, status, errMsg, _ := forwardSubagentEvents(
+			cogAEventChan(subagent.Event{Type: "error", Error: "boom"}),
+			func(ev SubagentEvent) { seen = append(seen, ev) },
+			"agent-7", meta,
+		)
+		if status != "failed" || errMsg != "boom" {
+			t.Errorf("status/err = %q/%q, want failed/boom", status, errMsg)
+		}
+		if len(seen) != 1 || seen[0].Content != "boom" {
+			t.Errorf("forwarded = %+v, want the error text as content", seen)
+		}
+	})
+
+	t.Run("error keeps its own content when it has some", func(t *testing.T) {
+		var seen []SubagentEvent
+		forwardSubagentEvents(
+			cogAEventChan(subagent.Event{Type: "error", Content: "detail", Error: "boom"}),
+			func(ev SubagentEvent) { seen = append(seen, ev) },
+			"agent-7", meta,
+		)
+		if len(seen) != 1 || seen[0].Content != "detail" {
+			t.Errorf("forwarded = %+v, want content left alone", seen)
+		}
+	})
+
+	t.Run("an empty session id does not overwrite", func(t *testing.T) {
+		_, _, _, sessID := forwardSubagentEvents(
+			cogAEventChan(
+				subagent.Event{Type: "message_start", SessionID: "sess-1"},
+				subagent.Event{Type: "message_start"},
+			),
+			nil, "agent-7", meta,
+		)
+		if sessID != "sess-1" {
+			t.Errorf("sessID = %q, want sess-1", sessID)
+		}
+	})
+
+	t.Run("run_done is forwarded but does not change the status", func(t *testing.T) {
+		// Parallel and chain report "completed" for a timed-out run; only
+		// single mode reads the terminal status. Pinned so a later merge of
+		// the two loops cannot change it silently.
+		var seen []SubagentEvent
+		_, status, _, _ := forwardSubagentEvents(
+			cogAEventChan(subagent.Event{Type: "run_done", Status: "timeout"}),
+			func(ev SubagentEvent) { seen = append(seen, ev) },
+			"agent-7", meta,
+		)
+		if status != "completed" {
+			t.Errorf("status = %q, want completed", status)
+		}
+		if len(seen) != 1 || seen[0].Kind != "run_done" {
+			t.Errorf("forwarded = %+v, want the run_done event passed through", seen)
+		}
+	})
+
+	t.Run("a nil callback is safe", func(t *testing.T) {
+		text, status, _, _ := forwardSubagentEvents(
+			cogAEventChan(subagent.Event{Type: "text_delta", Content: "hi"}), nil, "agent-7", meta)
+		if text != "hi" || status != "completed" {
+			t.Errorf("text/status = %q/%q, want hi/completed", text, status)
+		}
+	})
+}
+
+// TestCogAForwardSingleModeEvents covers single mode's extra arm: run_done
+// promotes the status to "timeout", and a later error still wins because the
+// stream is read in order.
+func TestCogAForwardSingleModeEvents(t *testing.T) {
+	t.Run("run_done timeout becomes the status", func(t *testing.T) {
+		var seen []SubagentEvent
+		text, status, errMsg, sessID := forwardSingleModeEvents(
+			cogAEventChan(
+				subagent.Event{Type: "message_start", SessionID: "sub-1"},
+				subagent.Event{Type: "text_delta", Content: "partial"},
+				subagent.Event{Type: "run_done", Status: "timeout"},
+			),
+			func(ev SubagentEvent) { seen = append(seen, ev) },
+			"agent-1", "pipe-9",
+		)
+		if status != "timeout" {
+			t.Errorf("status = %q, want timeout", status)
+		}
+		if text != "partial" || errMsg != "" || sessID != "sub-1" {
+			t.Errorf("text/err/sess = %q/%q/%q", text, errMsg, sessID)
+		}
+		for i, ev := range seen {
+			if ev.Mode != "single" || ev.Step != 1 || ev.Total != 1 || ev.PipelineID != "pipe-9" {
+				t.Errorf("event %d = %+v, want single-mode metadata", i, ev)
+			}
+		}
+	})
+
+	t.Run("a non-timeout run_done leaves the status alone", func(t *testing.T) {
+		_, status, _, _ := forwardSingleModeEvents(
+			cogAEventChan(subagent.Event{Type: "run_done", Status: "completed"}), nil, "agent-1", "pipe-9")
+		if status != "completed" {
+			t.Errorf("status = %q, want completed", status)
+		}
+	})
+
+	t.Run("the last terminal event in the stream wins", func(t *testing.T) {
+		_, status, errMsg, _ := forwardSingleModeEvents(
+			cogAEventChan(
+				subagent.Event{Type: "run_done", Status: "timeout"},
+				subagent.Event{Type: "error", Error: "crashed"},
+			), nil, "agent-1", "pipe-9")
+		if status != "failed" || errMsg != "crashed" {
+			t.Errorf("status/err = %q/%q, want failed/crashed", status, errMsg)
+		}
+	})
+
+	t.Run("error content falls back to the error text", func(t *testing.T) {
+		var seen []SubagentEvent
+		forwardSingleModeEvents(
+			cogAEventChan(subagent.Event{Type: "error", Error: "boom"}),
+			func(ev SubagentEvent) { seen = append(seen, ev) }, "agent-1", "pipe-9")
+		if len(seen) != 1 || seen[0].Content != "boom" {
+			t.Errorf("forwarded = %+v, want the error text as content", seen)
+		}
+	})
+}
+
+// TestCogASubagentTaskConversion pins that the two input shapes convert to the
+// shared task without reordering or losing a field.
+func TestCogASubagentTaskConversion(t *testing.T) {
+	if got := subagentTask(TaskItem{Agent: "a", Task: "t"}); got != (subagentTask{Agent: "a", Task: "t"}) {
+		t.Errorf("from TaskItem = %+v", got)
+	}
+	if got := subagentTask(ChainItem{Agent: "b", Task: "u"}); got != (subagentTask{Agent: "b", Task: "u"}) {
+		t.Errorf("from ChainItem = %+v", got)
+	}
+}

--- a/internal/tools/complexity_cog_tools_b_test.go
+++ b/internal/tools/complexity_cog_tools_b_test.go
@@ -1,0 +1,963 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+// The expectations in this file were captured by running the same inputs
+// against the pre-refactor source (git archive of the parent commit into a
+// scratch tree), so they pin the observable output of the originals rather than
+// agreeing with the flattened code about what it happens to produce.
+
+// cogBSearchLines builds n lines from format, substituting the line index.
+func cogBSearchLines(n int, format string) string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf(format, i)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// cogBSearchLinesMod builds n lines from format, substituting i%mod then i so
+// the results spread across mod distinct files.
+func cogBSearchLinesMod(n, mod int, format string) string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf(format, i%mod, i)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// cogBBlankAlternating builds n lines where every even index is blank, so the
+// grouper has to drop empty lines.
+func cogBBlankAlternating(n int) string {
+	lines := make([]string, n)
+	for i := range lines {
+		if i%2 != 0 {
+			lines[i] = fmt.Sprintf("b.go:%d:v", i)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestCogBGroupSearchOutputGolden(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		total  int
+		per    int
+		wantOK bool
+		want   string
+	}{
+		{
+			name:   "short",
+			in:     cogBSearchLines(5, "a.go:%d:hit"),
+			total:  100,
+			per:    20,
+			wantOK: false,
+			want:   "a.go:0:hit\na.go:1:hit\na.go:2:hit\na.go:3:hit\na.go:4:hit",
+		},
+		{
+			name:   "nocolon",
+			in:     cogBSearchLines(25, "plainline%d"),
+			total:  100,
+			per:    20,
+			wantOK: false,
+			want:   "plainline0\nplainline1\nplainline2\nplainline3\nplainline4\nplainline5\nplainline6\nplainline7\nplainline8\nplainline9\nplainline10\nplainline11\nplainline12\nplainline13\nplainline14\nplainline15\nplainline16\nplainline17\nplainline18\nplainline19\nplainline20\nplainline21\nplainline22\nplainline23\nplainline24",
+		},
+		{
+			name:   "basic",
+			in:     cogBSearchLinesMod(30, 3, "file%d.go:%d:some match text here"),
+			total:  100,
+			per:    20,
+			wantOK: true,
+			want:   "file0.go (10 matches):\n  0:some match text here\n  3:some match text here\n  6:some match text here\n  9:some match text here\n  12:some match text here\n  15:some match text here\n  18:some match text here\n  21:some match text here\n  24:some match text here\n  27:some match text here\nfile1.go (10 matches):\n  1:some match text here\n  4:some match text here\n  7:some match text here\n  10:some match text here\n  13:some match text here\n  16:some match text here\n  19:some match text here\n  22:some match text here\n  25:some match text here\n  28:some match text here\nfile2.go (10 matches):\n  2:some match text here\n  5:some match text here\n  8:some match text here\n  11:some match text here\n  14:some match text here\n  17:some match text here\n  20:some match text here\n  23:some match text here\n  26:some match text here\n  29:some match text here\n",
+		},
+		{
+			name:   "perfile",
+			in:     cogBSearchLinesMod(30, 2, "f%d.go:%d:xx"),
+			total:  100,
+			per:    3,
+			wantOK: true,
+			want:   "f0.go (15 matches):\n  0:xx\n  2:xx\n  4:xx\n  ... and 12 more matches\nf1.go (15 matches):\n  1:xx\n  3:xx\n  5:xx\n  ... and 12 more matches\n",
+		},
+		{
+			name:   "total",
+			in:     cogBSearchLinesMod(40, 4, "f%d.go:%d:yy"),
+			total:  5,
+			per:    3,
+			wantOK: true,
+			want:   "f0.go (10 matches):\n  0:yy\n  4:yy\n  8:yy\n  ... and 7 more matches\nf1.go (10 matches):\n  1:yy\n  5:yy\n\n... (5 total matches shown, limited to 5)\n",
+		},
+		{
+			name:   "totalzero",
+			in:     cogBSearchLines(25, "z.go:%d:q"),
+			total:  0,
+			per:    3,
+			wantOK: true,
+			want:   "z.go (25 matches):\n\n... (0 total matches shown, limited to 0)\n",
+		},
+		{
+			name:   "blanks",
+			in:     cogBBlankAlternating(25),
+			total:  100,
+			per:    20,
+			wantOK: true,
+			want:   "b.go (12 matches):\n  1:v\n  3:v\n  5:v\n  7:v\n  9:v\n  11:v\n  13:v\n  15:v\n  17:v\n  19:v\n  21:v\n  23:v\n",
+		},
+		{
+			name:   "nolinenum",
+			in:     cogBSearchLines(22, "c.go:content %d"),
+			total:  100,
+			per:    20,
+			wantOK: true,
+			want:   "c.go (22 matches):\n  content 0\n  content 1\n  content 2\n  content 3\n  content 4\n  content 5\n  content 6\n  content 7\n  content 8\n  content 9\n  content 10\n  content 11\n  content 12\n  content 13\n  content 14\n  content 15\n  content 16\n  content 17\n  content 18\n  content 19\n  ... and 2 more matches\n",
+		},
+		{
+			name:   "grows",
+			in:     cogBSearchLines(21, "d.go:%d:"),
+			total:  100,
+			per:    20,
+			wantOK: true,
+			want:   "d.go (21 matches):\n  0:\n  1:\n  2:\n  3:\n  4:\n  5:\n  6:\n  7:\n  8:\n  9:\n  10:\n  11:\n  12:\n  13:\n  14:\n  15:\n  16:\n  17:\n  18:\n  19:\n  ... and 1 more matches\n",
+		},
+		{
+			name:   "onematch",
+			in:     cogBSearchLines(20, "e%d.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			total:  100,
+			per:    20,
+			wantOK: false,
+			want:   "e0.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne1.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne2.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne3.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne4.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne5.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne6.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne7.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne8.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne9.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne10.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne11.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne12.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne13.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne14.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne15.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne16.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne17.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne18.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa\ne19.go:1:aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultCompactorConfig()
+			cfg.MaxSearchTotal = tt.total
+			cfg.MaxSearchPerFile = tt.per
+
+			got, ok := groupSearchOutput(tt.in, cfg)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("output mismatch\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCogBGroupSearchLinesByFile(t *testing.T) {
+	byFile, order := groupSearchLinesByFile([]string{
+		"b.go:1:x", "", "nocolon", "a.go:2:y", "b.go:3:z", ":leading colon",
+	})
+
+	if want := []string{"b.go", "a.go", ""}; !cogBEqualStrings(order, want) {
+		t.Errorf("order = %v, want %v", order, want)
+	}
+	if len(byFile["b.go"]) != 2 {
+		t.Errorf("b.go matches = %d, want 2", len(byFile["b.go"]))
+	}
+	if len(byFile[""]) != 1 {
+		t.Errorf("empty-file matches = %d, want 1", len(byFile[""]))
+	}
+	if _, ok := byFile["nocolon"]; ok {
+		t.Error("line without a colon was grouped")
+	}
+}
+
+func cogBEqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCogBStripSearchLinePrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"a.go:12:hit", "12:hit"},
+		{"nocolon", "nocolon"},
+		{":", ""},
+		{"", ""},
+	}
+	for _, tt := range cases {
+		if got := stripSearchLinePrefix(tt.in); got != tt.want {
+			t.Errorf("stripSearchLinePrefix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCogBWriteSearchFileGroup(t *testing.T) {
+	cfg := DefaultCompactorConfig()
+	cfg.MaxSearchTotal = 4
+	cfg.MaxSearchPerFile = 2
+
+	var b strings.Builder
+	total := writeSearchFileGroup(&b, "x.go", []string{"x.go:1:a", "x.go:2:b", "x.go:3:c"}, 0, cfg)
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	want := "x.go (3 matches):\n  1:a\n  2:b\n  ... and 1 more matches\n"
+	if b.String() != want {
+		t.Errorf("got %q, want %q", b.String(), want)
+	}
+
+	// Already at the running total: header only, no matches, total unchanged.
+	var b2 strings.Builder
+	total2 := writeSearchFileGroup(&b2, "y.go", []string{"y.go:1:a"}, 4, cfg)
+	if total2 != 4 {
+		t.Errorf("total2 = %d, want 4", total2)
+	}
+	if b2.String() != "y.go (1 matches):\n" {
+		t.Errorf("got %q, want header only", b2.String())
+	}
+}
+
+// cogBSourceLong builds a >50-line file mixing doc comments, block comments,
+// hash comments, trailing comments and blank runs.
+func cogBSourceLong() string {
+	body := cogBSourceBody()
+	var lines []string
+	for len(lines) < 60 {
+		lines = append(lines, body...)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// cogBSourceShort returns the same body once, which is under the 50-line floor.
+func cogBSourceShort() string {
+	return strings.Join(cogBSourceBody(), "\n")
+}
+
+func cogBSourceBody() []string {
+	return []string{
+		"package main",
+		"",
+		"",
+		"",
+		"// doc comment line",
+		"// second doc line",
+		"import \"fmt\"",
+		"",
+		"/* block start",
+		"   block middle",
+		"   block end */",
+		"func main() {",
+		"\t// inner comment",
+		"\tfmt.Println(\"hi\") // trailing",
+		"",
+		"",
+		"\t# not go but hash",
+		"\t/* one line block */",
+		"\tx := 1",
+		"}",
+	}
+}
+
+// cogBSourceUnterminated builds a file whose block comment never closes, so the
+// in-block state stays set for the rest of the scan.
+func cogBSourceUnterminated() string {
+	var lines []string
+	for len(lines) < 55 {
+		lines = append(lines, "/* never closed", "still inside", "more")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// cogBSourceNoComments builds a file with nothing the filter can remove.
+func cogBSourceNoComments() string {
+	lines := make([]string, 60)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line%d", i)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestCogBFilterSourceCodeGolden(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		level  string
+		wantOK bool
+		want   string
+	}{
+		{
+			name:   "long-aggressive",
+			in:     cogBSourceLong(),
+			level:  "aggressive",
+			wantOK: true,
+			want:   "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\") // trailing\n\n\tx := 1\n}\npackage main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\") // trailing\n\n\tx := 1\n}\npackage main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\") // trailing\n\n\tx := 1\n}",
+		},
+		{
+			name:   "short-aggressive",
+			in:     cogBSourceShort(),
+			level:  "aggressive",
+			wantOK: false,
+			want:   "package main\n\n\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "long-minimal",
+			in:     cogBSourceLong(),
+			level:  "minimal",
+			wantOK: true,
+			want:   "package main\n\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "short-minimal",
+			in:     cogBSourceShort(),
+			level:  "minimal",
+			wantOK: false,
+			want:   "package main\n\n\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "long-moderate",
+			in:     cogBSourceLong(),
+			level:  "moderate",
+			wantOK: true,
+			want:   "package main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "short-moderate",
+			in:     cogBSourceShort(),
+			level:  "moderate",
+			wantOK: false,
+			want:   "package main\n\n\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "long-",
+			in:     cogBSourceLong(),
+			level:  "",
+			wantOK: true,
+			want:   "package main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "short-",
+			in:     cogBSourceShort(),
+			level:  "",
+			wantOK: false,
+			want:   "package main\n\n\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "long-none",
+			in:     cogBSourceLong(),
+			level:  "none",
+			wantOK: true,
+			want:   "package main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}\npackage main\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "short-none",
+			in:     cogBSourceShort(),
+			level:  "none",
+			wantOK: false,
+			want:   "package main\n\n\n\n// doc comment line\n// second doc line\nimport \"fmt\"\n\n/* block start\n   block middle\n   block end */\nfunc main() {\n\t// inner comment\n\tfmt.Println(\"hi\") // trailing\n\n\n\t# not go but hash\n\t/* one line block */\n\tx := 1\n}",
+		},
+		{
+			name:   "unterm-aggressive",
+			in:     cogBSourceUnterminated(),
+			level:  "aggressive",
+			wantOK: true,
+			want:   "",
+		},
+		{
+			name:   "unterm-minimal",
+			in:     cogBSourceUnterminated(),
+			level:  "minimal",
+			wantOK: false,
+			want:   "/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore",
+		},
+		{
+			name:   "unterm-moderate",
+			in:     cogBSourceUnterminated(),
+			level:  "moderate",
+			wantOK: false,
+			want:   "/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore\n/* never closed\nstill inside\nmore",
+		},
+		{
+			name:   "blank-aggressive",
+			in:     strings.Repeat("\n", 60),
+			level:  "aggressive",
+			wantOK: true,
+			want:   "",
+		},
+		{
+			name:   "blank-minimal",
+			in:     strings.Repeat("\n", 60),
+			level:  "minimal",
+			wantOK: true,
+			want:   "",
+		},
+		{
+			name:   "blank-moderate",
+			in:     strings.Repeat("\n", 60),
+			level:  "moderate",
+			wantOK: true,
+			want:   "",
+		},
+		{
+			name:   "keep-aggressive",
+			in:     cogBSourceNoComments(),
+			level:  "aggressive",
+			wantOK: false,
+			want:   "line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15\nline16\nline17\nline18\nline19\nline20\nline21\nline22\nline23\nline24\nline25\nline26\nline27\nline28\nline29\nline30\nline31\nline32\nline33\nline34\nline35\nline36\nline37\nline38\nline39\nline40\nline41\nline42\nline43\nline44\nline45\nline46\nline47\nline48\nline49\nline50\nline51\nline52\nline53\nline54\nline55\nline56\nline57\nline58\nline59",
+		},
+		{
+			name:   "keep-minimal",
+			in:     cogBSourceNoComments(),
+			level:  "minimal",
+			wantOK: false,
+			want:   "line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15\nline16\nline17\nline18\nline19\nline20\nline21\nline22\nline23\nline24\nline25\nline26\nline27\nline28\nline29\nline30\nline31\nline32\nline33\nline34\nline35\nline36\nline37\nline38\nline39\nline40\nline41\nline42\nline43\nline44\nline45\nline46\nline47\nline48\nline49\nline50\nline51\nline52\nline53\nline54\nline55\nline56\nline57\nline58\nline59",
+		},
+		{
+			name:   "keep-moderate",
+			in:     cogBSourceNoComments(),
+			level:  "moderate",
+			wantOK: false,
+			want:   "line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15\nline16\nline17\nline18\nline19\nline20\nline21\nline22\nline23\nline24\nline25\nline26\nline27\nline28\nline29\nline30\nline31\nline32\nline33\nline34\nline35\nline36\nline37\nline38\nline39\nline40\nline41\nline42\nline43\nline44\nline45\nline46\nline47\nline48\nline49\nline50\nline51\nline52\nline53\nline54\nline55\nline56\nline57\nline58\nline59",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := filterSourceCode(tt.in, tt.level)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("output mismatch\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCogBSourceLineFilterState(t *testing.T) {
+	// Blank-run collapsing keeps the first blank of each run and resets on the
+	// next non-blank line.
+	f := sourceLineFilter{level: "moderate"}
+	seq := []struct {
+		line string
+		want bool
+	}{
+		{"", true},
+		{"", false},
+		{"  ", false},
+		{"code", true},
+		{"", true},
+		{"", false},
+	}
+	for i, s := range seq {
+		if got := f.keep(s.line); got != s.want {
+			t.Errorf("step %d keep(%q) = %v, want %v", i, s.line, got, s.want)
+		}
+	}
+
+	// Aggressive drops every line from /* until the closing */ inclusive.
+	a := sourceLineFilter{level: "aggressive"}
+	for _, line := range []string{"/* open", "inside", "close */"} {
+		if a.keep(line) {
+			t.Errorf("aggressive kept block line %q", line)
+		}
+	}
+	if !a.keep("code") {
+		t.Error("aggressive dropped code after the block closed")
+	}
+	if a.keep("// comment") || a.keep("# comment") {
+		t.Error("aggressive kept a line comment")
+	}
+
+	// Minimal keeps block bodies and hash lines, drops only leading // lines.
+	m := sourceLineFilter{level: "minimal"}
+	if !m.keep("/* open") || !m.keep("inside") || !m.keep("close */") {
+		t.Error("minimal dropped a block comment line")
+	}
+	if !m.keep("# comment") {
+		t.Error("minimal dropped a hash comment")
+	}
+	if m.keep("// doc") {
+		t.Error("minimal kept a // comment")
+	}
+	if !m.keep("code() // trailing") {
+		t.Error("minimal dropped a trailing comment line")
+	}
+}
+
+// cogBWriteTree creates files (path -> contents) under a fresh temp dir.
+func cogBWriteTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for p, c := range files {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// cogBFormatPatterns renders patterns in a sorted, stable form. Sorting is
+// deliberate: loadGitignore merges its per-directory buckets by ranging over a
+// map, so the order across directories is not defined.
+func cogBFormatPatterns(pats []GitignorePattern) string {
+	out := make([]string, 0, len(pats))
+	for _, p := range pats {
+		out = append(out, fmt.Sprintf("{%q,%q,%v,%v}", p.dir, p.pattern, p.isNeg, p.isDir))
+	}
+	sort.Strings(out)
+	return "[" + strings.Join(out, " ") + "]"
+}
+
+func TestCogBLoadGitignoreGolden(t *testing.T) {
+	trees := map[string]map[string]string{
+		"root-only": {
+			".gitignore": "# comment\n\n*.log\nbuild/\n!keep.log\nnode_modules\ndocs/**/*.tmp\n  \n!*.keep\n",
+			"a.go":       "x",
+		},
+		"nested": {
+			"sub/.gitignore": "*.bak\n!important.bak\n",
+			"sub/a.go":       "x",
+		},
+		"none": {
+			"a.go": "x",
+		},
+		"crlf": {
+			".gitignore": "*.log\r\ntmp/\r\n",
+		},
+		// Pruned directories are never descended into, so their .gitignore
+		// files contribute nothing.
+		"pruned": {
+			"node_modules/.gitignore": "*.everything\n",
+			".git/.gitignore":         "*.gitinternal\n",
+			"vendor/.gitignore":       "*.vendored\n",
+			".gitignore":              "*.top\n",
+		},
+	}
+
+	want := map[string]string{
+		"crlf":      "[{\"\",\"*.log\",false,false} {\"\",\"tmp\",false,true}]",
+		"nested":    "[{\"sub\",\"*.bak\",false,false} {\"sub\",\"important.bak\",true,false}]",
+		"none":      "[]",
+		"pruned":    "[{\"\",\"*.top\",false,false}]",
+		"root-only": "[{\"\",\"  \",false,false} {\"\",\"*.keep\",true,false} {\"\",\"*.log\",false,false} {\"\",\"build\",false,true} {\"\",\"docs/*/*.tmp\",false,false} {\"\",\"keep.log\",true,false} {\"\",\"node_modules\",false,false}]",
+	}
+
+	for name, files := range trees {
+		t.Run(name, func(t *testing.T) {
+			sb, err := NewSandbox(cogBWriteTree(t, files))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer sb.Close()
+
+			pats, err := sb.loadGitignore()
+			if err != nil {
+				t.Fatalf("loadGitignore: %v", err)
+			}
+			if got := cogBFormatPatterns(pats); got != want[name] {
+				t.Errorf("patterns mismatch\n got: %s\nwant: %s", got, want[name])
+			}
+		})
+	}
+}
+
+func TestCogBLoadGitignoreUnreadableFile(t *testing.T) {
+	// A .gitignore that cannot be read contributes no patterns and does not
+	// abort the walk: the sibling directory's file is still collected.
+	dir := cogBWriteTree(t, map[string]string{
+		".gitignore":     "*.unreadable\n",
+		"sub/.gitignore": "*.readable\n",
+	})
+	if err := os.Chmod(filepath.Join(dir, ".gitignore"), 0o000); err != nil {
+		t.Skipf("chmod unsupported: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, ".gitignore"), 0o644) })
+
+	sb, err := NewSandbox(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	pats, err := sb.loadGitignore()
+	if err != nil {
+		t.Fatalf("loadGitignore: %v", err)
+	}
+	for _, p := range pats {
+		if p.pattern == "*.unreadable" {
+			t.Fatal("unreadable .gitignore contributed a pattern")
+		}
+	}
+	if got := cogBFormatPatterns(pats); got != `[{"sub","*.readable",false,false}]` {
+		t.Errorf("patterns = %s", got)
+	}
+}
+
+// cogBEntry is a minimal fs.DirEntry for exercising path-skipping decisions.
+type cogBEntry struct {
+	name  string
+	isDir bool
+}
+
+func (e cogBEntry) Name() string               { return e.name }
+func (e cogBEntry) IsDir() bool                { return e.isDir }
+func (e cogBEntry) Type() os.FileMode          { return 0 }
+func (e cogBEntry) Info() (os.FileInfo, error) { return nil, nil }
+
+// cogBSkipPatterns is the pattern list the shouldSkipPath golden was captured
+// against: a glob, a directory-only pattern, a negation shadowed by the glob,
+// and a pattern scoped to a subdirectory.
+func cogBSkipPatterns() []GitignorePattern {
+	return []GitignorePattern{
+		{dir: "", pattern: "*.log"},
+		{dir: "", pattern: "build", isDir: true},
+		{dir: "", pattern: "keep.log", isNeg: true},
+		{dir: "sub", pattern: "*.bak"},
+	}
+}
+
+func TestCogBShouldSkipPathGolden(t *testing.T) {
+	cases := []struct {
+		path  string
+		isDir bool
+		want  bool
+	}{
+		{path: "a.log", isDir: false, want: true},
+		{path: "keep.log", isDir: false, want: true},
+		{path: "build", isDir: true, want: true},
+		{path: "build", isDir: false, want: false},
+		{path: "a.go", isDir: false, want: false},
+		{path: ".hidden", isDir: false, want: true},
+		{path: ".pi-go", isDir: true, want: false},
+		{path: ".claude", isDir: true, want: false},
+		{path: ".cursor", isDir: true, want: false},
+		{path: "node_modules", isDir: true, want: true},
+		{path: "vendor", isDir: true, want: true},
+		{path: "__pycache__", isDir: true, want: true},
+		{path: "target", isDir: true, want: true},
+		{path: ".", isDir: true, want: false},
+		{path: "sub/x.bak", isDir: false, want: true},
+		{path: "other/x.bak", isDir: false, want: false},
+		{path: "sub/deep/x.bak", isDir: false, want: true},
+		{path: "sub/x.log", isDir: false, want: true},
+	}
+
+	pats := cogBSkipPatterns()
+	for _, tt := range cases {
+		name := tt.path
+		if tt.isDir {
+			name += "/"
+		}
+		t.Run(name, func(t *testing.T) {
+			e := cogBEntry{name: filepath.Base(tt.path), isDir: tt.isDir}
+			if got := shouldSkipPath(tt.path, e, pats); got != tt.want {
+				t.Errorf("shouldSkipPath(%q, isDir=%v) = %v, want %v", tt.path, tt.isDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCogBShouldSkipPathNegationWins(t *testing.T) {
+	// A negation reached before any matching positive pattern un-skips the path.
+	pats := []GitignorePattern{
+		{dir: "", pattern: "keep.log", isNeg: true},
+		{dir: "", pattern: "*.log"},
+	}
+	e := cogBEntry{name: "keep.log"}
+	if shouldSkipPath("keep.log", e, pats) {
+		t.Error("negation listed first did not un-skip keep.log")
+	}
+	if !shouldSkipPath("other.log", cogBEntry{name: "other.log"}, pats) {
+		t.Error("other.log should still be skipped")
+	}
+}
+
+func TestCogBGitignorePatternMatchesGolden(t *testing.T) {
+	pats := []GitignorePattern{
+		{dir: "", pattern: "*.log"},
+		{dir: "docs", pattern: "*.tmp"},
+		{dir: "", pattern: "build", isDir: true},
+	}
+
+	cases := []struct {
+		pat  int
+		path string
+		want bool
+	}{
+		{pat: 0, path: "a.log", want: true},
+		{pat: 1, path: "a.log", want: false},
+		{pat: 2, path: "a.log", want: false},
+		{pat: 0, path: "sub/a.log", want: true},
+		{pat: 1, path: "sub/a.log", want: false},
+		{pat: 2, path: "sub/a.log", want: false},
+		{pat: 0, path: "docs/x.tmp", want: false},
+		{pat: 1, path: "docs/x.tmp", want: true},
+		{pat: 2, path: "docs/x.tmp", want: false},
+		{pat: 0, path: "docsx/x.tmp", want: false},
+		{pat: 1, path: "docsx/x.tmp", want: false},
+		{pat: 2, path: "docsx/x.tmp", want: false},
+		{pat: 0, path: "docs/deep/x.tmp", want: false},
+		{pat: 1, path: "docs/deep/x.tmp", want: true},
+		{pat: 2, path: "docs/deep/x.tmp", want: false},
+		{pat: 0, path: "build", want: false},
+		{pat: 1, path: "build", want: false},
+		{pat: 2, path: "build", want: true},
+		{pat: 0, path: "sub/build", want: false},
+		{pat: 1, path: "sub/build", want: false},
+		{pat: 2, path: "sub/build", want: true},
+	}
+
+	for _, tt := range cases {
+		if got := pats[tt.pat].matches(tt.path); got != tt.want {
+			t.Errorf("pattern %d (%q, dir=%q).matches(%q) = %v, want %v",
+				tt.pat, pats[tt.pat].pattern, pats[tt.pat].dir, tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestCogBAppendPartsText(t *testing.T) {
+	var sb strings.Builder
+	appendPartsText(&sb, a2a.ContentParts{
+		a2a.NewTextPart("one"),
+		a2a.NewTextPart(""),
+		a2a.NewTextPart("two"),
+	})
+	if sb.String() != "onetwo" {
+		t.Errorf("got %q, want %q", sb.String(), "onetwo")
+	}
+
+	var empty strings.Builder
+	appendPartsText(&empty, nil)
+	if empty.String() != "" {
+		t.Errorf("nil parts wrote %q", empty.String())
+	}
+}
+
+func TestCogBAppendStreamEvent(t *testing.T) {
+	cases := []struct {
+		name     string
+		event    a2a.Event
+		wantText string
+		wantEnd  bool
+	}{
+		{
+			name:     "message is terminal",
+			event:    a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello"), a2a.NewTextPart("")),
+			wantText: "hello",
+			wantEnd:  true,
+		},
+		{
+			name: "task is terminal",
+			event: &a2a.Task{History: []*a2a.Message{
+				a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("done")),
+			}},
+			wantText: "done",
+			wantEnd:  true,
+		},
+		{
+			name:     "empty task is terminal and silent",
+			event:    &a2a.Task{},
+			wantText: "",
+			wantEnd:  true,
+		},
+		{
+			name:     "terminal status ends the stream",
+			event:    &a2a.TaskStatusUpdateEvent{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+			wantText: "",
+			wantEnd:  true,
+		},
+		{
+			name:     "working status continues the stream",
+			event:    &a2a.TaskStatusUpdateEvent{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+			wantText: "",
+			wantEnd:  false,
+		},
+		{
+			name: "artifact accumulates and continues",
+			event: &a2a.TaskArtifactUpdateEvent{Artifact: &a2a.Artifact{
+				Parts: a2a.ContentParts{a2a.NewTextPart("chunk"), a2a.NewTextPart("")},
+			}},
+			wantText: "chunk",
+			wantEnd:  false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			end := appendStreamEvent(&sb, tt.event)
+			if end != tt.wantEnd {
+				t.Errorf("terminal = %v, want %v", end, tt.wantEnd)
+			}
+			if sb.String() != tt.wantText {
+				t.Errorf("text = %q, want %q", sb.String(), tt.wantText)
+			}
+		})
+	}
+}
+
+func TestCogBAppendStreamEventAccumulates(t *testing.T) {
+	// Two artifact chunks then a terminal status: the builder keeps both.
+	var sb strings.Builder
+	for _, chunk := range []string{"a", "b"} {
+		e := &a2a.TaskArtifactUpdateEvent{Artifact: &a2a.Artifact{
+			Parts: a2a.ContentParts{a2a.NewTextPart(chunk)},
+		}}
+		if appendStreamEvent(&sb, e) {
+			t.Fatal("artifact event reported the stream as ended")
+		}
+	}
+	if !appendStreamEvent(&sb, &a2a.TaskStatusUpdateEvent{
+		Status: a2a.TaskStatus{State: a2a.TaskStateFailed},
+	}) {
+		t.Fatal("failed status did not end the stream")
+	}
+	if sb.String() != "ab" {
+		t.Errorf("accumulated %q, want %q", sb.String(), "ab")
+	}
+}
+
+// cogBAnchoredGitignore is a .gitignore exercising the pattern forms that
+// decide sandbox enforcement: anchored (/x), recursive (**/x), path-bearing
+// (a/b/c), plain globs, negations and directory-only forms.
+const cogBAnchoredGitignore = "/anchored.log\n**/deep.txt\na/b/c.txt\n*.o\n!.gitkeep\n/build/\n!/build/keep/\n\\#literal\n"
+
+func TestCogBLoadGitignoreAnchoredForms(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(cogBAnchoredGitignore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sb, err := NewSandbox(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	pats, err := sb.loadGitignore()
+	if err != nil {
+		t.Fatalf("loadGitignore: %v", err)
+	}
+
+	want := `[{"","*.o",false,false} {"","*/deep.txt",false,false} {"",".gitkeep",true,false} ` +
+		`{"","/anchored.log",false,false} {"","/build",false,true} {"","/build/keep",true,true} ` +
+		`{"","\\#literal",false,false} {"","a/b/c.txt",false,false}]`
+	if got := cogBFormatPatterns(pats); got != want {
+		t.Errorf("patterns mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestCogBAnchoredPatternsMatchNothing pins a pre-existing limitation that the
+// refactor must not silently change in either direction. GitignorePattern.matches
+// globs against filepath.Base(path), so any pattern still containing a slash
+// after parsing - anchored (/anchored.log), recursive (**/deep.txt -> */deep.txt)
+// or path-bearing (a/b/c.txt) - can never match, because a base name never
+// contains a separator. Only slash-free patterns are enforced, and those match
+// at any depth.
+//
+// The expectations here were captured from the pre-refactor code. If a later
+// change fixes the limitation, this test is the thing that will notice.
+func TestCogBAnchoredPatternsMatchNothing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(cogBAnchoredGitignore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sb, err := NewSandbox(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	pats, err := sb.loadGitignore()
+	if err != nil {
+		t.Fatalf("loadGitignore: %v", err)
+	}
+
+	// path -> the patterns that match it, by pattern text.
+	want := map[string][]string{
+		"anchored.log":     nil, // "/anchored.log" is inert: it holds a slash
+		"sub/anchored.log": nil,
+		"deep.txt":         nil, // "**/deep.txt" parsed to "*/deep.txt": inert
+		"x/deep.txt":       nil,
+		"a/b/c.txt":        nil, // path-bearing pattern: inert
+		"c.txt":            nil,
+		"build":            nil, // "/build/" parsed to "/build": inert
+		"build/keep":       nil,
+		"foo.o":            {"*.o"}, // slash-free glob: matches at root
+		"sub/foo.o":        {"*.o"}, // ... and at any depth
+		".gitkeep":         {".gitkeep"},
+		"#literal":         {"\\#literal"},
+	}
+
+	for path, wantPats := range want {
+		var got []string
+		for _, p := range pats {
+			if p.matches(path) {
+				got = append(got, p.pattern)
+			}
+		}
+		if !cogBEqualStrings(got, wantPats) {
+			t.Errorf("matches(%q) = %v, want %v", path, got, wantPats)
+		}
+	}
+}
+
+func TestCogBParseGitignoreLineGolden(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantOK  bool
+		pattern string
+		isNeg   bool
+		isDir   bool
+	}{
+		{"", false, "", false, false},                          // blank line skipped
+		{"#comment", false, "", false, false},                  // comment skipped
+		{"  ", true, "  ", false, false},                       // whitespace is a live pattern
+		{"*.log", true, "*.log", false, false},                 // plain glob
+		{"!keep.log", true, "keep.log", true, false},           // negation
+		{"build/", true, "build", false, true},                 // directory-only
+		{"!build/", true, "build", true, true},                 // negated directory-only
+		{"/anchored", true, "/anchored", false, false},         // anchor kept verbatim
+		{"**/deep", true, "*/deep", false, false},              // ** collapses to *
+		{"a/**/b", true, "a/*/b", false, false},                // ** collapses mid-path
+		{"**", true, "*", false, false},                        // bare ** collapses
+		{"trailing\r", true, "trailing", false, false},         // CR stripped
+		{"!/neg/", true, "/neg", true, true},                   // negated anchored dir
+		{"a/b/c", true, "a/b/c", false, false},                 // path kept
+		{"\\#literal", true, "\\#literal", false, false},       // escaped hash kept
+		{"space in name", true, "space in name", false, false}, // spaces kept
+		{"*.log ", true, "*.log ", false, false},               // trailing space NOT trimmed
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.in, func(t *testing.T) {
+			p, ok := parseGitignoreLine(tt.in, "somedir")
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if p.pattern != tt.pattern || p.isNeg != tt.isNeg || p.isDir != tt.isDir {
+				t.Errorf("got {%q,%v,%v}, want {%q,%v,%v}",
+					p.pattern, p.isNeg, p.isDir, tt.pattern, tt.isNeg, tt.isDir)
+			}
+			if p.dir != "somedir" {
+				t.Errorf("dir = %q, want %q", p.dir, "somedir")
+			}
+		})
+	}
+}

--- a/internal/tools/find.go
+++ b/internal/tools/find.go
@@ -62,61 +62,82 @@ func findHandler(sb *Sandbox, input FindInput) (FindOutput, error) {
 	// Normalize doublestar patterns: since WalkDir already recurses,
 	// strip "**/" prefixes so filepath.Match can handle the rest.
 	// e.g. "**/*.go" → "*.go", "src/**/*.go" → "src/**/*.go" (handled below)
-	pattern := input.Pattern
-	filePattern := normalizeGlobPattern(pattern)
+	w := &findWalk{
+		root:        rel,
+		pattern:     input.Pattern,
+		filePattern: normalizeGlobPattern(input.Pattern),
+		patterns:    patterns,
+	}
 
-	var files []string
-	total := 0
-
-	_ = fs.WalkDir(fsys, rel, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if shouldSkipDir(d.Name()) {
-				return filepath.SkipDir
-			}
-			// Apply .gitignore: if any pattern says skip this directory, skip it
-			if shouldSkipPath(path, d, patterns) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		// Apply .gitignore file filters
-		if shouldSkipPath(path, d, patterns) {
-			return nil
-		}
-
-		// Match against the filename using the normalized pattern
-		name := d.Name()
-		matched, _ := filepath.Match(filePattern, name)
-		if !matched {
-			// Try matching against relative path for patterns like "src/*.go"
-			relPath, relErr := filepath.Rel(rel, path)
-			if relErr == nil {
-				matched, _ = filepath.Match(filePattern, relPath)
-				if !matched {
-					// For patterns like "src/**/*.go", match each path segment
-					matched = matchDoublestar(pattern, relPath)
-				}
-			}
-		}
-
-		if matched {
-			total++
-			if len(files) < maxFindResults {
-				files = append(files, path)
-			}
-		}
-		return nil
-	})
+	_ = fs.WalkDir(fsys, rel, w.visit)
 
 	return FindOutput{
-		Files:      files,
-		TotalFiles: total,
-		Truncated:  total > len(files),
+		Files:      w.files,
+		TotalFiles: w.total,
+		Truncated:  w.total > len(w.files),
 	}, nil
+}
+
+// findWalk carries the state one find walk accumulates. Holding it here keeps
+// the WalkDir callback a named method at nesting depth zero instead of a
+// closure buried inside findHandler.
+type findWalk struct {
+	root        string // walk root, relative to the sandbox
+	pattern     string // the caller's pattern, as given
+	filePattern string // pattern with leading "**/" stripped
+	patterns    []GitignorePattern
+	files       []string
+	total       int
+}
+
+// visit is the fs.WalkDir callback: it prunes skipped directories, drops
+// gitignored and non-matching files, and records the rest.
+func (w *findWalk) visit(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return nil
+	}
+	if d.IsDir() {
+		// Skip always-ignored directories, and any the .gitignore prunes.
+		if shouldSkipDir(d.Name()) || shouldSkipPath(path, d, w.patterns) {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+
+	// Apply .gitignore file filters
+	if shouldSkipPath(path, d, w.patterns) {
+		return nil
+	}
+	if !w.matches(path, d.Name()) {
+		return nil
+	}
+
+	w.total++
+	if len(w.files) < maxFindResults {
+		w.files = append(w.files, path)
+	}
+	return nil
+}
+
+// matches reports whether a file is a hit: by filename first, then by path
+// relative to the walk root, then by doublestar expansion of that path.
+func (w *findWalk) matches(path, name string) bool {
+	// Match against the filename using the normalized pattern
+	if matched, _ := filepath.Match(w.filePattern, name); matched {
+		return true
+	}
+
+	// Try matching against relative path for patterns like "src/*.go"
+	relPath, relErr := filepath.Rel(w.root, path)
+	if relErr != nil {
+		return false
+	}
+	if matched, _ := filepath.Match(w.filePattern, relPath); matched {
+		return true
+	}
+
+	// For patterns like "src/**/*.go", match each path segment
+	return matchDoublestar(w.pattern, relPath)
 }
 
 // shouldSkipDir returns true for directories that should always be skipped.

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -449,22 +449,10 @@ func (s *Sandbox) loadGitignore() ([]GitignorePattern, error) {
 		if d.IsDir() && path != "." && shouldSkipDir(d.Name()) {
 			return filepath.SkipDir
 		}
-		if d.Name() == ".gitignore" {
-			gitignoreData, readErr := readFileFromFS(fsys, path)
-			if readErr != nil {
-				return nil
-			}
-			gitignoreDir := filepath.Dir(path)
-			if gitignoreDir == "." {
-				gitignoreDir = ""
-			}
-			scanner := bufio.NewScanner(strings.NewReader(string(gitignoreData)))
-			for scanner.Scan() {
-				if pat, ok := parseGitignoreLine(scanner.Text(), gitignoreDir); ok {
-					dirPatterns[gitignoreDir] = append(dirPatterns[gitignoreDir], pat)
-				}
-			}
+		if d.Name() != ".gitignore" {
+			return nil
 		}
+		collectGitignoreFile(fsys, path, dirPatterns)
 		return nil
 	})
 	if err != nil {
@@ -477,6 +465,28 @@ func (s *Sandbox) loadGitignore() ([]GitignorePattern, error) {
 	}
 
 	return patterns, nil
+}
+
+// collectGitignoreFile parses the .gitignore at path and appends its patterns
+// to the bucket for the directory that contains it. An unreadable file is
+// skipped: a .gitignore that cannot be read contributes no patterns.
+func collectGitignoreFile(fsys fs.FS, path string, dirPatterns map[string][]GitignorePattern) {
+	gitignoreData, readErr := readFileFromFS(fsys, path)
+	if readErr != nil {
+		return
+	}
+
+	gitignoreDir := filepath.Dir(path)
+	if gitignoreDir == "." {
+		gitignoreDir = ""
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(gitignoreData)))
+	for scanner.Scan() {
+		if pat, ok := parseGitignoreLine(scanner.Text(), gitignoreDir); ok {
+			dirPatterns[gitignoreDir] = append(dirPatterns[gitignoreDir], pat)
+		}
+	}
 }
 
 // readFileFromFS reads a file from an fs.FS.

--- a/internal/tools/session_sweep.go
+++ b/internal/tools/session_sweep.go
@@ -86,21 +86,34 @@ func (t *sweepTotals) sortedTools(key func(*toolUsage) int) []*toolUsage {
 // keys case-insensitively.
 type sweepEvent struct {
 	Content struct {
-		Parts []struct {
-			FunctionCall *struct {
-				Name string `json:"name"`
-			} `json:"functionCall"`
-			FunctionResponse *struct {
-				Name     string          `json:"name"`
-				Response json.RawMessage `json:"response"`
-			} `json:"functionResponse"`
-		} `json:"parts"`
+		Parts []sweepPart `json:"parts"`
 	} `json:"content"`
-	UsageMetadata *struct {
-		PromptTokenCount     int `json:"promptTokenCount"`
-		CandidatesTokenCount int `json:"candidatesTokenCount"`
-	} `json:"usageMetadata"`
-	ErrorMessage string `json:"errorMessage"`
+	UsageMetadata *sweepUsage `json:"usageMetadata"`
+	ErrorMessage  string      `json:"errorMessage"`
+}
+
+// sweepPart is one content part: a tool call, a tool result, or neither.
+type sweepPart struct {
+	FunctionCall     *sweepFunctionCall     `json:"functionCall"`
+	FunctionResponse *sweepFunctionResponse `json:"functionResponse"`
+}
+
+// sweepFunctionCall names the tool the model asked for.
+type sweepFunctionCall struct {
+	Name string `json:"name"`
+}
+
+// sweepFunctionResponse carries a tool result verbatim, so its size on the
+// wire is what the scan measures.
+type sweepFunctionResponse struct {
+	Name     string          `json:"name"`
+	Response json.RawMessage `json:"response"`
+}
+
+// sweepUsage is the per-turn token accounting.
+type sweepUsage struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
 }
 
 // accumulateSweepFile folds one session's events into the totals. seen is per
@@ -121,39 +134,50 @@ func accumulateSweepFile(totals *sweepTotals, path string) {
 		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
 			continue
 		}
-
-		if ev.UsageMetadata != nil {
-			totals.PromptTokens += ev.UsageMetadata.PromptTokenCount
-			totals.OutputTokens += ev.UsageMetadata.CandidatesTokenCount
-		}
-		if detail := abortDetail(ev.ErrorMessage); detail != "" {
-			totals.Aborts[detail]++
-		}
-
-		for _, p := range ev.Content.Parts {
-			if p.FunctionCall != nil {
-				totals.tool(p.FunctionCall.Name).Calls++
-			}
-			if p.FunctionResponse == nil {
-				continue
-			}
-			u := totals.tool(p.FunctionResponse.Name)
-			body := string(p.FunctionResponse.Response)
-			u.Bytes += len(body)
-			totals.ToolBytes += len(body)
-			if strings.Contains(body, `"error"`) {
-				u.Errors++
-			}
-			if len(body) > oversizeChars {
-				u.Oversized += len(body) - oversizeChars
-			}
-			if seen[body] {
-				totals.DupBytes += len(body)
-			} else {
-				seen[body] = true
-			}
-		}
+		accumulateSweepEvent(totals, seen, ev)
 	}
+}
+
+// accumulateSweepEvent folds one event — its token usage, its abort reason if
+// it carries one, and each of its content parts — into the totals.
+func accumulateSweepEvent(totals *sweepTotals, seen map[string]bool, ev sweepEvent) {
+	if ev.UsageMetadata != nil {
+		totals.PromptTokens += ev.UsageMetadata.PromptTokenCount
+		totals.OutputTokens += ev.UsageMetadata.CandidatesTokenCount
+	}
+	if detail := abortDetail(ev.ErrorMessage); detail != "" {
+		totals.Aborts[detail]++
+	}
+
+	for _, p := range ev.Content.Parts {
+		if p.FunctionCall != nil {
+			totals.tool(p.FunctionCall.Name).Calls++
+		}
+		if p.FunctionResponse == nil {
+			continue
+		}
+		accumulateSweepResponse(totals, seen, p.FunctionResponse)
+	}
+}
+
+// accumulateSweepResponse folds one tool result into the per-tool and
+// cross-session totals: volume, error rate, oversize excess and duplicates.
+func accumulateSweepResponse(totals *sweepTotals, seen map[string]bool, resp *sweepFunctionResponse) {
+	u := totals.tool(resp.Name)
+	body := string(resp.Response)
+	u.Bytes += len(body)
+	totals.ToolBytes += len(body)
+	if strings.Contains(body, `"error"`) {
+		u.Errors++
+	}
+	if len(body) > oversizeChars {
+		u.Oversized += len(body) - oversizeChars
+	}
+	if seen[body] {
+		totals.DupBytes += len(body)
+		return
+	}
+	seen[body] = true
 }
 
 // abortDetail extracts the reason from a loop-guard abort, or "" when the

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -250,46 +250,7 @@ func singleModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input Sub
 	})
 
 	// Consume events, forward to TUI, accumulate result.
-	forwardAndConsume := func(events <-chan subagent.Event) (string, string, string, string) {
-		var result strings.Builder
-		st := "completed"
-		var em string
-		var sessID string
-		for ev := range events {
-			evContent := ev.Content
-			if ev.Type == "error" && evContent == "" {
-				evContent = ev.Error
-			}
-			emitEvent(onEvent, SubagentEvent{
-				AgentID: agentID, Kind: ev.Type, Content: evContent,
-				PipelineID: pipelineID, Mode: "single", Step: 1, Total: 1,
-			})
-			switch ev.Type {
-			case "text_delta":
-				result.WriteString(ev.Content)
-			case "error":
-				st = "failed"
-				em = ev.Error
-			case "message_start":
-				if ev.SessionID != "" {
-					sessID = ev.SessionID
-				}
-			case "run_done":
-				// The orchestrator's terminal status is more specific than the
-				// "failed" inferred from an error event: it distinguishes a
-				// timeout from a crash. That distinction is actionable for the
-				// model — a timed-out agent is worth retrying with a narrower
-				// task, a crashed one is not — and until now it was computed
-				// and then dropped on the floor here.
-				if ev.Status == "timeout" {
-					st = "timeout"
-				}
-			}
-		}
-		return truncateOutput(result.String()), st, em, sessID
-	}
-
-	resultText, status, errMsg, subSessionID := forwardAndConsume(events)
+	resultText, status, errMsg, subSessionID := forwardSingleModeEvents(events, onEvent, agentID, pipelineID)
 
 	emitEvent(onEvent, SubagentEvent{
 		AgentID: agentID, Kind: "done",
@@ -313,31 +274,98 @@ func singleModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input Sub
 	}, nil
 }
 
-// parallelModeHandler spawns multiple agents concurrently and collects all results.
-func parallelModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input SubagentInput, onEvent SubagentEventCallback) (SubagentOutput, error) {
-	start := time.Now()
-	pipelineID := fmt.Sprintf("pipe-%d", time.Now().UnixNano())
-	total := len(input.Tasks)
+// forwardSingleModeEvents drains the single agent's event channel, forwarding
+// each event to the TUI, and returns the accumulated output, terminal status,
+// error message and sub-session id.
+//
+// It stays separate from forwardSubagentEvents because single mode reads one
+// more event kind: run_done, whose status distinguishes a timeout from a
+// crash. Parallel and chain do not, and folding the two paths together would
+// change what they report.
+func forwardSingleModeEvents(events <-chan subagent.Event, onEvent SubagentEventCallback, agentID, pipelineID string) (resultText, status, errMsg, sessID string) {
+	var result strings.Builder
+	status = "completed"
+	for ev := range events {
+		evContent := ev.Content
+		if ev.Type == "error" && evContent == "" {
+			evContent = ev.Error
+		}
+		emitEvent(onEvent, SubagentEvent{
+			AgentID: agentID, Kind: ev.Type, Content: evContent,
+			PipelineID: pipelineID, Mode: "single", Step: 1, Total: 1,
+		})
+		switch ev.Type {
+		case "text_delta":
+			result.WriteString(ev.Content)
+		case "error":
+			status = "failed"
+			errMsg = ev.Error
+		case "message_start":
+			if ev.SessionID != "" {
+				sessID = ev.SessionID
+			}
+		case "run_done":
+			// The orchestrator's terminal status is more specific than the
+			// "failed" inferred from an error event: it distinguishes a
+			// timeout from a crash. That distinction is actionable for the
+			// model — a timed-out agent is worth retrying with a narrower
+			// task, a crashed one is not — and until now it was computed
+			// and then dropped on the floor here.
+			if ev.Status == "timeout" {
+				status = "timeout"
+			}
+		}
+	}
+	return truncateOutput(result.String()), status, errMsg, sessID
+}
 
-	// Enforce max parallel tasks.
-	if total > maxParallelTasks {
+// subagentTask is one agent-and-prompt pair, the shape parallel and chain mode
+// have in common once TaskItem and ChainItem are past the JSON boundary.
+type subagentTask struct {
+	Agent string
+	Task  string
+}
+
+// subagentPipelineSpec is what differs between the two multi-agent modes: the
+// mode name reported back, the noun used in the over-limit message, and the
+// per-call limit itself.
+type subagentPipelineSpec struct {
+	Mode  string // "parallel" or "chain"
+	Noun  string // "parallel tasks" or "chain steps"
+	Limit int
+}
+
+// subagentStepMeta is the pipeline position stamped onto every event emitted
+// for one step, so the TUI can group and order them.
+type subagentStepMeta struct {
+	PipelineID string
+	Mode       string
+	Step       int // 1-based
+	Total      int
+}
+
+// checkSubagentPipeline enforces the per-call limit and validates that every
+// named agent exists, before anything is spawned. It returns the failure
+// output and false when the call cannot run.
+func checkSubagentPipeline(orch *subagent.Orchestrator, spec subagentPipelineSpec, tasks []subagentTask, start time.Time) (SubagentOutput, bool) {
+	total := len(tasks)
+	if total > spec.Limit {
 		return SubagentOutput{
-			Mode:    "parallel",
-			Summary: fmt.Sprintf("too many parallel tasks: %d (max %d)", total, maxParallelTasks),
+			Mode:    spec.Mode,
+			Summary: fmt.Sprintf("too many %s: %d (max %d)", spec.Noun, total, spec.Limit),
 			Results: []AgentResult{{
-				Agent:    "parallel",
+				Agent:    spec.Mode,
 				Status:   "failed",
-				Error:    fmt.Sprintf("too many parallel tasks: %d exceeds maximum of %d", total, maxParallelTasks),
+				Error:    fmt.Sprintf("too many %s: %d exceeds maximum of %d", spec.Noun, total, spec.Limit),
 				Duration: time.Since(start).Truncate(time.Millisecond).String(),
 			}},
-		}, nil
+		}, false
 	}
 
-	// Validate all agents exist upfront before spawning any.
-	for _, task := range input.Tasks {
+	for _, task := range tasks {
 		if _, err := orch.LookupAgent(task.Agent); err != nil {
 			return SubagentOutput{
-				Mode: "parallel",
+				Mode: spec.Mode,
 				Results: []AgentResult{{
 					Agent:    task.Agent,
 					Status:   "failed",
@@ -345,101 +373,127 @@ func parallelModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input S
 					Duration: time.Since(start).Truncate(time.Millisecond).String(),
 				}},
 				Summary: fmt.Sprintf("validation failed: unknown agent %q", task.Agent),
-			}, nil
+			}, false
+		}
+	}
+	return SubagentOutput{}, true
+}
+
+// runSubagentStep spawns one agent, forwards its events to the callback and
+// returns the finished result. A spawn failure comes back as a failed
+// AgentResult, never as an error: the model can act on the former.
+func runSubagentStep(ctx context.Context, orch *subagent.Orchestrator, onEvent SubagentEventCallback, meta subagentStepMeta, agentName, prompt string) AgentResult {
+	stepStart := time.Now()
+
+	events, agentID, err := orch.SpawnWithInput(ctx, subagent.AgentInput{
+		Type:   agentName,
+		Prompt: prompt,
+	})
+	if err != nil {
+		return AgentResult{
+			Agent:    agentName,
+			Status:   "failed",
+			Error:    err.Error(),
+			Duration: time.Since(stepStart).Truncate(time.Millisecond).String(),
 		}
 	}
 
+	emitEvent(onEvent, SubagentEvent{
+		AgentID:    agentID,
+		Kind:       "spawn",
+		Content:    agentName,
+		PipelineID: meta.PipelineID,
+		Mode:       meta.Mode,
+		Step:       meta.Step,
+		Total:      meta.Total,
+	})
+
+	resultText, status, errMsg, sessID := forwardSubagentEvents(events, onEvent, agentID, meta)
+
+	emitEvent(onEvent, SubagentEvent{
+		AgentID:    agentID,
+		Kind:       "done",
+		PipelineID: meta.PipelineID,
+		Mode:       meta.Mode,
+		Step:       meta.Step,
+		Total:      meta.Total,
+	})
+
+	return AgentResult{
+		Agent:     agentName,
+		AgentID:   agentID,
+		Status:    status,
+		Result:    resultText,
+		Error:     errMsg,
+		Duration:  time.Since(stepStart).Truncate(time.Millisecond).String(),
+		SessionID: sessID,
+	}
+}
+
+// forwardSubagentEvents drains one agent's event channel, forwarding each
+// event to the callback with pipeline metadata attached, and returns the
+// accumulated output, terminal status, error message and sub-session id.
+func forwardSubagentEvents(events <-chan subagent.Event, onEvent SubagentEventCallback, agentID string, meta subagentStepMeta) (resultText, status, errMsg, sessID string) {
+	var result strings.Builder
+	status = "completed"
+
+	for ev := range events {
+		evContent := ev.Content
+		if ev.Type == "error" && evContent == "" {
+			evContent = ev.Error
+		}
+		emitEvent(onEvent, SubagentEvent{
+			AgentID:    agentID,
+			Kind:       ev.Type,
+			Content:    evContent,
+			PipelineID: meta.PipelineID,
+			Mode:       meta.Mode,
+			Step:       meta.Step,
+			Total:      meta.Total,
+		})
+
+		switch ev.Type {
+		case "text_delta":
+			result.WriteString(ev.Content)
+		case "error":
+			status = "failed"
+			errMsg = ev.Error
+		case "message_start":
+			if ev.SessionID != "" {
+				sessID = ev.SessionID
+			}
+		}
+	}
+	return truncateOutput(result.String()), status, errMsg, sessID
+}
+
+// parallelModeHandler spawns multiple agents concurrently and collects all results.
+func parallelModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input SubagentInput, onEvent SubagentEventCallback) (SubagentOutput, error) {
+	start := time.Now()
+	pipelineID := fmt.Sprintf("pipe-%d", time.Now().UnixNano())
+
+	tasks := make([]subagentTask, len(input.Tasks))
+	for i, t := range input.Tasks {
+		tasks[i] = subagentTask(t)
+	}
+
+	spec := subagentPipelineSpec{Mode: "parallel", Noun: "parallel tasks", Limit: maxParallelTasks}
+	if out, ok := checkSubagentPipeline(orch, spec, tasks, start); !ok {
+		return out, nil
+	}
+
 	// Spawn all agents concurrently and collect results.
+	total := len(tasks)
 	results := make([]AgentResult, total)
 	var wg sync.WaitGroup
 	spawnCtx := resolveContext(ctx)
 
-	for i, task := range input.Tasks {
+	for i, task := range tasks {
 		wg.Add(1)
-		go func(idx int, t TaskItem) {
+		go func(idx int, t subagentTask) {
 			defer wg.Done()
-			taskStart := time.Now()
-			step := idx + 1 // 1-based
-
-			// Spawn agent.
-			events, agentID, err := orch.SpawnWithInput(spawnCtx, subagent.AgentInput{
-				Type:   t.Agent,
-				Prompt: t.Task,
-			})
-			if err != nil {
-				results[idx] = AgentResult{
-					Agent:    t.Agent,
-					Status:   "failed",
-					Error:    err.Error(),
-					Duration: time.Since(taskStart).Truncate(time.Millisecond).String(),
-				}
-				return
-			}
-
-			// Emit spawn event.
-			emitEvent(onEvent, SubagentEvent{
-				AgentID:    agentID,
-				Kind:       "spawn",
-				Content:    t.Agent,
-				PipelineID: pipelineID,
-				Mode:       "parallel",
-				Step:       step,
-				Total:      total,
-			})
-
-			// Consume events, accumulate result, forward to callback.
-			var result strings.Builder
-			status := "completed"
-			var errMsg string
-			var sessID string
-
-			for ev := range events {
-				evContent := ev.Content
-				if ev.Type == "error" && evContent == "" {
-					evContent = ev.Error
-				}
-				emitEvent(onEvent, SubagentEvent{
-					AgentID:    agentID,
-					Kind:       ev.Type,
-					Content:    evContent,
-					PipelineID: pipelineID,
-					Mode:       "parallel",
-					Step:       step,
-					Total:      total,
-				})
-
-				switch ev.Type {
-				case "text_delta":
-					result.WriteString(ev.Content)
-				case "error":
-					status = "failed"
-					errMsg = ev.Error
-				case "message_start":
-					if ev.SessionID != "" {
-						sessID = ev.SessionID
-					}
-				}
-			}
-
-			// Emit done event.
-			emitEvent(onEvent, SubagentEvent{
-				AgentID:    agentID,
-				Kind:       "done",
-				PipelineID: pipelineID,
-				Mode:       "parallel",
-				Step:       step,
-				Total:      total,
-			})
-
-			results[idx] = AgentResult{
-				Agent:     t.Agent,
-				AgentID:   agentID,
-				Status:    status,
-				Result:    truncateOutput(result.String()),
-				Error:     errMsg,
-				Duration:  time.Since(taskStart).Truncate(time.Millisecond).String(),
-				SessionID: sessID,
-			}
+			meta := subagentStepMeta{PipelineID: pipelineID, Mode: spec.Mode, Step: idx + 1, Total: total}
+			results[idx] = runSubagentStep(spawnCtx, orch, onEvent, meta, t.Agent, t.Task)
 		}(i, task)
 	}
 
@@ -447,7 +501,7 @@ func parallelModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input S
 
 	duration := time.Since(start).Truncate(time.Millisecond).String()
 	return SubagentOutput{
-		Mode:    "parallel",
+		Mode:    spec.Mode,
 		Results: results,
 		Summary: buildParallelSummary(results, total, duration),
 	}, nil
@@ -458,144 +512,41 @@ func parallelModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input S
 func chainModeHandler(ctx agent.Context, orch *subagent.Orchestrator, input SubagentInput, onEvent SubagentEventCallback) (SubagentOutput, error) {
 	start := time.Now()
 	pipelineID := fmt.Sprintf("pipe-%d", time.Now().UnixNano())
-	total := len(input.Chain)
 
-	// Enforce max chain steps.
-	if total > maxChainSteps {
-		return SubagentOutput{
-			Mode:    "chain",
-			Summary: fmt.Sprintf("too many chain steps: %d (max %d)", total, maxChainSteps),
-			Results: []AgentResult{{
-				Agent:    "chain",
-				Status:   "failed",
-				Error:    fmt.Sprintf("too many chain steps: %d exceeds maximum of %d", total, maxChainSteps),
-				Duration: time.Since(start).Truncate(time.Millisecond).String(),
-			}},
-		}, nil
+	tasks := make([]subagentTask, len(input.Chain))
+	for i, step := range input.Chain {
+		tasks[i] = subagentTask(step)
 	}
 
-	// Validate all agents exist upfront before executing any.
-	for _, step := range input.Chain {
-		if _, err := orch.LookupAgent(step.Agent); err != nil {
-			return SubagentOutput{
-				Mode: "chain",
-				Results: []AgentResult{{
-					Agent:    step.Agent,
-					Status:   "failed",
-					Error:    err.Error(),
-					Duration: time.Since(start).Truncate(time.Millisecond).String(),
-				}},
-				Summary: fmt.Sprintf("validation failed: unknown agent %q", step.Agent),
-			}, nil
-		}
+	spec := subagentPipelineSpec{Mode: "chain", Noun: "chain steps", Limit: maxChainSteps}
+	if out, ok := checkSubagentPipeline(orch, spec, tasks, start); !ok {
+		return out, nil
 	}
 
 	// Execute steps sequentially, passing results forward.
+	total := len(tasks)
 	results := make([]AgentResult, 0, total)
 	spawnCtx := resolveContext(ctx)
 	previousResult := ""
 
-	for idx, step := range input.Chain {
-		stepStart := time.Now()
-		stepNum := idx + 1 // 1-based
-
+	for idx, step := range tasks {
+		meta := subagentStepMeta{PipelineID: pipelineID, Mode: spec.Mode, Step: idx + 1, Total: total}
 		// Expand template placeholders in the task prompt.
-		prompt := expandChainTemplate(step.Task, previousResult)
+		res := runSubagentStep(spawnCtx, orch, onEvent, meta, step.Agent, expandChainTemplate(step.Task, previousResult))
+		results = append(results, res)
 
-		// Spawn agent.
-		events, agentID, err := orch.SpawnWithInput(spawnCtx, subagent.AgentInput{
-			Type:   step.Agent,
-			Prompt: prompt,
-		})
-		if err != nil {
-			results = append(results, AgentResult{
-				Agent:    step.Agent,
-				Status:   "failed",
-				Error:    err.Error(),
-				Duration: time.Since(stepStart).Truncate(time.Millisecond).String(),
-			})
-			// Chain stops on first failure.
-			break
-		}
-
-		// Emit spawn event.
-		emitEvent(onEvent, SubagentEvent{
-			AgentID:    agentID,
-			Kind:       "spawn",
-			Content:    step.Agent,
-			PipelineID: pipelineID,
-			Mode:       "chain",
-			Step:       stepNum,
-			Total:      total,
-		})
-
-		// Consume events, accumulate result, forward to callback.
-		var result strings.Builder
-		status := "completed"
-		var errMsg string
-		var sessID string
-
-		for ev := range events {
-			evContent := ev.Content
-			if ev.Type == "error" && evContent == "" {
-				evContent = ev.Error
-			}
-			emitEvent(onEvent, SubagentEvent{
-				AgentID:    agentID,
-				Kind:       ev.Type,
-				Content:    evContent,
-				PipelineID: pipelineID,
-				Mode:       "chain",
-				Step:       stepNum,
-				Total:      total,
-			})
-
-			switch ev.Type {
-			case "text_delta":
-				result.WriteString(ev.Content)
-			case "error":
-				status = "failed"
-				errMsg = ev.Error
-			case "message_start":
-				if ev.SessionID != "" {
-					sessID = ev.SessionID
-				}
-			}
-		}
-
-		// Emit done event.
-		emitEvent(onEvent, SubagentEvent{
-			AgentID:    agentID,
-			Kind:       "done",
-			PipelineID: pipelineID,
-			Mode:       "chain",
-			Step:       stepNum,
-			Total:      total,
-		})
-
-		resultText := truncateOutput(result.String())
-		results = append(results, AgentResult{
-			Agent:     step.Agent,
-			AgentID:   agentID,
-			Status:    status,
-			Result:    resultText,
-			Error:     errMsg,
-			Duration:  time.Since(stepStart).Truncate(time.Millisecond).String(),
-			SessionID: sessID,
-		})
-
-		// Chain stops on failure.
-		if status != "completed" {
+		// Chain stops on the first failure, spawn failures included.
+		if res.Status != "completed" {
 			break
 		}
 
 		// Pass result to next step.
-		previousResult = resultText
+		previousResult = res.Result
 	}
 
 	duration := time.Since(start).Truncate(time.Millisecond).String()
 	return SubagentOutput{
-		Mode:    "chain",
+		Mode:    spec.Mode,
 		Results: results,
 		Summary: buildChainSummary(results, total, duration),
 	}, nil

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -931,58 +931,99 @@ func (m *model) emitEventParts(
 	log *logger.Logger,
 ) error {
 	for _, part := range ev.Content.Parts {
-		switch {
-		case part.Text != "" && ev.Content.Role == "thinking":
-			log.Thinking(ev.Author, part.Text)
-			ch <- agentThinkingMsg{text: part.Text}
-			if err := stuckErr(detector.observeOutput(part.Text)); err != nil {
-				return err
-			}
-
-		case part.Text != "":
-			if dedup.SkipText(ev) {
-				continue // aggregate re-send; deltas already went out
-			}
-			log.LLMText(ev.Author, part.Text)
-			ch <- agentTextMsg{text: part.Text}
-			if err := stuckErr(detector.observeOutput(part.Text)); err != nil {
-				return err
-			}
-		}
-
-		if fc := part.FunctionCall; fc != nil {
-			// Emit the tool call first so the user sees the offending call
-			// before the loop aborts. The stuck-detector threshold still
-			// fires after `maxRepeatToolCalls` observations, so the abort
-			// semantics are unchanged — only the message ordering moves.
-			log.ToolCall(ev.Author, fc.Name, fc.Args)
-			ch <- agentToolCallMsg{id: fc.ID, name: fc.Name, args: fc.Args}
-
-			if err := stuckErr(detector.observe(fc.Name, fc.Args)); err != nil {
-				return err
-			}
-		}
-
-		if fr := part.FunctionResponse; fr != nil {
-			respJSON, _ := json.Marshal(fr.Response)
-			log.ToolResult(ev.Author, fr.Name, string(respJSON))
-			ch <- agentToolResultMsg{id: fr.ID, name: fr.Name, content: string(respJSON)}
-
-			// A changed result on a repeated call is progress, not a loop
-			// (a poll returning fresh output) — let it reset the
-			// identical-call streak before the next call is observed.
-			detector.observeResult(fr.Name, fr.Response)
-
-			// Track per-tool error streaks: ADK wraps tool errors as
-			// map[string]any{"error": ...}. Anything else (including a
-			// missing key) is treated as success and resets the streak.
-			_, isErr := fr.Response["error"]
-			if err := stuckErr(detector.observeError(fr.Name, isErr)); err != nil {
-				return err
-			}
+		if err := m.emitEventPart(ch, ev, dedup, detector, log, part); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// emitEventPart forwards one part of an event. Returning nil ends this part and
+// moves on to the next, which is what the dedup skip below relies on.
+func (m *model) emitEventPart(
+	ch chan agentMsg,
+	ev *session.Event,
+	dedup *agent.StreamDedup,
+	detector *stuckDetector,
+	log *logger.Logger,
+	part *genai.Part,
+) error {
+	if part.Text != "" {
+		skipped, err := m.emitPartText(ch, ev, dedup, detector, log, part.Text)
+		if err != nil {
+			return err
+		}
+		if skipped {
+			return nil // aggregate re-send; deltas already went out
+		}
+	}
+
+	if fc := part.FunctionCall; fc != nil {
+		// Emit the tool call first so the user sees the offending call
+		// before the loop aborts. The stuck-detector threshold still
+		// fires after `maxRepeatToolCalls` observations, so the abort
+		// semantics are unchanged — only the message ordering moves.
+		log.ToolCall(ev.Author, fc.Name, fc.Args)
+		ch <- agentToolCallMsg{id: fc.ID, name: fc.Name, args: fc.Args}
+
+		if err := stuckErr(detector.observe(fc.Name, fc.Args)); err != nil {
+			return err
+		}
+	}
+
+	if fr := part.FunctionResponse; fr != nil {
+		return m.emitPartResponse(ch, ev, detector, log, fr)
+	}
+	return nil
+}
+
+// emitPartText forwards one part's text, as thinking or as reply text. It
+// reports whether the text was the deduplicated aggregate re-send, in which
+// case the caller must skip the rest of the part rather than emit it twice.
+func (m *model) emitPartText(
+	ch chan agentMsg,
+	ev *session.Event,
+	dedup *agent.StreamDedup,
+	detector *stuckDetector,
+	log *logger.Logger,
+	text string,
+) (skipped bool, err error) {
+	if ev.Content.Role == "thinking" {
+		log.Thinking(ev.Author, text)
+		ch <- agentThinkingMsg{text: text}
+		return false, stuckErr(detector.observeOutput(text))
+	}
+
+	if dedup.SkipText(ev) {
+		return true, nil
+	}
+	log.LLMText(ev.Author, text)
+	ch <- agentTextMsg{text: text}
+	return false, stuckErr(detector.observeOutput(text))
+}
+
+// emitPartResponse forwards one tool result and feeds it to the stuck detector.
+func (m *model) emitPartResponse(
+	ch chan agentMsg,
+	ev *session.Event,
+	detector *stuckDetector,
+	log *logger.Logger,
+	fr *genai.FunctionResponse,
+) error {
+	respJSON, _ := json.Marshal(fr.Response)
+	log.ToolResult(ev.Author, fr.Name, string(respJSON))
+	ch <- agentToolResultMsg{id: fr.ID, name: fr.Name, content: string(respJSON)}
+
+	// A changed result on a repeated call is progress, not a loop
+	// (a poll returning fresh output) — let it reset the
+	// identical-call streak before the next call is observed.
+	detector.observeResult(fr.Name, fr.Response)
+
+	// Track per-tool error streaks: ADK wraps tool errors as
+	// map[string]any{"error": ...}. Anything else (including a
+	// missing key) is treated as success and resets the streak.
+	_, isErr := fr.Response["error"]
+	return stuckErr(detector.observeError(fr.Name, isErr))
 }
 
 // stuckError is a loop abort the run can recover from. It is distinguished
@@ -1377,27 +1418,41 @@ func findPollCard(messages []message, handle string) int {
 // rather than leaving the result unrendered.
 func matchToolResultCard(messages []message, id, name string) int {
 	if id != "" {
-		claimed := false
-		for i := len(messages) - 1; i >= 0; i-- {
-			if messages[i].role != "tool" || messages[i].toolID != id {
-				continue
-			}
-			// pendingRefresh: a repeated poll folded into this card and its
-			// result is the one arriving now. The card still shows the previous
-			// poll's window — that is the point, it keeps the card from blanking
-			// while the poll runs — so the non-empty content must not read as
-			// "already answered" here.
-			if messages[i].content == "" || messages[i].pendingRefresh {
-				return i
-			}
-			// The card for this call already has its result: a duplicate
-			// re-send, which must not spill onto a different call's card.
-			claimed = true
-		}
-		if claimed {
-			return -1
+		if i, claimed := matchToolCardByID(messages, id); i >= 0 || claimed {
+			return i
 		}
 	}
+	return matchToolCardByName(messages, name)
+}
+
+// matchToolCardByID finds the card waiting on call id, newest first. It reports
+// claimed when a card for that id exists but already holds its result — a
+// duplicate re-send, which must be dropped rather than fall through to name
+// matching and spill onto a different call's card. (-1, false) means no card
+// carries the id at all.
+func matchToolCardByID(messages []message, id string) (idx int, claimed bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].role != "tool" || messages[i].toolID != id {
+			continue
+		}
+		// pendingRefresh: a repeated poll folded into this card and its
+		// result is the one arriving now. The card still shows the previous
+		// poll's window — that is the point, it keeps the card from blanking
+		// while the poll runs — so the non-empty content must not read as
+		// "already answered" here.
+		if messages[i].content == "" || messages[i].pendingRefresh {
+			return i, false
+		}
+		claimed = true
+	}
+	return -1, claimed
+}
+
+// matchToolCardByName finds an unanswered card for the named tool, preferring
+// an ID-less one so an ID-less result cannot steal a card that belongs to an
+// identified call. Returns the newest identified candidate as a last resort,
+// or -1 when nothing is waiting.
+func matchToolCardByName(messages []message, name string) int {
 	fallback := -1
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].role != "tool" || messages[i].tool != name || messages[i].content != "" {

--- a/internal/tui/complexity_cog_tui_test.go
+++ b/internal/tui/complexity_cog_tui_test.go
@@ -1,0 +1,1194 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"sort"
+	"strings"
+	"testing"
+
+	llmmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// This file is the behavior-preservation evidence for the cognitive-complexity
+// refactor of four functions in this package:
+//
+//	(*model).failedAgentIDs   run.go
+//	(*model).emitEventParts   agent_loop.go
+//	matchToolResultCard       agent_loop.go
+//	executePing               ping.go
+//
+// Every test here was written and run against the pre-refactor source, and the
+// expected values below are the values that source produced. Passing after the
+// refactor is therefore evidence the refactor is a no-op, not evidence the new
+// code agrees with itself.
+//
+// The golden corpus in complexity_render_test.go does not reach any of these
+// four: it renders chat cards, tool cards, status lines and tool summaries, and
+// none of the functions here produce rendered text. executePing does build a
+// markdown blob, so it gets the same treatment locally — its table pins the
+// exact bytes — while the other three are pinned as classification verdicts and
+// emitted-message sequences instead.
+
+// ---------------------------------------------------------------------------
+// failedAgentIDs — run.go
+// ---------------------------------------------------------------------------
+
+// cogOrchWithStatuses builds an orchestrator whose Get() answers for each
+// agentID in statuses. Agents absent from the map stay unknown, which is the
+// race failedAgentIDs treats as a failure.
+func cogOrchWithStatuses(t *testing.T, statuses map[string]string) *subagent.Orchestrator {
+	t.Helper()
+	// No Shutdown cleanup: SetStatusForTest records a state with no Process
+	// behind it, and ShutdownWithTimeout cancels every agent still marked
+	// "running" — which nil-derefs on a synthetic one. Nothing here starts a
+	// goroutine, so there is nothing to shut down.
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	ids := make([]string, 0, len(statuses))
+	for id := range statuses {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		if !orch.SetStatusForTest(id, statuses[id]) {
+			t.Fatalf("SetStatusForTest(%q) refused", id)
+		}
+	}
+	return orch
+}
+
+// TestCogFailedAgentIDs_Classification pins the failed/not-failed verdict for
+// every agent state the orchestrator can be in, in both single and parallel
+// mode. This is the classification the post-run summary reports and the merge
+// path keys off, so each row is named for the state it encodes.
+//
+// Note the deliberate mismatch preserved from the original: the doc comment
+// says "anything other than completed or running", but the code has always
+// tested `status != "completed"`, so a still-"running" agent counts as failed.
+// The refactor keeps the code's behavior, not the comment's.
+func TestCogFailedAgentIDs_Classification(t *testing.T) {
+	tests := []struct {
+		name     string
+		run      *runState
+		statuses map[string]string // orchestrator records; nil map = empty orchestrator
+		noOrch   bool
+		want     []string
+	}{
+		{
+			name: "nil run",
+			run:  nil,
+			want: nil,
+		},
+		{
+			name:   "no orchestrator",
+			run:    &runState{agentID: "a1", status: "failed"},
+			noOrch: true,
+			want:   nil,
+		},
+		{
+			name: "single: local status completed",
+			run:  &runState{agentID: "a1", status: "completed"},
+			want: nil,
+		},
+		{
+			name: "single: local status failed",
+			run:  &runState{agentID: "a1", status: "failed"},
+			want: []string{"a1"},
+		},
+		{
+			name: "single: local status canceled",
+			run:  &runState{agentID: "a1", status: "canceled"},
+			want: []string{"a1"},
+		},
+		{
+			name: "single: local status killed",
+			run:  &runState{agentID: "a1", status: "killed"},
+			want: []string{"a1"},
+		},
+		{
+			name: "single: local status running counts as failed",
+			run:  &runState{agentID: "a1", status: "running"},
+			want: []string{"a1"},
+		},
+		{
+			name:     "single: empty status falls back to orchestrator completed",
+			run:      &runState{agentID: "a1"},
+			statuses: map[string]string{"a1": "completed"},
+			want:     nil,
+		},
+		{
+			name:     "single: empty status falls back to orchestrator failed",
+			run:      &runState{agentID: "a1"},
+			statuses: map[string]string{"a1": "failed"},
+			want:     []string{"a1"},
+		},
+		{
+			name:     "single: empty status falls back to orchestrator running",
+			run:      &runState{agentID: "a1"},
+			statuses: map[string]string{"a1": "running"},
+			want:     []string{"a1"},
+		},
+		{
+			name:     "single: unknown to orchestrator is failed",
+			run:      &runState{agentID: "a1"},
+			statuses: map[string]string{"other": "completed"},
+			want:     []string{"a1"},
+		},
+		{
+			name: "single: no agent id yet",
+			run:  &runState{},
+			want: nil,
+		},
+		{
+			name: "single: local status wins over orchestrator",
+			run:  &runState{agentID: "a1", status: "completed"},
+			statuses: map[string]string{
+				"a1": "failed",
+			},
+			want: nil,
+		},
+		{
+			name: "parallel: all completed",
+			run: &runState{parallel: []*parallelAgent{
+				{agentID: "p1", status: "completed"},
+				{agentID: "p2", status: "completed"},
+			}},
+			want: nil,
+		},
+		{
+			name: "parallel: mixed local statuses preserve order",
+			run: &runState{parallel: []*parallelAgent{
+				{agentID: "p1", status: "completed"},
+				{agentID: "p2", status: "failed"},
+				{agentID: "p3", status: "canceled"},
+				{agentID: "p4", status: "completed"},
+				{agentID: "p5", status: "running"},
+			}},
+			want: []string{"p2", "p3", "p5"},
+		},
+		{
+			name: "parallel: empty statuses fall back per agent",
+			run: &runState{parallel: []*parallelAgent{
+				{agentID: "p1"},
+				{agentID: "p2"},
+				{agentID: "p3"},
+			}},
+			statuses: map[string]string{"p1": "completed", "p2": "failed"},
+			want:     []string{"p2", "p3"}, // p3 unknown to orchestrator
+		},
+		{
+			name: "parallel: empty agent id still classified",
+			run: &runState{parallel: []*parallelAgent{
+				{agentID: "", status: ""},
+			}},
+			want: []string{""},
+		},
+		{
+			name: "parallel: single-element slice is still parallel",
+			run: &runState{parallel: []*parallelAgent{
+				{agentID: "p1", status: "failed"},
+			}},
+			want: []string{"p1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &model{}
+			m.run = tt.run
+			if !tt.noOrch {
+				m.cfg.Orchestrator = cogOrchWithStatuses(t, tt.statuses)
+			}
+
+			got := m.failedAgentIDs()
+			if !cogEqualStrings(got, tt.want) {
+				t.Errorf("failedAgentIDs() = %#v, want %#v", got, tt.want)
+			}
+			if tt.want == nil && got != nil {
+				t.Errorf("failedAgentIDs() = %#v, want a nil slice", got)
+			}
+		})
+	}
+}
+
+// TestCogResolvedAgentStatus pins the status-resolution helper directly,
+// including the nil-orchestrator branch. failedAgentIDs cannot reach that
+// branch — it returns early on a nil orchestrator — but the original code
+// carried the same redundant `&& m.cfg.Orchestrator != nil` guard, so the
+// helper keeps it and this test says what it does.
+func TestCogResolvedAgentStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		agentID  string
+		statuses map[string]string
+		noOrch   bool
+		want     string
+	}{
+		{name: "explicit status is returned as-is", status: "failed", agentID: "a1", want: "failed"},
+		{
+			name:     "explicit status is not overridden by the orchestrator",
+			status:   "completed",
+			agentID:  "a1",
+			statuses: map[string]string{"a1": "failed"},
+			want:     "completed",
+		},
+		{name: "nil orchestrator resolves to empty", status: "", agentID: "a1", noOrch: true, want: ""},
+		{
+			name:     "empty status resolves from the orchestrator",
+			status:   "",
+			agentID:  "a1",
+			statuses: map[string]string{"a1": "canceled"},
+			want:     "canceled",
+		},
+		{
+			name:     "unknown agent resolves to empty",
+			status:   "",
+			agentID:  "a1",
+			statuses: map[string]string{"other": "completed"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &model{}
+			if !tt.noOrch {
+				m.cfg.Orchestrator = cogOrchWithStatuses(t, tt.statuses)
+			}
+			if got := m.resolvedAgentStatus(tt.status, tt.agentID); got != tt.want {
+				t.Errorf("resolvedAgentStatus(%q, %q) = %q, want %q", tt.status, tt.agentID, got, tt.want)
+			}
+		})
+	}
+}
+
+// cogEqualStrings compares two string slices, treating nil and empty as equal
+// in content (nil-ness is asserted separately where it matters).
+func cogEqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// matchToolResultCard — agent_loop.go
+// ---------------------------------------------------------------------------
+
+// TestCogMatchToolResultCard_Boundaries pins the branch structure of the
+// ID-then-name match: which card an arriving result lands on, and when a
+// result is dropped rather than spilled onto a card that belongs to a
+// different call.
+func TestCogMatchToolResultCard_Boundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		msgs []message
+		id   string
+		tool string
+		want int
+	}{
+		{
+			name: "no messages",
+			msgs: nil,
+			id:   "c1",
+			tool: "read",
+			want: -1,
+		},
+		{
+			name: "id matches the only empty card",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c1"},
+			},
+			id: "c1", tool: "read", want: 0,
+		},
+		{
+			name: "id picks its own card, not the newest same-named one",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c1"},
+				{role: "tool", tool: "read", toolID: "c2"},
+			},
+			id: "c1", tool: "read", want: 0,
+		},
+		{
+			name: "id scan walks newest first among duplicate ids",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c1"},
+				{role: "tool", tool: "read", toolID: "c1"},
+			},
+			id: "c1", tool: "read", want: 1,
+		},
+		{
+			name: "id card already answered: duplicate re-send is dropped",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c1", content: "done"},
+				{role: "tool", tool: "read", toolID: "c2"},
+			},
+			id: "c1", tool: "read", want: -1,
+		},
+		{
+			name: "pendingRefresh reclaims a card that already has content",
+			msgs: []message{
+				{role: "tool", tool: "bash_wait", toolID: "c1", content: "old window", pendingRefresh: true},
+			},
+			id: "c1", tool: "bash_wait", want: 0,
+		},
+		{
+			name: "answered card older than an empty one with the same id",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c1", content: "done"},
+				{role: "tool", tool: "read", toolID: "c1"},
+			},
+			id: "c1", tool: "read", want: 1,
+		},
+		{
+			name: "unknown id falls through to name matching",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c9"},
+			},
+			id: "c1", tool: "read", want: 0,
+		},
+		{
+			name: "unknown id, name match prefers the id-less card",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c8"},
+				{role: "tool", tool: "read"},
+				{role: "tool", tool: "read", toolID: "c9"},
+			},
+			id: "c1", tool: "read", want: 1,
+		},
+		{
+			name: "unknown id, only identified cards: newest is the fallback",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c8"},
+				{role: "tool", tool: "read", toolID: "c9"},
+			},
+			id: "c1", tool: "read", want: 1,
+		},
+		{
+			name: "empty id skips the id scan entirely",
+			msgs: []message{
+				{role: "tool", tool: "read", toolID: "c1"},
+				{role: "tool", tool: "read"},
+			},
+			id: "", tool: "read", want: 1,
+		},
+		{
+			name: "empty id, answered card is not reused",
+			msgs: []message{
+				{role: "tool", tool: "read", content: "done"},
+			},
+			id: "", tool: "read", want: -1,
+		},
+		{
+			name: "empty id ignores pendingRefresh (name path has no such rule)",
+			msgs: []message{
+				{role: "tool", tool: "read", content: "old", pendingRefresh: true},
+			},
+			id: "", tool: "read", want: -1,
+		},
+		{
+			name: "name mismatch",
+			msgs: []message{
+				{role: "tool", tool: "bash"},
+			},
+			id: "", tool: "read", want: -1,
+		},
+		{
+			name: "non-tool role is never matched by id",
+			msgs: []message{
+				{role: "assistant", tool: "read", toolID: "c1"},
+			},
+			id: "c1", tool: "read", want: -1,
+		},
+		{
+			name: "non-tool role is never matched by name",
+			msgs: []message{
+				{role: "assistant", tool: "read"},
+			},
+			id: "", tool: "read", want: -1,
+		},
+		{
+			name: "id claimed on a non-tool row does not block the name path",
+			msgs: []message{
+				{role: "assistant", tool: "read", toolID: "c1", content: "x"},
+				{role: "tool", tool: "read"},
+			},
+			id: "c1", tool: "read", want: 1,
+		},
+		{
+			name: "grounding-style synthetic pair matches by name",
+			msgs: []message{
+				{role: "tool", tool: groundingToolName},
+			},
+			id: "", tool: groundingToolName, want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchToolResultCard(tt.msgs, tt.id, tt.tool); got != tt.want {
+				t.Errorf("matchToolResultCard(%q, %q) = %d, want %d", tt.id, tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// emitEventParts — agent_loop.go
+// ---------------------------------------------------------------------------
+
+// cogEmitTrace runs emitEventParts over ev and renders what it put on the
+// channel, one line per message, followed by the error it returned. The exact
+// sequence is the specification: order, content and count all matter, because
+// this is what the transcript is built from.
+func cogEmitTrace(t *testing.T, ev *session.Event, dedup *agent.StreamDedup, det *stuckDetector) string {
+	t.Helper()
+	m := &model{}
+	ch := make(chan agentMsg, 64)
+	err := m.emitEventParts(ch, ev, dedup, det, nil)
+	close(ch)
+
+	var b strings.Builder
+	for msg := range ch {
+		switch v := msg.(type) {
+		case agentThinkingMsg:
+			fmt.Fprintf(&b, "thinking(%s)\n", v.text)
+		case agentTextMsg:
+			fmt.Fprintf(&b, "text(%s)\n", v.text)
+		case agentToolCallMsg:
+			fmt.Fprintf(&b, "call(%s,%s,%v)\n", v.id, v.name, v.args)
+		case agentToolResultMsg:
+			fmt.Fprintf(&b, "result(%s,%s,%s)\n", v.id, v.name, v.content)
+		default:
+			fmt.Fprintf(&b, "other(%T)\n", v)
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(&b, "err(%s)\n", err.Error())
+	} else {
+		b.WriteString("err(nil)\n")
+	}
+	return b.String()
+}
+
+// cogEvent builds a model-authored event carrying the given parts.
+func cogEvent(role string, partial bool, parts ...*genai.Part) *session.Event {
+	ev := &session.Event{}
+	ev.Author = "cog"
+	ev.Partial = partial
+	ev.Content = &genai.Content{Role: role, Parts: parts}
+	return ev
+}
+
+// cogStuckPhrase is a phrase long and varied enough to trip observeOutput:
+// 32 bytes repeated past outputCheckEvery, well over minOutputPeriod and
+// minPeriodVariety.
+var cogStuckPhrase = strings.Repeat("the quick brown fox jumps over! ", 24)
+
+// TestCogEmitEventParts_Sequences pins the message stream emitted for each
+// shape of part, including the dedup skip that must also suppress the rest of
+// its part, and the four points at which the stuck detector can abort mid-part.
+func TestCogEmitEventParts_Sequences(t *testing.T) {
+	fpRead := toolFingerprint("read", map[string]any{"file_path": "a.go"})
+
+	tests := []struct {
+		name  string
+		ev    *session.Event
+		dedup func() *agent.StreamDedup
+		det   func() *stuckDetector
+		want  string
+	}{
+		{
+			name: "no parts",
+			ev:   cogEvent("model", false),
+			want: "err(nil)\n",
+		},
+		{
+			name: "plain model text",
+			ev:   cogEvent("model", false, &genai.Part{Text: "hello"}),
+			want: "text(hello)\nerr(nil)\n",
+		},
+		{
+			name: "thinking text uses the thinking message",
+			ev:   cogEvent("thinking", false, &genai.Part{Text: "pondering"}),
+			want: "thinking(pondering)\nerr(nil)\n",
+		},
+		{
+			name: "empty text emits nothing",
+			ev:   cogEvent("model", false, &genai.Part{Text: ""}),
+			want: "err(nil)\n",
+		},
+		{
+			name: "empty text in a thinking event emits nothing",
+			ev:   cogEvent("thinking", false, &genai.Part{Text: ""}),
+			want: "err(nil)\n",
+		},
+		{
+			name: "several text parts emit in order",
+			ev: cogEvent("model", false,
+				&genai.Part{Text: "one"},
+				&genai.Part{Text: "two"},
+			),
+			want: "text(one)\ntext(two)\nerr(nil)\n",
+		},
+		{
+			name: "function call",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+			}),
+			want: "call(c1,read,map[file_path:a.go])\nerr(nil)\n",
+		},
+		{
+			name: "function response, success",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"content": "hi"}},
+			}),
+			want: "result(c1,read,{\"content\":\"hi\"})\nerr(nil)\n",
+		},
+		{
+			name: "function response, error payload still emits normally",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"error": "boom"}},
+			}),
+			want: "result(c1,read,{\"error\":\"boom\"})\nerr(nil)\n",
+		},
+		{
+			name: "nil response map marshals to null",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read"},
+			}),
+			want: "result(c1,read,null)\nerr(nil)\n",
+		},
+		{
+			name: "text and call in one part: both emit",
+			ev: cogEvent("model", false, &genai.Part{
+				Text:         "calling",
+				FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+			}),
+			want: "text(calling)\ncall(c1,read,map[file_path:a.go])\nerr(nil)\n",
+		},
+		{
+			name: "thinking text and call in one part: both emit",
+			ev: cogEvent("thinking", false, &genai.Part{
+				Text:         "planning",
+				FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+			}),
+			want: "thinking(planning)\ncall(c1,read,map[file_path:a.go])\nerr(nil)\n",
+		},
+		{
+			name: "call and response in one part: call first",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionCall:     &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"content": "hi"}},
+			}),
+			want: "call(c1,read,map[file_path:a.go])\nresult(c1,read,{\"content\":\"hi\"})\nerr(nil)\n",
+		},
+		{
+			name: "dedup skips the aggregate re-send",
+			ev:   cogEvent("model", false, &genai.Part{Text: "hello"}),
+			dedup: func() *agent.StreamDedup {
+				d := &agent.StreamDedup{}
+				d.SkipText(cogEvent("model", true, &genai.Part{Text: "hel"})) // record a delta
+				return d
+			},
+			want: "err(nil)\n",
+		},
+		{
+			name: "dedup skip also suppresses the call in the same part",
+			ev: cogEvent("model", false, &genai.Part{
+				Text:         "hello",
+				FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+			}),
+			dedup: func() *agent.StreamDedup {
+				d := &agent.StreamDedup{}
+				d.SkipText(cogEvent("model", true, &genai.Part{Text: "hel"}))
+				return d
+			},
+			want: "err(nil)\n",
+		},
+		{
+			name: "dedup skip does not suppress a later part",
+			ev: cogEvent("model", false,
+				&genai.Part{Text: "hello", FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read"}},
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "c2", Name: "bash"}},
+			),
+			dedup: func() *agent.StreamDedup {
+				d := &agent.StreamDedup{}
+				d.SkipText(cogEvent("model", true, &genai.Part{Text: "hel"}))
+				return d
+			},
+			want: "call(c2,bash,map[])\nerr(nil)\n",
+		},
+		{
+			name: "dedup never skips thinking text",
+			ev:   cogEvent("thinking", false, &genai.Part{Text: "pondering"}),
+			dedup: func() *agent.StreamDedup {
+				d := &agent.StreamDedup{}
+				d.SkipText(cogEvent("model", true, &genai.Part{Text: "hel"}))
+				return d
+			},
+			want: "thinking(pondering)\nerr(nil)\n",
+		},
+		{
+			name: "stuck on thinking output aborts after emitting",
+			ev:   cogEvent("thinking", false, &genai.Part{Text: cogStuckPhrase}),
+			want: "thinking(" + cogStuckPhrase + ")\nerr(agent loop aborted: model repeated a 64-character phrase 12 times)\n",
+		},
+		{
+			name: "stuck on model output aborts after emitting",
+			ev:   cogEvent("model", false, &genai.Part{Text: cogStuckPhrase}),
+			want: "text(" + cogStuckPhrase + ")\nerr(agent loop aborted: model repeated a 64-character phrase 12 times)\n",
+		},
+		{
+			name: "stuck output abort stops before a later part",
+			ev: cogEvent("model", false,
+				&genai.Part{Text: cogStuckPhrase},
+				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "c2", Name: "bash"}},
+			),
+			want: "text(" + cogStuckPhrase + ")\nerr(agent loop aborted: model repeated a 64-character phrase 12 times)\n",
+		},
+		{
+			name: "stuck on repeated tool call: the call is emitted first",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionCall: &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+			}),
+			det: func() *stuckDetector {
+				return &stuckDetector{lastPrint: fpRead, lastName: "read", streak: maxRepeatToolCalls - 1}
+			},
+			want: "call(c1,read,map[file_path:a.go])\nerr(agent loop aborted: identical tool call \"read\" repeated 10 times)\n",
+		},
+		{
+			name: "stuck call abort stops before the response in the same part",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionCall:     &genai.FunctionCall{ID: "c1", Name: "read", Args: map[string]any{"file_path": "a.go"}},
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"content": "hi"}},
+			}),
+			det: func() *stuckDetector {
+				return &stuckDetector{lastPrint: fpRead, lastName: "read", streak: maxRepeatToolCalls - 1}
+			},
+			want: "call(c1,read,map[file_path:a.go])\nerr(agent loop aborted: identical tool call \"read\" repeated 10 times)\n",
+		},
+		{
+			name: "stuck on tool-error streak: the result is emitted first",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"error": "boom"}},
+			}),
+			det: func() *stuckDetector {
+				return &stuckDetector{lastErrTool: "read", errStreak: maxToolErrorStreak - 1}
+			},
+			want: "result(c1,read,{\"error\":\"boom\"})\nerr(agent loop aborted: tool \"read\" failed 10 times in a row)\n",
+		},
+		{
+			name: "a successful result resets the error streak",
+			ev: cogEvent("model", false, &genai.Part{
+				FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"content": "hi"}},
+			}),
+			det: func() *stuckDetector {
+				return &stuckDetector{lastErrTool: "read", errStreak: maxToolErrorStreak - 1}
+			},
+			want: "result(c1,read,{\"content\":\"hi\"})\nerr(nil)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dedup := &agent.StreamDedup{}
+			if tt.dedup != nil {
+				dedup = tt.dedup()
+			}
+			det := &stuckDetector{}
+			if tt.det != nil {
+				det = tt.det()
+			}
+			if got := cogEmitTrace(t, tt.ev, dedup, det); got != tt.want {
+				t.Errorf("emitEventParts trace:\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCogEmitEventParts_ObserveResultResetsCallStreak pins the interaction the
+// original code documents inline: a repeated call whose response changed resets
+// the identical-call streak, so the next observation of that call does not
+// abort. It needs two events, so it lives outside the table.
+func TestCogEmitEventParts_ObserveResultResetsCallStreak(t *testing.T) {
+	args := map[string]any{"handle": "bg_1"}
+	fp := toolFingerprint("bash_wait", args)
+	// lastResult must be non-empty for observeResult to treat a differing
+	// response as progress: the first result of a streak only records a
+	// fingerprint, it does not reset.
+	det := &stuckDetector{
+		lastPrint:  fp,
+		lastName:   "bash_wait",
+		lastResult: "0000000000000000",
+		streak:     maxRepeatToolCalls - 2,
+	}
+	dedup := &agent.StreamDedup{}
+
+	// A fresh result arrives: progress, so the streak drops back to 1.
+	got := cogEmitTrace(t, cogEvent("model", false, &genai.Part{
+		FunctionResponse: &genai.FunctionResponse{ID: "r1", Name: "bash_wait", Response: map[string]any{"stdout": "new output"}},
+	}), dedup, det)
+	if want := "result(r1,bash_wait,{\"stdout\":\"new output\"})\nerr(nil)\n"; got != want {
+		t.Fatalf("result event trace:\n got: %q\nwant: %q", got, want)
+	}
+
+	// The same call again would have been the 10th and aborted; after the
+	// reset it is the 2nd and passes.
+	got = cogEmitTrace(t, cogEvent("model", false, &genai.Part{
+		FunctionCall: &genai.FunctionCall{ID: "c1", Name: "bash_wait", Args: args},
+	}), dedup, det)
+	if want := "call(c1,bash_wait,map[handle:bg_1])\nerr(nil)\n"; got != want {
+		t.Fatalf("call event trace:\n got: %q\nwant: %q", got, want)
+	}
+	if det.streak != 1 {
+		t.Errorf("streak = %d, want 1 after observeResult reset", det.streak)
+	}
+}
+
+// TestCogEmitEventParts_StuckErrorIsStuckError pins the error type, not just
+// its text: runAgentLoop distinguishes a recoverable stuck abort from a fatal
+// error by type assertion, so a refactor that returned a plain error would
+// silently turn a recoverable turn into a dead one.
+func TestCogEmitEventParts_StuckErrorIsStuckError(t *testing.T) {
+	m := &model{}
+	ch := make(chan agentMsg, 8)
+	det := &stuckDetector{lastErrTool: "read", errStreak: maxToolErrorStreak - 1}
+	err := m.emitEventParts(ch, cogEvent("model", false, &genai.Part{
+		FunctionResponse: &genai.FunctionResponse{ID: "c1", Name: "read", Response: map[string]any{"error": "boom"}},
+	}), &agent.StreamDedup{}, det, nil)
+
+	var stuck *stuckError
+	if !cogAsStuckError(err, &stuck) {
+		t.Fatalf("error %T (%v) is not a *stuckError", err, err)
+	}
+	if got := stuck.Detail(); got != `tool "read" failed 10 times in a row` {
+		t.Errorf("Detail() = %q", got)
+	}
+}
+
+func cogAsStuckError(err error, out **stuckError) bool {
+	se, ok := err.(*stuckError) //nolint:errorlint // exact type is the point
+	if ok {
+		*out = se
+	}
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// executePing — ping.go
+// ---------------------------------------------------------------------------
+
+// cogPingLLM yields a scripted sequence of responses, so a test can control
+// part layout, usage metadata and error position independently.
+type cogPingLLM struct {
+	steps []cogPingStep
+}
+
+type cogPingStep struct {
+	texts []string // parts to return; nil means a nil Content
+	usage *genai.GenerateContentResponseUsageMetadata
+	err   error
+}
+
+func (l *cogPingLLM) Name() string { return "cog-ping" }
+
+func (l *cogPingLLM) GenerateContent(_ context.Context, _ *llmmodel.LLMRequest, _ bool) iter.Seq2[*llmmodel.LLMResponse, error] {
+	return func(yield func(*llmmodel.LLMResponse, error) bool) {
+		for _, step := range l.steps {
+			if step.err != nil {
+				if !yield(nil, step.err) {
+					return
+				}
+				continue
+			}
+			resp := &llmmodel.LLMResponse{UsageMetadata: step.usage}
+			if step.texts != nil {
+				parts := make([]*genai.Part, 0, len(step.texts))
+				for _, txt := range step.texts {
+					parts = append(parts, &genai.Part{Text: txt})
+				}
+				resp.Content = &genai.Content{Role: string(genai.RoleModel), Parts: parts}
+			}
+			if !yield(resp, nil) {
+				return
+			}
+		}
+	}
+}
+
+func cogUsage(in, out int32) *genai.GenerateContentResponseUsageMetadata {
+	return &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: in, CandidatesTokenCount: out}
+}
+
+// TestCogExecutePing_Output pins the exact markdown executePing produces, plus
+// the reply and error it returns, across every branch: ping-pong vs custom
+// prompt, both truncation boundaries, multi-part and multi-chunk accumulation,
+// missing usage metadata, a nil Content chunk, the error path and the
+// empty-reply path.
+func TestCogExecutePing_Output(t *testing.T) {
+	long90 := strings.Repeat("R", 90)
+	long50 := strings.Repeat("P", 50)
+
+	tests := []struct {
+		name      string
+		steps     []cogPingStep
+		provider  string
+		modelName string
+		prompt    string
+		wantOut   string
+		wantReply string
+		wantErr   string
+	}{
+		{
+			name:      "ping-pong default prompt",
+			steps:     []cogPingStep{{texts: []string{"prompt-prompt"}, usage: cogUsage(10, 5)}},
+			provider:  "anthropic",
+			modelName: "claude-sonnet-4",
+			prompt:    "",
+			wantOut: "**Provider:** anthropic  \n" +
+				"**Model:** claude-sonnet-4  \n" +
+				"**Test:** prompt-prompt  \n" +
+				"**Tokens:** 10in / 5out  \n" +
+				"**Reply:** prompt-prompt  \n\n" +
+				"✓ Model **claude-sonnet-4** is ALIVE",
+			wantReply: "prompt-prompt",
+		},
+		{
+			name:      "custom prompt echoes the prompt line",
+			steps:     []cogPingStep{{texts: []string{"4"}, usage: cogUsage(7, 1)}},
+			provider:  "openai",
+			modelName: "gpt-4o",
+			prompt:    "What is 2+2",
+			wantOut: "**Provider:** openai  \n" +
+				"**Model:** gpt-4o  \n" +
+				"**Prompt:** What is 2+2  \n" +
+				"**Tokens:** 7in / 1out  \n" +
+				"**Reply:** 4  \n\n" +
+				"✓ Model **gpt-4o** is ALIVE",
+			wantReply: "4",
+		},
+		{
+			name:      "reply is trimmed before the empty check and before display",
+			steps:     []cogPingStep{{texts: []string{"  \n pong \n "}, usage: cogUsage(1, 2)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** hi  \n" +
+				"**Tokens:** 1in / 2out  \n" +
+				"**Reply:** pong  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "pong",
+		},
+		{
+			name:      "prompt of exactly 40 chars is not truncated",
+			steps:     []cogPingStep{{texts: []string{"ok"}, usage: cogUsage(1, 1)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    strings.Repeat("P", 40),
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** " + strings.Repeat("P", 40) + "  \n" +
+				"**Tokens:** 1in / 1out  \n" +
+				"**Reply:** ok  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "ok",
+		},
+		{
+			name:      "prompt over 40 chars is truncated with an ellipsis",
+			steps:     []cogPingStep{{texts: []string{"ok"}, usage: cogUsage(1, 1)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    long50,
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** " + strings.Repeat("P", 40) + "...  \n" +
+				"**Tokens:** 1in / 1out  \n" +
+				"**Reply:** ok  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "ok",
+		},
+		{
+			name:      "reply of exactly 80 chars is not truncated",
+			steps:     []cogPingStep{{texts: []string{strings.Repeat("R", 80)}, usage: cogUsage(1, 1)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** hi  \n" +
+				"**Tokens:** 1in / 1out  \n" +
+				"**Reply:** " + strings.Repeat("R", 80) + "  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: strings.Repeat("R", 80),
+		},
+		{
+			name:      "reply over 80 chars is truncated in display but returned whole",
+			steps:     []cogPingStep{{texts: []string{long90}, usage: cogUsage(1, 1)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** hi  \n" +
+				"**Tokens:** 1in / 1out  \n" +
+				"**Reply:** " + strings.Repeat("R", 80) + "...  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: long90,
+		},
+		{
+			name: "multiple parts and chunks concatenate; last usage wins",
+			steps: []cogPingStep{
+				{texts: []string{"po", "ng"}, usage: cogUsage(1, 1)},
+				{texts: []string{" again"}, usage: cogUsage(11, 22)},
+			},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** hi  \n" +
+				"**Tokens:** 11in / 22out  \n" +
+				"**Reply:** pong again  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "pong again",
+		},
+		{
+			name: "a chunk with nil usage leaves the previous counts standing",
+			steps: []cogPingStep{
+				{texts: []string{"pong"}, usage: cogUsage(3, 4)},
+				{texts: []string{"!"}},
+			},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** hi  \n" +
+				"**Tokens:** 3in / 4out  \n" +
+				"**Reply:** pong!  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "pong!",
+		},
+		{
+			name: "a nil-Content chunk is skipped",
+			steps: []cogPingStep{
+				{usage: cogUsage(2, 0)},
+				{texts: []string{"pong"}, usage: cogUsage(2, 3)},
+			},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Prompt:** hi  \n" +
+				"**Tokens:** 2in / 3out  \n" +
+				"**Reply:** pong  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "pong",
+		},
+		{
+			name:      "no usage metadata at all reports zeros",
+			steps:     []cogPingStep{{texts: []string{"pong"}}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "",
+			wantOut: "**Provider:** p  \n" +
+				"**Model:** m  \n" +
+				"**Test:** prompt-prompt  \n" +
+				"**Tokens:** 0in / 0out  \n" +
+				"**Reply:** pong  \n\n" +
+				"✓ Model **m** is ALIVE",
+			wantReply: "pong",
+		},
+		{
+			name:      "empty text parts are dropped and the reply is empty",
+			steps:     []cogPingStep{{texts: []string{"", ""}, usage: cogUsage(1, 0)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut:   "",
+			wantReply: "",
+			wantErr:   "model returned empty response",
+		},
+		{
+			name:      "whitespace-only reply is empty after trimming",
+			steps:     []cogPingStep{{texts: []string{"  \n\t "}, usage: cogUsage(1, 0)}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut:   "",
+			wantReply: "",
+			wantErr:   "model returned empty response",
+		},
+		{
+			name:      "no chunks at all is an empty response",
+			steps:     nil,
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut:   "",
+			wantReply: "",
+			wantErr:   "model returned empty response",
+		},
+		{
+			name:      "error on the first chunk",
+			steps:     []cogPingStep{{err: fmt.Errorf("connection refused")}},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut:   "**✗ Error:** connection refused",
+			wantReply: "",
+			wantErr:   "connection refused",
+		},
+		{
+			name: "error after text discards the text",
+			steps: []cogPingStep{
+				{texts: []string{"pong"}, usage: cogUsage(1, 1)},
+				{err: fmt.Errorf("stream broke")},
+			},
+			provider:  "p",
+			modelName: "m",
+			prompt:    "hi",
+			wantOut:   "**✗ Error:** stream broke",
+			wantReply: "",
+			wantErr:   "stream broke",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llm := &cogPingLLM{steps: tt.steps}
+			out, reply, err := executePing(context.Background(), llm, tt.provider, tt.modelName, tt.prompt)
+
+			if out != tt.wantOut {
+				t.Errorf("output:\n got: %q\nwant: %q", out, tt.wantOut)
+			}
+			if reply != tt.wantReply {
+				t.Errorf("reply = %q, want %q", reply, tt.wantReply)
+			}
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Errorf("unexpected error: %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Errorf("expected error %q, got nil", tt.wantErr)
+			case tt.wantErr != "" && err.Error() != tt.wantErr:
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestCogExecutePing_SystemInstruction pins the two system prompts and the
+// user content executePing sends, which the output cannot show. The ping-pong
+// instruction is what makes an "is it alive" check answerable exactly, so a
+// refactor that swapped the two branches would still print a plausible report.
+func TestCogExecutePing_SystemInstruction(t *testing.T) {
+	tests := []struct {
+		name       string
+		prompt     string
+		wantUser   string
+		wantSystem string
+	}{
+		{
+			name:       "empty prompt uses the ping-pong instruction",
+			prompt:     "",
+			wantUser:   "prompt-prompt",
+			wantSystem: `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`,
+		},
+		{
+			name:       "custom prompt uses the brief instruction",
+			prompt:     "What is 2+2",
+			wantUser:   "What is 2+2",
+			wantSystem: "You are a connectivity test. Reply briefly and concisely.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := &cogCapturingLLM{}
+			if _, _, err := executePing(context.Background(), capture, "p", "m", tt.prompt); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if capture.req == nil {
+				t.Fatal("no request captured")
+			}
+			if got := cogContentText(capture.req.Contents[0]); got != tt.wantUser {
+				t.Errorf("user content = %q, want %q", got, tt.wantUser)
+			}
+			if got := cogContentText(capture.req.Config.SystemInstruction); got != tt.wantSystem {
+				t.Errorf("system instruction = %q, want %q", got, tt.wantSystem)
+			}
+			if got := capture.req.Contents[0].Role; got != string(genai.RoleUser) {
+				t.Errorf("user role = %q, want %q", got, genai.RoleUser)
+			}
+			if capture.streaming {
+				t.Error("executePing must call GenerateContent with streaming=false")
+			}
+		})
+	}
+}
+
+// TestCogCollectPingReply_DiscardsTextBeforeAnError pins the helper's error
+// contract directly rather than through executePing. executePing returns ""
+// for the reply on any error, so text accumulated before the error cannot
+// escape through it — which makes "keep the partial text" an unobservable
+// change at that level. Pinning the helper says the discard is deliberate.
+func TestCogCollectPingReply_DiscardsTextBeforeAnError(t *testing.T) {
+	llm := &cogPingLLM{steps: []cogPingStep{
+		{texts: []string{"partial"}, usage: cogUsage(9, 9)},
+		{err: fmt.Errorf("stream broke")},
+	}}
+
+	res, err := collectPingReply(context.Background(), llm, &llmmodel.LLMRequest{})
+	if err == nil || err.Error() != "stream broke" {
+		t.Fatalf("err = %v, want \"stream broke\"", err)
+	}
+	if res != (pingReply{}) {
+		t.Errorf("res = %+v, want the zero pingReply (text and counts discarded)", res)
+	}
+}
+
+// cogCapturingLLM records the request it is handed and answers with "pong".
+type cogCapturingLLM struct {
+	req       *llmmodel.LLMRequest
+	streaming bool
+}
+
+func (l *cogCapturingLLM) Name() string { return "cog-capture" }
+
+func (l *cogCapturingLLM) GenerateContent(_ context.Context, req *llmmodel.LLMRequest, streaming bool) iter.Seq2[*llmmodel.LLMResponse, error] {
+	l.req = req
+	l.streaming = streaming
+	return func(yield func(*llmmodel.LLMResponse, error) bool) {
+		yield(&llmmodel.LLMResponse{
+			Content: &genai.Content{Role: string(genai.RoleModel), Parts: []*genai.Part{{Text: "pong"}}},
+		}, nil)
+	}
+}
+
+func cogContentText(c *genai.Content) string {
+	if c == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range c.Parts {
+		b.WriteString(p.Text)
+	}
+	return b.String()
+}

--- a/internal/tui/ping.go
+++ b/internal/tui/ping.go
@@ -51,12 +51,9 @@ func executePing(ctx context.Context, llm llmmodel.LLM, providerName, modelName,
 
 	isPingPong := prompt == ""
 	testPrompt := prompt
-	if isPingPong {
-		testPrompt = "prompt-prompt"
-	}
-
 	systemMsg := "You are a connectivity test. Reply briefly and concisely."
 	if isPingPong {
+		testPrompt = "prompt-prompt"
 		systemMsg = `You are a connectivity test. When the user says "prompt-prompt", reply with exactly "prompt-prompt" and nothing else.`
 	}
 
@@ -70,41 +67,15 @@ func executePing(ctx context.Context, llm llmmodel.LLM, providerName, modelName,
 	}
 
 	// Non-streaming test.
-	var reply strings.Builder
-	var totalIn int32
-	var totalOut int32
-	for resp, err := range llm.GenerateContent(ctx, req, false) {
-		if err != nil {
-			w("**✗ Error:** %v", err)
-			return buf.String(), "", err
-		}
-		if resp.Content != nil {
-			for _, part := range resp.Content.Parts {
-				if part.Text != "" {
-					reply.WriteString(part.Text)
-				}
-			}
-		}
-		if resp.UsageMetadata != nil {
-			totalIn = resp.UsageMetadata.PromptTokenCount
-			totalOut = resp.UsageMetadata.CandidatesTokenCount
-		}
+	res, err := collectPingReply(ctx, llm, req)
+	if err != nil {
+		w("**✗ Error:** %v", err)
+		return buf.String(), "", err
 	}
 
-	replyText := strings.TrimSpace(reply.String())
+	replyText := strings.TrimSpace(res.text)
 	if replyText == "" {
 		return buf.String(), "", fmt.Errorf("model returned empty response")
-	}
-
-	// Format the reply for display - truncate if too long
-	displayReply := replyText
-	if len(displayReply) > 80 {
-		displayReply = displayReply[:80] + "..."
-	}
-
-	truncPrompt := testPrompt
-	if len(truncPrompt) > 40 {
-		truncPrompt = truncPrompt[:40] + "..."
 	}
 
 	w("**Provider:** %s  \n", providerName)
@@ -112,11 +83,62 @@ func executePing(ctx context.Context, llm llmmodel.LLM, providerName, modelName,
 	if isPingPong {
 		w("**Test:** prompt-prompt  \n")
 	} else {
-		w("**Prompt:** %s  \n", truncPrompt)
+		w("**Prompt:** %s  \n", truncatePingText(testPrompt, 40))
 	}
-	w("**Tokens:** %din / %dout  \n", totalIn, totalOut)
-	w("**Reply:** %s  \n\n", displayReply)
+	w("**Tokens:** %din / %dout  \n", res.inTokens, res.outTokens)
+	w("**Reply:** %s  \n\n", truncatePingText(replyText, 80))
 	w("✓ Model **%s** is ALIVE", modelName)
 
 	return buf.String(), replyText, nil
+}
+
+// pingReply is what one non-streaming ping exchange produced: the model's text
+// with every chunk and part concatenated, and the token counts from the last
+// chunk that carried usage metadata.
+type pingReply struct {
+	text      string
+	inTokens  int32
+	outTokens int32
+}
+
+// collectPingReply drains the response iterator. An error from any chunk ends
+// the exchange immediately, discarding whatever text came before it.
+func collectPingReply(ctx context.Context, llm llmmodel.LLM, req *llmmodel.LLMRequest) (pingReply, error) {
+	var res pingReply
+	var reply strings.Builder
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			return pingReply{}, err
+		}
+		appendPingText(&reply, resp.Content)
+		if resp.UsageMetadata != nil {
+			res.inTokens = resp.UsageMetadata.PromptTokenCount
+			res.outTokens = resp.UsageMetadata.CandidatesTokenCount
+		}
+	}
+	res.text = reply.String()
+	return res, nil
+}
+
+// appendPingText writes every non-empty text part of content to dst. A nil
+// content contributes nothing — providers send chunks that carry only usage.
+func appendPingText(dst *strings.Builder, content *genai.Content) {
+	if content == nil {
+		return
+	}
+	for _, part := range content.Parts {
+		if part.Text != "" {
+			dst.WriteString(part.Text)
+		}
+	}
+}
+
+// truncatePingText shortens s to max characters plus an ellipsis, for the
+// one-line prompt and reply previews in the ping report. Length is counted in
+// bytes, as it always has been, so a cut can land inside a multi-byte rune.
+func truncatePingText(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -1015,31 +1015,39 @@ func (m *model) failedAgentIDs() []string {
 	if m.run == nil || m.cfg.Orchestrator == nil {
 		return nil
 	}
-	var bad []string
 	if m.run.isParallel() {
+		var bad []string
 		for _, pa := range m.run.parallel {
-			status := pa.status
-			if status == "" && m.cfg.Orchestrator != nil {
-				if st, ok := m.cfg.Orchestrator.Get(pa.agentID); ok {
-					status = st.Status
-				}
-			}
-			if status != "completed" {
+			if m.resolvedAgentStatus(pa.status, pa.agentID) != "completed" {
 				bad = append(bad, pa.agentID)
 			}
 		}
-	} else if m.run.agentID != "" {
-		status := m.run.status
-		if status == "" && m.cfg.Orchestrator != nil {
-			if st, ok := m.cfg.Orchestrator.Get(m.run.agentID); ok {
-				status = st.Status
-			}
-		}
-		if status != "completed" {
-			bad = append(bad, m.run.agentID)
-		}
+		return bad
 	}
-	return bad
+	if m.run.agentID == "" {
+		return nil
+	}
+	if m.resolvedAgentStatus(m.run.status, m.run.agentID) != "completed" {
+		return []string{m.run.agentID}
+	}
+	return nil
+}
+
+// resolvedAgentStatus returns status when the run already carries one, and
+// otherwise asks the orchestrator for agentID's recorded status. An agent the
+// orchestrator has no record of resolves to "", which every caller reads as
+// "not completed" — see failedAgentIDs.
+func (m *model) resolvedAgentStatus(status, agentID string) string {
+	if status != "" {
+		return status
+	}
+	if m.cfg.Orchestrator == nil {
+		return ""
+	}
+	if st, ok := m.cfg.Orchestrator.Get(agentID); ok {
+		return st.Status
+	}
+	return ""
 }
 
 // runWorktreePathsFor returns a markdown bullet list of worktree paths

--- a/internal/voicegemini/complexity_cog_voicegemini_test.go
+++ b/internal/voicegemini/complexity_cog_voicegemini_test.go
@@ -1,0 +1,215 @@
+package voicegemini
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// These cases were captured against the pre-refactor sanitizeSchemaNode and are
+// pasted in as literals, so they pin what the flattened version must reproduce
+// exactly rather than agreeing with whatever it now does.
+//
+// The function guards a startup path that cannot be observed locally: a keyword
+// Gemini rejects closes the live session with WebSocket 1007 before a single
+// microphone byte is sent, so a silent change in what gets stripped only
+// surfaces against a live model.
+func TestSanitizeSchemaNodePinnedOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// --- recursion depth -------------------------------------------------
+		{
+			name: "recurses through nested properties to depth three",
+			in:   `{"type":"object","additionalProperties":false,"properties":{"a":{"type":"object","additionalProperties":false,"properties":{"b":{"type":["null","string"],"additionalProperties":true}}}}}`,
+			want: `{"properties":{"a":{"properties":{"b":{"nullable":true,"type":"string"}},"type":"object"}},"type":"object"}`,
+		},
+		{
+			name: "recurses into items of items",
+			in:   `{"type":"array","items":{"type":"array","items":{"type":"object","additionalProperties":false}}}`,
+			want: `{"items":{"items":{"type":"object"},"type":"array"},"type":"array"}`,
+		},
+		{
+			name: "recurses into anyOf members and their properties",
+			in:   `{"anyOf":[{"type":["null","object"],"properties":{"a":{"additionalProperties":false}}},{"type":"string"}]}`,
+			want: `{"anyOf":[{"nullable":true,"properties":{"a":{}},"type":"object"},{"type":"string"}]}`,
+		},
+
+		// --- the type-union collapse ----------------------------------------
+		{
+			name: "keeps the first non-null member of a multi-member union",
+			in:   `{"type":["string","number","null"]}`,
+			want: `{"nullable":true,"type":"string"}`,
+		},
+		{
+			name: "an empty type array drops the type",
+			in:   `{"type":[]}`,
+			want: `{}`,
+		},
+		{
+			name: "a non-string union member is kept verbatim",
+			in:   `{"type":[123,"null"]}`,
+			want: `{"nullable":true,"type":123}`,
+		},
+		{
+			name: "an existing nullable survives a union without null",
+			in:   `{"type":["string"],"nullable":false}`,
+			want: `{"nullable":false,"type":"string"}`,
+		},
+		{
+			name: "a union with null overwrites an existing nullable",
+			in:   `{"type":["null","string"],"nullable":false}`,
+			want: `{"nullable":true,"type":"string"}`,
+		},
+		{
+			name: "a scalar type is left alone",
+			in:   `{"type":"object"}`,
+			want: `{"type":"object"}`,
+		},
+		{
+			name: "a non-array non-string type is left alone",
+			in:   `{"type":7}`,
+			want: `{"type":7}`,
+		},
+
+		// --- containers that are not schema objects -------------------------
+		// Quirks of the pre-refactor code, preserved deliberately: only the
+		// exact shapes above are descended into, so anything else passes
+		// through untouched, additionalProperties included.
+		{
+			name: "a non-object property value is not descended into",
+			in:   `{"properties":{"a":"not-a-schema","b":[1,2]}}`,
+			want: `{"properties":{"a":"not-a-schema","b":[1,2]}}`,
+		},
+		{
+			name: "an array-valued items is not descended into",
+			in:   `{"items":[{"additionalProperties":false}]}`,
+			want: `{"items":[{"additionalProperties":false}]}`,
+		},
+		{
+			name: "an object-valued anyOf is not descended into",
+			in:   `{"anyOf":{"a":{"additionalProperties":false}}}`,
+			want: `{"anyOf":{"a":{"additionalProperties":false}}}`,
+		},
+		{
+			name: "a non-object anyOf member is skipped",
+			in:   `{"anyOf":["x",{"additionalProperties":false}]}`,
+			want: `{"anyOf":["x",{}]}`,
+		},
+		{
+			name: "a non-object properties value is not descended into",
+			in:   `{"properties":["a"]}`,
+			want: `{"properties":["a"]}`,
+		},
+
+		// --- keywords the function knows nothing about ----------------------
+		{
+			name: "a $ref passes through untouched",
+			in:   `{"$ref":"#/$defs/Foo","additionalProperties":false}`,
+			want: `{"$ref":"#/$defs/Foo"}`,
+		},
+		{
+			name: "$defs is not descended into",
+			in:   `{"$defs":{"Foo":{"additionalProperties":false}},"$ref":"#/$defs/Foo"}`,
+			want: `{"$defs":{"Foo":{"additionalProperties":false}},"$ref":"#/$defs/Foo"}`,
+		},
+		{
+			name: "required and enum pass through",
+			in:   `{"type":"object","required":["a"],"enum":["x","y"],"additionalProperties":false}`,
+			want: `{"enum":["x","y"],"required":["a"],"type":"object"}`,
+		},
+
+		// --- empty and null shapes ------------------------------------------
+		{
+			name: "an empty object stays empty",
+			in:   `{}`,
+			want: `{}`,
+		},
+		{
+			name: "a null property value is preserved",
+			in:   `{"properties":{"a":null}}`,
+			want: `{"properties":{"a":null}}`,
+		},
+		{
+			name: "a null items is preserved",
+			in:   `{"items":null}`,
+			want: `{"items":null}`,
+		},
+		{
+			name: "an empty anyOf is preserved",
+			in:   `{"anyOf":[]}`,
+			want: `{"anyOf":[]}`,
+		},
+		{
+			name: "a top-level array is returned verbatim",
+			in:   `[1,2]`,
+			want: `[1,2]`,
+		},
+		{
+			name: "a top-level string is returned verbatim",
+			in:   `"x"`,
+			want: `"x"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizeSchema(json.RawMessage(tt.in))
+			if err != nil {
+				t.Fatalf("SanitizeSchema(%s) = %v", tt.in, err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("SanitizeSchema(%s)\n got %s\nwant %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The realistic case: what Go schema inference emits for a tool with a pointer
+// field, a slice field and a nested struct. This is the shape that actually
+// reaches Gemini at setup.
+func TestSanitizeSchemaInferredToolSchema(t *testing.T) {
+	in := `{"type":"object","additionalProperties":false,"required":["path"],` +
+		`"properties":{` +
+		`"path":{"type":"string"},` +
+		`"limit":{"type":["null","integer"]},` +
+		`"tags":{"type":["null","array"],"items":{"type":"string"}},` +
+		`"opts":{"type":"object","additionalProperties":false,"properties":{"deep":{"type":["null","boolean"]}}}` +
+		`}}`
+	want := `{"properties":{` +
+		`"limit":{"nullable":true,"type":"integer"},` +
+		`"opts":{"properties":{"deep":{"nullable":true,"type":"boolean"}},"type":"object"},` +
+		`"path":{"type":"string"},` +
+		`"tags":{"items":{"type":"string"},"nullable":true,"type":"array"}` +
+		`},"required":["path"],"type":"object"}`
+
+	got, err := SanitizeSchema(json.RawMessage(in))
+	if err != nil {
+		t.Fatalf("SanitizeSchema() = %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("SanitizeSchema()\n got %s\nwant %s", got, want)
+	}
+}
+
+// sanitizeSchemaNode edits the map it is handed. SanitizeSchema only ever hands
+// it a map decoded from fresh bytes, but the in-place contract is what makes
+// that safe, so pin it directly.
+func TestSanitizeSchemaNodeEditsInPlace(t *testing.T) {
+	node := map[string]any{
+		"additionalProperties": false,
+		"type":                 []any{"null", "string"},
+	}
+	sanitizeSchemaNode(node)
+
+	if _, ok := node["additionalProperties"]; ok {
+		t.Error("additionalProperties survived")
+	}
+	if node["type"] != "string" {
+		t.Errorf("type = %v, want \"string\"", node["type"])
+	}
+	if node["nullable"] != true {
+		t.Errorf("nullable = %v, want true", node["nullable"])
+	}
+}

--- a/internal/voicegemini/schema.go
+++ b/internal/voicegemini/schema.go
@@ -44,44 +44,68 @@ func SanitizeSchema(raw json.RawMessage) (json.RawMessage, error) {
 // through every container the Gemini Schema field set can nest a schema in.
 func sanitizeSchemaNode(node map[string]any) {
 	delete(node, "additionalProperties")
-
-	if types, ok := node["type"].([]any); ok {
-		var nullable bool
-		var kept any
-		for _, t := range types {
-			if s, _ := t.(string); s == "null" {
-				nullable = true
-				continue
-			}
-			if kept == nil {
-				kept = t
-			}
-		}
-		if kept != nil {
-			node["type"] = kept
-		} else {
-			delete(node, "type")
-		}
-		if nullable {
-			node["nullable"] = true
-		}
-	}
+	collapseTypeUnion(node)
 
 	if props, ok := node["properties"].(map[string]any); ok {
-		for _, p := range props {
-			if sub, ok := p.(map[string]any); ok {
-				sanitizeSchemaNode(sub)
-			}
-		}
+		sanitizeSchemaMap(props)
 	}
 	if items, ok := node["items"].(map[string]any); ok {
 		sanitizeSchemaNode(items)
 	}
 	if anyOf, ok := node["anyOf"].([]any); ok {
-		for _, e := range anyOf {
-			if sub, ok := e.(map[string]any); ok {
-				sanitizeSchemaNode(sub)
-			}
+		sanitizeSchemaList(anyOf)
+	}
+}
+
+// collapseTypeUnion rewrites an array-valued "type" into the single enum
+// Gemini's Schema expects: the first non-null member wins, "null" becomes
+// "nullable": true, and a union with no non-null member drops "type" entirely.
+// A "type" that is not an array is left exactly as it is.
+func collapseTypeUnion(node map[string]any) {
+	types, ok := node["type"].([]any)
+	if !ok {
+		return
+	}
+
+	var nullable bool
+	var kept any
+	for _, t := range types {
+		if s, _ := t.(string); s == "null" {
+			nullable = true
+			continue
+		}
+		if kept == nil {
+			kept = t
+		}
+	}
+
+	if kept != nil {
+		node["type"] = kept
+	} else {
+		delete(node, "type")
+	}
+	if nullable {
+		node["nullable"] = true
+	}
+}
+
+// sanitizeSchemaMap sanitizes every value of m that is itself a schema object.
+// Values of any other shape are left untouched — the function strips only what
+// it knows about.
+func sanitizeSchemaMap(m map[string]any) {
+	for _, v := range m {
+		if sub, ok := v.(map[string]any); ok {
+			sanitizeSchemaNode(sub)
+		}
+	}
+}
+
+// sanitizeSchemaList sanitizes every element of l that is itself a schema
+// object, with the same pass-through rule as sanitizeSchemaMap.
+func sanitizeSchemaList(l []any) {
+	for _, v := range l {
+		if sub, ok := v.(map[string]any); ok {
+			sanitizeSchemaNode(sub)
 		}
 	}
 }

--- a/piagent/complexity_cog_piagent_test.go
+++ b/piagent/complexity_cog_piagent_test.go
@@ -1,0 +1,322 @@
+package piagent
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// These tests drive observeTurn directly with a synthetic runner, so each
+// branch of the turn accounting — a nil event, an event with no content, an
+// error carried on the event rather than the iteration, an abandoned range
+// loop — is exercised without needing a provider. The observable contract is
+// the TurnInfo the after-turn hooks receive.
+
+// cogPair is one (event, error) the fake runner yields.
+type cogPair struct {
+	ev  *session.Event
+	err error
+}
+
+// cogRunner yields the given pairs and records how many times it was invoked
+// and with what.
+type cogRunner struct {
+	pairs    []cogPair
+	calls    int
+	lastSess string
+	lastMsg  string
+}
+
+func (r *cogRunner) fn() runner {
+	return func(_ context.Context, sessionID, message string) iter.Seq2[*session.Event, error] {
+		r.calls++
+		r.lastSess, r.lastMsg = sessionID, message
+		return func(yield func(*session.Event, error) bool) {
+			for _, p := range r.pairs {
+				if !yield(p.ev, p.err) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// cogTextEvent is an ordinary assistant-text event.
+func cogTextEvent(text string) *session.Event {
+	return &session.Event{LLMResponse: model.LLMResponse{
+		Content: genai.NewContentFromText(text, genai.RoleModel),
+	}}
+}
+
+// cogToolEvent is an event carrying n function calls in one content block.
+func cogToolEvent(n int) *session.Event {
+	parts := make([]*genai.Part, 0, n+1)
+	parts = append(parts, &genai.Part{Text: "calling"})
+	for i := 0; i < n; i++ {
+		parts = append(parts, &genai.Part{FunctionCall: &genai.FunctionCall{Name: "ls"}})
+	}
+	return &session.Event{LLMResponse: model.LLMResponse{
+		Content: &genai.Content{Role: string(genai.RoleModel), Parts: parts},
+	}}
+}
+
+// cogErrEvent is an event that reports a provider failure in-band.
+func cogErrEvent(code, msg string) *session.Event {
+	return &session.Event{LLMResponse: model.LLMResponse{ErrorCode: code, ErrorMessage: msg}}
+}
+
+// cogEmptyEvent has no content at all, which must still count as an event.
+func cogEmptyEvent() *session.Event {
+	return &session.Event{}
+}
+
+// cogDrain ranges the whole sequence and returns what it saw.
+func cogDrain(seq iter.Seq2[*session.Event, error]) (events int, errs []error) {
+	for ev, err := range seq {
+		if ev != nil {
+			events++
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return events, errs
+}
+
+// cogAgent builds an Agent with only the hook fields observeTurn reads.
+func cogAgent(before []BeforeTurnFunc, after []AfterTurnFunc) *Agent {
+	return &Agent{beforeTurn: before, afterTurn: after}
+}
+
+// cogTurnCase is one runner script and the accounting it must produce.
+type cogTurnCase struct {
+	name          string
+	pairs         []cogPair
+	wantEvents    int
+	wantToolCalls int
+	wantErr       string
+}
+
+func checkTurnInfo(t *testing.T, info TurnInfo, tt cogTurnCase) {
+	t.Helper()
+	if info.SessionID != "sess-1" || info.Message != "hello" {
+		t.Errorf("SessionID/Message = %q/%q, want %q/%q", info.SessionID, info.Message, "sess-1", "hello")
+	}
+	if info.Events != tt.wantEvents {
+		t.Errorf("Events = %d, want %d", info.Events, tt.wantEvents)
+	}
+	if info.ToolCalls != tt.wantToolCalls {
+		t.Errorf("ToolCalls = %d, want %d", info.ToolCalls, tt.wantToolCalls)
+	}
+	switch {
+	case tt.wantErr == "" && info.Err != nil:
+		t.Errorf("Err = %v, want nil", info.Err)
+	case tt.wantErr != "" && (info.Err == nil || info.Err.Error() != tt.wantErr):
+		t.Errorf("Err = %v, want %q", info.Err, tt.wantErr)
+	}
+	if info.Abandoned {
+		t.Error("Abandoned = true for a fully consumed turn")
+	}
+	if info.Duration <= 0 {
+		t.Error("Duration = 0, want the turn to be timed")
+	}
+}
+
+func TestObserveTurn_AccountingAcrossEventShapes(t *testing.T) {
+	tests := []cogTurnCase{
+		{
+			name:       "text only",
+			pairs:      []cogPair{{ev: cogTextEvent("a")}, {ev: cogTextEvent("b")}},
+			wantEvents: 2,
+		},
+		{
+			name:          "function calls counted per part, not per event",
+			pairs:         []cogPair{{ev: cogToolEvent(3)}, {ev: cogTextEvent("done")}},
+			wantEvents:    2,
+			wantToolCalls: 3,
+		},
+		{
+			name:       "an event with no content still counts as an event",
+			pairs:      []cogPair{{ev: cogEmptyEvent()}, {ev: cogTextEvent("x")}},
+			wantEvents: 2,
+		},
+		{
+			name:       "a nil event with no error counts as nothing",
+			pairs:      []cogPair{{}, {ev: cogTextEvent("x")}},
+			wantEvents: 1,
+		},
+		{
+			name:       "an iteration error is reported",
+			pairs:      []cogPair{{ev: cogTextEvent("x")}, {err: errors.New("iteration failed")}},
+			wantEvents: 1,
+			wantErr:    "iteration failed",
+		},
+		{
+			name:       "an in-band provider failure is reported",
+			pairs:      []cogPair{{ev: cogErrEvent("STREAM_ERROR", "400 Bad Request")}},
+			wantEvents: 1,
+			wantErr:    "400 Bad Request",
+		},
+		{
+			name: "the first error wins over a later one",
+			pairs: []cogPair{
+				{err: errors.New("first")},
+				{ev: cogErrEvent("API_ERROR", "second")},
+			},
+			wantEvents: 1,
+			wantErr:    "first",
+		},
+		{
+			name: "an iteration error on the same event does not mask the event error",
+			pairs: []cogPair{
+				{ev: cogErrEvent("API_ERROR", "in band"), err: errors.New("on iteration")},
+			},
+			wantEvents: 1,
+			wantErr:    "on iteration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []TurnInfo
+			ag := cogAgent(nil, []AfterTurnFunc{func(_ context.Context, info TurnInfo) {
+				got = append(got, info)
+			}})
+
+			cogDrain(ag.observeTurn(t.Context(), "sess-1", "hello", (&cogRunner{pairs: tt.pairs}).fn()))
+
+			if len(got) != 1 {
+				t.Fatalf("after-turn hook ran %d times, want 1", len(got))
+			}
+			checkTurnInfo(t, got[0], tt)
+		})
+	}
+}
+
+func TestObserveTurn_AbandonedTurnReportsWhatWasConsumed(t *testing.T) {
+	var got []TurnInfo
+	ag := cogAgent(nil, []AfterTurnFunc{func(_ context.Context, info TurnInfo) {
+		got = append(got, info)
+	}})
+	r := &cogRunner{pairs: []cogPair{
+		{ev: cogToolEvent(1)},
+		{ev: cogToolEvent(1)},
+		{ev: cogToolEvent(1)},
+	}}
+
+	for range ag.observeTurn(t.Context(), "s", "m", r.fn()) {
+		break
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("after-turn hook ran %d times, want 1", len(got))
+	}
+	info := got[0]
+	if !info.Abandoned {
+		t.Error("Abandoned = false after the caller broke out of the range loop")
+	}
+	if info.Events != 1 || info.ToolCalls != 1 {
+		t.Errorf("Events/ToolCalls = %d/%d, want 1/1 — only the consumed event counts", info.Events, info.ToolCalls)
+	}
+}
+
+func TestObserveTurn_BeforeHookFailureAbortsTheTurn(t *testing.T) {
+	sentinel := errors.New("over budget")
+	var ran []string
+	var afterRan int
+
+	ag := cogAgent(
+		[]BeforeTurnFunc{
+			func(_ context.Context, _, _ string) error { ran = append(ran, "first"); return nil },
+			func(_ context.Context, _, _ string) error { ran = append(ran, "second"); return sentinel },
+			func(_ context.Context, _, _ string) error { ran = append(ran, "third"); return nil },
+		},
+		[]AfterTurnFunc{func(context.Context, TurnInfo) { afterRan++ }},
+	)
+	r := &cogRunner{pairs: []cogPair{{ev: cogTextEvent("never")}}}
+
+	events, errs := cogDrain(ag.observeTurn(t.Context(), "s", "m", r.fn()))
+
+	if events != 0 {
+		t.Errorf("yielded %d events, want 0 — the turn never reached the model", events)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("yielded %d errors, want exactly 1", len(errs))
+	}
+	if want := "piagent: before-turn hook: over budget"; errs[0].Error() != want {
+		t.Errorf("error = %q, want %q", errs[0], want)
+	}
+	if !errors.Is(errs[0], sentinel) {
+		t.Error("wrapped error does not unwrap to the hook's error")
+	}
+	if len(ran) != 2 || ran[0] != "first" || ran[1] != "second" {
+		t.Errorf("hooks ran %v, want [first second] — order preserved, stop at the first error", ran)
+	}
+	if r.calls != 0 {
+		t.Errorf("runner invoked %d times, want 0", r.calls)
+	}
+	if afterRan != 0 {
+		t.Errorf("after-turn hook ran %d times, want 0 — the turn never started", afterRan)
+	}
+}
+
+func TestObserveTurn_EveryAfterHookRunsInOrder(t *testing.T) {
+	var order []string
+	ag := cogAgent(
+		[]BeforeTurnFunc{func(context.Context, string, string) error { return nil }},
+		[]AfterTurnFunc{
+			func(context.Context, TurnInfo) { order = append(order, "a") },
+			func(context.Context, TurnInfo) { order = append(order, "b") },
+			func(context.Context, TurnInfo) { order = append(order, "c") },
+		},
+	)
+	r := &cogRunner{pairs: []cogPair{{ev: cogTextEvent("x")}}}
+
+	cogDrain(ag.observeTurn(t.Context(), "s", "m", r.fn()))
+
+	if len(order) != 3 || order[0] != "a" || order[1] != "b" || order[2] != "c" {
+		t.Errorf("after-turn hooks ran %v, want [a b c]", order)
+	}
+}
+
+func TestObserveTurn_HooksAreLazyAndTheRunnerSeesTheTurn(t *testing.T) {
+	var before, after int
+	ag := cogAgent(
+		[]BeforeTurnFunc{func(context.Context, string, string) error { before++; return nil }},
+		[]AfterTurnFunc{func(context.Context, TurnInfo) { after++ }},
+	)
+	r := &cogRunner{pairs: []cogPair{{ev: cogTextEvent("x")}}}
+
+	seq := ag.observeTurn(t.Context(), "sess-9", "the message", r.fn())
+	if before != 0 || after != 0 || r.calls != 0 {
+		t.Fatalf("before/after/runner = %d/%d/%d before iteration, want 0/0/0", before, after, r.calls)
+	}
+
+	cogDrain(seq)
+
+	if before != 1 || after != 1 || r.calls != 1 {
+		t.Errorf("before/after/runner = %d/%d/%d after iteration, want 1/1/1", before, after, r.calls)
+	}
+	if r.lastSess != "sess-9" || r.lastMsg != "the message" {
+		t.Errorf("runner saw %q/%q, want %q/%q", r.lastSess, r.lastMsg, "sess-9", "the message")
+	}
+}
+
+func TestObserveTurn_NoHooksSkipsTheWrapper(t *testing.T) {
+	ag := cogAgent(nil, nil)
+	r := &cogRunner{pairs: []cogPair{{ev: cogTextEvent("x")}, {ev: cogTextEvent("y")}}}
+
+	events, errs := cogDrain(ag.observeTurn(t.Context(), "s", "m", r.fn()))
+
+	if events != 2 || len(errs) != 0 {
+		t.Errorf("events/errors = %d/%d, want 2/0", events, len(errs))
+	}
+	if r.calls != 1 {
+		t.Errorf("runner invoked %d times, want 1", r.calls)
+	}
+}

--- a/piagent/turn.go
+++ b/piagent/turn.go
@@ -73,14 +73,12 @@ func (a *Agent) observeTurn(ctx context.Context, sessionID, message string, run 
 	}
 
 	return func(yield func(*session.Event, error) bool) {
-		for _, fn := range a.beforeTurn {
-			if err := fn(ctx, sessionID, message); err != nil {
-				// Matches how internal/agent reports a pre-turn failure: as
-				// the sole element of the sequence, so a caller's existing
-				// error branch handles it without a second code path.
-				yield(nil, fmt.Errorf("piagent: before-turn hook: %w", err))
-				return
-			}
+		if err := a.runBeforeTurn(ctx, sessionID, message); err != nil {
+			// Matches how internal/agent reports a pre-turn failure: as the
+			// sole element of the sequence, so a caller's existing error
+			// branch handles it without a second code path.
+			yield(nil, err)
+			return
 		}
 
 		info := TurnInfo{SessionID: sessionID, Message: message, Abandoned: true}
@@ -89,32 +87,59 @@ func (a *Agent) observeTurn(ctx context.Context, sessionID, message string, run 
 		// range loop, which is the case an explicit call at the end misses.
 		defer func() {
 			info.Duration = time.Since(started)
-			for _, fn := range a.afterTurn {
-				fn(ctx, info)
-			}
+			a.runAfterTurn(ctx, info)
 		}()
 
 		for ev, err := range run(ctx, sessionID, message) {
-			if err != nil {
-				info.Err = err
-			}
-			if ev != nil {
-				info.Events++
-				if evErr := agent.EventError(ev); evErr != nil && info.Err == nil {
-					info.Err = evErr
-				}
-				if ev.Content != nil {
-					for _, part := range ev.Content.Parts {
-						if part.FunctionCall != nil {
-							info.ToolCalls++
-						}
-					}
-				}
-			}
+			info.record(ev, err)
 			if !yield(ev, err) {
 				return // abandoned; the defer above still reports it
 			}
 		}
 		info.Abandoned = false
+	}
+}
+
+// runBeforeTurn runs the admission-control hooks in order, stopping at the
+// first failure. The returned error is already wrapped for the caller to
+// yield as-is.
+func (a *Agent) runBeforeTurn(ctx context.Context, sessionID, message string) error {
+	for _, fn := range a.beforeTurn {
+		if err := fn(ctx, sessionID, message); err != nil {
+			return fmt.Errorf("piagent: before-turn hook: %w", err)
+		}
+	}
+	return nil
+}
+
+// runAfterTurn reports a finished turn to every after-turn hook. Hooks cannot
+// change the outcome, so none of them can stop the others from running.
+func (a *Agent) runAfterTurn(ctx context.Context, info TurnInfo) {
+	for _, fn := range a.afterTurn {
+		fn(ctx, info)
+	}
+}
+
+// record folds one (event, error) pair from the turn into the running counts.
+// The first error seen wins, whether it arrived on the iteration channel or
+// inside an ordinary event.
+func (info *TurnInfo) record(ev *session.Event, err error) {
+	if err != nil {
+		info.Err = err
+	}
+	if ev == nil {
+		return
+	}
+	info.Events++
+	if evErr := agent.EventError(ev); evErr != nil && info.Err == nil {
+		info.Err = evErr
+	}
+	if ev.Content == nil {
+		return
+	}
+	for _, part := range ev.Content.Parts {
+		if part.FunctionCall != nil {
+			info.ToolCalls++
+		}
 	}
 }


### PR DESCRIPTION
Follows #197, which took every function to cyclomatic complexity ≤ 15. This does the same for **cognitive** complexity.

## Result

| Metric | Before (post-#197) | After |
|---|---|---|
| **Functions over COG 20** | **40** | **0** |
| Max cognitive complexity | 41 | < 20 |
| Total cognitive complexity | 11,188 | ~10,700 |
| **Functions over CC 15** | 0 | **0** ✅ |

Against the original `main` baseline, the two passes together take max cognitive complexity from **89 → under 20** and max cyclomatic from **37 → 15**.

The CC row is the one that mattered most. Nine agents refactoring concurrently did **not** trade one metric for the other — that was the main risk of this pass, so it was a hard constraint rather than a preference.

## Why this isn't more of the same work

The two metrics reward opposite moves. Cyclomatic counts branches, so splitting a function relocates them. Cognitive counts how hard code is to *follow* and applies a **nesting multiplier** — an `if` at depth 3 costs 4, the same `if` at depth 0 costs 1, and a flat `switch` arm costs nothing.

So the lever is **flattening, not splitting**: guard clauses, inverted conditions with early `continue`, collapsing `else`-after-`return`, and hoisting deeply-nested blocks (extracted code restarts at depth 0, paying twice).

## Headline movements

| Function | COG | CC |
|---|---|---|
| `(*Agent).observeTurn` | **41 → 9** | 15 → 6 |
| `TrajectoryDigest` | 37 → 5 | 14 → 5 |
| `ollamaGenaiToolsToOllama` | 36 → 8 | — |
| `antGenaiToolsToAnthropic` / `…ToBetaAnthropic` | **31 → 1** (both) | 11 → 2 |
| `findHandler` | 30 → 4 | 15 → 5 |
| `sanitizeSchemaNode` | 30 → 4 | — |
| `BuildReadImageCallback` | **29 → 0** | 12 → 1 |
| `(*Server).handlePrompt` | 28 → 1 | 15 → 1 |
| `(*anthropicModel).GenerateContent` | **26 → 0** | 14 → 1 |

## Coverage

**Every package touched gained coverage. None regressed.** Mean across all 45 packages: **90.29% → 90.83%**.

| Package | Before | After | |
|---|---|---|---|
| `internal/jsonrpc` | 84.9% | 91.3% | **+6.4** |
| `internal/extension` | 87.5% | 91.0% | +3.5 |
| `internal/codex` | 86.0% | 89.4% | +3.4 |
| `internal/tools` | 89.8% | 92.0% | +2.2 |
| `internal/eval` | 80.7% | 82.8% | +2.1 |
| `internal/atif` | 86.6% | 88.2% | +1.6 |
| `internal/provider` | 93.5% | 94.9% | +1.4 |
| `internal/subagent` | 91.8% | 92.4% | +0.6 |
| `internal/session` | 88.6% | 89.2% | +0.6 |
| `internal/auth` | 90.5% | 91.0% | +0.5 |

~700 new cases in 20 new `complexity_cog_*_test.go` files. **No existing test file was modified.**

## How behaviour preservation was established

Not by "the tests still pass" — the pre-existing tests didn't reach many of these branches, which is how the functions got this deep.

**Tests written in full and run green against unmodified source *before* any edit.** This caught a real mistake rather than merely confirming one: a shed test asserted a collapse the original doesn't perform, because `responseTargetKey` keys a response through its paired `FunctionCall`'s args when one exists and through `responseMapKey` otherwise — different keys for the same file, so a paired response never collapses against an unpaired one. Written after the fact, that test would have agreed with itself and buried the asymmetry.

**Mutation testing.** `anthropic.go`'s goldens killed **20 of 21** mutants, with the survivor verified genuinely equivalent. Adopting a cross-file helper was validated by measuring the pre-refactor *wire output* for six `required` shapes and killing both hazards — the nil-vs-empty distinction is wire-visible under `json:"required,omitzero"`, which omits `nil` but emits `[]` for a non-nil empty slice.

**Wire-level proof of a shared core.** The standard and beta Anthropic tool converters emit byte-identical JSON across 23 declaration shapes, so they now share one implementation — and a test asserts `std == beta` on every case, making the premise an enforced invariant rather than a comment that rots.

## Where reduction was refused

`antRunNonStreaming` keeps its own shape. It looks like it should get the same extraction as the beta path, but the goldens show the standard path emits **empty parts** for empty text/thinking blocks and has no name/id guard on `tool_use`, where beta drops all three. A shared `*genai.Part`-or-nil helper would have silently changed the most-used path in the product. Several flat `switch` ladders and already-linear functions were likewise left alone — a flat switch is not a defect.

## Pre-existing defects found, preserved, and pinned

Both are recorded by tests that will **fail if anyone fixes them**, so the change becomes visible rather than silent:

- **`Sandbox.loadGitignore` globs against `filepath.Base`**, so every pattern containing a slash is inert — `/anchored.log`, `a/b/c.txt` and `**/deep.txt` match nothing — while slash-free patterns match at every depth. Worth a follow-up: `.gitignore`-style exclusions people reasonably expect to work silently don't.
- **`summarizeArgs` spends its three-entry budget on map entries that emit nothing**, and iterates in random order. The test asserts the invariant that actually holds rather than a determinism the code lacks.

## One test rewritten before commit

A new `jsonrpc` test called `handlePrompt` from two goroutines sharing one encoder and tripped `-race`. That cannot happen in the server: `handleConn` dispatches a connection's requests **sequentially** with one encoder per connection, and `runMu` guards `agent.Run` (the ADK Runner mutates shared state) rather than encoder writes. The test invented a scenario the server can't reach, then raced on the buffer it invented. It now models two *connections* with separate encoders — which is what `runMu` actually serializes — with a comment explaining why sharing one would be wrong.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test ./... -count=1` | **45 packages, 0 failures** |
| `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` | **0 issues** |
| `-race` on lsp, jsonrpc, agent, codex, subagent, provider | clean |

Lint runs with golangci-lint's configured truncation disabled (`max-issues-per-linter: 50`, `max-same-issues: 5`) — a default run hides a systematic problem behind a count of 5. Tests run with all provider credentials stripped, so nothing passes locally by reaching a real endpoint and then fails in CI.

https://claude.ai/code/session_011EA5xKa7i4BnC1TzWADXCE
