### PR TITLE
fix(retry): retry EADDRNOTAVAIL stream failures 3x at 3/5/7s and show retries in TUI

### DIFF
--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"iter"
 	"time"
@@ -40,16 +41,25 @@ func retryDelay(cfg RetryConfig, attempt int) time.Duration {
 // finer net is in internal/provider, which retries the single failed HTTP
 // request without disturbing the turn around it.
 func WithRetry(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error]) iter.Seq2[*session.Event, error] {
+	return WithRetryContext(context.Background(), cfg, runFn)
+}
+
+// WithRetryContext is WithRetry with a context: each retry is announced to the
+// retry.Notifier carried on ctx (see retry.WithNotifier), so the front-end can
+// show that it is waiting on a retry rather than on the model, and the backoff
+// sleep ends early if ctx is canceled.
+func WithRetryContext(ctx context.Context, cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error]) iter.Seq2[*session.Event, error] {
 	return func(yield func(*session.Event, error) bool) {
-		retryLoop(cfg, runFn, yield)
+		retryLoop(ctx, cfg, runFn, yield)
 	}
 }
 
 // retryLoop runs runFn up to cfg.MaxRetries+1 times, sleeping between attempts.
 // It returns as soon as an attempt finishes without a transient error — which
 // includes the case where the consumer stopped ranging, since runAttempt stops
-// with no transient error then.
-func retryLoop(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error], yield func(*session.Event, error) bool) {
+// with no transient error then. Each retry is announced to the retry.Notifier
+// on ctx before the pause, and a canceled ctx ends the pause and the loop.
+func retryLoop(ctx context.Context, cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error], yield func(*session.Event, error) bool) {
 	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
 		hadEvents, transientErr := runAttempt(runFn, yield)
 
@@ -64,7 +74,17 @@ func retryLoop(cfg RetryConfig, runFn func() iter.Seq2[*session.Event, error], y
 		}
 
 		if attempt < cfg.MaxRetries {
-			time.Sleep(retry.Delay(cfg, attempt, transientErr))
+			delay := retry.Delay(cfg, attempt, transientErr)
+			retry.Notify(ctx, retry.Attempt{
+				Attempt:    attempt + 1,
+				MaxRetries: cfg.MaxRetries,
+				Delay:      delay,
+				Err:        transientErr,
+			})
+			if !sleepContext(ctx, delay) {
+				_ = yield(nil, ctx.Err())
+				return
+			}
 			continue
 		}
 
@@ -90,4 +110,19 @@ func runAttempt(runFn func() iter.Seq2[*session.Event, error], yield func(*sessi
 		}
 	}
 	return hadEvents, nil
+}
+
+// sleepContext waits for d, reporting false if ctx was canceled first.
+func sleepContext(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }

