### PR TITLE
test: improve coverage across eval, memory, palace, procs, attest, voicegemini

### DIFF
--- a/TEST_COVERAGE_REVIEW.md
+++ b/TEST_COVERAGE_REVIEW.md
@@ -1,0 +1,335 @@
+# Test coverage gap review
+
+Reviewed packages: `internal/attest`, `internal/voice`, `internal/eval`,
+`internal/memory`, `internal/palace`, and `internal/procs`.
+
+This is a source-and-test review against the supplied fresh coverage snapshot. It
+does not treat a higher percentage as the goal by itself: deterministic policy,
+serialization, path handling, and process-lifecycle behavior should be covered
+first; declarations and network/model wrappers should not acquire brittle tests
+solely to move the number.
+
+## Recommended order
+
+1. **Fix and test `eval.sparkline`.** The uncovered function currently indexes a
+   UTF-8 string by byte, so even an all-zero series emits an invalid UTF-8 byte
+   instead of `▁`. This is a real output defect found by reviewing the gap.
+2. **Test Palace's git-ignore wrappers with a temporary git repository.** These
+   tests are local, deterministic, and protect a path that avoids unnecessary
+   embedding work.
+3. **Test `eval.WriteReport` end to end with `t.TempDir()`.** This covers the
+   persisted artifact contract, not just rendering.
+4. **Add a narrow runner seam to `memory.SubagentCompressor`, then table-test
+   stream and failure behavior.** Most of the uncovered lines are orchestration
+   glue and become deterministic with one small interface.
+5. **Exercise `attest.Verifier.Verify` with an offline SHA-256 fixture.** This is
+   the highest security impact, but needs a fixture whose subject and workflow
+   identity match the production policy.
+6. **Cover local embedding input handling through a pure helper or runner seam.**
+   Keep the real-model test as an integration test.
+7. **Add the one missing `procs.terminate` timer branch test.** Existing process
+   tests already cover the important escalation and stale-PID behavior.
+
+## `internal/eval` — 82.8%
+
+### `WriteReport` (`internal/eval/report.go:15`)
+
+`WriteReport` creates the destination, chooses timestamped filenames, writes
+indented JSON, renders Markdown, writes it, and returns both paths plus the exact
+Markdown. Existing tests call `RenderMarkdown`, but none assert this persistence
+contract.
+
+Add `internal/eval/report_test.go`:
+
+- `TestWriteReport_WritesJSONAndMarkdown`: use a fixed UTC timestamp and a
+  representative `RunReport`; call `WriteReport(report, t.TempDir())`; assert
+  basename `eval-<spec>-YYYYMMDD-HHMMSS.{json,md}`, both files exist, returned
+  Markdown equals the Markdown file, and decoded JSON is structurally equal to
+  the input. Also assert both files have permission `0644` on platforms where
+  permission bits are meaningful.
+- `TestWriteReport_CreatesNestedOutputDir`: pass a not-yet-created nested path
+  beneath `t.TempDir()` and assert both artifacts are produced.
+- `TestWriteReport_OutputPathIsNotDirectory`: create a regular file and pass its
+  path as `outDir`; assert the error contains `create report dir`. This covers a
+  stable error branch without relying on root/user permission behavior.
+- Decide and pin the filename policy for `Metadata.Spec`. It is interpolated
+  directly into a path. A spec containing `/` currently turns into a nested path
+  and fails, while `../name` can write outside `outDir`. If spec is not already
+  validated at the caller, add `TestWriteReport_RejectsUnsafeSpec` for empty,
+  absolute, separator-containing, and `..` values and validate before writing.
+
+The JSON marshal error is not naturally reachable because `RunReport` contains
+only JSON-supported field types. Do not add production indirection just to force
+that branch.
+
+### `sparkline` (`internal/eval/report.go:223`)
+
+This is the best immediate unit-test target. `levels := "▁▂▃▄▅▆▇█"` is a UTF-8
+string, but `levels[idx]` selects one byte and `WriteByte` writes it. `len(levels)`
+is 24 bytes, not eight glyphs. The output is therefore invalid UTF-8 for normal
+inputs and the scaling has 24 byte positions instead of eight levels.
+
+Add these cases to `internal/eval/report_test.go` and change the implementation
+to use `[]rune("▁▂▃▄▅▆▇█")` plus `WriteRune`:
+
+- `TestSparkline_Empty`: nil and empty slices return `""`.
+- `TestSparkline_UsesValidUnicodeLevels`: samples with running counts
+  `0, 1, 2, 4, 8` produce valid UTF-8, exactly five graph runes before the
+  annotation, begin at `▁`, end at `█`, and report `(max 8, 5 samples)`.
+- `TestSparkline_AllZero`: verifies the scale floor of one and expects only low
+  blocks plus `(max 1, N samples)`.
+- `TestSparkline_BucketsToWidth`: construct 201 samples with isolated peaks at
+  bucket boundaries; assert exactly 100 graph runes, all peaks survive max
+  aggregation, and the annotation still reports 201 original samples.
+- `TestRenderMarkdown_IncludesConcurrencySparkline`: one integration-level
+  assertion that non-empty samples produce the fenced sparkline, while no
+  samples omit it.
+
+Negative `Running` values would currently create a negative index and panic.
+`ComputeConcurrencyMetrics` produces non-negative counts, so either document
+that invariant or clamp at zero and add a negative-input case if `sparkline` is
+expected to be defensive.
+
+## `internal/palace` — 87.3%
+
+### `GitIgnoredSet` and `IsGitIgnoredSet` (`internal/palace/miner.go:295`)
+
+The exported functions are untested wrappers over substantial git/path logic.
+This is high-impact because a miss causes ignored content to be mined and
+embedded, the expensive part of a mining run.
+
+Add `internal/palace/miner_gitignore_test.go`:
+
+- `TestGitIgnoredSet_FromRepositoryRoot`: initialize a temporary repository with
+  `git init`, write `.gitignore` entries for an exact file, a directory, a glob,
+  and a negated file, then create the files. Assert ignored entries are present,
+  the negated file and ordinary tracked/untracked files are absent, and returned
+  keys use slash-separated paths.
+- `TestGitIgnoredSet_FromNestedDirectory`: call the function on a repository
+  subdirectory and assert returned paths are relative to that mining directory.
+  This directly protects the `--full-name`/`filepath.Rel` logic.
+- `TestGitIgnoredSet_NonRepository`: a plain `t.TempDir()` returns nil.
+- `TestIsGitIgnoredSet_ExactAndAncestor`: table-test nil and empty maps, exact
+  file match, ignored-directory ancestor match such as `tmp/pi/cache.db` when
+  `tmp/pi` is in the set, similar prefixes that must not match (`tmp/piano`), and
+  a top-level ordinary file.
+
+Use the real local git binary rather than mocking `exec.Command`; skip only when
+`exec.LookPath("git")` fails. Configure repository-local identity only if a
+commit becomes necessary (it should not be for `ls-files`).
+
+### Local `Embed` and `Close` (`internal/palace/embedder.go:84`, `:102`)
+
+The uncovered local embedder is coupled to concrete Hugot session and pipeline
+types. The normal unit suite cannot construct it successfully without model
+weights. `internal/palace/embedder_integration_test.go` exercises the real path
+only when a model is available, so it should remain an integration layer rather
+than become a mandatory download.
+
+Two achievable improvements:
+
+- Extract the length limiting loop into a pure helper such as
+  `limitEmbeddingInputs([]string) []string` and add table tests in
+  `internal/palace/embedder_test.go` for empty input, exactly 512 bytes, 513+
+  bytes, multiple inputs preserving order, and non-ASCII text at the boundary.
+  The current byte slice `texts[i][:maxCharLength]` can split a UTF-8 code point;
+  a valid-UTF-8 assertion will force an explicit byte-versus-rune policy. Prefer
+  returning a new slice so `Embed` does not silently mutate its caller's input.
+- If full unit coverage of `Embed`/`Close` is desired, make the pipeline call and
+  session destruction narrow internal interfaces. A fake runner can assert the
+  limited inputs, return known vectors, and return a sentinel error to verify the
+  `run embedding pipeline` wrapping; a fake destroyer can assert `Close` calls
+  destroy once and tolerates its error by contract.
+
+There are already two tests calling `Close` on `&localEmbedder{}` with a nil
+session (`internal/palace/embedder_test.go:179` and `:220`). They cover only the
+nil branch and are duplicates; merge them. If the fresh profile still labels
+the whole function 0%, confirm the profile/build tags before adding another
+identical test. The Ollama `Embed` path is already covered extensively by
+`embedder_ollama_test.go` and `embedder_ollama_serial_test.go`, including empty
+input, batching, ordering, retry, shrinking, serialization, and errors.
+
+## `internal/memory` — 85.6%
+
+### `NewSubagentCompressor`, `CompressObservation`, and `SummarizeSession`
+(`internal/memory/compress.go:22`, `:36`, `:161`)
+
+The parsing and prompt helpers have good direct tests. The remaining gap is the
+adapter around `*subagent.Orchestrator`, which is concrete and therefore cannot
+be faked without launching the subagent machinery.
+
+Introduce an unexported interface held by `SubagentCompressor` with only the two
+methods it uses: `LookupAgent(string)` and `Spawn(context.Context,
+subagent.SpawnInput)`. Keep `NewSubagentCompressor(*subagent.Orchestrator)` as
+the public constructor so callers do not change; tests in package `memory` can
+construct the compressor with a fake runner directly.
+
+Extend `internal/memory/compress_test.go`:
+
+- `TestNewSubagentCompressor`: assert the supplied orchestrator is retained.
+  This is low-value alone but will be covered naturally by adapter tests.
+- `TestSubagentCompressor_CompressObservation`: fake lookup and spawn; capture
+  `SpawnInput`; stream JSON over multiple `text_delta` events with an unrelated
+  event between them; close the channel; assert the agent name, prompt fields,
+  parsed observation, and copied raw metadata (`SessionID`, `Project`,
+  `ToolName`, `Timestamp`).
+- Table-test lookup failure, synchronous spawn failure, streamed `error` event,
+  closed stream with no text, and malformed accumulated JSON. Assert the
+  contextual prefixes (`finding`, `spawning`, `memory-compressor error`, and
+  `parsing compressor response`) so failures remain diagnosable.
+- `TestSubagentCompressor_SummarizeSession`: stream a fenced JSON response in
+  multiple deltas; assert the captured prompt includes every observation and
+  source file, and the result preserves supplied session/project metadata.
+- Give summary the same lookup, spawn, streamed-error, empty-stream, and invalid
+  JSON table. Assert `CreatedAt` falls between timestamps captured immediately
+  before and after the call rather than comparing it exactly.
+- Add a canceled-context case only if the fake runner is defined to return
+  `ctx.Err()` from `Spawn`; the compressor itself does not otherwise own context
+  cancellation.
+
+This seam tests the package's real responsibilities without invoking a model,
+subprocess, pool, worktree, or provider configuration.
+
+## `internal/attest` — 72.8%
+
+### `TUFCacheDir` (`internal/attest/attest.go:184`)
+
+Add to `internal/attest/attest_test.go`:
+
+- `TestTUFCacheDir`: set the platform home environment to a temporary path and
+  assert `<home>/.pi-go/sigstore`, cleaned with `filepath.Clean`.
+- On Unix, an unset/empty `HOME` exercises the wrapped `locating home directory`
+  error from `os.UserHomeDir`. Put this in a Unix build-tagged test if the suite
+  must remain portable; Windows uses different environment variables.
+
+Do not run this test in parallel because it changes process environment.
+
+### `NewVerifier` (`internal/attest/attest.go:195`)
+
+The function performs a live Sigstore TUF refresh, so a normal unit test would
+be network- and cache-state-dependent. Extract a small internal helper that
+accepts a trusted-root fetch function (or an interface) while the exported
+wrapper still passes `root.FetchTrustedRootWithOptions`.
+
+Then add:
+
+- `TestNewVerifierWithFetcher_UsesPiCache`: fake the fetch, inspect the received
+  `*tuf.Options`, return the pinned trusted root from `testdata`, and assert the
+  cache path is `TUFCacheDir()` and the resulting verifier carries the requested
+  repository/SAN policy.
+- `TestNewVerifierWithFetcher_FetchError`: return a sentinel and assert
+  `fetching Sigstore trust root` plus `errors.Is` preservation.
+- `TestNewVerifierWithFetcher_InvalidRepo`: return pinned material and assert an
+  owner/name validation error is propagated from `NewVerifierWithMaterial`.
+
+An optional explicitly tagged integration test may call `NewVerifier` against
+live TUF, but it should not be the only coverage of this wrapper.
+
+### `Verifier.Verify` (`internal/attest/attest.go:262`)
+
+Existing `TestVerify_RealBundle` deliberately bypasses `Verify` with
+`verifyStatementOnly` because its fixture has a SHA-512 subject and a branch
+SAN. Consequently the production SHA-256 artifact binding is not tested.
+
+Add immediately:
+
+- `TestVerifierVerify_InvalidDigest`: build a verifier from pinned material and
+  pass non-hex and odd-length strings; assert the `invalid digest` error. This is
+  cheap and covers input rejection before cryptographic verification.
+- `TestVerifierVerify_RejectsDigestMismatch`: call `Verify` on a valid bundle
+  fixture with a syntactically valid but incorrect 32-byte digest and assert
+  verification fails. This proves the production entry point applies an
+  artifact policy, although the current SHA-512 fixture may fail for multiple
+  policy reasons and therefore is not sufficient by itself.
+
+Highest-value follow-up: add a small, immutable offline Sigstore bundle whose
+in-toto subject uses SHA-256 and whose certificate SAN is
+`https://github.com/<fixture-repo>/.github/workflows/release.yml@refs/tags/<tag>`.
+Store the bundle and its public-good trusted root under
+`internal/attest/testdata/`, record the expected subject digest in the test, and
+add:
+
+- `TestVerifierVerify_ValidSHA256Bundle`: expect predicate type, signer SAN,
+  timestamp, and parsed provenance/SBOM fields.
+- Subtests changing one factor at a time: one digest nibble, repository name,
+  workflow path, branch instead of tag, and malformed predicate. Each must fail
+  for the intended production policy.
+
+That fixture closes the meaningful security gap. A mocked `verify.Verifier`
+would raise line coverage but would not demonstrate certificate identity,
+transparency log, timestamp, and artifact-digest policy composition.
+
+## `internal/procs` — 86.5%; `terminate` 66.7%
+
+`internal/procs/procs_fallback_test.go` and `selfkill_test.go` already cover the
+important behavior: TERM-to-KILL escalation, no delayed signal after reap,
+direct-child fallback, own-process-group protection, nil/unstarted
+`signalGroup`, and caller timing wiring.
+
+Add one focused Unix test to `internal/procs/procs_fallback_test.go`:
+
+- `TestTerminate_UnstartedCommandDoesNotEscalate`: create but do not start an
+  `exec.Cmd`, call `terminate` with a very short grace, wait past the timer, and
+  assert the test remains alive. This covers the timer callback's
+  `cmd.Process == nil` return at `procs_unix.go:52`.
+
+There is a related defensive inconsistency: `signalGroup(nil, ...)` is a no-op,
+but `terminate(nil, grace)` schedules a closure that dereferences `cmd` and will
+panic asynchronously. Production cancellation always supplies a command, so
+this is lower priority. If nil is intended to share `signalGroup`'s contract,
+guard it before scheduling and add `TestTerminate_NilIsNoOp`.
+
+The early `return err` branch depends on an actual OS signaling error other than
+already-gone (`ESRCH`) and is difficult to provoke safely and portably. Do not
+introduce syscall indirection solely for that final branch unless process
+signaling is being refactored for another reason.
+
+## `internal/voice` — no tests
+
+`internal/voice/voice.go` contains only the `SessionCreator` interface and the
+`Session` data type. It has no executable statements, so package-local tests
+cannot improve statement coverage meaningfully. The behavior belongs to its
+implementer and consumer, and is already exercised in
+`internal/voicegemini/voicegemini_test.go` and
+`internal/webserver/voice_test.go` (creation, expiry presence, realtime relay
+descriptor, storage, and credential non-leakage).
+
+Recommended contract hardening, not percentage chasing:
+
+- Add `var _ voice.SessionCreator = (*Creator)(nil)` in
+  `internal/voicegemini/voicegemini_test.go` (or beside `Creator`) to make
+  interface drift a compile-time failure.
+- Keep the behavioral cases in `voicegemini`: missing API key, expiry close to
+  `now + SessionTTL`, and a realtime map containing transport/model/rates but no
+  API key. Missing-key and credential/descriptor coverage already exists;
+  strengthen the current non-zero expiry assertion to bound the TTL, and add
+  explicit model/rate assertions if they are not pinned elsewhere.
+- If `Session` later gains validation, cloning, or JSON behavior, create
+  `internal/voice/voice_test.go` then. A test that merely constructs a struct or
+  calls a fake through the interface adds maintenance without testing package
+  logic.
+
+## Suggested implementation slices
+
+### Slice A — no production seams
+
+- Fix/test `sparkline`.
+- Add `WriteReport` happy path and stable filesystem error tests.
+- Add Palace git-ignore tests.
+- Add `Verify` invalid-digest test.
+- Add the unstarted-command `terminate` test.
+- Add the `voicegemini.Creator` compile-time assertion.
+
+### Slice B — small internal seams
+
+- Introduce the memory runner interface and cover both event-stream adapters.
+- Extract Palace input limiting; decide and test UTF-8 and input-mutation
+  semantics.
+- Inject trusted-root fetching into an internal `NewVerifier` helper.
+
+### Slice C — offline integration fixtures
+
+- Add a release-tag/SHA-256 Sigstore fixture for the complete production
+  `Verifier.Verify` path.
+- Keep the local embedding model test opt-in, but run it in the model-bearing CI
+  job for both default and `ORT` builds if those artifacts are supported.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - "cmd/"
+  # Test-only helpers, imported solely from _test.go files; the Windows arms
+  # of these helpers can never execute on the Linux coverage job.
+  - "internal/testenv/"

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/sigstore/sigstore-go/pkg/bundle"
@@ -291,4 +292,51 @@ func loadFixtureBundle(t *testing.T) *bundle.Bundle {
 		t.Fatalf("loading fixture bundle: %v", err)
 	}
 	return b
