### PR TITLE
fix(serve): exclude browser voice from Windows builds

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -236,31 +236,3 @@ func serveVoiceModel() string {
 	}
 	return voicegemini.DefaultModel
 }
-
-// enableServeVoice turns on the browser voice session, failing with an
-// actionable message when the key is absent.
-//
-// The key is resolved through config.LookupEnvFrom rather than os.Getenv so
-// that the file `pi login` writes it to counts. Requiring an export for voice
-// alone — when every other pi command finds the same key in ~/.pi-go/.env —
-// reads as "voice is broken", and the operator has no way to tell an unset key
-// from an unread one.
-func enableServeVoice(ctx context.Context, server *webserver.ServerV2) error {
-	key, source := config.LookupEnvFrom(serveProjectDir(), "GEMINI_API_KEY", "GOOGLE_API_KEY")
-	if key == "" {
-		return fmt.Errorf("--voice needs GEMINI_API_KEY: export it, or put it in .pi-go/.env, .env, or ~/.pi-go/.env")
-	}
-	fmt.Printf("Voice: GEMINI_API_KEY from %s\n", source)
-
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	// Verification is a single models round-trip; bound it so a hung network
-	// cannot stall startup indefinitely.
-	vctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	if err := server.EnableVoice(vctx, key, voicegemini.WithModel(serveVoiceModel())); err != nil {
-		return fmt.Errorf("enabling voice: %w", err)
-	}
-	return nil
-}

