### PR TITLE
feat(provider): look up OpenRouter context window from model metadata

### DIFF
--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -322,10 +322,16 @@ func resolveSessionProvider(cfg config.Config, flagBaseURL, modelName, providerN
 }
 
 // sessionContextWindow returns the model's context window, preferring the size
-// a running Ollama reports over the static table.
+// a running Ollama reports or the OpenRouter listing publishes over the static
+// table.
 func sessionContextWindow(ctx context.Context, info provider.Info, baseURL string) int64 {
 	if info.Ollama {
 		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
+			return n
+		}
+	}
+	if info.Provider == "openrouter" {
+		if n := provider.OpenRouterContextWindowSize(ctx, baseURL, info.Model); n > 0 {
 			return n
 		}
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -351,6 +351,11 @@ func resolveRuntimeContextWindow(ctx context.Context, cfg config.Config, info pr
 			ctxWindowSize = n
 		}
 	}
+	if info.Provider == "openrouter" {
+		if n := provider.OpenRouterContextWindowSize(ctx, baseURL, info.Model); n > 0 {
+			ctxWindowSize = n
+		}
+	}
 	// An explicit config value wins: the embedded catalog does not cover every
 	// provider's models, and auto-compaction needs a real window to work from.
 	if cfg.ContextWindow > 0 {

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -1000,6 +1000,11 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 			ctxWindowSize = n
 		}
 	}
