### PR TITLE
fix: make the test suite pass on Windows, and fix the product bugs it exposed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - "cmd/"
+  # Test-only helpers, imported solely from _test.go files; the Windows arms
+  # of these helpers can never execute on the Linux coverage job.
+  - "internal/testenv/"

--- a/internal/cli/memory_model.go
+++ b/internal/cli/memory_model.go
@@ -50,6 +50,11 @@ Use --onnx to specify a specific ONNX file, e.g.:
 	return cmd
 }
 
+// downloadModel is the fetcher runMemoryModelDownload delegates to. A variable
+// so tests can substitute a fake instead of pulling the real weights from
+// Hugging Face into the test HOME.
+var downloadModel = palace.DownloadModel
+
 func runMemoryModelDownload(dest string, onnxFilePath string) error {
 	if dest == "" {
 		home, err := os.UserHomeDir()
@@ -71,7 +76,7 @@ func runMemoryModelDownload(dest string, onnxFilePath string) error {
 
 	fmt.Printf("Downloading embedding model to %s ...\n", dest)
 
-	modelPath, err := palace.DownloadModel(dest, onnxFilePath)
+	modelPath, err := downloadModel(dest, onnxFilePath)
 	if err != nil {
 		return fmt.Errorf("downloading model: %w", err)
 	}

--- a/internal/cli/memory_model_test.go
+++ b/internal/cli/memory_model_test.go
@@ -2,10 +2,13 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/testenv"
 )
 
@@ -136,18 +139,71 @@ func TestRunMemoryModelDownload_ExplicitOnnxPath(t *testing.T) {
 	}
 }
 
+// stubDownloadModel replaces the fetcher for the duration of the test and
+// returns a pointer to the arguments it was last called with.
+//
+// The real fetcher pulls the embedding model from Hugging Face into HOME. This
+// test used to do exactly that and only appeared to pass because an earlier
+// test left HOME unset; with HOME isolated properly the download ran, and two
+// things broke under -race: go-huggingface's parallel download has a data
+// race, and every later palace-backed test in this package then found the
+// weights and ran real inference, where gomlx's AVX2 matmul kernel trips
+// checkptr. A fake fetcher keeps the path covered without any of that.
+func stubDownloadModel(t *testing.T, result string, err error) *struct{ dest, onnx string } {
+	t.Helper()
+	var got struct{ dest, onnx string }
+	orig := downloadModel
+	downloadModel = func(dest, onnx string) (string, error) {
+		got.dest, got.onnx = dest, onnx
+		return result, err
+	}
+	t.Cleanup(func() { downloadModel = orig })
+	return &got
+}
+
 func TestRunMemoryModelDownload_DefaultDest(t *testing.T) {
-	// This downloads the real embedding model from Hugging Face into the
-	// package's shared test HOME. It only ever appeared to pass: an earlier
-	// test used to leave HOME unset, so runMemoryModelDownload failed before
-	// reaching the network. With HOME isolated properly the download runs, and
-	// two things break under -race: go-huggingface's parallel download has a
-	// data race, and every later palace-backed test in this package then finds
-	// the weights and runs real inference, where gomlx's AVX2 matmul kernel
-	// trips checkptr. Skip it like its siblings above.
-	t.Skip("skipping: downloads a real model over the network; go-huggingface races under -race and the weights poison later palace tests")
-	err := runMemoryModelDownload("", "")
-	if err != nil {
-		t.Logf("expected error: %v", err)
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	got := stubDownloadModel(t, "model-path", nil)
+
+	out := captureStdout(t, func() {
+		if err := runMemoryModelDownload("", ""); err != nil {
+			t.Errorf("runMemoryModelDownload: %v", err)
+		}
+	})
+
+	wantDest := filepath.Join(home, ".pi-go", "models")
+	if got.dest != wantDest {
+		t.Errorf("dest = %q, want the default under HOME %q", got.dest, wantDest)
+	}
+	if info, err := os.Stat(wantDest); err != nil || !info.IsDir() {
+		t.Errorf("default model directory was not created: %v", err)
+	}
+	if got.onnx != palace.DetectPlatformOnnxFile() {
+		t.Errorf("onnx = %q, want the auto-detected %q", got.onnx, palace.DetectPlatformOnnxFile())
+	}
+	if !strings.Contains(out, "Model downloaded: model-path") {
+		t.Errorf("output = %q, want the downloaded path reported", out)
+	}
+}
+
+func TestRunMemoryModelDownload_ExplicitDestAndOnnxReachTheFetcher(t *testing.T) {
+	got := stubDownloadModel(t, "", nil)
+	dest := filepath.Join(t.TempDir(), "models")
+
+	if err := runMemoryModelDownload(dest, "onnx/custom.onnx"); err != nil {
+		t.Fatalf("runMemoryModelDownload: %v", err)
+	}
+	if got.dest != dest || got.onnx != "onnx/custom.onnx" {
+		t.Errorf("fetcher got dest=%q onnx=%q, want %q / onnx/custom.onnx", got.dest, got.onnx, dest)
+	}
+}
+
+func TestRunMemoryModelDownload_FetcherErrorIsWrapped(t *testing.T) {
+	stubDownloadModel(t, "", errors.New("offline"))
+
+	err := runMemoryModelDownload(t.TempDir(), "")
+	if err == nil || !strings.Contains(err.Error(), "downloading model: offline") {
+		t.Errorf("err = %v, want the fetcher error wrapped as \"downloading model\"", err)
 	}
 }

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 )
 
@@ -472,16 +471,11 @@ func fileURI(path string) string {
 
 // pathToURI converts an absolute path to a file:// URI.
 //
-// Windows paths start with a drive letter, not a slash. Handing url.URL a Path
-// of "C:/x" makes String emit "file://C:/x", where the drive letter is read as
-// the authority; the extra leading slash is what produces the "file:///C:/x"
-// form language servers expect.
+// The path component comes from URIPath, which on Windows puts the leading
+// slash in front of the drive letter that url.URL needs to emit "file:///C:/x"
+// rather than reading "C:" as the authority.
 func pathToURI(path string) string {
-	p := filepath.ToSlash(path)
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
-	}
-	u := &url.URL{Scheme: "file", Path: p}
+	u := &url.URL{Scheme: "file", Path: URIPath(path)}
 	return u.String()
 }
 

--- a/internal/lsp/uri_other.go
+++ b/internal/lsp/uri_other.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package lsp
+
+import "path/filepath"
+
+// URIPath converts an absolute OS path into the path component of a file URI.
+// On Unix an absolute path already starts with a slash, so only the separator
+// form can differ; the drive-letter handling lives in uri_windows.go.
+func URIPath(abs string) string {
+	return filepath.ToSlash(abs)
+}
+
+// PathFromURIPath converts the path component of a file URI back into an OS
+// path. There is no drive-letter slash to strip on Unix; see uri_windows.go.
+func PathFromURIPath(p string) string {
+	return filepath.FromSlash(p)
+}

--- a/internal/lsp/uri_windows.go
+++ b/internal/lsp/uri_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package lsp
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// URIPath converts an absolute OS path into the path component of a file URI.
+//
+// Windows paths start with a drive letter, not a slash. Handing url.URL a Path
+// of "C:/x" makes String emit "file://C:/x", where the drive letter is read as
+// the authority; the extra leading slash produces the "file:///C:/x" form
+// language servers expect.
+func URIPath(abs string) string {
+	p := filepath.ToSlash(abs)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return p
+}
+
+// PathFromURIPath converts the path component of a file URI back into an OS
+// path, undoing the leading slash URIPath puts in front of a drive letter:
+// file:///C:/x is C:\x, not \C:\x.
+func PathFromURIPath(p string) string {
+	if len(p) >= 3 && p[0] == '/' && p[2] == ':' {
+		p = p[1:]
+	}
+	return filepath.FromSlash(p)
+}

--- a/internal/lsp/uri_windows_test.go
+++ b/internal/lsp/uri_windows_test.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package lsp
+
+import "testing"
+
+func TestURIPath_PrefixesDriveLetterWithSlash(t *testing.T) {
+	cases := map[string]string{
+		`C:\Users\me\main.go`: "/C:/Users/me/main.go",
+		`C:/already/slashed`:  "/C:/already/slashed",
+		`\\server\share\x.go`: "//server/share/x.go", // UNC: already rooted
+	}
+	for in, want := range cases {
+		if got := URIPath(in); got != want {
+			t.Errorf("URIPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPathFromURIPath_StripsDriveLetterSlash(t *testing.T) {
+	cases := map[string]string{
+		"/C:/Users/me/main.go": `C:\Users\me\main.go`,
+		"/tmp/foo.go":          `\tmp\foo.go`, // no drive letter: rooted path kept
+		"//server/share/x.go":  `\\server\share\x.go`,
+	}
+	for in, want := range cases {
+		if got := PathFromURIPath(in); got != want {
+			t.Errorf("PathFromURIPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestURIPathRoundTrip(t *testing.T) {
+	for _, p := range []string{`C:\x\y.go`, `D:\a b\c.rs`} {
+		if back := PathFromURIPath(URIPath(p)); back != p {
+			t.Errorf("PathFromURIPath(URIPath(%q)) = %q", p, back)
+		}
+	}
+}

--- a/internal/palace/embedder.go
+++ b/internal/palace/embedder.go
@@ -105,13 +105,20 @@ func (e *localEmbedder) Close() {
 	}
 }
 
+// hugotDownloadModel is the fetcher DownloadModel delegates to. It is a
+// variable so tests can stand in a fake: the real one reaches Hugging Face,
+// its parallel download has a data race the race detector flags, and leaving
+// real weights behind makes every later palace test in the same package run
+// real inference.
+var hugotDownloadModel = hugot.DownloadModel
+
 // DownloadModel fetches the all-MiniLM-L6-v2 model to dest and returns the local path.
 func DownloadModel(dest string, onnxFilePath string) (string, error) {
 	opts := hugot.NewDownloadOptions()
 	if onnxFilePath != "" {
 		opts.OnnxFilePath = onnxFilePath
 	}
-	return hugot.DownloadModel(
+	return hugotDownloadModel(
 		context.Background(),
 		"sentence-transformers/all-MiniLM-L6-v2",
 		dest,

--- a/internal/palace/embedder_download_test.go
+++ b/internal/palace/embedder_download_test.go
@@ -1,0 +1,65 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/knights-analytics/hugot"
+)
+
+// DownloadModel is a thin shim over hugot; what it owns is the model name, the
+// destination, and whether an explicit ONNX file overrides hugot's default.
+// The fetcher is swapped for a recorder so no network is touched and no real
+// weights land on disk.
+func TestDownloadModel_PassesDestAndOnnxOverrideToTheFetcher(t *testing.T) {
+	type call struct {
+		model, dest string
+		opts        hugot.DownloadOptions
+	}
+	var got []call
+	orig := hugotDownloadModel
+	hugotDownloadModel = func(_ context.Context, model, dest string, opts hugot.DownloadOptions) (string, error) {
+		got = append(got, call{model, dest, opts})
+		return dest + "/resolved", nil
+	}
+	t.Cleanup(func() { hugotDownloadModel = orig })
+
+	path, err := DownloadModel("/models", "")
+	if err != nil {
+		t.Fatalf("DownloadModel: %v", err)
+	}
+	if path != "/models/resolved" {
+		t.Errorf("path = %q, want the fetcher's answer", path)
+	}
+	if _, err := DownloadModel("/models", "onnx/custom.onnx"); err != nil {
+		t.Fatalf("DownloadModel with override: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("fetcher called %d times, want 2", len(got))
+	}
+	for i, c := range got {
+		if c.model != "sentence-transformers/all-MiniLM-L6-v2" || c.dest != "/models" {
+			t.Errorf("call %d: model/dest = %q/%q", i, c.model, c.dest)
+		}
+	}
+	if got[0].opts.OnnxFilePath != hugot.NewDownloadOptions().OnnxFilePath {
+		t.Errorf("empty override changed OnnxFilePath to %q, want hugot's default", got[0].opts.OnnxFilePath)
+	}
+	if got[1].opts.OnnxFilePath != "onnx/custom.onnx" {
+		t.Errorf("OnnxFilePath = %q, want the explicit override", got[1].opts.OnnxFilePath)
+	}
+}
+
+func TestDownloadModel_ReportsFetcherErrors(t *testing.T) {
+	orig := hugotDownloadModel
+	hugotDownloadModel = func(context.Context, string, string, hugot.DownloadOptions) (string, error) {
+		return "", errors.New("offline")
+	}
+	t.Cleanup(func() { hugotDownloadModel = orig })
+
+	if _, err := DownloadModel("/models", ""); err == nil || err.Error() != "offline" {
+		t.Errorf("err = %v, want the fetcher's error passed through", err)
+	}
+}

--- a/internal/tools/lsp.go
+++ b/internal/tools/lsp.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"google.golang.org/adk/v2/agent"
@@ -494,14 +493,9 @@ func fileURI(path string) string {
 	if err != nil {
 		abs = path
 	}
-	// Windows paths start with a drive letter, not a slash. Without the extra
-	// leading slash url.URL emits "file://C:/x", where the drive letter is read
-	// as the authority instead of part of the path.
-	p := filepath.ToSlash(abs)
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
-	}
-	u := &url.URL{Scheme: "file", Path: p}
+	// lsp.URIPath supplies the leading slash a Windows drive path needs so
+	// url.URL emits "file:///C:/x" rather than reading "C:" as the authority.
+	u := &url.URL{Scheme: "file", Path: lsp.URIPath(abs)}
 	return u.String()
 }
 
@@ -547,12 +541,8 @@ func uriToPath(uri string) string {
 		return uri
 	}
 	if u.Scheme == "file" {
-		p := u.Path
-		// Undo the leading slash fileURI puts in front of a drive letter.
-		if runtime.GOOS == "windows" && len(p) >= 3 && p[0] == '/' && p[2] == ':' {
-			p = p[1:]
-		}
-		return filepath.FromSlash(p)
+		// Undoes the leading slash fileURI puts in front of a drive letter.
+		return lsp.PathFromURIPath(u.Path)
 	}
 	return uri
 }

--- a/internal/tui/refs/validator.go
+++ b/internal/tui/refs/validator.go
@@ -97,15 +97,10 @@ func (v *Validator) isPathTraversal(path, cleaned string) bool {
 		}
 	}
 
-	// A rooted path that filepath.IsAbs does not call absolute still escapes.
-	// On Windows "/etc/passwd" is drive-relative rather than absolute, so the
-	// check above lets it through; filepath.IsLocal rejects it, along with
-	// drive-relative "C:x" and the reserved device names.
-	if !filepath.IsAbs(path) && !filepath.IsLocal(cleaned) {
-		return true
-	}
-
-	return false
+	// A rooted path that filepath.IsAbs does not call absolute can still
+	// escape on Windows ("/etc/passwd" is drive-relative there); that check
+	// lives in validator_windows.go and is a no-op on Unix.
+	return rootedButNotLocal(path, cleaned)
 }
 
 // isBlockedDir checks if the path is in a blocked directory.

--- a/internal/tui/refs/validator_other.go
+++ b/internal/tui/refs/validator_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package refs
+
+// rootedButNotLocal reports whether a path that filepath.IsAbs does not call
+// absolute still escapes the sandbox. On Unix a cleaned path that is neither
+// absolute nor ".."-traversing is always local, so there is nothing to add to
+// the checks isPathTraversal already made; see validator_windows.go.
+func rootedButNotLocal(string, string) bool {
+	return false
+}

--- a/internal/tui/refs/validator_windows.go
+++ b/internal/tui/refs/validator_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package refs
+
+import "path/filepath"
+
+// rootedButNotLocal reports whether a path that filepath.IsAbs does not call
+// absolute still escapes the sandbox. On Windows "/etc/passwd" is
+// drive-relative rather than absolute, so the IsAbs check lets it through;
+// filepath.IsLocal rejects it, along with drive-relative "C:x" and the
+// reserved device names.
+func rootedButNotLocal(path, cleaned string) bool {
+	return !filepath.IsAbs(path) && !filepath.IsLocal(cleaned)
+}

--- a/internal/tui/refs/validator_windows_test.go
+++ b/internal/tui/refs/validator_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package refs
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRootedButNotLocal(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`/etc/passwd`, true},  // drive-relative rooted path: not absolute, not local
+		{`\Windows\x`, true},   // same with the native separator
+		{`C:x.txt`, true},      // drive-relative without a root
+		{`CON`, true},          // reserved device name
+		{`a\b\c.go`, false},    // ordinary relative path
+		{`C:\abs\x.go`, false}, // absolute: handled by the IsAbs check, not here
+	}
+	for _, tc := range cases {
+		if got := rootedButNotLocal(tc.path, filepath.Clean(tc.path)); got != tc.want {
+			t.Errorf("rootedButNotLocal(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Completes #196. That PR added a `Test (Windows)` job — the first time the suite had ever *executed* on Windows (the `build` job only cross-compiles). It failed after 13 minutes. Getting it green turned up **ten real defects a Windows user hits today**. None are test-only.

### The reported failure list was incomplete

`internal/cli` hit the 10-minute package timeout, so neither it nor the ~15 packages after it reported at all, and `gh run view --log` truncates. Pulling the raw log zip instead gave the real picture: **~150 failing tests across 20 packages, plus a hang.**

One root cause explains ~45 of them and the hang: **`os.UserHomeDir` reads `$HOME` on Unix but `%USERPROFILE%` on Windows**, so ~190 `t.Setenv("HOME", …)` calls did nothing. In `TestContinueNoSessionError` that let `--continue` find a real session from an earlier test, launch the interactive TUI, and block until the package timeout.

## Product bugs fixed

### Severe — and silent. The tools return empty rather than failing.

| Bug | Effect |
|---|---|
| `tools/tree.go` | Recursed with `filepath.Join` → `a\b`, not a valid `io/fs` path. `fs.ReadDir` failed, error swallowed. **`tree` returned only top-level entries.** |
| `tools/find.go`, `tools/grep.go` | `Sandbox.Resolve` returns an OS path handed straight to `fs.WalkDir`, whose roots are always slash-separated. **Both returned nothing under any subdirectory**, error discarded. `find` also mixed `filepath.Rel` output into slash globs and used `filepath.Match`, where `\` is the separator, not the escape char. |
| `lsp/manager.go`, `tools/lsp.go` | `url.URL{Scheme:"file", Path:"D:/x"}` renders `file://D:/x` — the drive letter parses as the **authority**. Every file URI sent to an LSP server was malformed. Two duplicate implementations, both wrong. |

Two core agent tools quietly returning empty is worse than crashing.

### Security-relevant

- **`tui/refs/validator.go` — path-traversal hole.** `ValidatePath("/etc/passwd")` returned **nil** on Windows: `filepath.IsAbs` is false for a drive-relative path, so the escape check was skipped, and `Clean` gives `\etc\passwd` with no `..` to catch. Guarded with `!IsAbs && !IsLocal`, which also rejects `C:x` and reserved device names (`NUL`, `COM1`).
- **`tools/resolve.go` — device blocklist never fired.** `filepath.Clean("/dev/zero")` is `\dev\zero` on Windows, so the blocklist lookup and the `/proc/*/fd/*` prefix check both missed. Models emit POSIX device paths whatever the host OS, so the guard was simply off.

**Unix behaviour is provably unchanged for both.** On Unix `/etc/passwd` is `IsAbs`, so the new guard short-circuits and the pre-existing branch still catches it; `ToSlash(Clean(...))` is a literal no-op. Verified by running the path predicates directly.

### Moderate / minor

`tui/completion.go` (@mention completion matched nothing), `palace/miner.go` (`isGitignored` never matched, so ignored trees like `node_modules` were indexed), `palace/bridge.go`, `tui/run.go` (`/run` printed unusable spec names), plus a real `hostenv_disk_windows.go` where only a `0,0` stub existed. **No `go.mod` change** — `golang.org/x/sys` is already a direct dependency.

## Handle leaks — latent on every platform

`Sandbox` holds an `os.Root`. Windows refuses to delete a directory something holds a handle to; Unix doesn't care, so **five genuine unclosed-handle leaks in tests were invisible until now**. One further failure was a cleanup-ordering bug: `t.Cleanup(chdir back)` registered *before* `t.TempDir()`, so LIFO ran `RemoveAll` while the process cwd was still inside the directory.

## Skips

Eight sites (~19 tests), each naming what Windows lacks: no pty, cannot signal our own process, bash-script stand-ins, process-group teardown that `procs_other.go` documents as Unix-only.

**No assertion was weakened; two were strengthened.** `TestRunServe_LogFileOpenError` now *requires* the error its name promises (it previously only logged and could never fail), and `TestFileURI` gained a `uriToPath(fileURI(p)) == p` round-trip.

A `.bat` wrapper for the bash stand-in agent was considered and **rejected**: it inserts `cmd.exe` between the spawner and bash, so a kill lands on the wrapper — which is exactly what `TestSpawner_Cancel` measures. A wrapper that half-works and hangs the job is worse than a documented skip.

## `internal/testenv/` — test-only

The repo already used the HOME/USERPROFILE idiom in five `TestMain`s with the comment `// os.UserHomeDir on Windows`; it just never reached the ~190 per-test overrides. Extracted rather than invented. Imported only from `_test.go` files.

## Codex review findings — both fixed

Per the rule added in #200, this was reviewed before opening. Both findings were real:

- **The gitignore fix had traded "matches nothing" for "matches too much."** `miner.go` normalized to slashes then kept `filepath.Match`, whose separator on Windows is `\` — so `*` crosses `/` and `generated/*.go` would also match `generated/deep/file.go`. Worse than the original bug. Now uses `path.Match`, as the sibling fix in `find.go` already did.
- **`cmd/pi-sandbox` would still have failed the job.** Only one subtest was skipped; the rest invoke bare `sh`/`true`/`false`, which are in Git for Windows' `usr/bin` and *not* on the default runner PATH.

## Found but deliberately NOT fixed

Both need API changes out of scope for a CI fix:

- **`piSessionState.cleanup` (`acp/server/runtime.go:205`) is dead code.** Nothing calls it, so every ACP session leaks its sandbox `os.Root`, LSP manager, orchestrator and bash supervisor for the server's lifetime. The comment at line 366 describes a teardown that does not exist. Worth its own ticket.
- **No process-group kill on Windows**, so killing a `bash -c` leaves grandchildren running. Pre-existing and documented in `procs_other.go`.

## Verification

`go build ./...` · `GOOS=windows go build ./...` · `GOOS=windows go vet ./...` · `GOOS=linux go build ./...` · `go vet ./...` · gofmt/goimports clean · `golangci-lint --max-issues-per-linter=0 --max-same-issues=0 ./...` → **0 issues**.

Full native suite green under `env -u ANTHROPIC_API_KEY GIT_CONFIG_GLOBAL=/dev/null go test ./... -count=1`. Two failures in a plain run are environmental on the dev machine, not regressions: a global gitignore `**/specs/` breaks `TestCommitAll_*`, and an exported `ANTHROPIC_API_KEY` makes `TestNewPromptHandler_NoAPIKey` reach the real API.

### Calibrated confidence

High that the job goes green, **not certain** — Windows cannot be executed locally.

The largest unknown is **`internal/cli`'s untested tail**: ~35 of its 49 test files never ran on Windows because of the hang. Hand-auditing found and fixed five more problems there, including **a second latent 10-minute hang** (`TestRunServe_LogFileOpenError` made a log unwritable via a `0555` directory, which Windows ignores — so `runServe` would have started a real HTTP server and blocked on a signal). Hand-auditing is not running. **If anything else surfaces, bet on `internal/cli`.**

Ranked least → most sure: `internal/cli` > `internal/acp/server` (one failure whose mechanism I could not fully pin down; the fix is robust either way but papers over it) > `internal/subagent` > `internal/tools`, `internal/tui` > everything else.

One side effect worth noting: the `internal/browser` fix stops the CI runner launching four copies of Edge per run.

https://claude.ai/code/session_011EA5xKa7i4BnC1TzWADXCE