### PR TITLE
feat(mcp): style OAuth callback page and cache tokens for 24h

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -729,7 +729,7 @@ func handleCallback(w http.ResponseWriter, r *http.Request, expectedState string
 		}
 		logf("callback: oauth error=%s description=%q", errParam, desc)
 		ch <- codeResult{err: fmt.Errorf("OAuth error: %s", desc)}
-		http.Error(w, "Authentication failed: "+desc, http.StatusBadRequest)
+		RenderCallbackPage(w, http.StatusBadRequest, false, "Authentication failed", desc)
 		return
 	}
 
@@ -744,19 +744,14 @@ func handleCallback(w http.ResponseWriter, r *http.Request, expectedState string
 	if code == "" {
 		logf("callback: no code received")
 		ch <- codeResult{err: fmt.Errorf("no authorization code received")}
-		http.Error(w, "No code received", http.StatusBadRequest)
+		RenderCallbackPage(w, http.StatusBadRequest, false, "No code received", "")
 		return
 	}
 
 	logf("callback: ok code_len=%d", len(code))
 	ch <- codeResult{code: code}
 
-	w.Header().Set("Content-Type", "text/html")
-	_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body>
-<h2>✓ Authentication successful</h2>
-<p>You can close this tab and return to pi.</p>
-<script>window.close()</script>
-</body></html>`)
+	RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
 }
 
 func exchangeCode(ctx context.Context, prov Provider, code, redirectURI, verifier string) (*TokenResponse, error) {

--- a/internal/auth/callback_page.go
+++ b/internal/auth/callback_page.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"html"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// callbackPageTemplate renders the OAuth authorization-result page shown in
+// the user's browser after the identity provider redirects back to the local
+// loopback callback server. Visual language matches https://pi-go.sh/ (dark
+// neon theme, grid and scanline overlays, Orbitron/Rajdhani type). All CSS is
+// embedded so the page renders offline; the webfont link degrades gracefully.
+const callbackPageTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>pi-go — {{TITLE}}</title>
+  <link rel="icon" href="data:,">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700&family=Rajdhani:wght@500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #0a0a12;
+      --card: rgba(15, 15, 30, 0.72);
+      --text: #e0e0f0;
+      --muted: #8888aa;
+      --cyan: #00f0ff;
+      --magenta: #ff00aa;
+      --green: #00ff88;
+      --border: rgba(0, 240, 255, 0.25);
+      --glow: 0 0 20px rgba(0, 240, 255, 0.22), 0 0 60px rgba(0, 240, 255, 0.08);
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html, body { height: 100%; }
+
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Rajdhani', 'Segoe UI', system-ui, sans-serif;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Grid background */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background:
+        linear-gradient(rgba(0, 240, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 240, 255, 0.03) 1px, transparent 1px);
+      background-size: 60px 60px;
+    }
+
+    /* Scanline overlay */
+    body::after {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: repeating-linear-gradient(0deg,
+        transparent, transparent 2px,
+        rgba(0, 0, 0, 0.05) 2px, rgba(0, 0, 0, 0.05) 4px);
+      pointer-events: none;
+    }
+
+    .card {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.9rem;
+      max-width: 92vw;
+      padding: 3rem 3.5rem;
+      text-align: center;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      box-shadow: var(--glow);
+      animation: rise 0.45s ease-out;
+    }
+
+    .card.err {
+      border-color: rgba(255, 0, 170, 0.35);
+      box-shadow: 0 0 20px rgba(255, 0, 170, 0.25), 0 0 60px rgba(255, 0, 170, 0.08);
+    }
+
+    .mark {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      font-family: 'Orbitron', monospace;
+      font-size: 1.7rem;
+      color: var(--green);
+      border: 1px solid var(--green);
+      box-shadow: 0 0 20px rgba(0, 255, 136, 0.35), inset 0 0 12px rgba(0, 255, 136, 0.12);
+    }
+
+    .err .mark {
+      color: var(--magenta);
+      border-color: var(--magenta);
+      box-shadow: 0 0 20px rgba(255, 0, 170, 0.35), inset 0 0 12px rgba(255, 0, 170, 0.12);
+    }
+
+    h1 {
+      font-family: 'Orbitron', 'Rajdhani', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: 1px;
+    }
+
+    p { color: var(--muted); font-weight: 500; }
+
+    .brand {
+      margin-top: 0.8rem;
+      font-family: 'Orbitron', monospace;
+      font-size: 0.95rem;
+      font-weight: 700;
+      letter-spacing: 1px;
+      color: var(--cyan);
+      text-decoration: none;
+      text-shadow: 0 0 10px rgba(0, 240, 255, 0.5), 0 0 30px rgba(0, 240, 255, 0.2);
+    }
+
+    .brand span { color: var(--magenta); }
+
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: none; }
+    }
+  </style>
+</head>
+<body>
+  <main class="card{{CLASS}}">
+    <div class="mark">{{MARK}}</div>
+    <h1>{{TITLE}}</h1>
+    {{SUB}}<a class="brand" href="https://pi-go.sh/">PI-GO<span>.SH</span></a>
+  </main>
+  <script>window.close()</script>
+</body>
+</html>
+`
+
+// RenderCallbackPage writes the OAuth authorization-result page in the
+// pi-go.sh visual style. ok selects the success (green check) or failure
+// (magenta cross) variant. title and detail are HTML-escaped before
+// rendering; detail may be empty.
+func RenderCallbackPage(w http.ResponseWriter, status int, ok bool, title, detail string) {
+	variant, mark := "", "✓"
+	if !ok {
+		variant, mark = " err", "✗"
+	}
+
+	sub := ""
+	if detail != "" {
+		sub = "<p>" + html.EscapeString(detail) + "</p>\n    "
+	}
+
+	page := strings.NewReplacer(
+		"{{CLASS}}", variant,
+		"{{MARK}}", mark,
+		"{{TITLE}}", html.EscapeString(title),
+		"{{SUB}}", sub,
+	).Replace(callbackPageTemplate)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, page)
+}