+}
+
+// TestTUFCacheDir pins the TUF cache location under the user's own state dir.
+// The test is not parallel: it mutates process environment.
+func TestTUFCacheDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows reads this, not HOME.
+
+	got, err := TUFCacheDir()
+	if err != nil {
+		t.Fatalf("TUFCacheDir: %v", err)
+	}
+	want := filepath.Join(home, ".pi-go", "sigstore")
+	if got != want {
+		t.Errorf("TUFCacheDir() = %q, want %q", got, want)
+	}
+}
+
+// TestVerify_InvalidDigest covers input rejection before any cryptographic
+// work: non-hex and odd-length digests must fail fast.
+func TestVerify_InvalidDigest(t *testing.T) {
+	// A verifier is needed only for the digest-decode step; any valid one works.
+	material := loadPinnedTrustRoot(t)
+	v, err := NewVerifierWithMaterial(DefaultRepo, material)
+	if err != nil {
+		t.Fatalf("NewVerifierWithMaterial: %v", err)
+	}
+
+	for _, digest := range []string{"zzz", "abc", "123"} {
+		if _, err := v.Verify(nil, digest); err == nil {
+			t.Errorf("Verify with digest %q succeeded, want invalid-digest error", digest)
+		} else if !strings.Contains(err.Error(), "invalid digest") {
+			t.Errorf("Verify(%q) error = %q, want \"invalid digest\"", digest, err)
+		}
+	}
+}
+
+// TestNewVerifierWithMaterial_BadRepo: an invalid owner/name form must fail at
+// construction, before any trust material is consulted.
+func TestNewVerifierWithMaterial_BadRepo(t *testing.T) {
+	material := loadPinnedTrustRoot(t)
+	for _, repo := range []string{"", "noslash", "too/many/slashes"} {
+		if _, err := NewVerifierWithMaterial(repo, material); err == nil {
+			t.Errorf("NewVerifierWithMaterial(%q) succeeded, want an error", repo)
+		}
+	}
 }

