### PR TITLE
docs: add OpenRouter to provider help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sandboxed tools, integrates LSP, and ships with a process-based subagent system.
 
 ## Features
 
-- **Multi-provider LLM** — Claude (Anthropic), GPT/O-series (OpenAI), Gemini (Google), OpenCode, and Ollama (local or cloud) for models
+- **Multi-provider LLM** — Claude (Anthropic), GPT/O-series (OpenAI), Gemini (Google), Mistral, Grok (xAI), Azure OpenAI, OpenRouter, OpenCode, and Ollama (local or cloud) for models
 - **Sandboxed tools** — read, write, edit, shell, grep, find, tree, and git operations. All tools are restricted to the project directory via `os.Root`.
 - **Interactive TUI** — Bubble Tea v2 with Markdown rendering (Glamour), slash commands, and theming
 - **Session persistence** — JSONL append-only event logs with branching, compaction, and resume
@@ -189,6 +189,7 @@ Set the API key for your provider as an environment variable. The provider is in
 | Google Gemini | `gemini-*` | `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | `GEMINI_BASE_URL` |
 | Mistral | `mistral-*`, `magistral-*` | `MISTRAL_API_KEY` | `MISTRAL_BASE_URL` |
 | xAI (Grok) | `grok-*` | `XAI_API_KEY` | `XAI_BASE_URL` |
+| OpenRouter | `openrouter/<model>` | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL` |
 | Azure OpenAI | `azure/<deployment>` | `AZURE_OPENAI_API_KEY` | — |
 | OpenCode | `opencode/<model>` | `OPENCODE_API_KEY` | `OPENCODE_BASE_URL` |
 | Ollama (local) | `ollama/<model>` | none | `OLLAMA_HOST` (default `http://localhost:11434`) |
@@ -198,6 +199,9 @@ Set the API key for your provider as an environment variable. The provider is in
 export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
 export GEMINI_API_KEY="..."
+export MISTRAL_API_KEY="..."     # optional — only if you use Mistral models
+export XAI_API_KEY="..."         # optional — only if you use Grok models
+export OPENROUTER_API_KEY="..."  # optional — only if you use OpenRouter models
 export OPENCODE_API_KEY="..."
 export OLLAMA_API_KEY="..."   # only for Ollama Cloud (:cloud suffix)
 ```
@@ -224,6 +228,10 @@ pi
 pi --model claude:sonnet
 pi --model openai:gpt-4o
 pi --model gemini:gemini-2.5-pro
+pi --model mistral-large-latest
+pi --model grok-4.6
+pi --model azure/my-gpt5-deployment
+pi --model openrouter/google/gemini-3.7-flash
 pi --model ollama/gemma4:12b-mlx
 pi --model opencode/kimi-k3
 pi --model minimax-m3:cloud # automatically detect ollama if :cloud
@@ -371,7 +379,7 @@ Self-hosted or LAN endpoints can be declared in config instead of exported in ev
 ```
 
 Precedence is `--url` flag, then environment variable, then `baseURLs` config. The matching env vars are
-`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `MISTRAL_BASE_URL`, `XAI_BASE_URL`, `OPENCODE_BASE_URL`, and `OLLAMA_HOST`. A per-shell or
+`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `MISTRAL_BASE_URL`, `XAI_BASE_URL`, `OPENROUTER_BASE_URL`, `OPENCODE_BASE_URL`, and `OLLAMA_HOST`. A per-shell or
 CI override still takes effect. An empty env var does not mask a configured value.
 
 ### Ollama generation tuning

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -112,6 +112,7 @@ routing you need:
   gemini-*                 Google Gemini   GEMINI_API_KEY (or GOOGLE_API_KEY)
   mistral-*, magistral-*   Mistral         MISTRAL_API_KEY
   grok-*                   xAI             XAI_API_KEY
+  openrouter/<model>       OpenRouter      OPENROUTER_API_KEY
   ollama/<model>           Ollama, local   none; http://localhost:11434
   <model>:cloud            Ollama Cloud    OLLAMA_API_KEY; https://api.ollama.com
   azure/<deployment>       Azure OpenAI    AZURE_OPENAI_API_KEY
@@ -136,6 +137,9 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 
   # xAI
   pi --model grok-4.6 "trace where this request handler blocks"
+
+  # OpenRouter — any model in the OpenRouter catalog, vendor-prefixed ID
+  pi --model openrouter/google/gemini-3.7-flash "compare these two APIs"
 
   # Ollama against a local daemon — no API key needed
   pi --model ollama/gemma4:e4b "rename this symbol everywhere"

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -144,7 +144,8 @@ func TestRootExampleCoversEveryProvider(t *testing.T) {
 	example := newRootCmd().Example
 	for _, want := range []string{
 		"--model claude-", "--model gpt-", "--model gemini-", "--model mistral-",
-		"--model ollama/", "--model minimax-m3:cloud", "--model azure/", "--model opencode/",
+		"--model grok-", "--model openrouter/", "--model ollama/", "--model minimax-m3:cloud",
+		"--model azure/", "--model opencode/",
 	} {
 		if !strings.Contains(example, want) {
 			t.Errorf("root examples missing %q", want)


### PR DESCRIPTION
## Summary

OpenRouter was fully wired (`openrouter/` prefix in `provider.Resolve`, a `NewLLM` case, `OPENROUTER_API_KEY` / `OPENROUTER_BASE_URL` env vars) but missing from every user-facing provider enumeration.

- **Root --help**: added `openrouter/<model>` to the provider routing table and an OpenRouter example to Example
- **README**: added OpenRouter (plus Mistral/xAI/Azure where absent) to the features list, API-key table, export block, usage examples, and base-URL env var list
- **Test**: TestRootExampleCoversEveryProvider now pins `--model openrouter/` so it cannot rot out again

## Verification

- go build ./... passes
- Targeted cli tests pass
- Full internal/cli package run wedges at TestRunInteractive_CancelContext inside this sandbox (needs a TTY; same class as the documented httptest trap) - hangs identically on clean main, so it is environmental, not from these changes
- golangci-lint via pre-commit hook: 0 issues