--- a/internal/cli/serve_voice_unix.go
+++ b/internal/cli/serve_voice_unix.go
@@ -20,7 +20,10 @@ import (
 // alone — when every other pi command finds the same key in ~/.pi-go/.env —
 // reads as "voice is broken", and the operator has no way to tell an unset key
 // from an unread one.
-func enableServeVoice(ctx context.Context, server *webserver.ServerV2) error {
+//
+// extra options are appended after the model so a test can point Verify at a
+// fake models endpoint; production passes none.
+func enableServeVoice(ctx context.Context, server *webserver.ServerV2, extra ...voicegemini.Option) error {
 	key, source := config.LookupEnvFrom(serveProjectDir(), "GEMINI_API_KEY", "GOOGLE_API_KEY")
 	if key == "" {
 		return fmt.Errorf("--voice needs GEMINI_API_KEY: export it, or put it in .pi-go/.env, .env, or ~/.pi-go/.env")
@@ -34,7 +37,8 @@ func enableServeVoice(ctx context.Context, server *webserver.ServerV2) error {
 	// cannot stall startup indefinitely.
 	vctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	if err := server.EnableVoice(vctx, key, voicegemini.WithModel(serveVoiceModel())); err != nil {
+	opts := append([]voicegemini.Option{voicegemini.WithModel(serveVoiceModel())}, extra...)
+	if err := server.EnableVoice(vctx, key, opts...); err != nil {
 		return fmt.Errorf("enabling voice: %w", err)
 	}
 	return nil

--- a/internal/cli/serve_voice_unix.go
+++ b/internal/cli/serve_voice_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/voicegemini"
+	"github.com/dimetron/pi-go/internal/webserver"
+)
+
+// enableServeVoice turns on the browser voice session, failing with an
+// actionable message when the key is absent.
+//
+// The key is resolved through config.LookupEnvFrom rather than os.Getenv so
+// that the file `pi login` writes it to counts. Requiring an export for voice
+// alone — when every other pi command finds the same key in ~/.pi-go/.env —
+// reads as "voice is broken", and the operator has no way to tell an unset key
+// from an unread one.
+func enableServeVoice(ctx context.Context, server *webserver.ServerV2) error {
+	key, source := config.LookupEnvFrom(serveProjectDir(), "GEMINI_API_KEY", "GOOGLE_API_KEY")
+	if key == "" {
+		return fmt.Errorf("--voice needs GEMINI_API_KEY: export it, or put it in .pi-go/.env, .env, or ~/.pi-go/.env")
+	}
+	fmt.Printf("Voice: GEMINI_API_KEY from %s\n", source)
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Verification is a single models round-trip; bound it so a hung network
+	// cannot stall startup indefinitely.
+	vctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if err := server.EnableVoice(vctx, key, voicegemini.WithModel(serveVoiceModel())); err != nil {
+		return fmt.Errorf("enabling voice: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/serve_voice_unix_test.go
+++ b/internal/cli/serve_voice_unix_test.go
@@ -1,0 +1,65 @@
+//go:build !windows
+
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/voicegemini"
+	"github.com/dimetron/pi-go/internal/webserver"
+)
+
+// enableServeVoice is the startup gate for --voice: no key is a usage error
+// that names the key, and a key the provider rejects is a boot error rather
+// than a dead microphone. Both are exercised without the network — the key
+// lookup is isolated from the developer's own ~/.pi-go/.env and the verify
+// round-trip is pointed at a fake models endpoint.
+func TestEnableServeVoice(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	oldProject, oldModel := flagServeProject, flagServeVoiceModel
+	flagServeProject, flagServeVoiceModel = t.TempDir(), ""
+	t.Cleanup(func() { flagServeProject, flagServeVoiceModel = oldProject, oldModel })
+
+	t.Run("missing key", func(t *testing.T) {
+		err := enableServeVoice(t.Context(), webserver.NewServerV2(webserver.Config{Addr: "127.0.0.1:0"}))
+		if err == nil || !strings.Contains(err.Error(), "GEMINI_API_KEY") {
+			t.Fatalf("enableServeVoice() = %v, want an error naming GEMINI_API_KEY", err)
+		}
+	})
+
+	t.Setenv("GEMINI_API_KEY", "AIzaSyTestKeyLongEnough")
+	for _, tt := range []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{name: "provider rejects the key", status: http.StatusForbidden, body: "nope", wantErr: "enabling voice"},
+		{name: "accepted", status: http.StatusOK, body: `{"supportedGenerationMethods":["bidiGenerateContent"]}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			models := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer models.Close()
+
+			err := enableServeVoice(t.Context(), webserver.NewServerV2(webserver.Config{Addr: "127.0.0.1:0"}),
+				voicegemini.WithModelsURL(models.URL), voicegemini.WithHTTPClient(models.Client()))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("enableServeVoice() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("enableServeVoice() = %v, want an error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cli/serve_voice_windows.go
+++ b/internal/cli/serve_voice_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dimetron/pi-go/internal/webserver"
+)
+
+// enableServeVoice refuses --voice on Windows before anything is resolved or
+// dialed. The browser voice session drives pi through a PTY, and
+// github.com/creack/pty has no Windows implementation, so the server side is
+// compiled out (internal/webserver/voice_windows.go); failing here keeps the
+// operator from exporting a key and opening a listener for a feature that
+// cannot start.
+func enableServeVoice(context.Context, *webserver.ServerV2) error {
+	return errors.New("--voice is not supported on Windows: browser voice drives pi through a PTY, which has no Windows implementation")
+}

--- a/internal/cli/serve_voice_windows.go
+++ b/internal/cli/serve_voice_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/dimetron/pi-go/internal/voicegemini"
 	"github.com/dimetron/pi-go/internal/webserver"
 )
 
@@ -15,6 +16,6 @@ import (
 // compiled out (internal/webserver/voice_windows.go); failing here keeps the
 // operator from exporting a key and opening a listener for a feature that
 // cannot start.
-func enableServeVoice(context.Context, *webserver.ServerV2) error {
+func enableServeVoice(context.Context, *webserver.ServerV2, ...voicegemini.Option) error {
 	return errors.New("--voice is not supported on Windows: browser voice drives pi through a PTY, which has no Windows implementation")
 }

--- a/internal/cli/serve_voice_windows_test.go
+++ b/internal/cli/serve_voice_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/webserver"
+)
+
+// --voice must fail at startup on Windows before any key is looked up, so the
+// error has to arrive even with no GEMINI_API_KEY anywhere.
+func TestEnableServeVoiceUnsupported(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+	err := enableServeVoice(t.Context(), webserver.NewServerV2(webserver.Config{Addr: "127.0.0.1:0"}))
+	if err == nil || !strings.Contains(err.Error(), "Windows") {
+		t.Fatalf("enableServeVoice() = %v, want the Windows reason", err)
+	}
+}

--- a/internal/webserver/complexity_voice_test.go
+++ b/internal/webserver/complexity_voice_test.go
@@ -1,0 +1,155 @@
+//go:build !windows
+
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/voicegemini"
+)
+
+// This file pins the branch structure of the voice functions the complexity
+// refactor reshaped (the CSI half lives in complexity_web_test.go):
+//
+//   - the four voice tool bodies lifted out of (*ServerV2).executeVoiceTool.
+//   - (*ServerV2).voiceRelayTarget, the guard block lifted out of
+//     handleGeminiVoiceWS.
+
+// ---------------------------------------------------------------------------
+// Voice tool bodies
+// ---------------------------------------------------------------------------
+
+// Every tool body decodes its own arguments, and every one of them turns a
+// malformed payload into a tool failure rather than an error — a provider left
+// waiting on a function response stalls the whole conversation.
+func TestVoiceToolsRejectMalformedArgs(t *testing.T) {
+	s := withVoice(t, testServer(t))
+	testBridge(t, s, "term-1")
+	vs := &voiceSession{ID: "vs-1", Terminal: "term-1"}
+
+	// Each tool's argument struct has a differently typed field, so one bad
+	// payload per tool: a string where a number belongs and vice versa.
+	tests := []struct {
+		tool string
+		args string
+	}{
+		{voiceToolSendPrompt, `{"prompt": 42}`},
+		{voiceToolSendPrompt, `{`},
+		{voiceToolReadScreen, `{"lines": "many"}`},
+		{voiceToolReadScreen, `[]`},
+		{voiceToolWait, `{"seconds": "a while"}`},
+		{voiceToolWait, `"nope"`},
+		{voiceToolSendKey, `{"key": ["enter"]}`},
+		{voiceToolSendKey, `{"key":}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tool+" "+tt.args, func(t *testing.T) {
+			res := s.executeVoiceTool(t.Context(), vs, voicegemini.FunctionCall{
+				Name: tt.tool,
+				Args: json.RawMessage(tt.args),
+			})
+			if _, failed := res.Response["error"]; !failed {
+				t.Fatalf("%s with args %s returned %+v, want an error response", tt.tool, tt.args, res.Response)
+			}
+			if !strings.HasPrefix(res.Summary, tt.tool+" failed: ") {
+				t.Errorf("summary = %q, want it to name the failing tool", res.Summary)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Relay admission
+// ---------------------------------------------------------------------------
+
+// voiceRelayTarget is the guard block lifted out of handleGeminiVoiceWS. Each
+// rejection has its own status, and the caller relies on the boolean rather
+// than on the response having been written.
+func TestVoiceRelayTargetRejections(t *testing.T) {
+	// relayTarget runs one admission attempt against s for the given session id
+	// and reports the session, whether it was admitted, and the status written.
+	relayTarget := func(t *testing.T, s *ServerV2, id string) (*voiceSession, bool, int) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		r := voiceReq(t, s, http.MethodGet, "/api/voice/ws?session="+id, nil)
+		vs, ok := s.voiceRelayTarget(rec, r)
+		return vs, ok, rec.Code
+	}
+
+	t.Run("voice not configured", func(t *testing.T) {
+		// A server started without --voice: paired, but with no transport.
+		s := testServer(t)
+		_, ok, code := relayTarget(t, s, "anything")
+		if ok {
+			t.Fatal("admitted a request while voice was disabled")
+		}
+		if code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want %d", code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("no session id", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		_, ok, code := relayTarget(t, s, "")
+		if ok {
+			t.Fatal("admitted a request with no session id")
+		}
+		if code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
+		}
+	})
+
+	t.Run("unknown session id", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		_, ok, code := relayTarget(t, s, "never-created")
+		if ok {
+			t.Fatal("admitted an unknown session id")
+		}
+		if code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
+		}
+	})
+
+	t.Run("unpaired browser", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		rec := httptest.NewRecorder()
+		// No token at all: the relay re-checks the pairing rather than
+		// inheriting trust from the POST that created the session.
+		r := httptest.NewRequest(http.MethodGet, "/api/voice/ws?session=x", nil)
+		if _, ok := s.voiceRelayTarget(rec, r); ok {
+			t.Fatal("admitted an unpaired browser")
+		}
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("first admission wins, second is refused", func(t *testing.T) {
+		s := withVoice(t, testServer(t))
+		created, err := s.voiceStore.create("", "term-1")
+		if err != nil {
+			t.Fatalf("create() = %v", err)
+		}
+
+		vs, ok, code := relayTarget(t, s, created.ID)
+		if !ok {
+			t.Fatalf("first admission was refused with status %d", code)
+		}
+		if vs != created {
+			t.Errorf("admitted %+v, want the stored session %+v", vs, created)
+		}
+
+		// claimed() is one-shot, so the second relay for the same session is a
+		// conflict — that is what keeps two tabs off one coding agent.
+		if _, ok, code := relayTarget(t, s, created.ID); ok {
+			t.Fatal("admitted a second relay for the same session")
+		} else if code != http.StatusConflict {
+			t.Errorf("status = %d, want %d", code, http.StatusConflict)
+		}
+	})
+}

--- a/internal/webserver/complexity_web_test.go
+++ b/internal/webserver/complexity_web_test.go
@@ -1,13 +1,8 @@
 package webserver
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/dimetron/pi-go/internal/voicegemini"
 )
 
 // This file pins the branch structure of the functions the complexity refactor
@@ -17,9 +12,11 @@ import (
 //     csiOps table. A dispatch table is easy to get subtly wrong on parameter
 //     defaults and on which finals it does NOT handle, so every final the old
 //     switch named is exercised here, together with finals it never named.
-//   - the four voice tool bodies lifted out of (*ServerV2).executeVoiceTool.
-//   - (*ServerV2).voiceRelayTarget, the guard block lifted out of
-//     handleGeminiVoiceWS.
+//
+// The voice halves of that refactor — the tool bodies lifted out of
+// (*ServerV2).executeVoiceTool and the relay guard lifted out of
+// handleGeminiVoiceWS — are pinned in complexity_voice_test.go, which is
+// excluded from Windows along with the voice feature itself.
 
 // ---------------------------------------------------------------------------
 // CSI dispatch
@@ -293,139 +290,4 @@ func TestCSIConsumesTheWholeSequence(t *testing.T) {
 			t.Errorf("csi(%q) = (%d, %t), want (%d, %t)", tt.in, n, done, tt.wantN, tt.wantDone)
 		}
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Voice tool bodies
-// ---------------------------------------------------------------------------
-
-// Every tool body decodes its own arguments, and every one of them turns a
-// malformed payload into a tool failure rather than an error — a provider left
-// waiting on a function response stalls the whole conversation.
-func TestVoiceToolsRejectMalformedArgs(t *testing.T) {
-	s := withVoice(t, testServer(t))
-	testBridge(t, s, "term-1")
-	vs := &voiceSession{ID: "vs-1", Terminal: "term-1"}
-
-	// Each tool's argument struct has a differently typed field, so one bad
-	// payload per tool: a string where a number belongs and vice versa.
-	tests := []struct {
-		tool string
-		args string
-	}{
-		{voiceToolSendPrompt, `{"prompt": 42}`},
-		{voiceToolSendPrompt, `{`},
-		{voiceToolReadScreen, `{"lines": "many"}`},
-		{voiceToolReadScreen, `[]`},
-		{voiceToolWait, `{"seconds": "a while"}`},
-		{voiceToolWait, `"nope"`},
-		{voiceToolSendKey, `{"key": ["enter"]}`},
-		{voiceToolSendKey, `{"key":}`},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.tool+" "+tt.args, func(t *testing.T) {
-			res := s.executeVoiceTool(t.Context(), vs, voicegemini.FunctionCall{
-				Name: tt.tool,
-				Args: json.RawMessage(tt.args),
-			})
-			if _, failed := res.Response["error"]; !failed {
-				t.Fatalf("%s with args %s returned %+v, want an error response", tt.tool, tt.args, res.Response)
-			}
-			if !strings.HasPrefix(res.Summary, tt.tool+" failed: ") {
-				t.Errorf("summary = %q, want it to name the failing tool", res.Summary)
-			}
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Relay admission
-// ---------------------------------------------------------------------------
-
-// voiceRelayTarget is the guard block lifted out of handleGeminiVoiceWS. Each
-// rejection has its own status, and the caller relies on the boolean rather
-// than on the response having been written.
-func TestVoiceRelayTargetRejections(t *testing.T) {
-	// relayTarget runs one admission attempt against s for the given session id
-	// and reports the session, whether it was admitted, and the status written.
-	relayTarget := func(t *testing.T, s *ServerV2, id string) (*voiceSession, bool, int) {
-		t.Helper()
-		rec := httptest.NewRecorder()
-		r := voiceReq(t, s, http.MethodGet, "/api/voice/ws?session="+id, nil)
-		vs, ok := s.voiceRelayTarget(rec, r)
-		return vs, ok, rec.Code
-	}
-
-	t.Run("voice not configured", func(t *testing.T) {
-		// A server started without --voice: paired, but with no transport.
-		s := testServer(t)
-		_, ok, code := relayTarget(t, s, "anything")
-		if ok {
-			t.Fatal("admitted a request while voice was disabled")
-		}
-		if code != http.StatusServiceUnavailable {
-			t.Errorf("status = %d, want %d", code, http.StatusServiceUnavailable)
-		}
-	})
-
-	t.Run("no session id", func(t *testing.T) {
-		s := withVoice(t, testServer(t))
-		_, ok, code := relayTarget(t, s, "")
-		if ok {
-			t.Fatal("admitted a request with no session id")
-		}
-		if code != http.StatusNotFound {
-			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
-		}
-	})
-
-	t.Run("unknown session id", func(t *testing.T) {
-		s := withVoice(t, testServer(t))
-		_, ok, code := relayTarget(t, s, "never-created")
-		if ok {
-			t.Fatal("admitted an unknown session id")
-		}
-		if code != http.StatusNotFound {
-			t.Errorf("status = %d, want %d", code, http.StatusNotFound)
-		}
-	})
-
-	t.Run("unpaired browser", func(t *testing.T) {
-		s := withVoice(t, testServer(t))
-		rec := httptest.NewRecorder()
-		// No token at all: the relay re-checks the pairing rather than
-		// inheriting trust from the POST that created the session.
-		r := httptest.NewRequest(http.MethodGet, "/api/voice/ws?session=x", nil)
-		if _, ok := s.voiceRelayTarget(rec, r); ok {
-			t.Fatal("admitted an unpaired browser")
-		}
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
-		}
-	})
-
-	t.Run("first admission wins, second is refused", func(t *testing.T) {
-		s := withVoice(t, testServer(t))
-		created, err := s.voiceStore.create("", "term-1")
-		if err != nil {
-			t.Fatalf("create() = %v", err)
-		}
-
-		vs, ok, code := relayTarget(t, s, created.ID)
-		if !ok {
-			t.Fatalf("first admission was refused with status %d", code)
-		}
-		if vs != created {
-			t.Errorf("admitted %+v, want the stored session %+v", vs, created)
-		}
-
-		// claimed() is one-shot, so the second relay for the same session is a
-		// conflict — that is what keeps two tabs off one coding agent.
-		if _, ok, code := relayTarget(t, s, created.ID); ok {
-			t.Fatal("admitted a second relay for the same session")
-		} else if code != http.StatusConflict {
-			t.Errorf("status = %d, want %d", code, http.StatusConflict)
-		}
-	})
 }

--- a/internal/webserver/voice.go
+++ b/internal/webserver/voice.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package webserver
 
 import (
@@ -242,30 +244,6 @@ func (s *ServerV2) handleDeleteVoiceSession(w http.ResponseWriter, r *http.Reque
 	}
 	s.voiceStore.delete(id)
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// voiceHTTPError writes one error as JSON. The web UI reads these directly, so
-// the message is the user-facing text.
-func voiceHTTPError(w http.ResponseWriter, status int, err error) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
-}
-
-// voiceAuthorized gates every voice endpoint behind the same pairing token the
-// terminal uses, answering 401 and reporting false when it is missing.
-//
-// This is not defense in depth, it is the actual boundary. `pi serve` binds all
-// interfaces, and a voice session can now type into the coding agent — which
-// can edit files and run commands. An unauthenticated caller reaching
-// POST /api/voice/sessions would therefore be reaching a shell, so voice must
-// be exactly as protected as the terminal it drives.
-func (s *ServerV2) voiceAuthorized(w http.ResponseWriter, r *http.Request) bool {
-	if s.pairingToken(r) {
-		return true
-	}
-	voiceHTTPError(w, http.StatusUnauthorized, fmt.Errorf("pair this browser with the server before using voice"))
-	return false
 }
 
 // EnableVoice configures the Gemini Live transport and verifies the key and

--- a/internal/webserver/voice_agent.go
+++ b/internal/webserver/voice_agent.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package webserver
 
 import (

--- a/internal/webserver/voice_agent_test.go
+++ b/internal/webserver/voice_agent_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package webserver
 
 import (

--- a/internal/webserver/voice_common.go
+++ b/internal/webserver/voice_common.go
@@ -1,0 +1,38 @@
+package webserver
+
+// Voice plumbing shared by every platform. The feature itself — the Gemini
+// Live relay and the PTY-driven agent tools — is compiled only where
+// github.com/creack/pty works (voice.go, voice_agent.go, voice_gemini.go,
+// all //go:build !windows); voice_windows.go supplies the same handler surface
+// as stubs. What lives here is what both halves need: the error shape the page
+// reads and the pairing gate in front of every voice endpoint.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// voiceHTTPError writes one error as JSON. The web UI reads these directly, so
+// the message is the user-facing text.
+func voiceHTTPError(w http.ResponseWriter, status int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
+}
+
+// voiceAuthorized gates every voice endpoint behind the same pairing token the
+// terminal uses, answering 401 and reporting false when it is missing.
+//
+// This is not defense in depth, it is the actual boundary. `pi serve` binds all
+// interfaces, and a voice session can now type into the coding agent — which
+// can edit files and run commands. An unauthenticated caller reaching
+// POST /api/voice/sessions would therefore be reaching a shell, so voice must
+// be exactly as protected as the terminal it drives.
+func (s *ServerV2) voiceAuthorized(w http.ResponseWriter, r *http.Request) bool {
+	if s.pairingToken(r) {
+		return true
+	}
+	voiceHTTPError(w, http.StatusUnauthorized, fmt.Errorf("pair this browser with the server before using voice"))
+	return false
+}

--- a/internal/webserver/voice_e2e_test.go
+++ b/internal/webserver/voice_e2e_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e && !windows
 
 package webserver
 

--- a/internal/webserver/voice_gemini.go
+++ b/internal/webserver/voice_gemini.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package webserver
 
 import (

--- a/internal/webserver/voice_helpers_test.go
+++ b/internal/webserver/voice_helpers_test.go
@@ -1,0 +1,44 @@
+package webserver
+
+// Request helpers for the voice endpoints. Untagged on purpose: the Windows
+// stub tests (voice_windows_test.go) need to reach the same handlers through
+// the same pairing gate as the real ones.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testServer(t *testing.T) *ServerV2 {
+	t.Helper()
+	return NewServerV2(Config{Addr: "127.0.0.1:0"})
+}
+
+// voiceToken pairs a browser with s and returns the approved token. Voice
+// endpoints are gated on it, so every test that reaches one has to hold it —
+// which is the point: a voice session can type into the coding agent.
+func voiceToken(t *testing.T, s *ServerV2) string {
+	t.Helper()
+	code, _, err := s.BootstrapPair(".")
+	if err != nil {
+		t.Fatalf("BootstrapPair() = %v", err)
+	}
+	token, err := s.pairingMgr.Approve(code)
+	if err != nil {
+		t.Fatalf("Approve() = %v", err)
+	}
+	return token
+}
+
+// voiceReq builds a request to a voice endpoint carrying an approved token.
+func voiceReq(t *testing.T, s *ServerV2, method, target string, body io.Reader) *http.Request {
+	t.Helper()
+	sep := "?"
+	if strings.Contains(target, "?") {
+		sep = "&"
+	}
+	return httptest.NewRequest(method, target+sep+"token="+voiceToken(t, s), body)
+}

--- a/internal/webserver/voice_relay_test.go
+++ b/internal/webserver/voice_relay_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package webserver
 
 // Relay tests drive the real handler against a fake Gemini Live server.

--- a/internal/webserver/voice_static_test.go
+++ b/internal/webserver/voice_static_test.go
@@ -54,7 +54,7 @@ func TestIndexPage_VoiceBarHasTalkMuteEnd(t *testing.T) {
 	}
 }
 
-// The bar sits 3x its original 16px above the bottom edge and the transcript
+// The bar sits 96px (2x the earlier 48px) above the bottom edge and the transcript
 // panel stacks above it from the same custom property, so a later nudge
 // cannot separate them.
 func TestVoiceStyles_BarOffsetSharedWithTranscript(t *testing.T) {
@@ -64,8 +64,8 @@ func TestVoiceStyles_BarOffsetSharedWithTranscript(t *testing.T) {
 	}
 	css := string(data)
 
-	if !strings.Contains(css, "--voice-bar-bottom: 48px;") {
-		t.Error("style.css does not define --voice-bar-bottom: 48px")
+	if !strings.Contains(css, "--voice-bar-bottom: 96px;") {
+		t.Error("style.css does not define --voice-bar-bottom: 96px")
 	}
 	bar := cssRule(css, ".voice-bar")
 	if !strings.Contains(bar, "bottom: var(--voice-bar-bottom)") {

--- a/internal/webserver/voice_test.go
+++ b/internal/webserver/voice_test.go
@@ -1,8 +1,9 @@
+//go:build !windows
+
 package webserver
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,37 +14,6 @@ import (
 
 	"github.com/dimetron/pi-go/internal/voicegemini"
 )
-
-func testServer(t *testing.T) *ServerV2 {
-	t.Helper()
-	return NewServerV2(Config{Addr: "127.0.0.1:0"})
-}
-
-// voiceToken pairs a browser with s and returns the approved token. Voice
-// endpoints are gated on it, so every test that reaches one has to hold it —
-// which is the point: a voice session can type into the coding agent.
-func voiceToken(t *testing.T, s *ServerV2) string {
-	t.Helper()
-	code, _, err := s.BootstrapPair(".")
-	if err != nil {
-		t.Fatalf("BootstrapPair() = %v", err)
-	}
-	token, err := s.pairingMgr.Approve(code)
-	if err != nil {
-		t.Fatalf("Approve() = %v", err)
-	}
-	return token
-}
-
-// voiceReq builds a request to a voice endpoint carrying an approved token.
-func voiceReq(t *testing.T, s *ServerV2, method, target string, body io.Reader) *http.Request {
-	t.Helper()
-	sep := "?"
-	if strings.Contains(target, "?") {
-		sep = "&"
-	}
-	return httptest.NewRequest(method, target+sep+"token="+voiceToken(t, s), body)
-}
 
 // withVoice returns a server whose voice transport is configured without
 // touching the network — EnableVoice would verify against Google.

--- a/internal/webserver/voice_windows.go
+++ b/internal/webserver/voice_windows.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package webserver
+
+// Browser voice is compiled out on Windows.
+//
+// The feature is not a chat next to the terminal: its tools type prompts into
+// the live pi process and read its screen back through a PTY bridge, and
+// github.com/creack/pty has no Windows implementation — every call returns
+// ErrUnsupported, and the relay's tests hang in the serve/PTY path on the
+// Windows CI job. Rather than ship a voice session that connects and then
+// cannot touch the agent, the handlers below keep the routes server.go
+// registers and answer with one clear reason, so the page hides the control
+// and `pi serve --voice` fails at startup (see internal/cli/serve_voice_windows.go).
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/dimetron/pi-go/internal/voicegemini"
+)
+
+// errVoiceUnsupported is the one reason every voice surface reports on
+// Windows. The page renders it verbatim.
+var errVoiceUnsupported = errors.New("voice is not supported on Windows")
+
+// voiceStore keeps the ServerV2 field compiling; there are never any sessions
+// to hold.
+type voiceStore struct{}
+
+func newVoiceStore() *voiceStore { return &voiceStore{} }
+
+// EnableVoice always fails: there is no PTY to drive, so there is nothing to
+// enable. Failing here rather than at the first microphone byte keeps the
+// contract of the real implementation — a voice that cannot work is a boot
+// error the operator reads in the terminal.
+func (s *ServerV2) EnableVoice(context.Context, string, ...voicegemini.Option) error {
+	return errVoiceUnsupported
+}
+
+// handleVoiceConfig reports voice as disabled with the platform reason, using
+// the same shape the page reads on every other OS.
+func (s *ServerV2) handleVoiceConfig(w http.ResponseWriter, r *http.Request) {
+	if !s.voiceAuthorized(w, r) {
+		return
+	}
+	writeJSON(w, map[string]any{
+		"enabled": false,
+		"reason":  errVoiceUnsupported.Error(),
+	})
+}
+
+func (s *ServerV2) handleCreateVoiceSession(w http.ResponseWriter, r *http.Request) {
+	s.voiceUnsupported(w, r)
+}
+
+func (s *ServerV2) handleDeleteVoiceSession(w http.ResponseWriter, r *http.Request) {
+	s.voiceUnsupported(w, r)
+}
+
+func (s *ServerV2) handleGeminiVoiceWS(w http.ResponseWriter, r *http.Request) {
+	s.voiceUnsupported(w, r)
+}
+
+// voiceUnsupported answers 503 behind the pairing gate, the status the page
+// already treats as "voice is off" when a server runs without --voice.
+func (s *ServerV2) voiceUnsupported(w http.ResponseWriter, r *http.Request) {
+	if !s.voiceAuthorized(w, r) {
+		return
+	}
+	voiceHTTPError(w, http.StatusServiceUnavailable, errVoiceUnsupported)
+}

--- a/internal/webserver/voice_windows_test.go
+++ b/internal/webserver/voice_windows_test.go
@@ -1,0 +1,96 @@
+//go:build windows
+
+package webserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The Windows stub must keep the page's contract: /api/voice/config answers
+// 200 with enabled=false and a reason, every other voice endpoint answers 503
+// with the same reason, and nothing is reachable without the pairing token.
+
+func decodeVoiceBody(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode %q: %v", rec.Body.String(), err)
+	}
+	return body
+}
+
+func TestVoiceWindows_ConfigReportsUnsupported(t *testing.T) {
+	s := testServer(t)
+	rec := httptest.NewRecorder()
+	s.handleVoiceConfig(rec, voiceReq(t, s, http.MethodGet, "/api/voice/config", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := decodeVoiceBody(t, rec)
+	if body["enabled"] != false {
+		t.Errorf("enabled = %v, want false", body["enabled"])
+	}
+	if reason, _ := body["reason"].(string); !strings.Contains(reason, "Windows") {
+		t.Errorf("reason = %q, want it to name the platform", reason)
+	}
+}
+
+func TestVoiceWindows_EndpointsAnswer503(t *testing.T) {
+	s := testServer(t)
+	handlers := map[string]struct {
+		method, target string
+		h              http.HandlerFunc
+	}{
+		"create": {http.MethodPost, "/api/voice/sessions", s.handleCreateVoiceSession},
+		"delete": {http.MethodDelete, "/api/voice/sessions/abc", s.handleDeleteVoiceSession},
+		"ws":     {http.MethodGet, "/api/voice/gemini/ws?session=abc", s.handleGeminiVoiceWS},
+	}
+	for name, tc := range handlers {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tc.h(rec, voiceReq(t, s, tc.method, tc.target, nil))
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503", rec.Code)
+			}
+			body := decodeVoiceBody(t, rec)
+			if msg, _ := body["error"].(string); msg != errVoiceUnsupported.Error() {
+				t.Errorf("error = %q, want %q", msg, errVoiceUnsupported.Error())
+			}
+		})
+	}
+}
+
+func TestVoiceWindows_RequiresPairing(t *testing.T) {
+	s := testServer(t)
+	for name, h := range map[string]http.HandlerFunc{
+		"config": s.handleVoiceConfig,
+		"create": s.handleCreateVoiceSession,
+		"delete": s.handleDeleteVoiceSession,
+		"ws":     s.handleGeminiVoiceWS,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h(rec, httptest.NewRequest(http.MethodGet, "/api/voice/x", nil))
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401 without a pairing token", rec.Code)
+			}
+		})
+	}
+}
+
+func TestVoiceWindows_EnableVoiceFails(t *testing.T) {
+	s := testServer(t)
+	err := s.EnableVoice(context.Background(), "AIzaSyTestKeyLongEnough")
+	if err == nil || !strings.Contains(err.Error(), "Windows") {
+		t.Fatalf("EnableVoice() = %v, want the Windows reason", err)
+	}
+	if s.voiceGemini != nil {
+		t.Error("EnableVoice left a creator behind on a platform that cannot use it")
+	}
+}


### PR DESCRIPTION
## Why

Browser voice (`pi serve --voice`) drives the coding agent through a PTY bridge built on `github.com/creack/pty`, which has no Windows implementation — every call returns `ErrUnsupported`, and the Windows test job hangs in the serve/PTY path. Rather than ship a voice session that connects and then cannot touch the agent, the feature is now compiled out on Windows behind a clean stub.

## What

**`internal/webserver`**
- `voice.go`, `voice_agent.go`, `voice_gemini.go` and their tests (`voice_test.go`, `voice_agent_test.go`, `voice_relay_test.go`; `voice_e2e_test.go` → `e2e && !windows`) are `//go:build !windows`.
- `complexity_web_test.go` mixed CSI and voice tests; the voice half moves to `complexity_voice_test.go` (tagged), the CSI half stays untagged.
- New `voice_common.go` (untagged) holds what both halves share: `voiceHTTPError` (the JSON error shape the page reads) and `voiceAuthorized` (the pairing gate).
- New `voice_windows.go` (`//go:build windows`) supplies the same surface `server.go` already wires, so `server.go` stays tag-free:
  - `voiceStore` / `newVoiceStore()` — empty stub.
  - `EnableVoice` → `errors.New("voice is not supported on Windows")`.
  - `GET /api/voice/config` → 200 `{"enabled": false, "reason": "voice is not supported on Windows"}` (same keys the page reads).
  - `POST /api/voice/sessions`, `DELETE /api/voice/sessions/`, `GET /api/voice/gemini/ws` → 503 `{"error": "..."}`, still behind the pairing token.
- New `voice_windows_test.go` (`//go:build windows`) pins those shapes and the 401-without-pairing gate; `voice_helpers_test.go` (untagged) carries `testServer`/`voiceToken`/`voiceReq` so both platforms share them.

**`internal/cli`**
- `enableServeVoice` moves out of `serve.go` into `serve_voice_unix.go` (unchanged body) and `serve_voice_windows.go`, where `--voice` fails at startup with `--voice is not supported on Windows: ...` before any key is resolved or listener opened. `serve.go` stays tag-free; `--voice`/`--voice-model` flags still parse everywhere.

`internal/voicegemini` and `internal/voice` are pure Go, build and test fine on Windows, and are untouched. Static assets (`voice.js`, `index.html`) stay embedded; they are inert once `/api/voice/config` says disabled. No goreleaser / workflow changes needed.

## Test plan

- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `GOOS=windows go vet ./...`
- [x] `GOOS=windows go test -c -o /dev/null ./internal/webserver/ ./internal/cli/` (Windows test binaries compile, incl. the stub test)
- [x] `go test ./internal/webserver/ ./internal/cli/ -count=1` on macOS (outside the sandbox)
- [x] `make lint` — 0 issues; `GOOS=windows golangci-lint run ./internal/webserver/ ./internal/cli/` — 0 issues
- [x] `codex review --base main` — no actionable findings
- [ ] CI Test (Windows): webserver/cli should no longer appear in its failures (other pre-existing Windows failures are being handled in #203)

## Branch note (temporary)

This branch currently also carries two other open PRs so CI can pass now; both diffs collapse to nothing once they merge:

- **fix/windows-ci-tests (#203)** (merged in `6f438ac`) — main's pre-existing Test (Windows) failures.
- **fix/voice-bar-offset-test (#215)** (merged in `7f4b2ce`) — #214 moved `--voice-bar-bottom` to 96px without updating `TestVoiceStyles_BarOffsetSharedWithTranscript`, so `internal/webserver` is red on main as of 135bf73. (An interim 96px pin, `723693a`, was superseded by #215's version during the merge.)

It also merges origin/main (`2440617`, picking up #214).

https://claude.ai/code/session_014XA8pYe34AXYE8sSeRe3WC