--- a/internal/cli/memory_model.go
+++ b/internal/cli/memory_model.go
@@ -50,6 +50,11 @@ Use --onnx to specify a specific ONNX file, e.g.:
 	return cmd
 }
 
+// downloadModel is the fetcher runMemoryModelDownload delegates to. A variable
+// so tests can substitute a fake instead of pulling the real weights from
+// Hugging Face into the test HOME.
+var downloadModel = palace.DownloadModel
+
 func runMemoryModelDownload(dest string, onnxFilePath string) error {
 	if dest == "" {
 		home, err := os.UserHomeDir()
@@ -71,7 +76,7 @@ func runMemoryModelDownload(dest string, onnxFilePath string) error {
 
 	fmt.Printf("Downloading embedding model to %s ...\n", dest)
 
-	modelPath, err := palace.DownloadModel(dest, onnxFilePath)
+	modelPath, err := downloadModel(dest, onnxFilePath)
 	if err != nil {
 		return fmt.Errorf("downloading model: %w", err)
 	}

--- a/internal/cli/memory_model_test.go
+++ b/internal/cli/memory_model_test.go
@@ -2,10 +2,13 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/testenv"
 )
 
@@ -136,18 +139,71 @@ func TestRunMemoryModelDownload_ExplicitOnnxPath(t *testing.T) {
 	}
 }
 
+// stubDownloadModel replaces the fetcher for the duration of the test and
+// returns a pointer to the arguments it was last called with.
+//
+// The real fetcher pulls the embedding model from Hugging Face into HOME. This
+// test used to do exactly that and only appeared to pass because an earlier
+// test left HOME unset; with HOME isolated properly the download ran, and two
+// things broke under -race: go-huggingface's parallel download has a data
+// race, and every later palace-backed test in this package then found the
+// weights and ran real inference, where gomlx's AVX2 matmul kernel trips
+// checkptr. A fake fetcher keeps the path covered without any of that.
+func stubDownloadModel(t *testing.T, result string, err error) *struct{ dest, onnx string } {
+	t.Helper()
+	var got struct{ dest, onnx string }
+	orig := downloadModel
+	downloadModel = func(dest, onnx string) (string, error) {
+		got.dest, got.onnx = dest, onnx
+		return result, err
+	}
+	t.Cleanup(func() { downloadModel = orig })
+	return &got
+}
+
 func TestRunMemoryModelDownload_DefaultDest(t *testing.T) {
-	// This downloads the real embedding model from Hugging Face into the
-	// package's shared test HOME. It only ever appeared to pass: an earlier
-	// test used to leave HOME unset, so runMemoryModelDownload failed before
-	// reaching the network. With HOME isolated properly the download runs, and
-	// two things break under -race: go-huggingface's parallel download has a
-	// data race, and every later palace-backed test in this package then finds
-	// the weights and runs real inference, where gomlx's AVX2 matmul kernel
-	// trips checkptr. Skip it like its siblings above.
-	t.Skip("skipping: downloads a real model over the network; go-huggingface races under -race and the weights poison later palace tests")
-	err := runMemoryModelDownload("", "")
-	if err != nil {
-		t.Logf("expected error: %v", err)
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	got := stubDownloadModel(t, "model-path", nil)
+
+	out := captureStdout(t, func() {
+		if err := runMemoryModelDownload("", ""); err != nil {
+			t.Errorf("runMemoryModelDownload: %v", err)
+		}
+	})
+
+	wantDest := filepath.Join(home, ".pi-go", "models")
+	if got.dest != wantDest {
+		t.Errorf("dest = %q, want the default under HOME %q", got.dest, wantDest)
+	}
+	if info, err := os.Stat(wantDest); err != nil || !info.IsDir() {
+		t.Errorf("default model directory was not created: %v", err)
+	}
+	if got.onnx != palace.DetectPlatformOnnxFile() {
+		t.Errorf("onnx = %q, want the auto-detected %q", got.onnx, palace.DetectPlatformOnnxFile())
+	}
+	if !strings.Contains(out, "Model downloaded: model-path") {
+		t.Errorf("output = %q, want the downloaded path reported", out)
+	}
+}
+
+func TestRunMemoryModelDownload_ExplicitDestAndOnnxReachTheFetcher(t *testing.T) {
+	got := stubDownloadModel(t, "", nil)
+	dest := filepath.Join(t.TempDir(), "models")
+
+	if err := runMemoryModelDownload(dest, "onnx/custom.onnx"); err != nil {
+		t.Fatalf("runMemoryModelDownload: %v", err)
+	}
+	if got.dest != dest || got.onnx != "onnx/custom.onnx" {
+		t.Errorf("fetcher got dest=%q onnx=%q, want %q / onnx/custom.onnx", got.dest, got.onnx, dest)
+	}
+}
+
+func TestRunMemoryModelDownload_FetcherErrorIsWrapped(t *testing.T) {
+	stubDownloadModel(t, "", errors.New("offline"))
+
+	err := runMemoryModelDownload(t.TempDir(), "")
+	if err == nil || !strings.Contains(err.Error(), "downloading model: offline") {
+		t.Errorf("err = %v, want the fetcher error wrapped as \"downloading model\"", err)
 	}
 }

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -249,7 +249,7 @@ func sparkline(samples []ConcurrencySample) string {
 		}
 	}
 
-	levels := "▁▂▃▄▅▆▇█"
+	levels := []rune("▁▂▃▄▅▆▇█")
 	scale := 1
 	for _, v := range buckets {
 		if v > scale {
@@ -262,7 +262,10 @@ func sparkline(samples []ConcurrencySample) string {
 	var b strings.Builder
 	for _, v := range buckets {
 		idx := (v * (len(levels) - 1)) / scale
-		b.WriteByte(levels[idx])
+		if idx < 0 {
+			idx = 0
+		}
+		b.WriteRune(levels[idx])
 	}
 	fmt.Fprintf(&b, "  (max %d, %d samples)", scale, n)
 	return b.String()

--- a/internal/eval/report_write_test.go
+++ b/internal/eval/report_write_test.go
@@ -1,0 +1,225 @@
+package eval
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// TestSparkline_Empty: nil and empty series produce no output.
+func TestSparkline_Empty(t *testing.T) {
+	if got := sparkline(nil); got != "" {
+		t.Errorf("sparkline(nil) = %q, want empty", got)
+	}
+	if got := sparkline([]ConcurrencySample{}); got != "" {
+		t.Errorf("sparkline(empty) = %q, want empty", got)
+	}
+}
+
+// TestSparkline_UsesValidUnicodeLevels is the core fix regression: the levels
+// string is UTF-8 (8 runes), and indexing by byte produced invalid UTF-8.
+func TestSparkline_UsesValidUnicodeLevels(t *testing.T) {
+	samples := []ConcurrencySample{
+		{Running: 0}, {Running: 1}, {Running: 2}, {Running: 4}, {Running: 8},
+	}
+	got := sparkline(samples)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("sparkline output is not valid UTF-8: %q", got)
+	}
+
+	// The graph glyphs should be exactly 5 runes before the annotation.
+	body := strings.TrimSuffix(got, "  (max 8, 5 samples)")
+	graph := []rune(body)
+	if len(graph) != 5 {
+		t.Fatalf("graph has %d runes, want 5: %q", len(graph), body)
+	}
+	// Scale 0..8 over 8 levels: 0→▁, 1→▁/▂, 2→▂, 4→▄, 8→█.
+	if graph[0] != '▁' {
+		t.Errorf("first glyph = %c, want ▁", graph[0])
+	}
+	if graph[4] != '█' {
+		t.Errorf("last glyph = %c, want █", graph[4])
+	}
+}
+
+// TestSparkline_AllZero: the scale floor keeps all-zero series valid.
+func TestSparkline_AllZero(t *testing.T) {
+	samples := []ConcurrencySample{{Running: 0}, {Running: 0}, {Running: 0}}
+	got := sparkline(samples)
+	if !strings.HasSuffix(got, "  (max 1, 3 samples)") {
+		t.Errorf("annotation = %q, want max 1", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("output is not valid UTF-8: %q", got)
+	}
+}
+
+// TestSparkline_BucketsToWidth: more samples than columns collapses to width
+// and keeps isolated peaks under max aggregation.
+func TestSparkline_BucketsToWidth(t *testing.T) {
+	const width = 100
+	n := 201
+	samples := make([]ConcurrencySample, 0, n)
+	for i := 0; i < n; i++ {
+		// Peaks at bucket boundaries and mid-bucket so aggregation is exercised.
+		running := 0
+		switch i {
+		case 0, 100, 200:
+			running = 5
+		}
+		samples = append(samples, ConcurrencySample{Running: running})
+	}
+	got := sparkline(samples)
+
+	body := strings.TrimSuffix(got, "  (max 5, 201 samples)")
+	graph := []rune(body)
+	if len(graph) != width {
+		t.Errorf("graph has %d runes, want %d", len(graph), width)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("output is not valid UTF-8: %q", got)
+	}
+}
+
+// TestSparkline_NegativeValuesAreClamped: negative Running values must not
+// panic on a negative index.
+func TestSparkline_NegativeValuesAreClamped(t *testing.T) {
+	samples := []ConcurrencySample{{Running: -1}, {Running: 2}}
+	got := sparkline(samples)
+	if !utf8.ValidString(got) {
+		t.Errorf("output is not valid UTF-8: %q", got)
+	}
+}
+
+// TestRenderMarkdown_IncludesConcurrencySparkline: non-empty samples render
+// the fenced sparkline; empty samples omit it.
+func TestRenderMarkdown_IncludesConcurrencySparkline(t *testing.T) {
+	r := &RunReport{
+		Concurrency: ConcurrencyMetrics{
+			PoolBudget: 4,
+			Samples: []ConcurrencySample{
+				{Running: 0}, {Running: 1}, {Running: 2}, {Running: 3}, {Running: 4},
+			},
+		},
+	}
+	md := RenderMarkdown(r)
+	if !strings.Contains(md, "```\n") {
+		t.Errorf("markdown does not include the fenced sparkline:\n%s", md)
+	}
+	if !strings.Contains(md, "samples)") {
+		t.Errorf("markdown sparkline is missing the sample count:\n%s", md)
+	}
+
+	empty := RenderMarkdown(&RunReport{})
+	if strings.Contains(empty, "```\n▁") {
+		t.Errorf("empty-samples markdown still has a sparkline:\n%s", empty)
+	}
+}
+
+// TestWriteReport_WritesJSONAndMarkdown is the persisted-artifact contract:
+// both files exist, the returned Markdown matches the file, and the JSON
+// round-trips structurally.
+func TestWriteReport_WritesJSONAndMarkdown(t *testing.T) {
+	ts := time.Date(2025, 8, 21, 14, 30, 5, 0, time.UTC)
+	report := &RunReport{
+		Metadata: ReportMetadata{
+			Spec:      "spec-a",
+			Mode:      "single",
+			Model:     "claude",
+			Binary:    "/usr/local/bin/pi",
+			GitHead:   "abcdef1234567890abcdef",
+			Timestamp: ts,
+			Duration:  "1m30s",
+		},
+		Outcome: RunOutcome{FinalPhase: "done", Retries: 0},
+		Concurrency: ConcurrencyMetrics{
+			PoolBudget: 4,
+			Samples:    []ConcurrencySample{{Timestamp: ts, Running: 2}},
+		},
+		Trajectory: TrajectoryMetrics{TotalSteps: 1},
+	}
+
+	outDir := t.TempDir()
+	jsonPath, mdPath, md, err := WriteReport(report, outDir)
+	if err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	wantBase := "eval-spec-a-20250821-143005"
+	if filepath.Base(jsonPath) != wantBase+".json" {
+		t.Errorf("json basename = %s, want %s.json", filepath.Base(jsonPath), wantBase)
+	}
+	if filepath.Base(mdPath) != wantBase+".md" {
+		t.Errorf("md basename = %s, want %s.md", filepath.Base(mdPath), wantBase)
+	}
+
+	// Files exist with 0644.
+	for _, p := range []string{jsonPath, mdPath} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o644 {
+			t.Errorf("mode of %s = %o, want 644", p, perm)
+		}
+	}
+
+	// Returned Markdown matches the file.
+	mdBytes, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(mdBytes) != md {
+		t.Errorf("returned Markdown != file contents:\n---returned---\n%s\n---file---\n%s", md, mdBytes)
+	}
+
+	// JSON round-trips.
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded RunReport
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if decoded.Metadata.Spec != "spec-a" || decoded.Metadata.Model != "claude" {
+		t.Errorf("decoded metadata mismatch: %+v", decoded.Metadata)
+	}
+}
+
+// TestWriteReport_CreatesNestedOutputDir: a not-yet-created nested path works.
+func TestWriteReport_CreatesNestedOutputDir(t *testing.T) {
+	report := &RunReport{Metadata: ReportMetadata{Spec: "nested", Timestamp: time.Now()}}
+	nested := filepath.Join(t.TempDir(), "deep", "report")
+	jsonPath, mdPath, _, err := WriteReport(report, nested)
+	if err != nil {
+		t.Fatalf("WriteReport into nested dir: %v", err)
+	}
+	for _, p := range []string{jsonPath, mdPath} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("stat %s: %v", p, err)
+		}
+	}
+}
+
+// TestWriteReport_OutputPathIsNotDirectory: a regular file passed as outDir
+// yields a stable, wrapped error.
+func TestWriteReport_OutputPathIsNotDirectory(t *testing.T) {
+	report := &RunReport{Metadata: ReportMetadata{Spec: "x", Timestamp: time.Now()}}
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err := WriteReport(report, blocker)
+	if err == nil {
+		t.Fatal("expected an error when outDir is a regular file")
+	}
+	if !strings.Contains(err.Error(), "create report dir") {
+		t.Errorf("error does not wrap the mkdir context: %v", err)
+	}
+}

--- a/internal/eval/report_write_test.go
+++ b/internal/eval/report_write_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -158,13 +159,14 @@ func TestWriteReport_WritesJSONAndMarkdown(t *testing.T) {
 		t.Errorf("md basename = %s, want %s.md", filepath.Base(mdPath), wantBase)
 	}
 
-	// Files exist with 0644.
+	// Files exist with 0644. Windows has no Unix permission bits: Go reports
+	// every writable file there as 0666, so only the existence check applies.
 	for _, p := range []string{jsonPath, mdPath} {
 		info, err := os.Stat(p)
 		if err != nil {
 			t.Fatalf("stat %s: %v", p, err)
 		}
-		if perm := info.Mode().Perm(); perm != 0o644 {
+		if perm := info.Mode().Perm(); runtime.GOOS != "windows" && perm != 0o644 {
 			t.Errorf("mode of %s = %o, want 644", p, perm)
 		}
 	}

--- a/internal/memory/compress.go
+++ b/internal/memory/compress.go
@@ -13,14 +13,23 @@ import (
 // maxPromptOutput is the maximum size of tool output included in the compression prompt.
 const maxPromptOutput = 4096
 
+// compressorRunner is the minimal orchestrator surface the compressor needs.
+// Production code uses *subagent.Orchestrator (which satisfies it); tests use
+// a fake so the adapter's event-stream handling is exercised without launching
+// the subagent machinery.
+type compressorRunner interface {
+	LookupAgent(name string) (subagent.AgentConfig, error)
+	Spawn(ctx context.Context, input subagent.SpawnInput) (<-chan subagent.Event, string, error)
+}
+
 // SubagentCompressor uses a bundled subagent to compress raw observations.
 type SubagentCompressor struct {
-	orchestrator *subagent.Orchestrator
+	runner compressorRunner
 }
 
 // NewSubagentCompressor creates a compressor that uses the memory-compressor subagent.
 func NewSubagentCompressor(orch *subagent.Orchestrator) *SubagentCompressor {
-	return &SubagentCompressor{orchestrator: orch}
+	return &SubagentCompressor{runner: orch}
 }
 
 // compressedResponse is the JSON structure expected from the compression subagent.
@@ -37,13 +46,13 @@ func (c *SubagentCompressor) CompressObservation(ctx context.Context, raw RawObs
 	prompt := buildCompressionPrompt(raw)
 
 	// Look up the memory-compressor agent config.
-	agent, err := c.orchestrator.LookupAgent("memory-compressor")
+	agent, err := c.runner.LookupAgent("memory-compressor")
 	if err != nil {
 		return nil, fmt.Errorf("finding memory-compressor agent: %w", err)
 	}
 
 	// Spawn the compression subagent.
-	events, _, err := c.orchestrator.Spawn(ctx, subagent.SpawnInput{
+	events, _, err := c.runner.Spawn(ctx, subagent.SpawnInput{
 		Agent:  agent,
 		Prompt: prompt,
 	})
@@ -161,12 +170,12 @@ func truncateForError(s string) string {
 func (c *SubagentCompressor) SummarizeSession(ctx context.Context, sessionID, project string, observations []*Observation) (*SessionSummary, error) {
 	prompt := buildSummaryPrompt(observations)
 
-	agent, err := c.orchestrator.LookupAgent("memory-compressor")
+	agent, err := c.runner.LookupAgent("memory-compressor")
 	if err != nil {
 		return nil, fmt.Errorf("finding memory-compressor agent: %w", err)
 	}
 
-	events, _, err := c.orchestrator.Spawn(ctx, subagent.SpawnInput{
+	events, _, err := c.runner.Spawn(ctx, subagent.SpawnInput{
 		Agent:  agent,
 		Prompt: prompt,
 	})

--- a/internal/memory/compress_adapter_test.go
+++ b/internal/memory/compress_adapter_test.go
@@ -1,0 +1,251 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// fakeRunner is a scriptable compressorRunner for adapter tests.
+type fakeRunner struct {
+	agent     subagent.AgentConfig
+	lookupErr error
+	events    []subagent.Event
+	spawnErr  error
+	spawnIn   subagent.SpawnInput
+}
+
+func (f *fakeRunner) LookupAgent(name string) (subagent.AgentConfig, error) {
+	return f.agent, f.lookupErr
+}
+
+func (f *fakeRunner) Spawn(ctx context.Context, input subagent.SpawnInput) (<-chan subagent.Event, string, error) {
+	f.spawnIn = input
+	if f.spawnErr != nil {
+		return nil, "", f.spawnErr
+	}
+	ch := make(chan subagent.Event, len(f.events))
+	for _, ev := range f.events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, "fake-agent", nil
+}
+
+// streamEvents builds a fake that emits the given events, then closes.
+func newStreamingFake(events ...subagent.Event) *fakeRunner {
+	return &fakeRunner{events: events, agent: subagent.AgentConfig{Name: "memory-compressor"}}
+}
+
+// newFake is a short alias for newStreamingFake.
+func newFake(events ...subagent.Event) *fakeRunner {
+	return newStreamingFake(events...)
+}
+
+// TestCompressor_CompressObservation_Success: streamed text_delta events are
+// accumulated, JSON is parsed, and raw metadata is preserved.
+func TestCompressor_CompressObservation_Success(t *testing.T) {
+	raw := RawObservation{
+		SessionID: "sess-1",
+		Project:   "/proj",
+		ToolName:  "Read",
+		Timestamp: time.Date(2026, 3, 20, 1, 2, 3, 0, time.UTC),
+	}
+	// Split a fenced JSON response across deltas with an unrelated event between.
+	fake := newStreamingFake(
+		subagent.Event{Type: "text_delta", Content: "```json\n{\"title\": \"Read main.go\","},
+		subagent.Event{Type: "tool_call", Content: "read"},
+		subagent.Event{Type: "text_delta", Content: " \"type\": \"discovery\", \"text\": \"explored\"}"},
+		subagent.Event{Type: "message_end"},
+	)
+	c := &SubagentCompressor{runner: fake}
+
+	obs, err := c.CompressObservation(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("CompressObservation: %v", err)
+	}
+	if obs.Title != "Read main.go" {
+		t.Errorf("title = %q, want %q", obs.Title, "Read main.go")
+	}
+	if obs.Type != TypeDiscovery {
+		t.Errorf("type = %q, want discovery", obs.Type)
+	}
+	if obs.SessionID != "sess-1" {
+		t.Errorf("sessionID = %q, want sess-1", obs.SessionID)
+	}
+	if obs.Project != "/proj" {
+		t.Errorf("project = %q, want /proj", obs.Project)
+	}
+	if obs.ToolName != "Read" {
+		t.Errorf("toolName = %q, want Read", obs.ToolName)
+	}
+	if !obs.CreatedAt.Equal(raw.Timestamp) {
+		t.Errorf("createdAt = %v, want %v", obs.CreatedAt, raw.Timestamp)
+	}
+	// SpawnInput carries the prompt.
+	if fake.spawnIn.Prompt == "" {
+		t.Error("spawn prompt is empty")
+	}
+}
+
+// TestCompressor_CompressObservation_LookupFailure
+func TestCompressor_CompressObservation_LookupFailure(t *testing.T) {
+	fake := &fakeRunner{lookupErr: errors.New("no agent")}
+	c := &SubagentCompressor{runner: fake}
+	_, err := c.CompressObservation(context.Background(), RawObservation{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !contains(err.Error(), "finding memory-compressor agent") {
+		t.Errorf("error should have lookup context: %v", err)
+	}
+}
+
+// TestCompressor_CompressObservation_SpawnFailure
+func TestCompressor_CompressObservation_SpawnFailure(t *testing.T) {
+	fake := &fakeRunner{spawnErr: errors.New("spawn boom")}
+	c := &SubagentCompressor{runner: fake}
+	_, err := c.CompressObservation(context.Background(), RawObservation{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !contains(err.Error(), "spawning memory-compressor") {
+		t.Errorf("error should have spawn context: %v", err)
+	}
+}
+
+// TestCompressor_CompressObservation_ErrorEvent
+func TestCompressor_CompressObservation_ErrorEvent(t *testing.T) {
+	fake := newFake(
+		subagent.Event{Type: "text_delta", Content: "partial"},
+		subagent.Event{Type: "error", Error: "model refused"},
+	)
+	c := &SubagentCompressor{runner: fake}
+	_, err := c.CompressObservation(context.Background(), RawObservation{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !contains(err.Error(), "memory-compressor error") {
+		t.Errorf("error should carry event context: %v", err)
+	}
+}
+
+// TestCompressor_CompressObservation_EmptyStream: a closed stream with no text
+// yields the "empty response" parse error.
+func TestCompressor_CompressObservation_EmptyStream(t *testing.T) {
+	c := &SubagentCompressor{runner: newFake()}
+	_, err := c.CompressObservation(context.Background(), RawObservation{})
+	if err == nil {
+		t.Fatal("expected error for an empty event stream")
+	}
+	if !contains(err.Error(), "parsing compressor response") {
+		t.Errorf("error should wrap parse context: %v", err)
+	}
+}
+
+// TestCompressor_CompressObservation_MalformedJSON: accumulated text is not JSON.
+func TestCompressor_CompressObservation_MalformedJSON(t *testing.T) {
+	c := &SubagentCompressor{runner: newFake(
+		subagent.Event{Type: "text_delta", Content: "this is not json"},
+	)}
+	_, err := c.CompressObservation(context.Background(), RawObservation{})
+	if err == nil {
+		t.Fatal("expected error for malformed accumulated JSON")
+	}
+	if !contains(err.Error(), "parsing compressor response") {
+		t.Errorf("error should wrap parse context: %v", err)
+	}
+}
+
+// TestCompressor_SummarizeSession_Success
+func TestCompressor_SummarizeSession_Success(t *testing.T) {
+	observations := []*Observation{
+		{Title: "read a.go", Type: TypeDiscovery, Text: "explored", SourceFiles: []string{"/p/a.go"}},
+		{Title: "fixed bug", Type: TypeBugfix, Text: "nil guard"},
+	}
+	// Stream a fenced JSON response across deltas with a tool event between.
+	fake := newFake(
+		subagent.Event{Type: "text_delta", Content: "```json\n{\"request\":\"fix x\",\"investigated\":\"read\""},
+		subagent.Event{Type: "tool_call", Content: "edit"},
+		subagent.Event{Type: "text_delta", Content: `,"learned":"nil check","completed":"guarded","next_steps":"test"}`},
+		subagent.Event{Type: "text_delta", Content: "\n```"},
+	)
+	c := &SubagentCompressor{runner: fake}
+
+	sum, err := c.SummarizeSession(context.Background(), "sess-1", "/proj", observations)
+	if err != nil {
+		t.Fatalf("SummarizeSession: %v", err)
+	}
+	if sum.Request != "fix x" {
+		t.Errorf("request = %q, want %q", sum.Request, "fix x")
+	}
+	if sum.SessionID != "sess-1" || sum.Project != "/proj" {
+		t.Errorf("metadata = %q/%q, want sess-1//proj", sum.SessionID, sum.Project)
+	}
+	// Prompt includes every observation's title and source files.
+	p := fake.spawnIn.Prompt
+	if !contains(p, "read a.go") {
+		t.Errorf("prompt should include observation titles: %q", p)
+	}
+	if !contains(p, "a.go") {
+		t.Errorf("prompt should include source files: %q", p)
+	}
+	// CreatedAt is near now.
+	if age := time.Since(sum.CreatedAt); age < 0 || age > time.Second {
+		t.Errorf("createdAt = %v, expected within the last second", sum.CreatedAt)
+	}
+}
+
+// TestCompressor_SummarizeSession_LookupFailure
+func TestCompressor_SummarizeSession_LookupFailure(t *testing.T) {
+	fake := &fakeRunner{lookupErr: errors.New("no agent")}
+	c := &SubagentCompressor{runner: fake}
+	_, err := c.SummarizeSession(context.Background(), "s", "/p", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !contains(err.Error(), "finding memory-compressor agent") {
+		t.Errorf("error should have lookup context: %v", err)
+	}
+}
+
+// TestCompressor_SummarizeSession_SpawnFailure
+func TestCompressor_SummarizeSession_SpawnFailure(t *testing.T) {
+	fake := &fakeRunner{spawnErr: errors.New("boom")}
+	c := &SubagentCompressor{runner: fake}
+	_, err := c.SummarizeSession(context.Background(), "s", "/p", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !contains(err.Error(), "spawning memory-compressor for summary") {
+		t.Errorf("error should have summary spawn context: %v", err)
+	}
+}
+
+// TestCompressor_SummarizeSession_ErrorEvent
+func TestCompressor_SummarizeSession_ErrorEvent(t *testing.T) {
+	fake := newFake(subagent.Event{Type: "error", Error: "timeout"})
+	c := &SubagentCompressor{runner: fake}
+	_, err := c.SummarizeSession(context.Background(), "s", "/p", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !contains(err.Error(), "memory-compressor summary error") {
+		t.Errorf("error should carry summary error context: %v", err)
+	}
+}
+
+// TestCompressor_SummarizeSession_EmptyStream
+func TestCompressor_SummarizeSession_EmptyStream(t *testing.T) {
+	c := &SubagentCompressor{runner: newFake()}
+	_, err := c.SummarizeSession(context.Background(), "s", "/p", nil)
+	if err == nil {
+		t.Fatal("expected error for empty stream")
+	}
+	if !contains(err.Error(), "empty summary response") {
+		t.Errorf("error should mention empty summary: %v", err)
+	}
+}

--- a/internal/palace/embedder.go
+++ b/internal/palace/embedder.go
@@ -105,13 +105,20 @@ func (e *localEmbedder) Close() {
 	}
 }
 
+// hugotDownloadModel is the fetcher DownloadModel delegates to. It is a
+// variable so tests can stand in a fake: the real one reaches Hugging Face,
+// its parallel download has a data race the race detector flags, and leaving
+// real weights behind makes every later palace test in the same package run
+// real inference.
+var hugotDownloadModel = hugot.DownloadModel
+
 // DownloadModel fetches the all-MiniLM-L6-v2 model to dest and returns the local path.
 func DownloadModel(dest string, onnxFilePath string) (string, error) {
 	opts := hugot.NewDownloadOptions()
 	if onnxFilePath != "" {
 		opts.OnnxFilePath = onnxFilePath
 	}
-	return hugot.DownloadModel(
+	return hugotDownloadModel(
 		context.Background(),
 		"sentence-transformers/all-MiniLM-L6-v2",
 		dest,

--- a/internal/palace/embedder_download_test.go
+++ b/internal/palace/embedder_download_test.go
@@ -1,0 +1,65 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/knights-analytics/hugot"
+)
+
+// DownloadModel is a thin shim over hugot; what it owns is the model name, the
+// destination, and whether an explicit ONNX file overrides hugot's default.
+// The fetcher is swapped for a recorder so no network is touched and no real
+// weights land on disk.
+func TestDownloadModel_PassesDestAndOnnxOverrideToTheFetcher(t *testing.T) {
+	type call struct {
+		model, dest string
+		opts        hugot.DownloadOptions
+	}
+	var got []call
+	orig := hugotDownloadModel
+	hugotDownloadModel = func(_ context.Context, model, dest string, opts hugot.DownloadOptions) (string, error) {
+		got = append(got, call{model, dest, opts})
+		return dest + "/resolved", nil
+	}
+	t.Cleanup(func() { hugotDownloadModel = orig })
+
+	path, err := DownloadModel("/models", "")
+	if err != nil {
+		t.Fatalf("DownloadModel: %v", err)
+	}
+	if path != "/models/resolved" {
+		t.Errorf("path = %q, want the fetcher's answer", path)
+	}
+	if _, err := DownloadModel("/models", "onnx/custom.onnx"); err != nil {
+		t.Fatalf("DownloadModel with override: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("fetcher called %d times, want 2", len(got))
+	}
+	for i, c := range got {
+		if c.model != "sentence-transformers/all-MiniLM-L6-v2" || c.dest != "/models" {
+			t.Errorf("call %d: model/dest = %q/%q", i, c.model, c.dest)
+		}
+	}
+	if got[0].opts.OnnxFilePath != hugot.NewDownloadOptions().OnnxFilePath {
+		t.Errorf("empty override changed OnnxFilePath to %q, want hugot's default", got[0].opts.OnnxFilePath)
+	}
+	if got[1].opts.OnnxFilePath != "onnx/custom.onnx" {
+		t.Errorf("OnnxFilePath = %q, want the explicit override", got[1].opts.OnnxFilePath)
+	}
+}
+
+func TestDownloadModel_ReportsFetcherErrors(t *testing.T) {
+	orig := hugotDownloadModel
+	hugotDownloadModel = func(context.Context, string, string, hugot.DownloadOptions) (string, error) {
+		return "", errors.New("offline")
+	}
+	t.Cleanup(func() { hugotDownloadModel = orig })
+
+	if _, err := DownloadModel("/models", ""); err == nil || err.Error() != "offline" {
+		t.Errorf("err = %v, want the fetcher's error passed through", err)
+	}
+}

--- a/internal/palace/miner_gitignore_test.go
+++ b/internal/palace/miner_gitignore_test.go
@@ -1,0 +1,162 @@
+package palace
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helper: initialize a temporary git repository at dir with the given
+// .gitignore contents and the named files (empty). Returns a cleanup.
+func initGitRepo(t *testing.T, dir, gitignore string, files ...string) {
+	t.Helper()
+	git := gitLookPath(t)
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(git, append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	// git init needs an identity for some operations; configure locally only.
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	if gitignore != "" {
+		if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(gitignore), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, "/") {
+			if err := os.MkdirAll(filepath.Join(dir, strings.TrimSuffix(f, "/")), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		path := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func gitLookPath(t *testing.T) string {
+	t.Helper()
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not available:", err)
+	}
+	return git
+}
+
+// TestGitIgnoredSet_FromRepositoryRoot: exact file, directory, glob, and
+// negated entries are handled by git's own ignore machinery.
+func TestGitIgnoredSet_FromRepositoryRoot(t *testing.T) {
+	gitLookPath(t)
+	dir := t.TempDir()
+	initGitRepo(t, dir,
+		"*.log\n/dist\n/tmp/\n!important.log\n",
+		"app.log", "dist/bundle.js", "tmp/pi/cache.db", "important.log", "src/main.go",
+	)
+
+	ignored := GitIgnoredSet(dir)
+	if ignored == nil {
+		t.Fatal("GitIgnoredSet returned nil for a git repository")
+	}
+
+	// *.log → app.log ignored.
+	if !ignored["app.log"] {
+		t.Errorf("app.log should be ignored")
+	}
+	// Negated important.log is NOT ignored.
+	if ignored["important.log"] {
+		t.Errorf("important.log should not be ignored (negated)")
+	}
+	// /dist/ → entire directory ignored.
+	if !ignored["dist/bundle.js"] && !ignored["dist/"] {
+		t.Errorf("dist/bundle.js should be under an ignored directory, got set=%v", ignored)
+	}
+	// /tmp/ → ignored.
+	if !ignored["tmp/pi/cache.db"] && !ignored["tmp/pi/"] && !ignored["tmp/"] {
+		t.Errorf("tmp/pi/cache.db should be ignored")
+	}
+	// Ordinary tracked file not in the set.
+	if ignored["src/main.go"] {
+		t.Errorf("src/main.go should not be ignored")
+	}
+}
+
+// TestGitIgnoredSet_FromNestedDirectory: paths come back relative to the
+// mining directory, not the repo root.
+func TestGitIgnoredSet_FromNestedDirectory(t *testing.T) {
+	gitLookPath(t)
+	dir := t.TempDir()
+	initGitRepo(t, dir, "sub/**/generated/\n", "sub/one/generated/x.go", "sub/one/normal.go")
+
+	nested := filepath.Join(dir, "sub", "one")
+	ignored := GitIgnoredSet(nested)
+	if ignored == nil {
+		t.Fatal("GitIgnoredSet returned nil for a nested repo directory")
+	}
+	if !ignored["generated/x.go"] && !ignored["generated/"] {
+		t.Errorf("expected generated/x.go relative to nested dir, got set=%v", ignored)
+	}
+	if ignored["normal.txt"] {
+		t.Errorf("normal.txt should not be ignored")
+	}
+	// No path may escape the mining directory.
+	for key := range ignored {
+		if strings.HasPrefix(key, "..") || filepath.IsAbs(key) {
+			t.Errorf("ignored key escapes the mining dir: %q", key)
+		}
+	}
+}
+
+// TestGitIgnoredSet_NonRepository: a plain temp dir yields nil, not an error.
+func TestGitIgnoredSet_NonRepository(t *testing.T) {
+	gitLookPath(t)
+	if got := GitIgnoredSet(t.TempDir()); got != nil {
+		t.Errorf("GitIgnoredSet on a non-repo = %v, want nil", got)
+	}
+}
+
+// TestIsGitIgnoredSet_ExactAndAncestor covers the ancestor-walk that finds
+// files inside a collapsed ignored directory.
+func TestIsGitIgnoredSet_ExactAndAncestor(t *testing.T) {
+	ignored := map[string]bool{
+		"tmp/pi": true,
+		"dist":   true,
+	}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"", false},
+		{"src/main.go", false},
+		{"tmp/pi/cache.db", true},    // exact ancestor
+		{"dist/bundle.js", true},     // ancestor dir in set
+		{"tmp/piano/note.go", false}, // similar prefix must not match
+		{"tmp/pi", true},             // exact
+		{"dist", true},               // exact
+	}
+	for _, tt := range tests {
+		if got := IsGitIgnoredSet(tt.path, ignored); got != tt.want {
+			t.Errorf("IsGitIgnoredSet(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+
+	// nil and empty sets are always false.
+	if IsGitIgnoredSet("tmp/pi/cache.db", nil) {
+		t.Error("nil ignored set should return false")
+	}
+	if IsGitIgnoredSet("tmp/pi/cache.db", map[string]bool{}) {
+		t.Error("empty ignored set should return false")
+	}
+}

--- a/internal/procs/procs_fallback_test.go
+++ b/internal/procs/procs_fallback_test.go
@@ -27,6 +27,22 @@ func TestSignalGroup_NilAndUnstartedAreNoOps(t *testing.T) {
 	}
 }
 
+// TestTerminate_UnstartedCommandDoesNotEscalate covers the timer callback's
+// cmd.Process == nil return at procs_unix.go:52: terminate on a command that
+// never started must schedule a SIGKILL that finds no process and no-ops,
+// leaving the test runner alive.
+func TestTerminate_UnstartedCommandDoesNotEscalate(t *testing.T) {
+	cmd := exec.Command("bash", "-c", "true") // never started: Process is nil
+	if err := terminate(cmd, 20*time.Millisecond); err != nil {
+		t.Fatalf("terminate(unstarted) = %v, want nil", err)
+	}
+	// Wait past the grace so the AfterFunc timer fires with cmd.Process == nil.
+	time.Sleep(50 * time.Millisecond)
+	if err := syscall.Kill(syscall.Getpid(), 0); err != nil {
+		t.Fatalf("the test process was signaled by a stale timer: %v", err)
+	}
+}
+
 // TestSignalGroup_WithoutSetpgidSignalsTheChildOnly is the safety property that
 // matters most in this file.
 //

--- a/internal/voicegemini/voicegemini_test.go
+++ b/internal/voicegemini/voicegemini_test.go
@@ -7,7 +7,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/voice"
 )
+
+// Compile-time contract: Creator must satisfy voice.SessionCreator, so an
+// interface drift is a build failure rather than a runtime surprise.
+var _ voice.SessionCreator = (*Creator)(nil)
 
 func TestVerify(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Codex review (stored at `TEST_COVERAGE_REVIEW.md`) identified coverage gaps and a real output bug. This lands the highest-value fixes.

## Changes

| Package | Before | After | Notes |
|---|---|---|---|
| `internal/eval` | 82.8% | **89.6%** | Fixed `sparkline` UTF-8 bug (block glyphs indexed by byte emitted invalid UTF-8); added sparkline/WriteReport/RenderMarkdown tests |
| `internal/memory` | 85.6% | **91.1%** | Added `compressorRunner` seam to make `SubagentCompressor` testable; both adapters now 100% |
| `internal/palace` | 87.3% | **87.4%** | `GitIgnoredSet`/`IsGitIgnoredSet` wrappers 0%→100% via real temp git repo |
| `internal/procs` | 86.5% | **89.2%** | `terminate` unstarted-command timer no-op |
| `internal/attest` | 72.8% | **77.2%** | `TUFCacheDir`, `Verify` invalid-digest rejection |
| `internal/voicegemini` | 90.2% | + | compile-time `voice.SessionCreator` assertion |

### Key bug fixed
`eval.sparkline` indexed the UTF-8 string `"▁▂▃▄▅▆▇█"` by byte (24 bytes, not 8 runes), emitting invalid UTF-8 for normal inputs. Now uses `[]rune` + `WriteRune`.

## Verification
- `go build ./...` — OK
- `go vet` on all changed packages — clean
- `gofmt -l internal/` — clean
- All affected package tests pass; dependent packages (`piagent`, `pimodels`, `internal/subagent`) pass

## Follow-ups (deferred)
Per the review, Slice B/C remain: attest verifier fetch seam, and an offline SHA-256 Sigstore bundle fixture to exercise the full production `Verifier.Verify` path.

## CI note (temporary)

This branch temporarily carries two other open PRs so CI can pass now; both diffs collapse to nothing once they merge:

- **fix/windows-ci-tests (#203)** (merged in `6529674`, re-synced to its 2b6518f head in `b8cfa40`) — main's pre-existing `Test (Windows)` failure set (`cmd/pi-sandbox`, `internal/acp/*`, `internal/auth`, `internal/browser`, and the `internal/cli` TUI test that killed the job). None of those involve this PR's files.
- **fix/voice-bar-offset-test (#215)** (merged in `35915c5`; #215's branch has since been advanced to a #203 merge commit, so `b8cfa40` contains it too) — main at 135bf73 is red because `TestVoiceStyles_BarOffsetSharedWithTranscript` pins `--voice-bar-bottom: 48px` while `style.css` says 96px, which fails `Test` and `Coverage` for every PR on top of it.

It also merges origin/main (`78ff0ff`, picking up #214). One portability tweak was needed for this PR's new tests now that they actually run on Windows: the `WriteReport` 0644 mode assertion is skipped there (`e8af805`; Go reports 0666 on Windows).

`codecov/patch` (not a required check) reports below target only because #203's product-code diff is now counted against this PR; the uncovered lines are its Windows-only branches (`internal/tools/lsp.go`, `internal/lsp/manager.go`, `internal/tui/refs/validator.go`; `internal/testenv` is now codecov-ignored by #203), unreachable from the Linux coverage job. This PR's own diff was 100% covered at a3a5f5b.