--- a/internal/auth/callback_page_test.go
+++ b/internal/auth/callback_page_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderCallbackPage_Success(t *testing.T) {
+	w := httptest.NewRecorder()
+	RenderCallbackPage(w, 200, true, "Authentication successful", "You can close this tab and return to pi.")
+
+	if w.Code != 200 {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"Authentication successful",
+		"You can close this tab and return to pi.",
+		"PI-GO<span>.SH</span>",
+		"window.close()",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected body to contain %q", want)
+		}
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/html") || !strings.Contains(ct, "utf-8") {
+		t.Errorf("expected html+utf8 content type, got %q", ct)
+	}
+}
+
+func TestRenderCallbackPage_Failure(t *testing.T) {
+	w := httptest.NewRecorder()
+	RenderCallbackPage(w, 400, false, "Authentication failed", "access_denied")
+
+	if w.Code != 400 {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"card err", "✗", "Authentication failed", "access_denied"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected body to contain %q", want)
+		}
+	}
+}
+
+func TestRenderCallbackPage_EscapesDetail(t *testing.T) {
+	w := httptest.NewRecorder()
+	RenderCallbackPage(w, 200, true, "T<i>tle", "<script>alert(1)</script>")
+
+	body := w.Body.String()
+	if strings.Contains(body, "T<i>tle") || strings.Contains(body, "<script>alert") {
+		t.Error("expected title and detail to be HTML-escaped")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Error("expected escaped script tag in detail")
+	}
+}

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -292,7 +292,7 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 			}
 		}
 		if srv.OAuth {
-			handler, err := newMCPOAuthHandler(srv.Name)
+			handler, err := newMCPOAuthHandler(srv.Name, srv.URL)
 			if err != nil {
 				return nil, fmt.Errorf("MCP server %q: %w", srv.Name, err)
 			}
@@ -332,7 +332,7 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 // received and exchanged for a token. The token source is held by the handler
 // and reused for the lifetime of the connection, so the flow runs only on the
 // first connect (or after the token expires).
-func newMCPOAuthHandler(name string) (auth.OAuthHandler, error) {
+func newMCPOAuthHandler(name, serverURL string) (auth.OAuthHandler, error) {
 	// Pick a free loopback port for the callback server.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -341,17 +341,37 @@ func newMCPOAuthHandler(name string) (auth.OAuthHandler, error) {
 	port := listener.Addr().(*net.TCPAddr).Port //nolint:errcheck // TCP listener guaranteed
 	redirectURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
 
+	// authChan is buffered so the browser's callback handler never blocks,
+	// even if it fires twice or after the flow has moved on.
 	authChan := make(chan *auth.AuthorizationResult, 1)
-	errChan := make(chan error, 1)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		authChan <- &auth.AuthorizationResult{
-			Code:  r.URL.Query().Get("code"),
-			State: r.URL.Query().Get("state"),
-			Iss:   r.URL.Query().Get("iss"),
+		q := r.URL.Query()
+		if errParam := q.Get("error"); errParam != "" {
+			desc := q.Get("error_description")
+			if desc == "" {
+				desc = errParam
+			}
+			piauth.RenderCallbackPage(w, http.StatusBadRequest, false, "Authentication failed", desc)
+			return
 		}
-		piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
+		code := q.Get("code")
+		if code == "" {
+			piauth.RenderCallbackPage(w, http.StatusBadRequest, false, "No code received", "")
+			return
+		}
+		select {
+		case authChan <- &auth.AuthorizationResult{
+			Code:  code,
+			State: q.Get("state"),
+			Iss:   q.Get("iss"),
+		}:
+			piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
+		default:
+			// Flow already completed with this handler; ignore duplicates.
+			piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
+		}
 	})
 	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(listener) }()
@@ -361,14 +381,21 @@ func newMCPOAuthHandler(name string) (auth.OAuthHandler, error) {
 		if err := browser.Open(args.URL); err != nil {
 			fmt.Fprintf(os.Stderr, "pi-go: could not open browser for %q; visit this URL manually:\n%s\n", name, args.URL)
 		}
+		defer func() { _ = srv.Close() }() // one-shot: stop serving after the first result
 		select {
 		case res := <-authChan:
 			return res, nil
-		case err := <-errChan:
-			return nil, err
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
+	}
+
+	// Reuse a persisted token from a previous session so the browser flow
+	// runs only once per mcpOAuthTokenTTL. Nil when nothing usable is cached,
+	// which triggers a normal interactive authorization.
+	cachedTS := loadMCPOAuthTokenSource(name, serverURL)
+	if cachedTS != nil {
+		_ = srv.Close() // no browser round-trip ahead; free the loopback port
 	}
 
 	handler, err := auth.NewAuthorizationCodeHandler(&auth.AuthorizationCodeHandlerConfig{
@@ -384,17 +411,17 @@ func newMCPOAuthHandler(name string) (auth.OAuthHandler, error) {
 		},
 		AuthorizationCodeFetcher: fetcher,
 		RequestRefreshToken:      true,
-		// Reuse a persisted token from a previous session so the browser
-		// flow runs only once per mcpOAuthTokenTTL. Nil when nothing usable
-		// is cached, which triggers a normal interactive authorization.
-		InitialTokenSource: loadMCPOAuthTokenSource(name),
+		InitialTokenSource:       cachedTS,
 		// Persist each freshly authorized token along with the OAuth config
 		// needed to refresh it next session.
 		NewTokenSource: func(ctx context.Context, cfg *oauth2.Config, tok *oauth2.Token) (oauth2.TokenSource, error) {
-			if err := saveMCPOAuthToken(name, cfg, tok); err != nil {
+			if err := saveMCPOAuthToken(name, serverURL, cfg, tok); err != nil {
 				fmt.Fprintf(os.Stderr, "pi-go: could not cache OAuth token for MCP server %q: %v\n", name, err)
 			}
-			return cfg.TokenSource(ctx, tok), nil
+			// Wrap so rotated refresh tokens are written back to disk too.
+			return newPersistingTokenSource(cfg.TokenSource(ctx, tok), nil, func(t *oauth2.Token) error {
+				return saveMCPOAuthToken(name, serverURL, cfg, t)
+			}), nil
 		},
 	})
 	if err != nil {

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -341,62 +341,26 @@ func newMCPOAuthHandler(name, serverURL string) (auth.OAuthHandler, error) {
 	port := listener.Addr().(*net.TCPAddr).Port //nolint:errcheck // TCP listener guaranteed
 	redirectURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
 
-	// authChan is buffered so the browser's callback handler never blocks,
+	// resultChan is buffered so the browser's callback handler never blocks,
 	// even if it fires twice or after the flow has moved on.
-	authChan := make(chan *auth.AuthorizationResult, 1)
+	resultChan := make(chan mcpOAuthCallbackResult, 1)
 
+	// The callback server lives as long as the handler: the SDK re-runs the
+	// authorization flow (and so the fetcher) whenever the server answers 401
+	// — a cached token that was revoked, say — or asks for step-up scopes,
+	// and the redirect URI registered with the authorization server carries
+	// this port, so it cannot be rebound later.
 	mux := http.NewServeMux()
-	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query()
-		if errParam := q.Get("error"); errParam != "" {
-			desc := q.Get("error_description")
-			if desc == "" {
-				desc = errParam
-			}
-			piauth.RenderCallbackPage(w, http.StatusBadRequest, false, "Authentication failed", desc)
-			return
-		}
-		code := q.Get("code")
-		if code == "" {
-			piauth.RenderCallbackPage(w, http.StatusBadRequest, false, "No code received", "")
-			return
-		}
-		select {
-		case authChan <- &auth.AuthorizationResult{
-			Code:  code,
-			State: q.Get("state"),
-			Iss:   q.Get("iss"),
-		}:
-			piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
-		default:
-			// Flow already completed with this handler; ignore duplicates.
-			piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
-		}
-	})
+	mux.HandleFunc("/callback", mcpOAuthCallbackHandler(resultChan))
 	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(listener) }()
 
-	fetcher := func(ctx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
-		fmt.Fprintf(os.Stderr, "pi-go: MCP server %q requires authorization. Opening browser...\n", name)
-		if err := browser.Open(args.URL); err != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: could not open browser for %q; visit this URL manually:\n%s\n", name, args.URL)
-		}
-		defer func() { _ = srv.Close() }() // one-shot: stop serving after the first result
-		select {
-		case res := <-authChan:
-			return res, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
+	fetcher := mcpOAuthCodeFetcher(name, resultChan, browser.Open)
 
 	// Reuse a persisted token from a previous session so the browser flow
 	// runs only once per mcpOAuthTokenTTL. Nil when nothing usable is cached,
 	// which triggers a normal interactive authorization.
 	cachedTS := loadMCPOAuthTokenSource(name, serverURL)
-	if cachedTS != nil {
-		_ = srv.Close() // no browser round-trip ahead; free the loopback port
-	}
 
 	handler, err := auth.NewAuthorizationCodeHandler(&auth.AuthorizationCodeHandlerConfig{
 		RedirectURL: redirectURL,
@@ -414,21 +378,107 @@ func newMCPOAuthHandler(name, serverURL string) (auth.OAuthHandler, error) {
 		InitialTokenSource:       cachedTS,
 		// Persist each freshly authorized token along with the OAuth config
 		// needed to refresh it next session.
-		NewTokenSource: func(ctx context.Context, cfg *oauth2.Config, tok *oauth2.Token) (oauth2.TokenSource, error) {
-			if err := saveMCPOAuthToken(name, serverURL, cfg, tok); err != nil {
-				fmt.Fprintf(os.Stderr, "pi-go: could not cache OAuth token for MCP server %q: %v\n", name, err)
-			}
-			// Wrap so rotated refresh tokens are written back to disk too.
-			return newPersistingTokenSource(cfg.TokenSource(ctx, tok), nil, func(t *oauth2.Token) error {
-				return saveMCPOAuthToken(name, serverURL, cfg, t)
-			}), nil
-		},
+		NewTokenSource: mcpOAuthNewTokenSource(name, serverURL),
 	})
 	if err != nil {
 		_ = srv.Close()
 		return nil, fmt.Errorf("creating OAuth handler: %w", err)
 	}
 	return handler, nil
+}
+
+// mcpOAuthCallbackResult is what the loopback callback hands to the waiting
+// fetcher: either the authorization result or the error the authorization
+// server redirected back with (e.g. the user denied access).
+type mcpOAuthCallbackResult struct {
+	res *auth.AuthorizationResult
+	err error
+}
+
+// mcpOAuthCallbackHandler serves the loopback redirect endpoint of the
+// authorization-code flow. It renders the pi-go.sh-styled result page and
+// delivers the outcome — code or provider error — exactly once on resultChan;
+// a second redirect after the flow has consumed the result is answered with
+// the same page but otherwise ignored, so a stale browser tab can never block
+// or re-trigger the flow.
+func mcpOAuthCallbackHandler(resultChan chan<- mcpOAuthCallbackResult) http.HandlerFunc {
+	deliver := func(r mcpOAuthCallbackResult) {
+		select {
+		case resultChan <- r:
+		default:
+			// Flow already has a pending result; ignore duplicates.
+		}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if errParam := q.Get("error"); errParam != "" {
+			desc := q.Get("error_description")
+			if desc == "" {
+				desc = errParam
+			}
+			deliver(mcpOAuthCallbackResult{err: fmt.Errorf("OAuth error: %s", desc)})
+			piauth.RenderCallbackPage(w, http.StatusBadRequest, false, "Authentication failed", desc)
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			deliver(mcpOAuthCallbackResult{err: fmt.Errorf("no authorization code received")})
+			piauth.RenderCallbackPage(w, http.StatusBadRequest, false, "No code received", "")
+			return
+		}
+		deliver(mcpOAuthCallbackResult{res: &auth.AuthorizationResult{
+			Code:  code,
+			State: q.Get("state"),
+			Iss:   q.Get("iss"),
+		}})
+		piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
+	}
+}
+
+// mcpOAuthCodeFetcher returns the AuthorizationCodeFetcher for the SDK
+// handler: it opens the authorization URL with openURL (browser.Open in
+// production; injectable so tests never launch anything), then blocks until
+// the callback delivers an outcome on resultChan or ctx is done. Any outcome
+// left over from an earlier flow (a late duplicate redirect, say) is dropped
+// first so it cannot be mistaken for this flow's result; the SDK additionally
+// checks the returned state against the one it issued.
+func mcpOAuthCodeFetcher(
+	name string,
+	resultChan <-chan mcpOAuthCallbackResult,
+	openURL func(string) error,
+) func(context.Context, *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
+	return func(ctx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
+		select {
+		case <-resultChan: // drop stale outcome from a previous flow
+		default:
+		}
+		fmt.Fprintf(os.Stderr, "pi-go: MCP server %q requires authorization. Opening browser...\n", name)
+		if err := openURL(args.URL); err != nil {
+			fmt.Fprintf(os.Stderr, "pi-go: could not open browser for %q; visit this URL manually:\n%s\n", name, args.URL)
+		}
+		select {
+		case r := <-resultChan:
+			return r.res, r.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// mcpOAuthNewTokenSource returns the NewTokenSource hook for the SDK handler.
+// It persists each freshly authorized token for the server identity and wraps
+// the refreshing source so rotated tokens are written back to disk too. A
+// failed cache write is reported and otherwise ignored: the in-memory source
+// still works for this session, and the next one simply re-authorizes.
+func mcpOAuthNewTokenSource(name, serverURL string) func(context.Context, *oauth2.Config, *oauth2.Token) (oauth2.TokenSource, error) {
+	return func(ctx context.Context, cfg *oauth2.Config, tok *oauth2.Token) (oauth2.TokenSource, error) {
+		if err := saveMCPOAuthToken(name, serverURL, cfg, tok); err != nil {
+			fmt.Fprintf(os.Stderr, "pi-go: could not cache OAuth token for MCP server %q: %v\n", name, err)
+		}
+		return newPersistingTokenSource(cfg.TokenSource(ctx, tok), nil, func(t *oauth2.Token) error {
+			return saveMCPOAuthToken(name, serverURL, cfg, t)
+		}), nil
+	}
 }
 
 // headerRoundTripper injects static HTTP headers (e.g., API keys, usernames)

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/modelcontextprotocol/go-sdk/oauthex"
@@ -17,6 +19,7 @@ import (
 	"google.golang.org/adk/v2/tool"
 	"google.golang.org/adk/v2/tool/mcptoolset"
 
+	piauth "github.com/dimetron/pi-go/internal/auth" // SDK auth pkg is imported above
 	"github.com/dimetron/pi-go/internal/browser"
 )
 
@@ -348,12 +351,7 @@ func newMCPOAuthHandler(name string) (auth.OAuthHandler, error) {
 			State: r.URL.Query().Get("state"),
 			Iss:   r.URL.Query().Get("iss"),
 		}
-		w.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body>
-<h2>✓ Authentication successful</h2>
-<p>You can close this tab and return to pi.</p>
-<script>window.close()</script>
-</body></html>`)
+		piauth.RenderCallbackPage(w, http.StatusOK, true, "Authentication successful", "You can close this tab and return to pi.")
 	})
 	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(listener) }()
@@ -386,6 +384,18 @@ func newMCPOAuthHandler(name string) (auth.OAuthHandler, error) {
 		},
 		AuthorizationCodeFetcher: fetcher,
 		RequestRefreshToken:      true,
+		// Reuse a persisted token from a previous session so the browser
+		// flow runs only once per mcpOAuthTokenTTL. Nil when nothing usable
+		// is cached, which triggers a normal interactive authorization.
+		InitialTokenSource: loadMCPOAuthTokenSource(name),
+		// Persist each freshly authorized token along with the OAuth config
+		// needed to refresh it next session.
+		NewTokenSource: func(ctx context.Context, cfg *oauth2.Config, tok *oauth2.Token) (oauth2.TokenSource, error) {
+			if err := saveMCPOAuthToken(name, cfg, tok); err != nil {
+				fmt.Fprintf(os.Stderr, "pi-go: could not cache OAuth token for MCP server %q: %v\n", name, err)
+			}
+			return cfg.TokenSource(ctx, tok), nil
+		},
 	})
 	if err != nil {
 		_ = srv.Close()

--- a/internal/extension/mcp_oauth_handler_test.go
+++ b/internal/extension/mcp_oauth_handler_test.go
@@ -1,0 +1,282 @@
+package extension
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	"golang.org/x/oauth2"
+)
+
+func TestMCPOAuthCallbackHandler(t *testing.T) {
+	t.Run("provider error renders failure page and fails the flow", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/callback?error=access_denied&error_description=User+said+no", nil)
+		mcpOAuthCallbackHandler(ch)(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Authentication failed") || !strings.Contains(body, "User said no") {
+			t.Errorf("expected failure page with description, got %q", body)
+		}
+		select {
+		case r := <-ch:
+			if r.res != nil || r.err == nil || !strings.Contains(r.err.Error(), "User said no") {
+				t.Errorf("expected provider error delivered, got %+v", r)
+			}
+		default:
+			t.Fatal("provider error must be delivered to the waiting fetcher")
+		}
+	})
+
+	t.Run("provider error without description falls back to code", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/callback?error=invalid_scope", nil)
+		mcpOAuthCallbackHandler(ch)(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", w.Code)
+		}
+		if !strings.Contains(w.Body.String(), "invalid_scope") {
+			t.Error("expected error code used as description")
+		}
+		if r := <-ch; r.err == nil || !strings.Contains(r.err.Error(), "invalid_scope") {
+			t.Errorf("expected error code in delivered error, got %+v", r)
+		}
+	})
+
+	t.Run("missing code renders failure page and fails the flow", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/callback?state=s1", nil)
+		mcpOAuthCallbackHandler(ch)(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", w.Code)
+		}
+		if !strings.Contains(w.Body.String(), "No code received") {
+			t.Error("expected 'No code received' page")
+		}
+		if r := <-ch; r.res != nil || r.err == nil {
+			t.Errorf("expected missing-code error delivered, got %+v", r)
+		}
+	})
+
+	t.Run("success delivers result once and ignores duplicates", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		h := mcpOAuthCallbackHandler(ch)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/callback?code=abc&state=s1&iss=https://as.example.com", nil)
+		h(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", w.Code)
+		}
+		if !strings.Contains(w.Body.String(), "Authentication successful") {
+			t.Error("expected success page")
+		}
+		select {
+		case r := <-ch:
+			if r.err != nil || r.res == nil || r.res.Code != "abc" || r.res.State != "s1" || r.res.Iss != "https://as.example.com" {
+				t.Errorf("unexpected result %+v", r)
+			}
+		default:
+			t.Fatal("expected result on resultChan")
+		}
+
+		// Fill the channel again so a second redirect hits the "already
+		// pending" branch; it must still render success and not block.
+		ch <- mcpOAuthCallbackResult{res: &auth.AuthorizationResult{Code: "first"}}
+		w2 := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() {
+			h(w2, httptest.NewRequest(http.MethodGet, "/callback?code=dup", nil))
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("duplicate callback blocked")
+		}
+		if w2.Code != http.StatusOK {
+			t.Errorf("duplicate status = %d, want 200", w2.Code)
+		}
+		if r := <-ch; r.res == nil || r.res.Code != "first" {
+			t.Errorf("duplicate must not replace the pending result, got %+v", r)
+		}
+	})
+}
+
+func TestMCPOAuthCodeFetcher(t *testing.T) {
+	t.Run("returns callback result and opens browser", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		var opened string
+		fetch := mcpOAuthCodeFetcher("srv", ch, func(u string) error {
+			opened = u
+			// The browser redirect lands on the callback after the URL opens.
+			ch <- mcpOAuthCallbackResult{res: &auth.AuthorizationResult{Code: "code-1", State: "st"}}
+			return nil
+		})
+
+		res, err := fetch(context.Background(), &auth.AuthorizationArgs{URL: "https://as.example.com/authorize?x=1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Code != "code-1" || res.State != "st" {
+			t.Errorf("unexpected result %+v", res)
+		}
+		if opened != "https://as.example.com/authorize?x=1" {
+			t.Errorf("browser opened with %q", opened)
+		}
+	})
+
+	t.Run("stale outcome is dropped before the flow starts", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		ch <- mcpOAuthCallbackResult{res: &auth.AuthorizationResult{Code: "stale"}}
+		fetch := mcpOAuthCodeFetcher("srv", ch, func(string) error {
+			// Simulate the browser redirect arriving during the flow.
+			ch <- mcpOAuthCallbackResult{res: &auth.AuthorizationResult{Code: "fresh", State: "s"}}
+			return nil
+		})
+		res, err := fetch(context.Background(), &auth.AuthorizationArgs{URL: "https://as.example.com/authorize"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Code != "fresh" {
+			t.Errorf("expected fresh result, got %+v", res)
+		}
+	})
+
+	t.Run("provider error is returned", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		fetch := mcpOAuthCodeFetcher("srv", ch, func(string) error {
+			ch <- mcpOAuthCallbackResult{err: errors.New("OAuth error: access_denied")}
+			return nil
+		})
+		res, err := fetch(context.Background(), &auth.AuthorizationArgs{URL: "https://as.example.com/authorize"})
+		if err == nil || !strings.Contains(err.Error(), "access_denied") {
+			t.Fatalf("expected provider error, got res=%v err=%v", res, err)
+		}
+	})
+
+	t.Run("browser failure is non-fatal and context cancel aborts", func(t *testing.T) {
+		ch := make(chan mcpOAuthCallbackResult, 1)
+		fetch := mcpOAuthCodeFetcher("srv", ch, func(string) error { return errors.New("no browser") })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		res, err := fetch(ctx, &auth.AuthorizationArgs{URL: "https://as.example.com/authorize"})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got res=%v err=%v", res, err)
+		}
+	})
+}
+
+func TestMCPOAuthNewTokenSource_PersistsAndWraps(t *testing.T) {
+	setTestHome(t)
+	const server, url = "nts", "https://n.example.com/mcp"
+
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "at", RefreshToken: "rt", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}
+
+	ts, err := mcpOAuthNewTokenSource(server, url)(context.Background(), cfg, tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ts.(*persistingTokenSource); !ok {
+		t.Fatalf("expected *persistingTokenSource, got %T", ts)
+	}
+	got, err := ts.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "at" {
+		t.Errorf("unexpected token %+v", got)
+	}
+
+	// The token must be cached for the next session with its refresh config.
+	cached := loadMCPOAuthTokenSource(server, url)
+	if cached == nil {
+		t.Fatal("expected token to be cached on disk")
+	}
+	if _, ok := cached.(*persistingTokenSource); !ok {
+		t.Errorf("expected cached entry to carry refresh config, got %T", cached)
+	}
+}
+
+func TestMCPOAuthNewTokenSource_CacheFailureIsNonFatal(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	cfg := &oauth2.Config{}
+	tok := &oauth2.Token{AccessToken: "at", Expiry: time.Now().Add(time.Hour)}
+	ts, err := mcpOAuthNewTokenSource("x", "https://x")(context.Background(), cfg, tok)
+	if err != nil {
+		t.Fatalf("cache failure must not fail token source creation: %v", err)
+	}
+	got, err := ts.Token()
+	if err != nil || got.AccessToken != "at" {
+		t.Fatalf("expected in-memory token to work, got %+v err=%v", got, err)
+	}
+}
+
+func TestNewMCPOAuthHandler_UsesCachedToken(t *testing.T) {
+	setTestHome(t)
+	const server, url = "cached-srv", "https://c.example.com/mcp"
+
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "cached-at", RefreshToken: "rt", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(server, url, cfg, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := newMCPOAuthHandler(server, url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ach, ok := h.(*auth.AuthorizationCodeHandler)
+	if !ok {
+		t.Fatalf("expected *auth.AuthorizationCodeHandler, got %T", h)
+	}
+	ts, err := ach.TokenSource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts == nil {
+		t.Fatal("expected cached token source to be injected as InitialTokenSource")
+	}
+	got, err := ts.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "cached-at" {
+		t.Errorf("expected cached access token, got %+v", got)
+	}
+}
+
+func TestNewMCPOAuthHandler_NoCacheStartsUnauthorized(t *testing.T) {
+	setTestHome(t)
+	h, err := newMCPOAuthHandler("fresh-srv", "https://f.example.com/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ach, ok := h.(*auth.AuthorizationCodeHandler)
+	if !ok {
+		t.Fatalf("expected *auth.AuthorizationCodeHandler, got %T", h)
+	}
+	ts, err := ach.TokenSource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts != nil {
+		t.Errorf("expected no token source before authorization, got %T", ts)
+	}
+}

--- a/internal/extension/mcp_oauth_store.go
+++ b/internal/extension/mcp_oauth_store.go
@@ -1,0 +1,128 @@
+package extension
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// mcpOAuthTokenTTL bounds how long a persisted MCP OAuth token is reused.
+// After this window the cached credentials are discarded and the next connect
+// runs the browser authorization flow again.
+const mcpOAuthTokenTTL = 24 * time.Hour
+
+// mcpOAuthToken is the JSON document persisted per MCP server under
+// ~/.pi-go/mcp-oauth/. ClientID and TokenURL are captured from the OAuth
+// config at authorize time so a later session can rebuild a refreshing token
+// source (refreshing needs both) without re-running discovery/registration.
+type mcpOAuthToken struct {
+	Server       string    `json:"server"`
+	SavedAt      time.Time `json:"saved_at"`
+	ClientID     string    `json:"client_id,omitempty"`
+	TokenURL     string    `json:"token_url,omitempty"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenType    string    `json:"token_type,omitempty"`
+	Expiry       time.Time `json:"expiry,omitempty"`
+}
+
+// mcpOAuthTokenFile returns the cache-file path for a server. The name is
+// sanitized for filesystem use and suffixed with a short hash of the exact
+// name so distinct server names never collide on one file.
+func mcpOAuthTokenFile(server string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	var sb strings.Builder
+	for _, r := range strings.ToLower(server) {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			sb.WriteRune(r)
+			continue
+		}
+		sb.WriteByte('-')
+	}
+	sum := sha256.Sum256([]byte(server))
+	name := fmt.Sprintf("%s-%s.json", sb.String(), hex.EncodeToString(sum[:4]))
+	return filepath.Join(home, ".pi-go", "mcp-oauth", name), nil
+}
+
+// loadMCPOAuthTokenSource returns a token source rebuilt from the cached
+// credentials for server, or nil when nothing usable is stored (missing,
+// older than mcpOAuthTokenTTL, or expired with no refresh token).
+func loadMCPOAuthTokenSource(server string) oauth2.TokenSource {
+	path, err := mcpOAuthTokenFile(server)
+	if err != nil {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var st mcpOAuthToken
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil
+	}
+	if st.AccessToken == "" || time.Since(st.SavedAt) > mcpOAuthTokenTTL {
+		_ = os.Remove(path) // stale beyond the reuse window
+		return nil
+	}
+	tok := &oauth2.Token{
+		AccessToken:  st.AccessToken,
+		RefreshToken: st.RefreshToken,
+		TokenType:    st.TokenType,
+		Expiry:       st.Expiry,
+	}
+	if !tok.Valid() && tok.RefreshToken == "" {
+		return nil // expired and cannot refresh
+	}
+	if st.ClientID == "" || st.TokenURL == "" || tok.RefreshToken == "" {
+		return oauth2.StaticTokenSource(tok)
+	}
+	cfg := &oauth2.Config{
+		ClientID: st.ClientID,
+		Endpoint: oauth2.Endpoint{TokenURL: st.TokenURL},
+	}
+	return cfg.TokenSource(context.Background(), tok)
+}
+
+// saveMCPOAuthToken persists the token obtained for server, along with the
+// OAuth config values needed to refresh it in a later session.
+func saveMCPOAuthToken(server string, cfg *oauth2.Config, tok *oauth2.Token) error {
+	if tok == nil || tok.AccessToken == "" {
+		return nil
+	}
+	path, err := mcpOAuthTokenFile(server)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating MCP OAuth cache directory: %w", err)
+	}
+	st := mcpOAuthToken{
+		Server:       server,
+		SavedAt:      time.Now(),
+		ClientID:     cfg.ClientID,
+		TokenURL:     cfg.Endpoint.TokenURL,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		TokenType:    tok.TokenType,
+		Expiry:       tok.Expiry,
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing MCP OAuth cache: %w", err)
+	}
+	return nil
+}

--- a/internal/extension/mcp_oauth_store.go
+++ b/internal/extension/mcp_oauth_store.go
@@ -3,12 +3,12 @@ package extension
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -23,8 +23,12 @@ const mcpOAuthTokenTTL = 24 * time.Hour
 // ~/.pi-go/mcp-oauth/. ClientID and TokenURL are captured from the OAuth
 // config at authorize time so a later session can rebuild a refreshing token
 // source (refreshing needs both) without re-running discovery/registration.
+// Server and URL identify the cache entry: a token minted for one endpoint
+// must never be replayed against another, so loading validates both against
+// the configured server and discards mismatches.
 type mcpOAuthToken struct {
 	Server       string    `json:"server"`
+	URL          string    `json:"url,omitempty"`
 	SavedAt      time.Time `json:"saved_at"`
 	ClientID     string    `json:"client_id,omitempty"`
 	TokenURL     string    `json:"token_url,omitempty"`
@@ -34,10 +38,11 @@ type mcpOAuthToken struct {
 	Expiry       time.Time `json:"expiry,omitempty"`
 }
 
-// mcpOAuthTokenFile returns the cache-file path for a server. The name is
-// sanitized for filesystem use and suffixed with a short hash of the exact
-// name so distinct server names never collide on one file.
-func mcpOAuthTokenFile(server string) (string, error) {
+// mcpOAuthTokenFile returns the cache-file path for a server identity. The
+// name carries a sanitized form of the server name for readability and the
+// full SHA-256 of "name\0url" for uniqueness, so distinct identities never
+// share a file and renaming or retargeting a server invalidates old entries.
+func mcpOAuthTokenFile(server, serverURL string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
@@ -50,16 +55,17 @@ func mcpOAuthTokenFile(server string) (string, error) {
 		}
 		sb.WriteByte('-')
 	}
-	sum := sha256.Sum256([]byte(server))
-	name := fmt.Sprintf("%s-%s.json", sb.String(), hex.EncodeToString(sum[:4]))
+	sum := sha256.Sum256([]byte(server + "\x00" + serverURL))
+	name := fmt.Sprintf("%s-%x.json", sb.String(), sum)
 	return filepath.Join(home, ".pi-go", "mcp-oauth", name), nil
 }
 
 // loadMCPOAuthTokenSource returns a token source rebuilt from the cached
-// credentials for server, or nil when nothing usable is stored (missing,
-// older than mcpOAuthTokenTTL, or expired with no refresh token).
-func loadMCPOAuthTokenSource(server string) oauth2.TokenSource {
-	path, err := mcpOAuthTokenFile(server)
+// credentials for the given server identity, or nil when nothing usable is
+// stored (missing, older than mcpOAuthTokenTTL, expired with no refresh
+// token, or written for a different server URL).
+func loadMCPOAuthTokenSource(server, serverURL string) oauth2.TokenSource {
+	path, err := mcpOAuthTokenFile(server, serverURL)
 	if err != nil {
 		return nil
 	}
@@ -73,6 +79,10 @@ func loadMCPOAuthTokenSource(server string) oauth2.TokenSource {
 	}
 	if st.AccessToken == "" || time.Since(st.SavedAt) > mcpOAuthTokenTTL {
 		_ = os.Remove(path) // stale beyond the reuse window
+		return nil
+	}
+	if st.Server != server || st.URL != serverURL {
+		_ = os.Remove(path) // identity drift (retargeted or renamed server)
 		return nil
 	}
 	tok := &oauth2.Token{
@@ -91,24 +101,77 @@ func loadMCPOAuthTokenSource(server string) oauth2.TokenSource {
 		ClientID: st.ClientID,
 		Endpoint: oauth2.Endpoint{TokenURL: st.TokenURL},
 	}
-	return cfg.TokenSource(context.Background(), tok)
+	// Wrap the refreshing source so rotated tokens are written back to disk;
+	// otherwise a provider that rotates refresh tokens leaves the revoked
+	// value persisted and every restart fails to refresh.
+	ts := cfg.TokenSource(context.Background(), tok)
+	return newPersistingTokenSource(ts, tok, func(t *oauth2.Token) error {
+		return saveMCPOAuthToken(server, serverURL, cfg, t)
+	})
 }
 
-// saveMCPOAuthToken persists the token obtained for server, along with the
-// OAuth config values needed to refresh it in a later session.
-func saveMCPOAuthToken(server string, cfg *oauth2.Config, tok *oauth2.Token) error {
+// persistingTokenSource wraps an inner source and persists newly issued
+// tokens whenever access or refresh credentials change. Persistence errors
+// are reported but do not fail the token call: a lost cache write degrades
+// to a future re-authorization, not a broken request.
+type persistingTokenSource struct {
+	mu     sync.Mutex
+	inner  oauth2.TokenSource
+	last   *oauth2.Token
+	saveFn func(*oauth2.Token) error
+}
+
+func newPersistingTokenSource(inner oauth2.TokenSource, last *oauth2.Token, saveFn func(*oauth2.Token) error) oauth2.TokenSource {
+	return &persistingTokenSource{inner: inner, last: last, saveFn: saveFn}
+}
+
+func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	tok, err := p.inner.Token()
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	snapshot := p.last
+	changed := snapshot == nil ||
+		tok.AccessToken != snapshot.AccessToken ||
+		tok.RefreshToken != snapshot.RefreshToken ||
+		!tok.Expiry.Equal(snapshot.Expiry)
+	if changed {
+		cp := *tok
+		p.last = &cp
+	}
+	p.mu.Unlock()
+
+	if changed {
+		if err := p.saveFn(tok); err != nil {
+			fmt.Fprintf(os.Stderr, "pi-go: could not update cached MCP OAuth token: %v\n", err)
+		}
+	}
+	return tok, nil
+}
+
+// saveMCPOAuthToken persists the token obtained for a server identity, along
+// with the OAuth config values needed to refresh it in a later session. The
+// write is atomic (temp file + rename in the target directory) and the
+// permissions of pre-existing directories are tightened, since MkdirAll modes
+// only apply at creation time.
+func saveMCPOAuthToken(server, serverURL string, cfg *oauth2.Config, tok *oauth2.Token) error {
 	if tok == nil || tok.AccessToken == "" {
 		return nil
 	}
-	path, err := mcpOAuthTokenFile(server)
+	path, err := mcpOAuthTokenFile(server, serverURL)
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating MCP OAuth cache directory: %w", err)
 	}
+	_ = os.Chmod(dir, 0o700) // tighten pre-existing directories
+
 	st := mcpOAuthToken{
 		Server:       server,
+		URL:          serverURL,
 		SavedAt:      time.Now(),
 		ClientID:     cfg.ClientID,
 		TokenURL:     cfg.Endpoint.TokenURL,
@@ -121,8 +184,30 @@ func saveMCPOAuthToken(server string, cfg *oauth2.Config, tok *oauth2.Token) err
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+
+	// Atomic write: temp file in the target directory, then rename. CreateTemp
+	// uses 0600, so the installed file is never more permissive than that.
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return fmt.Errorf("creating MCP OAuth cache temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = tmp.Close(); _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
 		return fmt.Errorf("writing MCP OAuth cache: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("syncing MCP OAuth cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing MCP OAuth cache: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("installing MCP OAuth cache: %w", err)
 	}
 	return nil
 }

--- a/internal/extension/mcp_oauth_store_test.go
+++ b/internal/extension/mcp_oauth_store_test.go
@@ -1,0 +1,110 @@
+package extension
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestMCPOAuthTokenFile(t *testing.T) {
+	path, err := mcpOAuthTokenFile("My Server/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(path) == "My Server/1.json" {
+		t.Error("expected sanitized filename")
+	}
+	if filepath.Ext(path) != ".json" {
+		t.Errorf("expected .json suffix, got %q", path)
+	}
+	other, err := mcpOAuthTokenFile("My-Server-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other == path {
+		t.Error("distinct server names must not share a cache file")
+	}
+}
+
+func TestSaveLoadMCPOAuthToken_RoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := &oauth2.Config{
+		ClientID: "client-123",
+		Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"},
+	}
+	tok := &oauth2.Token{
+		AccessToken:  "at",
+		RefreshToken: "rt",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+	if err := saveMCPOAuthToken("cloudflare", cfg, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := loadMCPOAuthTokenSource("cloudflare")
+	if ts == nil {
+		t.Fatal("expected usable token source after save")
+	}
+	got, err := ts.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "at" || got.RefreshToken != "rt" {
+		t.Errorf("unexpected token round-trip: %+v", got)
+	}
+}
+
+func TestLoadMCPOAuthToken_Missing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if ts := loadMCPOAuthTokenSource("nope"); ts != nil {
+		t.Error("expected nil token source with no cached file")
+	}
+}
+
+func TestLoadMCPOAuthToken_TTLExpired(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := mcpOAuthTokenFile("stale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	st := mcpOAuthToken{
+		Server:      "stale",
+		SavedAt:     time.Now().Add(-mcpOAuthTokenTTL - time.Minute),
+		AccessToken: "old",
+	}
+	data, _ := json.Marshal(st)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if ts := loadMCPOAuthTokenSource("stale"); ts != nil {
+		t.Error("expected nil token source past the reuse window")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected stale cache file to be removed")
+	}
+}
+
+func TestSaveMCPOAuthToken_IgnoresEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := saveMCPOAuthToken("x", &oauth2.Config{}, &oauth2.Token{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveMCPOAuthToken("x", &oauth2.Config{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ts := loadMCPOAuthTokenSource("x"); ts != nil {
+		t.Error("expected no token source for empty tokens")
+	}
+}

--- a/internal/extension/mcp_oauth_store_test.go
+++ b/internal/extension/mcp_oauth_store_test.go
@@ -2,14 +2,29 @@ package extension
 
 import (
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/oauth2"
 )
+
+// setTestHome points os.UserHomeDir at a fresh temp directory for the test.
+// Both HOME (Unix) and USERPROFILE (Windows) are set so the store never
+// touches the real user profile on any platform.
+func setTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
 
 func TestMCPOAuthTokenFile(t *testing.T) {
 	path, err := mcpOAuthTokenFile("My Server/1", "https://a.example.com/mcp")
@@ -44,7 +59,7 @@ func TestMCPOAuthTokenFile(t *testing.T) {
 }
 
 func TestSaveLoadMCPOAuthToken_RoundTrip(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 
 	cfg := &oauth2.Config{
 		ClientID: "client-123",
@@ -74,7 +89,7 @@ func TestSaveLoadMCPOAuthToken_RoundTrip(t *testing.T) {
 }
 
 func TestLoadMCPOAuthToken_IdentityDrift(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	url := "https://srv.example.com/mcp"
 
 	cfg := &oauth2.Config{ClientID: "c", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
@@ -96,15 +111,14 @@ func TestLoadMCPOAuthToken_IdentityDrift(t *testing.T) {
 }
 
 func TestLoadMCPOAuthToken_Missing(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	if ts := loadMCPOAuthTokenSource("nope", "https://x.example.com"); ts != nil {
 		t.Error("expected nil token source with no cached file")
 	}
 }
 
 func TestLoadMCPOAuthToken_TTLExpired(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t)
 
 	path, err := mcpOAuthTokenFile("stale", "https://s.example.com")
 	if err != nil {
@@ -170,7 +184,7 @@ func TestPersistingTokenSource_SavesRotatedTokens(t *testing.T) {
 }
 
 func TestSaveMCPOAuthToken_IgnoresEmpty(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	if err := saveMCPOAuthToken("x", "https://x", &oauth2.Config{}, &oauth2.Token{}); err != nil {
 		t.Fatal(err)
 	}
@@ -179,5 +193,281 @@ func TestSaveMCPOAuthToken_IgnoresEmpty(t *testing.T) {
 	}
 	if ts := loadMCPOAuthTokenSource("x", "https://x"); ts != nil {
 		t.Error("expected no token source for empty tokens")
+	}
+}
+
+// writeMCPOAuthTokenFile writes st verbatim at the cache path computed for
+// (server, serverURL), bypassing saveMCPOAuthToken so tests can plant
+// malformed or mismatched entries.
+func writeMCPOAuthTokenFile(t *testing.T, server, serverURL string, data []byte) string {
+	t.Helper()
+	path, err := mcpOAuthTokenFile(server, serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadMCPOAuthToken_IdentityMismatchInFile(t *testing.T) {
+	setTestHome(t)
+	const server, url = "cloudflare", "https://srv.example.com/mcp"
+
+	// A file at the right path whose payload claims a different identity
+	// (e.g. copied from another machine or tampered with) must be rejected
+	// and removed.
+	data, _ := json.Marshal(mcpOAuthToken{
+		Server:      "other",
+		URL:         "https://evil.example.com/mcp",
+		SavedAt:     time.Now(),
+		AccessToken: "at",
+		Expiry:      time.Now().Add(time.Hour),
+	})
+	path := writeMCPOAuthTokenFile(t, server, url, data)
+
+	if ts := loadMCPOAuthTokenSource(server, url); ts != nil {
+		t.Error("expected nil token source for mismatched identity")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected mismatched cache file to be removed")
+	}
+}
+
+func TestLoadMCPOAuthToken_CorruptJSON(t *testing.T) {
+	setTestHome(t)
+	writeMCPOAuthTokenFile(t, "bad", "https://b.example.com", []byte("{not json"))
+	if ts := loadMCPOAuthTokenSource("bad", "https://b.example.com"); ts != nil {
+		t.Error("expected nil token source for corrupt cache file")
+	}
+}
+
+func TestLoadMCPOAuthToken_ExpiredWithoutRefresh(t *testing.T) {
+	setTestHome(t)
+	const server, url = "exp", "https://e.example.com"
+	cfg := &oauth2.Config{ClientID: "c", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "at", Expiry: time.Now().Add(-time.Minute)}
+	if err := saveMCPOAuthToken(server, url, cfg, tok); err != nil {
+		t.Fatal(err)
+	}
+	if ts := loadMCPOAuthTokenSource(server, url); ts != nil {
+		t.Error("expected nil token source for expired token with no refresh token")
+	}
+}
+
+func TestLoadMCPOAuthToken_StaticWithoutRefreshConfig(t *testing.T) {
+	setTestHome(t)
+	const server, url = "static", "https://s.example.com"
+
+	// Valid access token but no refresh token: nothing to refresh with, so
+	// the loader hands back a static source for the remaining lifetime.
+	tok := &oauth2.Token{AccessToken: "at-static", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(server, url, &oauth2.Config{}, tok); err != nil {
+		t.Fatal(err)
+	}
+	ts := loadMCPOAuthTokenSource(server, url)
+	if ts == nil {
+		t.Fatal("expected static token source")
+	}
+	got, err := ts.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "at-static" || got.TokenType != "Bearer" {
+		t.Errorf("unexpected token: %+v", got)
+	}
+
+	// Refresh token present but no client/token URL recorded: still static,
+	// since a refresh cannot be performed without them.
+	tok2 := &oauth2.Token{AccessToken: "at2", RefreshToken: "rt2", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(server, url, &oauth2.Config{}, tok2); err != nil {
+		t.Fatal(err)
+	}
+	ts2 := loadMCPOAuthTokenSource(server, url)
+	if ts2 == nil {
+		t.Fatal("expected static token source")
+	}
+	if _, isPersisting := ts2.(*persistingTokenSource); isPersisting {
+		t.Error("expected a static source when refresh config is missing")
+	}
+}
+
+func TestLoadMCPOAuthToken_RefreshesAndPersistsRotatedToken(t *testing.T) {
+	setTestHome(t)
+	const server, url = "rot", "https://r.example.com/mcp"
+
+	// Fake token endpoint: every refresh returns a rotated pair.
+	var refreshes int
+	as := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "rt1" {
+			t.Errorf("unexpected refresh request: %v", r.Form)
+		}
+		refreshes++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at2","refresh_token":"rt2","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer as.Close()
+
+	cfg := &oauth2.Config{ClientID: "client-1", Endpoint: oauth2.Endpoint{TokenURL: as.URL}}
+	expired := &oauth2.Token{AccessToken: "at1", RefreshToken: "rt1", Expiry: time.Now().Add(-time.Minute)}
+	if err := saveMCPOAuthToken(server, url, cfg, expired); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := loadMCPOAuthTokenSource(server, url)
+	if ts == nil {
+		t.Fatal("expected refreshing token source for expired token with refresh token")
+	}
+	if _, ok := ts.(*persistingTokenSource); !ok {
+		t.Fatalf("expected *persistingTokenSource, got %T", ts)
+	}
+	got, err := ts.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "at2" || got.RefreshToken != "rt2" {
+		t.Errorf("expected refreshed token at2/rt2, got %+v", got)
+	}
+	if refreshes != 1 {
+		t.Errorf("expected exactly one refresh, got %d", refreshes)
+	}
+
+	// The rotated pair must now be on disk: a new load must not need the
+	// revoked rt1 any more.
+	path, _ := mcpOAuthTokenFile(server, url)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var st mcpOAuthToken
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatal(err)
+	}
+	if st.AccessToken != "at2" || st.RefreshToken != "rt2" {
+		t.Errorf("expected rotated token persisted, got %+v", st)
+	}
+	if st.ClientID != "client-1" || st.TokenURL != as.URL {
+		t.Errorf("expected refresh config preserved, got client=%q url=%q", st.ClientID, st.TokenURL)
+	}
+}
+
+type errTokenSource struct{ err error }
+
+func (e errTokenSource) Token() (*oauth2.Token, error) { return nil, e.err }
+
+func TestPersistingTokenSource_InnerErrorPropagates(t *testing.T) {
+	saved := false
+	ts := newPersistingTokenSource(errTokenSource{err: errors.New("boom")}, nil,
+		func(*oauth2.Token) error { saved = true; return nil })
+	if _, err := ts.Token(); err == nil || err.Error() != "boom" {
+		t.Fatalf("expected inner error, got %v", err)
+	}
+	if saved {
+		t.Error("save must not run when the inner source fails")
+	}
+}
+
+func TestPersistingTokenSource_SaveErrorIsNonFatal(t *testing.T) {
+	ts := newPersistingTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "at"}), nil,
+		func(*oauth2.Token) error { return errors.New("disk full") })
+	got, err := ts.Token()
+	if err != nil {
+		t.Fatalf("persistence failure must not fail the token call: %v", err)
+	}
+	if got.AccessToken != "at" {
+		t.Errorf("unexpected token %+v", got)
+	}
+}
+
+func TestSaveMCPOAuthToken_MkdirError(t *testing.T) {
+	home := setTestHome(t)
+	// A regular file where the cache directory's parent should be makes
+	// MkdirAll fail on every platform.
+	if err := os.WriteFile(filepath.Join(home, ".pi-go"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &oauth2.Config{}
+	tok := &oauth2.Token{AccessToken: "at"}
+	err := saveMCPOAuthToken("x", "https://x", cfg, tok)
+	if err == nil || !strings.Contains(err.Error(), "cache directory") {
+		t.Fatalf("expected cache directory error, got %v", err)
+	}
+}
+
+func TestMCPOAuthTokenFile_NoHomeDir(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	if _, err := mcpOAuthTokenFile("x", "https://x"); err == nil {
+		t.Error("expected error when home directory is unknown")
+	}
+	if ts := loadMCPOAuthTokenSource("x", "https://x"); ts != nil {
+		t.Error("expected nil token source when home directory is unknown")
+	}
+	err := saveMCPOAuthToken("x", "https://x", &oauth2.Config{}, &oauth2.Token{AccessToken: "at"})
+	if err == nil {
+		t.Error("expected save error when home directory is unknown")
+	}
+}
+
+func TestSaveMCPOAuthToken_FilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	home := setTestHome(t)
+	cfg := &oauth2.Config{}
+	if err := saveMCPOAuthToken("perm", "https://p.example.com", cfg, &oauth2.Token{AccessToken: "at"}); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := mcpOAuthTokenFile("perm", "https://p.example.com")
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("expected 0600 cache file, got %o", fi.Mode().Perm())
+	}
+	di, err := os.Stat(filepath.Join(home, ".pi-go", "mcp-oauth"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if di.Mode().Perm() != 0o700 {
+		t.Errorf("expected 0700 cache dir, got %o", di.Mode().Perm())
+	}
+	// No temp file left behind after the atomic rename.
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestSaveMCPOAuthToken_RenameErrorCleansTemp(t *testing.T) {
+	setTestHome(t)
+	path, err := mcpOAuthTokenFile("clash", "https://c.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A non-empty directory squatting on the target path makes the final
+	// rename fail on every platform; the temp file must not be left behind.
+	if err := os.MkdirAll(filepath.Join(path, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	err = saveMCPOAuthToken("clash", "https://c.example.com", &oauth2.Config{}, &oauth2.Token{AccessToken: "at"})
+	if err == nil || !strings.Contains(err.Error(), "installing MCP OAuth cache") {
+		t.Fatalf("expected rename error, got %v", err)
+	}
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
 	}
 }

--- a/internal/extension/mcp_oauth_store_test.go
+++ b/internal/extension/mcp_oauth_store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,21 +12,33 @@ import (
 )
 
 func TestMCPOAuthTokenFile(t *testing.T) {
-	path, err := mcpOAuthTokenFile("My Server/1")
+	path, err := mcpOAuthTokenFile("My Server/1", "https://a.example.com/mcp")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if filepath.Base(path) == "My Server/1.json" {
-		t.Error("expected sanitized filename")
+	base := filepath.Base(path)
+	if strings.Contains(base, " ") || strings.Contains(base, "/") {
+		t.Errorf("expected sanitized filename, got %q", base)
 	}
 	if filepath.Ext(path) != ".json" {
 		t.Errorf("expected .json suffix, got %q", path)
 	}
-	other, err := mcpOAuthTokenFile("My-Server-1")
+
+	// Different URL under the same name must produce a different file.
+	otherURL, err := mcpOAuthTokenFile("My Server/1", "https://b.example.com/mcp")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if other == path {
+	if otherURL == path {
+		t.Error("same name with different URL must not share a cache file")
+	}
+
+	// Different name, similar sanitized form, must not collide either.
+	otherName, err := mcpOAuthTokenFile("My-Server-1", "https://a.example.com/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherName == path {
 		t.Error("distinct server names must not share a cache file")
 	}
 }
@@ -43,11 +56,11 @@ func TestSaveLoadMCPOAuthToken_RoundTrip(t *testing.T) {
 		TokenType:    "Bearer",
 		Expiry:       time.Now().Add(time.Hour),
 	}
-	if err := saveMCPOAuthToken("cloudflare", cfg, tok); err != nil {
+	if err := saveMCPOAuthToken("cloudflare", "https://srv.example.com/mcp", cfg, tok); err != nil {
 		t.Fatal(err)
 	}
 
-	ts := loadMCPOAuthTokenSource("cloudflare")
+	ts := loadMCPOAuthTokenSource("cloudflare", "https://srv.example.com/mcp")
 	if ts == nil {
 		t.Fatal("expected usable token source after save")
 	}
@@ -60,9 +73,31 @@ func TestSaveLoadMCPOAuthToken_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestLoadMCPOAuthToken_IdentityDrift(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	url := "https://srv.example.com/mcp"
+
+	cfg := &oauth2.Config{ClientID: "c", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "at", RefreshToken: "rt", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken("cloudflare", url, cfg, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retargeted URL: the identity hash differs, so the old entry is never
+	// consulted and nothing is returned.
+	if ts := loadMCPOAuthTokenSource("cloudflare", "https://evil.example.com/mcp"); ts != nil {
+		t.Error("expected nil for retargeted URL")
+	}
+
+	// Renamed server: entry must be rejected as well.
+	if ts := loadMCPOAuthTokenSource("other", url); ts != nil {
+		t.Error("expected nil for renamed server")
+	}
+}
+
 func TestLoadMCPOAuthToken_Missing(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if ts := loadMCPOAuthTokenSource("nope"); ts != nil {
+	if ts := loadMCPOAuthTokenSource("nope", "https://x.example.com"); ts != nil {
 		t.Error("expected nil token source with no cached file")
 	}
 }
@@ -71,7 +106,7 @@ func TestLoadMCPOAuthToken_TTLExpired(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	path, err := mcpOAuthTokenFile("stale")
+	path, err := mcpOAuthTokenFile("stale", "https://s.example.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,6 +115,7 @@ func TestLoadMCPOAuthToken_TTLExpired(t *testing.T) {
 	}
 	st := mcpOAuthToken{
 		Server:      "stale",
+		URL:         "https://s.example.com",
 		SavedAt:     time.Now().Add(-mcpOAuthTokenTTL - time.Minute),
 		AccessToken: "old",
 	}
@@ -88,7 +124,7 @@ func TestLoadMCPOAuthToken_TTLExpired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ts := loadMCPOAuthTokenSource("stale"); ts != nil {
+	if ts := loadMCPOAuthTokenSource("stale", "https://s.example.com"); ts != nil {
 		t.Error("expected nil token source past the reuse window")
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -96,15 +132,52 @@ func TestLoadMCPOAuthToken_TTLExpired(t *testing.T) {
 	}
 }
 
+func TestPersistingTokenSource_SavesRotatedTokens(t *testing.T) {
+	saved := 0
+	initial := &oauth2.Token{AccessToken: "at1", RefreshToken: "rt1"}
+	ts := newPersistingTokenSource(
+		oauth2.StaticTokenSource(initial),
+		nil,
+		func(*oauth2.Token) error { saved++; return nil },
+	)
+
+	// First call sees a change vs the nil snapshot and persists.
+	if _, err := ts.Token(); err != nil {
+		t.Fatal(err)
+	}
+	if saved != 1 {
+		t.Fatalf("expected 1 save after first Token(), got %d", saved)
+	}
+
+	// Unchanged token must not trigger another write.
+	if _, err := ts.Token(); err != nil {
+		t.Fatal(err)
+	}
+	if saved != 1 {
+		t.Fatalf("expected no extra save for unchanged token, got %d saves", saved)
+	}
+
+	// Rotated access token must be persisted.
+	rotated := &oauth2.Token{AccessToken: "at2", RefreshToken: "rt1"}
+	ts2 := newPersistingTokenSource(oauth2.StaticTokenSource(rotated), initial,
+		func(*oauth2.Token) error { saved++; return nil })
+	if _, err := ts2.Token(); err != nil {
+		t.Fatal(err)
+	}
+	if saved != 2 {
+		t.Fatalf("expected save for rotated token, got %d saves", saved)
+	}
+}
+
 func TestSaveMCPOAuthToken_IgnoresEmpty(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := saveMCPOAuthToken("x", &oauth2.Config{}, &oauth2.Token{}); err != nil {
+	if err := saveMCPOAuthToken("x", "https://x", &oauth2.Config{}, &oauth2.Token{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := saveMCPOAuthToken("x", &oauth2.Config{}, nil); err != nil {
+	if err := saveMCPOAuthToken("x", "https://x", &oauth2.Config{}, nil); err != nil {
 		t.Fatal(err)
 	}
-	if ts := loadMCPOAuthTokenSource("x"); ts != nil {
+	if ts := loadMCPOAuthTokenSource("x", "https://x"); ts != nil {
 		t.Error("expected no token source for empty tokens")
 	}
 }


### PR DESCRIPTION
## Summary
- Render the OAuth authorization-result page in the pi-go.sh visual style: dark neon theme (#0a0a12), grid + scanline overlays, Orbitron/Rajdhani type, glowing card with success (green ✓) / failure (magenta ✗) variants. All CSS is embedded so the page renders offline.
- Shared renderer `auth.RenderCallbackPage` now backs both callback paths: SSO PKCE `handleCallback` (success + error/state/no-code responses) and the MCP OAuth loopback callback.
- Persist MCP OAuth tokens per server under `~/.pi-go/mcp-oauth/` (0600) with a 24h reuse window (`mcpOAuthTokenTTL`).
- Reuse path: cached token is injected via the SDK's `InitialTokenSource`, so restarts within 24h skip the browser flow entirely; expired-without-refresh or stale entries are discarded.
- Capture path: freshly authorized tokens are persisted through `NewTokenSource`, storing `client_id`/`token_url` alongside the token so later sessions can rebuild a refreshing token source without re-running discovery/dynamic client registration.

## Follow-up (ffc88af) — codex review findings
- **Callback server now lives for the handler's lifetime.** The SDK re-runs `Authorize` (and so the code fetcher) on every 401 — e.g. a cached token that was revoked — and on `insufficient_scope` step-up, and the redirect URI registered via DCR carries the loopback port. Closing the listener after loading a cached token / after the first flow broke re-authorization. The fetcher also drops any stale outcome left from an earlier flow before opening the browser.
- **Provider error redirects (user clicked Deny) are surfaced to the fetcher** instead of leaving it waiting for the connect timeout: the callback delivers either the authorization result or the OAuth error on one result channel.
- Handler internals split into `mcpOAuthCallbackHandler`, `mcpOAuthCodeFetcher` (injectable URL opener) and `mcpOAuthNewTokenSource` so they are unit-testable without a listener or a browser.
- Dismissed (round 2, P2): "restore cached granted scopes before step-up". `auth.AuthorizationCodeHandlerConfig` has no way to seed the SDK's private `grantedScopes` map; the only alternative is not caching at all. Worst case after a restart is one extra authorization prompt on an `insufficient_scope` step-up, which is the pre-PR behaviour on every start. Would need an upstream SDK hook.

## Test plan
- `go build ./...`, `go vet`, `make lint` (0 issues), `go test -race ./internal/extension/`
- `go test ./internal/auth/ ./internal/extension/ -count=1` — new tests cover: page rendering/escaping/failure variant; callback handler (error / no-code / success / duplicate); fetcher (result, stale drain, provider error, ctx cancel); `NewTokenSource` hook; `InitialTokenSource` reuse of a cached token; store branches (identity mismatch inside the file, corrupt JSON, expired-without-refresh, static fallback, real refresh against a fake token endpoint with rotated-token write-back, mkdir/rename/home errors, permissions). Store tests set `USERPROFILE` as well as `HOME` so they are hermetic on Windows. `internal/extension` coverage 85.2% → 91.3%.

## CI notes
- The earlier **Lint** failure was `golangci-lint config verify` timing out while downloading the JSON schema — infra, not a finding. Green on re-run.
- **Test (Windows)** fails on `main` too (since `cd33d6a`), with the same set of pre-existing failures (`internal/auth` `TestSaveKey*`, `internal/browser`, `internal/acp/*`, `internal/cli` 600s timeout, `internal/extension` `hooks_test.go`/`complexity_extension_test.go`, …). None of this PR's tests fail on Windows. PR #203 tracks the Windows fix.
- One `Test` (Linux) run hit a pre-existing data race in `internal/acp/client/test_helper_agent_test.go` (`agentConn` assigned after `NewAgentSideConnection` starts receiving); passed on re-run. Not touched by this PR.

https://claude.ai/code/session_014XA8pYe34AXYE8sSeRe3WC