--- a/internal/agent/retry_test.go
+++ b/internal/agent/retry_test.go
@@ -1,12 +1,15 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"iter"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/retry"
 
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session"
@@ -257,5 +260,72 @@ func TestIsTransientTimeoutInterfaceFalse(t *testing.T) {
 	err := fmt.Errorf("unique non-matching error xyz123")
 	if isTransient(err) {
 		t.Errorf("isTransient(non-matching error) = true, want false")
+	}
+}
+
+// Each replay is announced to the notifier on the context, numbered against
+// the budget, so the TUI can show "Retrying in … (n/3)" instead of a silent
+// pause.
+func TestWithRetryContextNotifies(t *testing.T) {
+	ev := newTestEvent("hello")
+	calls := 0
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}
+
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			if calls <= 2 {
+				yield(nil, errors.New("read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address"))
+				return
+			}
+			yield(ev, nil)
+		}
+	}
+
+	var notices []retry.Attempt
+	ctx := retry.WithNotifier(context.Background(), func(a retry.Attempt) { notices = append(notices, a) })
+
+	for _, err := range WithRetryContext(ctx, cfg, runFn) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	if len(notices) != 2 {
+		t.Fatalf("notifier called %d times, want 2", len(notices))
+	}
+	for i, n := range notices {
+		if n.Attempt != i+1 || n.MaxRetries != 3 || n.Err == nil {
+			t.Errorf("notice %d = %+v", i, n)
+		}
+	}
+}
+
+// A canceled context ends the backoff sleep and the retry loop with it: the
+// user has walked away, so there is nothing to re-send for.
+func TestWithRetryContextCanceledDuringBackoff(t *testing.T) {
+	cfg := RetryConfig{MaxRetries: 3, InitialDelay: time.Hour, MaxDelay: time.Hour}
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = retry.WithNotifier(ctx, func(retry.Attempt) { cancel() })
+
+	calls := 0
+	runFn := func() iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			calls++
+			yield(nil, errors.New("503 service unavailable"))
+		}
+	}
+
+	var got error
+	for _, err := range WithRetryContext(ctx, cfg, runFn) {
+		got = err
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+	if !errors.Is(got, context.Canceled) {
+		t.Errorf("want context.Canceled, got %v", got)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/pirpc"
 	"github.com/dimetron/pi-go/internal/provider"
+	"github.com/dimetron/pi-go/internal/retry"
 	pisession "github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/subagent"
 	"github.com/dimetron/pi-go/internal/tools"
@@ -1484,13 +1485,18 @@ func runPrint(ctx context.Context, ag *agent.Agent, sessionID, prompt string, lo
 		_ = ag.SetSessionTitle(sessionID, title)
 	}
 	retryCfg := agent.DefaultRetryConfig()
+	// Say when a request is being re-sent, so a backoff pause is not mistaken
+	// for a hung run. stderr keeps it out of the captured reply.
+	ctx = retry.WithNotifier(ctx, func(a retry.Attempt) {
+		fmt.Fprintln(os.Stderr, a.String())
+	})
 	// GroundingMetadata repeats on every chunk of the response it grounds;
 	// report each search once.
 	groundedSeen := map[string]bool{}
 	// SSE delivers the reply as deltas and then once more as an aggregate;
 	// without this the whole answer prints twice.
 	var dedup agent.StreamDedup
-	for ev, err := range agent.WithRetry(retryCfg, func() iter.Seq2[*session.Event, error] {
+	for ev, err := range agent.WithRetryContext(ctx, retryCfg, func() iter.Seq2[*session.Event, error] {
 		return ag.RunStreaming(ctx, sessionID, prompt)
 	}) {
 		if err != nil {
@@ -1604,7 +1610,7 @@ func runJSON(ctx context.Context, ag *agent.Agent, sessionID, prompt string, log
 	var dedup agent.StreamDedup
 
 	retryCfg := agent.DefaultRetryConfig()
-	for ev, err := range agent.WithRetry(retryCfg, func() iter.Seq2[*session.Event, error] {
+	for ev, err := range agent.WithRetryContext(ctx, retryCfg, func() iter.Seq2[*session.Event, error] {
 		return ag.RunStreaming(ctx, sessionID, prompt)
 	}) {
 		if err != nil {

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -14,9 +14,12 @@ import (
 type streamAttempt func(yield func(*model.LLMResponse, error) bool)
 
 // streamRetry is the budget for re-sending a request that died before it
-// produced anything. It is deliberately smaller than the agent-level budget:
-// this retries a single HTTP request, so it runs inside whatever timeout the
-// caller already set for the turn.
+// produced anything: three retries, paced 3s, 5s, 7s. It is deliberately
+// smaller than the agent-level budget — this retries a single HTTP request, so
+// it runs inside whatever timeout the caller already set for the turn — and it
+// is paced linearly rather than exponentially because the faults it is meant
+// to ride out (a dropped socket, a reset stream, a 5xx blip) clear in seconds,
+// not minutes. A server-supplied rate-limit window still overrides the pace.
 //
 // It is a package variable so the provider tests, which drive real error
 // responses through httptest servers, can shrink the pauses instead of paying
@@ -26,6 +29,7 @@ var streamRetry = defaultStreamRetry()
 func defaultStreamRetry() retry.Config {
 	cfg := retry.DefaultConfig()
 	cfg.MaxRetries = 3
+	cfg.Delays = []time.Duration{3 * time.Second, 5 * time.Second, 7 * time.Second}
 	return cfg
 }
 
@@ -89,7 +93,14 @@ func retryStream(ctx context.Context, cfg retry.Config, yield func(*model.LLMRes
 			return
 		}
 
-		if !sleepCtx(ctx, retry.Delay(cfg, attempt, cause)) {
+		delay := retry.Delay(cfg, attempt, cause)
+		retry.Notify(ctx, retry.Attempt{
+			Attempt:    attempt + 1,
+			MaxRetries: cfg.MaxRetries,
+			Delay:      delay,
+			Err:        cause,
+		})
+		if !sleepCtx(ctx, delay) {
 			// Canceled while waiting: same reasoning as above.
 			_ = yield(canceledResponse(), nil)
 			return

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -288,5 +289,85 @@ func TestStreamFailure(t *testing.T) {
 	got := streamFailure(&model.LLMResponse{ErrorCode: "DAILY_LIMIT_EXCEEDED", ErrorMessage: "over budget"}, nil)
 	if got == nil || got.Error() != "DAILY_LIMIT_EXCEEDED: over budget" {
 		t.Errorf("want code and message, got %v", got)
+	}
+}
+
+// The production budget: three retries before the failure is surfaced, paced
+// 3s, 5s, 7s. Pinned here because the schedule is the user-visible contract —
+// "it retries three times, a few seconds apart" — and TestMain hides it from
+// every other test in the package.
+func TestDefaultStreamRetrySchedule(t *testing.T) {
+	cfg := defaultStreamRetry()
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", cfg.MaxRetries)
+	}
+	want := []time.Duration{3 * time.Second, 5 * time.Second, 7 * time.Second}
+	for i, d := range want {
+		if got := retry.Delay(cfg, i, errors.New("503")); got != d {
+			t.Errorf("retry %d waits %v, want %v", i+1, got, d)
+		}
+	}
+}
+
+// The failure that motivated the schedule: the local socket under an open
+// stream went away. It must be re-sent, and each re-send must be announced to
+// the notifier on the context so the TUI can say what it is waiting on.
+func TestRetryStreamRetriesAddrNotAvailAndNotifies(t *testing.T) {
+	const sockErr = "read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address"
+
+	var notices []retry.Attempt
+	ctx := retry.WithNotifier(context.Background(), func(a retry.Attempt) { notices = append(notices, a) })
+
+	calls := 0
+	got := collectStream(ctx, t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		if calls < 4 {
+			y(streamError(sockErr), nil)
+			return
+		}
+		y(textResponse("recovered"), nil)
+	})
+
+	if calls != 4 {
+		t.Errorf("attempts = %d, want 4 (1 + 3 retries)", calls)
+	}
+	if len(got) != 1 || got[0].ErrorCode != "" {
+		t.Fatalf("want the recovered response only, got %+v", got)
+	}
+	if len(notices) != 3 {
+		t.Fatalf("notifier called %d times, want 3", len(notices))
+	}
+	for i, n := range notices {
+		if n.Attempt != i+1 || n.MaxRetries != 3 {
+			t.Errorf("notice %d = %d/%d, want %d/3", i, n.Attempt, n.MaxRetries, i+1)
+		}
+		if n.Err == nil || !strings.Contains(n.Err.Error(), "can't assign requested address") {
+			t.Errorf("notice %d carries %v, want the socket error", i, n.Err)
+		}
+	}
+}
+
+// Once the budget is spent the original failure is surfaced, after exactly
+// MaxRetries notices — the fourth failure is reported, not announced.
+func TestRetryStreamExhaustedAfterThreeRetries(t *testing.T) {
+	const sockErr = "read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address"
+
+	notices := 0
+	ctx := retry.WithNotifier(context.Background(), func(retry.Attempt) { notices++ })
+
+	calls := 0
+	got := collectStream(ctx, t, fastRetry(3), func(y func(*model.LLMResponse, error) bool) {
+		calls++
+		y(streamError(sockErr), nil)
+	})
+
+	if calls != 4 {
+		t.Errorf("attempts = %d, want 4", calls)
+	}
+	if notices != 3 {
+		t.Errorf("notices = %d, want 3", notices)
+	}
+	if len(got) != 1 || got[0].ErrorMessage != sockErr {
+		t.Errorf("want the original error forwarded once, got %+v", got)
 	}
 }

--- a/internal/retry/notify.go
+++ b/internal/retry/notify.go
@@ -1,0 +1,64 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Attempt describes a retry that is about to be made: the failure that
+// triggered it, which retry this is, and how long the caller will wait first.
+type Attempt struct {
+	// Attempt is the 1-based number of the retry about to run.
+	Attempt int
+	// MaxRetries is the total retry budget, for "1/3"-style reporting.
+	MaxRetries int
+	// Delay is the pause before the retry is sent.
+	Delay time.Duration
+	// Err is the transient failure being retried.
+	Err error
+}
+
+// String renders the attempt as a one-line notice suitable for a status line
+// or a transcript warning, e.g.
+//
+//	Retrying in 3s (1/3): read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address
+func (a Attempt) String() string {
+	msg := "unknown error"
+	if a.Err != nil {
+		msg = a.Err.Error()
+	}
+	return fmt.Sprintf("Retrying in %s (%d/%d): %s",
+		a.Delay.Round(100*time.Millisecond), a.Attempt, a.MaxRetries, msg)
+}
+
+// Notifier is told about each retry before the pause that precedes it. It is
+// how a front-end shows "retrying…" while the provider re-sends a request
+// that died underneath it; without one, retries are silent and a stalled
+// stream is indistinguishable from a slow model.
+type Notifier func(Attempt)
+
+type notifierKey struct{}
+
+// WithNotifier returns a context that carries fn to every retry loop run
+// under it. Contexts are the only thing that travels from a front-end through
+// the ADK runner down to the provider's HTTP call, which is why the hook rides
+// on one rather than on a config struct.
+func WithNotifier(ctx context.Context, fn Notifier) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, notifierKey{}, fn)
+}
+
+// Notify reports an imminent retry to the Notifier on ctx, if any. A nil ctx
+// or a ctx without a notifier is a no-op, so retry loops can call this
+// unconditionally.
+func Notify(ctx context.Context, a Attempt) {
+	if ctx == nil {
+		return
+	}
+	if fn, ok := ctx.Value(notifierKey{}).(Notifier); ok && fn != nil {
+		fn(a)
+	}
+}

--- a/internal/retry/notify_test.go
+++ b/internal/retry/notify_test.go
@@ -1,0 +1,109 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// The failure from ~/.pi-go/sessions/260822-0917-d94e2-b868d: the stream's
+// local socket went away (EADDRNOTAVAIL) and the turn died on the spot. Both
+// the macOS and Linux spellings must be retryable, since a fresh dial picks a
+// live address.
+func TestIsTransientSocketGoneAway(t *testing.T) {
+	for _, msg := range []string{
+		"read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address",
+		"dial tcp 104.18.2.115:443: connect: cannot assign requested address",
+		"dial tcp 104.18.2.115:443: connect: network is unreachable",
+		"dial tcp 104.18.2.115:443: connect: no route to host",
+		"write tcp 10.5.50.62:58742->104.18.2.115:443: write: broken pipe",
+		"read tcp 10.5.50.62:58742->104.18.2.115:443: read: connection aborted",
+	} {
+		if !IsTransient(errors.New(msg)) {
+			t.Errorf("IsTransient(%q) = false, want true", msg)
+		}
+		if IsTerminal(errors.New(msg)) {
+			t.Errorf("IsTerminal(%q) = true, want false", msg)
+		}
+	}
+}
+
+// An explicit schedule replaces the exponential backoff and reuses its last
+// entry past the end, so a 3/5/7 schedule with a larger retry budget keeps
+// waiting 7s rather than falling back to doubling.
+func TestDelayExplicitSchedule(t *testing.T) {
+	cfg := Config{
+		MaxRetries:   5,
+		InitialDelay: time.Second,
+		MaxDelay:     time.Minute,
+		Delays:       []time.Duration{3 * time.Second, 5 * time.Second, 7 * time.Second},
+	}
+	err := errors.New("503 service unavailable")
+	for attempt, want := range map[int]time.Duration{
+		0: 3 * time.Second,
+		1: 5 * time.Second,
+		2: 7 * time.Second,
+		3: 7 * time.Second,
+		9: 7 * time.Second,
+	} {
+		if got := Delay(cfg, attempt, err); got != want {
+			t.Errorf("Delay(attempt %d) = %v, want %v", attempt, got, want)
+		}
+	}
+}
+
+func TestDelayExplicitScheduleClampedAndOverridden(t *testing.T) {
+	cfg := Config{
+		MaxRetries: 3,
+		MaxDelay:   4 * time.Second,
+		Delays:     []time.Duration{3 * time.Second, 5 * time.Second, 7 * time.Second},
+	}
+	if got := Delay(cfg, 2, errors.New("503")); got != 4*time.Second {
+		t.Errorf("schedule entry above MaxDelay = %v, want the 4s cap", got)
+	}
+	// The server's own window still beats the schedule.
+	if got := Delay(cfg, 0, providerErr("Please try again in 1s.")); got != time.Second {
+		t.Errorf("server hint = %v, want 1s", got)
+	}
+}
+
+func TestNotify(t *testing.T) {
+	// No notifier: a no-op, including on a nil context.
+	Notify(context.Background(), Attempt{Attempt: 1})
+	Notify(nil, Attempt{Attempt: 1}) //nolint:staticcheck // nil ctx is the case under test
+
+	var got []Attempt
+	ctx := WithNotifier(context.Background(), func(a Attempt) { got = append(got, a) })
+	want := Attempt{Attempt: 2, MaxRetries: 3, Delay: 5 * time.Second, Err: errors.New("boom")}
+	Notify(ctx, want)
+
+	if len(got) != 1 {
+		t.Fatalf("notifier called %d times, want 1", len(got))
+	}
+	if got[0].Attempt != 2 || got[0].MaxRetries != 3 || got[0].Delay != 5*time.Second || got[0].Err == nil {
+		t.Errorf("notifier got %+v, want %+v", got[0], want)
+	}
+
+	// A nil notifier leaves the context alone rather than installing a hook
+	// that panics when called.
+	if WithNotifier(ctx, nil) != ctx {
+		t.Error("WithNotifier(ctx, nil) should return ctx unchanged")
+	}
+}
+
+func TestAttemptString(t *testing.T) {
+	a := Attempt{
+		Attempt:    1,
+		MaxRetries: 3,
+		Delay:      3 * time.Second,
+		Err:        errors.New("read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address"),
+	}
+	const want = "Retrying in 3s (1/3): read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address"
+	if got := a.String(); got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+	if got := (Attempt{Attempt: 1, MaxRetries: 1}).String(); got != "Retrying in 0s (1/1): unknown error" {
+		t.Errorf("String() with nil err = %q", got)
+	}
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -32,6 +32,12 @@ type Config struct {
 	// MaxDelay caps the exponential backoff, and also caps any delay the
 	// server itself asked for.
 	MaxDelay time.Duration
+
+	// Delays, when set, is an explicit pause schedule that replaces the
+	// exponential backoff: retry attempt n waits Delays[n], and attempts past
+	// the end of the slice reuse its last entry. A server-supplied hint still
+	// wins, and MaxDelay still caps the result.
+	Delays []time.Duration
 }
 
 // DefaultConfig returns the shared defaults.
@@ -111,6 +117,18 @@ var transientPatterns = []string{
 	"timeout",
 	"timed out",
 	"deadline exceeded",
+
+	// The local socket or route went away under an open connection. macOS
+	// reports EADDRNOTAVAIL as "read tcp 10.5.50.62:58742->104.18.2.115:443:
+	// read: can't assign requested address" when the interface a stream was
+	// bound to drops (VPN reconnect, Wi-Fi roam, sleep); Linux spells it
+	// "cannot assign requested address". A fresh dial picks a live address.
+	"can't assign requested address",
+	"cannot assign requested address",
+	"network is unreachable",
+	"no route to host",
+	"broken pipe",
+	"connection aborted",
 
 	// A stream that died mid-flight. An HTTP/2 reset arrives as
 	// "stream error: stream ID 9; INTERNAL_ERROR; received from peer", and a
@@ -237,8 +255,9 @@ func ServerDelay(err error) (time.Duration, bool) {
 
 // Delay returns how long to wait before the given retry attempt (0-based).
 //
-// A server-supplied hint wins over the computed backoff, since the server knows
-// when its window reopens and we do not. Both are clamped to cfg.MaxDelay so a
+// A server-supplied hint wins over the configured schedule, since the server
+// knows when its window reopens and we do not. An explicit cfg.Delays schedule
+// wins over the exponential backoff. All three are clamped to cfg.MaxDelay so a
 // provider cannot park a turn indefinitely.
 func Delay(cfg Config, attempt int, err error) time.Duration {
 	maxDelay := cfg.MaxDelay
@@ -248,6 +267,11 @@ func Delay(cfg Config, attempt int, err error) time.Duration {
 
 	if hinted, ok := ServerDelay(err); ok {
 		return min(hinted, maxDelay)
+	}
+
+	if n := len(cfg.Delays); n > 0 {
+		idx := max(0, min(attempt, n-1))
+		return min(cfg.Delays[idx], maxDelay)
 	}
 
 	initial := cfg.InitialDelay

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/logger"
 	"github.com/dimetron/pi-go/internal/otel"
+	"github.com/dimetron/pi-go/internal/retry"
 )
 
 const (
@@ -802,6 +803,15 @@ func (m *model) runAgentLoop(ctx context.Context, prompt string, ch chan agentMs
 		otel.AttributeInt("prompt.length", len(prompt)),
 	)
 
+	// Surface every retry — the provider re-sending a request that died under
+	// it, or WithRetry replaying a run that produced nothing — as a warning in
+	// the transcript. Without this the pause reads as the model thinking, and
+	// a turn that fails after the budget is spent looks like it failed once.
+	ctx = retry.WithNotifier(ctx, func(a retry.Attempt) {
+		log.Info(a.String())
+		ch <- agentWarningMsg{text: a.String()}
+	})
+
 	// Every exit below reports through fail, so the "tell the user, then stop"
 	// pair can't drift apart. Logger methods are nil-safe (logger.Log guards a
 	// nil receiver), so no call site needs to check.
@@ -875,7 +885,7 @@ func (m *model) streamTurn(
 	// with an error on screen. Mid-turn failures are handled a layer down, in
 	// the provider, where a single request can be re-sent without replaying the
 	// tool calls that already ran.
-	for ev, err := range agent.WithRetry(agent.DefaultRetryConfig(), func() iter.Seq2[*session.Event, error] {
+	for ev, err := range agent.WithRetryContext(ctx, agent.DefaultRetryConfig(), func() iter.Seq2[*session.Event, error] {
 		return run.agent.RunStreaming(ctx, run.sessionID, prompt)
 	}) {
 		if err != nil {


### PR DESCRIPTION
## Summary
Session `260822-0917-d94e2-b868d` (openrouter / `stealth/ox-alpha`) died on its first `read tcp 10.5.50.62:58742->104.18.2.115:443: read: can't assign requested address` — EADDRNOTAVAIL, the local socket under an open stream going away (VPN/Wi-Fi change). `retryStream` was already wired on every provider path, but `retry.IsTransient` did not recognise the message, so the failure bypassed it and ended the turn.

- **retry**: classify EADDRNOTAVAIL (macOS `can't assign` / Linux `cannot assign`) and sibling socket faults (network unreachable, no route to host, broken pipe, connection aborted) as transient.
- **retry**: `Config.Delays` — explicit pause schedule replacing the exponential backoff (server `retry in Ns` hints still win, `MaxDelay` still caps).
- **provider**: stream retry budget is now **3 retries at 3s, 5s, 7s** before the failure is surfaced.
- **retry**: `WithNotifier` / `Notify` carried on the context; `Attempt.String()` renders `Retrying in 3s (1/3): <err>`.
- **agent**: `WithRetryContext` notifies and honours cancellation during the backoff sleep; `WithRetry` delegates to it.
- **tui**: each retry appends a warning line to the transcript instead of a silent pause; print mode writes the same line to stderr.

## Testing
- `go test ./internal/retry/ ./internal/agent/ ./internal/provider/ ./internal/tui/ ./internal/cli/` — all pass (cli run outside the sandbox).
- `golangci-lint` clean on the touched packages.
- `codex review --base main`: no actionable defects.

https://claude.ai/code/session_01Xwo521M3vULLQU5zXLjPeA