+	if info.Provider == "openrouter" {
+		if n := provider.OpenRouterContextWindowSize(ctx, baseURL, info.Model); n > 0 {
+			ctxWindowSize = n
+		}
+	}
 	// An explicit config value wins: the embedded catalog does not cover every
 	// provider's models, and auto-compaction needs a real window to work from.
 	if cfg.ContextWindow > 0 {

--- a/internal/provider/openrouter.go
+++ b/internal/provider/openrouter.go
@@ -2,9 +2,14 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"iter"
 	"net/http"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -13,6 +18,9 @@ import (
 )
 
 const openrouterDefaultBaseURL = "https://openrouter.ai/api/v1"
+
+// openrouterListTimeout bounds each /models fetch for context-window lookup.
+const openrouterListTimeout = 10 * time.Second
 
 // openrouterModel implements model.LLM for the OpenRouter API.
 // OpenRouter exposes an OpenAI-compatible chat completions endpoint,
@@ -93,4 +101,123 @@ func (m *openrouterModel) GenerateContent(ctx context.Context, req *model.LLMReq
 // OpenRouter uses the same finish reasons as OpenAI.
 func openrouterFinishReasonToGenai(reason string) genai.FinishReason {
 	return oaiFinishReasonToGenai(reason)
+}
+
+// OpenRouterContextWindowSize queries OpenRouter's /models listing for the
+// context window of the given model, preferring top_provider.context_length
+// (what the best endpoint for this model enforces) over the model-level
+// context_length. Returns 0 if the size cannot be determined — mirroring
+// OllamaContextWindowSize, so callers can treat 0 as "no live answer" and fall
+// back to the static catalog.
+//
+// OpenRouter has no per-model endpoint (it answers 404), so every lookup scans
+// the full ~700KB listing; results are cached per base URL for an hour.
+func OpenRouterContextWindowSize(ctx context.Context, baseURL, modelName string) int64 {
+	name := strings.ToLower(strings.TrimSpace(modelName))
+	if name == "" || name == "auto" {
+		return 0
+	}
+
+	models, ok := openrouterModelContextLengths(ctx, baseURL)
+	if !ok {
+		return 0
+	}
+	return models[name]
+}
+
+// openrouterCacheTTL is how long a fetched /models listing stays trusted.
+const openrouterCacheTTL = time.Hour
+
+// openrouterWindowEntry pairs a parsed model→window table with the time it
+// was fetched, so repeat lookups can tell a fresh entry from a stale one.
+type openrouterWindowEntry struct {
+	models    map[string]int64
+	fetchedAt time.Time
+}
+
+var (
+	openrouterWindowCacheMu sync.Mutex
+	// openrouterWindowCache maps a base URL to its last fetched listing.
+	openrouterWindowCache = map[string]openrouterWindowEntry{}
+)
+
+// openrouterModelContextLengths fetches and parses OpenRouter's /models
+// listing into a lowercase model ID → context length table, serving repeat
+// lookups from a per-base-URL cache until openrouterCacheTTL elapses. ok is
+// false when the listing cannot be fetched or understood; callers treat that
+// as "unknown window".
+func openrouterModelContextLengths(ctx context.Context, baseURL string) (map[string]int64, bool) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = openrouterDefaultBaseURL
+	}
+
+	openrouterWindowCacheMu.Lock()
+	entry, ok := openrouterWindowCache[baseURL]
+	openrouterWindowCacheMu.Unlock()
+	if ok && time.Since(entry.fetchedAt) < openrouterCacheTTL {
+		return entry.models, true
+	}
+
+	models := openrouterFetchModelContextLengths(ctx, baseURL)
+	if models == nil {
+		return nil, false
+	}
+
+	entry = openrouterWindowEntry{models: models, fetchedAt: time.Now()}
+	openrouterWindowCacheMu.Lock()
+	openrouterWindowCache[baseURL] = entry
+	openrouterWindowCacheMu.Unlock()
+	return entry.models, true
+}
+
+// openrouterFetchModelContextLengths performs the live GET <base>/models and
+// extracts each model's context length. It never returns an error: any failure
+// yields nil, matching the Ollama helper's no-error contract.
+func openrouterFetchModelContextLengths(ctx context.Context, baseURL string) map[string]int64 {
+	fetchCtx, cancel := context.WithTimeout(ctx, openrouterListTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, baseURL+"/models", nil)
+	if err != nil {
+		return nil
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var payload struct {
+		Data []struct {
+			ID            string `json:"id"`
+			ContextLength int64  `json:"context_length"`
+			TopProvider   struct {
+				ContextLength int64 `json:"context_length"`
+			} `json:"top_provider"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&payload); err != nil {
+		return nil
+	}
+
+	models := make(map[string]int64, len(payload.Data))
+	for _, m := range payload.Data {
+		id := strings.ToLower(strings.TrimSpace(m.ID))
+		if id == "" {
+			continue
+		}
+		size := m.TopProvider.ContextLength
+		if size <= 0 {
+			size = m.ContextLength
+		}
+		if size > 0 {
+			models[id] = size
+		}
+	}
+	return models
 }

--- a/internal/provider/openrouter_test.go
+++ b/internal/provider/openrouter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"google.golang.org/adk/v2/model"
@@ -272,4 +273,124 @@ func TestOpenRouterFinishReasonMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+// openrouterResetWindowCache empties the shared /models cache between tests so
+// each one starts with a cold lookup.
+func openrouterResetWindowCache() {
+	openrouterWindowCacheMu.Lock()
+	openrouterWindowCache = map[string]openrouterWindowEntry{}
+	openrouterWindowCacheMu.Unlock()
+}
+
+func TestOpenRouterContextWindowSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		json  string
+		model string
+		want  int64
+	}{
+		{
+			name:  "top_provider context length wins",
+			json:  `{"data":[{"id":"a/model","context_length":1000000,"top_provider":{"context_length":200000}}]}`,
+			model: "a/model",
+			want:  200000,
+		},
+		{
+			name:  "falls back to model-level context length",
+			json:  `{"data":[{"id":"a/model","context_length":262144}]}`,
+			model: "a/model",
+			want:  262144,
+		},
+		{
+			name:  "lookup is case-insensitive",
+			json:  `{"data":[{"id":"A/Model","context_length":4096}]}`,
+			model: "A/Model",
+			want:  4096,
+		},
+		{
+			name:  "zero or negative lengths are not answers",
+			json:  `{"data":[{"id":"a/model","context_length":0,"top_provider":{"context_length":-5}}]}`,
+			model: "a/model",
+			want:  0,
+		},
+		{
+			name:  "unknown model yields zero",
+			json:  `{"data":[{"id":"other/model","context_length":8192}]}`,
+			model: "a/model",
+			want:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			openrouterResetWindowCache()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.json))
+			}))
+			t.Cleanup(srv.Close)
+
+			if got := OpenRouterContextWindowSize(context.Background(), srv.URL, tc.model); got != tc.want {
+				t.Errorf("OpenRouterContextWindowSize = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenRouterContextWindowSizeFailures(t *testing.T) {
+	t.Run("empty model name", func(t *testing.T) {
+		if got := OpenRouterContextWindowSize(context.Background(), "http://example.invalid", ""); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+	t.Run("openrouter/auto has no window of its own", func(t *testing.T) {
+		if got := OpenRouterContextWindowSize(context.Background(), "http://example.invalid", "auto"); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+	t.Run("unparseable base URL", func(t *testing.T) {
+		openrouterResetWindowCache()
+		if got := OpenRouterContextWindowSize(context.Background(), "http://[::1", "m"); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+	t.Run("server error", func(t *testing.T) {
+		openrouterResetWindowCache()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		if got := OpenRouterContextWindowSize(context.Background(), srv.URL, "m"); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+	t.Run("malformed JSON body", func(t *testing.T) {
+		openrouterResetWindowCache()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("<html>not json</html>"))
+		}))
+		t.Cleanup(srv.Close)
+		if got := OpenRouterContextWindowSize(context.Background(), srv.URL, "m"); got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+	t.Run("repeat lookups are served from the cache", func(t *testing.T) {
+		openrouterResetWindowCache()
+		var fetches int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&fetches, 1)
+			_, _ = w.Write([]byte(`{"data":[{"id":"m","context_length":1234}]}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		for range 3 {
+			if got := OpenRouterContextWindowSize(context.Background(), srv.URL, "m"); got != 1234 {
+				t.Fatalf("OpenRouterContextWindowSize = %d, want 1234", got)
+			}
+		}
+		if n := atomic.LoadInt32(&fetches); n != 1 {
+			t.Errorf("server handled %d requests, want 1 (cache miss only)", n)
+		}
+	})
 }


### PR DESCRIPTION
Query OpenRouter's /models listing for a model's context window,
preferring top_provider.context_length (what the best endpoint for the
model enforces) over the model-level context_length. The full ~700KB
listing is fetched once and cached per base URL for an hour; any
failure yields 0 so callers fall back to the static catalog, matching
OllamaContextWindowSize.

Wire the lookup into the three places that already consult the Ollama
daemon for the same reason: resolveRuntimeContextWindow in internal/cli
and the interactive/ACP session equivalents.

Signed-off-by: dimetron <dimetron@me.com>
