### PR TITLE
docs: require a codex review before opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,38 @@ branch never touched (currently 10 `SA1019` deprecation errors in
 `hack/test/mcp/`). When that happens, stop and report it — the fix is to clear
 the unrelated lint failure or to have the user decide, not to bypass the hook.
 
+## Review with codex before opening a PR
+
+**Always run a `codex` review of the changes before opening a pull request.**
+Not after, not instead of the other gates — before, so findings are fixed in the
+branch rather than in review comments.
+
+```bash
+cd <the worktree holding the branch>
+codex review --base main --title "<short description>"
+```
+
+`--base <BRANCH>` and a custom `[PROMPT]` are mutually exclusive: passing both
+fails with `the argument '--base <BRANCH>' cannot be used with '[PROMPT]'`. Use
+`--base` alone for branch review; use `--commit <SHA>` or `--uncommitted` for the
+other scopes.
+
+Treat the output as a real reviewer, not a formality:
+
+- Act on findings before pushing. Verify each one against the code yourself
+  before accepting or dismissing it — a finding is a claim, not a verdict.
+- If a finding is wrong, say why in the PR description rather than silently
+  ignoring it.
+- Codex prints a long execution trace; the findings are at the end of the output.
+- A CLI usage error is not a clean review. `exit 0` with an argument-parsing
+  message means the review never ran — re-run it properly.
+
+This has already paid for itself: a codex review of the worktree stash fix found
+a time-of-check/time-of-use race that the tests, `-race`, and `golangci-lint` all
+passed over — `git stash list` returns positional `stash@{N}` refs, so an
+external push or drop between lookup and use renumbers the list and a positional
+drop deletes a stranger's work.
+
 ## Creating a pull request
 
 When the user asks to create a PR, open the browser link to the PR after it is


### PR DESCRIPTION
Adds a rule to `CLAUDE.md`: run a `codex` review on the branch **before** opening a PR, so findings get fixed in the branch rather than in review comments.

```bash
cd <the worktree holding the branch>
codex review --base main --title "<short description>"
```

The rule also records the CLI trap that cost a round trip today: **`--base <BRANCH>` and a custom `[PROMPT]` are mutually exclusive.** Passing both exits with `the argument '--base <BRANCH>' cannot be used with '[PROMPT]'` and never runs a review. An unnoticed usage error reads as a clean review, which is worse than no review at all — so the rule says explicitly that a usage error is not a clean result.

And it says to treat findings as claims to verify, not verdicts to obey — dismissing one is fine, but the reasoning belongs in the PR description rather than being silent.

### Why this earns its place

It is not process for its own sake. A codex review of the worktree stash fix (#198) found a real time-of-check/time-of-use race that **the test suite, `-race`, and `golangci-lint` all passed over**:

`git stash list` returns *positional* `stash@{N}` refs. An external `git stash push` or `drop` between our lookup and our use renumbers every entry beneath it — so a captured ref can name a different entry by the time it is used. The apply restores the wrong work; the drop **permanently deletes a stash belonging to someone else**.

The earlier gates could not have caught it. Tests, the race detector and the linter all observe only *this* process. The hazard is a second process mutating shared repository state between two of our own git calls.

That finding is now fixed in #198 by addressing entries by immutable object id.

https://claude.ai/code/session_011EA5xKa7i4BnC1TzWADXCE