### PR TITLE
feat(provider): stream OpenRouter reasoning tokens to the TUI

### DIFF
--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -212,6 +212,7 @@ func oaiGenaiToolsToOpenAI(tools []*genai.Tool) []openai.ChatCompletionToolUnion
 // oaiStreamState holds accumulated state from processing OpenAI stream chunks (Chat Completions path).
 type oaiStreamState struct {
 	text             string
+	thinking         string
 	toolCalls        map[int64]map[string]any
 	finishReason     string
 	promptTokens     int64
@@ -244,9 +245,17 @@ func buildOaiFinalResponse(s *oaiStreamState) *model.LLMResponse {
 	}
 	slices.Sort(indices)
 
-	finalParts := make([]*genai.Part, 0, 1+len(s.toolCalls))
+	finalParts := make([]*genai.Part, 0, 2+len(s.toolCalls))
 	if s.text != "" {
 		finalParts = append(finalParts, &genai.Part{Text: s.text})
+	} else if s.thinking != "" && len(s.toolCalls) == 0 {
+		// The model spent the whole turn reasoning and never answered
+		// (e.g. reasoning forced on a non-reasoning model). Surface the
+		// reasoning as the turn's content rather than returning nothing —
+		// the same fallback the Ollama provider applies to thinking-only
+		// turns. Skipped when tool calls follow, where the reasoning is
+		// scratch work ahead of the calls.
+		finalParts = append(finalParts, &genai.Part{Text: s.thinking})
 	}
 	for _, idx := range indices {
 		tc := s.toolCalls[idx]
@@ -282,6 +291,17 @@ func buildOaiFinalResponse(s *oaiStreamState) *model.LLMResponse {
 }
 
 func oaiRunStreaming(ctx context.Context, client *openai.Client, params openai.ChatCompletionNewParams, yield func(*model.LLMResponse, error) bool) {
+	oaiRunStreamingExtract(ctx, client, params, yield, nil)
+}
+
+// oaiRunStreamingExtract is oaiRunStreaming with an optional hook that pulls
+// reasoning text out of each chunk's raw JSON. The openai-go SDK has no field
+// for OpenRouter's delta.reasoning / delta.reasoning_details, so providers
+// backed by OpenRouter pass openrouterDeltaThinking here; nil skips the
+// extraction. Reasoning streams as "thinking"-role partials (the same shape
+// the Anthropic and Ollama providers emit, which the TUI renders with 💭);
+// it is re-sent as turn content only when the model produced nothing else.
+func oaiRunStreamingExtract(ctx context.Context, client *openai.Client, params openai.ChatCompletionNewParams, yield func(*model.LLMResponse, error) bool, extractThinking func(rawChunk string) string) {
 	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{
 		IncludeUsage: param.NewOpt(true),
 	}
@@ -297,6 +317,18 @@ func oaiRunStreaming(ctx context.Context, client *openai.Client, params openai.C
 			state.promptTokens = chunk.Usage.PromptTokens
 			state.completionTokens = chunk.Usage.CompletionTokens
 			state.cachedTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+		}
+		if extractThinking != nil && len(chunk.Choices) > 0 {
+			if think := extractThinking(chunk.RawJSON()); think != "" {
+				state.thinking += think
+				if !yield(&model.LLMResponse{
+					Partial:      true,
+					TurnComplete: false,
+					Content:      &genai.Content{Role: "thinking", Parts: []*genai.Part{{Text: think}}},
+				}, nil) {
+					return
+				}
+			}
 		}
 		if len(chunk.Choices) == 0 {
 			continue
@@ -334,6 +366,13 @@ func oaiRunStreaming(ctx context.Context, client *openai.Client, params openai.C
 }
 
 func oaiRunNonStreaming(ctx context.Context, client *openai.Client, params openai.ChatCompletionNewParams, yield func(*model.LLMResponse, error) bool) {
+	oaiRunNonStreamingExtract(ctx, client, params, yield, nil)
+}
+
+// oaiRunNonStreamingExtract is oaiRunNonStreaming with an optional hook that
+// pulls reasoning text out of the completion's raw JSON (see
+// oaiRunStreamingExtract). The reasoning is prepended to the response parts.
+func oaiRunNonStreamingExtract(ctx context.Context, client *openai.Client, params openai.ChatCompletionNewParams, yield func(*model.LLMResponse, error) bool, extractThinking func(rawResponse string) string) {
 	completion, err := client.Chat.Completions.New(ctx, params)
 	if err != nil {
 		yield(nil, fmt.Errorf("OpenAI chat completion failed: %w", err))
@@ -345,7 +384,12 @@ func oaiRunNonStreaming(ctx context.Context, client *openai.Client, params opena
 	}
 	choice := completion.Choices[0]
 	msg := choice.Message
-	parts := make([]*genai.Part, 0, 1+len(msg.ToolCalls))
+	parts := make([]*genai.Part, 0, 2+len(msg.ToolCalls))
+	if extractThinking != nil {
+		if thinking := extractThinking(completion.RawJSON()); thinking != "" {
+			parts = append(parts, &genai.Part{Text: thinking})
+		}
+	}
 	if msg.Content != "" {
 		parts = append(parts, &genai.Part{Text: msg.Content})
 	}

--- a/internal/provider/openrouter.go
+++ b/internal/provider/openrouter.go
@@ -26,13 +26,16 @@ const openrouterListTimeout = 10 * time.Second
 // OpenRouter exposes an OpenAI-compatible chat completions endpoint,
 // so we reuse the OpenAI SDK with a custom base URL.
 type openrouterModel struct {
-	modelName string
-	client    openai.Client
+	modelName     string
+	client        openai.Client
+	thinkingLevel string // "none", "low", "medium", "high", "max"
 }
 
 // NewOpenRouter creates an OpenRouter model.LLM.
 // If baseURL is empty, the default OpenRouter API endpoint is used.
-func NewOpenRouter(_ context.Context, modelName, apiKey, baseURL string, llmOpts *LLMOptions) (model.LLM, error) {
+// thinkingLevel maps to OpenRouter's unified `reasoning.effort` request
+// parameter; empty or "none" leaves reasoning at the model's default.
+func NewOpenRouter(_ context.Context, modelName, apiKey, baseURL, thinkingLevel string, llmOpts *LLMOptions) (model.LLM, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("openrouter API key is required (set OPENROUTER_API_KEY)")
 	}
@@ -56,7 +59,7 @@ func NewOpenRouter(_ context.Context, modelName, apiKey, baseURL string, llmOpts
 		}
 	}
 	client := openai.NewClient(opts...)
-	return &openrouterModel{modelName: modelName, client: client}, nil
+	return &openrouterModel{modelName: modelName, client: client, thinkingLevel: thinkingLevel}, nil
 }
 
 func (m *openrouterModel) Name() string { return m.modelName }
@@ -87,12 +90,20 @@ func (m *openrouterModel) GenerateContent(ctx context.Context, req *model.LLMReq
 			}
 		}
 
+		if effort := openrouterReasoningEffort(m.thinkingLevel); effort != "" {
+			// The SDK has no field for OpenRouter's unified `reasoning`
+			// object, so inject it into the request body directly.
+			params.SetExtraFields(map[string]any{
+				"reasoning": map[string]string{"effort": effort},
+			})
+		}
+
 		if stream {
 			retryStream(ctx, streamRetryConfig(), yield, func(y func(*model.LLMResponse, error) bool) {
-				oaiRunStreaming(ctx, &m.client, params, y)
+				oaiRunStreamingExtract(ctx, &m.client, params, y, openrouterDeltaThinking)
 			})
 		} else {
-			oaiRunNonStreaming(ctx, &m.client, params, yield)
+			oaiRunNonStreamingExtract(ctx, &m.client, params, yield, openrouterMessageReasoning)
 		}
 	}
 }
@@ -101,6 +112,95 @@ func (m *openrouterModel) GenerateContent(ctx context.Context, req *model.LLMReq
 // OpenRouter uses the same finish reasons as OpenAI.
 func openrouterFinishReasonToGenai(reason string) genai.FinishReason {
 	return oaiFinishReasonToGenai(reason)
+}
+
+// openrouterReasoningEffort maps a thinking level string to OpenRouter's
+// unified reasoning.effort value. Empty and "none" return "" (leave the
+// model's default in force — several reasoning models have no off switch,
+// and effort "none" is rejected by some providers behind OpenRouter).
+func openrouterReasoningEffort(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "low":
+		return "low"
+	case "medium":
+		return "medium"
+	case "high":
+		return "high"
+	default:
+		// "max" and unknown levels land on the highest documented tier.
+		if strings.EqualFold(strings.TrimSpace(level), "max") {
+			return "max"
+		}
+		return ""
+	}
+}
+
+// Reasoning arrives on OpenRouter chunks as choices[].delta.reasoning (a plain
+// string, the common case) or choices[].delta.reasoning_details[] (typed
+// objects whose text lives under "text" for reasoning.text entries). The
+// openai-go SDK has no fields for either, so both are recovered from the
+// chunk's raw JSON. Non-streaming responses carry them on message.reasoning.
+// See https://openrouter.ai/docs/guides/best-practices/reasoning-tokens.
+
+// openrouterDeltaThinking extracts the reasoning text from one streaming
+// chunk's raw JSON. Returns "" when the chunk carries none.
+func openrouterDeltaThinking(rawChunk string) string {
+	var payload struct {
+		Choices []struct {
+			Delta struct {
+				Reasoning        string `json:"reasoning"`
+				ReasoningDetails []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"reasoning_details"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(rawChunk), &payload); err != nil {
+		return ""
+	}
+	if len(payload.Choices) == 0 {
+		return ""
+	}
+	delta := payload.Choices[0].Delta
+	if delta.Reasoning != "" {
+		return delta.Reasoning
+	}
+	var sb strings.Builder
+	for _, d := range delta.ReasoningDetails {
+		sb.WriteString(d.Text)
+	}
+	return sb.String()
+}
+
+// openrouterMessageReasoning extracts the reasoning from a non-streaming
+// completion's raw JSON. Returns "" when the response carries none.
+func openrouterMessageReasoning(rawResponse string) string {
+	var payload struct {
+		Choices []struct {
+			Message struct {
+				Reasoning        string `json:"reasoning"`
+				ReasoningDetails []struct {
+					Text string `json:"text"`
+				} `json:"reasoning_details"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(rawResponse), &payload); err != nil {
+		return ""
+	}
+	if len(payload.Choices) == 0 {
+		return ""
+	}
+	msg := payload.Choices[0].Message
+	if msg.Reasoning != "" {
+		return msg.Reasoning
+	}
+	var sb strings.Builder
+	for _, d := range msg.ReasoningDetails {
+		sb.WriteString(d.Text)
+	}
+	return sb.String()
 }
 
 // OpenRouterContextWindowSize queries OpenRouter's /models listing for the

--- a/internal/provider/openrouter_e2e_test.go
+++ b/internal/provider/openrouter_e2e_test.go
@@ -25,7 +25,7 @@ func testGetOpenRouterAPIKey(t *testing.T) string {
 func TestE2EOpenRouterNonStreaming(t *testing.T) {
 	key := testGetOpenRouterAPIKey(t)
 
-	llm, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", key, "", nil)
+	llm, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", key, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewOpenRouter() error: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestE2EOpenRouterNonStreaming(t *testing.T) {
 func TestE2EOpenRouterStreaming(t *testing.T) {
 	key := testGetOpenRouterAPIKey(t)
 
-	llm, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", key, "", nil)
+	llm, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", key, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewOpenRouter() error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestE2EOpenRouterStreaming(t *testing.T) {
 func TestE2EOpenRouterWithSystemPrompt(t *testing.T) {
 	key := testGetOpenRouterAPIKey(t)
 
-	llm, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", key, "", nil)
+	llm, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", key, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewOpenRouter() error: %v", err)
 	}

--- a/internal/provider/openrouter_test.go
+++ b/internal/provider/openrouter_test.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -13,14 +15,14 @@ import (
 )
 
 func TestNewOpenRouterRequiresAPIKey(t *testing.T) {
-	_, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "", "", nil)
+	_, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "", "", "", nil)
 	if err == nil {
 		t.Fatal("expected error when API key is empty")
 	}
 }
 
 func TestNewOpenRouterDefaultBaseURL(t *testing.T) {
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "", nil)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -30,7 +32,7 @@ func TestNewOpenRouterDefaultBaseURL(t *testing.T) {
 }
 
 func TestNewOpenRouterCustomBaseURL(t *testing.T) {
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "https://custom.example.com/v1", nil)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "https://custom.example.com/v1", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -43,7 +45,7 @@ func TestNewOpenRouterWithExtraHeaders(t *testing.T) {
 	opts := &LLMOptions{
 		ExtraHeaders: map[string]string{"X-Custom": "value"},
 	}
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "", opts)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "", "", opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -54,7 +56,7 @@ func TestNewOpenRouterWithExtraHeaders(t *testing.T) {
 
 func TestNewOpenRouterWithInsecureTLS(t *testing.T) {
 	opts := &LLMOptions{InsecureSkipTLS: true}
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "", opts)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", "", "", opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +87,7 @@ func TestOpenRouterNonStreaming(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, nil)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
 	if err != nil {
 		t.Fatalf("NewOpenRouter() error: %v", err)
 	}
@@ -134,7 +136,7 @@ func TestOpenRouterStreaming(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, nil)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
 	if err != nil {
 		t.Fatalf("NewOpenRouter() error: %v", err)
 	}
@@ -197,7 +199,7 @@ func TestOpenRouterWithToolCalls(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, nil)
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
 	if err != nil {
 		t.Fatalf("NewOpenRouter() error: %v", err)
 	}
@@ -393,4 +395,639 @@ func TestOpenRouterContextWindowSizeFailures(t *testing.T) {
 			t.Errorf("server handled %d requests, want 1 (cache miss only)", n)
 		}
 	})
+}
+
+func TestOpenRouterStreamingReasoning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reasoning arrives as delta.reasoning string chunks, then the
+		// answer as delta.content — OpenRouter's documented streaming shape.
+		w.Header().Set("Content-Type", "text/event-stream")
+		chunks := []string{
+			`{"id":"chat-1","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"reasoning":"Let me think"},"finish_reason":null}]}`,
+			`{"id":"chat-1","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"reasoning":" about it."},"finish_reason":null}]}`,
+			`{"id":"chat-1","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"content":"The answer is 42."},"finish_reason":null}]}`,
+			`{"id":"chat-1","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":9,"total_tokens":14}}`,
+		}
+		for _, c := range chunks {
+			w.Write([]byte("data: " + c + "\n\n"))
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	var responses []*model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+
+	var thinkingTexts []string
+	var final *model.LLMResponse
+	for _, r := range responses {
+		if r.Content == nil || len(r.Content.Parts) == 0 {
+			continue
+		}
+		if r.Content.Role == "thinking" && r.Partial {
+			thinkingTexts = append(thinkingTexts, r.Content.Parts[0].Text)
+			continue
+		}
+		if !r.Partial && r.TurnComplete {
+			final = r
+		}
+	}
+
+	if got := strings.Join(thinkingTexts, ""); got != "Let me think about it." {
+		t.Errorf("streamed thinking = %q, want %q", got, "Let me think about it.")
+	}
+
+	if final == nil {
+		t.Fatal("expected a final TurnComplete response")
+	}
+	if len(final.Content.Parts) != 1 || final.Content.Parts[0].Text != "The answer is 42." {
+		parts := make([]string, 0, len(final.Content.Parts))
+		for _, p := range final.Content.Parts {
+			parts = append(parts, p.Text)
+		}
+		t.Errorf("final parts = %v, want [The answer is 42.]", parts)
+	}
+}
+
+func TestOpenRouterStreamingReasoningDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Anthropic-backed models surface reasoning as typed entries in
+		// delta.reasoning_details instead of a plain delta.reasoning string.
+		w.Header().Set("Content-Type", "text/event-stream")
+		chunks := []string{
+			`{"id":"chat-2","object":"chat.completion.chunk","model":"anthropic/claude-sonnet-4.5","choices":[{"index":0,"delta":{"reasoning_details":[{"type":"reasoning.text","text":"Step one.","format":"anthropic-claude-v1","index":0}]},"finish_reason":null}]}`,
+			`{"id":"chat-2","object":"chat.completion.chunk","model":"anthropic/claude-sonnet-4.5","choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}`,
+			`{"id":"chat-2","object":"chat.completion.chunk","model":"anthropic/claude-sonnet-4.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		}
+		for _, c := range chunks {
+			w.Write([]byte("data: " + c + "\n\n"))
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "anthropic/claude-sonnet-4.5", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	var gotThinking string
+	var gotAnswer string
+	sawThinkingPartial := false
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		if resp.Content == nil || len(resp.Content.Parts) == 0 {
+			continue
+		}
+		text := resp.Content.Parts[0].Text
+		switch {
+		case resp.Content.Role == "thinking" && resp.Partial:
+			sawThinkingPartial = true
+			gotThinking += text
+		case !resp.Partial && resp.TurnComplete:
+			if text == "Step one." {
+				gotThinking += "(aggregate:" + text + ")"
+			} else {
+				gotAnswer += text
+			}
+		}
+	}
+
+	if !sawThinkingPartial || gotThinking == "" {
+		t.Errorf("expected streamed thinking partials, got %q (partial seen: %v)", gotThinking, sawThinkingPartial)
+	}
+	if !strings.Contains(gotAnswer, "Done.") {
+		t.Errorf("expected answer text, got %q", gotAnswer)
+	}
+}
+
+func TestOpenRouterNonStreamingReasoning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"id":     "chat-9",
+			"object": "chat.completion",
+			"model":  "google/gemini-3.7-flash",
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":      "assistant",
+					"content":   "The answer is 42.",
+					"reasoning": "I computed this carefully.",
+				},
+				"finish_reason": "stop",
+			}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	var responses []*model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	parts := responses[0].Content.Parts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts (reasoning + answer), got %d", len(parts))
+	}
+	if parts[0].Text != "I computed this carefully." {
+		t.Errorf("parts[0].Text = %q, want reasoning first", parts[0].Text)
+	}
+	if parts[1].Text != "The answer is 42." {
+		t.Errorf("parts[1].Text = %q, want the answer second", parts[1].Text)
+	}
+}
+
+func TestOpenRouterReasoningEffortRequest(t *testing.T) {
+	tests := []struct {
+		level    string
+		wantBody bool
+		effort   string
+	}{
+		{"high", true, "high"},
+		{"medium", true, "medium"},
+		{"low", true, "low"},
+		{"max", true, "max"},
+		{"none", false, ""},
+		{"", false, ""},
+	}
+	for _, tc := range tests {
+		t.Run("level="+tc.level, func(t *testing.T) {
+			var body map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(raw, &body)
+				resp := map[string]any{
+					"id":     "chat-e",
+					"object": "chat.completion",
+					"model":  "google/gemini-3.7-flash",
+					"choices": []map[string]any{{
+						"index":         0,
+						"message":       map[string]any{"role": "assistant", "content": "ok"},
+						"finish_reason": "stop",
+					}},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			}))
+			defer srv.Close()
+
+			m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, tc.level, nil)
+			if err != nil {
+				t.Fatalf("NewOpenRouter() error: %v", err)
+			}
+			req := &model.LLMRequest{
+				Contents: []*genai.Content{
+					{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+				},
+			}
+			for _, err := range m.GenerateContent(context.Background(), req, false) {
+				if err != nil {
+					t.Fatalf("GenerateContent error: %v", err)
+				}
+			}
+
+			reasoning, ok := body["reasoning"].(map[string]any)
+			if tc.wantBody {
+				if !ok {
+					t.Fatalf("expected reasoning object in request body, got %v", body["reasoning"])
+				}
+				if reasoning["effort"] != tc.effort {
+					t.Errorf("reasoning.effort = %v, want %q", reasoning["effort"], tc.effort)
+				}
+			} else if ok {
+				t.Errorf("did not expect a reasoning object in request body, got %v", reasoning)
+			}
+		})
+	}
+}
+
+func TestOpenRouterDeltaThinkingRawExtraction(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "plain reasoning string",
+			raw:  `{"choices":[{"delta":{"reasoning":"hmm"},"finish_reason":null}]}`,
+			want: "hmm",
+		},
+		{
+			name: "reasoning_details array",
+			raw:  `{"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","text":"a"},{"type":"reasoning.text","text":"b"}]},"finish_reason":null}]}`,
+			want: "ab",
+		},
+		{
+			name: "summary-only details contribute no text",
+			raw:  `{"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.summary","summary":"analyzed"}]},"finish_reason":null}]}`,
+			want: "",
+		},
+		{
+			name: "no choices",
+			raw:  `{"object":"chat.completion.chunk"}`,
+			want: "",
+		},
+		{
+			name: "invalid json",
+			raw:  `{broken`,
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := openrouterDeltaThinking(tc.raw); got != tc.want {
+				t.Errorf("openrouterDeltaThinking = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenRouterMessageReasoningRawExtraction(t *testing.T) {
+	if got := openrouterMessageReasoning(`{"choices":[{"message":{"role":"assistant","content":"x","reasoning":"why"}}]}`); got != "why" {
+		t.Errorf("openrouterMessageReasoning = %q, want %q", got, "why")
+	}
+	if got := openrouterMessageReasoning(`{"choices":[{"message":{"role":"assistant","content":"x","reasoning_details":[{"type":"reasoning.text","text":"trace"}]}}]}`); got != "trace" {
+		t.Errorf("openrouterMessageReasoning via details = %q, want %q", got, "trace")
+	}
+	if got := openrouterMessageReasoning(`{"choices":[{"message":{"role":"assistant","content":"x"}}]}`); got != "" {
+		t.Errorf("openrouterMessageReasoning without reasoning = %q, want empty", got)
+	}
+	if got := openrouterMessageReasoning(`not json`); got != "" {
+		t.Errorf("openrouterMessageReasoning invalid json = %q, want empty", got)
+	}
+}
+
+func TestOpenRouterReasoningEffortMapping(t *testing.T) {
+	tests := []struct {
+		level string
+		want  string
+	}{
+		{"", ""},
+		{"none", ""},
+		{"low", "low"},
+		{"medium", "medium"},
+		{"high", "high"},
+		{"max", "max"},
+	}
+	for _, tc := range tests {
+		if got := openrouterReasoningEffort(tc.level); got != tc.want {
+			t.Errorf("openrouterReasoningEffort(%q) = %q, want %q", tc.level, got, tc.want)
+		}
+	}
+}
+
+func TestOpenRouterStreamingThinkingOnlyTurn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The model reasoned but never produced answer content — the final
+		// response must surface the reasoning rather than return nothing.
+		w.Header().Set("Content-Type", "text/event-stream")
+		chunks := []string{
+			`{"id":"chat-3","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"pondering"},"finish_reason":null}]}`,
+			`{"id":"chat-3","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"reasoning":" deeply"},"finish_reason":null}]}`,
+			`{"id":"chat-3","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`,
+		}
+		for _, c := range chunks {
+			w.Write([]byte("data: " + c + "\n\n"))
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	var responses []*model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+
+	var final *model.LLMResponse
+	thinkingPartials := 0
+	for _, r := range responses {
+		if r.Content != nil && r.Content.Role == "thinking" && r.Partial {
+			thinkingPartials++
+			continue
+		}
+		if !r.Partial && r.TurnComplete {
+			final = r
+		}
+	}
+	if thinkingPartials != 2 {
+		t.Errorf("got %d thinking partials, want 2", thinkingPartials)
+	}
+	if final == nil {
+		t.Fatal("expected a final TurnComplete response")
+	}
+	if len(final.Content.Parts) != 1 || final.Content.Parts[0].Text != "pondering deeply" {
+		parts := make([]string, 0, len(final.Content.Parts))
+		for _, p := range final.Content.Parts {
+			parts = append(parts, p.Text)
+		}
+		t.Errorf("final parts = %v, want [pondering deeply]", parts)
+	}
+}
+
+func TestOpenRouterStreamingThinkingWithToolCalls(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reasoning followed by a tool call: the reasoning is scratch work
+		// ahead of the calls and must NOT be duplicated into the final
+		// response's text parts.
+		w.Header().Set("Content-Type", "text/event-stream")
+		chunks := []string{
+			`{"id":"chat-4","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"I should read the file"},"finish_reason":null}]}`,
+			`{"id":"chat-4","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"read_file","arguments":""}}]},"finish_reason":null}]}`,
+			`{"id":"chat-4","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":\"/tmp/x\"}"}}]},"finish_reason":null}]}`,
+			`{"id":"chat-4","object":"chat.completion.chunk","model":"google/gemini-3.7-flash","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		}
+		for _, c := range chunks {
+			w.Write([]byte("data: " + c + "\n\n"))
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "read /tmp/x"}}},
+		},
+	}
+
+	var responses []*model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+
+	var final *model.LLMResponse
+	for _, r := range responses {
+		if !r.Partial && r.TurnComplete {
+			final = r
+		}
+	}
+	if final == nil {
+		t.Fatal("expected a final TurnComplete response")
+	}
+	if len(final.Content.Parts) != 1 {
+		t.Fatalf("expected exactly 1 part (the function call), got %d", len(final.Content.Parts))
+	}
+	fc := final.Content.Parts[0].FunctionCall
+	if fc == nil || fc.Name != "read_file" {
+		t.Errorf("expected a read_file function call part, got %+v", final.Content.Parts[0])
+	}
+	if fc != nil && fc.Args["path"] != "/tmp/x" {
+		t.Errorf("fc.Args[path] = %v, want /tmp/x", fc.Args["path"])
+	}
+}
+
+func TestOpenRouterStreamingInterleavedOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Some providers interleave reasoning and content deltas; each must
+		// land in its own stream in arrival order.
+		w.Header().Set("Content-Type", "text/event-stream")
+		chunks := []string{
+			`{"choices":[{"index":0,"delta":{"reasoning":"think1"}}]}`,
+			`{"choices":[{"index":0,"delta":{"content":"say1"}}]}`,
+			`{"choices":[{"index":0,"delta":{"reasoning":"think2"}}]}`,
+			`{"choices":[{"index":0,"delta":{"content":"say2"}}]}`,
+			`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		}
+		for _, c := range chunks {
+			w.Write([]byte("data: " + `{"id":"c","object":"chat.completion.chunk","model":"m",` + c[1:] + "\n\n"))
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	var thinking strings.Builder
+	var answer strings.Builder
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		if resp.Content == nil || len(resp.Content.Parts) == 0 || resp.Content.Parts[0].Text == "" {
+			continue
+		}
+		if resp.Partial && resp.Content.Role == "thinking" {
+			thinking.WriteString(resp.Content.Parts[0].Text)
+		} else if !resp.Partial {
+			for _, p := range resp.Content.Parts {
+				answer.WriteString(p.Text)
+			}
+		}
+	}
+
+	if thinking.String() != "think1think2" {
+		t.Errorf("thinking stream = %q, want %q", thinking.String(), "think1think2")
+	}
+	if answer.String() != "say1say2" {
+		t.Errorf("answer aggregate = %q, want %q", answer.String(), "say1say2")
+	}
+}
+
+func TestOpenRouterNonStreamingReasoningDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"id":     "chat-10",
+			"object": "chat.completion",
+			"model":  "anthropic/claude-sonnet-4.5",
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "Done.",
+					"reasoning_details": []map[string]any{
+						{"type": "reasoning.text", "text": "Step one."},
+						{"type": "reasoning.text", "text": "Step two."},
+					},
+				},
+				"finish_reason": "stop",
+			}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "anthropic/claude-sonnet-4.5", "test-key", srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	for resp, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		parts := resp.Content.Parts
+		if len(parts) != 2 {
+			t.Fatalf("expected 2 parts (reasoning + answer), got %d", len(parts))
+		}
+		if parts[0].Text != "Step one.Step two." {
+			t.Errorf("parts[0].Text = %q, want concatenated reasoning_details", parts[0].Text)
+		}
+		if parts[1].Text != "Done." {
+			t.Errorf("parts[1].Text = %q, want Done.", parts[1].Text)
+		}
+	}
+}
+
+func TestOpenRouterReasoningEffortOnStreamRequest(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte(`data: {"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n"))
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenRouter(context.Background(), "google/gemini-3.7-flash", "test-key", srv.URL, "high", nil)
+	if err != nil {
+		t.Fatalf("NewOpenRouter() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+	for _, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+	}
+
+	reasoning, ok := body["reasoning"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected reasoning object in streaming request body, got %v", body["reasoning"])
+	}
+	if reasoning["effort"] != "high" {
+		t.Errorf("streaming reasoning.effort = %v, want high", reasoning["effort"])
+	}
+}
+
+func TestOAIPlainProviderIgnoresReasoningChunks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// An OpenAI-compat backend that emits delta.reasoning without the
+		// extraction hook (plain openai provider): nothing may crash or leak
+		// into the text stream.
+		w.Header().Set("Content-Type", "text/event-stream")
+		chunks := []string{
+			`{"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"hidden"},"finish_reason":null}]}`,
+			`{"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"visible"},"finish_reason":null}]}`,
+			`{"id":"c1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		}
+		for _, c := range chunks {
+			w.Write([]byte("data: " + c + "\n\n"))
+		}
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	m, err := NewOpenAI(context.Background(), "gpt-4o", "test-key", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewOpenAI() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Hi"}}},
+		},
+	}
+
+	var responses []*model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+
+	for i, r := range responses {
+		if r.Content != nil && r.Content.Role == "thinking" {
+			t.Errorf("response[%d]: unexpected thinking-role event from un-hooked provider", i)
+		}
+	}
+	last := responses[len(responses)-1]
+	if last.Content == nil || len(last.Content.Parts) != 1 || last.Content.Parts[0].Text != "visible" {
+		t.Errorf("final response should carry only the visible text, got %+v", last.Content)
+	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -489,7 +489,7 @@ func NewLLM(ctx context.Context, info Info, apiKey, baseURL, thinkingLevel strin
 	case "mistral":
 		return NewMistral(ctx, info.Model, apiKey, baseURL, opts)
 	case "openrouter":
-		return NewOpenRouter(ctx, info.Model, apiKey, baseURL, opts)
+		return NewOpenRouter(ctx, info.Model, apiKey, baseURL, thinkingLevel, opts)
 	case "xai":
 		// xAI server-side tools, including x_search, are enabled for the
 		// xAI provider by default. PI_NO_XAI_TOOLS remains the kill switch.


### PR DESCRIPTION
OpenRouter returns model reasoning as choices[].delta.reasoning /
delta.reasoning_details in streams and message.reasoning /
message.reasoning_details in non-streaming responses. The openai-go SDK
has no fields for any of these, so the OpenRouter provider dropped them
silently and thinking never reached the UI.

Recover the reasoning from raw JSON and emit it as "thinking"-role
partial events — the same contract the Anthropic and Ollama providers
use, so the TUI's existing thought rendering shows it with no changes.
The final aggregate carries the reasoning only for thinking-only turns
(mirroring Ollama), keeping StreamDedup semantics intact.

Also thread thinkingLevel into NewOpenRouter and map it onto
OpenRouter's unified reasoning.effort request parameter; several
reasoning models (e.g. Claude behind OpenRouter) produce no reasoning
unless explicitly asked.

Signed-off-by: dimetron <dimetron@me.com>
