### PR TITLE
feat(serve): voice panel with Talk/Mute/End controls, raised 3x

### DIFF
--- a/internal/webserver/static/index.html
+++ b/internal/webserver/static/index.html
@@ -90,7 +90,14 @@
     <!-- Voice controls stay hidden until /api/voice/config reports enabled, so
          a build without GEMINI_API_KEY shows no button that would 503. -->
     <div class="voice-bar" id="voice-bar" hidden>
-        <button type="button" class="voice-button" id="voice-toggle">🎙 Talk</button>
+        <div class="voice-controls" role="group" aria-label="Voice controls">
+            <button type="button" class="voice-button" id="voice-talk"
+                    title="Start a voice session">🎙 Talk</button>
+            <button type="button" class="voice-button" id="voice-mute"
+                    title="Mute the microphone; the session stays live" aria-pressed="false" disabled>🔊 Mute</button>
+            <button type="button" class="voice-button" id="voice-end"
+                    title="End the voice session" disabled>⏹ End</button>
+        </div>
         <span class="voice-status" id="voice-status"></span>
     </div>
     <div class="voice-transcript" id="voice-transcript" hidden></div>
@@ -408,7 +415,9 @@
         const voiceCfg = await loadVoiceConfig();
         if (voiceCfg.enabled) {
             const bar = document.getElementById('voice-bar');
-            const btn = document.getElementById('voice-toggle');
+            const talkBtn = document.getElementById('voice-talk');
+            const muteBtn = document.getElementById('voice-mute');
+            const endBtn = document.getElementById('voice-end');
             const statusEl = document.getElementById('voice-status');
             const panel = document.getElementById('voice-transcript');
             bar.hidden = false;
@@ -432,9 +441,23 @@
             const voice = initVoice({
                 onStatus(status, message) {
                     statusEl.textContent = message ? status + ' — ' + message : status;
-                    btn.textContent = (status === 'active' || status === 'connecting') ? '⏹ Stop' : '🎙 Talk';
-                    btn.classList.toggle('active', status === 'active');
+                    // Talk only ever starts; End only ever stops. One button
+                    // that did both was too easy to hit mid-sentence.
+                    const live = status === 'active' || status === 'connecting';
+                    talkBtn.disabled = live;
+                    talkBtn.textContent = status === 'active' ? '🎙 Talking…'
+                        : status === 'connecting' ? '🎙 Connecting…' : '🎙 Talk';
+                    talkBtn.classList.toggle('active', status === 'active');
+                    muteBtn.disabled = !live;
+                    endBtn.disabled = !live;
                     if (status === 'error') line('error', message || 'voice error');
+                },
+                onMute(muted) {
+                    muteBtn.classList.toggle('muted', muted);
+                    muteBtn.setAttribute('aria-pressed', String(muted));
+                    muteBtn.textContent = muted ? '🔇 Mute' : '🔊 Mute';
+                    muteBtn.title = muted ? 'Unmute the microphone'
+                        : 'Mute the microphone; the session stays live';
                 },
                 onUserTranscript(text, first) {
                     if (first || !userLine) userLine = line('user', text);
@@ -467,7 +490,9 @@
                 terminalSession: () => sessionID,
             });
 
-            btn.addEventListener('click', () => voice.toggle(voiceCfg.model));
+            talkBtn.addEventListener('click', () => voice.start(voiceCfg.model));
+            muteBtn.addEventListener('click', () => voice.toggleMute());
+            endBtn.addEventListener('click', () => voice.stop());
             // A tab that goes away mid-session should release the relay slot
             // now rather than at the session TTL.
             window.addEventListener('pagehide', () => voice.stop());

--- a/internal/webserver/static/style.css
+++ b/internal/webserver/static/style.css
@@ -168,14 +168,28 @@ button:disabled {
    terminal's size is negotiated with the PTY, so anything that reflows it on
    an unrelated event costs a resize round-trip. */
 
+/* The bar and the transcript share one offset so the panel always stacks
+   above the buttons; change it here, not in either rule. */
+:root {
+    --voice-bar-bottom: 48px;
+}
+
 .voice-bar {
     position: fixed;
     right: 16px;
-    bottom: 16px;
+    bottom: var(--voice-bar-bottom);
     display: flex;
     align-items: center;
     gap: 10px;
     z-index: 10;
+}
+
+/* Talk | Mute | End as three pills. Each does one thing: Talk starts, End
+   stops, and Mute gates the mic without touching the session. */
+.voice-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .voice-button {
@@ -193,10 +207,30 @@ button:disabled {
     border-color: #5a5a5a;
 }
 
+.voice-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    box-shadow: none;
+    border-color: #3a3a3a;
+}
+
 .voice-button.active {
     background: #7d2020;
     border-color: #a83232;
     animation: pulse 1.6s ease-in-out infinite;
+}
+
+/* Talk is disabled while a session is live, but it reads as "on", not as
+   unavailable: full opacity, pulsing, and no forbidden cursor. */
+.voice-button.active:disabled {
+    opacity: 1;
+    cursor: default;
+}
+
+.voice-button.muted {
+    background: #3d2e0a;
+    border-color: #d19a2a;
+    color: #f3d58a;
 }
 
 .voice-status {
@@ -211,7 +245,8 @@ button:disabled {
 .voice-transcript {
     position: fixed;
     right: 16px;
-    bottom: 64px;
+    /* Bar height plus a gap, measured from the same offset as the bar. */
+    bottom: calc(var(--voice-bar-bottom) + 48px);
     width: min(46ch, calc(100vw - 32px));
     max-height: 40vh;
     overflow-y: auto;

--- a/internal/webserver/static/voice.js
+++ b/internal/webserver/static/voice.js
@@ -132,6 +132,7 @@ const CAPTURE_WORKLET = `registerProcessor('pi-pcm-capture', class extends Audio
 //   onAssistantFinal(text)     — the turn's assistant transcript, complete
 //   onInterrupt()              — the model was cut off mid-utterance
 //   onToolCall(name, summary)  — voice drove the coding agent
+//   onMute(muted)              — the microphone was muted or unmuted
 //   onLog(stage, detail)       — optional diagnostics
 //   terminalSession()          — the PTY session id to bind the voice session
 //                                to, so its tools drive the terminal this tab
@@ -145,6 +146,10 @@ export function initVoice(deps = {}) {
   let playCtx = null;
   let playTime = 0;
   let sources = [];
+  // muted gates the uplink only. The session, the socket and the model's
+  // audio all stay live, so unmuting resumes mid-conversation with nothing to
+  // reconnect.
+  let muted = false;
 
   const log = (stage, detail) => deps.onLog && deps.onLog(stage, detail);
   // Resolved per start, not once: a tab that reconnects keeps its session id in
@@ -191,6 +196,27 @@ export function initVoice(deps = {}) {
     }
   }
 
+  // applyMute records the flag, mirrors it onto the mic tracks and tells the
+  // UI. Disabling the tracks, rather than only dropping frames, is what makes
+  // the browser and OS microphone indicators go dark while muted.
+  function applyMute(next) {
+    muted = next;
+    if (micStream) micStream.getAudioTracks().forEach((t) => { t.enabled = !next; });
+    deps.onMute && deps.onMute(next);
+  }
+
+  function setMuted(next) {
+    if (state.status !== 'connecting' && state.status !== 'active') {
+      log('mute', 'ignored: no session is live');
+      return false;
+    }
+    if (muted !== next) {
+      applyMute(next);
+      log('mute', next ? 'microphone muted' : 'microphone live');
+    }
+    return muted;
+  }
+
   // flushPlayback drops every scheduled output chunk. This is barge-in: the
   // relay transport plays a queue of buffers rather than a live stream, so
   // stopping the model means stopping each one already handed to the clock.
@@ -220,7 +246,12 @@ export function initVoice(deps = {}) {
   }
 
   function cleanup() {
-    if (ws) { try { ws.close(); } catch { /* already closed */ } }
+    if (ws) {
+      // close() delivers onclose asynchronously. Detach first, or a socket
+      // torn down by End can see the next session's "connecting" and fail it.
+      ws.onopen = ws.onmessage = ws.onclose = ws.onerror = null;
+      try { ws.close(); } catch { /* already closed */ }
+    }
     flushPlayback();
     if (capCtx) { try { capCtx.close(); } catch { /* already closed */ } }
     if (playCtx) { try { playCtx.close(); } catch { /* already closed */ } }
@@ -229,6 +260,9 @@ export function initVoice(deps = {}) {
     capCtx = null;
     playCtx = null;
     micStream = null;
+    // A session that ends muted must not leave the next one muted: the UI
+    // would show a live mic the relay never hears.
+    if (muted) applyMute(false);
   }
 
   async function start(model) {
@@ -237,6 +271,7 @@ export function initVoice(deps = {}) {
       return;
     }
     state = createVoiceState();
+    if (muted) applyMute(false);
     setStatus('connecting');
 
     let realtime;
@@ -269,6 +304,9 @@ export function initVoice(deps = {}) {
       log('microphone', 'requesting getUserMedia({audio:true})');
       micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
       log('microphone', 'granted');
+      // Mute can be pressed while the permission prompt is up; the tracks
+      // did not exist then, so mirror the flag onto them now.
+      if (muted) micStream.getAudioTracks().forEach((t) => { t.enabled = false; });
     } catch (e) {
       fail('microphone', 'microphone permission was refused: ' + e.message);
       return;
@@ -327,6 +365,9 @@ export function initVoice(deps = {}) {
       const srcNode = capCtx.createMediaStreamSource(micStream);
       const capNode = new AudioWorkletNode(capCtx, 'pi-pcm-capture');
       capNode.port.onmessage = (e) => {
+        // Disabled tracks already yield silence; not sending it at all is what
+        // keeps a muted tab from streaming 40ms of zeros 25 times a second.
+        if (muted) return;
         if (ws && ws.readyState === WebSocket.OPEN) ws.send(pcm16FromFloat32(e.data).buffer);
       };
       srcNode.connect(capNode);
@@ -340,23 +381,37 @@ export function initVoice(deps = {}) {
   }
 
   async function stop() {
-    log('stop', 'ending session ' + sessionID);
+    const id = sessionID;
+    log('stop', 'ending session ' + id);
     cleanup();
-    if (sessionID) {
+    // Go idle before the DELETE, not after: while that request is in flight
+    // the session is already torn down, and a status still reading "active"
+    // would let mute() re-arm on a dead session and a start() race the late
+    // `sessionID = ''` below.
+    sessionID = '';
+    setStatus('idle');
+    if (id) {
       // Best-effort: the relay's own teardown already frees the slot when this
       // never lands.
       try {
-        await fetch('/api/voice/sessions/' + encodeURIComponent(sessionID), { method: 'DELETE' });
+        await fetch('/api/voice/sessions/' + encodeURIComponent(id), { method: 'DELETE' });
       } catch { /* the relay teardown covers it */ }
-      sessionID = '';
     }
-    setStatus('idle');
   }
 
   return {
     start,
     stop,
     get status() { return state.status; },
+    // mute/unmute/toggleMute are no-ops without a live session and return the
+    // resulting flag. Mute only stops the uplink: the model's audio keeps
+    // playing, and stop()/start() both reset it to false.
+    mute() { return setMuted(true); },
+    unmute() { return setMuted(false); },
+    toggleMute() { return setMuted(!muted); },
+    get muted() { return muted; },
+    // toggle is the one-button form kept for callers that predate the
+    // Talk/Mute/End panel.
     toggle(model) { return state.status === 'active' || state.status === 'connecting' ? stop() : start(model); },
   };
 }

--- a/internal/webserver/voice_static_test.go
+++ b/internal/webserver/voice_static_test.go
@@ -1,0 +1,151 @@
+package webserver
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The voice bar is three single-purpose buttons: Talk starts, Mute gates the
+// mic, End stops. A regression to one toggle, or a button that is not a real
+// <button type="button">, would ship silently — nothing else loads this page.
+func TestIndexPage_VoiceBarHasTalkMuteEnd(t *testing.T) {
+	data, err := embeddedStaticFiles.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := string(data)
+
+	for _, id := range []string{"voice-talk", "voice-mute", "voice-end"} {
+		re := regexp.MustCompile(`<button[^>]*\bid="` + id + `"[^>]*>`)
+		m := re.FindString(page)
+		if m == "" {
+			t.Errorf("index.html has no <button id=%q>", id)
+			continue
+		}
+		if !strings.Contains(m, `type="button"`) {
+			t.Errorf("%s is not type=\"button\": %s", id, m)
+		}
+		if !strings.Contains(m, `title=`) {
+			t.Errorf("%s has no title", id)
+		}
+	}
+	if !regexp.MustCompile(`id="voice-mute"[^>]*aria-pressed="false"`).MatchString(page) {
+		t.Error("the Mute button must carry aria-pressed so its state is exposed")
+	}
+	if strings.Contains(page, "voice-toggle") {
+		t.Error("index.html still references the retired single voice toggle")
+	}
+	// Talk must start and only start; End must stop and only stop.
+	if !strings.Contains(page, "talkBtn.addEventListener('click', () => voice.start(") {
+		t.Error("Talk is not wired to voice.start()")
+	}
+	if !strings.Contains(page, "endBtn.addEventListener('click', () => voice.stop())") {
+		t.Error("End is not wired to voice.stop()")
+	}
+	if !strings.Contains(page, "muteBtn.addEventListener('click', () => voice.toggleMute())") {
+		t.Error("Mute is not wired to voice.toggleMute()")
+	}
+	if !strings.Contains(page, "onMute(muted)") {
+		t.Error("the page does not render mute state via onMute")
+	}
+}
+
+// The bar sits 3x its original 16px above the bottom edge and the transcript
+// panel stacks above it from the same custom property, so a later nudge
+// cannot separate them.
+func TestVoiceStyles_BarOffsetSharedWithTranscript(t *testing.T) {
+	data, err := embeddedStaticFiles.ReadFile("static/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := string(data)
+
+	if !strings.Contains(css, "--voice-bar-bottom: 48px;") {
+		t.Error("style.css does not define --voice-bar-bottom: 48px")
+	}
+	bar := cssRule(css, ".voice-bar")
+	if !strings.Contains(bar, "bottom: var(--voice-bar-bottom)") {
+		t.Errorf(".voice-bar does not take its bottom from --voice-bar-bottom:\n%s", bar)
+	}
+	if !strings.Contains(bar, "position: fixed") {
+		t.Error(".voice-bar must stay position: fixed so it never takes a terminal row")
+	}
+	panel := cssRule(css, ".voice-transcript")
+	if !strings.Contains(panel, "bottom: calc(var(--voice-bar-bottom) + 48px)") {
+		t.Errorf(".voice-transcript does not stack above the bar from the same offset:\n%s", panel)
+	}
+	for _, sel := range []string{".voice-button:disabled", ".voice-button.muted", ".voice-button.active"} {
+		if cssRule(css, sel) == "" {
+			t.Errorf("style.css has no %s rule", sel)
+		}
+	}
+}
+
+// cssRule returns the body of the first rule whose selector list is exactly sel.
+func cssRule(css, sel string) string {
+	i := strings.Index(css, "\n"+sel+" {")
+	if i < 0 {
+		return ""
+	}
+	rest := css[i:]
+	j := strings.Index(rest, "}")
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}
+
+// voice.js is an ES module with no test runner of its own. When node is on
+// PATH, load it and check the mute API's idle contract: muting without a live
+// session is a no-op, and toggle() is still exported for older callers.
+func TestVoiceJS_MuteAPI(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH")
+	}
+	src, err := embeddedStaticFiles.ReadFile("static/voice.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "voice.mjs"), src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := `
+import { initVoice, createVoiceState } from './voice.mjs';
+const calls = [];
+const v = initVoice({ onMute: (m) => calls.push(m), onLog: () => {} });
+const must = (cond, msg) => { if (!cond) { console.error('FAIL: ' + msg); process.exit(1); } };
+for (const fn of ['start', 'stop', 'toggle', 'mute', 'unmute', 'toggleMute']) {
+  must(typeof v[fn] === 'function', fn + ' is not exported');
+}
+must(v.status === 'idle', 'initial status is ' + v.status);
+must(v.muted === false, 'initial muted is ' + v.muted);
+must(v.mute() === false, 'mute() with no session must stay false');
+must(v.toggleMute() === false, 'toggleMute() with no session must stay false');
+must(v.muted === false, 'muted flipped without a live session');
+must(calls.length === 0, 'onMute fired without a live session');
+must(createVoiceState().status === 'idle', 'createVoiceState status');
+// stop() with nothing live is a no-op that still lands on idle and unmuted.
+await v.stop();
+must(v.status === 'idle', 'status after stop() is ' + v.status);
+must(v.muted === false, 'muted after stop() is ' + v.muted);
+console.log('ok');
+`
+	if err := os.WriteFile(filepath.Join(dir, "check.mjs"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(node, "check.mjs")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node check failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "ok") {
+		t.Fatalf("unexpected node output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

The `pi serve` web terminal's voice bar had one button that both started and stopped the session. It is now a three-button panel, **[ 🎙 Talk | 🔊 Mute | ⏹ End ]**, and sits three times higher off the bottom edge.

- **Talk** only starts (`voice.start(model)`). While live it reads "Connecting…"/"Talking…", pulses, and is disabled so it can never end the session.
- **Mute** gates the microphone without tearing the session down. New `voice.js` API: `mute()`, `unmute()`, `toggleMute()`, `get muted`, plus an `onMute(muted)` dep. Muting drops PCM frames at the capture worklet *and* sets the mic tracks' `enabled=false` so the browser/OS mic indicators go dark; the model's audio keeps playing. The flag resets on `start()`/`stop()`; the button is disabled when nothing is live and carries `aria-pressed`.
- **End** only stops (`voice.stop()`); disabled when idle.
- `toggle()` is kept for callers that predate the panel.

### Position

| | before | after |
|---|---|---|
| `.voice-bar` bottom | 16px | **48px** (`--voice-bar-bottom`) |
| `.voice-transcript` bottom | 64px | **96px** (`calc(var(--voice-bar-bottom) + 48px)`) |

Both derive from one custom property so the panel always stacks above the bar. The bar stays `position: fixed` (it must not take a terminal row).

### Styling

Three pills with an 8px gap: `.active` pulse on Talk while live (full opacity even though disabled), amber border/background for Mute when on, reduced opacity for disabled buttons.

### Codex findings (acted on)

1. `stop()` ran `cleanup()` but stayed `active` until the DELETE returned, so a Mute click in that window re-armed `muted` on a dead session. Fixed: `stop()` goes idle and clears the session id *before* the best-effort DELETE (which also stops a late `sessionID = ''` from clobbering a freshly started session).
2. After (1), a quick End → Talk could be failed by the old socket's asynchronous `onclose` seeing the new session's `connecting`. Fixed: `cleanup()` detaches the socket handlers before `close()`.

Third codex pass was clean.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/webserver/ -count=1` (outside the sandbox) — passes, including new `voice_static_test.go`: asserts the three `<button type="button">`s with titles and `aria-pressed`, no leftover `#voice-toggle`, the wiring to `start`/`toggleMute`/`stop`, the CSS offsets, and (when `node` is on PATH) loads `voice.js` as an ES module to check the mute API's idle contract.
- [x] `make lint` — 0 issues
- [x] Visual check: served `internal/webserver` statically, unhid the bar, verified computed `bottom` 48px / 96px, and screenshotted idle and active+muted states — panel bottom edge sits 11px above the bar, no overlap.
- [ ] Live run with `pi serve --voice` and `GEMINI_API_KEY` (not available in this environment)

https://claude.ai/code/session_014XA8pYe34AXYE8sSeRe3WC
