### PR TITLE
feat(eval): tool-coverage eval suite for the coding agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-unit test-integration test-e2e test-all test-coverage test-ollama check-cve sbom lint vet e2e clean sandbox-run sandbox-log eval-run eval-pin eval-judge
+.PHONY: build install test test-unit test-integration test-e2e test-all test-coverage test-ollama check-cve sbom lint vet e2e clean sandbox-run sandbox-log eval-run eval-pin eval-judge eval-tools eval-tools-judge
 
 # Go 1.26's simd/archsimd, which gomlx's Go backend uses for its matmul kernels
 # (gomlx/compute internal/gobackend/dot/matmul). Those kernels are gated on
@@ -95,6 +95,20 @@ PI_EVAL_JUDGE_MODEL ?= claude-sonnet-4-6
 eval-judge: build
 	PI_EVAL_RUN=1 PI_EVAL_BASELINE=eval/golden PI_EVAL_JUDGE_MODEL=$(PI_EVAL_JUDGE_MODEL) \
 		PI_BINARY=$(abspath ./pi) go test -tags e2e -v -run '^TestEvalRun$$' ./internal/tui/ -timeout 45m
+
+# Tool-coverage eval: one headless `pi --mode print` scenario per tool family,
+# graded deterministically and rolled up into a coverage matrix over every
+# registered tool. Requires a built binary and an LLM API key. Knobs:
+# PI_EVAL_MODEL, PI_EVAL_SCENARIO=<name,...>, PI_EVAL_THINKING, PI_EVAL_TIMEOUT,
+# PI_EVAL_STRICT=1, PI_EVAL_SERIAL=1. See internal/eval/scenarios/README.md.
+eval-tools: build
+	PI_EVAL_TOOLS=1 PI_BINARY=$(abspath ./pi) go test -tags e2e -v -run '^TestEvalTools$$' \
+		./internal/eval/scenarios/ -parallel 4 -timeout 60m
+
+# Same, with the LLM judge grading the suite (PI_EVAL_JUDGE_MODEL to override).
+eval-tools-judge: build
+	PI_EVAL_TOOLS=1 PI_EVAL_JUDGE_MODEL=$(PI_EVAL_JUDGE_MODEL) PI_BINARY=$(abspath ./pi) \
+		go test -tags e2e -v -run '^TestEvalTools$$' ./internal/eval/scenarios/ -parallel 4 -timeout 60m
 
 test-all: test-unit test-integration test-e2e
 

--- a/cmd/pi-sandbox/main_test.go
+++ b/cmd/pi-sandbox/main_test.go
@@ -91,6 +91,14 @@ func TestIsNoiseLogLine(t *testing.T) {
 // exitCodeFor forwards the child's own exit code, so `pi-sandbox` is
 // transparent to callers and CI.
 func TestExitCodeFor(t *testing.T) {
+	// Needs a POSIX shell to produce a child with a chosen exit code. Git for
+	// Windows ships one, but its usr/bin is not on the default runner PATH, and
+	// pi-sandbox is a macOS launcher (sandbox-exec + log stream) with no Windows
+	// behavior to cover here.
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a POSIX shell; pi-sandbox is macOS-only")
+	}
+
 	var stderr bytes.Buffer
 
 	if code := exitCodeFor(nil, &stderr); code != 0 {
@@ -162,6 +170,15 @@ exit 0
 // and the macOS log stream, so the orchestration is exercised without spawning
 // a real sandbox.
 func TestRun(t *testing.T) {
+	// Every subtest stands in for sandbox-exec and `log stream` with bare
+	// `sh`/`true`/`false`. Those live in Git for Windows' usr/bin, which is not
+	// on the default windows-latest PATH, so they would fail to exec rather than
+	// exercise anything. pi-sandbox is macOS-only; there is no Windows path here
+	// that these tests would otherwise cover.
+	if runtime.GOOS == "windows" {
+		t.Skip("stub commands are POSIX utilities; pi-sandbox is macOS-only")
+	}
+
 	newCfg := func(t *testing.T, sandboxCmd string) config {
 		t.Helper()
 		return config{

--- a/cmd/pi-sandbox/main_test.go
+++ b/cmd/pi-sandbox/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -213,6 +214,13 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("denials are written to the log file", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			// The stub child is a #!/bin/sh script and the stub log stream is
+			// printf(1); Windows honors neither. pi-sandbox itself is a macOS
+			// launcher (sandbox-exec plus `log stream`), so there is no Windows
+			// behavior being hidden here.
+			t.Skip("stub child is a shell script; pi-sandbox is macOS-only")
+		}
 		cfg := newCfg(t, "true")
 		// Stub log stream: one header line (dropped) and one denial (kept).
 		cfg.logCmd = []string{"printf", "Filtering the log data\ndeny file-write /etc/passwd\n"}

--- a/internal/acp/client/cursor/cursor_test.go
+++ b/internal/acp/client/cursor/cursor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	shared "github.com/dimetron/pi-go/internal/acp"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestRunnerStartRejectsEmptyPrompt(t *testing.T) {
@@ -122,8 +123,10 @@ func TestDefaultBinaryPathsPrefersAgent(t *testing.T) {
 	if !slices.Contains(DefaultBinaryPaths, "cursor-agent") {
 		t.Errorf("DefaultBinaryPaths should keep 'cursor-agent' as legacy fallback; got %v", DefaultBinaryPaths)
 	}
-	// The Cursor installer's canonical path is $HOME/.local/bin/agent.
-	homeAgent := filepath.Join(".local", "bin", "agent")
+	// The Cursor installer's canonical path is $HOME/.local/bin/agent. This is
+	// a fixed entry in a literal list, not a path built for the running OS, so
+	// it is spelled with a forward slash on every platform.
+	const homeAgent = ".local/bin/agent"
 	if !slices.Contains(DefaultBinaryPaths, homeAgent) {
 		t.Errorf("DefaultBinaryPaths should include %q (Cursor install location); got %v", homeAgent, DefaultBinaryPaths)
 	}
@@ -143,8 +146,10 @@ exit 0
 
 	runner := Runner{}
 	req := RunRequest{
-		Prompt:  "test",
-		Command: []string{"/bin/bash", scriptPath},
+		Prompt: "test",
+		// Invoke the shell explicitly rather than relying on the script's
+		// shebang, which Windows does not honor.
+		Command: []string{testenv.RequireShell(t), filepath.ToSlash(scriptPath)},
 	}
 	session, err := runner.Start(context.Background(), req)
 	if err != nil {
@@ -408,12 +413,18 @@ func TestFindBinaryEdgeCases(t *testing.T) {
 	})
 
 	t.Run("absolute path exists", func(t *testing.T) {
-		got, err := findBinary([]string{"/bin/ls"})
-		if err != nil {
-			t.Fatalf("findBinary(/bin/ls) error: %v", err)
+		// A real file under t.TempDir() stands in for a hardcoded /bin/ls, which
+		// does not exist on Windows.
+		abs := filepath.Join(t.TempDir(), "agent")
+		if err := os.WriteFile(abs, nil, 0o700); err != nil {
+			t.Fatal(err)
 		}
-		if got != "/bin/ls" {
-			t.Errorf("findBinary(/bin/ls) = %q, want /bin/ls", got)
+		got, err := findBinary([]string{abs})
+		if err != nil {
+			t.Fatalf("findBinary(%s) error: %v", abs, err)
+		}
+		if got != abs {
+			t.Errorf("findBinary(%s) = %q, want %s", abs, got, abs)
 		}
 	})
 

--- a/internal/acp/client/gemini/gemini_test.go
+++ b/internal/acp/client/gemini/gemini_test.go
@@ -392,20 +392,13 @@ func TestFindBinaryBranches(t *testing.T) {
 	if err := os.WriteFile(absBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("setup: write file: %v", err)
 	}
-	// Compute a relative path from the test's CWD to the temp file so os.Stat
-	// succeeds for the relative-path branch.
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("setup: getwd: %v", err)
-	}
-	relBin, err := filepath.Rel(cwd, absBin)
-	if err != nil {
-		t.Fatalf("setup: rel path: %v", err)
-	}
-	// Ensure it starts with "." so findBinary treats it as a relative path.
-	if !strings.HasPrefix(relBin, ".") {
-		relBin = "./" + relBin
-	}
+	// Run from the temp dir so the relative-path branch has something to stat.
+	// Relativizing the temp dir against the source tree instead would fail on
+	// Windows, where TEMP and the checkout routinely sit on different volumes
+	// and filepath.Rel cannot cross a drive letter.
+	t.Chdir(tmpDir)
+	// The leading "." is what makes findBinary treat this as a relative path.
+	relBin := "./gemini-fake"
 	nonexistentRel := "./nonexistent-relative-binary"
 	nonexistentAbs := filepath.Join(tmpDir, "no-such-file")
 

--- a/internal/acp/client/runner_test.go
+++ b/internal/acp/client/runner_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -59,13 +58,11 @@ func TestRunnerCompletesPromptTurn(t *testing.T) {
 }
 
 func TestRunningSessionCancel(t *testing.T) {
-	scriptDir := t.TempDir()
-	scriptPath := filepath.Join(scriptDir, "sleep.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 10\n"), 0o755); err != nil {
-		t.Fatalf("write script: %v", err)
-	}
-
-	cmd := exec.Command("/bin/sh", scriptPath)
+	// Any process that stays alive until it is killed will do. Re-exec the test
+	// binary as the ACP helper agent rather than a #!/bin/sh script, which
+	// Windows cannot run: the helper blocks reading stdio just the same.
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	cmd := exec.Command(os.Args[0], "-test.run=TestACPClientHelperProcess", "--")
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		t.Fatalf("stderr pipe: %v", err)

--- a/internal/acp/server/agent_test.go
+++ b/internal/acp/server/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -572,7 +573,17 @@ func TestNewPromptHandlerModelOverrideUsesRealConfig(t *testing.T) {
 			}}, nil
 		},
 	})
-	res, err := h(context.Background(), PromptTurn{Prompt: "hello", CWD: t.TempDir()})
+	// Not t.TempDir: a session built by this handler keeps an os.Root open on
+	// its CWD for the life of the process (piSessionState.cleanup has no
+	// caller), so on Windows the directory cannot be removed while the test
+	// binary is still running. Removal is best-effort here.
+	cwd, err := os.MkdirTemp("", "acp-prompt-cwd-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(cwd) })
+
+	res, err := h(context.Background(), PromptTurn{Prompt: "hello", CWD: cwd})
 	if err != nil {
 		if strings.Contains(err.Error(), "echo:") {
 			t.Fatalf("handler fell back to echo stub: %v", err)

--- a/internal/acp/server/commands_test.go
+++ b/internal/acp/server/commands_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/dimetron/pi-go/internal/extension"
 )
@@ -26,14 +25,13 @@ func TestNormalizeDiscoveryCWD(t *testing.T) {
 }
 
 func TestDefaultSkillDirsIn(t *testing.T) {
-	// Save original cwd
-	origCwd, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chdir(origCwd) })
-
-	// Change to temp dir for isolation
+	// Change to temp dir for isolation. t.Chdir registers its restore after
+	// t.TempDir registered its removal, and cleanups run last-registered-first,
+	// so the working directory moves back out before the directory is deleted.
+	// Doing the chdir by hand got that order backwards, and Windows refuses to
+	// delete the process's own working directory.
 	tmpDir := t.TempDir()
-	require.NoError(t, os.Chdir(tmpDir))
+	t.Chdir(tmpDir)
 
 	dirs := extension.DefaultSkillDirsIn(tmpDir)
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/testenv"
 	"github.com/dimetron/pi-go/internal/tools"
 )
 
@@ -463,7 +464,7 @@ func TestRunStreaming(t *testing.T) {
 }
 
 func TestLoadInstructionInjectsRuntimeEnvironment(t *testing.T) {
-	t.Setenv("HOME", "/tmp/test-home")
+	testenv.SetHome(t, "/tmp/test-home")
 	t.Setenv("USER", "test-user")
 	t.Setenv("PWD", "/tmp/test-project")
 
@@ -475,7 +476,7 @@ func TestLoadInstructionInjectsRuntimeEnvironment(t *testing.T) {
 }
 
 func TestLoadInstructionInjectsWorkingDirectoryWhenPWDUnset(t *testing.T) {
-	t.Setenv("HOME", "/tmp/test-home")
+	testenv.SetHome(t, "/tmp/test-home")
 	t.Setenv("USER", "test-user")
 	t.Setenv("PWD", "")
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestGeneratePKCE(t *testing.T) {
@@ -524,9 +526,7 @@ func TestFindProvider(t *testing.T) {
 
 func TestSaveKey(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	_ = os.Setenv("HOME", tmpDir)
-	defer func() { _ = os.Setenv("HOME", origHome) }()
+	testenv.SetHome(t, tmpDir)
 
 	if err := SaveKey("TEST_KEY", "test-value-123"); err != nil {
 		t.Fatalf("SaveKey error: %v", err)
@@ -988,9 +988,7 @@ func TestPollDeviceToken_SlowDown(t *testing.T) {
 
 func TestSaveKey_ExistingFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	_ = os.Setenv("HOME", tmpDir)
-	defer func() { _ = os.Setenv("HOME", origHome) }()
+	testenv.SetHome(t, tmpDir)
 
 	piDir := filepath.Join(tmpDir, ".pi-go")
 	_ = os.MkdirAll(piDir, 0700)
@@ -1169,12 +1167,10 @@ func TestPollDeviceToken_FatalError(t *testing.T) {
 }
 
 func TestSaveKey_MkdirAllError(t *testing.T) {
-	origHome := os.Getenv("HOME")
 	// Point HOME to a file (not directory) to make MkdirAll fail.
 	tmpFile := filepath.Join(t.TempDir(), "fakefile")
 	_ = os.WriteFile(tmpFile, []byte("x"), 0600)
-	os.Setenv("HOME", tmpFile) // .pi-go will be tmpFile/.pi-go which can't be created
-	defer func() { _ = os.Setenv("HOME", origHome) }()
+	testenv.SetHome(t, tmpFile)
 
 	err := SaveKey("TEST_KEY", "test")
 	if err == nil {
@@ -1187,9 +1183,7 @@ func TestSaveKey_MkdirAllError(t *testing.T) {
 
 func TestSaveKey_WriteFileError(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	_ = os.Setenv("HOME", tmpDir)
-	defer func() { _ = os.Setenv("HOME", origHome) }()
+	testenv.SetHome(t, tmpDir)
 
 	// Create .pi-go/.env as a directory to make WriteFile fail.
 	envDir := filepath.Join(tmpDir, ".pi-go", ".env")

--- a/internal/auth/codex_e2e_test.go
+++ b/internal/auth/codex_e2e_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // TestCodexLoginE2E_BrowserPKCE is the primary e2e test for codex login.
@@ -169,9 +171,7 @@ func TestCodexLoginE2E_BrowserPKCE(t *testing.T) {
 
 	// --- Save key and verify ---
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	testenv.SetHome(t, tmpDir)
 
 	if err := SaveKey(result.EnvVar, result.APIKey); err != nil {
 		t.Fatalf("SaveKey() error: %v", err)

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// recordEnv names the file the test binary writes the URL it was handed to
+// when it is re-executed as a stand-in browser. See TestMain.
+const recordEnv = "PI_TEST_BROWSER_RECORD"
+
+// TestMain doubles as the fake browser. Open resolves handlers through
+// exec.LookPath and runs them, so the stand-in has to be a real executable:
+// a #!/bin/sh script is neither executable nor even findable on Windows, where
+// LookPath only accepts the PATHEXT suffixes. Re-executing the test binary
+// works everywhere.
+func TestMain(m *testing.M) {
+	if record := os.Getenv(recordEnv); record != "" {
+		// Acting as the browser: the URL is the last argument we were given.
+		_ = os.WriteFile(record, []byte(os.Args[len(os.Args)-1]), 0o600)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
 func TestHandlers(t *testing.T) {
 	t.Parallel()
 
@@ -112,16 +130,9 @@ func TestOpen_NoHandler(t *testing.T) {
 // The stand-in handler is a script that records its arguments, which also pins
 // that Open passes the URL through unmangled.
 func TestOpen_UsesBrowserEnv(t *testing.T) {
-	dir := t.TempDir()
-	record := filepath.Join(dir, "opened.txt")
-	handler := filepath.Join(dir, "fake-browser")
-
-	script := "#!/bin/sh\nprintf '%s' \"$1\" > " + record + "\n"
-	if err := os.WriteFile(handler, []byte(script), 0o700); err != nil {
-		t.Fatalf("writing fake browser: %v", err)
-	}
-
-	t.Setenv("BROWSER", handler)
+	record := filepath.Join(t.TempDir(), "opened.txt")
+	t.Setenv(recordEnv, record)
+	t.Setenv("BROWSER", os.Args[0])
 
 	const url = "https://auth.openai.com/codex/device"
 	if err := Open(url); err != nil {
@@ -147,16 +158,12 @@ func TestOpen_UsesBrowserEnv(t *testing.T) {
 // An entry that is not on PATH must be skipped rather than aborting the whole
 // search — that fallthrough is what makes the per-platform handler list useful.
 func TestOpen_SkipsMissingHandlers(t *testing.T) {
-	dir := t.TempDir()
-	handler := filepath.Join(dir, "fallback-browser")
-	if err := os.WriteFile(handler, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
-		t.Fatalf("writing fake browser: %v", err)
-	}
+	t.Setenv(recordEnv, filepath.Join(t.TempDir(), "opened.txt"))
 
 	// An empty PATH means every platform default fails LookPath; only the
 	// absolute $BROWSER path can resolve.
 	t.Setenv("PATH", t.TempDir())
-	t.Setenv("BROWSER", handler)
+	t.Setenv("BROWSER", os.Args[0])
 
 	if err := Open("https://example.invalid/"); err != nil {
 		t.Errorf("Open() = %v, want nil; the reachable handler was skipped", err)

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/audit"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestNewAuditCmd(t *testing.T) {
@@ -294,15 +295,18 @@ func min(a, b int) int {
 // -----------------------------------------------------------------------
 
 func TestRunAuditOutputWriteError(t *testing.T) {
-	// Trying to write to a read-only directory should produce an error.
+	// An unwritable output path should produce an error.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.md")
 	os.WriteFile(path, []byte("Clean content"), 0644)
 
-	// Create a directory we can't write to.
-	readOnlyDir := filepath.Join(dir, "readonly")
-	os.MkdirAll(readOnlyDir, 0555)
-	outPath := filepath.Join(readOnlyDir, "out.txt")
+	// Point --output at a directory. Every OS refuses to open a directory for
+	// writing; a chmod 0555 parent would not, since Windows ignores the mode
+	// bits entirely.
+	outPath := filepath.Join(dir, "out.txt")
+	if err := os.MkdirAll(outPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	err := runAudit(nil, "", path, false, false, false, false, "text", outPath)
 	if err == nil {
@@ -313,9 +317,7 @@ func TestRunAuditOutputWriteError(t *testing.T) {
 func TestRunAuditDefaultDirsWithNoSkills(t *testing.T) {
 	// When no skill directories exist, runAudit should handle gracefully.
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	t.Setenv("HOME", tmpDir)
-	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+	testenv.SetHome(t, tmpDir)
 
 	// runAudit scans defaultSkillDirs() — with HOME set to tmpDir
 	// there are no skill dirs under the standard paths, so it should

--- a/internal/cli/autocompact_config_test.go
+++ b/internal/cli/autocompact_config_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/logger"
 	pisession "github.com/dimetron/pi-go/internal/session"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // TestAutoCompactConfigFrom covers the config.Config -> AutoCompactConfig
@@ -100,7 +101,7 @@ func withEnabled(c pisession.AutoCompactConfig, v bool) pisession.AutoCompactCon
 // appends to the developer's real ~/.pi-go/log tree.
 func newTempLogger(t *testing.T) *logger.Logger {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	l, err := logger.New()
 	if err != nil {
 		t.Fatalf("logger.New: %v", err)

--- a/internal/cli/cli_coverage_test.go
+++ b/internal/cli/cli_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/memory"
 	"github.com/dimetron/pi-go/internal/subagent"
+	"github.com/dimetron/pi-go/internal/testenv"
 	"github.com/dimetron/pi-go/internal/tools"
 	"github.com/dimetron/pi-go/internal/webserver"
 )
@@ -23,7 +24,7 @@ import (
 func TestCliCleanupWithSessionLog(t *testing.T) {
 	// Create a real logger so cleanup exercises the sessionLog.Close() path.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	lg, err := logger.New()
 	if err != nil {
@@ -93,7 +94,7 @@ func TestCliCleanupWithMemoryWorker(t *testing.T) {
 func TestCliCleanupAllResources(t *testing.T) {
 	// Exercise cleanup with every field populated.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	lg, err := logger.New()
 	if err != nil {
@@ -212,7 +213,7 @@ func TestCliNewRootCmdFlagDefaults(t *testing.T) {
 func TestCliPrintModeNoPromptExitsCleanly(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"--model", "gpt-5.4", "--mode", "print"})
@@ -225,7 +226,7 @@ func TestCliPrintModeNoPromptExitsCleanly(t *testing.T) {
 func TestCliJSONModeNoPromptExitsCleanly(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"--model", "gpt-5.4", "--mode", "json"})
@@ -331,7 +332,7 @@ func TestCliRunJSONNilLogger(t *testing.T) {
 
 func TestCliRunPrintWithLogger(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	lg, err := logger.New()
 	if err != nil {
@@ -365,7 +366,7 @@ func TestCliRunPrintWithLogger(t *testing.T) {
 
 func TestCliRunJSONWithLogger(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	lg, err := logger.New()
 	if err != nil {
@@ -648,7 +649,7 @@ func TestFindMemoryDB_PalaceLegacy(t *testing.T) {
 
 func TestFindMemoryDB_NotFound(t *testing.T) {
 	// Override HOME so the global fallback doesn't find a real DB.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	_, err := findMemoryDB(t.TempDir())
 	if err == nil {
 		t.Error("expected error when DB not found")

--- a/internal/cli/cli_extra_test.go
+++ b/internal/cli/cli_extra_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,14 +172,32 @@ func TestLastLoggedError_MultipleDateDirsUsesLast(t *testing.T) {
 // checkForRapidRestartAndWarn — exercise the lastLoggedError branch.
 // -----------------------------------------------------------------------
 
+// lastSessionJSON renders a last-session.json record for workDir stamped
+// "now". It goes through the encoder rather than string concatenation because
+// a Windows temp dir holds backslashes, which an unescaped `"work_dir":"C:\Users\..."`
+// turns into invalid JSON -- readLastSession then fails and the warning under
+// test is never printed.
+func lastSessionJSON(t *testing.T, workDir string) string {
+	t.Helper()
+	blob, err := json.Marshal(map[string]string{
+		"timestamp":  nowTimeStr(),
+		"session_id": "s1",
+		"work_dir":   workDir,
+		"model":      "gpt",
+	})
+	if err != nil {
+		t.Fatalf("marshal last-session: %v", err)
+	}
+	return string(blob)
+}
+
 func TestCheckForRapidRestartAndWarn_WithLoggedError(t *testing.T) {
 	tmpDir := t.TempDir()
 	testenv.SetHome(t, tmpDir)
 
 	// Set up a recent last-session.json for the same workdir.
 	f := filepath.Join(tmpDir, "last-session.json")
-	content := `{"timestamp":"` + nowTimeStr() + `","session_id":"s1","work_dir":"` + tmpDir + `","model":"gpt"}`
-	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(f, []byte(lastSessionJSON(t, tmpDir)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	orig := lastSessionFile
@@ -207,8 +226,7 @@ func TestCheckForRapidRestartAndWarn_NoLoggedError(t *testing.T) {
 	testenv.SetHome(t, tmpDir)
 
 	f := filepath.Join(tmpDir, "last-session.json")
-	content := `{"timestamp":"` + nowTimeStr() + `","session_id":"s1","work_dir":"` + tmpDir + `","model":"gpt"}`
-	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(f, []byte(lastSessionJSON(t, tmpDir)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	orig := lastSessionFile

--- a/internal/cli/cli_extra_test.go
+++ b/internal/cli/cli_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // -----------------------------------------------------------------------
@@ -15,7 +16,7 @@ import (
 
 func TestLastLoggedError_NoLogDir(t *testing.T) {
 	// Fresh HOME with no ~/.pi-go/log directory => returns "", "", nil.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	path, msg, err := lastLoggedError()
 	if err != nil {
 		t.Fatalf("lastLoggedError: %v", err)
@@ -29,15 +30,13 @@ func TestLastLoggedError_HomeError(t *testing.T) {
 	// Unset HOME so os.UserHomeDir fails. On Darwin/Linux this typically
 	// falls back to /etc/passwd, which may still succeed. Skip the error
 	// assertion and only verify no panic.
-	orig := os.Getenv("HOME")
-	defer func() { _ = os.Setenv("HOME", orig) }()
-	_ = os.Unsetenv("HOME")
+	testenv.UnsetHome(t)
 	_, _, _ = lastLoggedError() // Should not panic.
 }
 
 func TestLastLoggedError_EmptyLogDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	// Create empty log dir.
 	logDir := filepath.Join(tmpDir, ".pi-go", "log")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
@@ -55,7 +54,7 @@ func TestLastLoggedError_EmptyLogDir(t *testing.T) {
 
 func TestLastLoggedError_WithErrorEntry(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	// Create a dated log directory with a session file.
 	dateDir := filepath.Join(tmpDir, ".pi-go", "log", "2024-01-15")
@@ -85,7 +84,7 @@ func TestLastLoggedError_WithErrorEntry(t *testing.T) {
 
 func TestLastLoggedError_NoErrorEntries(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	dateDir := filepath.Join(tmpDir, ".pi-go", "log", "2024-01-15")
 	if err := os.MkdirAll(dateDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -110,7 +109,7 @@ func TestLastLoggedError_NoErrorEntries(t *testing.T) {
 
 func TestLastLoggedError_SkipsNonSessionFiles(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	dateDir := filepath.Join(tmpDir, ".pi-go", "log", "2024-02-20")
 	if err := os.MkdirAll(dateDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -143,7 +142,7 @@ func TestLastLoggedError_SkipsNonSessionFiles(t *testing.T) {
 
 func TestLastLoggedError_MultipleDateDirsUsesLast(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	logRoot := filepath.Join(tmpDir, ".pi-go", "log")
 
 	// Older directory with an error.
@@ -174,7 +173,7 @@ func TestLastLoggedError_MultipleDateDirsUsesLast(t *testing.T) {
 
 func TestCheckForRapidRestartAndWarn_WithLoggedError(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	// Set up a recent last-session.json for the same workdir.
 	f := filepath.Join(tmpDir, "last-session.json")
@@ -205,7 +204,7 @@ func TestCheckForRapidRestartAndWarn_WithLoggedError(t *testing.T) {
 
 func TestCheckForRapidRestartAndWarn_NoLoggedError(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	f := filepath.Join(tmpDir, "last-session.json")
 	content := `{"timestamp":"` + nowTimeStr() + `","session_id":"s1","work_dir":"` + tmpDir + `","model":"gpt"}`

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
 	pisession "github.com/dimetron/pi-go/internal/session"
+	"github.com/dimetron/pi-go/internal/testenv"
 	"github.com/dimetron/pi-go/internal/tools"
 )
 
@@ -198,7 +199,7 @@ func TestCLI_SmolFlag(t *testing.T) {
 			"smol": {"model": "gpt-5.4-mini", "provider": "openai"}
 		}
 	}`), 0o644)
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Chdir(tmpDir)
 
 	cmd := newRootCmd()
@@ -226,7 +227,7 @@ func TestCLI_RoleFlagsMutuallyExclusive(t *testing.T) {
 	// When multiple role flags are set, the switch statement picks one (smol wins due to order).
 	// This just verifies no crash occurs.
 	// Isolate HOME so loadDotEnv and config.Load don't pick up real machine credentials.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Set all provider keys so whichever role resolves has a key available.
 	t.Setenv("ANTHROPIC_API_KEY", "test-key-anthropic")
@@ -264,7 +265,7 @@ func TestRootCmdMissingAPIKey(t *testing.T) {
 	// (or, worse, a codex OAuth token) and the test's "no key set" intent
 	// never reaches buildRootRuntime.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Chdir(tmpDir)
 
 	// Ensure no provider API keys are set.
@@ -316,9 +317,7 @@ func TestContinueNoSessionError(t *testing.T) {
 	defer os.Unsetenv("OPENAI_API_KEY")
 
 	// Use a temp dir so there are no existing sessions.
-	tmpDir := t.TempDir()
-	os.Setenv("HOME", tmpDir)
-	defer os.Unsetenv("HOME")
+	testenv.SetHome(t, t.TempDir())
 
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"--model", "gpt-5.6-sol", "--continue", "hello"})
@@ -702,12 +701,7 @@ func TestLoadDotEnv(t *testing.T) {
 			}
 
 			// Override home dir
-			origHome := os.Getenv("HOME")
-			if err := os.Setenv("HOME", tmpDir); err != nil {
-				t.Fatalf("failed to set HOME: %v", err)
-			}
-			// Use Setenv in cleanup but ignore error (cleanup shouldn't fail test)
-			t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
+			testenv.SetHome(t, tmpDir)
 
 			if tt.setEnv != "" {
 				if err := os.Setenv("TEST_KEY", tt.setEnv); err != nil {
@@ -728,12 +722,7 @@ func TestLoadDotEnv(t *testing.T) {
 
 func TestLoadDotEnvNoFile(t *testing.T) {
 	// Should not panic when .env doesn't exist
-	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("failed to set HOME: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
+	testenv.SetHome(t, t.TempDir())
 
 	loadDotEnv() // Should not panic
 }
@@ -1048,7 +1037,7 @@ func TestLoadDotEnvQuotedValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Cleanup(func() { _ = os.Unsetenv("TEST_QUOTED_KEY") })
 
 	loadDotEnv()
@@ -1069,7 +1058,7 @@ func TestLoadDotEnvMultipleKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Cleanup(func() {
 		_ = os.Unsetenv("TEST_MULTI_A")
 		_ = os.Unsetenv("TEST_MULTI_B")
@@ -1106,7 +1095,7 @@ func TestLoadDotEnvProjectOverridesGlobal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", homeDir)
+	testenv.SetHome(t, homeDir)
 	t.Setenv("TEST_PROJECT_ENV", "shell")
 	t.Cleanup(func() { _ = os.Unsetenv("TEST_GLOBAL_ONLY") })
 	oldWD, err := os.Getwd()
@@ -1142,7 +1131,7 @@ func TestLoadDotEnvFileWinsOverShellEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("TEST_EXISTING", "from-env")
 
 	loadDotEnv()
@@ -1155,7 +1144,7 @@ func TestLoadDotEnvFileWinsOverShellEnv(t *testing.T) {
 func TestBuildCommitMsgFuncNoDefaultRole(t *testing.T) {
 	// Config with no roles: buildCommitMsgFunc should return nil (no model available).
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"roles":{}}`), 0o644)
@@ -1177,7 +1166,7 @@ func TestBuildCommitMsgFuncNoDefaultRole(t *testing.T) {
 func TestBuildCommitMsgFuncWithDefaultRole(t *testing.T) {
 	// Config with default role that has no valid API key: should return nil or a func that errors.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{
@@ -1204,7 +1193,7 @@ func TestBuildCommitMsgFuncWithDefaultRole(t *testing.T) {
 func TestBuildCommitMsgFuncCommitRoleFallback(t *testing.T) {
 	// Config with a "commit" role: buildCommitMsgFunc should use it.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{
@@ -1305,7 +1294,7 @@ func TestRunJSONThinkingDelta(t *testing.T) {
 // Ollama is not reachable, the function should return nil gracefully.
 func TestBuildCommitMsgFuncOllama(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	// Use an Ollama model (qwen2.5 resolves to ollama provider).
@@ -1332,7 +1321,7 @@ func TestBuildCommitMsgFuncOllama(t *testing.T) {
 // Ollama models inside buildCommitMsgFunc (info.Ollama == true, baseURL == "").
 func TestBuildCommitMsgFuncOllamaWithBaseURL(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -95,40 +95,45 @@ func (m *cliToolCallingLLM) GenerateContent(_ context.Context, _ *model.LLMReque
 // captureStdout captures os.Stdout during fn execution.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	origStdout := os.Stdout
-	os.Stdout = w
-
-	fn()
-
-	w.Close()
-	os.Stdout = origStdout
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	return buf.String()
+	return captureFD(t, &os.Stdout, fn)
 }
 
 // captureStderr captures os.Stderr during fn execution.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
+	return captureFD(t, &os.Stderr, fn)
+}
+
+// captureFD swaps *fd for the write end of a pipe while fn runs and returns
+// everything fn wrote to it.
+//
+// The read end is drained concurrently, not after fn returns: a pipe has a
+// fixed buffer (64 KiB on Linux, only 4 KiB on Windows), and a writer that
+// fills it blocks until someone reads. Draining afterwards therefore deadlocks
+// any fn whose output exceeds the buffer -- the rpc server's
+// get_available_models reply already does on Windows.
+func captureFD(t *testing.T, fd **os.File, fn func()) string {
+	t.Helper()
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
-	origStderr := os.Stderr
-	os.Stderr = w
+	orig := *fd
+	*fd = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = buf.ReadFrom(r)
+	}()
 
 	fn()
 
-	w.Close()
-	os.Stderr = origStderr
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_ = w.Close()
+	*fd = orig
+	<-done
+	_ = r.Close()
 	return buf.String()
 }
 

--- a/internal/cli/complexity_core_test.go
+++ b/internal/cli/complexity_core_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dimetron/pi-go/internal/memory"
 	"github.com/dimetron/pi-go/internal/provider"
 	pisession "github.com/dimetron/pi-go/internal/session"
+	"github.com/dimetron/pi-go/internal/testenv"
 	"github.com/dimetron/pi-go/internal/tools"
 )
 
@@ -372,7 +373,7 @@ func TestAppendNonInteractiveLSPTools(t *testing.T) {
 
 func TestOpenSessionService(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	path, svc, err := openSessionService()
 	if err != nil {
@@ -553,7 +554,7 @@ func errorLogLine(content string) string {
 
 func TestLastLoggedError(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	t.Run("absent log root is not an error", func(t *testing.T) {
 		path, msg, err := lastLoggedError()

--- a/internal/cli/complexity_ping_test.go
+++ b/internal/cli/complexity_ping_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dimetron/pi-go/internal/memory"
 	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/provider"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // These tests pin the branch structure that the complexity refactor extracted
@@ -788,7 +789,7 @@ func TestResolvePingCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
+			testenv.SetHome(t, t.TempDir())
 			t.Setenv("OLLAMA_HOST", "")
 			for k, v := range tt.env {
 				t.Setenv(k, v)
@@ -868,7 +869,7 @@ func TestResolvePingModelInfo(t *testing.T) {
 	origURL, origModel := flagURL, flagModel
 	t.Cleanup(func() { flagURL, flagModel = origURL, origModel })
 	flagURL, flagModel = "", ""
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	t.Run("a configured provider wins over inference", func(t *testing.T) {
 		cfg := config.Config{Roles: map[string]config.RoleConfig{
@@ -1374,7 +1375,7 @@ func TestPrintMineFileList(t *testing.T) {
 }
 
 func TestMinePalaceConfig(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	cfg := minePalaceConfig("/tmp/db.sqlite", "/tmp/model")
 	if cfg.DBPath != "/tmp/db.sqlite" || cfg.ModelPath != "/tmp/model" {
 		t.Errorf("paths not carried through: %+v", cfg)

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // writeGlobalConfig points HOME at a temp dir holding the given config, so
@@ -14,7 +16,7 @@ import (
 func writeGlobalConfig(t *testing.T, cfg map[string]any) {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	dir := filepath.Join(home, ".pi-go")
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/internal/cli/interactive_deferred_test.go
+++ b/internal/cli/interactive_deferred_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/guardrail"
+	"github.com/dimetron/pi-go/internal/testenv"
 	"github.com/dimetron/pi-go/internal/tui"
 )
 
@@ -20,7 +21,7 @@ import (
 
 func TestDeferredInit_MemoryOffBasic(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	// Save and restore package-level flags.
 	origMemOff := flagMemoryOff
@@ -90,7 +91,7 @@ func TestDeferredInit_MemoryOffBasic(t *testing.T) {
 
 func TestDeferredInit_WithMCP(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	origMemOff := flagMemoryOff
 	origSystem := flagSystem
@@ -136,7 +137,7 @@ func TestDeferredInit_WithMCP(t *testing.T) {
 
 func TestDeferredInit_WithMemoryEnabled(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	origMemOff := flagMemoryOff
 	defer func() { flagMemoryOff = origMemOff }()
@@ -190,7 +191,7 @@ func TestDeferredInit_WithMemoryEnabled(t *testing.T) {
 
 func TestBuildSwitchedLLM_OpenAI(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	origURL := flagURL
 	origInsecure := flagInsecure
@@ -230,7 +231,7 @@ func TestBuildSwitchedLLM_OpenAI(t *testing.T) {
 
 func TestBuildSwitchedLLM_InvalidModel(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	origURL := flagURL
 	origHeaders := flagHeaders
@@ -262,7 +263,7 @@ func TestBuildSwitchedLLM_InvalidModel(t *testing.T) {
 
 func TestBuildSwitchedLLM_NoProvider(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	origURL := flagURL
 	origHeaders := flagHeaders
@@ -295,7 +296,7 @@ func TestBuildSwitchedLLM_NoProvider(t *testing.T) {
 
 func TestBuildSwitchedLLM_AnthropicProvider(t *testing.T) {
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	origURL := flagURL
 	origHeaders := flagHeaders
@@ -364,7 +365,7 @@ func TestDeferredInitTotal(t *testing.T) {
 func TestDeferredInit_WithSkillDir(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	// Create a skill file.
 	skillsDir := filepath.Join(tmpHome, ".pi-go", "skills", "my-skill")

--- a/internal/cli/interactive_lazystore_test.go
+++ b/internal/cli/interactive_lazystore_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/memory"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // mockNamedTool is a minimal adktool.Tool used to drive afterTool.
@@ -157,7 +158,7 @@ func TestDeferredMemoryDBPath(t *testing.T) {
 		t.Errorf("explicit DBPath = %q, want /x/y.db", got)
 	}
 	// Without an explicit path it derives from HOME.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	if got := deferredMemoryDBPath(config.MemoryConfig{}); got == "" {
 		t.Error("expected non-empty derived DB path")
 	}

--- a/internal/cli/login_codex_device_test.go
+++ b/internal/cli/login_codex_device_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -184,9 +185,10 @@ func TestOpenBrowserDefault_PrintsURLWhenNoHandlerExists(t *testing.T) {
 // With a handler available the URL is handed off silently; printing it too
 // would be noise in the middle of an interactive login.
 func TestOpenBrowserDefault_SilentWhenAHandlerExists(t *testing.T) {
-	// `true` accepts any arguments and exits 0, so it stands in for a browser
-	// launcher without opening anything.
-	t.Setenv("BROWSER", "/usr/bin/true")
+	// Re-execute this binary in stub mode: it accepts any arguments and exits
+	// 0, standing in for a browser launcher without opening anything.
+	t.Setenv(testBrowserStubEnv, "1")
+	t.Setenv("BROWSER", os.Args[0])
 
 	var err error
 	out := captureStdout(t, func() {

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/auth"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // -----------------------------------------------------------------------
@@ -219,7 +220,7 @@ func TestSaveResult_WithErrorField(t *testing.T) {
 func TestSaveResult_Success(t *testing.T) {
 	// Redirect HOME so SaveKey writes into a temp dir.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	// Prevent polluting the real env.
 	t.Setenv("TEST_SAVE_RESULT_KEY", "")
@@ -258,7 +259,7 @@ func TestSaveResult_Success(t *testing.T) {
 
 func TestRunLogin_UnknownProvider(t *testing.T) {
 	// Redirect HOME so loadDotEnv doesn't blow up.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	cmd := newLoginCmd()
 	cmd.SetArgs([]string{"not-a-real-provider"})
@@ -278,7 +279,7 @@ func TestRunLogin_UnknownProvider(t *testing.T) {
 func TestRunLogin_PromptCanceled(t *testing.T) {
 	// When no provider is specified and promptProvider returns "" (user cancels),
 	// runLogin returns nil without error.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	cmd := newLoginCmd()
 	cmd.SetArgs([]string{})

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -20,7 +20,19 @@ import (
 //
 // Tests that need their own HOME can still override it; t.Setenv restores this
 // value rather than the developer's when they finish.
+// testBrowserStubEnv switches this binary into stand-in-browser mode. A test
+// that needs $BROWSER to point at something runnable sets it and points BROWSER
+// at os.Args[0]: the child exits here, before m.Run, so no tests are re-run and
+// no real browser is launched. A literal path like /usr/bin/true does not
+// travel -- on Windows it fails exec.LookPath, and Open falls through to
+// "cmd /c start", which opens the runner's actual browser.
+const testBrowserStubEnv = "PI_TEST_BROWSER_STUB"
+
 func TestMain(m *testing.M) {
+	if os.Getenv(testBrowserStubEnv) != "" {
+		os.Exit(0)
+	}
+
 	dir, err := os.MkdirTemp("", "pi-go-test-home-")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "isolating HOME: %v\n", err)

--- a/internal/cli/memory_init_test.go
+++ b/internal/cli/memory_init_test.go
@@ -63,10 +63,17 @@ func TestNewMemoryInitCmd_MaxArgs(t *testing.T) {
 }
 
 func TestRunMemoryInit_AbsDirError(t *testing.T) {
-	// Test with an invalid directory path.
-	err := runMemoryInit("/nonexistent/path/that/cannot/be/resolved", "")
+	// A directory below a regular file cannot be created on any OS. A literal
+	// "/nonexistent/..." only fails on Unix: on Windows the leading slash is
+	// drive-relative, so MkdirAll happily creates C:\nonexistent\... and the
+	// test passes for the wrong reason while leaving litter on the drive.
+	notADir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notADir, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := runMemoryInit(filepath.Join(notADir, "project"), "")
 	if err == nil {
-		t.Error("expected error for non-existent directory")
+		t.Error("expected error for a directory that cannot be created")
 	}
 }
 
@@ -215,7 +222,7 @@ func TestScanRoomCandidates_DotDirs(t *testing.T) {
 }
 
 func TestScanRoomCandidates_UnreadableDir(t *testing.T) {
-	rooms := scanRoomCandidates("/nonexistent/path")
+	rooms := scanRoomCandidates(filepath.Join(t.TempDir(), "nonexistent", "path"))
 	if rooms != nil {
 		t.Errorf("expected nil rooms, got %v", rooms)
 	}

--- a/internal/cli/memory_kg_test.go
+++ b/internal/cli/memory_kg_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -178,8 +179,14 @@ func TestNewMemoryKGCmd_Subcommands(t *testing.T) {
 }
 
 func TestOpenPalaceDB_InvalidPath(t *testing.T) {
-	// Non-existent directory with no parent creation should fail.
-	_, err := openPalaceDB("/nonexistent/dir/that/does/not/exist/palace.db")
+	// A database below a regular file cannot be created on any OS. A literal
+	// "/nonexistent/..." only fails on Unix: on Windows the leading slash is
+	// drive-relative and the parent directories get created on C:\.
+	notADir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notADir, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := openPalaceDB(filepath.Join(notADir, "palace.db"))
 	if err == nil {
 		t.Error("expected error for invalid path")
 	}

--- a/internal/cli/memory_mine.go
+++ b/internal/cli/memory_mine.go
@@ -168,7 +168,11 @@ var supportedExtensions = map[string]bool{
 // isGitignored returns true if the path matches any gitignore pattern.
 // This is a simplified check for common patterns.
 func isGitignored(relPath string, patterns map[string]bool) bool {
-	parts := strings.Split(relPath, string(filepath.Separator))
+	// Callers pass filepath.Rel output, which is backslash-separated on
+	// Windows, while .gitignore patterns (and the "*/" prefix form below) are
+	// always slash-form. Normalise before splitting so a directory pattern
+	// matches the same path components on every OS.
+	parts := strings.Split(filepath.ToSlash(relPath), "/")
 	for _, part := range parts {
 		if patterns[part] {
 			return true

--- a/internal/cli/memory_model_test.go
+++ b/internal/cli/memory_model_test.go
@@ -137,6 +137,15 @@ func TestRunMemoryModelDownload_ExplicitOnnxPath(t *testing.T) {
 }
 
 func TestRunMemoryModelDownload_DefaultDest(t *testing.T) {
+	// This downloads the real embedding model from Hugging Face into the
+	// package's shared test HOME. It only ever appeared to pass: an earlier
+	// test used to leave HOME unset, so runMemoryModelDownload failed before
+	// reaching the network. With HOME isolated properly the download runs, and
+	// two things break under -race: go-huggingface's parallel download has a
+	// data race, and every later palace-backed test in this package then finds
+	// the weights and runs real inference, where gomlx's AVX2 matmul kernel
+	// trips checkptr. Skip it like its siblings above.
+	t.Skip("skipping: downloads a real model over the network; go-huggingface races under -race and the weights poison later palace tests")
 	err := runMemoryModelDownload("", "")
 	if err != nil {
 		t.Logf("expected error: %v", err)

--- a/internal/cli/memory_model_test.go
+++ b/internal/cli/memory_model_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestRunMemoryModelDownload_AutoDetectPlatformBranch(t *testing.T) {
@@ -42,9 +44,7 @@ func TestNewMemoryModelStatusCmd_RunE(t *testing.T) {
 
 func TestRunMemoryModelDownload_HomeDirError(t *testing.T) {
 	// Test when os.UserHomeDir returns an error (non-existent HOME).
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", "/nonexistent/user/dir")
-	defer os.Setenv("HOME", origHome)
+	testenv.SetUnwritableHome(t)
 
 	// With empty dest and non-existent HOME, should fail.
 	err := runMemoryModelDownload("", "")

--- a/internal/cli/memory_recent_test.go
+++ b/internal/cli/memory_recent_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dimetron/pi-go/internal/memory"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestMemoryRecent_NoDB(t *testing.T) {
@@ -160,7 +161,7 @@ func TestMemoryRecent_TypeFilter(t *testing.T) {
 func TestNewMemoryRecentCmd_NoArgExecute(t *testing.T) {
 	resetGlobalFlags(t)
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 
 	origCwd, _ := os.Getwd()
 	workDir := filepath.Join(tmp, "work")
@@ -180,7 +181,7 @@ func TestNewMemoryRecentCmd_NoArgExecute(t *testing.T) {
 func TestNewMemoryRecentCmd_WithArgExecute(t *testing.T) {
 	resetGlobalFlags(t)
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 
 	cmd := newMemoryRecentCmd()
 	cmd.SetArgs([]string{tmp})
@@ -210,7 +211,7 @@ func TestNewMemoryRecentCmd_Flags(t *testing.T) {
 func TestRunMemoryRecent_CurrentDir(t *testing.T) {
 	// Use current directory with no DB.
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	// Create a memory DB in project-specific location.
 	memDir := filepath.Join(tmpDir, "proj", ".pi-go", "memory")

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/provider"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // runModelList executes the cobra "model list" command with the given args,
@@ -35,7 +36,7 @@ func runModelListCapture(t *testing.T, args ...string) (string, error) {
 // helper, so those values are not wiped.
 func isolateRunModelListEnv(t *testing.T) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	// Clear system-level credentials that may leak through loadDotEnv or
 	// config.APIKeys/BaseURLs lookups. Do NOT clear vars the caller may have
 	// already set; we clear here only the unprefixed "real machine" sources

--- a/internal/cli/ollama_callsite_test.go
+++ b/internal/cli/ollama_callsite_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/guardrail"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // The endpoint decision has to be the same one in every place that builds an
@@ -16,7 +17,7 @@ import (
 // :cloud model, which is the direction each of them used to get wrong.
 
 func TestBuildSwitchedLLM_OllamaRoutesByTag(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
 	t.Setenv("OLLAMA_HOST", "")
 
@@ -53,7 +54,7 @@ func TestBuildSwitchedLLM_OllamaRoutesByTag(t *testing.T) {
 // nil rather than an error when the model cannot be reached, so the assertion
 // is that a cloud tag yields a usable callback with no local daemon present.
 func TestBuildCommitMsgFunc_OllamaCloudTagSkipsLocalDaemon(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
 	t.Setenv("OLLAMA_HOST", "")
 
@@ -77,7 +78,7 @@ func TestBuildCommitMsgFunc_OllamaCloudTagSkipsLocalDaemon(t *testing.T) {
 // localhost — so `pi ping` against a :cloud model probed a daemon that does
 // not serve it. It now asks the same resolver as everything else.
 func TestResolvePingTarget_OllamaRoutesByTag(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
 	t.Setenv("OLLAMA_HOST", "")
 
@@ -114,7 +115,7 @@ func TestResolvePingTarget_OllamaRoutesByTag(t *testing.T) {
 // deterministic without depending on whether a daemon happens to be running.
 func TestBuildRootRuntime_OllamaHealthCheckFailureIsReported(t *testing.T) {
 	resetGlobalFlags(t)
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OLLAMA_API_KEY", "")
 	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
 
@@ -134,7 +135,7 @@ func TestBuildRootRuntime_OllamaHealthCheckFailureIsReported(t *testing.T) {
 // /commit degrades to no generated message rather than failing the session.
 func TestBuildCommitMsgFunc_OllamaUnreachableDaemonYieldsNil(t *testing.T) {
 	resetGlobalFlags(t)
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OLLAMA_API_KEY", "")
 	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
 

--- a/internal/cli/ollama_routing_test.go
+++ b/internal/cli/ollama_routing_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // The bug this pins: OLLAMA_API_KEY exported for a :cloud model used to be read
@@ -30,7 +32,7 @@ func TestBuildRootRuntime_OllamaKeyDoesNotForceCloud(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resetGlobalFlags(t)
-			t.Setenv("HOME", t.TempDir())
+			testenv.SetHome(t, t.TempDir())
 			// Set, as it must be for any cloud model — and irrelevant to where
 			// a local model goes.
 			t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
@@ -54,7 +56,7 @@ func TestBuildRootRuntime_OllamaKeyDoesNotForceCloud(t *testing.T) {
 // container, or an authenticated proxy, so it outranks the tag either way.
 func TestBuildRootRuntime_OllamaHostWinsOverTag(t *testing.T) {
 	resetGlobalFlags(t)
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
 	t.Setenv("OLLAMA_HOST", "http://gpu-box.lan:11434")
 

--- a/internal/cli/ping_run_test.go
+++ b/internal/cli/ping_run_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // newOllamaHTTPServer returns an httptest server that emulates the subset of
@@ -44,7 +46,7 @@ func newOllamaHTTPServer(t *testing.T, models []string) *httptest.Server {
 func TestRunPing_OllamaModel_Happy(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	srv := newOllamaHTTPServer(t, []string{"llama3:8b"})
 	defer srv.Close()
@@ -70,7 +72,7 @@ func TestRunPing_OllamaModel_Happy(t *testing.T) {
 func TestRunPing_DNSResolutionFailure(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
@@ -95,7 +97,7 @@ func TestRunPing_DNSResolutionFailure(t *testing.T) {
 func TestRunPing_InvalidURLParse(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
@@ -115,7 +117,7 @@ func TestRunPing_InvalidURLParse(t *testing.T) {
 func TestRunPing_InvalidModelResolution(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	_ = os.MkdirAll(cfgDir, 0o755)
@@ -137,7 +139,7 @@ func TestRunPing_InvalidModelResolution(t *testing.T) {
 func TestRunPing_HTTPServerReachable(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "sk-test-fake")
 
 	// httptest server that responds 200 to GET /v1/models.
@@ -164,7 +166,7 @@ func TestRunPing_HTTPServerReachable(t *testing.T) {
 func TestRunPing_HTTPServer401(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "sk-test-fake")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -189,7 +191,7 @@ func TestRunPing_HTTPServer401(t *testing.T) {
 func TestRunPing_HTTPServer500(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "sk-test-fake")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -214,7 +216,7 @@ func TestRunPing_HTTPServer500(t *testing.T) {
 func TestRunPing_AnthropicAuthHeaders(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 
 	var gotAPIKey, gotVersion string
@@ -248,7 +250,7 @@ func TestRunPing_AnthropicAuthHeaders(t *testing.T) {
 func TestRunPing_WithPromptArg(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -275,7 +277,7 @@ func TestRunPing_InvalidURL(t *testing.T) {
 	// We need to go through runPing but it requires config resolution.
 	// Instead, test that with a model that doesn't exist, we get an error.
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	// Point config to a model that doesn't resolve.
 	tmpDir := t.TempDir()

--- a/internal/cli/resume_model_test.go
+++ b/internal/cli/resume_model_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // writeSessionMeta creates a session directory whose meta.json records model.
@@ -31,7 +32,7 @@ func withFlags(t *testing.T, session, model string) {
 
 func TestApplyResumedModel(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	writeSessionMeta(t, home, "sess-gpt", "gpt-5.6-luna")
 	writeSessionMeta(t, home, "sess-unknown", "unknown")
 
@@ -70,7 +71,7 @@ func TestApplyResumedModel(t *testing.T) {
 // would route the restored model to the wrong API.
 func TestApplyResumedModel_ClearsStaleProvider(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	writeSessionMeta(t, home, "sess-gpt", "gpt-5.6-luna")
 	withFlags(t, "sess-gpt", "")
 
@@ -89,7 +90,7 @@ func TestApplyResumedModel_ClearsStaleProvider(t *testing.T) {
 // rewritten, or an explicitly configured provider would be dropped for nothing.
 func TestApplyResumedModel_KeepsProviderWhenModelMatches(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	writeSessionMeta(t, home, "sess-same", "claude-sonnet-4-6")
 	withFlags(t, "sess-same", "")
 

--- a/internal/cli/root_cmd_test.go
+++ b/internal/cli/root_cmd_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestLoadRootConfig_ModelOverride(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	flagModel = "gpt-5.4-mini"
 	cfg, err := loadRootConfig()
@@ -31,7 +32,7 @@ func TestLoadRootConfig_ModelOverride(t *testing.T) {
 func TestLoadRootConfig_NoOverride(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	flagModel = ""
 	cfg, err := loadRootConfig()
@@ -45,7 +46,7 @@ func TestLoadRootConfig_NoOverride(t *testing.T) {
 func TestBuildRootRuntime_InvalidModel(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	// Set all known provider keys so we cover the key lookup.
 	t.Setenv("OPENAI_API_KEY", "key")
 	t.Setenv("ANTHROPIC_API_KEY", "key")
@@ -64,7 +65,7 @@ func TestBuildRootRuntime_InvalidModel(t *testing.T) {
 func TestBuildRootRuntime_ContinueNoSession(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	flagContinue = true
@@ -83,7 +84,7 @@ func TestBuildRootRuntime_ContinueNoSession(t *testing.T) {
 func TestBuildRootRuntime_HappyPath(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "key-ok")
 
 	flagModel = "gpt-5.4"
@@ -107,7 +108,7 @@ func TestBuildRootRuntime_HappyPath(t *testing.T) {
 func TestInitNonInteractiveRuntime_Basic(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	cfg := &config.Config{}
 	cwd := tmpHome
@@ -139,7 +140,7 @@ func TestInitNonInteractiveRuntime_CloseNil(t *testing.T) {
 func TestRunRoot_WithPprofFlag(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	// Use a weird port to avoid listen conflicts; even if it fails, we want
@@ -156,7 +157,7 @@ func TestRunRoot_WithPprofFlag(t *testing.T) {
 func TestRunRoot_WithPprofTrace(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	flagPprof = "trace"
@@ -180,7 +181,7 @@ func TestGitHelpersSkippableWithoutGit(t *testing.T) {
 
 func TestPalaceConfigFromCLI_Defaults(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 
 	cfg := palaceConfigFromCLI(&config.Config{})
 	if cfg.DBPath == "" {
@@ -208,7 +209,7 @@ func TestRunRoot_InvalidDotEnv(t *testing.T) {
 	// Write invalid .env (should not crash loadDotEnv).
 	os.WriteFile(filepath.Join(piDir, ".env"), []byte("invalid yaml: ["), 0644)
 
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 
 	cmd := newRootCmd()
@@ -220,7 +221,7 @@ func TestRunRoot_InvalidDotEnv(t *testing.T) {
 
 func TestRunRoot_NoAPIKeyWithOllamaModel(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	cfgDir := filepath.Join(tmpDir, ".pi-go")
 	os.MkdirAll(cfgDir, 0755)
 	os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(`{"roles":{"default":{"model":"llama3:8b","provider":"ollama"}}}`), 0644)

--- a/internal/cli/run_modes_test.go
+++ b/internal/cli/run_modes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/guardrail"
 	"github.com/dimetron/pi-go/internal/provider"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestResolveMode_ExplicitFlag(t *testing.T) {
@@ -56,7 +57,7 @@ func TestRunInteractive_CancelContext(t *testing.T) {
 	resetGlobalFlags(t)
 	flagMemoryOff = true
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	llm := &cliMockLLM{name: "test-interactive", response: "ok"}
 	cfg := config.Config{}
@@ -98,7 +99,7 @@ func provInfo(providerName, model string) provider.Info {
 func TestRunNonInteractive_JSONEmptyPromptEarlyExit(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	flagMemoryOff = true
@@ -113,7 +114,7 @@ func TestRunNonInteractive_JSONEmptyPromptEarlyExit(t *testing.T) {
 func TestRunNonInteractive_PrintEmptyPromptEarlyExit(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	flagMemoryOff = true
@@ -128,7 +129,7 @@ func TestRunNonInteractive_PrintEmptyPromptEarlyExit(t *testing.T) {
 func TestRunNonInteractive_WithSystemAndHooks(t *testing.T) {
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 	t.Setenv("OPENAI_API_KEY", "k")
 
 	cfgDir := filepath.Join(tmpDir, ".pi-go")

--- a/internal/cli/serve_cmd_test.go
+++ b/internal/cli/serve_cmd_test.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,6 +13,13 @@ import (
 )
 
 func TestRunServe_ValidHeadersShortRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// runServe only returns once it is interrupted, and a process cannot
+		// signal itself on Windows: os.Process.Signal supports Kill alone
+		// there, so the interrupt never lands and the server would keep
+		// running for the rest of the package.
+		t.Skip("cannot raise an interrupt against our own process on Windows")
+	}
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
 
@@ -58,6 +66,13 @@ func TestRunServe_ValidHeadersShortRun(t *testing.T) {
 }
 
 func TestRunServe_EmptyProjectUsesCWD(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// runServe only returns once it is interrupted, and a process cannot
+		// signal itself on Windows: os.Process.Signal supports Kill alone
+		// there, so the interrupt never lands and the server would keep
+		// running for the rest of the package.
+		t.Skip("cannot raise an interrupt against our own process on Windows")
+	}
 	resetGlobalFlags(t)
 	tmpDir := t.TempDir()
 

--- a/internal/cli/serve_run_test.go
+++ b/internal/cli/serve_run_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -17,6 +18,14 @@ import (
 // -----------------------------------------------------------------------
 
 func TestRunServe_CleanShutdown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The shutdown path under test is driven by SIGINT, and a process
+		// cannot deliver one to itself on Windows: os.Process.Signal supports
+		// only Kill there, so proc.Signal(syscall.SIGINT) returns an error and
+		// runServe would be left serving for the rest of the package run.
+		t.Skip("cannot raise SIGINT against our own process on Windows")
+	}
+
 	// Use an ephemeral port (:0) so we don't collide with other tests.
 	tmpDir := t.TempDir()
 
@@ -87,31 +96,27 @@ func TestRunServe_CleanShutdown(t *testing.T) {
 }
 
 func TestRunServe_LogFileOpenError(t *testing.T) {
-	// If the CWD is not writable, os.OpenFile("serve.log", ...) should fail.
-	// We simulate by pointing to a path that cannot be written.
-	// On most systems, we can create a read-only directory and chdir into it.
-	tmpDir := t.TempDir()
-	readOnly := filepath.Join(tmpDir, "ro")
-	if err := os.MkdirAll(readOnly, 0o555); err != nil {
+	// runServe opens ./serve.log before it does anything else, so a directory
+	// sitting at that name makes the open fail on every OS. The previous
+	// spelling -- chdir into a 0555 directory -- was a no-op on Windows, where
+	// mode bits do not restrict a directory: the open would succeed and
+	// runServe would go on to serve until it was signaled, hanging the test
+	// until the package timeout. It was also a no-op for root on Unix.
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "serve.log"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(readOnly, 0o755)
-
-	origCwd, _ := os.Getwd()
-	if err := os.Chdir(readOnly); err != nil {
-		t.Skip("could not chdir into read-only dir:", err)
-	}
-	defer func() { _ = os.Chdir(origCwd) }()
+	t.Chdir(dir)
 
 	origProject := flagServeProject
-	flagServeProject = readOnly
+	flagServeProject = dir
 	defer func() { flagServeProject = origProject }()
 
-	cmd := &cobra.Command{}
-	err := runServe(cmd, nil)
-	// Should fail to open serve.log (CWD is read-only) — but only if running
-	// as a non-root user. Root users can still write to 0555 dirs.
-	if err != nil && !strings.Contains(err.Error(), "serve.log") {
-		t.Logf("runServe error: %v", err)
+	err := runServe(&cobra.Command{}, nil)
+	if err == nil {
+		t.Fatal("runServe() = nil, want the serve.log open to fail")
+	}
+	if !strings.Contains(err.Error(), "serve.log") {
+		t.Errorf("runServe() = %v, want an error naming serve.log", err)
 	}
 }

--- a/internal/cli/session_state_test.go
+++ b/internal/cli/session_state_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestWriteLastSession_CreatesFile(t *testing.T) {
@@ -32,7 +34,7 @@ func TestWriteLastSession_CreatesFile(t *testing.T) {
 
 func TestLastLoggedError_CorruptedLogLine(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testenv.SetHome(t, tmpDir)
 
 	dateDir := filepath.Join(tmpDir, ".pi-go", "log", "2024-07-01")
 	if err := os.MkdirAll(dateDir, 0o755); err != nil {

--- a/internal/cli/session_state_test.go
+++ b/internal/cli/session_state_test.go
@@ -183,8 +183,14 @@ func TestCheckForRapidRestartAndWarn_OlderThan3Seconds(t *testing.T) {
 
 func TestWriteLastSession_MkdirAllError(t *testing.T) {
 	orig := lastSessionFile
-	// Point to a path that cannot be created.
-	lastSessionFile = "/sys/fake/last-session.json"
+	// Point to a path that cannot be created: a file below a regular file. A
+	// literal "/sys/fake/..." only fails on Linux; on Windows the leading slash
+	// is drive-relative and MkdirAll creates C:\sys\fake.
+	notADir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notADir, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lastSessionFile = filepath.Join(notADir, "last-session.json")
 	defer func() { lastSessionFile = orig }()
 
 	err := writeLastSession("/fake", "provider", "model")

--- a/internal/codex/client_test.go
+++ b/internal/codex/client_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // fakeServer is an in-process stand-in for `codex app-server`: it reads JSONL
@@ -413,10 +415,5 @@ func TestFindBinary_AbsolutePath(t *testing.T) {
 // returns its path.
 func writeFakeBinary(t *testing.T, name string) string {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write fake binary: %v", err)
-	}
-	return path
+	return testenv.FakeBinary(t, t.TempDir(), name)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestDefaults(t *testing.T) {
@@ -280,13 +282,7 @@ func TestLoad_WithGlobalAndProjectConfig(t *testing.T) {
 	}
 
 	// Override home directory
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", home); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.Setenv("HOME", origHome)
-	}()
+	testenv.SetHome(t, home)
 
 	// Change to project dir
 	origWd, _ := os.Getwd()
@@ -541,7 +537,7 @@ func TestLoad_MigratesDefaultModelToRolesActual(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	// Change to tmp dir so no project config is found.
 	origWd, _ := os.Getwd()
 	if err := os.Chdir(tmp); err != nil {
@@ -580,7 +576,7 @@ func TestLoad_MigratesDefaultModelWhenDefaultRoleMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	origWd, _ := os.Getwd()
 	if err := os.Chdir(tmp); err != nil {
 		t.Fatal(err)
@@ -642,7 +638,7 @@ func TestLoadMCPServers_GlobalOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	servers := LoadMCPServers()
 	if len(servers) != 1 {
 		t.Fatalf("expected 1 server, got %d", len(servers))
@@ -681,7 +677,7 @@ func TestLoadMCPServers_ProjectOverridesGlobal(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.Chdir(origWd) }()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	servers := LoadMCPServers()
 	if len(servers) != 1 {
@@ -696,7 +692,7 @@ func TestLoadMCPServers_NoFiles(t *testing.T) {
 	// Use a temp dir with no mcp.json anywhere.
 	tmp := t.TempDir()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	origWd, _ := os.Getwd()
 	if err := os.Chdir(tmp); err != nil {
@@ -733,7 +729,7 @@ func TestLoad_MergesMCPJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.Chdir(origWd) }()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	cfg, err := Load()
 	if err != nil {
@@ -774,7 +770,7 @@ func TestLoad_MCPConfigOverridesMCPJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.Chdir(origWd) }()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	cfg, err := Load()
 	if err != nil {
@@ -821,7 +817,7 @@ func TestLoadFrom_UsesProvidedCWDForProjectMCPJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.Chdir(origWd) }()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	cfg, err := LoadFrom(sessionCWD)
 	if err != nil {
@@ -853,7 +849,7 @@ func TestLoadMCPServers_ObjectFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.Chdir(origWd) }()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	servers := LoadMCPServers()
 	if len(servers) != 2 {
@@ -1130,9 +1126,7 @@ func TestMergeEnvFile_PreservesExistingKeys(t *testing.T) {
 func TestConfig_Save(t *testing.T) {
 	// Create a temp HOME directory.
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	testenv.SetHome(t, tmpDir)
 
 	cfg := &Config{
 		DefaultModel: "test-model",
@@ -1165,9 +1159,7 @@ func TestConfig_Save(t *testing.T) {
 
 func TestSaveDefaultRole(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	testenv.SetHome(t, tmpDir)
 
 	// SaveDefaultRole is a package-level function.
 	if err := SaveDefaultRole("my-model", "openai"); err != nil {

--- a/internal/eval/coverage.go
+++ b/internal/eval/coverage.go
@@ -1,0 +1,252 @@
+package eval
+
+import (
+	"sort"
+	"strings"
+)
+
+// Exclusion documents a registered tool that deliberately has no eval
+// scenario. Every tool in the inventory must be either targeted by a scenario
+// or excluded here with a reason — TestScenarios_CoverInventory enforces it —
+// so a new tool cannot silently go unmeasured.
+type Exclusion struct {
+	// Tool is the exact tool name, or a "prefix*" pattern for a whole family
+	// (e.g. "palace-*").
+	Tool   string `json:"tool"`
+	Reason string `json:"reason"`
+}
+
+// matches reports whether the exclusion covers the named tool.
+func (e Exclusion) matches(name string) bool {
+	if strings.HasSuffix(e.Tool, "*") {
+		return strings.HasPrefix(name, strings.TrimSuffix(e.Tool, "*"))
+	}
+	return e.Tool == name
+}
+
+// Coverage status values, from best to worst.
+const (
+	// CoverageOK: the tool was called and at least one call produced a
+	// result that does not look like an error.
+	CoverageOK = "ok"
+	// CoverageErrorsOnly: every call to the tool produced an error-looking
+	// result (or no result at all).
+	CoverageErrorsOnly = "errors-only"
+	// CoverageNotCalled: the tool has a scenario but no trajectory called it.
+	CoverageNotCalled = "not-called"
+	// CoverageExcluded: the tool is documented as excluded from the suite.
+	CoverageExcluded = "excluded"
+	// CoverageUnmapped: the tool has neither a scenario nor an exclusion.
+	// This is the state the mapping test exists to prevent.
+	CoverageUnmapped = "unmapped"
+)
+
+// ToolCoverage is one row of the coverage matrix.
+type ToolCoverage struct {
+	Name     string `json:"name"`
+	Group    string `json:"group"`
+	Requires string `json:"requires,omitempty"`
+	// Scenarios that target this tool (may be empty for excluded tools).
+	Scenarios []string `json:"scenarios,omitempty"`
+	// Excluded carries the exclusion reason when the tool is excluded.
+	Excluded string `json:"excluded,omitempty"`
+	Calls    int    `json:"calls"`
+	Results  int    `json:"results"`
+	Errors   int    `json:"errors"`
+	Wasted   int    `json:"wasted"`
+	Status   string `json:"status"`
+}
+
+// Coverage is the tool coverage matrix for a set of trajectories against the
+// registered tool inventory.
+type Coverage struct {
+	Tools []ToolCoverage `json:"tools"`
+	// Summary counts over Tools.
+	Total     int `json:"total"`
+	OK        int `json:"ok"`
+	NotCalled int `json:"not_called"`
+	Errors    int `json:"errors_only"`
+	Excluded  int `json:"excluded"`
+	Unmapped  int `json:"unmapped"`
+	// Unknown lists tools that were called but are not in the inventory —
+	// MCP tools, or a tool the inventory does not know how to construct.
+	Unknown []string `json:"unknown,omitempty"`
+	// Gap is the list of non-excluded tools that were never successfully
+	// exercised (status not-called, errors-only or unmapped).
+	Gap []string `json:"gap,omitempty"`
+}
+
+// ComputeCoverage builds the coverage matrix: for each inventoried tool, the
+// scenarios targeting it, its exclusion (if any), and what the trajectories
+// show — calls, results, error-looking results and wasted calls.
+func ComputeCoverage(inv []ToolInfo, scenarios []Scenario, exclusions []Exclusion, loaded []*LoadedTrajectory) Coverage {
+	targets := scenarioTargets(scenarios)
+	calls := callStatsByTool(loaded)
+
+	cov := Coverage{Total: len(inv)}
+	known := make(map[string]bool, len(inv))
+	for _, ti := range inv {
+		known[ti.Name] = true
+		row := ToolCoverage{
+			Name:      ti.Name,
+			Group:     ti.Group,
+			Requires:  ti.Requires,
+			Scenarios: targets[ti.Name],
+			Excluded:  exclusionReason(exclusions, ti.Name),
+		}
+		if st, ok := calls[ti.Name]; ok {
+			row.Calls, row.Results, row.Errors, row.Wasted = st.calls, st.results, st.errors, st.wasted
+		}
+		row.Status = coverageStatus(row)
+		cov.Tools = append(cov.Tools, row)
+		cov.count(row)
+	}
+
+	for name := range calls {
+		if !known[name] {
+			cov.Unknown = append(cov.Unknown, name)
+		}
+	}
+	sort.Strings(cov.Unknown)
+	sort.Strings(cov.Gap)
+	return cov
+}
+
+// count folds one row into the summary counters.
+func (c *Coverage) count(row ToolCoverage) {
+	switch row.Status {
+	case CoverageOK:
+		c.OK++
+	case CoverageExcluded:
+		c.Excluded++
+	case CoverageNotCalled:
+		c.NotCalled++
+		c.Gap = append(c.Gap, row.Name)
+	case CoverageErrorsOnly:
+		c.Errors++
+		c.Gap = append(c.Gap, row.Name)
+	case CoverageUnmapped:
+		c.Unmapped++
+		c.Gap = append(c.Gap, row.Name)
+	}
+}
+
+// coverageStatus derives a row's status. A successful call wins over an
+// exclusion: an excluded tool that was exercised anyway is covered, and the
+// exclusion reason stays on the row for context.
+func coverageStatus(row ToolCoverage) string {
+	switch {
+	case row.Results-row.Errors > 0:
+		return CoverageOK
+	case row.Calls > 0:
+		return CoverageErrorsOnly
+	case row.Excluded != "":
+		return CoverageExcluded
+	case len(row.Scenarios) > 0:
+		return CoverageNotCalled
+	default:
+		return CoverageUnmapped
+	}
+}
+
+// exclusionReason returns the reason of the first exclusion matching name.
+func exclusionReason(exclusions []Exclusion, name string) string {
+	for _, e := range exclusions {
+		if e.matches(name) {
+			return e.Reason
+		}
+	}
+	return ""
+}
+
+// scenarioTargets maps every tool name to the scenarios that target it,
+// expanding alternatives ("grep|ripgrep") so either spelling is covered.
+func scenarioTargets(scenarios []Scenario) map[string][]string {
+	out := make(map[string][]string)
+	for _, s := range scenarios {
+		for _, target := range s.Tools {
+			for _, name := range strings.Split(target, "|") {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				out[name] = append(out[name], s.Name)
+			}
+		}
+	}
+	return out
+}
+
+// UnmappedTools returns the inventory tools that have neither a scenario
+// targeting them nor an exclusion. A non-empty result means the suite has a
+// blind spot; the mapping test fails on it.
+func UnmappedTools(inv []ToolInfo, scenarios []Scenario, exclusions []Exclusion) []string {
+	targets := scenarioTargets(scenarios)
+	var out []string
+	for _, ti := range inv {
+		if len(targets[ti.Name]) == 0 && exclusionReason(exclusions, ti.Name) == "" {
+			out = append(out, ti.Name)
+		}
+	}
+	return out
+}
+
+// UnknownTargets returns scenario tool targets that match nothing in the
+// inventory — a typo, a renamed tool, or a tool that was removed. For an
+// alternatives target ("grep|ripgrep") at least one alternative must exist.
+func UnknownTargets(inv []ToolInfo, scenarios []Scenario) []string {
+	known := make(map[string]bool, len(inv))
+	for _, ti := range inv {
+		known[ti.Name] = true
+	}
+	var out []string
+	for _, s := range scenarios {
+		for _, target := range s.Tools {
+			if !anyKnown(known, target) {
+				out = append(out, s.Name+": "+target)
+			}
+		}
+	}
+	return out
+}
+
+func anyKnown(known map[string]bool, target string) bool {
+	for _, name := range strings.Split(target, "|") {
+		if known[strings.TrimSpace(name)] {
+			return true
+		}
+	}
+	return false
+}
+
+// toolCallStats is the per-tool call bookkeeping shared by the coverage matrix
+// and the scenario evaluation.
+type toolCallStats struct {
+	calls, results, errors, wasted int
+}
+
+// callStatsByTool pairs every call in every trajectory with its observation
+// and folds the outcome into per-tool counts.
+func callStatsByTool(loaded []*LoadedTrajectory) map[string]toolCallStats {
+	out := make(map[string]toolCallStats)
+	for _, lt := range loaded {
+		if lt == nil || lt.Traj == nil {
+			continue
+		}
+		for _, rec := range pairCalls(lt.Traj) {
+			st := out[rec.fn]
+			st.calls++
+			switch {
+			case !rec.observed:
+				st.wasted++
+			case rec.isError:
+				st.results++
+				st.errors++
+			default:
+				st.results++
+			}
+			out[rec.fn] = st
+		}
+	}
+	return out
+}

--- a/internal/eval/coverage_test.go
+++ b/internal/eval/coverage_test.go
@@ -1,0 +1,242 @@
+package eval
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/atif"
+)
+
+func TestInventory_CoreAndOptionalGroups(t *testing.T) {
+	inv, err := Inventory(t.TempDir())
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	byName := make(map[string]ToolInfo, len(inv))
+	for _, ti := range inv {
+		if ti.Name == "" {
+			t.Errorf("tool with empty name in group %s", ti.Group)
+		}
+		if _, dup := byName[ti.Name]; dup {
+			t.Errorf("duplicate tool name %q", ti.Name)
+		}
+		byName[ti.Name] = ti
+	}
+	// The core set the CLI always registers in print mode.
+	for _, name := range []string{"read", "read_image", "write", "edit", "bash", "find", "ls", "tree",
+		"git-overview", "git-file-diff", "git-hunk", "session-stats", "bash_wait", "bash_kill", "subagent"} {
+		ti, ok := byName[name]
+		if !ok {
+			t.Errorf("core tool %q missing from inventory", name)
+			continue
+		}
+		if ti.Requires != "" {
+			t.Errorf("core tool %q should not have a requirement, got %q", name, ti.Requires)
+		}
+	}
+	if _, grep := byName["grep"]; !grep {
+		if _, rg := byName["ripgrep"]; !rg {
+			t.Error("neither grep nor ripgrep in inventory")
+		}
+	}
+	// Optional groups carry the capability they are gated on.
+	for name, want := range map[string]string{
+		"mem-search": "memory", "lsp-symbols": "lsp", "fetch_docs": "llms-config",
+		"a2a": "a2a-config", "palace-status": "palace", "google_search": "gemini",
+	} {
+		ti, ok := byName[name]
+		if !ok {
+			t.Errorf("optional tool %q missing from inventory", name)
+			continue
+		}
+		if ti.Requires != want {
+			t.Errorf("%q requires %q, want %q", name, ti.Requires, want)
+		}
+	}
+	if got := ToolNames(inv); len(got) != len(inv) || got[0] != inv[0].Name {
+		t.Errorf("ToolNames mismatch: %v", got)
+	}
+}
+
+// loadFixture writes the trajectories to a temp sessions dir and loads them
+// back through LoadTrajectories, so content goes through JSON like a real run.
+func loadFixture(t *testing.T, trajs ...*atif.Trajectory) []*LoadedTrajectory {
+	t.Helper()
+	dir := t.TempDir()
+	for _, traj := range trajs {
+		writeTraj(t, dir, traj.SessionID, traj)
+	}
+	loaded, err := LoadTrajectories(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loaded
+}
+
+func callStep(id int, callID, fn string, args map[string]any, result any) atif.Step {
+	s := atif.Step{
+		StepID:    id,
+		ToolCalls: []atif.ToolCall{{ToolCallID: callID, FunctionName: fn, Arguments: args}},
+	}
+	if result != nil {
+		s.Observation = &atif.Observation{Results: []atif.ObservationResult{{SourceCallID: callID, Content: result}}}
+	}
+	return s
+}
+
+func TestComputeCoverage_Statuses(t *testing.T) {
+	inv := []ToolInfo{
+		{Name: "read", Group: "core"},
+		{Name: "bash", Group: "core"},
+		{Name: "write", Group: "core"},
+		{Name: "a2a", Group: "a2a", Requires: "a2a-config"},
+		{Name: "palace-status", Group: "palace", Requires: "palace"},
+		{Name: "mystery", Group: "core"},
+	}
+	scenarios := []Scenario{
+		{Name: "s-read", Tools: []string{"read"}},
+		{Name: "s-bash", Tools: []string{"bash", "write"}},
+		{Name: "s-read-2", Tools: []string{"read"}},
+	}
+	exclusions := []Exclusion{
+		{Tool: "a2a", Reason: "external service"},
+		{Tool: "palace-*", Reason: "needs palace"},
+	}
+	loaded := loadFixture(t, &atif.Trajectory{SessionID: "s1", Steps: []atif.Step{
+		callStep(1, "c1", "read", map[string]any{"path": "a"}, map[string]any{"content": "x"}),
+		callStep(2, "c2", "read", map[string]any{"path": "b"}, map[string]any{"error": "not found"}),
+		callStep(3, "c3", "bash", map[string]any{"command": "false"}, map[string]any{"exit_code": 1, "stdout": ""}),
+		callStep(4, "c4", "bash", map[string]any{"command": "x"}, nil), // wasted
+		callStep(5, "c5", "mcp_thing", map[string]any{}, map[string]any{"ok": true}),
+	}})
+
+	cov := ComputeCoverage(inv, scenarios, exclusions, loaded)
+
+	want := map[string]string{
+		"read":          CoverageOK,
+		"bash":          CoverageErrorsOnly,
+		"write":         CoverageNotCalled,
+		"a2a":           CoverageExcluded,
+		"palace-status": CoverageExcluded,
+		"mystery":       CoverageUnmapped,
+	}
+	rows := make(map[string]ToolCoverage)
+	for _, row := range cov.Tools {
+		rows[row.Name] = row
+	}
+	for name, status := range want {
+		if rows[name].Status != status {
+			t.Errorf("%s: status %q, want %q", name, rows[name].Status, status)
+		}
+	}
+	if r := rows["read"]; r.Calls != 2 || r.Results != 2 || r.Errors != 1 || !reflect.DeepEqual(r.Scenarios, []string{"s-read", "s-read-2"}) {
+		t.Errorf("read row = %+v", r)
+	}
+	if r := rows["bash"]; r.Calls != 2 || r.Results != 1 || r.Errors != 1 || r.Wasted != 1 {
+		t.Errorf("bash row = %+v", r)
+	}
+	if rows["a2a"].Excluded != "external service" || rows["palace-status"].Excluded != "needs palace" {
+		t.Errorf("exclusion reasons not carried: %+v / %+v", rows["a2a"], rows["palace-status"])
+	}
+	if cov.Total != 6 || cov.OK != 1 || cov.Errors != 1 || cov.NotCalled != 1 || cov.Excluded != 2 || cov.Unmapped != 1 {
+		t.Errorf("summary = %+v", cov)
+	}
+	if !reflect.DeepEqual(cov.Gap, []string{"bash", "mystery", "write"}) {
+		t.Errorf("gap = %v", cov.Gap)
+	}
+	if !reflect.DeepEqual(cov.Unknown, []string{"mcp_thing"}) {
+		t.Errorf("unknown = %v", cov.Unknown)
+	}
+}
+
+func TestComputeCoverage_ExcludedButCalledIsOK(t *testing.T) {
+	inv := []ToolInfo{{Name: "a2a", Group: "a2a"}}
+	loaded := loadFixture(t, &atif.Trajectory{SessionID: "s1", Steps: []atif.Step{
+		callStep(1, "c1", "a2a", nil, map[string]any{"response": "hi"}),
+	}})
+	cov := ComputeCoverage(inv, nil, []Exclusion{{Tool: "a2a", Reason: "x"}}, loaded)
+	if cov.Tools[0].Status != CoverageOK || cov.Tools[0].Excluded != "x" {
+		t.Errorf("row = %+v", cov.Tools[0])
+	}
+}
+
+func TestUnmappedAndUnknownTargets(t *testing.T) {
+	inv := []ToolInfo{{Name: "read"}, {Name: "ripgrep"}, {Name: "write"}, {Name: "palace-a"}, {Name: "palace-b"}}
+	scenarios := []Scenario{
+		{Name: "a", Tools: []string{"read", "grep|ripgrep"}},
+		{Name: "b", Tools: []string{"nope", "grep|rg"}},
+	}
+	exclusions := []Exclusion{{Tool: "palace-*", Reason: "r"}}
+
+	if got := UnmappedTools(inv, scenarios, exclusions); !reflect.DeepEqual(got, []string{"write"}) {
+		t.Errorf("UnmappedTools = %v", got)
+	}
+	if got := UnknownTargets(inv, scenarios); !reflect.DeepEqual(got, []string{"b: nope", "b: grep|rg"}) {
+		t.Errorf("UnknownTargets = %v", got)
+	}
+}
+
+func TestLooksLikeError_StructuredResults(t *testing.T) {
+	cases := []struct {
+		name    string
+		content any
+		want    bool
+	}{
+		{"error field", map[string]any{"error": "boom"}, true},
+		{"empty error field", map[string]any{"error": "", "content": "ok"}, false},
+		{"nonzero exit (float)", map[string]any{"exit_code": float64(2)}, true},
+		{"nonzero exit (int)", map[string]any{"exit_code": 127}, true},
+		{"zero exit", map[string]any{"exit_code": 0, "stdout": "hi"}, false},
+		{"running (-1)", map[string]any{"exit_code": -1, "running": true}, false},
+		{"plain map", map[string]any{"content": "error: nothing"}, false},
+		{"string marker", "command not found", true},
+		{"string clean", "all good", false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeError(tc.content); got != tc.want {
+			t.Errorf("%s: looksLikeError = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestComputeToolsMetrics_CountsStructuredErrors(t *testing.T) {
+	loaded := loadFixture(t, &atif.Trajectory{SessionID: "s1", Steps: []atif.Step{
+		callStep(1, "c1", "bash", map[string]any{"command": "false"}, map[string]any{"exit_code": 1}),
+		callStep(2, "c2", "read", map[string]any{"path": "x"}, map[string]any{"error": "not found"}),
+		callStep(3, "c3", "read", map[string]any{"path": "y"}, map[string]any{"content": "ok"}),
+	}})
+	m := ComputeToolsMetrics(loaded)
+	if m.ByTool["bash"].Errors != 1 || m.ByTool["read"].Errors != 1 || m.ByTool["read"].Results != 2 {
+		t.Errorf("by tool = %+v", m.ByTool)
+	}
+}
+
+func TestExclusion_Matches(t *testing.T) {
+	if !(Exclusion{Tool: "palace-*"}).matches("palace-search") {
+		t.Error("glob should match prefix")
+	}
+	if (Exclusion{Tool: "palace-*"}).matches("mem-search") {
+		t.Error("glob should not match other prefix")
+	}
+	if !(Exclusion{Tool: "a2a"}).matches("a2a") || (Exclusion{Tool: "a2a"}).matches("a2a-x") {
+		t.Error("exact match semantics broken")
+	}
+}
+
+// The JSON shape of the coverage report is consumed by the PR body / CI
+// tooling; pin the field names.
+func TestCoverage_JSONShape(t *testing.T) {
+	cov := ComputeCoverage([]ToolInfo{{Name: "read", Group: "core"}}, []Scenario{{Name: "s", Tools: []string{"read"}}}, nil, nil)
+	data, err := json.Marshal(cov)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"tools"`, `"total"`, `"ok"`, `"not_called"`, `"errors_only"`, `"excluded"`, `"unmapped"`, `"gap"`, `"status":"not-called"`} {
+		if !strings.Contains(string(data), key) {
+			t.Errorf("coverage JSON missing %s: %s", key, data)
+		}
+	}
+}

--- a/internal/eval/eval.md
+++ b/internal/eval/eval.md
@@ -160,3 +160,76 @@ grading its own trace is a weaker check.
   `TempDir`'s cleanup cannot unlink those files and fails the test *after* a
   successful measurement. The harness chmods the tree writable before removing
   it, and logs rather than fails if removal still cannot finish.
+
+## Tool-coverage eval (`make eval-tools`)
+
+`make eval-tools` answers a different question from `make eval-run`: not "how
+well does `/run` orchestrate", but **"does the agent actually use every tool it
+advertises, and does each tool work when it does?"**. It is a suite of small
+headless scenarios — one per tool family — each run through the real `pi`
+binary in print mode, graded deterministically, and rolled up into a coverage
+matrix over the registered tool inventory. The scenarios and the runner live in
+`internal/eval/scenarios/` (see its README for the scenario table, the check
+vocabulary and how to add one); the pure pieces live here:
+
+| piece | what it does |
+|---|---|
+| `Inventory` (`inventory.go`) | enumerates every tool by constructing them through the same constructors the CLI uses (core, bash-control, subagent, memory, lsp, llms, a2a, palace, Gemini grounding). Not a hand-kept list — a new tool shows up automatically. |
+| `Scenario` / `Check` / `EvaluateScenario` (`scenario.go`) | the declarative scenario shape, workspace/memory seeding, and the grader: every target tool called with ≥1 non-error result, every check satisfied. |
+| `ComputeCoverage` (`coverage.go`) | the matrix: per tool, its scenarios or exclusion, calls/results/errors/wasted from the trajectories, and a status (`ok`, `errors-only`, `not-called`, `excluded`, `unmapped`). `UnmappedTools` / `UnknownTargets` back the mapping test. |
+| `ToolsReport` (`report_tools.go`) | JSON + Markdown report, `eval-reports/eval-tools-<ts>.{json,md}`. |
+| `JudgeTools` (`judge_tools.go`) | an advisory LLM grade on `outcome_correctness`, `tool_selection`, `tools_efficiency`, `trajectory_quality`; same degrade-to-a-note semantics as the `/run` judge. `ProviderComplete` builds the judge's LLM call from a model name. |
+
+**Structured error detection.** ATIF records a tool's response map, not a
+string, so `looksLikeError` now also recognizes `{"error": "..."}` (how the ADK
+runner reports a tool failure), a non-empty `error` field, and a bash
+`exit_code` that is neither 0 nor −1. This improves the `errors` column of the
+`/run` report too.
+
+### Running
+
+```bash
+make build
+make eval-tools                                   # whole suite, report in eval-reports/
+PI_EVAL_SCENARIO=git,edit make eval-tools         # a subset
+go test -tags e2e -run 'TestEvalTools/scenario/grep' ./internal/eval/scenarios/   # one, via -run
+PI_EVAL_JUDGE_MODEL=claude-sonnet-4-6 make eval-tools-judge
+```
+
+| Env | Effect |
+|---|---|
+| `PI_EVAL_TOOLS=1` | Gate; the test skips without it. Set by the Makefile targets. |
+| `PI_BINARY`, `PI_EVAL_MODEL`, `PI_EVAL_OUT`, `PI_EVAL_JUDGE_MODEL`, `PI_EVAL_JUDGE_MAX_CALLS` | As for `eval-run`. |
+| `PI_EVAL_SCENARIO` | Comma-separated scenario names to run. A filtered run's coverage gap is partial and the report says so. |
+| `PI_EVAL_THINKING` | Thinking level in the seeded config. Default `none` — cheapest, and the only level every model accepts. |
+| `PI_EVAL_TIMEOUT` | Per-scenario timeout (default `5m`; slow scenarios carry their own longer floor). |
+| `PI_EVAL_STRICT=1` | Fail the subtest on a scenario FAIL/ERROR and the run on a non-empty coverage gap. Default: outcomes are reported, not asserted, like `eval-run`. |
+| `PI_EVAL_SERIAL=1` | Run scenarios one at a time (default: parallel subtests, `-parallel 4`). |
+| `PI_EVAL_OFFLINE=1`, `PI_EVAL_NO_VISION=1` | Declare the host cannot do network / vision; scenarios requiring them are skipped. LSP availability is probed. |
+
+Each scenario gets its own isolated `HOME` (seeded `config.json`: the eval
+model on every role, memory/palace off unless the scenario seeds memory, no
+hooks/MCP/A2A) and its own workspace, so a scenario cannot see another's
+sessions and the user's real `~/.pi-go` is never touched. Git signing is forced
+off for the run, as in `eval-run`.
+
+### The coverage gate is a unit test
+
+`TestScenarios_CoverInventory` in `internal/eval/scenarios` runs in `make test`
+(no binary, no model) and fails when a registered tool has neither a scenario
+nor an entry in `Exclusions`, when a scenario targets a tool that does not
+exist, or when an exclusion is stale. That is what makes "every tool has an
+eval" a property of the repo rather than a one-time audit.
+
+### Interpreting the report
+
+- **Scenarios** — PASS/FAIL/skip/ERROR per scenario with per-tool ✓/✗ and each
+  check's outcome. `skip` means an unmet host requirement; `ERROR` means the
+  `pi` process itself failed (its output tail is in the JSON).
+- **Tool coverage** — the matrix. `gap` is the list of non-excluded tools that
+  no scenario exercised successfully; on a full, unfiltered run it should be
+  empty. `called but not inventoried` catches MCP tools or a constructor the
+  inventory does not know.
+- **Tools efficiency / Tokens** — the same metrics as the `/run` report, over
+  every trajectory the suite produced (including subagents).
+- **LLM judge** — advisory, as above.

--- a/internal/eval/inventory.go
+++ b/internal/eval/inventory.go
@@ -1,0 +1,149 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	adktool "google.golang.org/adk/v2/tool"
+
+	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/lsp"
+	"github.com/dimetron/pi-go/internal/memory"
+	"github.com/dimetron/pi-go/internal/palace"
+	"github.com/dimetron/pi-go/internal/subagent"
+	"github.com/dimetron/pi-go/internal/tools"
+)
+
+// ToolInfo describes one tool the pi agent can expose to the model.
+type ToolInfo struct {
+	// Name is the function name the model calls — exactly what lands in
+	// ATIF tool_calls[].function_name.
+	Name string `json:"name"`
+	// Group is the constructor family the tool comes from (core, bash-control,
+	// subagent, memory, lsp, llms, a2a, palace, provider).
+	Group string `json:"group"`
+	// Requires names the capability the tool is gated on in a real session:
+	// "" when it is always registered in print mode, otherwise the config or
+	// environment a session needs before the tool is advertised at all.
+	Requires string `json:"requires,omitempty"`
+}
+
+// Inventory enumerates every tool the pi agent can register, by constructing
+// them through the same constructors the CLI uses (tools.CoreTools,
+// tools.BashControlTools, tools.SubagentTools, tools.MemoryTools,
+// tools.LSPToolsFor, tools.LLMSTools, tools.A2ATools, palace.PalaceTools and
+// the Gemini grounding tool). It is the source of truth for "which tools
+// exist": a tool added to any of those constructors shows up here without
+// anyone editing a list, which is what lets the coverage check catch a new
+// tool that has no eval scenario.
+//
+// Tools are constructed against a throwaway sandbox rooted at dir and never
+// run, so the call is cheap and side-effect free. Optional groups are built
+// with an empty configuration (no LSP server, no llms sources, no A2A agents,
+// an in-memory observation store, a zero palace): the tool objects exist
+// regardless of whether the capability behind them would work, which is
+// exactly what is needed to learn their names.
+func Inventory(dir string) ([]ToolInfo, error) {
+	var out []ToolInfo
+	add := func(group, requires string, ts []adktool.Tool) {
+		for _, t := range ts {
+			out = append(out, ToolInfo{Name: t.Name(), Group: group, Requires: requires})
+		}
+	}
+
+	sb, err := tools.NewSandbox(dir)
+	if err != nil {
+		return nil, fmt.Errorf("inventory sandbox: %w", err)
+	}
+	defer func() { _ = sb.Close() }()
+
+	sup := tools.NewBashSupervisor()
+	core, err := tools.CoreTools(sb, tools.WithBashSupervisor(sup))
+	if err != nil {
+		return nil, fmt.Errorf("inventory core tools: %w", err)
+	}
+	add("core", "", core)
+
+	bashCtl, err := tools.BashControlTools(sup)
+	if err != nil {
+		return nil, fmt.Errorf("inventory bash control tools: %w", err)
+	}
+	add("bash-control", "", bashCtl)
+
+	cfg := config.Defaults()
+	orch := subagent.NewOrchestrator(&cfg, "", nil)
+	defer orch.Shutdown()
+	sub, err := tools.SubagentTools(orch, nil)
+	if err != nil {
+		return nil, fmt.Errorf("inventory subagent tools: %w", err)
+	}
+	add("subagent", "", sub)
+
+	memDB, err := memory.OpenDB(":memory:")
+	if err != nil {
+		return nil, fmt.Errorf("inventory memory store: %w", err)
+	}
+	memStore := memory.NewSQLiteStore(memDB)
+	memTools, err := tools.MemoryTools(memStore)
+	_ = memStore.Close()
+	if err != nil {
+		return nil, fmt.Errorf("inventory memory tools: %w", err)
+	}
+	add("memory", "memory", memTools)
+
+	lspTools, err := tools.LSPToolsFor(lsp.NewManager(nil), tools.LSPFull)
+	if err != nil {
+		return nil, fmt.Errorf("inventory lsp tools: %w", err)
+	}
+	add("lsp", "lsp", lspTools)
+
+	add("llms", "llms-config", tools.LLMSTools(tools.NewLLMSToolset(&config.LLMSConfig{})))
+	add("a2a", "a2a-config", tools.A2ATools(tools.NewClientCache(&config.A2AConfig{})))
+
+	palaceTools, err := palace.PalaceTools(&palace.Palace{})
+	if err != nil {
+		return nil, fmt.Errorf("inventory palace tools: %w", err)
+	}
+	add("palace", "palace", palaceTools)
+
+	// The grounding tool is provider-supplied (Gemini only); it is gated on
+	// the PI_NO_GROUNDING kill switch, which must not hide it from the
+	// inventory.
+	if gt, ok := withEnvUnset("PI_NO_GROUNDING", func() (adktool.Tool, bool) {
+		return agent.GeminiGroundingTool("gemini")
+	}); ok {
+		add("provider", "gemini", []adktool.Tool{gt})
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Group != out[j].Group {
+			return out[i].Group < out[j].Group
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// withEnvUnset runs fn with the named environment variable cleared and
+// restores it afterwards.
+func withEnvUnset[T any](name string, fn func() (T, bool)) (T, bool) {
+	prev, had := os.LookupEnv(name)
+	_ = os.Unsetenv(name)
+	defer func() {
+		if had {
+			_ = os.Setenv(name, prev)
+		}
+	}()
+	return fn()
+}
+
+// ToolNames returns the names of an inventory in order.
+func ToolNames(inv []ToolInfo) []string {
+	names := make([]string, 0, len(inv))
+	for _, ti := range inv {
+		names = append(names, ti.Name)
+	}
+	return names
+}

--- a/internal/eval/judge_tools.go
+++ b/internal/eval/judge_tools.go
@@ -1,0 +1,182 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	llmmodel "google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/provider"
+)
+
+// ToolsJudgeDimensions are the axes the tool-coverage judge grades.
+var ToolsJudgeDimensions = []string{
+	"outcome_correctness",
+	"tool_selection",
+	"tools_efficiency",
+	"trajectory_quality",
+}
+
+const toolsJudgeSystemPrompt = `You are grading the execution traces of an autonomous coding agent across a suite of
+small tool-usage scenarios, not the code it wrote.
+
+Each scenario seeds a workspace and asks the agent to accomplish something that a competent
+agent would do with specific tools (read, edit, grep, git-*, subagent, lsp-*, ...). You are
+given the per-scenario verdicts the harness computed deterministically (target tools called,
+assertions on files and results), the tool coverage matrix, and a condensed tool-call
+timeline per scenario.
+
+Grade these dimensions from 1 (bad) to 5 (excellent):
+
+- outcome_correctness: did the scenarios reach their goals? Weigh the harness verdicts most
+  heavily. A suite where several scenarios failed their assertions cannot score above 2.
+- tool_selection: did the agent pick the tool the task called for — the dedicated tool
+  rather than a bash workaround, and without calling tools the task did not need?
+- tools_efficiency: were tool calls economical? Penalize duplicate calls, calls whose
+  results were never used, error-producing calls repeated without changing approach, and
+  pulling far more content than needed.
+- trajectory_quality: was each path direct and purposeful? Penalize aimless exploration,
+  re-reading the same files, and long detours before the first relevant call.
+
+Judge only what the evidence shows. If the timeline is too sparse to assess a dimension,
+score it 3 and say so in the rationale.
+
+Reply with ONLY a JSON object, no prose and no code fences:
+
+{
+  "scores": [
+    {"dimension": "outcome_correctness", "score": 1-5, "rationale": "one or two sentences"},
+    {"dimension": "tool_selection", "score": 1-5, "rationale": "..."},
+    {"dimension": "tools_efficiency", "score": 1-5, "rationale": "..."},
+    {"dimension": "trajectory_quality", "score": 1-5, "rationale": "..."}
+  ],
+  "verdict": "pass" or "fail",
+  "summary": "two or three sentences on how this suite went",
+  "issues": ["specific, actionable problem", "..."]
+}
+
+Set verdict to "fail" if more than a quarter of the scenarios failed or any dimension scores 1.`
+
+// JudgeTools asks an LLM to grade a tool-coverage run. Like Judge, every
+// failure comes back as a verdict carrying Error rather than a Go error, so an
+// unavailable judge degrades the report instead of failing the eval.
+func JudgeTools(ctx context.Context, complete CompleteFunc, model string, r *ToolsReport, digest string) JudgeVerdict {
+	if complete == nil {
+		return JudgeVerdict{Model: model, Error: "no judge model configured"}
+	}
+	reply, err := complete(ctx, toolsJudgeSystemPrompt, BuildToolsJudgePrompt(r, digest))
+	if err != nil {
+		return JudgeVerdict{Model: model, Error: err.Error()}
+	}
+	v, err := ParseJudgeVerdict(reply)
+	if err != nil {
+		return JudgeVerdict{Model: model, Error: err.Error()}
+	}
+	v.Model = model
+	return v
+}
+
+// BuildToolsJudgePrompt renders the evidence the tools judge grades: the
+// per-scenario verdicts, the coverage summary, then the per-scenario
+// tool-call timelines.
+func BuildToolsJudgePrompt(r *ToolsReport, digest string) string {
+	var b strings.Builder
+	b.WriteString("# Tool-coverage suite under review\n\n")
+	if r != nil {
+		writeToolsEvidence(&b, r)
+	}
+	if strings.TrimSpace(digest) != "" {
+		b.WriteString("\n## Tool-call timelines\n\n")
+		b.WriteString(digest)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func writeToolsEvidence(b *strings.Builder, r *ToolsReport) {
+	fmt.Fprintf(b, "Model: %s\n\n", r.Metadata.Model)
+	fmt.Fprintf(b, "## Scenarios (%d passed, %d failed, %d skipped, %d errored)\n\n",
+		r.Metadata.Passed, r.Metadata.Failed, r.Metadata.Skipped, r.Metadata.Errored)
+	for _, s := range r.Scenarios {
+		fmt.Fprintf(b, "- %s: %s", s.Name, s.Status)
+		if s.Reason != "" {
+			fmt.Fprintf(b, " — %s", truncate(oneLine(s.Reason), 300))
+		}
+		fmt.Fprintf(b, " (%d session(s), %d tool call(s))\n", s.Sessions, s.ToolCalls)
+	}
+
+	c := r.Coverage
+	fmt.Fprintf(b, "\n## Coverage\n\n")
+	fmt.Fprintf(b, "- registered tools: %d; exercised ok: %d; errors only: %d; not called: %d; excluded: %d; unmapped: %d\n",
+		c.Total, c.OK, c.Errors, c.NotCalled, c.Excluded, c.Unmapped)
+	if len(c.Gap) > 0 {
+		fmt.Fprintf(b, "- gap: %s\n", strings.Join(c.Gap, ", "))
+	}
+
+	tm := r.Tools
+	fmt.Fprintf(b, "\n## Tools\n\n")
+	fmt.Fprintf(b, "- total calls: %d (results: %d)\n", tm.TotalCalls, tm.TotalResults)
+	fmt.Fprintf(b, "- calls with no result: %d\n", tm.Wasted)
+	fmt.Fprintf(b, "- duplicate calls (same tool, same arguments): %d\n", tm.Duplicates)
+	if len(tm.ByTool) > 0 {
+		b.WriteString("\n| tool | calls | errors | wasted | duplicates | avg result bytes |\n")
+		b.WriteString("|---|---|---|---|---|---|\n")
+		for _, name := range sortedKeys(tm.ByTool) {
+			st := tm.ByTool[name]
+			fmt.Fprintf(b, "| %s | %d | %d | %d | %d | %d |\n",
+				name, st.Calls, st.Errors, st.Wasted, st.Duplicates, st.AvgResultBytes)
+		}
+	}
+}
+
+// ProviderComplete builds the single-shot LLM call a judge uses, resolving the
+// model the same way the CLI resolves any model. It returns nil and a reason
+// when the model is unresolvable or has no API key, so the caller can record
+// "judge unavailable" and still produce its measured report.
+func ProviderComplete(model string) (CompleteFunc, string) {
+	if model == "" {
+		return nil, "no judge model configured"
+	}
+	info, err := provider.Resolve(model)
+	if err != nil {
+		return nil, fmt.Sprintf("judge model %q unresolvable: %v", model, err)
+	}
+	apiKey := config.APIKeys()[info.Provider]
+	if apiKey == "" && !info.Ollama {
+		return nil, fmt.Sprintf("judge model %q has no API key for provider %q", model, info.Provider)
+	}
+
+	return func(ctx context.Context, system, user string) (string, error) {
+		llm, err := provider.NewLLM(ctx, info, apiKey, "", "none", &provider.LLMOptions{})
+		if err != nil {
+			return "", fmt.Errorf("create judge llm: %w", err)
+		}
+		req := &llmmodel.LLMRequest{
+			Contents: []*genai.Content{genai.NewContentFromText(user, genai.RoleUser)},
+			Config: &genai.GenerateContentConfig{
+				SystemInstruction: genai.NewContentFromText(system, genai.RoleUser),
+			},
+		}
+		var reply strings.Builder
+		for resp, err := range llm.GenerateContent(ctx, req, false) {
+			if err != nil {
+				return "", fmt.Errorf("judge llm: %w", err)
+			}
+			if resp.Content == nil {
+				continue
+			}
+			for _, part := range resp.Content.Parts {
+				if part.Text != "" && !part.Thought {
+					reply.WriteString(part.Text)
+				}
+			}
+		}
+		if strings.TrimSpace(reply.String()) == "" {
+			return "", fmt.Errorf("judge returned an empty reply")
+		}
+		return reply.String(), nil
+	}, ""
+}

--- a/internal/eval/metrics.go
+++ b/internal/eval/metrics.go
@@ -599,11 +599,52 @@ func contentBytes(content any) int {
 // reads as a failure. It is intentionally conservative — a successful tool can
 // legitimately contain the word "error" in its output, but the most common
 // failure signatures are distinctive enough to be worth counting.
+//
+// Structured results (the normal case: ATIF records the tool's response map)
+// are judged by shape rather than by text: the ADK runner reports a tool
+// handler error as {"error": "..."}, several tools carry an "error" field of
+// their own, and a bash result with a non-zero exit code is a failed command
+// even though the shell ran fine.
 func looksLikeError(content any) bool {
-	s, ok := content.(string)
-	if !ok {
+	switch v := content.(type) {
+	case string:
+		return textLooksLikeError(v)
+	case map[string]any:
+		return mapLooksLikeError(v)
+	default:
 		return false
 	}
+}
+
+// mapLooksLikeError judges a structured tool result: a non-empty "error"
+// field, or a bash-style exit_code that is neither 0 nor -1 (still running).
+func mapLooksLikeError(m map[string]any) bool {
+	if s, ok := m["error"].(string); ok && strings.TrimSpace(s) != "" {
+		return true
+	}
+	if code, ok := numericField(m["exit_code"]); ok && code != 0 && code != -1 {
+		return true
+	}
+	return false
+}
+
+// numericField reads a JSON number whether it was decoded from disk (float64)
+// or built in-process (int).
+func numericField(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// textLooksLikeError applies the marker heuristic to a plain-string result.
+func textLooksLikeError(s string) bool {
 	lower := strings.ToLower(s)
 	for _, marker := range []string{
 		"error:", "exit status", "panic:", "failed", "timed out", "not found",

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -3,8 +3,6 @@ package eval
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -13,28 +11,13 @@ import (
 // returns both paths. The Markdown rendering is also returned so the caller
 // can print it to stdout without re-reading the file.
 func WriteReport(report *RunReport, outDir string) (jsonPath, mdPath, md string, err error) {
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		return "", "", "", fmt.Errorf("create report dir: %w", err)
-	}
-
 	jsonBytes, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return "", "", "", fmt.Errorf("marshal report: %w", err)
 	}
-
-	ts := report.Metadata.Timestamp.Format("20060102-150405")
-	jsonPath = filepath.Join(outDir, fmt.Sprintf("eval-%s-%s.json", report.Metadata.Spec, ts))
-	if err := os.WriteFile(jsonPath, jsonBytes, 0o644); err != nil {
-		return "", "", "", fmt.Errorf("write json report: %w", err)
-	}
-
 	md = RenderMarkdown(report)
-	mdPath = filepath.Join(outDir, fmt.Sprintf("eval-%s-%s.md", report.Metadata.Spec, ts))
-	if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
-		return "", "", "", fmt.Errorf("write md report: %w", err)
-	}
-
-	return jsonPath, mdPath, md, nil
+	jsonPath, mdPath, err = writeReportFiles(outDir, report.Metadata.Spec, report.Metadata.Timestamp, jsonBytes, md)
+	return jsonPath, mdPath, md, err
 }
 
 // RenderMarkdown renders a RunReport as human-readable Markdown for stdout.

--- a/internal/eval/report_tools.go
+++ b/internal/eval/report_tools.go
@@ -1,0 +1,235 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ToolsReport is the machine-readable output of one tool-coverage eval run
+// (make eval-tools): per-scenario verdicts, the coverage matrix against the
+// registered tool inventory, and the usual tool/token metrics over every
+// trajectory the scenarios produced.
+type ToolsReport struct {
+	Metadata  ToolsReportMetadata `json:"metadata"`
+	Scenarios []ScenarioResult    `json:"scenarios"`
+	Coverage  Coverage            `json:"coverage"`
+	Tools     ToolsMetrics        `json:"tools"`
+	Tokens    TokenMetrics        `json:"tokens"`
+	// Judge is the LLM grader's advisory verdict, absent when no judge ran.
+	Judge *JudgeVerdict `json:"judge,omitempty"`
+}
+
+// ToolsReportMetadata describes what was run and when.
+type ToolsReportMetadata struct {
+	Model     string    `json:"model"`
+	Binary    string    `json:"binary"`
+	GitHead   string    `json:"git_head"`
+	Timestamp time.Time `json:"timestamp"`
+	Duration  string    `json:"duration"`
+	// Selected is the scenario filter in effect (PI_EVAL_SCENARIO), empty for
+	// the whole suite. A filtered run's coverage gap is not meaningful.
+	Selected string `json:"selected,omitempty"`
+	Passed   int    `json:"passed"`
+	Failed   int    `json:"failed"`
+	Skipped  int    `json:"skipped"`
+	Errored  int    `json:"errored"`
+}
+
+// Tally counts the scenario statuses into the metadata.
+func (r *ToolsReport) Tally() {
+	m := &r.Metadata
+	m.Passed, m.Failed, m.Skipped, m.Errored = 0, 0, 0, 0
+	for _, s := range r.Scenarios {
+		switch s.Status {
+		case StatusPass:
+			m.Passed++
+		case StatusFail:
+			m.Failed++
+		case StatusSkip:
+			m.Skipped++
+		default:
+			m.Errored++
+		}
+	}
+}
+
+// WriteToolsReport writes the report as JSON and Markdown into outDir
+// (eval-tools-<ts>.json / .md) and returns both paths plus the Markdown.
+func WriteToolsReport(report *ToolsReport, outDir string) (jsonPath, mdPath, md string, err error) {
+	jsonBytes, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return "", "", "", fmt.Errorf("marshal tools report: %w", err)
+	}
+	md = RenderToolsMarkdown(report)
+	jsonPath, mdPath, err = writeReportFiles(outDir, "tools", report.Metadata.Timestamp, jsonBytes, md)
+	return jsonPath, mdPath, md, err
+}
+
+// writeReportFiles writes the JSON and Markdown renderings of a report under
+// outDir as eval-<kind>-<ts>.{json,md}.
+func writeReportFiles(outDir, kind string, ts time.Time, jsonBytes []byte, md string) (jsonPath, mdPath string, err error) {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return "", "", fmt.Errorf("create report dir: %w", err)
+	}
+	stamp := ts.Format("20060102-150405")
+	jsonPath = filepath.Join(outDir, fmt.Sprintf("eval-%s-%s.json", kind, stamp))
+	if err := os.WriteFile(jsonPath, jsonBytes, 0o644); err != nil {
+		return "", "", fmt.Errorf("write json report: %w", err)
+	}
+	mdPath = filepath.Join(outDir, fmt.Sprintf("eval-%s-%s.md", kind, stamp))
+	if err := os.WriteFile(mdPath, []byte(md), 0o644); err != nil {
+		return "", "", fmt.Errorf("write md report: %w", err)
+	}
+	return jsonPath, mdPath, nil
+}
+
+// RenderToolsMarkdown renders a ToolsReport as human-readable Markdown.
+func RenderToolsMarkdown(r *ToolsReport) string {
+	var b strings.Builder
+	meta := r.Metadata
+
+	fmt.Fprintf(&b, "# Eval run: tool coverage\n\n")
+	fmt.Fprintf(&b, "- **model**: %s  \n", meta.Model)
+	fmt.Fprintf(&b, "- **binary**: %s  \n", meta.Binary)
+	fmt.Fprintf(&b, "- **git head**: `%s`  \n", shortHead(meta.GitHead))
+	fmt.Fprintf(&b, "- **timestamp**: %s  \n", meta.Timestamp.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- **duration**: %s  \n", meta.Duration)
+	if meta.Selected != "" {
+		fmt.Fprintf(&b, "- **selected**: `%s` (filtered run — coverage gap is partial)  \n", meta.Selected)
+	}
+	fmt.Fprintf(&b, "- **scenarios**: %d passed, %d failed, %d skipped, %d errored  \n",
+		meta.Passed, meta.Failed, meta.Skipped, meta.Errored)
+
+	renderScenarios(&b, r.Scenarios)
+	renderCoverage(&b, &r.Coverage)
+	renderJudge(&b, r.Judge)
+	renderToolsTable(&b, &r.Tools)
+	renderTokens(&b, &r.Tokens)
+	return b.String()
+}
+
+func renderScenarios(b *strings.Builder, scenarios []ScenarioResult) {
+	fmt.Fprintf(b, "\n## Scenarios\n\n")
+	if len(scenarios) == 0 {
+		fmt.Fprintf(b, "- none run\n")
+		return
+	}
+	fmt.Fprintf(b, "| scenario | status | tools | sessions | tool calls | duration | detail |\n")
+	fmt.Fprintf(b, "|---|---|---|---|---|---|---|\n")
+	for _, s := range scenarios {
+		fmt.Fprintf(b, "| `%s` | %s | %s | %d | %d | %s | %s |\n",
+			s.Name, statusMark(s.Status), toolsCell(s.Tools), s.Sessions, s.ToolCalls, s.Duration, escapeCell(truncate(s.Reason, 300)))
+	}
+	for _, s := range scenarios {
+		if len(s.Checks) == 0 {
+			continue
+		}
+		fmt.Fprintf(b, "\n**%s** checks:\n\n", s.Name)
+		for _, c := range s.Checks {
+			mark := "✓"
+			if !c.Passed {
+				mark = "✗"
+			}
+			fmt.Fprintf(b, "- %s `%s`", mark, c.Check)
+			if c.Detail != "" {
+				fmt.Fprintf(b, " — %s", escapeCell(c.Detail))
+			}
+			fmt.Fprintf(b, "\n")
+		}
+	}
+}
+
+// toolsCell renders the per-target outcomes as "name ✓/✗" pairs.
+func toolsCell(tools []ToolOutcome) string {
+	parts := make([]string, 0, len(tools))
+	for _, t := range tools {
+		mark := "✓"
+		if !t.OK {
+			mark = "✗"
+		}
+		parts = append(parts, fmt.Sprintf("`%s` %s", t.Tool, mark))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func statusMark(status string) string {
+	switch status {
+	case StatusPass:
+		return "PASS"
+	case StatusFail:
+		return "FAIL"
+	case StatusSkip:
+		return "skip"
+	default:
+		return strings.ToUpper(status)
+	}
+}
+
+func renderCoverage(b *strings.Builder, c *Coverage) {
+	fmt.Fprintf(b, "\n## Tool coverage\n\n")
+	fmt.Fprintf(b, "- **registered tools**: %d  \n", c.Total)
+	fmt.Fprintf(b, "- **exercised ok**: %d  \n", c.OK)
+	fmt.Fprintf(b, "- **errors only**: %d  \n", c.Errors)
+	fmt.Fprintf(b, "- **not called**: %d  \n", c.NotCalled)
+	fmt.Fprintf(b, "- **excluded**: %d  \n", c.Excluded)
+	fmt.Fprintf(b, "- **unmapped** (no scenario, no exclusion): %d  \n", c.Unmapped)
+	if len(c.Gap) > 0 {
+		fmt.Fprintf(b, "- **gap**: %s  \n", strings.Join(backticked(c.Gap), ", "))
+	}
+	if len(c.Unknown) > 0 {
+		fmt.Fprintf(b, "- **called but not inventoried**: %s  \n", strings.Join(backticked(c.Unknown), ", "))
+	}
+	if len(c.Tools) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n| tool | group | status | calls | results | errors | wasted | scenarios / exclusion |\n")
+	fmt.Fprintf(b, "|---|---|---|---|---|---|---|---|\n")
+	for _, t := range c.Tools {
+		mapping := strings.Join(t.Scenarios, ", ")
+		if t.Excluded != "" {
+			mapping = "excluded: " + t.Excluded
+		}
+		fmt.Fprintf(b, "| `%s` | %s | %s | %d | %d | %d | %d | %s |\n",
+			t.Name, t.Group, t.Status, t.Calls, t.Results, t.Errors, t.Wasted, escapeCell(mapping))
+	}
+}
+
+func backticked(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = "`" + n + "`"
+	}
+	return out
+}
+
+func renderToolsTable(b *strings.Builder, tm *ToolsMetrics) {
+	fmt.Fprintf(b, "\n## Tools efficiency\n\n")
+	fmt.Fprintf(b, "- **total calls**: %d  \n", tm.TotalCalls)
+	fmt.Fprintf(b, "- **total results**: %d  \n", tm.TotalResults)
+	fmt.Fprintf(b, "- **wasted calls** (no result): %d  \n", tm.Wasted)
+	fmt.Fprintf(b, "- **duplicate calls**: %d  \n", tm.Duplicates)
+	if len(tm.ByTool) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n| tool | calls | results | errors | wasted | duplicates | avg bytes | avg latency |\n")
+	fmt.Fprintf(b, "|---|---|---|---|---|---|---|---|\n")
+	for _, name := range sortedKeys(tm.ByTool) {
+		st := tm.ByTool[name]
+		fmt.Fprintf(b, "| `%s` | %d | %d | %d | %d | %d | %d | %dms |\n",
+			name, st.Calls, st.Results, st.Errors, st.Wasted, st.Duplicates, st.AvgResultBytes, st.AvgLatencyMs)
+	}
+}
+
+func renderTokens(b *strings.Builder, tk *TokenMetrics) {
+	fmt.Fprintf(b, "\n## Tokens\n\n")
+	fmt.Fprintf(b, "- **prompt tokens**: %d  \n", tk.PromptTokens)
+	fmt.Fprintf(b, "- **completion tokens**: %d  \n", tk.CompletionTokens)
+	if tk.CachedTokens > 0 {
+		fmt.Fprintf(b, "- **cached tokens**: %d  \n", tk.CachedTokens)
+	}
+	fmt.Fprintf(b, "- **total tokens**: %d  \n", tk.TotalTokens)
+}

--- a/internal/eval/scenario.go
+++ b/internal/eval/scenario.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -377,20 +378,38 @@ func subagentSpawned(loaded []*LoadedTrajectory) (bool, string) {
 
 // --- Workspace seeding ---
 
+// HomeEnv returns the environment entries that point the home directory at
+// home for a child process. os.UserHomeDir reads HOME on Unix but USERPROFILE
+// on Windows, so both are set there; with HOME alone a pi process on Windows
+// would silently read and write the runner's real ~/.pi-go (the same trap
+// internal/testenv.SetHome guards against in tests).
+func HomeEnv(home string) []string {
+	env := []string{"HOME=" + home}
+	if runtime.GOOS == "windows" {
+		env = append(env, "USERPROFILE="+home)
+	}
+	return env
+}
+
 // gitEnv returns an environment for fixture git commands that cannot touch the
 // user's identity or signing setup: HOME is the eval's isolated home, the
-// author is synthetic, and commit/tag signing is forced off.
+// author is synthetic, commit/tag signing is forced off, and line-ending
+// conversion is disabled so the LF fixtures land in the index and the working
+// tree byte-for-byte on every platform (a global core.autocrlf=true, the Git
+// for Windows default, would otherwise make file_contains checks and git
+// status depend on the host).
 func gitEnv(home string) []string {
-	return append(os.Environ(),
-		"HOME="+home,
+	env := append(os.Environ(), HomeEnv(home)...)
+	return append(env,
 		"GIT_AUTHOR_NAME=pi-eval",
 		"GIT_AUTHOR_EMAIL=pi-eval@example.invalid",
 		"GIT_COMMITTER_NAME=pi-eval",
 		"GIT_COMMITTER_EMAIL=pi-eval@example.invalid",
-		"GIT_CONFIG_COUNT=3",
+		"GIT_CONFIG_COUNT=4",
 		"GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
 		"GIT_CONFIG_KEY_1=tag.gpgsign", "GIT_CONFIG_VALUE_1=false",
 		"GIT_CONFIG_KEY_2=init.defaultBranch", "GIT_CONFIG_VALUE_2=main",
+		"GIT_CONFIG_KEY_3=core.autocrlf", "GIT_CONFIG_VALUE_3=false",
 	)
 }
 

--- a/internal/eval/scenario.go
+++ b/internal/eval/scenario.go
@@ -1,0 +1,525 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/memory"
+)
+
+// Scenario is one tool-coverage eval case: a seeded workspace, a prompt that
+// should make a competent agent reach for specific tools, and deterministic
+// assertions over the resulting trajectory and filesystem.
+//
+// Scenarios are declarative data so the table (internal/eval/scenarios) reads
+// as a spec and the runner (the e2e test in the same package) stays generic.
+type Scenario struct {
+	// Name identifies the scenario in reports and selects it with
+	// PI_EVAL_SCENARIO / -run. Lowercase, dash-separated.
+	Name string `json:"name"`
+	// Description says what the scenario exercises, for the report.
+	Description string `json:"description,omitempty"`
+	// Tools the agent must call at least once, each with at least one
+	// non-error result. An entry may list alternatives separated by "|"
+	// ("grep|ripgrep"): any one of them satisfies the requirement, and the
+	// scenario counts as covering all of them.
+	Tools []string `json:"tools"`
+	// Requires lists capabilities the host must provide: "lsp" (a language
+	// server on PATH), "network" (outbound HTTPS), "vision" (a model that
+	// accepts images). A scenario whose requirement is unmet is skipped, not
+	// failed.
+	Requires []string `json:"requires,omitempty"`
+	// Files are fixture files written into the workdir before the run, keyed
+	// by relative path.
+	Files map[string]string `json:"files,omitempty"`
+	// Git initializes a repository in the workdir and commits Files as the
+	// initial commit, so git-* tools have history to look at.
+	Git bool `json:"git,omitempty"`
+	// Modified files are written after the initial commit (uncommitted
+	// changes), so diffs are non-empty. Implies Git.
+	Modified map[string]string `json:"modified,omitempty"`
+	// Memory enables the observation memory system for the run and seeds
+	// the store with the given observations, so mem-* tools have something
+	// to find. Nil disables memory for the run (the default, because the
+	// memory worker spawns compressor subagents after every tool call).
+	Memory []MemorySeed `json:"memory,omitempty"`
+	// LLMS sources to configure, which registers the fetch_docs tool.
+	LLMS []config.LLMSSource `json:"llms,omitempty"`
+	// Args are extra flags passed to the pi binary (e.g. --lsp full).
+	Args []string `json:"args,omitempty"`
+	// Prompt is the single user turn the agent runs.
+	Prompt string `json:"prompt"`
+	// Checks are the deterministic assertions evaluated after the run, on
+	// top of the implicit "every target tool was called successfully".
+	Checks []Check `json:"checks,omitempty"`
+	// Timeout bounds one run of the scenario. Zero uses the runner default.
+	Timeout time.Duration `json:"-"`
+}
+
+// MemorySeed is one observation written into the memory store before the run.
+type MemorySeed struct {
+	Title string `json:"title"`
+	Text  string `json:"text"`
+	Type  string `json:"type,omitempty"` // memory.ObservationType; default "discovery"
+}
+
+// CheckKind enumerates the assertion vocabulary.
+type CheckKind string
+
+const (
+	// CheckFileExists: Path exists in the workdir.
+	CheckFileExists CheckKind = "file_exists"
+	// CheckFileAbsent: Path does not exist in the workdir.
+	CheckFileAbsent CheckKind = "file_absent"
+	// CheckFileContains: the file at Path contains Text.
+	CheckFileContains CheckKind = "file_contains"
+	// CheckFileNotContains: the file at Path does not contain Text.
+	CheckFileNotContains CheckKind = "file_not_contains"
+	// CheckToolArgContains: some call to Tool has an argument Arg whose
+	// string form contains Text. Arg empty = any argument.
+	CheckToolArgContains CheckKind = "tool_arg_contains"
+	// CheckToolResultContains: some result of Tool contains Text (the
+	// result is matched on its JSON/text rendering).
+	CheckToolResultContains CheckKind = "tool_result_contains"
+	// CheckSubagentSpawned: at least one observation links a nested
+	// subagent trajectory, i.e. a child pi session really ran.
+	CheckSubagentSpawned CheckKind = "subagent_spawned"
+	// CheckToolCalledAtLeast: Tool was called at least N times.
+	CheckToolCalledAtLeast CheckKind = "tool_called_at_least"
+)
+
+// Check is one deterministic assertion. Which fields matter depends on Kind.
+type Check struct {
+	Kind CheckKind `json:"kind"`
+	Path string    `json:"path,omitempty"`
+	Text string    `json:"text,omitempty"`
+	Tool string    `json:"tool,omitempty"`
+	Arg  string    `json:"arg,omitempty"`
+	N    int       `json:"n,omitempty"`
+}
+
+// String renders the check for reports.
+func (c Check) String() string {
+	switch c.Kind {
+	case CheckFileExists, CheckFileAbsent:
+		return fmt.Sprintf("%s %s", c.Kind, c.Path)
+	case CheckFileContains, CheckFileNotContains:
+		return fmt.Sprintf("%s %s %q", c.Kind, c.Path, c.Text)
+	case CheckToolArgContains:
+		if c.Arg != "" {
+			return fmt.Sprintf("%s %s.%s %q", c.Kind, c.Tool, c.Arg, c.Text)
+		}
+		return fmt.Sprintf("%s %s %q", c.Kind, c.Tool, c.Text)
+	case CheckToolResultContains:
+		return fmt.Sprintf("%s %s %q", c.Kind, c.Tool, c.Text)
+	case CheckToolCalledAtLeast:
+		return fmt.Sprintf("%s %s %d", c.Kind, c.Tool, c.N)
+	default:
+		return string(c.Kind)
+	}
+}
+
+// --- Results ---
+
+// ToolOutcome is what the trajectories show for one target tool.
+type ToolOutcome struct {
+	Tool    string `json:"tool"`
+	Calls   int    `json:"calls"`
+	Results int    `json:"results"`
+	Errors  int    `json:"errors"`
+	Wasted  int    `json:"wasted"`
+	OK      bool   `json:"ok"`
+}
+
+// CheckOutcome is the result of one Check.
+type CheckOutcome struct {
+	Check  string `json:"check"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ScenarioResult is the graded outcome of one scenario run.
+type ScenarioResult struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// Status is "pass", "fail", "skip" or "error" (the run itself broke).
+	Status   string         `json:"status"`
+	Reason   string         `json:"reason,omitempty"`
+	Duration string         `json:"duration,omitempty"`
+	Tools    []ToolOutcome  `json:"tools,omitempty"`
+	Checks   []CheckOutcome `json:"checks,omitempty"`
+	Sessions int            `json:"sessions"`
+	// ToolCalls is the total across every session the run produced,
+	// including subagents.
+	ToolCalls int `json:"tool_calls"`
+	// ExitCode of the pi process, -1 when it did not exit cleanly.
+	ExitCode int    `json:"exit_code"`
+	Output   string `json:"output,omitempty"`
+}
+
+// Scenario result statuses.
+const (
+	StatusPass  = "pass"
+	StatusFail  = "fail"
+	StatusSkip  = "skip"
+	StatusError = "error"
+)
+
+// EvaluateScenario grades a finished run: every target tool called with at
+// least one non-error result, and every Check satisfied. workDir is the
+// scenario's workspace after the run; loaded are the trajectories the run
+// wrote (root session plus any subagents).
+func EvaluateScenario(s Scenario, workDir string, loaded []*LoadedTrajectory) ScenarioResult {
+	res := ScenarioResult{Name: s.Name, Description: s.Description, Status: StatusPass}
+	stats := callStatsByTool(loaded)
+	var failures []string
+
+	for _, target := range s.Tools {
+		out := targetOutcome(target, stats)
+		res.Tools = append(res.Tools, out)
+		if !out.OK {
+			failures = append(failures, describeToolFailure(out))
+		}
+	}
+	for _, c := range s.Checks {
+		out := evaluateCheck(c, workDir, loaded)
+		res.Checks = append(res.Checks, out)
+		if !out.Passed {
+			failures = append(failures, out.Check+": "+out.Detail)
+		}
+	}
+
+	res.Sessions = len(loaded)
+	for _, lt := range loaded {
+		if lt != nil && lt.Traj != nil {
+			res.ToolCalls += countToolCalls(lt.Traj)
+		}
+	}
+	if len(failures) > 0 {
+		res.Status = StatusFail
+		res.Reason = strings.Join(failures, "; ")
+	}
+	return res
+}
+
+// targetOutcome folds the alternatives of one target ("grep|ripgrep") into a
+// single outcome under the target's label.
+func targetOutcome(target string, stats map[string]toolCallStats) ToolOutcome {
+	out := ToolOutcome{Tool: target}
+	for _, name := range strings.Split(target, "|") {
+		st := stats[strings.TrimSpace(name)]
+		out.Calls += st.calls
+		out.Results += st.results
+		out.Errors += st.errors
+		out.Wasted += st.wasted
+	}
+	out.OK = out.Results-out.Errors > 0
+	return out
+}
+
+func describeToolFailure(out ToolOutcome) string {
+	switch {
+	case out.Calls == 0:
+		return fmt.Sprintf("tool %s: never called", out.Tool)
+	case out.Results == 0:
+		return fmt.Sprintf("tool %s: %d call(s), no result", out.Tool, out.Calls)
+	default:
+		return fmt.Sprintf("tool %s: %d call(s), all %d result(s) look like errors", out.Tool, out.Calls, out.Errors)
+	}
+}
+
+// evaluateCheck runs one assertion against the workspace and trajectories.
+func evaluateCheck(c Check, workDir string, loaded []*LoadedTrajectory) CheckOutcome {
+	out := CheckOutcome{Check: c.String()}
+	switch c.Kind {
+	case CheckFileExists:
+		out.Passed, out.Detail = fileExists(filepath.Join(workDir, c.Path))
+	case CheckFileAbsent:
+		exists, _ := fileExists(filepath.Join(workDir, c.Path))
+		out.Passed = !exists
+		if exists {
+			out.Detail = "file exists"
+		}
+	case CheckFileContains:
+		out.Passed, out.Detail = fileContains(filepath.Join(workDir, c.Path), c.Text, true)
+	case CheckFileNotContains:
+		out.Passed, out.Detail = fileContains(filepath.Join(workDir, c.Path), c.Text, false)
+	case CheckToolArgContains:
+		out.Passed, out.Detail = toolArgContains(loaded, c.Tool, c.Arg, c.Text)
+	case CheckToolResultContains:
+		out.Passed, out.Detail = toolResultContains(loaded, c.Tool, c.Text)
+	case CheckSubagentSpawned:
+		out.Passed, out.Detail = subagentSpawned(loaded)
+	case CheckToolCalledAtLeast:
+		n := callsTo(loaded, c.Tool)
+		out.Passed = n >= c.N
+		out.Detail = fmt.Sprintf("called %d time(s)", n)
+	default:
+		out.Detail = "unknown check kind"
+	}
+	return out
+}
+
+func fileExists(path string) (bool, string) {
+	if _, err := os.Stat(path); err != nil {
+		return false, err.Error()
+	}
+	return true, ""
+}
+
+func fileContains(path, text string, want bool) (bool, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err.Error()
+	}
+	has := strings.Contains(string(data), text)
+	if has == want {
+		return true, ""
+	}
+	if want {
+		return false, fmt.Sprintf("text not found in %d bytes", len(data))
+	}
+	return false, "text still present"
+}
+
+// recordedCall is one tool call with its (optional) observation result, as
+// the checks see it.
+type recordedCall struct {
+	fn          string
+	args        map[string]any
+	result      any
+	hasResult   bool
+	subagentRef string
+}
+
+// callsOf collects every call to tool across the trajectories, paired with its
+// observation. tool "" collects every call.
+func callsOf(loaded []*LoadedTrajectory, tool string) []recordedCall {
+	var out []recordedCall
+	for _, lt := range loaded {
+		if lt == nil || lt.Traj == nil {
+			continue
+		}
+		results := resultsBySourceCall(lt)
+		for _, step := range lt.Traj.Steps {
+			for _, tc := range step.ToolCalls {
+				if tool != "" && !toolMatches(tool, tc.FunctionName) {
+					continue
+				}
+				rc := recordedCall{fn: tc.FunctionName, args: tc.Arguments}
+				if res, ok := results[tc.ToolCallID]; ok {
+					rc.result, rc.hasResult, rc.subagentRef = res.Content, true, res.SubagentTrajectoryRef
+				}
+				out = append(out, rc)
+			}
+		}
+	}
+	return out
+}
+
+// toolMatches honors "a|b" alternatives in a check's tool field.
+func toolMatches(target, name string) bool {
+	for _, alt := range strings.Split(target, "|") {
+		if strings.TrimSpace(alt) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func callsTo(loaded []*LoadedTrajectory, tool string) int {
+	return len(callsOf(loaded, tool))
+}
+
+func toolArgContains(loaded []*LoadedTrajectory, tool, arg, text string) (bool, string) {
+	calls := callsOf(loaded, tool)
+	for _, rc := range calls {
+		for k, v := range rc.args {
+			if arg != "" && k != arg {
+				continue
+			}
+			if strings.Contains(contentText(v), text) {
+				return true, ""
+			}
+		}
+	}
+	return false, fmt.Sprintf("no match across %d call(s)", len(calls))
+}
+
+func toolResultContains(loaded []*LoadedTrajectory, tool, text string) (bool, string) {
+	calls := callsOf(loaded, tool)
+	for _, rc := range calls {
+		if rc.hasResult && strings.Contains(contentText(rc.result), text) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("no match across %d call(s)", len(calls))
+}
+
+func subagentSpawned(loaded []*LoadedTrajectory) (bool, string) {
+	for _, rc := range callsOf(loaded, "") {
+		if rc.subagentRef != "" {
+			return true, ""
+		}
+	}
+	if len(loaded) > 1 {
+		return true, fmt.Sprintf("%d sessions present (no explicit subagent ref)", len(loaded))
+	}
+	return false, "no observation references a subagent trajectory"
+}
+
+// --- Workspace seeding ---
+
+// gitEnv returns an environment for fixture git commands that cannot touch the
+// user's identity or signing setup: HOME is the eval's isolated home, the
+// author is synthetic, and commit/tag signing is forced off.
+func gitEnv(home string) []string {
+	return append(os.Environ(),
+		"HOME="+home,
+		"GIT_AUTHOR_NAME=pi-eval",
+		"GIT_AUTHOR_EMAIL=pi-eval@example.invalid",
+		"GIT_COMMITTER_NAME=pi-eval",
+		"GIT_COMMITTER_EMAIL=pi-eval@example.invalid",
+		"GIT_CONFIG_COUNT=3",
+		"GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
+		"GIT_CONFIG_KEY_1=tag.gpgsign", "GIT_CONFIG_VALUE_1=false",
+		"GIT_CONFIG_KEY_2=init.defaultBranch", "GIT_CONFIG_VALUE_2=main",
+	)
+}
+
+// SeedWorkspace writes the scenario's fixture files into workDir, creating the
+// git history and uncommitted modifications it asks for. home is the isolated
+// HOME the run uses, so git never reads the user's global config.
+func SeedWorkspace(s Scenario, workDir, home string) error {
+	if err := writeFiles(workDir, s.Files); err != nil {
+		return err
+	}
+	if !s.Git && len(s.Modified) == 0 {
+		return nil
+	}
+	env := gitEnv(home)
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"add", "-A"},
+		{"commit", "-q", "-m", "initial fixture commit", "--allow-empty"},
+	} {
+		if err := runGit(workDir, env, args...); err != nil {
+			return err
+		}
+	}
+	return writeFiles(workDir, s.Modified)
+}
+
+func writeFiles(root string, files map[string]string) error {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("seed %s: %w", name, err)
+		}
+		if err := os.WriteFile(path, []byte(files[name]), 0o644); err != nil {
+			return fmt.Errorf("seed %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func runGit(dir string, env []string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, out)
+	}
+	return nil
+}
+
+// SeedMemory creates the observation store the run will open (the default
+// path under home) and inserts the seeds under a synthetic session, so the
+// mem-* tools have something to return.
+func SeedMemory(ctx context.Context, home, project string, seeds []MemorySeed) error {
+	if len(seeds) == 0 {
+		return nil
+	}
+	dbPath := filepath.Join(home, ".pi-go", "memory", "claude-mem.db")
+	db, err := memory.OpenDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("seed memory: %w", err)
+	}
+	store := memory.NewSQLiteStore(db)
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().Add(-time.Hour)
+	sess := &memory.Session{
+		SessionID:  "eval-seed-session",
+		Project:    project,
+		UserPrompt: "eval seed",
+		StartedAt:  now,
+		Status:     "completed",
+	}
+	if err := store.CreateSession(ctx, sess); err != nil {
+		return fmt.Errorf("seed memory session: %w", err)
+	}
+	for i, seed := range seeds {
+		typ := memory.ObservationType(seed.Type)
+		if typ == "" {
+			typ = memory.TypeDiscovery
+		}
+		obs := &memory.Observation{
+			SessionID:    sess.SessionID,
+			Project:      project,
+			Title:        seed.Title,
+			Type:         typ,
+			Text:         seed.Text,
+			ToolName:     "eval",
+			PromptNumber: 1,
+			CreatedAt:    now.Add(time.Duration(i) * time.Minute),
+		}
+		if err := store.InsertObservation(ctx, obs); err != nil {
+			return fmt.Errorf("seed memory observation %q: %w", seed.Title, err)
+		}
+	}
+	return nil
+}
+
+// ScenarioConfig derives the config.json a scenario's run is seeded with:
+// the eval model on every role, the given thinking level ("none" when empty —
+// cheapest, and the only level every model accepts), memory off unless the
+// scenario seeds it, llms sources when it asks for them, and no hooks, MCP
+// servers or A2A agents.
+func ScenarioConfig(s Scenario, model, thinking string) config.Config {
+	cfg := config.Defaults()
+	cfg.ThinkingLevel = thinking
+	if cfg.ThinkingLevel == "" {
+		cfg.ThinkingLevel = "none"
+	}
+	if model != "" {
+		for _, role := range []string{"default", "smol", "slow", "plan"} {
+			rc := cfg.Roles[role]
+			rc.Model = model
+			cfg.Roles[role] = rc
+		}
+	}
+	cfg.Memory = &config.MemoryConfig{Enabled: boolPtr(len(s.Memory) > 0)}
+	cfg.Palace = &config.PalaceConfig{Enabled: boolPtr(false)}
+	cfg.Hooks = nil
+	cfg.MCP = nil
+	cfg.A2A = nil
+	if len(s.LLMS) > 0 {
+		cfg.LLMS = &config.LLMSConfig{Sources: s.LLMS}
+	}
+	return cfg
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/eval/scenario_test.go
+++ b/internal/eval/scenario_test.go
@@ -1,0 +1,388 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/atif"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/memory"
+)
+
+func TestEvaluateScenario_ToolsAndChecks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "out.txt"), []byte("hello from pi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	child := &atif.Trajectory{SessionID: "child", Steps: []atif.Step{
+		callStep(1, "k1", "ripgrep", map[string]any{"pattern": "NEEDLE"}, map[string]any{"matches": []any{map[string]any{"file": "docs/notes.md"}}}),
+	}}
+	childPath := writeTraj(t, t.TempDir(), "child", child) // only the ref matters
+	parent := &atif.Trajectory{SessionID: "parent", Steps: []atif.Step{
+		callStep(1, "c1", "write", map[string]any{"path": "out.txt", "content": "hello from pi\n"}, map[string]any{"success": true}),
+		callStep(2, "c2", "bash", map[string]any{"command": "wc -l x"}, map[string]any{"exit_code": 1, "stderr": "no such file"}),
+		callStep(3, "c3", "bash", map[string]any{"command": "wc -l out.txt"}, map[string]any{"exit_code": 0, "stdout": "1"}),
+		{
+			StepID:    4,
+			ToolCalls: []atif.ToolCall{{ToolCallID: "c4", FunctionName: "subagent", Arguments: map[string]any{"agent": "explore"}}},
+			Observation: &atif.Observation{Results: []atif.ObservationResult{{
+				SourceCallID:          "c4",
+				Content:               map[string]any{"summary": "found docs/notes.md"},
+				SubagentTrajectoryRef: childPath,
+			}}},
+		},
+		callStep(5, "c5", "read", map[string]any{"path": "missing"}, map[string]any{"error": "not found"}),
+	}}
+	loaded := loadFixture(t, parent, child)
+
+	s := Scenario{
+		Name:  "synthetic",
+		Tools: []string{"write", "bash", "subagent", "grep|ripgrep", "read", "edit"},
+		Checks: []Check{
+			{Kind: CheckFileExists, Path: "out.txt"},
+			{Kind: CheckFileAbsent, Path: "nope.txt"},
+			{Kind: CheckFileContains, Path: "out.txt", Text: "hello"},
+			{Kind: CheckFileNotContains, Path: "out.txt", Text: "goodbye"},
+			{Kind: CheckToolArgContains, Tool: "bash", Arg: "command", Text: "wc"},
+			{Kind: CheckToolArgContains, Tool: "bash", Text: "out.txt"},
+			{Kind: CheckToolResultContains, Tool: "bash", Text: `"stdout":"1"`},
+			{Kind: CheckToolResultContains, Tool: "grep|ripgrep", Text: "notes.md"},
+			{Kind: CheckSubagentSpawned},
+			{Kind: CheckToolCalledAtLeast, Tool: "bash", N: 2},
+			// failing ones
+			{Kind: CheckFileContains, Path: "out.txt", Text: "absent-text"},
+			{Kind: CheckToolArgContains, Tool: "write", Arg: "path", Text: "other.txt"},
+			{Kind: CheckToolCalledAtLeast, Tool: "write", N: 3},
+			{Kind: CheckFileExists, Path: "nope.txt"},
+		},
+	}
+	res := EvaluateScenario(s, dir, loaded)
+
+	if res.Status != StatusFail {
+		t.Fatalf("status = %s, want fail", res.Status)
+	}
+	if res.Sessions != 2 || res.ToolCalls != 6 {
+		t.Errorf("sessions=%d toolCalls=%d", res.Sessions, res.ToolCalls)
+	}
+	outcomes := make(map[string]ToolOutcome)
+	for _, o := range res.Tools {
+		outcomes[o.Tool] = o
+	}
+	if o := outcomes["bash"]; !o.OK || o.Calls != 2 || o.Errors != 1 {
+		t.Errorf("bash outcome = %+v", o)
+	}
+	if o := outcomes["read"]; o.OK || o.Calls != 1 || o.Errors != 1 {
+		t.Errorf("read outcome = %+v (all-error call must not be OK)", o)
+	}
+	if o := outcomes["edit"]; o.OK || o.Calls != 0 {
+		t.Errorf("edit outcome = %+v", o)
+	}
+	if o := outcomes["grep|ripgrep"]; !o.OK {
+		t.Errorf("grep alternatives outcome = %+v", o)
+	}
+	if !strings.Contains(res.Reason, "tool edit: never called") || !strings.Contains(res.Reason, "tool read: 1 call(s), all 1 result(s) look like errors") {
+		t.Errorf("reason = %q", res.Reason)
+	}
+
+	passed := 0
+	for i, c := range res.Checks {
+		wantPass := i < 10
+		if c.Passed != wantPass {
+			t.Errorf("check %d %q: passed=%v detail=%q", i, c.Check, c.Passed, c.Detail)
+		}
+		if c.Passed {
+			passed++
+		}
+	}
+	if passed != 10 {
+		t.Errorf("passed %d checks, want 10", passed)
+	}
+}
+
+func TestEvaluateScenario_PassAndUnknownCheck(t *testing.T) {
+	loaded := loadFixture(t, &atif.Trajectory{SessionID: "s", Steps: []atif.Step{
+		callStep(1, "c1", "ls", map[string]any{"path": "."}, map[string]any{"entries": []any{}}),
+	}})
+	res := EvaluateScenario(Scenario{Name: "ok", Tools: []string{"ls"}}, t.TempDir(), loaded)
+	if res.Status != StatusPass || res.Reason != "" {
+		t.Fatalf("res = %+v", res)
+	}
+	res = EvaluateScenario(Scenario{Name: "bad", Tools: []string{"ls"}, Checks: []Check{{Kind: "bogus"}}}, t.TempDir(), loaded)
+	if res.Status != StatusFail || !strings.Contains(res.Reason, "unknown check kind") {
+		t.Fatalf("res = %+v", res)
+	}
+	// Wasted call: the tool was asked for but never answered.
+	wasted := loadFixture(t, &atif.Trajectory{SessionID: "w", Steps: []atif.Step{callStep(1, "c1", "ls", nil, nil)}})
+	res = EvaluateScenario(Scenario{Name: "w", Tools: []string{"ls"}}, t.TempDir(), wasted)
+	if res.Status != StatusFail || !strings.Contains(res.Reason, "no result") {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+func TestCheck_String(t *testing.T) {
+	cases := map[string]Check{
+		"file_exists a":                       {Kind: CheckFileExists, Path: "a"},
+		`file_contains a "x"`:                 {Kind: CheckFileContains, Path: "a", Text: "x"},
+		`tool_arg_contains bash.command "wc"`: {Kind: CheckToolArgContains, Tool: "bash", Arg: "command", Text: "wc"},
+		`tool_arg_contains bash "wc"`:         {Kind: CheckToolArgContains, Tool: "bash", Text: "wc"},
+		`tool_result_contains read "x"`:       {Kind: CheckToolResultContains, Tool: "read", Text: "x"},
+		"tool_called_at_least bash 2":         {Kind: CheckToolCalledAtLeast, Tool: "bash", N: 2},
+		"subagent_spawned":                    {Kind: CheckSubagentSpawned},
+	}
+	for want, c := range cases {
+		if got := c.String(); got != want {
+			t.Errorf("String() = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestSeedWorkspace_GitHistoryAndModifications(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	s := Scenario{
+		Git:      true,
+		Files:    map[string]string{"a.txt": "one\n", "sub/b.txt": "two\n"},
+		Modified: map[string]string{"a.txt": "one\nmore\n"},
+	}
+	if err := SeedWorkspace(s, dir, t.TempDir()); err != nil {
+		t.Fatalf("SeedWorkspace: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "a.txt"))
+	if string(got) != "one\nmore\n" {
+		t.Errorf("a.txt = %q", got)
+	}
+	out, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(out)) != "M a.txt" {
+		t.Errorf("git status = %q, want only a.txt modified", out)
+	}
+	log, _ := exec.Command("git", "-C", dir, "log", "--format=%an %s").Output()
+	if !strings.Contains(string(log), "pi-eval initial fixture commit") {
+		t.Errorf("git log = %q", log)
+	}
+	// Commit must not be signed: no gpgsig header.
+	raw, _ := exec.Command("git", "-C", dir, "cat-file", "commit", "HEAD").Output()
+	if strings.Contains(string(raw), "gpgsig") {
+		t.Error("fixture commit is signed; gitEnv should force signing off")
+	}
+}
+
+func TestSeedWorkspace_NoGit(t *testing.T) {
+	dir := t.TempDir()
+	if err := SeedWorkspace(Scenario{Files: map[string]string{"x/y.txt": "z"}}, dir, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		t.Error("unexpected .git")
+	}
+	if got, _ := os.ReadFile(filepath.Join(dir, "x", "y.txt")); string(got) != "z" {
+		t.Errorf("y.txt = %q", got)
+	}
+}
+
+func TestSeedMemory_SearchableByTool(t *testing.T) {
+	home := t.TempDir()
+	ctx := context.Background()
+	seeds := []MemorySeed{
+		{Title: "Widget rotation bug", Text: "widget rotation was wrong because rows were swapped", Type: "bugfix"},
+		{Title: "Cache decision", Text: "chose sqlite for the cache"},
+	}
+	if err := SeedMemory(ctx, home, "/tmp/proj", seeds); err != nil {
+		t.Fatalf("SeedMemory: %v", err)
+	}
+	if err := SeedMemory(ctx, home, "/tmp/proj", nil); err != nil {
+		t.Fatalf("SeedMemory(nil) = %v", err)
+	}
+
+	db, err := memory.OpenDB(filepath.Join(home, ".pi-go", "memory", "claude-mem.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewSQLiteStore(db)
+	defer store.Close()
+	res, err := store.Search(ctx, memory.SearchQuery{Query: "widget rotation", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if res == nil || len(res.Rows) != 1 || !strings.Contains(res.Rows[0].Title, "rotation") {
+		t.Fatalf("search result = %+v", res)
+	}
+	recent, err := store.RecentObservations(ctx, "/tmp/proj", 10)
+	if err != nil || len(recent) != 2 {
+		t.Fatalf("recent = %d, err=%v", len(recent), err)
+	}
+	if recent[0].Type != memory.TypeBugfix && recent[1].Type != memory.TypeBugfix {
+		t.Errorf("bugfix type not preserved: %+v", recent)
+	}
+}
+
+func TestScenarioConfig(t *testing.T) {
+	cfg := ScenarioConfig(Scenario{}, "test-model", "")
+	for _, role := range []string{"default", "smol", "slow", "plan"} {
+		if cfg.Roles[role].Model != "test-model" {
+			t.Errorf("role %s model = %q", role, cfg.Roles[role].Model)
+		}
+	}
+	if cfg.Memory == nil || cfg.Memory.Enabled == nil || *cfg.Memory.Enabled {
+		t.Error("memory should be disabled without seeds")
+	}
+	if cfg.Palace == nil || cfg.Palace.Enabled == nil || *cfg.Palace.Enabled {
+		t.Error("palace should be disabled")
+	}
+	if cfg.LLMS != nil || cfg.Hooks != nil || cfg.MCP != nil || cfg.A2A != nil {
+		t.Errorf("unexpected optional config: %+v", cfg)
+	}
+	if cfg.ThinkingLevel != "none" {
+		t.Errorf("thinking = %q, want none by default", cfg.ThinkingLevel)
+	}
+
+	cfg = ScenarioConfig(Scenario{
+		Memory: []MemorySeed{{Title: "t", Text: "x"}},
+		LLMS:   []config.LLMSSource{{Name: "n", URL: "https://example.com/llms.txt"}},
+	}, "", "medium")
+	if cfg.ThinkingLevel != "medium" {
+		t.Errorf("thinking = %q, want medium", cfg.ThinkingLevel)
+	}
+	if !*cfg.Memory.Enabled {
+		t.Error("memory should be enabled with seeds")
+	}
+	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
+		t.Error("llms sources not carried")
+	}
+	if cfg.Roles["default"].Model != config.Defaults().Roles["default"].Model {
+		t.Error("empty model must keep the default")
+	}
+}
+
+func TestToolsReport_RenderAndWrite(t *testing.T) {
+	r := &ToolsReport{
+		Metadata: ToolsReportMetadata{Model: "m", Binary: "/bin/pi", GitHead: "abcdef123456789", Timestamp: time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC), Duration: "1m", Selected: "grep"},
+		Scenarios: []ScenarioResult{
+			{Name: "explore", Status: StatusPass, Tools: []ToolOutcome{{Tool: "ls", OK: true}}, Sessions: 1, ToolCalls: 3, Duration: "10s",
+				Checks: []CheckOutcome{{Check: "file_exists a", Passed: true}}},
+			{Name: "git", Status: StatusFail, Reason: "tool git-hunk: never called | pipe", Tools: []ToolOutcome{{Tool: "git-hunk"}},
+				Checks: []CheckOutcome{{Check: "x", Passed: false, Detail: "no | match"}}},
+			{Name: "lsp", Status: StatusSkip, Reason: "requires lsp"},
+			{Name: "boom", Status: StatusError, Reason: "pi: exit 1"},
+		},
+		Coverage: ComputeCoverage(
+			[]ToolInfo{{Name: "ls", Group: "core"}, {Name: "git-hunk", Group: "core"}, {Name: "a2a", Group: "a2a"}},
+			[]Scenario{{Name: "explore", Tools: []string{"ls"}}, {Name: "git", Tools: []string{"git-hunk"}}},
+			[]Exclusion{{Tool: "a2a", Reason: "external"}},
+			loadFixture(t, &atif.Trajectory{SessionID: "s", Steps: []atif.Step{callStep(1, "c1", "ls", nil, map[string]any{"ok": true})}}),
+		),
+		Tools:  ToolsMetrics{TotalCalls: 1, ByTool: map[string]ToolStats{"ls": {Calls: 1, Results: 1}}},
+		Tokens: TokenMetrics{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15, CachedTokens: 2},
+		Judge:  &JudgeVerdict{Model: "j", Verdict: "pass", Overall: 4, Scores: []JudgeScore{{Dimension: "tool_selection", Score: 4, Rationale: "fine"}}},
+	}
+	r.Tally()
+	if r.Metadata.Passed != 1 || r.Metadata.Failed != 1 || r.Metadata.Skipped != 1 || r.Metadata.Errored != 1 {
+		t.Errorf("tally = %+v", r.Metadata)
+	}
+
+	md := RenderToolsMarkdown(r)
+	for _, want := range []string{
+		"# Eval run: tool coverage",
+		"**selected**: `grep`",
+		"1 passed, 1 failed, 1 skipped, 1 errored",
+		"| `explore` | PASS |",
+		"| `git` | FAIL |",
+		"| `lsp` | skip |",
+		"| `boom` | ERROR |",
+		`never called \| pipe`,
+		"## Tool coverage",
+		"**registered tools**: 3",
+		"**gap**: `git-hunk`",
+		"| `a2a` | a2a | excluded |",
+		"excluded: external",
+		"## LLM judge",
+		"| tool_selection | 4/5 | fine |",
+		"## Tools efficiency",
+		"**cached tokens**: 2",
+		"✗ `x` — no \\| match",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q\n%s", want, md)
+		}
+	}
+
+	out := t.TempDir()
+	jsonPath, mdPath, md2, err := WriteToolsReport(r, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md2 != md {
+		t.Error("returned markdown differs from render")
+	}
+	if filepath.Base(jsonPath) != "eval-tools-20260822-100000.json" || filepath.Base(mdPath) != "eval-tools-20260822-100000.md" {
+		t.Errorf("paths = %s, %s", jsonPath, mdPath)
+	}
+	data, err := os.ReadFile(jsonPath)
+	if err != nil || !strings.Contains(string(data), `"coverage"`) {
+		t.Errorf("json report: err=%v", err)
+	}
+}
+
+func TestJudgeTools(t *testing.T) {
+	r := &ToolsReport{
+		Metadata:  ToolsReportMetadata{Model: "m", Passed: 1, Failed: 1},
+		Scenarios: []ScenarioResult{{Name: "explore", Status: StatusPass, Sessions: 1, ToolCalls: 2}, {Name: "git", Status: StatusFail, Reason: "tool git-hunk: never called"}},
+		Coverage:  Coverage{Total: 3, OK: 1, Gap: []string{"git-hunk", "write"}},
+		Tools:     ToolsMetrics{TotalCalls: 2, ByTool: map[string]ToolStats{"ls": {Calls: 2, Results: 2}}},
+	}
+	prompt := BuildToolsJudgePrompt(r, "## scenario explore\n1. ls() -> 10 bytes\n")
+	for _, want := range []string{"Tool-coverage suite under review", "- explore: pass", "- git: fail — tool git-hunk: never called",
+		"gap: git-hunk, write", "| ls | 2 |", "## Tool-call timelines", "1. ls()"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q\n%s", want, prompt)
+		}
+	}
+	if got := BuildToolsJudgePrompt(nil, ""); !strings.Contains(got, "Tool-coverage suite under review") {
+		t.Errorf("nil report prompt = %q", got)
+	}
+
+	ctx := context.Background()
+	if v := JudgeTools(ctx, nil, "m", r, ""); v.Error != "no judge model configured" {
+		t.Errorf("nil complete: %+v", v)
+	}
+	failing := func(context.Context, string, string) (string, error) { return "", errors.New("transport down") }
+	if v := JudgeTools(ctx, failing, "m", r, ""); v.Error != "transport down" {
+		t.Errorf("failing complete: %+v", v)
+	}
+	garbage := func(context.Context, string, string) (string, error) { return "no json here", nil }
+	if v := JudgeTools(ctx, garbage, "m", r, ""); v.Error == "" {
+		t.Errorf("garbage reply should error: %+v", v)
+	}
+	var gotSystem, gotUser string
+	ok := func(_ context.Context, system, user string) (string, error) {
+		gotSystem, gotUser = system, user
+		return `{"scores":[{"dimension":"outcome_correctness","score":4,"rationale":"r"},{"dimension":"tool_selection","score":5,"rationale":"r"}],"verdict":"pass","summary":"s"}`, nil
+	}
+	v := JudgeTools(ctx, ok, "judge-model", r, "digest-text")
+	if v.Error != "" || v.Model != "judge-model" || v.Verdict != "pass" || v.Overall != 4.5 {
+		t.Errorf("verdict = %+v", v)
+	}
+	if !strings.Contains(gotSystem, "tool_selection") || !strings.Contains(gotUser, "digest-text") {
+		t.Error("judge did not receive the tools prompt and digest")
+	}
+}
+
+func TestProviderComplete_Unavailable(t *testing.T) {
+	if fn, reason := ProviderComplete(""); fn != nil || reason == "" {
+		t.Errorf("empty model: fn=%v reason=%q", fn != nil, reason)
+	}
+	if fn, reason := ProviderComplete("no-such-provider/definitely-not-a-model"); fn != nil || reason == "" {
+		// Either unresolvable or no key — both must come back as a reason, not a panic.
+		t.Errorf("bogus model: fn=%v reason=%q", fn != nil, reason)
+	}
+}

--- a/internal/eval/scenario_test.go
+++ b/internal/eval/scenario_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -174,6 +175,31 @@ func TestSeedWorkspace_GitHistoryAndModifications(t *testing.T) {
 	raw, _ := exec.Command("git", "-C", dir, "cat-file", "commit", "HEAD").Output()
 	if strings.Contains(string(raw), "gpgsig") {
 		t.Error("fixture commit is signed; gitEnv should force signing off")
+	}
+}
+
+func TestHomeEnv(t *testing.T) {
+	home := t.TempDir()
+	env := HomeEnv(home)
+	if env[0] != "HOME="+home {
+		t.Errorf("HomeEnv[0] = %q", env[0])
+	}
+	wantLen := 1
+	if runtime.GOOS == "windows" {
+		wantLen = 2
+		if env[1] != "USERPROFILE="+home {
+			t.Errorf("HomeEnv[1] = %q, want USERPROFILE (os.UserHomeDir reads it on Windows)", env[1])
+		}
+	}
+	if len(env) != wantLen {
+		t.Errorf("HomeEnv = %v, want %d entries", env, wantLen)
+	}
+	// gitEnv must carry the same redirection plus the signing/autocrlf overrides.
+	git := strings.Join(gitEnv(home), "\n")
+	for _, want := range []string{"HOME=" + home, "commit.gpgsign", "tag.gpgsign", "core.autocrlf", "GIT_CONFIG_VALUE_3=false"} {
+		if !strings.Contains(git, want) {
+			t.Errorf("gitEnv missing %q", want)
+		}
 	}
 }
 

--- a/internal/eval/scenarios/README.md
+++ b/internal/eval/scenarios/README.md
@@ -1,0 +1,131 @@
+# Tool-coverage eval scenarios
+
+This package is the **tool-coverage suite** for the pi coding agent: one
+declarative scenario per tool family, run headlessly through the real `pi`
+binary, graded deterministically, and rolled up into a coverage matrix over
+every tool the agent can register. It extends the `/run` eval harness in
+`internal/eval` (see `../eval.md`, section "Tool-coverage eval").
+
+```bash
+make build
+make eval-tools                          # whole suite
+PI_EVAL_SCENARIO=git,edit make eval-tools  # a subset
+PI_EVAL_JUDGE_MODEL=claude-sonnet-4-6 make eval-tools-judge
+```
+
+Reports land in `eval-reports/eval-tools-<ts>.{json,md}`. Knobs: `PI_EVAL_MODEL`
+(default: `config.Defaults()`), `PI_EVAL_THINKING` (default `none` — the
+cheapest level and the only one every model accepts), `PI_EVAL_TIMEOUT` (per
+scenario, default 5m), `PI_EVAL_OUT`, `PI_EVAL_STRICT=1`, `PI_EVAL_SERIAL=1`,
+`PI_EVAL_OFFLINE=1`, `PI_EVAL_NO_VISION=1`, `PI_EVAL_JUDGE_MODEL`.
+
+## What a scenario is
+
+`scenarios.go` holds the table. Each `eval.Scenario` has:
+
+| field | meaning |
+|---|---|
+| `Name` | id used in reports, `PI_EVAL_SCENARIO` and `-run 'TestEvalTools/scenario/<name>'` |
+| `Tools` | tools the agent **must** call, each with ≥1 non-error result. `"grep\|ripgrep"` lists alternatives (the content-search tool is named `ripgrep` when `rg` is on PATH) |
+| `Requires` | host capabilities: `lsp` (a language server on PATH, probed), `network` (opt out with `PI_EVAL_OFFLINE=1`; otherwise the runner probes the scenario's `LLMS` URLs from the test process and skips with the cause when one is unreachable), `vision` (skip with `PI_EVAL_NO_VISION=1`). Unmet → scenario **skipped**, not failed |
+| `Files` / `Git` / `Modified` | fixture files; `Git` commits them; `Modified` is written after the commit so `git-*` tools see a diff |
+| `Memory` | seeds observations into the memory store and turns memory on for the run (it is off otherwise — the memory worker spawns compressor subagents after every tool call) |
+| `LLMS` | llms.txt sources to configure, which registers `fetch_docs` |
+| `Args` | extra `pi` flags (`--lsp full`) |
+| `Prompt` | the single user turn |
+| `Checks` | deterministic assertions (below) |
+| `Timeout` | per-scenario override of `PI_EVAL_TIMEOUT` (default 5m) |
+
+### Check vocabulary
+
+| kind | asserts |
+|---|---|
+| `file_exists` / `file_absent` | path (relative to the workdir) exists / does not |
+| `file_contains` / `file_not_contains` | file content contains / lacks `Text` |
+| `tool_arg_contains` | some call to `Tool` has argument `Arg` (or any argument) containing `Text` |
+| `tool_result_contains` | some result of `Tool` contains `Text` (matched on its JSON/text rendering) |
+| `tool_called_at_least` | `Tool` called ≥ `N` times |
+| `subagent_spawned` | an observation links a nested subagent trajectory (a child `pi` really ran) |
+
+A scenario **passes** when every target tool has at least one non-error result
+and every check holds. A result "looks like an error" when it is
+`{"error": "..."}` (how the ADK runner reports a tool failure), carries a
+non-empty `error` field, or is a bash result with exit code ≠ 0/−1, or — for
+plain-string results — matches the legacy marker heuristic.
+
+## How a scenario runs
+
+`tools_e2e_test.go` (`TestEvalTools`, build tag `e2e`, gated by
+`PI_EVAL_TOOLS=1`) does, per scenario:
+
+1. Creates an isolated `HOME` and a workspace dir; seeds fixtures, git history,
+   memory and `$HOME/.pi-go/config.json` (`eval.ScenarioConfig`: the eval model
+   on every role, memory/palace off unless asked, no hooks/MCP/A2A).
+2. Runs `pi --mode print [Args] "<Prompt>"` in the workspace with `HOME`
+   redirected and git signing forced off, under a timeout.
+3. Loads every `trajectory.atif.json` under `$HOME/.pi-go/sessions` — root
+   session plus any subagents it spawned — and grades with
+   `eval.EvaluateScenario`.
+
+Scenarios run as parallel subtests (`-parallel 4` from the Makefile;
+`PI_EVAL_SERIAL=1` to serialize). Outcomes are **reported, not asserted** —
+the suite is a measurement, and LLM runs are not deterministic — unless
+`PI_EVAL_STRICT=1`, which fails the subtest on a scenario FAIL/ERROR and fails
+the run on a non-empty coverage gap.
+
+After all scenarios: `eval.ComputeCoverage` over the **full inventory**
+(`eval.Inventory`), tools/token metrics, optional LLM judge, report.
+
+## The coverage gate
+
+`eval.Inventory` enumerates every tool by constructing them through the same
+constructors the CLI uses (`tools.CoreTools`, `BashControlTools`,
+`SubagentTools`, `MemoryTools`, `LSPToolsFor(full)`, `LLMSTools`, `A2ATools`,
+`palace.PalaceTools`, the Gemini grounding tool). It is not a hand-kept list.
+
+`TestScenarios_CoverInventory` (a plain unit test, runs in `make test`) fails
+when any inventoried tool has neither a scenario targeting it nor an entry in
+`Exclusions`, when a scenario targets a tool that does not exist, or when an
+exclusion is stale. Adding a tool to the agent therefore requires either a
+scenario here or an explicit, reasoned exclusion.
+
+MCP tools are not in the inventory (they are whatever the user's MCP servers
+advertise); calls to them show up in the report under "called but not
+inventoried".
+
+## Scenario → tool map
+
+| scenario | tools | requires | key assertions |
+|---|---|---|---|
+| `explore` | `ls`, `tree`, `find`, `grep\|ripgrep` | | grep pattern has the needle; grep result names `notes.md`; find pattern has `.md` |
+| `read` | `read` | | read result contains `8471` |
+| `write` | `write` | | `hello.txt` contains `hello from pi` |
+| `edit` | `read`, `edit` | | `greet.go` has `"Howdy"`, not `"Hello"`, other const untouched |
+| `bash` | `bash` | | `count.txt` contains `5`; bash command contains `wc` |
+| `bash-background` | `bash`, `bash_wait`, `bash_kill` | | bash_wait result contains `FINISHED-OK`; bash_kill called with a handle (slow: ≥2 min by design) |
+| `git` | `git-overview`, `git-file-diff`, `git-hunk` | | overview lists `main.go`; diff/hunk called on `main.go`; diff shows `version 2` |
+| `subagent` | `subagent` | | a nested trajectory is linked; result mentions `gamma` |
+| `session-stats` | `session-stats` | | called, no error |
+| `memory` | `mem-search`, `mem-get`, `mem-timeline` | | mem-search result contains `rotation` |
+| `read-image` | `read_image` | vision | called, no error |
+| `fetch-docs` | `fetch_docs` | network | url has `llmstxt.org`; result contains `llms.txt` |
+| `lsp` | `lsp-symbols`, `lsp-diagnostics` | lsp | symbols contain `Alpha`; diagnostics mention `unusedValue` |
+| `lsp-full` | `lsp-hover`, `lsp-definition`, `lsp-references`, `lsp-workspace-symbol`, `lsp-code-action` | lsp | workspace-symbol query `Alpha`; references name `main.go` |
+
+Excluded (see `Exclusions` in `scenarios.go`): `a2a` (remote A2A server),
+`palace-*` (populated memory palace + embedding model), `google_search`
+(Gemini provider built-in).
+
+`fetch_docs` cannot be pointed at a local `httptest` server: the tool enforces
+`https://` and rejects private hosts, so the scenario uses a real public
+`llms.txt` and is tagged `network`.
+
+## Adding a scenario
+
+1. Add a constructor in `scenarios.go` and list it in `Suite()`.
+2. Name the tools it must exercise in `Tools`; keep prompts explicit about
+   *which* tool to use and tell the model not to fall back to bash.
+3. Prefer checks on files and tool arguments/results over prose in the reply.
+4. Run `go test ./internal/eval/...` — the mapping, seeding and
+   satisfiability tests run without a model — then `PI_EVAL_SCENARIO=<name>
+   make eval-tools` for a live pass.

--- a/internal/eval/scenarios/scenarios.go
+++ b/internal/eval/scenarios/scenarios.go
@@ -1,0 +1,378 @@
+// Package scenarios is the tool-coverage eval suite for the pi coding agent:
+// one declarative scenario per tool family, each seeding a workspace and
+// asking for something a competent agent does with specific tools, plus
+// deterministic assertions over the trajectory and filesystem.
+//
+// The table is data; the runner (TestEvalTools, build tag e2e) and the
+// grading (eval.EvaluateScenario) are generic. TestScenarios_CoverInventory
+// fails when a tool registered by the agent has neither a scenario here nor
+// an entry in Exclusions, so a new tool cannot ship unmeasured. See README.md.
+package scenarios
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/eval"
+)
+
+// GrepTool is the content-search tool's name: "grep" in a plain build, or
+// "ripgrep" when rg is on PATH at startup. A scenario target that lists both
+// accepts either.
+const GrepTool = "grep|ripgrep"
+
+// Exclusions lists registered tools the suite deliberately does not run, with
+// the reason. Every inventoried tool must be here or in a scenario.
+var Exclusions = []eval.Exclusion{
+	{Tool: "a2a", Reason: "needs a remote A2A agent server (external service); not registered without a2a config"},
+	{Tool: "palace-*", Reason: "needs a populated memory palace (embedding model + drawers); not registered in a fresh HOME"},
+	{Tool: "google_search", Reason: "Gemini provider built-in, not a pi tool; only present when the eval model is a Gemini model"},
+}
+
+// Suite returns the scenarios in run order.
+func Suite() []eval.Scenario {
+	return []eval.Scenario{
+		explore(),
+		readFile(),
+		writeFile(),
+		editFile(),
+		bashCmd(),
+		bashBackground(),
+		gitTools(),
+		subagentSpawn(),
+		sessionStats(),
+		memoryTools(),
+		readImage(),
+		fetchDocs(),
+		lspMin(),
+		lspFull(),
+	}
+}
+
+// Lookup returns the scenario with the given name.
+func Lookup(name string) (eval.Scenario, bool) {
+	for _, s := range Suite() {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return eval.Scenario{}, false
+}
+
+func explore() eval.Scenario {
+	return eval.Scenario{
+		Name:        "explore",
+		Description: "navigate a small tree with ls, tree, find and grep instead of bash",
+		Tools:       []string{"ls", "tree", "find", GrepTool},
+		Files: map[string]string{
+			"README.md":      "# demo\n\nA tiny fixture project.\n",
+			"docs/notes.md":  "# Notes\n\nThe magic token is NEEDLE-7f3a and lives only here.\n",
+			"docs/guide.md":  "# Guide\n\nNothing to see.\n",
+			"src/a.go":       "package src\n\n// A returns 1.\nfunc A() int { return 1 }\n",
+			"src/util/b.go":  "package util\n\n// B returns 2.\nfunc B() int { return 2 }\n",
+			"src/util/c.txt": "plain text\n",
+		},
+		Prompt: "Explore this workspace using the dedicated file tools, NOT bash. " +
+			"Do all four steps: (1) call the tree tool on the root directory; " +
+			"(2) call the ls tool on the src directory; " +
+			"(3) use the find tool with pattern **/*.md to list every markdown file; " +
+			"(4) use the grep tool (it may be named grep or ripgrep) to find which file contains the token NEEDLE-7f3a. " +
+			"Then reply with the markdown file list and the file that contains the token.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolArgContains, Tool: GrepTool, Text: "NEEDLE-7f3a"},
+			{Kind: eval.CheckToolResultContains, Tool: GrepTool, Text: "notes.md"},
+			{Kind: eval.CheckToolArgContains, Tool: "find", Text: ".md"},
+		},
+	}
+}
+
+func readFile() eval.Scenario {
+	return eval.Scenario{
+		Name:        "read",
+		Description: "read a config file with the read tool",
+		Tools:       []string{"read"},
+		Files: map[string]string{
+			"config/app.conf": "# app config\nname = demo\nport = 8471\nlog_level = info\n",
+		},
+		Prompt: "Use the read tool to read config/app.conf and tell me the value of the port setting. Do not use bash.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolResultContains, Tool: "read", Text: "8471"},
+		},
+	}
+}
+
+func writeFile() eval.Scenario {
+	return eval.Scenario{
+		Name:        "write",
+		Description: "create a new file with the write tool",
+		Tools:       []string{"write"},
+		Files:       map[string]string{"README.md": "# demo\n"},
+		Prompt: "Using the write tool, create a file named hello.txt whose entire content is exactly the line " +
+			"`hello from pi` followed by a newline. Do not use bash.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckFileContains, Path: "hello.txt", Text: "hello from pi"},
+		},
+	}
+}
+
+func editFile() eval.Scenario {
+	return eval.Scenario{
+		Name:        "edit",
+		Description: "change one string in a source file with read + edit",
+		Tools:       []string{"read", "edit"},
+		Files: map[string]string{
+			"greet.go": "package greet\n\n// Greeting is what we say.\nconst Greeting = \"Hello\"\n\n// Name is who we greet.\nconst Name = \"World\"\n",
+		},
+		Prompt: "In greet.go, change the value of the Greeting constant from \"Hello\" to \"Howdy\". " +
+			"Read the file with the read tool first, then apply the change with the edit tool. " +
+			"Do not change anything else and do not use bash.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckFileContains, Path: "greet.go", Text: "const Greeting = \"Howdy\""},
+			{Kind: eval.CheckFileNotContains, Path: "greet.go", Text: "\"Hello\""},
+			{Kind: eval.CheckFileContains, Path: "greet.go", Text: "const Name = \"World\""},
+		},
+	}
+}
+
+func bashCmd() eval.Scenario {
+	return eval.Scenario{
+		Name:        "bash",
+		Description: "run a shell pipeline with the bash tool and capture its output in a file",
+		Tools:       []string{"bash"},
+		Files: map[string]string{
+			"data/numbers.txt": "10\n20\n30\n40\n50\n",
+		},
+		Prompt: "Use the bash tool to count the lines in data/numbers.txt with `wc -l` and write just that number " +
+			"into a file named count.txt using shell redirection (one bash command is fine). Then tell me the number.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckFileContains, Path: "count.txt", Text: "5"},
+			{Kind: eval.CheckToolArgContains, Tool: "bash", Arg: "command", Text: "wc"},
+		},
+	}
+}
+
+func bashBackground() eval.Scenario {
+	return eval.Scenario{
+		Name:        "bash-background",
+		Description: "let a command outlive its timeout, then bash_wait on it and bash_kill another",
+		Tools:       []string{"bash", "bash_wait", "bash_kill"},
+		Files:       map[string]string{"README.md": "# demo\n"},
+		Timeout:     8 * time.Minute,
+		Prompt: "Two tasks, strictly in this order, using the bash tool and its companions bash_wait and bash_kill. " +
+			"(1) Run the command `sleep 70; echo FINISHED-OK` with timeout 60000 (the minimum). It will exceed the " +
+			"timeout and be moved to the background; the result carries running=true and a handle. Then call bash_wait " +
+			"with that handle and wait_ms 30000, repeating if needed, until it reports running=false and the output " +
+			"contains FINISHED-OK. " +
+			"(2) Run the command `sleep 600` with timeout 60000. Once it has been moved to the background, stop it with " +
+			"bash_kill using its handle. " +
+			"Finally report the outcome of both tasks.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolResultContains, Tool: "bash_wait", Text: "FINISHED-OK"},
+			{Kind: eval.CheckToolArgContains, Tool: "bash_kill", Arg: "handle", Text: ""},
+		},
+	}
+}
+
+func gitTools() eval.Scenario {
+	return eval.Scenario{
+		Name:        "git",
+		Description: "inspect a repo with uncommitted changes through git-overview, git-file-diff and git-hunk",
+		Tools:       []string{"git-overview", "git-file-diff", "git-hunk"},
+		Git:         true,
+		Files: map[string]string{
+			"README.md": "# demo\n",
+			"main.go":   "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"version 1\")\n}\n",
+			"util.go":   "package main\n\nfunc helper() int { return 1 }\n",
+		},
+		Modified: map[string]string{
+			"main.go": "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"version 2\")\n\tfmt.Println(\"added line\")\n}\n",
+		},
+		Prompt: "This directory is a git repository with uncommitted changes. Without using bash: " +
+			"(1) call git-overview to report the branch and which files changed; " +
+			"(2) call git-file-diff for main.go; " +
+			"(3) call git-hunk for main.go. " +
+			"Then summarize in two sentences what changed in main.go.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolResultContains, Tool: "git-overview", Text: "main.go"},
+			{Kind: eval.CheckToolArgContains, Tool: "git-file-diff", Arg: "file", Text: "main.go"},
+			{Kind: eval.CheckToolResultContains, Tool: "git-file-diff", Text: "version 2"},
+			{Kind: eval.CheckToolArgContains, Tool: "git-hunk", Arg: "file", Text: "main.go"},
+		},
+	}
+}
+
+func subagentSpawn() eval.Scenario {
+	return eval.Scenario{
+		Name:        "subagent",
+		Description: "delegate a lookup to the explore subagent and relay its answer",
+		Tools:       []string{"subagent"},
+		Timeout:     8 * time.Minute,
+		Files: map[string]string{
+			"pkg/alpha.go": "package pkg\n\n// Alpha does alpha things.\nfunc Alpha() int { return 1 }\n",
+			"pkg/beta.go":  "package pkg\n\n// Beta does beta things.\nfunc Beta() int { return 2 }\n",
+			"lib/gamma.go": "package lib\n\n// Frobnicate frobnicates.\nfunc Frobnicate() string { return \"frob\" }\n",
+		},
+		Prompt: "Use the subagent tool to spawn the `explore` agent with exactly this task: " +
+			"\"Find which file in this directory defines the function Frobnicate and report its relative path.\" " +
+			"Do not search for it yourself and do not use bash; relay the subagent's answer verbatim.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckSubagentSpawned},
+			{Kind: eval.CheckToolResultContains, Tool: "subagent", Text: "gamma"},
+		},
+	}
+}
+
+func sessionStats() eval.Scenario {
+	return eval.Scenario{
+		Name:        "session-stats",
+		Description: "scan the session store for anomalies with session-stats",
+		Tools:       []string{"session-stats"},
+		Files:       map[string]string{"README.md": "# demo\n"},
+		Prompt: "Call the session-stats tool with all=true to scan every recorded session, " +
+			"then summarize in two sentences how many sessions it found and whether any were flagged.",
+	}
+}
+
+func memoryTools() eval.Scenario {
+	return eval.Scenario{
+		Name:        "memory",
+		Description: "search, fetch and walk the observation memory with mem-search, mem-get and mem-timeline",
+		Tools:       []string{"mem-search", "mem-get", "mem-timeline"},
+		Files:       map[string]string{"README.md": "# demo\n"},
+		Memory: []eval.MemorySeed{
+			{
+				Title: "Widget rotation bug in the renderer",
+				Type:  "bugfix",
+				Text: "Widget rotation bug: icons rendered rotated by 90 degrees because the matrix rows were " +
+					"swapped in rotate.go. Fixed by transposing the matrix before the multiply.",
+			},
+			{
+				Title: "Decision: SQLite for the local cache",
+				Type:  "decision",
+				Text:  "Chose SQLite over a flat file for the local cache because concurrent writers need locking.",
+			},
+		},
+		Prompt: "Search the persistent observation memory. (1) Call mem-search with query `widget rotation`. " +
+			"(2) Call mem-get with the id of the top result. (3) Call mem-timeline with that id as the anchor. " +
+			"Then report in one sentence what the memory says caused the rotation bug.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolResultContains, Tool: "mem-search", Text: "rotation"},
+		},
+	}
+}
+
+func readImage() eval.Scenario {
+	return eval.Scenario{
+		Name:        "read-image",
+		Description: "look at a PNG with read_image (vision)",
+		Tools:       []string{"read_image"},
+		Requires:    []string{"vision"},
+		Files:       map[string]string{"logo.png": solidPNG(color.RGBA{R: 220, G: 20, B: 20, A: 255})},
+		Prompt: "Use the read_image tool to look at logo.png in this directory and tell me its dominant color " +
+			"in one word. Do not use bash.",
+	}
+}
+
+func fetchDocs() eval.Scenario {
+	return eval.Scenario{
+		Name:        "fetch-docs",
+		Description: "pull a public llms.txt with fetch_docs (needs outbound HTTPS)",
+		Tools:       []string{"fetch_docs"},
+		Requires:    []string{"network"},
+		Files:       map[string]string{"README.md": "# demo\n"},
+		LLMS:        []config.LLMSSource{{Name: "llmstxt", URL: "https://llmstxt.org/llms.txt"}},
+		Prompt: "Use the fetch_docs tool to fetch https://llmstxt.org/llms.txt and then summarize in two sentences " +
+			"what the llms.txt proposal is.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolArgContains, Tool: "fetch_docs", Arg: "url", Text: "llmstxt.org"},
+			{Kind: eval.CheckToolResultContains, Tool: "fetch_docs", Text: "llms.txt"},
+		},
+	}
+}
+
+// lspFixture is a tiny Go module with a deliberate compile error (an unused
+// variable) so diagnostics have something to report, and two files so
+// references and definitions cross a file boundary.
+//
+// main.go, 0-based positions: `Alpha` declaration at line 4 col 5; the call
+// `Alpha()` inside main at line 9 col 12.
+var lspFixture = map[string]string{
+	"go.mod": "module example.com/lspfix\n\ngo 1.22\n",
+	"main.go": "package main\n" + // 0
+		"\n" + // 1
+		"import \"fmt\"\n" + // 2
+		"\n" + // 3
+		"func Alpha() int { return 1 }\n" + // 4
+		"\n" + // 5
+		"func main() {\n" + // 6
+		"\tvar unusedValue int\n" + // 7
+		"\tfmt.Println(Beta())\n" + // 8
+		"\tfmt.Println(Alpha())\n" + // 9
+		"}\n", // 10
+	"beta.go": "package main\n\n// Beta returns two.\nfunc Beta() int { return 2 }\n",
+}
+
+func lspMin() eval.Scenario {
+	return eval.Scenario{
+		Name:        "lsp",
+		Description: "list symbols and diagnostics through the default (min) LSP tools",
+		Tools:       []string{"lsp-symbols", "lsp-diagnostics"},
+		Requires:    []string{"lsp"},
+		Files:       lspFixture,
+		Timeout:     6 * time.Minute,
+		Prompt: "This is a Go module. Using only the language-server tools, not bash or go build: " +
+			"(1) call lsp-symbols on main.go to list its symbols; " +
+			"(2) call lsp-diagnostics on main.go and report every problem it finds — the language server " +
+			"publishes diagnostics asynchronously, so if the first call reports no problems, call " +
+			"lsp-diagnostics on main.go once more before concluding the file is clean. " +
+			"Then summarize the symbols and the diagnostics.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolResultContains, Tool: "lsp-symbols", Text: "Alpha"},
+			{Kind: eval.CheckToolResultContains, Tool: "lsp-diagnostics", Text: "unusedValue"},
+		},
+	}
+}
+
+func lspFull() eval.Scenario {
+	return eval.Scenario{
+		Name:        "lsp-full",
+		Description: "navigate code with the full LSP surface (hover, definition, references, workspace symbol, code action)",
+		Tools:       []string{"lsp-hover", "lsp-definition", "lsp-references", "lsp-workspace-symbol", "lsp-code-action"},
+		Requires:    []string{"lsp"},
+		Files:       lspFixture,
+		Args:        []string{"--lsp", "full"},
+		Timeout:     8 * time.Minute,
+		Prompt: "This is a Go module. Using only the language-server tools (not bash or go build), do all five " +
+			"steps; lines and columns are 0-based: " +
+			"(1) call lsp-workspace-symbol with query Alpha; " +
+			"(2) call lsp-definition for the call to Alpha in main.go at line 9, column 14; " +
+			"(3) call lsp-references for Alpha at its declaration in main.go, line 4, column 5; " +
+			"(4) call lsp-hover on main.go at line 4, column 5; " +
+			"(5) call lsp-code-action on main.go for the range startLine 7, startCol 1, endLine 7, endCol 20. " +
+			"Then report what each call returned.",
+		Checks: []eval.Check{
+			{Kind: eval.CheckToolArgContains, Tool: "lsp-workspace-symbol", Arg: "query", Text: "Alpha"},
+			{Kind: eval.CheckToolResultContains, Tool: "lsp-references", Text: "main.go"},
+		},
+	}
+}
+
+// solidPNG renders a 16x16 PNG of one color as a string of bytes, so the
+// fixture needs no binary file in the repo.
+func solidPNG(c color.RGBA) string {
+	img := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	for y := 0; y < 16; y++ {
+		for x := 0; x < 16; x++ {
+			img.SetRGBA(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		panic(err) // a fixed-size in-memory encode cannot fail
+	}
+	return buf.String()
+}

--- a/internal/eval/scenarios/scenarios_test.go
+++ b/internal/eval/scenarios/scenarios_test.go
@@ -1,0 +1,230 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/atif"
+	"github.com/dimetron/pi-go/internal/eval"
+)
+
+// TestScenarios_CoverInventory is the coverage gate: every tool the agent can
+// register must be targeted by at least one scenario or be explicitly
+// excluded with a reason, and every scenario target and exclusion must name a
+// tool that actually exists. A new tool with no eval fails here.
+func TestScenarios_CoverInventory(t *testing.T) {
+	inv, err := eval.Inventory(t.TempDir())
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if len(inv) < 20 {
+		t.Fatalf("inventory suspiciously small: %d tools", len(inv))
+	}
+
+	if unmapped := eval.UnmappedTools(inv, Suite(), Exclusions); len(unmapped) > 0 {
+		t.Errorf("registered tools with neither a scenario nor an exclusion: %s\n"+
+			"add a scenario in internal/eval/scenarios/scenarios.go or an Exclusion with a reason",
+			strings.Join(unmapped, ", "))
+	}
+	if unknown := eval.UnknownTargets(inv, Suite()); len(unknown) > 0 {
+		t.Errorf("scenario targets that match no registered tool: %s", strings.Join(unknown, "; "))
+	}
+
+	names := make(map[string]bool, len(inv))
+	for _, ti := range inv {
+		names[ti.Name] = true
+	}
+	for _, ex := range Exclusions {
+		if ex.Reason == "" {
+			t.Errorf("exclusion %q has no reason", ex.Tool)
+		}
+		matched := false
+		for name := range names {
+			if strings.HasSuffix(ex.Tool, "*") && strings.HasPrefix(name, strings.TrimSuffix(ex.Tool, "*")) || ex.Tool == name {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("exclusion %q matches no registered tool (stale?)", ex.Tool)
+		}
+	}
+}
+
+func TestScenarios_WellFormed(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, s := range Suite() {
+		if s.Name == "" || strings.ContainsAny(s.Name, " /") {
+			t.Errorf("scenario %q: name must be non-empty and path/space free", s.Name)
+		}
+		if seen[s.Name] {
+			t.Errorf("duplicate scenario name %q", s.Name)
+		}
+		seen[s.Name] = true
+		if strings.TrimSpace(s.Prompt) == "" {
+			t.Errorf("scenario %q: empty prompt", s.Name)
+		}
+		if len(s.Tools) == 0 {
+			t.Errorf("scenario %q: no target tools", s.Name)
+		}
+		for _, c := range s.Checks {
+			if c.Tool != "" && !targetsTool(s, c.Tool) {
+				t.Errorf("scenario %q: check %q refers to tool %q which is not a target", s.Name, c, c.Tool)
+			}
+			if c.Kind == "" {
+				t.Errorf("scenario %q: check with empty kind", s.Name)
+			}
+		}
+		if len(s.Modified) > 0 && !s.Git {
+			t.Errorf("scenario %q: Modified set but Git is false", s.Name)
+		}
+		if _, ok := Lookup(s.Name); !ok {
+			t.Errorf("Lookup(%q) failed", s.Name)
+		}
+	}
+	if _, ok := Lookup("no-such-scenario"); ok {
+		t.Error("Lookup of unknown name succeeded")
+	}
+}
+
+func targetsTool(s eval.Scenario, tool string) bool {
+	for _, target := range s.Tools {
+		if target == tool {
+			return true
+		}
+	}
+	return false
+}
+
+// TestScenarios_Seed seeds every scenario's workspace and checks the fixtures
+// and git state are what the prompts assume.
+func TestScenarios_Seed(t *testing.T) {
+	home := t.TempDir()
+	for _, s := range Suite() {
+		t.Run(s.Name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := eval.SeedWorkspace(s, dir, home); err != nil {
+				t.Fatalf("SeedWorkspace: %v", err)
+			}
+			for name, want := range s.Files {
+				if _, modified := s.Modified[name]; modified {
+					continue
+				}
+				got, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(name)))
+				if err != nil || string(got) != want {
+					t.Errorf("fixture %s: err=%v match=%v", name, err, string(got) == want)
+				}
+			}
+			if !s.Git {
+				if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+					t.Error("non-git scenario has a .git directory")
+				}
+				return
+			}
+			out, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+			if err != nil {
+				t.Fatalf("git status: %v", err)
+			}
+			for name := range s.Modified {
+				if !strings.Contains(string(out), " M "+name) {
+					t.Errorf("expected %s to be modified, git status:\n%s", name, out)
+				}
+			}
+		})
+	}
+}
+
+// TestScenarios_GitSatisfiable builds a synthetic trajectory that does what
+// the git scenario asks for and checks the grading accepts it — i.e. the
+// scenario's checks are satisfiable by a correct run, not over-constrained.
+func TestScenarios_GitSatisfiable(t *testing.T) {
+	s, _ := Lookup("git")
+	dir := t.TempDir()
+	if err := eval.SeedWorkspace(s, dir, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	traj := &atif.Trajectory{SessionID: "s1", Steps: []atif.Step{
+		step(1, "git-overview", map[string]any{}, map[string]any{"branch": "main", "unstaged_files": []any{"main.go"}}),
+		step(2, "git-file-diff", map[string]any{"file": "main.go"}, map[string]any{"file": "main.go", "diff": "-version 1\n+version 2\n"}),
+		step(3, "git-hunk", map[string]any{"file": "main.go"}, map[string]any{"file": "main.go", "total_hunks": 1}),
+	}}
+	res := eval.EvaluateScenario(s, dir, roundTrip(t, traj))
+	if res.Status != eval.StatusPass {
+		t.Fatalf("git scenario not satisfiable by a correct run: %s", res.Reason)
+	}
+}
+
+// TestScenarios_EditSatisfiable does the same for the edit scenario, which
+// asserts on the filesystem rather than on results.
+func TestScenarios_EditSatisfiable(t *testing.T) {
+	s, _ := Lookup("edit")
+	dir := t.TempDir()
+	if err := eval.SeedWorkspace(s, dir, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "greet.go")
+	data, _ := os.ReadFile(path)
+	edited := strings.Replace(string(data), `"Hello"`, `"Howdy"`, 1)
+	if err := os.WriteFile(path, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	traj := &atif.Trajectory{SessionID: "s1", Steps: []atif.Step{
+		step(1, "read", map[string]any{"path": "greet.go"}, map[string]any{"content": data}),
+		step(2, "edit", map[string]any{"path": "greet.go"}, map[string]any{"success": true}),
+	}}
+	res := eval.EvaluateScenario(s, dir, roundTrip(t, traj))
+	if res.Status != eval.StatusPass {
+		t.Fatalf("edit scenario not satisfiable: %s", res.Reason)
+	}
+
+	// An agent that only read and never edited fails on the tool requirement.
+	untouched := t.TempDir()
+	_ = eval.SeedWorkspace(s, untouched, t.TempDir())
+	res = eval.EvaluateScenario(s, untouched, roundTrip(t, &atif.Trajectory{SessionID: "s2", Steps: []atif.Step{
+		step(1, "read", map[string]any{"path": "greet.go"}, map[string]any{"content": data}),
+	}}))
+	if res.Status != eval.StatusFail || !strings.Contains(res.Reason, "tool edit: never called") {
+		t.Fatalf("expected edit-never-called failure, got %s: %s", res.Status, res.Reason)
+	}
+}
+
+// step builds one ATIF step with a single call and its paired observation.
+func step(id int, fn string, args map[string]any, result map[string]any) atif.Step {
+	callID := "c" + string(rune('0'+id))
+	return atif.Step{
+		StepID:    id,
+		ToolCalls: []atif.ToolCall{{ToolCallID: callID, FunctionName: fn, Arguments: args}},
+		Observation: &atif.Observation{Results: []atif.ObservationResult{{
+			SourceCallID: callID,
+			Content:      result,
+		}}},
+	}
+}
+
+// roundTrip writes the trajectory to disk and loads it back, so the fixture
+// goes through the same JSON decoding as a real run (numbers become float64,
+// maps become map[string]any).
+func roundTrip(t *testing.T, traj *atif.Trajectory) []*eval.LoadedTrajectory {
+	t.Helper()
+	dir := t.TempDir()
+	sd := filepath.Join(dir, traj.SessionID)
+	if err := os.MkdirAll(sd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(traj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sd, "trajectory.atif.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := eval.LoadTrajectories(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loaded
+}

--- a/internal/eval/scenarios/tools_e2e_test.go
+++ b/internal/eval/scenarios/tools_e2e_test.go
@@ -1,0 +1,533 @@
+//go:build e2e
+
+// TestEvalTools runs the tool-coverage suite against a real pi binary: every
+// scenario gets an isolated HOME and a seeded workspace, runs headlessly
+// (`pi --mode print "<prompt>"`), and is graded from the trajectories it wrote
+// plus the filesystem it left behind. The coverage matrix over the registered
+// tool inventory and a JSON+Markdown report land in eval-reports/.
+//
+// Manually run — needs a built binary and an LLM API key. See
+// internal/eval/eval.md ("Tool-coverage eval") and README.md here.
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/eval"
+	"github.com/dimetron/pi-go/internal/lsp"
+)
+
+func TestEvalTools(t *testing.T) {
+	if os.Getenv("PI_EVAL_TOOLS") != "1" {
+		t.Skip("tool-coverage eval: set PI_EVAL_TOOLS=1 to run (make eval-tools)")
+	}
+	start := time.Now()
+
+	repoRoot := findRepoRoot(t)
+	bin := resolvePiBinary(t, repoRoot)
+	model := os.Getenv("PI_EVAL_MODEL")
+	if model == "" {
+		model = config.Defaults().Roles["default"].Model
+	}
+	inv, err := eval.Inventory(t.TempDir())
+	if err != nil {
+		t.Fatalf("tool inventory: %v", err)
+	}
+
+	selected := os.Getenv("PI_EVAL_SCENARIO")
+	suite := selectScenarios(Suite(), selected)
+	if len(suite) == 0 {
+		t.Fatalf("PI_EVAL_SCENARIO=%q matches no scenario (have: %s)", selected, strings.Join(scenarioNames(Suite()), ", "))
+	}
+	caps := hostCapabilities()
+	defaultTimeout := scenarioTimeout()
+	strict := os.Getenv("PI_EVAL_STRICT") == "1"
+	serial := os.Getenv("PI_EVAL_SERIAL") == "1"
+
+	var (
+		mu       sync.Mutex
+		results  = make(map[string]eval.ScenarioResult, len(suite))
+		perScen  = make(map[string][]*eval.LoadedTrajectory, len(suite))
+		allTrajs []*eval.LoadedTrajectory
+	)
+	// Scenario scratch dirs are cleaned up by the top-level test, not the
+	// subtest: the aggregate step below still reads each session's
+	// events.jsonl (token usage) after the subtests have finished.
+	root := t
+	t.Run("scenario", func(t *testing.T) {
+		for _, s := range suite {
+			t.Run(s.Name, func(t *testing.T) {
+				if !serial {
+					t.Parallel()
+				}
+				res, loaded := runScenario(t, root, bin, model, s, caps, defaultTimeout)
+				mu.Lock()
+				results[s.Name] = res
+				perScen[s.Name] = loaded
+				allTrajs = append(allTrajs, loaded...)
+				mu.Unlock()
+				reportScenario(t, res, strict)
+			})
+		}
+	})
+
+	// --- aggregate ----------------------------------------------------------
+	ordered := make([]eval.ScenarioResult, 0, len(suite))
+	for _, s := range suite {
+		if r, ok := results[s.Name]; ok {
+			ordered = append(ordered, r)
+		}
+	}
+	report := &eval.ToolsReport{
+		Metadata: eval.ToolsReportMetadata{
+			Model:     model,
+			Binary:    bin,
+			GitHead:   gitHead(repoRoot),
+			Timestamp: time.Now(),
+			Duration:  time.Since(start).Round(time.Second).String(),
+			Selected:  selected,
+		},
+		Scenarios: ordered,
+		Coverage:  eval.ComputeCoverage(inv, Suite(), Exclusions, allTrajs),
+		Tools:     eval.ComputeToolsMetrics(allTrajs),
+		Tokens:    eval.ComputeTokenMetrics(allTrajs),
+	}
+	report.Tally()
+
+	// --- LLM judge (advisory) -------------------------------------------------
+	if judgeModel := os.Getenv("PI_EVAL_JUDGE_MODEL"); judgeModel != "" {
+		complete, reason := eval.ProviderComplete(judgeModel)
+		if complete == nil {
+			t.Logf("judge unavailable: %s", reason)
+		}
+		digest := suiteDigest(suite, perScen, judgeDigestLimit())
+		judgeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		verdict := eval.JudgeTools(judgeCtx, complete, judgeModel, report, digest)
+		cancel()
+		report.Judge = &verdict
+		if verdict.Error != "" {
+			t.Logf("judge unavailable: %s", verdict.Error)
+		}
+	}
+
+	outDir := os.Getenv("PI_EVAL_OUT")
+	if outDir == "" {
+		outDir = filepath.Join(repoRoot, "eval-reports")
+	}
+	jsonPath, mdPath, md, err := eval.WriteToolsReport(report, outDir)
+	if err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+	fmt.Println(md)
+	fmt.Printf("Report: %s\nJSON:   %s\n", mdPath, jsonPath)
+
+	// --- sanity assertions (scenario outcomes are reported, not asserted,
+	// unless PI_EVAL_STRICT=1) --------------------------------------------------
+	if report.Metadata.Passed+report.Metadata.Failed+report.Metadata.Errored == 0 {
+		t.Skip("every selected scenario was skipped (unmet requirements)")
+	}
+	if len(allTrajs) == 0 {
+		t.Errorf("no trajectories parsed from any scenario")
+	}
+	if data, err := os.ReadFile(jsonPath); err != nil || !json.Valid(data) {
+		t.Errorf("report JSON invalid or unreadable: %v", err)
+	}
+	if strict && len(report.Coverage.Gap) > 0 && selected == "" {
+		t.Errorf("coverage gap: %s", strings.Join(report.Coverage.Gap, ", "))
+	}
+}
+
+// reportScenario surfaces one scenario's outcome in the test log, failing the
+// subtest only in strict mode.
+func reportScenario(t *testing.T, res eval.ScenarioResult, strict bool) {
+	t.Helper()
+	switch res.Status {
+	case eval.StatusSkip:
+		t.Skip(res.Reason)
+	case eval.StatusPass:
+		t.Logf("PASS (%s, %d session(s), %d tool call(s))", res.Duration, res.Sessions, res.ToolCalls)
+	default:
+		msg := fmt.Sprintf("%s: %s", strings.ToUpper(res.Status), res.Reason)
+		if res.Output != "" {
+			msg += "\n--- pi output (tail) ---\n" + res.Output
+		}
+		if strict {
+			t.Error(msg)
+		} else {
+			t.Log(msg)
+		}
+	}
+}
+
+// runScenario executes one scenario end to end and grades it. Scratch
+// directories are registered for cleanup on root (the top-level test) so they
+// outlive the subtest — the aggregate step reads them after it returns.
+func runScenario(t, root *testing.T, bin, model string, s eval.Scenario, caps map[string]bool, defaultTimeout time.Duration) (eval.ScenarioResult, []*eval.LoadedTrajectory) {
+	t.Helper()
+	if missing := unmetRequirements(s, caps); missing != "" {
+		return eval.ScenarioResult{Name: s.Name, Description: s.Description, Status: eval.StatusSkip, Reason: missing}, nil
+	}
+	started := time.Now()
+
+	home := tempDir(root, "pi-eval-tools-home-")
+	workDir := tempDir(root, "pi-eval-tools-ws-")
+	ctx := context.Background()
+
+	if err := eval.SeedWorkspace(s, workDir, home); err != nil {
+		return errorResult(s, started, "seed workspace: "+err.Error()), nil
+	}
+	if err := eval.SeedMemory(ctx, home, workDir, s.Memory); err != nil {
+		return errorResult(s, started, "seed memory: "+err.Error()), nil
+	}
+	cfg := eval.ScenarioConfig(s, model, os.Getenv("PI_EVAL_THINKING"))
+	if err := writeHomeConfig(home, &cfg); err != nil {
+		return errorResult(s, started, "seed config: "+err.Error()), nil
+	}
+
+	timeout := defaultTimeout
+	if s.Timeout > timeout {
+		timeout = s.Timeout
+	}
+	exitCode, output, runErr := runPi(ctx, bin, workDir, home, s, timeout)
+
+	sessionsDir := filepath.Join(home, ".pi-go", "sessions")
+	loaded, loadErr := eval.LoadTrajectories(sessionsDir)
+	if loadErr != nil {
+		t.Logf("%s: load trajectories: %v", s.Name, loadErr)
+	}
+
+	res := eval.EvaluateScenario(s, workDir, loaded)
+	res.Duration = time.Since(started).Round(time.Second).String()
+	res.ExitCode = exitCode
+	res.Output = tail(output, 4000)
+	// A process that timed out or exited non-zero is an error even when the
+	// partial trajectory happens to satisfy every check: the grading still
+	// shows per tool/check what was reached, but the scenario must not be
+	// tallied as a pass.
+	if runErr != nil {
+		res.Status = eval.StatusError
+		res.Reason = strings.TrimSuffix("pi: "+runErr.Error()+"; "+res.Reason, "; ")
+	}
+	return res, loaded
+}
+
+func errorResult(s eval.Scenario, started time.Time, reason string) eval.ScenarioResult {
+	return eval.ScenarioResult{
+		Name:        s.Name,
+		Description: s.Description,
+		Status:      eval.StatusError,
+		Reason:      reason,
+		Duration:    time.Since(started).Round(time.Second).String(),
+		ExitCode:    -1,
+	}
+}
+
+// runPi runs `pi --mode print [args] "<prompt>"` in workDir with HOME pointed
+// at the scenario's isolated home. Returns the exit code (-1 when the process
+// did not exit on its own), the combined output, and an error describing a
+// non-zero exit or timeout.
+func runPi(ctx context.Context, bin, workDir, home string, s eval.Scenario, timeout time.Duration) (int, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := append([]string{"--mode", "print"}, s.Args...)
+	args = append(args, s.Prompt)
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = workDir
+	cmd.Env = piEnv(home)
+	cmd.WaitDelay = 10 * time.Second
+	out, err := cmd.CombinedOutput()
+
+	switch {
+	case ctx.Err() != nil:
+		return -1, string(out), fmt.Errorf("timed out after %s", timeout)
+	case err != nil:
+		code := -1
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		}
+		return code, string(out), fmt.Errorf("exit %d: %v", code, err)
+	default:
+		return 0, string(out), nil
+	}
+}
+
+// piEnv is the environment a scenario's pi process runs with: the caller's
+// environment (API keys, PATH, go toolchain) with HOME redirected to the
+// isolated home, git signing forced off for anything the agent commits, and
+// the sandbox-root override dropped so the workspace is the sandbox.
+func piEnv(home string) []string {
+	var env []string
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		switch key {
+		case "HOME", "PI_SANDBOX_ROOT", "GIT_CONFIG_COUNT":
+			continue
+		}
+		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env,
+		"HOME="+home,
+		"GIT_AUTHOR_NAME=pi-eval", "GIT_AUTHOR_EMAIL=pi-eval@example.invalid",
+		"GIT_COMMITTER_NAME=pi-eval", "GIT_COMMITTER_EMAIL=pi-eval@example.invalid",
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
+		"GIT_CONFIG_KEY_1=tag.gpgsign", "GIT_CONFIG_VALUE_1=false",
+	)
+}
+
+// --- requirements -------------------------------------------------------------
+
+// hostCapabilities probes what this host can offer the scenarios that declare
+// Requires. Vision is assumed unless opted out (it cannot be probed without a
+// model call); LSP is probed for real; network is opted out with
+// PI_EVAL_OFFLINE=1 and otherwise probed per scenario against the URLs it
+// needs (see unmetRequirements), because a host can reach the LLM provider and
+// still be firewalled off from arbitrary documentation hosts.
+func hostCapabilities() map[string]bool {
+	return map[string]bool{
+		"lsp":     lsp.NewManager(nil).AnyAvailable(),
+		"network": os.Getenv("PI_EVAL_OFFLINE") != "1",
+		"vision":  os.Getenv("PI_EVAL_NO_VISION") != "1",
+	}
+}
+
+func unmetRequirements(s eval.Scenario, caps map[string]bool) string {
+	var missing []string
+	for _, r := range s.Requires {
+		if !caps[r] {
+			missing = append(missing, r)
+			continue
+		}
+		if r == "network" {
+			if reason := probeNetwork(s); reason != "" {
+				return "requires network: " + reason
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	return "requires " + strings.Join(missing, ", ") + " (unavailable on this host)"
+}
+
+// probeNetwork fetches each llms source URL the scenario configures and
+// returns a reason when any is unreachable from this host, so a firewalled
+// environment records a skip with the cause rather than a tool failure.
+// Results are cached per URL across scenarios.
+func probeNetwork(s eval.Scenario) string {
+	for _, src := range s.LLMS {
+		if reason := probeURL(src.URL); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+var (
+	probeMu    sync.Mutex
+	probeCache = map[string]string{}
+)
+
+func probeURL(url string) string {
+	probeMu.Lock()
+	defer probeMu.Unlock()
+	if reason, ok := probeCache[url]; ok {
+		return reason
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	reason := ""
+	resp, err := client.Get(url)
+	switch {
+	case err != nil:
+		reason = fmt.Sprintf("GET %s: %v", url, err)
+	case resp.StatusCode >= 400:
+		reason = fmt.Sprintf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	probeCache[url] = reason
+	return reason
+}
+
+// --- selection ------------------------------------------------------------------
+
+func selectScenarios(all []eval.Scenario, filter string) []eval.Scenario {
+	if strings.TrimSpace(filter) == "" {
+		return all
+	}
+	want := make(map[string]bool)
+	for _, n := range strings.Split(filter, ",") {
+		want[strings.TrimSpace(n)] = true
+	}
+	var out []eval.Scenario
+	for _, s := range all {
+		if want[s.Name] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func scenarioNames(all []eval.Scenario) []string {
+	names := make([]string, 0, len(all))
+	for _, s := range all {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+// suiteDigest concatenates the per-scenario tool-call timelines for the judge,
+// in suite order and labelled by scenario.
+func suiteDigest(suite []eval.Scenario, perScen map[string][]*eval.LoadedTrajectory, maxCalls int) string {
+	var b strings.Builder
+	for _, s := range suite {
+		loaded := perScen[s.Name]
+		if len(loaded) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "## scenario %s\n\n", s.Name)
+		b.WriteString(eval.TrajectoryDigest(loaded, maxCalls))
+	}
+	return b.String()
+}
+
+// --- environment helpers ---------------------------------------------------------
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repository root (no .git)")
+		}
+		dir = parent
+	}
+}
+
+func resolvePiBinary(t *testing.T, repoRoot string) string {
+	t.Helper()
+	if p := os.Getenv("PI_BINARY"); p != "" {
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(repoRoot, p)
+		}
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+		t.Skipf("PI_BINARY=%s not found", p)
+	}
+	for _, cand := range []string{filepath.Join(repoRoot, "pi"), filepath.Join(gopathBin(), "pi"), "pi"} {
+		if p, err := exec.LookPath(cand); err == nil {
+			return p
+		}
+	}
+	t.Skip("no pi binary found: set PI_BINARY, run make build, or make install")
+	return ""
+}
+
+func gopathBin() string {
+	if gp := os.Getenv("GOPATH"); gp != "" {
+		return filepath.Join(gp, "bin")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "go", "bin")
+}
+
+func writeHomeConfig(home string, cfg *config.Config) error {
+	dir := filepath.Join(home, ".pi-go")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "config.json"), data, 0o644)
+}
+
+// tempDir creates a scratch directory with permissive cleanup: the run may
+// leave read-only files behind (a Go module cache under $HOME/go, gopls
+// caches), which os.RemoveAll cannot unlink without a chmod pass first. A
+// cleanup failure is logged, never fatal — a harness that fails a run it
+// measured fine is worse than one that leaves a temp dir behind. t.Cleanup is
+// safe to call from a parallel subtest on the parent: it only appends.
+func tempDir(t *testing.T, prefix string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", prefix)
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			mode := os.FileMode(0o600)
+			if d.IsDir() {
+				mode = 0o700
+			}
+			_ = os.Chmod(path, mode)
+			return nil
+		})
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("temp dir %s left behind: %v", dir, err)
+		}
+	})
+	return dir
+}
+
+func scenarioTimeout() time.Duration {
+	if v := os.Getenv("PI_EVAL_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return 5 * time.Minute
+}
+
+func judgeDigestLimit() int {
+	if v := os.Getenv("PI_EVAL_JUDGE_MAX_CALLS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 40
+}
+
+func gitHead(repoRoot string) string {
+	out, err := exec.Command("git", "-C", repoRoot, "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…" + s[len(s)-n:]
+}

--- a/internal/eval/scenarios/tools_e2e_test.go
+++ b/internal/eval/scenarios/tools_e2e_test.go
@@ -265,15 +265,16 @@ func runPi(ctx context.Context, bin, workDir, home string, s eval.Scenario, time
 }
 
 // piEnv is the environment a scenario's pi process runs with: the caller's
-// environment (API keys, PATH, go toolchain) with HOME redirected to the
-// isolated home, git signing forced off for anything the agent commits, and
+// environment (API keys, PATH, go toolchain) with the home directory
+// redirected to the isolated home (HOME, plus USERPROFILE on Windows — see
+// eval.HomeEnv), git signing forced off for anything the agent commits, and
 // the sandbox-root override dropped so the workspace is the sandbox.
 func piEnv(home string) []string {
 	var env []string
 	for _, kv := range os.Environ() {
 		key, _, _ := strings.Cut(kv, "=")
 		switch key {
-		case "HOME", "PI_SANDBOX_ROOT", "GIT_CONFIG_COUNT":
+		case "HOME", "USERPROFILE", "PI_SANDBOX_ROOT", "GIT_CONFIG_COUNT":
 			continue
 		}
 		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
@@ -281,8 +282,8 @@ func piEnv(home string) []string {
 		}
 		env = append(env, kv)
 	}
+	env = append(env, eval.HomeEnv(home)...)
 	return append(env,
-		"HOME="+home,
 		"GIT_AUTHOR_NAME=pi-eval", "GIT_AUTHOR_EMAIL=pi-eval@example.invalid",
 		"GIT_COMMITTER_NAME=pi-eval", "GIT_COMMITTER_EMAIL=pi-eval@example.invalid",
 		"GIT_CONFIG_COUNT=2",

--- a/internal/extension/complexity_extension_test.go
+++ b/internal/extension/complexity_extension_test.go
@@ -3,6 +3,7 @@ package extension
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -267,9 +268,22 @@ func TestAppendDirSkillsMissingDir(t *testing.T) {
 	}
 }
 
+// skipIfReadDirOnFileIsNotAnError skips tests that stand a regular file in for
+// an unreadable directory. On Unix os.ReadDir fails on it with ENOTDIR, which
+// is not os.IsNotExist, so it exercises the fatal branch; on Windows the same
+// call does not produce such an error, so there is no way to reach that branch
+// from the filesystem.
+func skipIfReadDirOnFileIsNotAnError(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("os.ReadDir on a regular file is not a non-IsNotExist error on Windows")
+	}
+}
+
 // TestAppendDirSkillsUnreadableDir keeps the other half of that rule: a read
 // failure that is not "not exist" is fatal, and carries the directory name.
 func TestAppendDirSkillsUnreadableDir(t *testing.T) {
+	skipIfReadDirOnFileIsNotAnError(t)
 	// A regular file where a directory was expected: ReadDir fails with
 	// ENOTDIR, which is not os.IsNotExist.
 	notADir := filepath.Join(t.TempDir(), "file.txt")
@@ -466,6 +480,7 @@ func TestLoadSkillsWithOptionsUserOverridesBundled(t *testing.T) {
 // TestLoadSkillsWithOptionsMultipleDirsStopAtFirstError checks the error from
 // a later directory still aborts the whole load, as the inline loop did.
 func TestLoadSkillsWithOptionsMultipleDirsStopAtFirstError(t *testing.T) {
+	skipIfReadDirOnFileIsNotAnError(t)
 	good := t.TempDir()
 	setupSkillWithContent(t, good, "fine", "---\nname: fine\ndescription: d\n---\nB")
 

--- a/internal/extension/hooks_test.go
+++ b/internal/extension/hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -678,11 +679,14 @@ func (c *mockReadonlyContext) WithDelta(*agent.CommonContextDelta) agent.Context
 var _ agent.Context = (*mockReadonlyContext)(nil)
 
 func TestRunLifecycleHook(t *testing.T) {
-	dir := t.TempDir()
+	// Hooks run through "sh -c", which on Windows is Git Bash: a path with
+	// backslashes would be swallowed as escape sequences. Forward slashes are
+	// understood by both the shell and Go's file APIs.
+	dir := filepath.ToSlash(t.TempDir())
 	out := dir + "/out.json"
 	hook := HookConfig{
 		Event:   "turn_complete",
-		Command: "cat > " + out,
+		Command: `cat > "` + out + `"`,
 		Timeout: 5,
 	}
 	ctx := context.Background()
@@ -725,14 +729,17 @@ func TestRunLifecycleHookTimeout(t *testing.T) {
 // tool runs the command, a non-matching tool is skipped, and a failing command
 // is reported rather than propagated (a broken hook must not fail the tool).
 func TestBuildBeforeToolCallbacks_Invoke(t *testing.T) {
-	dir := t.TempDir()
+	// Hooks run through "sh -c", which on Windows is Git Bash: a path with
+	// backslashes would be swallowed as escape sequences. Forward slashes are
+	// understood by both the shell and Go's file APIs.
+	dir := filepath.ToSlash(t.TempDir())
 	ran := dir + "/ran"
 	var logged []string
 	SetHookLogger(func(msg string) { logged = append(logged, msg) })
 	t.Cleanup(func() { SetHookLogger(nil) })
 
 	cbs := BuildBeforeToolCallbacks([]HookConfig{
-		{Event: "before_tool", Tools: []string{"read"}, Command: "echo ran > " + ran, Timeout: 5},
+		{Event: "before_tool", Tools: []string{"read"}, Command: `echo ran > "` + ran + `"`, Timeout: 5},
 		{Event: "before_tool", Tools: []string{"read"}, Command: "exit 3", Timeout: 5},
 	})
 	if len(cbs) != 2 {
@@ -774,14 +781,17 @@ func TestBuildBeforeToolCallbacks_Invoke(t *testing.T) {
 // TestBuildAfterToolCallbacks_Invoke mirrors the before_tool case, and pins
 // that the tool's result passes through the callback unchanged.
 func TestBuildAfterToolCallbacks_Invoke(t *testing.T) {
-	dir := t.TempDir()
+	// Hooks run through "sh -c", which on Windows is Git Bash: a path with
+	// backslashes would be swallowed as escape sequences. Forward slashes are
+	// understood by both the shell and Go's file APIs.
+	dir := filepath.ToSlash(t.TempDir())
 	payload := dir + "/payload.json"
 	var logged []string
 	SetHookLogger(func(msg string) { logged = append(logged, msg) })
 	t.Cleanup(func() { SetHookLogger(nil) })
 
 	cbs := BuildAfterToolCallbacks([]HookConfig{
-		{Event: "after_tool", Tools: []string{"bash"}, Command: "cat > " + payload, Timeout: 5},
+		{Event: "after_tool", Tools: []string{"bash"}, Command: `cat > "` + payload + `"`, Timeout: 5},
 		{Event: "after_tool", Tools: []string{"bash"}, Command: "exit 3", Timeout: 5},
 	})
 	if len(cbs) != 2 {

--- a/internal/logger/httpsink_test.go
+++ b/internal/logger/httpsink_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/dimetron/pi-go/internal/httplog"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestHTTPSinkNilLogger(t *testing.T) {
@@ -15,7 +16,7 @@ func TestHTTPSinkNilLogger(t *testing.T) {
 }
 
 func TestHTTPSinkWritesRequestAndResponse(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	l, err := New()
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -84,7 +85,7 @@ func TestHTTPSinkWritesRequestAndResponse(t *testing.T) {
 }
 
 func TestHTTPSinkTransportError(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	l, err := New()
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -117,7 +118,7 @@ func TestHTTPSinkTransportError(t *testing.T) {
 // coalescer: only llm_text and thinking merge, so a run of HTTP entries must
 // stay one record each.
 func TestHTTPEntriesAreNotCoalesced(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	l, err := New()
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestNew(t *testing.T) {
@@ -15,11 +17,7 @@ func TestNew(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Set HOME env var to use temp dir
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	// Now New() will use our temp dir as home
 	log, err := New()
@@ -47,12 +45,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewHomeDirError(t *testing.T) {
-	// Set HOME to a non-existent path
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", "/nonexistent/path/that/does/not/exist"); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetUnwritableHome(t)
 
 	_, err := New()
 	if err == nil {
@@ -62,11 +55,7 @@ func TestNewHomeDirError(t *testing.T) {
 
 func TestPath(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -85,11 +74,7 @@ func TestPath(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -115,11 +100,7 @@ func TestCloseNil(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -137,11 +118,7 @@ func TestLog(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -154,11 +131,7 @@ func TestInfo(t *testing.T) {
 
 func TestError(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -171,11 +144,7 @@ func TestError(t *testing.T) {
 
 func TestErrorf(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -200,11 +169,7 @@ func TestErrorf(t *testing.T) {
 
 func TestUserMessage(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -217,11 +182,7 @@ func TestUserMessage(t *testing.T) {
 
 func TestLLMText(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -234,11 +195,7 @@ func TestLLMText(t *testing.T) {
 
 func TestLLMTextCoalescesContiguousChunks(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -277,11 +234,7 @@ func TestLLMTextCoalescesContiguousChunks(t *testing.T) {
 
 func TestLLMTextFlushesOnNonLLMEntry(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -311,11 +264,7 @@ func TestLLMTextFlushesOnNonLLMEntry(t *testing.T) {
 
 func TestLLMTextFlushesWhenAgentChanges(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -344,11 +293,7 @@ func TestLLMTextFlushesWhenAgentChanges(t *testing.T) {
 
 func TestLLMTextFlushesAfterWindow(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -461,11 +406,7 @@ func TestThinkingSurvivesTurnWithNoReply(t *testing.T) {
 
 func TestToolCall(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -478,11 +419,7 @@ func TestToolCall(t *testing.T) {
 
 func TestToolResult(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -495,11 +432,7 @@ func TestToolResult(t *testing.T) {
 
 func TestSessionStart(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("Failed to set HOME: %v", err)
-	}
-	defer func() { os.Setenv("HOME", origHome) }() //nolint:errcheck
+	testenv.SetHome(t, tmpDir)
 
 	log, err := New()
 	if err != nil {
@@ -516,7 +449,7 @@ func TestSessionStart(t *testing.T) {
 func newTestLogger(t *testing.T) *Logger {
 	t.Helper()
 
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := New()
 	if err != nil {

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -415,7 +416,7 @@ func TestNewClient(t *testing.T) {
 		clientConn.Close()
 	}()
 
-	c, err := NewClient("/bin/cat")
+	c, err := newStdioStubClient(t)
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)
 	}
@@ -490,10 +491,9 @@ func TestNewClient_NonExistentCommand(t *testing.T) {
 }
 
 func TestNewClient_ValidCommand(t *testing.T) {
-	// /bin/cat is a valid command that can be started.
-	c, err := NewClient("/bin/cat")
+	c, err := newStdioStubClient(t)
 	if err != nil {
-		t.Fatalf("NewClient(/bin/cat) failed: %v", err)
+		t.Fatalf("NewClient(stdio stub) failed: %v", err)
 	}
 	if c != nil {
 		// Force close without LSP handshake to avoid blocking.
@@ -634,4 +634,29 @@ func TestProtocol_DiagnosticSeverity(t *testing.T) {
 			t.Errorf("severity %d: got %q, want %q", tt.severity, got, tt.want)
 		}
 	}
+}
+
+// stdioStubEnv switches the re-executed test binary into stdio-stub mode.
+const stdioStubEnv = "PI_TEST_LSP_STDIO_STUB"
+
+// newStdioStubClient starts a client over a process that just holds its stdio
+// open, which is all these tests need from a "language server".
+//
+// It re-executes the test binary rather than running /bin/cat: Windows has no
+// such path, and no guaranteed equivalent on PATH.
+func newStdioStubClient(t *testing.T) (*Client, error) {
+	t.Helper()
+	t.Setenv(stdioStubEnv, "1")
+	return NewClient(os.Args[0], "-test.run=TestLSPStdioStub")
+}
+
+// TestLSPStdioStub is the stub process newStdioStubClient starts, not a test of
+// its own: it copies stdin to stdout and exits when the pipe closes. os.Exit
+// keeps the testing framework's own "PASS" output off the stub's stdout.
+func TestLSPStdioStub(t *testing.T) {
+	if os.Getenv(stdioStubEnv) != "1" {
+		return
+	}
+	_, _ = io.Copy(os.Stdout, os.Stdin)
+	os.Exit(0)
 }

--- a/internal/lsp/hooks_test.go
+++ b/internal/lsp/hooks_test.go
@@ -133,7 +133,10 @@ func TestCollectDiagnostics_FiltersToErrorsAndWarnings(t *testing.T) {
 	}
 
 	// Pre-populate diagnostics cache.
-	testURI := pathToURI("/tmp/test.go")
+	// fileURI, not pathToURI: the code under test keys its cache by fileURI,
+	// which makes the path absolute first. On Windows "/tmp/x.go" is
+	// drive-relative, so the two spellings would not match.
+	testURI := fileURI("/tmp/test.go")
 	mgr.diagnostics[testURI] = []Diagnostic{
 		{Range: Range{Start: Position{Line: 5, Character: 0}}, Severity: SeverityError, Message: "undefined: foo"},
 		{Range: Range{Start: Position{Line: 10, Character: 3}}, Severity: SeverityWarning, Message: "unused variable"},
@@ -446,7 +449,7 @@ func TestCollectDiagnosticsImmediate_OnlyErrors(t *testing.T) {
 		available:   make(map[string]bool),
 	}
 
-	testURI := pathToURI("/tmp/errors_only.go")
+	testURI := fileURI("/tmp/errors_only.go")
 	mgr.diagnostics[testURI] = []Diagnostic{
 		{Range: Range{Start: Position{Line: 0, Character: 0}}, Severity: SeverityError, Message: "syntax error"},
 	}
@@ -469,7 +472,7 @@ func TestCollectDiagnosticsImmediate_AllHintsFiltered(t *testing.T) {
 		available:   make(map[string]bool),
 	}
 
-	testURI := pathToURI("/tmp/hints_only.go")
+	testURI := fileURI("/tmp/hints_only.go")
 	mgr.diagnostics[testURI] = []Diagnostic{
 		{Range: Range{Start: Position{Line: 0, Character: 0}}, Severity: SeverityHint, Message: "consider using X"},
 		{Range: Range{Start: Position{Line: 1, Character: 0}}, Severity: SeverityInformation, Message: "info about Y"},
@@ -489,7 +492,7 @@ func TestCollectDiagnosticsImmediate_DiagnosticLineFormat(t *testing.T) {
 		available:   make(map[string]bool),
 	}
 
-	testURI := pathToURI("/tmp/format_test.go")
+	testURI := fileURI("/tmp/format_test.go")
 	mgr.diagnostics[testURI] = []Diagnostic{
 		{
 			Range:    Range{Start: Position{Line: 4, Character: 7}},
@@ -710,7 +713,7 @@ func TestBuildLSPAfterToolCallback_FullEditPath(t *testing.T) {
 	srv.opened[uri] = 1
 	srv.mu.Unlock()
 
-	testURI := pathToURI(tmpFile)
+	testURI := fileURI(tmpFile)
 	serverKey := "fakego:" + tmpDir
 	mgr := &Manager{
 		languages: map[string]*LanguageConfig{
@@ -783,7 +786,7 @@ func TestBuildLSPAfterToolCallback_EditTool_WithCachedServer(t *testing.T) {
 	serverKey := "fakego2:" + tmpDir
 
 	// Pre-populate diagnostics for the file.
-	testURI := pathToURI(tmpFile)
+	testURI := fileURI(tmpFile)
 	mgr := &Manager{
 		languages: map[string]*LanguageConfig{
 			"fakego2": {
@@ -825,7 +828,7 @@ func TestCollectDiagnostics_WaitForDiagnostics(t *testing.T) {
 	}
 
 	// Pre-populate diagnostics cache
-	testURI := pathToURI("/tmp/test.go")
+	testURI := fileURI("/tmp/test.go")
 	mgr.diagnostics[testURI] = []Diagnostic{
 		{Range: Range{Start: Position{Line: 5, Character: 0}}, Severity: SeverityError, Message: "error message"},
 	}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 )
 
@@ -470,8 +471,17 @@ func fileURI(path string) string {
 }
 
 // pathToURI converts an absolute path to a file:// URI.
+//
+// Windows paths start with a drive letter, not a slash. Handing url.URL a Path
+// of "C:/x" makes String emit "file://C:/x", where the drive letter is read as
+// the authority; the extra leading slash is what produces the "file:///C:/x"
+// form language servers expect.
 func pathToURI(path string) string {
-	u := &url.URL{Scheme: "file", Path: filepath.ToSlash(path)}
+	p := filepath.ToSlash(path)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	u := &url.URL{Scheme: "file", Path: p}
 	return u.String()
 }
 

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -542,10 +543,17 @@ func TestFileURIAbsoluteConversion(t *testing.T) {
 		t.Errorf("fileURI returned unexpected value: %s", uri)
 	}
 
-	// Absolute path should work normally.
-	uri2 := fileURI("/tmp/absolute.go")
-	if uri2 != "file:///tmp/absolute.go" {
-		t.Errorf("fileURI(/tmp/absolute.go) = %q, want file:///tmp/absolute.go", uri2)
+	// Absolute path should work normally. What counts as absolute is
+	// platform-dependent -- "/tmp/absolute.go" is drive-relative on Windows and
+	// resolves to C:\tmp\absolute.go -- so derive the expectation the same way
+	// fileURI does rather than hardcoding the Unix answer.
+	abs, err := filepath.Abs("/tmp/absolute.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "file:///" + strings.TrimPrefix(filepath.ToSlash(abs), "/")
+	if uri2 := fileURI("/tmp/absolute.go"); uri2 != want {
+		t.Errorf("fileURI(/tmp/absolute.go) = %q, want %q", uri2, want)
 	}
 }
 

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -296,15 +297,18 @@ func normalizeEndpointURL(endpoint, protocol string) string {
 // absolute it is used as-is; otherwise it is resolved as a filename within
 // ~/.pi-go/ (e.g. ".env" → ~/.pi-go/.env).
 func loadEnvFromDotEnv(dotEnvPath, key string) string {
+	// filepath.IsAbs, not a leading-slash check: a Windows absolute path starts
+	// with a drive letter, and treating it as relative resolved it under
+	// ~/.pi-go/ and silently read nothing.
 	var path string
-	if strings.HasPrefix(dotEnvPath, "/") {
+	if filepath.IsAbs(dotEnvPath) {
 		path = dotEnvPath
 	} else {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return ""
 		}
-		path = home + "/.pi-go/" + dotEnvPath
+		path = filepath.Join(home, ".pi-go", dotEnvPath)
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -10,6 +10,8 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestTracerReturnsTracer(t *testing.T) {
@@ -348,7 +350,7 @@ func TestIsAvailable_ProbesTheConfiguredHost(t *testing.T) {
 
 	// envOr consults ~/.pi-go/.env before the process environment, so an
 	// empty HOME is what makes t.Setenv authoritative here.
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
 
@@ -373,7 +375,7 @@ func TestDialAddress_InvalidEndpoint(t *testing.T) {
 }
 
 func TestIsAvailable_InvalidEndpoint_ReturnsFalse(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "%")

--- a/internal/palace/bridge.go
+++ b/internal/palace/bridge.go
@@ -67,7 +67,8 @@ func deriveWing(project string) string {
 		return "general"
 	}
 	base := filepath.Base(project)
-	if base == "." || base == "/" {
+	// filepath.Base of a root path is "/" on Unix but a backslash on Windows.
+	if base == "." || base == "/" || base == string(filepath.Separator) {
 		return "general"
 	}
 	return strings.ToLower(base)

--- a/internal/palace/complexity_palace_test.go
+++ b/internal/palace/complexity_palace_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -477,6 +478,9 @@ func TestMineConversations_ReportsProgressForEmptyParse(t *testing.T) {
 // unreadable subdirectory is tallied and the walk continues, rather than
 // abandoning the rest of the tree.
 func TestMineConversations_CountsWalkErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0o000) does not make a directory unreadable on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("running as root: permission bits do not make a directory unreadable")
 	}

--- a/internal/palace/miner.go
+++ b/internal/palace/miner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	gopath "path"
 	"path/filepath"
 	"strings"
 
@@ -200,13 +201,18 @@ func detectRoom(filePath string, rooms []RoomDef) string {
 	// Check glob patterns.
 	for _, room := range rooms {
 		for _, pattern := range room.Patterns {
-			matched, err := filepath.Match(pattern, rel)
+			// rel is slash-normalized above, so match with slash semantics.
+			// filepath.Match takes "\" as the separator on Windows, which lets a
+			// "*" run straight across the "/" boundaries and reach nested paths
+			// the pattern never meant to cover. filepath.Dir would likewise hand
+			// back a backslash path, producing a mixed "a\b/" to match against.
+			matched, err := gopath.Match(pattern, rel)
 			if err == nil && matched {
 				return room.Name
 			}
 			// Also try matching against just the directory prefix.
-			dir := filepath.Dir(rel)
-			if matched, err := filepath.Match(pattern, dir+"/"); err == nil && matched {
+			dir := gopath.Dir(rel)
+			if matched, err := gopath.Match(pattern, dir+"/"); err == nil && matched {
 				return room.Name
 			}
 		}
@@ -279,12 +285,14 @@ func isGitignored(relPath string, patterns []string) bool {
 		p = strings.TrimSuffix(p, "/")
 		// Check if any path component matches the pattern.
 		for _, part := range strings.Split(rel, "/") {
-			if matched, _ := filepath.Match(p, part); matched {
+			if matched, _ := gopath.Match(p, part); matched {
 				return true
 			}
 		}
-		// Also check the full relative path.
-		if matched, _ := filepath.Match(p, rel); matched {
+		// Also check the full relative path, again with slash semantics: under
+		// filepath.Match on Windows a pattern like "generated/*.go" would also
+		// match "generated/deep/file.go", because "/" is not a separator there.
+		if matched, _ := gopath.Match(p, rel); matched {
 			return true
 		}
 	}

--- a/internal/palace/miner.go
+++ b/internal/palace/miner.go
@@ -270,17 +270,21 @@ func loadGitignore(dir string) []string {
 // isGitignored checks whether a relative path matches any of the gitignore patterns.
 // This is a simplified check — not a full gitignore implementation.
 func isGitignored(relPath string, patterns []string) bool {
+	// .gitignore patterns are always slash-separated, so compare against a
+	// slash-separated path. Splitting on filepath.Separator instead left every
+	// pattern unmatched on Windows, where a backslash is also filepath.Match's
+	// escape character.
+	rel := filepath.ToSlash(relPath)
 	for _, p := range patterns {
 		p = strings.TrimSuffix(p, "/")
 		// Check if any path component matches the pattern.
-		parts := strings.Split(relPath, string(filepath.Separator))
-		for _, part := range parts {
+		for _, part := range strings.Split(rel, "/") {
 			if matched, _ := filepath.Match(p, part); matched {
 				return true
 			}
 		}
 		// Also check the full relative path.
-		if matched, _ := filepath.Match(p, relPath); matched {
+		if matched, _ := filepath.Match(p, rel); matched {
 			return true
 		}
 	}

--- a/internal/palace/miner_slashpath_test.go
+++ b/internal/palace/miner_slashpath_test.go
@@ -1,0 +1,67 @@
+package palace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// detectRoom matches a directory-style pattern ("internal/tools/") against the
+// file's directory prefix, not just the full path, and does so with slash
+// semantics on every OS.
+func TestDetectRoom_DirectoryPatternMatchesFilesBelowIt(t *testing.T) {
+	rooms := []RoomDef{
+		{Name: "tooling", Patterns: []string{"internal/tools/"}},
+		{Name: "ui", Patterns: []string{"internal/tui/*.go"}},
+	}
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"internal/tools/find.go", "tooling"},                      // dir-prefix branch
+		{filepath.Join("internal", "tools", "grep.go"), "tooling"}, // OS-native separators
+		{"internal/tui/run.go", "ui"},                              // full-path glob
+		{"internal/tui/refs/validator.go", "internal"},             // "*" must not cross "/"; no component names a room, so first component
+		{"src/ui/app.go", "ui"},                                    // a component named like a room
+		{"cmd/pi/main.go", "cmd"},                                  // first component fallback
+	}
+	for _, tc := range cases {
+		if got := detectRoom(tc.path, rooms); got != tc.want {
+			t.Errorf("detectRoom(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// A path-bearing .gitignore pattern is matched against the whole relative
+// path, and "*" stops at "/" there: "generated/*.go" covers one level only.
+func TestLoadGitignore_PathPatternsMatchWholeRelativePath(t *testing.T) {
+	dir := t.TempDir()
+	ignore := "# build output\n\ngenerated/*.go\n*.tmp\ncache/\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(ignore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patterns := loadGitignore(dir)
+	if len(patterns) != 3 {
+		t.Fatalf("loadGitignore = %v, want 3 patterns with the comment and blank line dropped", patterns)
+	}
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"generated/a.go", true},                   // full-path match
+		{filepath.Join("generated", "b.go"), true}, // OS-native separators
+		{"generated/deep/a.go", false},             // "*" does not cross "/"
+		{"generated/a.txt", false},                 // wrong suffix
+		{"src/x.tmp", true},                        // component match at any depth
+		{"cache/obj.o", true},                      // trailing "/" stripped, dir component matches
+		{"src/main.go", false},                     // nothing applies
+	}
+	for _, tc := range cases {
+		if got := isGitignored(tc.path, patterns); got != tc.want {
+			t.Errorf("isGitignored(%q, %v) = %v, want %v", tc.path, patterns, got, tc.want)
+		}
+	}
+}

--- a/internal/pirpc/rpc.go
+++ b/internal/pirpc/rpc.go
@@ -199,10 +199,21 @@ func (s *Server) dispatch(ctx context.Context, cmd command) {
 		s.mu.Lock()
 		cancel := s.cancel
 		s.mu.Unlock()
+		// Acknowledge before canceling. The turn goroutine emits agent_end and
+		// agent_settled as soon as its context is canceled, so replying
+		// afterwards races it: the response could land after agent_settled and
+		// a client that resolves the turn on agent_settled would then see a
+		// stray reply, and the turn's event stream would no longer end with
+		// its terminator. emit serializes writers, so once reply has returned
+		// the response is on the wire ahead of anything this cancel triggers.
+		// A turn that finishes on its own in this same instant can still
+		// settle first, but that is an abort of a turn that was already over
+		// -- the same shape as an abort with nothing running -- so the reply
+		// trailing its terminator is correct there.
+		s.reply(response{ID: cmd.ID, Command: cmd.Type, Success: true})
 		if cancel != nil {
 			cancel()
 		}
-		s.reply(response{ID: cmd.ID, Command: cmd.Type, Success: true})
 
 	case "get_state":
 		s.reply(response{ID: cmd.ID, Command: cmd.Type, Success: true, Data: s.state()})

--- a/internal/pirpc/turn_test.go
+++ b/internal/pirpc/turn_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/agent"
 	"github.com/dimetron/pi-go/internal/logger"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // scriptedLLM is an adkmodel.LLM whose reply depends on which invocation it is.
@@ -436,7 +437,7 @@ func TestAbortCancelsRunningTurn(t *testing.T) {
 // A successful switch has to be visible in get_state, since that is what the
 // client renders as the active model.
 func TestSetModelSuccessUpdatesState(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := logger.New()
 	if err != nil {
@@ -543,7 +544,7 @@ func TestSetModelRebuildFailureIsReported(t *testing.T) {
 // The log is optional, but when present every channel of a turn should reach
 // it — that log is the only record of a headless RPC session.
 func TestRunTurnWritesToTheSessionLog(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := logger.New()
 	if err != nil {
@@ -584,7 +585,7 @@ func TestRunTurnWritesToTheSessionLog(t *testing.T) {
 }
 
 func TestEmitErrorIsLoggedAndSurfaced(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := logger.New()
 	if err != nil {
@@ -616,7 +617,7 @@ func TestEmitErrorIsLoggedAndSurfaced(t *testing.T) {
 // does not exist makes a later session/load unresolvable.
 func TestStateAdvertisesSessionFileOnlyWhenItExists(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	s := NewServer(Config{SessionID: "sess-file", Model: "m"})
 	if _, ok := s.state()["sessionFile"]; ok {

--- a/internal/provider/complexity_cog_provider_a_test.go
+++ b/internal/provider/complexity_cog_provider_a_test.go
@@ -645,7 +645,7 @@ var cogPAGoldens = map[string]string{
   }
 ]`,
 	"TestCogPAXAIInputConversionError": `[
-  "xAI Responses API failed: Post \"http://127.0.0.1:1/responses\": dial tcp 127.0.0.1:1: connect: connection refused"
+  "xAI Responses API failed: Post \"nodial://127.0.0.1:1/responses\": unsupported protocol scheme \"nodial\""
 ]`,
 	"TestCogPAXAINilRequest": `[
   "xAI responses: nil LLM request"
@@ -1508,8 +1508,13 @@ func TestCogPAXAINilRequest(t *testing.T) {
 
 // TestCogPAXAIInputConversionError pins the wrapping of an input-conversion
 // failure, which happens before any request is built.
+//
+// The base URL carries a scheme net/http refuses, so the failure is reported
+// by the client itself rather than by the OS's dialer: a refused TCP connect
+// reads "connect: connection refused" on Linux but "connectex: No connection
+// could be made ..." on Windows, and a golden cannot hold both.
 func TestCogPAXAIInputConversionError(t *testing.T) {
-	llm, err := NewXAI(context.Background(), "grok-4.6", "k", "http://127.0.0.1:1", "", nil)
+	llm, err := NewXAI(context.Background(), "grok-4.6", "k", "nodial://127.0.0.1:1", "", nil)
 	if err != nil {
 		t.Fatalf("NewXAI: %v", err)
 	}

--- a/internal/session/hostenv_disk_other.go
+++ b/internal/session/hostenv_disk_other.go
@@ -1,9 +1,9 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package session
 
-// diskStats is unimplemented off Unix. Zero means "not reported" and is dropped
-// from meta.json by the omitempty tags.
+// diskStats is unimplemented outside Unix and Windows. Zero means "not
+// reported" and is dropped from meta.json by the omitempty tags.
 func diskStats(string) (total, free uint64) {
 	return 0, 0
 }

--- a/internal/session/hostenv_disk_windows.go
+++ b/internal/session/hostenv_disk_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package session
+
+import "golang.org/x/sys/windows"
+
+// diskStats reports total and available bytes for the volume holding path.
+//
+// The "available to caller" figure is used rather than the volume's total free
+// space, for the same reason the Unix implementation prefers Bavail over Bfree:
+// a disk quota can put free space out of this process's reach, and reporting
+// space pi cannot actually use would mislead whoever reads meta.json.
+func diskStats(path string) (total, free uint64) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, 0
+	}
+	var availableToCaller, totalBytes, totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(p, &availableToCaller, &totalBytes, &totalFree); err != nil {
+		return 0, 0
+	}
+	return totalBytes, availableToCaller
+}

--- a/internal/sop/sop_test.go
+++ b/internal/sop/sop_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestLoadPDD_EmbeddedDefault(t *testing.T) {
@@ -60,7 +62,7 @@ func TestLoadPDD_GlobalOverrideFromHome(t *testing.T) {
 	// Point HOME at a temp dir so os.UserHomeDir resolves there, then place a
 	// global override and confirm it is loaded when no project override exists.
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	globalSOPDir := filepath.Join(home, ".pi-go", "sops")
 	if err := os.MkdirAll(globalSOPDir, 0o755); err != nil {

--- a/internal/subagent/complexity_subagent_test.go
+++ b/internal/subagent/complexity_subagent_test.go
@@ -21,6 +21,7 @@ import (
 
 	sharedacp "github.com/dimetron/pi-go/internal/acp"
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // ---------------------------------------------------------------------------
@@ -795,7 +796,9 @@ func TestBuildCommand_NoExtraEnvOrWorkDir(t *testing.T) {
 }
 
 func TestStartChildProcess(t *testing.T) {
-	cmd := exec.Command("/bin/echo", "hello")
+	// /bin/echo does not exist on Windows; the runners do carry a POSIX shell.
+	sh := testenv.RequireShell(t)
+	cmd := exec.Command(sh, "-c", "echo hello")
 	stdout, stderr, err := startChildProcess(cmd)
 	if err != nil {
 		t.Fatalf("startChildProcess: %v", err)

--- a/internal/subagent/coverage_test.go
+++ b/internal/subagent/coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	sharedacp "github.com/dimetron/pi-go/internal/acp"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // TestOrchestrator_SetProviderOptions exercises the 0%-covered provider-option
@@ -534,7 +535,7 @@ func (e stubError) Error() string { return string(e) }
 func TestDiscoverAgents_UserDirReadError(t *testing.T) {
 	// Isolate HOME to a tempdir.
 	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	testenv.SetHome(t, tmpHome)
 
 	// Create ~/.pi-go/agents as a FILE (not a dir) so ReadDir errors.
 	piDir := filepath.Join(tmpHome, ".pi-go")

--- a/internal/subagent/coverage_test.go
+++ b/internal/subagent/coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -533,6 +534,11 @@ func (e stubError) Error() string { return string(e) }
 // only if readdir errors. Use a file named .pi-go/agents that's actually a
 // regular file so ReadDir returns a not-a-directory error.
 func TestDiscoverAgents_UserDirReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// os.ReadDir on a regular file is not a non-IsNotExist error there, so
+		// the "loading user agents" branch cannot be reached from the filesystem.
+		t.Skip("ReadDir on a file does not fail with ENOTDIR on Windows")
+	}
 	// Isolate HOME to a tempdir.
 	tmpHome := t.TempDir()
 	testenv.SetHome(t, tmpHome)

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dimetron/pi-go/internal/config"
@@ -442,7 +443,7 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 	}
 
 	// Generate agent ID.
-	agentID := fmt.Sprintf("%s-%d", agent.Name, time.Now().UnixNano())
+	agentID := fmt.Sprintf("%s-%d", agent.Name, uniqueNano())
 
 	// Determine if worktree is needed.
 	useWorktree := resolveWorktreeUsage(agent.Worktree, input.Worktree, input.WorkDir)
@@ -863,4 +864,28 @@ func (o *Orchestrator) SpawnWithInput(ctx context.Context, input AgentInput) (<-
 		return nil, "", err
 	}
 	return o.Spawn(ctx, spawnInput)
+}
+
+// lastAgentNano is the timestamp the previous agent ID was minted from.
+var lastAgentNano atomic.Int64
+
+// uniqueNano returns a strictly increasing nanosecond timestamp for agent IDs.
+//
+// The ID is "<name>-<nanos>", and the orchestrator keys its agent table on it,
+// so two spawns minted from the same clock reading collide and the second
+// silently replaces the first. On Linux that needs two spawns inside the same
+// nanosecond; on Windows the monotonic clock ticks in 100ns steps -- and
+// coarser still on older kernels -- so a retry after an instant crash, as
+// SpawnWithRetry performs, reproduced it.
+func uniqueNano() int64 {
+	for {
+		now := time.Now().UnixNano()
+		last := lastAgentNano.Load()
+		if now <= last {
+			now = last + 1
+		}
+		if lastAgentNano.CompareAndSwap(last, now) {
+			return now
+		}
+	}
 }

--- a/internal/subagent/spawner_test.go
+++ b/internal/subagent/spawner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,17 @@ import (
 // mockPiScript creates a temporary shell script that mimics pi --mode json output.
 func mockPiScript(t *testing.T, script string) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		// The stand-in agent is a #!/bin/bash script, and Spawner takes a single
+		// binary path with nowhere to name an interpreter. Go's os/exec on
+		// Windows starts either a real executable or a .bat/.cmd through
+		// cmd.exe; wrapping the script in a .bat would cover the simple cases
+		// but would put cmd.exe between the spawner and bash, so a kill would
+		// land on the wrapper rather than the agent -- which is precisely what
+		// the cancel and inactivity tests measure. Only the fixture is
+		// POSIX-bound here; Spawner itself execs whatever path it is given.
+		t.Skip("stand-in pi agent is a bash script; Windows cannot exec it directly")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mock-pi")
 	err := os.WriteFile(path, []byte("#!/bin/bash\n"+script), 0o755)

--- a/internal/subagent/spawner_timeout_test.go
+++ b/internal/subagent/spawner_timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,17 @@ import (
 // writes to stdout/stderr and how long it takes matters here.
 func fakePi(t *testing.T, script string) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		// The stand-in agent is a #!/bin/bash script, and Spawner takes a single
+		// binary path with nowhere to name an interpreter. Go's os/exec on
+		// Windows starts either a real executable or a .bat/.cmd through
+		// cmd.exe; wrapping the script in a .bat would cover the simple cases
+		// but would put cmd.exe between the spawner and bash, so a kill would
+		// land on the wrapper rather than the agent -- which is precisely what
+		// the cancel and inactivity tests measure. Only the fixture is
+		// POSIX-bound here; Spawner itself execs whatever path it is given.
+		t.Skip("stand-in pi agent is a bash script; Windows cannot exec it directly")
+	}
 	path := filepath.Join(t.TempDir(), "fake-pi")
 	body := "#!/bin/bash\n" + script + "\n"
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {

--- a/internal/subagent/unique_nano_test.go
+++ b/internal/subagent/unique_nano_test.go
@@ -1,0 +1,57 @@
+package subagent
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// uniqueNano feeds agent IDs, which key the orchestrator's agent table: two
+// equal stamps would make the second spawn silently replace the first.
+func TestUniqueNanoIsStrictlyIncreasingEvenWhenTheClockIsNot(t *testing.T) {
+	// Push the last stamp a full second into the future so every wall-clock
+	// reading during the test is <= it and the bump branch has to fire.
+	future := time.Now().UnixNano() + int64(time.Second)
+	lastAgentNano.Store(future)
+
+	prev := future
+	for i := 0; i < 1000; i++ {
+		got := uniqueNano()
+		if got <= prev {
+			t.Fatalf("call %d: uniqueNano() = %d, want > %d", i, got, prev)
+		}
+		prev = got
+	}
+}
+
+func TestUniqueNanoIsDistinctUnderContention(t *testing.T) {
+	const goroutines, perGoroutine = 32, 200
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		seen = make(map[int64]struct{}, goroutines*perGoroutine)
+		dups int
+	)
+	for g := 0; g < goroutines; g++ {
+		wg.Go(func() {
+			local := make([]int64, 0, perGoroutine)
+			for i := 0; i < perGoroutine; i++ {
+				local = append(local, uniqueNano())
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, n := range local {
+				if _, dup := seen[n]; dup {
+					dups++
+				}
+				seen[n] = struct{}{}
+			}
+		})
+	}
+	wg.Wait()
+
+	if dups != 0 {
+		t.Errorf("%d duplicate stamps across %d concurrent calls, want 0", dups, goroutines*perGoroutine)
+	}
+}

--- a/internal/subagent/worktree_test.go
+++ b/internal/subagent/worktree_test.go
@@ -19,6 +19,10 @@ func initTestRepo(t *testing.T) string {
 		{"git", "config", "user.name", "Test"},
 		{"git", "config", "commit.gpgsign", "false"},
 		{"git", "config", "tag.gpgsign", "false"},
+		// Git for Windows defaults core.autocrlf to true, which would rewrite
+		// every LF these tests write into CRLF on checkout and break the
+		// byte-for-byte content assertions.
+		{"git", "config", "core.autocrlf", "false"},
 		{"git", "commit", "--allow-empty", "-m", "initial commit"},
 	}
 	for _, args := range cmds {
@@ -533,9 +537,27 @@ func TestWorktree_CreateWithExistingBranch(t *testing.T) {
 	if !strings.Contains(string(out), "branch refs/heads/my-spec") {
 		t.Errorf("expected worktree on branch my-spec, got:\n%s", out)
 	}
-	if !strings.Contains(string(out), path) {
+	if !listingNamesPath(string(out), path) {
 		t.Errorf("expected worktree at %s in list:\n%s", path, out)
 	}
+}
+
+// listingNamesPath reports whether a `git worktree list --porcelain` listing
+// names path.
+//
+// git prints worktree paths with forward slashes, and on Windows it prints the
+// long form of a directory that t.TempDir hands back in 8.3 short form
+// (C:\Users\RUNNER~1\... vs C:/Users/runneradmin/...), so a plain substring
+// match is not enough there.
+func listingNamesPath(listing, path string) bool {
+	if strings.Contains(listing, path) || strings.Contains(listing, filepath.ToSlash(path)) {
+		return true
+	}
+	long, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(listing, filepath.ToSlash(long))
 }
 
 // TestWorktree_CreateWithExistingBranchAndWorktree verifies that Create

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,94 @@
+// Package testenv holds small helpers that keep tests portable across
+// operating systems. It is only imported from _test.go files.
+package testenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// SetHome points the user's home directory at dir for the duration of the test.
+//
+// os.UserHomeDir reads $HOME on Unix but %USERPROFILE% on Windows, so a test
+// that sets only HOME still resolves to the real profile directory there --
+// which makes the test read and write the developer's (or CI runner's) actual
+// ~/.pi-go instead of its sandbox.
+func SetHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+}
+
+// SetUnwritableHome points the home directory at a regular file for the
+// duration of the test, so anything the code under test tries to create below
+// ~ fails. It returns that path.
+//
+// Tests used to spell this as HOME=/nonexistent/..., which does not travel:
+// on Windows a leading slash is drive-relative, so os.MkdirAll cheerfully
+// creates the directory and the expected failure never happens.
+func SetUnwritableHome(t *testing.T) string {
+	t.Helper()
+	home := filepath.Join(t.TempDir(), "home-is-a-file")
+	if err := os.WriteFile(home, nil, 0o600); err != nil {
+		t.Fatalf("creating the file that stands in for HOME: %v", err)
+	}
+	SetHome(t, home)
+	return home
+}
+
+// RequireShell skips the test unless a POSIX shell is on PATH.
+//
+// The GitHub Windows runners ship Git for Windows, so "bash" and "sh" resolve
+// there; a bare Windows box has neither. Tests that drive shell commands call
+// this instead of hardcoding /bin/sh, which never exists on Windows.
+func RequireShell(t *testing.T) string {
+	t.Helper()
+	sh, err := exec.LookPath("bash")
+	if err != nil {
+		sh, err = exec.LookPath("sh")
+	}
+	if err != nil {
+		t.Skipf("no POSIX shell on PATH: %v", err)
+	}
+	return sh
+}
+
+// UnsetHome removes the home-directory environment variables for the duration
+// of the test, so os.UserHomeDir has nothing to resolve. Unsetting HOME alone
+// leaves %USERPROFILE% in place, which is the only variable Windows consults.
+func UnsetHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", "")
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", "")
+	}
+	os.Unsetenv("HOME")
+	if runtime.GOOS == "windows" {
+		os.Unsetenv("USERPROFILE")
+	}
+}
+
+// FakeBinary writes a do-nothing executable named name into dir and returns
+// its path.
+//
+// On Windows the file gets a .bat suffix, because exec.LookPath there resolves
+// only the suffixes listed in %PATHEXT% -- an extensionless file is invisible
+// to it, however executable its mode bits claim to be.
+func FakeBinary(t *testing.T, dir, name string) string {
+	t.Helper()
+	body := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		body = "@exit /b 0\r\n"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake binary %s: %v", path, err)
+	}
+	return path
+}

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -1,0 +1,92 @@
+package testenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSetHomeIsScopedToTheTest(t *testing.T) {
+	before, beforeErr := os.UserHomeDir()
+
+	dir := t.TempDir()
+	t.Run("inside", func(t *testing.T) {
+		SetHome(t, dir)
+		got, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatalf("UserHomeDir: %v", err)
+		}
+		if got != dir {
+			t.Errorf("UserHomeDir = %q, want %q", got, dir)
+		}
+	})
+
+	after, afterErr := os.UserHomeDir()
+	if after != before || (afterErr == nil) != (beforeErr == nil) {
+		t.Errorf("home after the subtest = %q (%v), want it restored to %q (%v)", after, afterErr, before, beforeErr)
+	}
+}
+
+func TestSetUnwritableHomeBlocksCreationBelowIt(t *testing.T) {
+	home := SetUnwritableHome(t)
+
+	info, err := os.Stat(home)
+	if err != nil {
+		t.Fatalf("stat %s: %v", home, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("%s is a directory, want a regular file standing in for HOME", home)
+	}
+	if got, _ := os.UserHomeDir(); got != home {
+		t.Errorf("UserHomeDir = %q, want %q", got, home)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".pi-go"), 0o755); err == nil {
+		t.Error("MkdirAll below the file succeeded, want an error")
+	}
+}
+
+func TestRequireShellReturnsARunnableShell(t *testing.T) {
+	sh := RequireShell(t)
+	if out, err := exec.Command(sh, "-c", "echo ok").Output(); err != nil || string(out) != "ok\n" {
+		t.Errorf("%s -c 'echo ok' = %q, %v", sh, out, err)
+	}
+}
+
+func TestRequireShellSkipsWithoutOne(t *testing.T) {
+	// An empty PATH makes LookPath fail for bash and sh alike, so the helper
+	// must skip rather than return a path that cannot run.
+	t.Setenv("PATH", "")
+	sh := RequireShell(t)
+	t.Errorf("RequireShell returned %q with an empty PATH, want the test skipped", sh)
+}
+
+func TestUnsetHomeLeavesNothingToResolve(t *testing.T) {
+	UnsetHome(t)
+	if home, err := os.UserHomeDir(); err == nil {
+		t.Errorf("UserHomeDir = %q, want an error with HOME unset", home)
+	}
+}
+
+func TestFakeBinaryRuns(t *testing.T) {
+	dir := t.TempDir()
+	bin := FakeBinary(t, dir, "tool")
+	if filepath.Dir(bin) != dir {
+		t.Errorf("binary written to %q, want it under %q", bin, dir)
+	}
+	run := exec.Command(bin)
+	if runtime.GOOS == "windows" {
+		// A .bat is not a PE image; it runs through the command interpreter.
+		run = exec.Command("cmd", "/c", bin)
+	}
+	if err := run.Run(); err != nil {
+		t.Errorf("running %s: %v", bin, err)
+	}
+	// It must also be found by name through PATH, which is what callers that
+	// put dir on PATH rely on.
+	t.Setenv("PATH", dir)
+	if _, err := exec.LookPath("tool"); err != nil {
+		t.Errorf("LookPath(tool) with PATH=%s: %v", dir, err)
+	}
+}

--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -334,7 +334,7 @@ func TestSupervisor_IdleTimeoutClampedToTimeout(t *testing.T) {
 
 	start := time.Now()
 	out, err := sup.Run(t.Context(), runRequest{
-		dir:         t.TempDir(),
+		dir:         bashWorkDir(t),
 		command:     "sleep 30",
 		timeout:     200 * time.Millisecond,
 		idleTimeout: time.Hour, // longer than the timeout; must be clamped
@@ -564,7 +564,7 @@ func TestBashWait_EndsWhenTheChildExits(t *testing.T) {
 	sup.heartbeat = 20 * time.Millisecond
 
 	out, err := sup.Run(t.Context(), runRequest{
-		dir:     t.TempDir(),
+		dir:     bashWorkDir(t),
 		command: `sleep 2 > out.log 2>&1`,
 		timeout: 300 * time.Millisecond,
 	})
@@ -608,7 +608,7 @@ func TestBashWait_LingeringGrandchildCostsTheExitStatus(t *testing.T) {
 	sup.heartbeat = 20 * time.Millisecond
 
 	out, err := sup.Run(t.Context(), runRequest{
-		dir:     t.TempDir(),
+		dir:     bashWorkDir(t),
 		command: `sleep 30 & echo started > out.log 2>&1; exit 0`,
 		timeout: 300 * time.Millisecond,
 	})

--- a/internal/tools/bash_supervisor_leak_test.go
+++ b/internal/tools/bash_supervisor_leak_test.go
@@ -94,7 +94,7 @@ func TestSupervisor_CanceledForegroundRunsLeakNoGoroutines(t *testing.T) {
 			cancel()
 		}()
 		defer cancel()
-		_, err := sup.Run(ctx, runRequest{dir: t.TempDir(), command: "sleep 30", timeout: 10 * time.Second})
+		_, err := sup.Run(ctx, runRequest{dir: bashWorkDir(t), command: "sleep 30", timeout: 10 * time.Second})
 		if err == nil {
 			t.Error("a canceled run returned no error")
 		}
@@ -116,6 +116,14 @@ func TestSupervisor_CanceledForegroundRunsLeakNoGoroutines(t *testing.T) {
 // TestSupervisor_KillAllReleasesEverything checks the session-teardown path
 // leaves nothing behind: no tracked handles, no lingering goroutines.
 func TestSupervisor_KillAllReleasesEverything(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// KillAll signals the shell, not a process group: procs.setGroup is a
+		// no-op off Unix (internal/procs/procs_other.go), so `sleep` outlives
+		// the `bash -c` that started it and its reaping goroutine stays parked
+		// on Wait. This asserts a teardown guarantee the code does not claim to
+		// offer on Windows; the Unix run still guards it.
+		t.Skip("process-group teardown is Unix-only; see internal/procs/procs_other.go")
+	}
 	sup := NewBashSupervisor()
 	sup.idleTimeout = 80 * time.Millisecond
 	sup.heartbeat = 20 * time.Millisecond

--- a/internal/tools/bash_supervisor_test.go
+++ b/internal/tools/bash_supervisor_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -20,10 +21,28 @@ func fastSupervisor(t *testing.T) *BashSupervisor {
 	return sup
 }
 
+// bashWorkDir returns a working directory for a backgrounded shell command.
+//
+// It deliberately does not use t.TempDir. A killed `bash -c` leaves its
+// grandchildren running on Windows -- procs.setGroup is a Unix-only job/process
+// group facility, see internal/procs/procs_other.go -- and Windows will not
+// remove a directory that a live process has as its working directory. That
+// would fail t.TempDir's own cleanup and, with it, tests that otherwise passed.
+// Removal here is best effort.
+func bashWorkDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "pi-bash-cwd-")
+	if err != nil {
+		t.Fatalf("creating shell working directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func run(t *testing.T, sup *BashSupervisor, command string, timeout time.Duration) BashOutput {
 	t.Helper()
 	out, err := sup.Run(context.Background(), runRequest{
-		dir:     t.TempDir(),
+		dir:     bashWorkDir(t),
 		command: command,
 		timeout: timeout,
 	})
@@ -190,7 +209,7 @@ func TestSupervisor_ForegroundCancellationKillsCommand(t *testing.T) {
 	}()
 
 	start := time.Now()
-	_, err := sup.Run(ctx, runRequest{dir: t.TempDir(), command: "sleep 30 | cat", timeout: time.Hour})
+	_, err := sup.Run(ctx, runRequest{dir: bashWorkDir(t), command: "sleep 30 | cat", timeout: time.Hour})
 	if err == nil {
 		t.Fatal("expected a cancellation error")
 	}

--- a/internal/tools/complexity_cog_tools_b_test.go
+++ b/internal/tools/complexity_cog_tools_b_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -575,6 +576,9 @@ func TestCogBLoadGitignoreGolden(t *testing.T) {
 }
 
 func TestCogBLoadGitignoreUnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0o000) does not make a file unreadable on Windows")
+	}
 	// A .gitignore that cannot be read contributes no patterns and does not
 	// abort the walk: the sibling directory's file is still collected.
 	dir := cogBWriteTree(t, map[string]string{

--- a/internal/tools/find.go
+++ b/internal/tools/find.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"io/fs"
+	gopath "path"
 	"path/filepath"
 	"strings"
 
@@ -59,8 +60,13 @@ func findHandler(sb *Sandbox, input FindInput) (FindOutput, error) {
 		patterns = nil
 	}
 
+	// fs.FS paths are always slash-separated, whatever the host OS. Resolve
+	// hands back an OS path, so it has to be converted before it can be used as
+	// a walk root or compared against a walked path.
+	root := filepath.ToSlash(rel)
+
 	// Normalize doublestar patterns: since WalkDir already recurses,
-	// strip "**/" prefixes so filepath.Match can handle the rest.
+	// strip "**/" prefixes so gopath.Match can handle the rest.
 	// e.g. "**/*.go" → "*.go", "src/**/*.go" → "src/**/*.go" (handled below)
 	pattern := input.Pattern
 	filePattern := normalizeGlobPattern(pattern)
@@ -68,45 +74,43 @@ func findHandler(sb *Sandbox, input FindInput) (FindOutput, error) {
 	var files []string
 	total := 0
 
-	_ = fs.WalkDir(fsys, rel, func(path string, d fs.DirEntry, err error) error {
+	_ = fs.WalkDir(fsys, root, func(walked string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if d.IsDir() {
 			if shouldSkipDir(d.Name()) {
-				return filepath.SkipDir
+				return fs.SkipDir
 			}
 			// Apply .gitignore: if any pattern says skip this directory, skip it
-			if shouldSkipPath(path, d, patterns) {
-				return filepath.SkipDir
+			if shouldSkipPath(walked, d, patterns) {
+				return fs.SkipDir
 			}
 			return nil
 		}
 
 		// Apply .gitignore file filters
-		if shouldSkipPath(path, d, patterns) {
+		if shouldSkipPath(walked, d, patterns) {
 			return nil
 		}
 
 		// Match against the filename using the normalized pattern
 		name := d.Name()
-		matched, _ := filepath.Match(filePattern, name)
+		matched, _ := gopath.Match(filePattern, name)
 		if !matched {
 			// Try matching against relative path for patterns like "src/*.go"
-			relPath, relErr := filepath.Rel(rel, path)
-			if relErr == nil {
-				matched, _ = filepath.Match(filePattern, relPath)
-				if !matched {
-					// For patterns like "src/**/*.go", match each path segment
-					matched = matchDoublestar(pattern, relPath)
-				}
+			relPath := relativeFSPath(root, walked)
+			matched, _ = gopath.Match(filePattern, relPath)
+			if !matched {
+				// For patterns like "src/**/*.go", match each path segment
+				matched = matchDoublestar(pattern, relPath)
 			}
 		}
 
 		if matched {
 			total++
 			if len(files) < maxFindResults {
-				files = append(files, path)
+				files = append(files, walked)
 			}
 		}
 		return nil
@@ -127,6 +131,16 @@ func shouldSkipDir(base string) bool {
 		return true
 	}
 	return base == "node_modules" || base == "vendor" || base == "__pycache__"
+}
+
+// relativeFSPath returns walked relative to root. Both are slash-separated
+// fs.FS paths, so filepath.Rel is the wrong tool: on Windows it would hand back
+// a backslash-separated result that no glob pattern can match.
+func relativeFSPath(root, walked string) string {
+	if root == "." || root == "" {
+		return walked
+	}
+	return strings.TrimPrefix(strings.TrimPrefix(walked, root), "/")
 }
 
 // normalizeGlobPattern strips leading "**/" from glob patterns since WalkDir
@@ -159,8 +173,8 @@ func matchDoublestar(pattern, path string) bool {
 	// The suffix after the last ** must match the filename
 	suffix := parts[len(parts)-1]
 	if suffix != "" {
-		name := filepath.Base(path)
-		matched, _ := filepath.Match(suffix, name)
+		name := gopath.Base(path)
+		matched, _ := gopath.Match(suffix, name)
 		return matched
 	}
 	return true

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -228,7 +228,9 @@ func grepHandler(sb *Sandbox, input GrepInput) (GrepOutput, error) {
 		if resolveErr != nil {
 			return GrepOutput{}, resolveErr
 		}
-		_ = fs.WalkDir(fsys, rel, walkFn)
+		// Resolve returns an OS path; fs.FS roots are always slash-separated,
+		// so on Windows the walk would find nothing under a subdirectory.
+		_ = fs.WalkDir(fsys, filepath.ToSlash(rel), walkFn)
 	} else {
 		matches = grepFileSandbox(sb, re, searchPath)
 		total = len(matches)

--- a/internal/tools/lsp.go
+++ b/internal/tools/lsp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"google.golang.org/adk/v2/agent"
@@ -493,7 +494,14 @@ func fileURI(path string) string {
 	if err != nil {
 		abs = path
 	}
-	u := &url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}
+	// Windows paths start with a drive letter, not a slash. Without the extra
+	// leading slash url.URL emits "file://C:/x", where the drive letter is read
+	// as the authority instead of part of the path.
+	p := filepath.ToSlash(abs)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	u := &url.URL{Scheme: "file", Path: p}
 	return u.String()
 }
 
@@ -539,7 +547,12 @@ func uriToPath(uri string) string {
 		return uri
 	}
 	if u.Scheme == "file" {
-		return filepath.FromSlash(u.Path)
+		p := u.Path
+		// Undo the leading slash fileURI puts in front of a drive letter.
+		if runtime.GOOS == "windows" && len(p) >= 3 && p[0] == '/' && p[2] == ':' {
+			p = p[1:]
+		}
+		return filepath.FromSlash(p)
 	}
 	return uri
 }

--- a/internal/tools/lsp_test.go
+++ b/internal/tools/lsp_test.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -190,14 +192,15 @@ func TestConvertLocations(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
-	if entries[0].File != "/tmp/foo.go" {
-		t.Errorf("expected /tmp/foo.go, got %s", entries[0].File)
+	// convertLocations returns OS paths, so the separator follows the platform.
+	if want := filepath.FromSlash("/tmp/foo.go"); entries[0].File != want {
+		t.Errorf("expected %s, got %s", want, entries[0].File)
 	}
 	if entries[0].Line != 10 || entries[0].Column != 5 {
 		t.Errorf("expected line=10 col=5, got line=%d col=%d", entries[0].Line, entries[0].Column)
 	}
-	if entries[1].File != "/tmp/bar.go" {
-		t.Errorf("expected /tmp/bar.go, got %s", entries[1].File)
+	if want := filepath.FromSlash("/tmp/bar.go"); entries[1].File != want {
+		t.Errorf("expected %s, got %s", want, entries[1].File)
 	}
 }
 
@@ -245,9 +248,18 @@ func TestURIToPath(t *testing.T) {
 		uri  string
 		want string
 	}{
-		{"file:///tmp/foo.go", "/tmp/foo.go"},
-		{"file:///home/user/bar.py", "/home/user/bar.py"},
+		// A file URI carries POSIX separators; the OS path does not.
+		{"file:///tmp/foo.go", filepath.FromSlash("/tmp/foo.go")},
+		{"file:///home/user/bar.py", filepath.FromSlash("/home/user/bar.py")},
 		{"https://example.com", "https://example.com"},
+	}
+	if runtime.GOOS == "windows" {
+		// The slash a file URI puts in front of a drive letter is not part of
+		// the path: file:///C:/x is C:\x, not \C:\x.
+		tests = append(tests, struct {
+			uri  string
+			want string
+		}{`file:///C:/tmp/foo.go`, `C:\tmp\foo.go`})
 	}
 	for _, tt := range tests {
 		got := uriToPath(tt.uri)
@@ -258,17 +270,23 @@ func TestURIToPath(t *testing.T) {
 }
 
 func TestFileURI(t *testing.T) {
-	tests := []struct {
-		path    string
-		wantPfx string
-	}{
-		{"/tmp/foo.go", "file:///tmp/foo.go"},
-		{"/home/user/project/main.go", "file:///home/user/project/main.go"},
-	}
-	for _, tt := range tests {
-		got := fileURI(tt.path)
-		if got != tt.wantPfx {
-			t.Errorf("fileURI(%q) = %q, want %q", tt.path, got, tt.wantPfx)
+	// fileURI makes the path absolute first, and what "absolute" means is
+	// platform-dependent: "/tmp/foo.go" is already absolute on Unix but is
+	// drive-relative on Windows, where it resolves to C:\tmp\foo.go and has
+	// to be encoded as file:///C:/tmp/foo.go. Derive the expectation the same
+	// way rather than hardcoding the Unix answer.
+	for _, path := range []string{"/tmp/foo.go", "/home/user/project/main.go"} {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "file:///" + strings.TrimPrefix(filepath.ToSlash(abs), "/")
+		got := fileURI(path)
+		if got != want {
+			t.Errorf("fileURI(%q) = %q, want %q", path, got, want)
+		}
+		if back := uriToPath(got); back != abs {
+			t.Errorf("uriToPath(fileURI(%q)) = %q, want %q", path, back, abs)
 		}
 	}
 }

--- a/internal/tools/read_ledger_wiring_test.go
+++ b/internal/tools/read_ledger_wiring_test.go
@@ -15,6 +15,10 @@ func newLedgerToolPair(t *testing.T, dir string) (readTool, writeTool any) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The sandbox holds an os.Root on dir. Leaving it open makes t.TempDir's
+	// own cleanup fail on Windows, which refuses to remove a directory that
+	// something still has a handle to.
+	t.Cleanup(func() { _ = sb.Close() })
 	ledger := NewReadLedger()
 	rt, err := newReadTool(sb, ledger)
 	if err != nil {

--- a/internal/tools/resolve.go
+++ b/internal/tools/resolve.go
@@ -29,7 +29,10 @@ var blockedPaths = map[string]bool{
 
 // isBlockedPath reports whether path names a device that must not be read.
 func isBlockedPath(path string) bool {
-	clean := filepath.Clean(path)
+	// Slash-normalized: these are POSIX device names, and a model hands them
+	// over spelled that way whatever it is running on. filepath.Clean would
+	// turn them into \dev\zero on Windows and the lookup would miss.
+	clean := filepath.ToSlash(filepath.Clean(path))
 	if blockedPaths[clean] {
 		return true
 	}

--- a/internal/tools/sandbox.go
+++ b/internal/tools/sandbox.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	gopath "path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -419,7 +420,12 @@ func (p GitignorePattern) matches(path string) bool {
 		return false
 	}
 
-	matched, _ := filepath.Match(p.pattern, name)
+	// path.Match, not filepath.Match: .gitignore syntax escapes with a
+	// backslash ("\#literal" names a file starting with '#'), and so does
+	// path.Match on every OS. filepath.Match on Windows treats '\' as an
+	// ordinary character instead, so such a pattern never matched there. The
+	// operand is a bare name with no separator, so the two agree otherwise.
+	matched, _ := gopath.Match(p.pattern, name)
 	if matched && p.isDir {
 		// Directory pattern: only match if path is a directory
 		// (handled by caller checking d.IsDir())

--- a/internal/tools/sandbox_test.go
+++ b/internal/tools/sandbox_test.go
@@ -550,7 +550,7 @@ func TestSandbox_Resolve_WorktreeRelativePathDeep(t *testing.T) {
 		desc string
 	}{
 		// ../../ from subdir = worktrees/agent-456
-		{"../../go.mod", "worktrees/go.mod", "file in worktrees dir"},
+		{"../../go.mod", filepath.Join("worktrees", "go.mod"), "file in worktrees dir"},
 		{"../go.sum", filepath.Join("worktrees", "agent-456", "go.sum"), "file in agent dir"},
 		{"../..", "worktrees", "parent of agent dir"},
 	}
@@ -1161,8 +1161,12 @@ func TestSandbox_Resolve_AbsoluteOutsideReturnsError(t *testing.T) {
 	sb := testSandbox(t, dir)
 
 	// An absolute path unrelated to sandbox should yield a relative path
-	// containing "..", which Resolve detects and rejects.
-	_, err := sb.Resolve("/completely/unrelated/path")
+	// containing "..", which Resolve detects and rejects. A literal
+	// "/completely/unrelated/path" would not do: on Windows a leading slash is
+	// drive-relative, not absolute, so Resolve would read it as a path inside
+	// the sandbox.
+	outside := filepath.Join(t.TempDir(), "completely", "unrelated", "path")
+	_, err := sb.Resolve(outside)
 	if err == nil {
 		t.Error("expected error for absolute path outside sandbox")
 	}

--- a/internal/tools/session_stats_test.go
+++ b/internal/tools/session_stats_test.go
@@ -463,7 +463,9 @@ func TestSessionStatsGitOpsAnomaly(t *testing.T) {
 	// Helper to build a session of N `git status` bash calls.
 	build := func(n int) string {
 		t.Helper()
-		id := filepath.Join(tmpDir, "s-"+time.Now().Format("150405.000000")+"-"+itoa(n))
+		// Just the directory name: joining tmpDir with an already-absolute id
+		// produced a path containing a drive letter mid-string on Windows.
+		id := "s-" + time.Now().Format("150405.000000") + "-" + itoa(n)
 		sessionPath := filepath.Join(tmpDir, id)
 		if err := os.MkdirAll(sessionPath, 0o755); err != nil {
 			t.Fatal(err)

--- a/internal/tools/tree.go
+++ b/internal/tools/tree.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"io/fs"
+	gopath "path"
 	"path/filepath"
 	"strings"
 
@@ -73,7 +74,8 @@ func treeHandler(sb *Sandbox, input TreeInput) (TreeOutput, error) {
 	b.WriteString("\n")
 
 	dirs, files, count := 0, 0, 0
-	buildTree(fsys, rel, "", depth, &b, &dirs, &files, &count)
+	// fs.FS paths are slash-separated on every OS; Resolve returns an OS path.
+	buildTree(fsys, filepath.ToSlash(rel), "", depth, &b, &dirs, &files, &count)
 
 	summary := fmt.Sprintf("\n%d directories, %d files", dirs, files)
 	if count >= maxTreeEntries {
@@ -130,7 +132,10 @@ func buildTree(fsys fs.FS, dir, prefix string, depth int, b *strings.Builder, di
 		if e.IsDir() {
 			*dirs++
 			b.WriteString(prefix + connector + name + "/\n")
-			buildTree(fsys, filepath.Join(dir, name), childPrefix, depth-1, b, dirs, files, count)
+			// gopath.Join, not filepath.Join: a backslash-joined name is not a
+			// path fs.ReadDir can open, so on Windows the tree stopped one
+			// level down and reported no nested files at all.
+			buildTree(fsys, gopath.Join(dir, name), childPrefix, depth-1, b, dirs, files, count)
 		} else {
 			*files++
 			b.WriteString(prefix + connector + name + "\n")

--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	stdlog "log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1407,7 +1408,10 @@ func TestAgentToolResultMsg_ClearsActiveTool(t *testing.T) {
 }
 
 func TestAgentDoneMsg_FiresLifecycleHooks(t *testing.T) {
-	dir := t.TempDir()
+	// Lifecycle hooks run through "sh -c", which is Git Bash on Windows and
+	// would eat the backslashes in a native path. Forward slashes work for both
+	// the shell and Go's file APIs.
+	dir := filepath.ToSlash(t.TempDir())
 	turnOut := dir + "/turn.json"
 	inputOut := dir + "/input.json"
 	m := &model{
@@ -1417,8 +1421,8 @@ func TestAgentDoneMsg_FiresLifecycleHooks(t *testing.T) {
 		agentCh:   make(chan agentMsg, 64),
 		cfg: Config{
 			LifecycleHooks: []extension.HookConfig{
-				{Event: "turn_complete", Command: "cat > " + turnOut, Timeout: 5},
-				{Event: "user_input_required", Command: "cat > " + inputOut, Timeout: 5},
+				{Event: "turn_complete", Command: `cat > "` + turnOut + `"`, Timeout: 5},
+				{Event: "user_input_required", Command: `cat > "` + inputOut + `"`, Timeout: 5},
 			},
 		},
 	}
@@ -1463,7 +1467,7 @@ func waitForHookOutput(t *testing.T, path string) []byte {
 // user_input_required — so a consumer that maps them onto an external status
 // would settle on the wrong final state if the two ran concurrently.
 func TestLifecycleHooks_RunInOrder(t *testing.T) {
-	out := t.TempDir() + "/order.txt"
+	out := filepath.ToSlash(t.TempDir()) + "/order.txt"
 	m := &model{
 		ctx:       context.Background(),
 		chatModel: ChatModel{Messages: []message{{role: "assistant"}}},
@@ -1473,8 +1477,8 @@ func TestLifecycleHooks_RunInOrder(t *testing.T) {
 			LifecycleHooks: []extension.HookConfig{
 				// The first hook sleeps, so an unserialized implementation
 				// would let the second one finish first.
-				{Event: "turn_complete", Command: "sleep 0.3; echo turn >> " + out, Timeout: 5},
-				{Event: "user_input_required", Command: "echo input >> " + out, Timeout: 5},
+				{Event: "turn_complete", Command: `sleep 0.3; echo turn >> "` + out + `"`, Timeout: 5},
+				{Event: "user_input_required", Command: `echo input >> "` + out + `"`, Timeout: 5},
 			},
 		},
 	}
@@ -1502,7 +1506,7 @@ func TestLifecycleHooks_RunInOrder(t *testing.T) {
 // Tea renderer owns the alternate screen, and anything written to stderr is
 // painted over it without the renderer knowing those cells were dirtied.
 func TestLifecycleHooks_DoNotWriteToStderr(t *testing.T) {
-	done := t.TempDir() + "/done"
+	done := filepath.ToSlash(t.TempDir()) + "/done"
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
@@ -1525,7 +1529,7 @@ func TestLifecycleHooks_DoNotWriteToStderr(t *testing.T) {
 			LifecycleHooks: []extension.HookConfig{
 				// Fails, and is noisy on both streams while doing so.
 				{Event: "turn_complete", Command: "echo noise; echo boom >&2; exit 1", Timeout: 5},
-				{Event: "user_input_required", Command: "echo done > " + done, Timeout: 5},
+				{Event: "user_input_required", Command: `echo done > "` + done + `"`, Timeout: 5},
 			},
 		},
 	}
@@ -1550,7 +1554,10 @@ func TestLifecycleHooks_DoNotWriteToStderr(t *testing.T) {
 }
 
 func TestAgentDoneMsg_ErrorDoesNotFireUserInputHook(t *testing.T) {
-	dir := t.TempDir()
+	// Lifecycle hooks run through "sh -c", which is Git Bash on Windows and
+	// would eat the backslashes in a native path. Forward slashes work for both
+	// the shell and Go's file APIs.
+	dir := filepath.ToSlash(t.TempDir())
 	turnOut := dir + "/turn.json"
 	inputOut := dir + "/input.json"
 	m := &model{
@@ -1559,8 +1566,8 @@ func TestAgentDoneMsg_ErrorDoesNotFireUserInputHook(t *testing.T) {
 		running:   true,
 		agentCh:   make(chan agentMsg, 64),
 		cfg: Config{LifecycleHooks: []extension.HookConfig{
-			{Event: "turn_complete", Command: "cat > " + turnOut, Timeout: 5},
-			{Event: "user_input_required", Command: "cat > " + inputOut, Timeout: 5},
+			{Event: "turn_complete", Command: `cat > "` + turnOut + `"`, Timeout: 5},
+			{Event: "user_input_required", Command: `cat > "` + inputOut + `"`, Timeout: 5},
 		}},
 	}
 

--- a/internal/tui/agent_loop_e2e_test.go
+++ b/internal/tui/agent_loop_e2e_test.go
@@ -54,6 +54,10 @@ func TestRunAgentLoop_AbortsStuckBashLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSandbox: %v", err)
 	}
+	// The sandbox keeps an os.Root open on dir; Windows will not remove a
+	// directory that anything still holds a handle to, so t.TempDir's cleanup
+	// fails unless it is closed.
+	t.Cleanup(func() { _ = sb.Close() })
 	coreTools, err := tools.CoreTools(sb)
 	if err != nil {
 		t.Fatalf("CoreTools: %v", err)

--- a/internal/tui/agent_loop_run_e2e_test.go
+++ b/internal/tui/agent_loop_run_e2e_test.go
@@ -61,6 +61,10 @@ func newRunTestAgent(t *testing.T, llm llmmodel.LLM) (*agent.Agent, string) {
 	if err != nil {
 		t.Fatalf("NewSandbox: %v", err)
 	}
+	// The sandbox keeps an os.Root open on that directory. Windows will not
+	// remove a directory anything still holds a handle to, so leaving it open
+	// fails t.TempDir's own cleanup.
+	t.Cleanup(func() { _ = sb.Close() })
 	coreTools, err := tools.CoreTools(sb)
 	if err != nil {
 		t.Fatalf("CoreTools: %v", err)

--- a/internal/tui/agent_loop_runaway_test.go
+++ b/internal/tui/agent_loop_runaway_test.go
@@ -125,6 +125,10 @@ func TestRunAgentLoop_AbortsRunawayOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSandbox: %v", err)
 	}
+	// The sandbox keeps an os.Root open on dir; Windows will not remove a
+	// directory that anything still holds a handle to, so t.TempDir's cleanup
+	// fails unless it is closed.
+	t.Cleanup(func() { _ = sb.Close() })
 	coreTools, err := tools.CoreTools(sb)
 	if err != nil {
 		t.Fatalf("CoreTools: %v", err)
@@ -191,6 +195,10 @@ func TestRunAgentLoop_WarnsOnTruncatedTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSandbox: %v", err)
 	}
+	// The sandbox keeps an os.Root open on dir; Windows will not remove a
+	// directory that anything still holds a handle to, so t.TempDir's cleanup
+	// fails unless it is closed.
+	t.Cleanup(func() { _ = sb.Close() })
 	coreTools, err := tools.CoreTools(sb)
 	if err != nil {
 		t.Fatalf("CoreTools: %v", err)

--- a/internal/tui/agent_loop_runaway_units_test.go
+++ b/internal/tui/agent_loop_runaway_units_test.go
@@ -127,6 +127,10 @@ func TestRunAgentLoop_AbortsRunawayReplyText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSandbox: %v", err)
 	}
+	// The sandbox keeps an os.Root open on dir; Windows will not remove a
+	// directory that anything still holds a handle to, so t.TempDir's cleanup
+	// fails unless it is closed.
+	t.Cleanup(func() { _ = sb.Close() })
 	coreTools, err := tools.CoreTools(sb)
 	if err != nil {
 		t.Fatalf("CoreTools: %v", err)

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"bytes"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -33,6 +34,12 @@ func newTestRenderer(t *testing.T) *glamour.TermRenderer {
 }
 
 func TestUpdateRendererDoesNotQueryTerminalBackground(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// creack/pty has no Windows implementation (pty.Open returns
+		// ErrUnsupported), and the behavior under test is a terminal
+		// OSC-11 background query that only a pty can observe.
+		t.Skip("no pty on Windows")
+	}
 	t.Setenv("TERM", "xterm-256color")
 	ptyMaster, ptySlave, err := pty.Open()
 	if err != nil {

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -288,7 +288,11 @@ func matchingFiles(prefix string, workDir string) []CompletionCandidate {
 		return nil
 	}
 
-	lowerPrefix := strings.ToLower(prefix)
+	// @mentions are written with forward slashes -- that is what a user types
+	// and what the model emits -- so both sides of the comparison are
+	// normalized to them. Matching raw OS paths meant "src/" found nothing on
+	// Windows, where the walk yields "src\main.go".
+	lowerPrefix := strings.ToLower(filepath.ToSlash(prefix))
 	var candidates []CompletionCandidate
 
 	_ = filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
@@ -299,6 +303,7 @@ func matchingFiles(prefix string, workDir string) []CompletionCandidate {
 		if rel == "." {
 			return nil
 		}
+		rel = filepath.ToSlash(rel)
 
 		base := d.Name()
 		if strings.HasPrefix(base, ".") || base == "node_modules" || base == "vendor" {

--- a/internal/tui/coverage_boost_test.go
+++ b/internal/tui/coverage_boost_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/auth"
 	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // -----------------------------------------------------------------------------
@@ -590,7 +591,7 @@ func TestFormatContextUsage_NoLimit(t *testing.T) {
 
 func TestHistoryDir_NoHome(t *testing.T) {
 	// Override HOME for this test.
-	t.Setenv("HOME", "")
+	testenv.SetHome(t, "")
 	t.Setenv("USERPROFILE", "") // windows
 	// On darwin/linux UserHomeDir returns error when HOME is empty.
 	dir := historyDir()
@@ -600,7 +601,7 @@ func TestHistoryDir_NoHome(t *testing.T) {
 
 func TestHistoryPathJSON_WithHome(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	p := historyPathJSON()
 	if p == "" {
 		t.Error("expected non-empty path")
@@ -612,7 +613,7 @@ func TestHistoryPathJSON_WithHome(t *testing.T) {
 
 func TestHistoryPathPlain_WithHome(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	p := historyPathPlain()
 	if p == "" {
 		t.Error("expected non-empty path")
@@ -621,7 +622,7 @@ func TestHistoryPathPlain_WithHome(t *testing.T) {
 
 func TestAppendHistory_WritesFile(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	appendHistory(HistoryEntry{Text: "hello"})
 	// File should exist.
 	p := filepath.Join(tmp, ".pi-go", "history.jsonl")
@@ -636,7 +637,7 @@ func TestAppendHistory_WritesFile(t *testing.T) {
 
 func TestLoadHistory_MigratePlainToJSON(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	piDir := filepath.Join(tmp, ".pi-go")
 	_ = os.MkdirAll(piDir, 0o700)
 	// Write legacy plain history.
@@ -654,7 +655,7 @@ func TestLoadHistory_MigratePlainToJSON(t *testing.T) {
 
 func TestLoadHistory_NoHistory(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	entries := loadHistory()
 	if entries != nil {
 		t.Errorf("expected nil for no history, got %v", entries)
@@ -685,7 +686,7 @@ func TestNewThemeManagerFromJSON_Invalid(t *testing.T) {
 
 func TestSaveThemeToConfig_WritesConfig(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	saveThemeToConfig("tokyo-night")
 	data, err := os.ReadFile(filepath.Join(tmp, ".pi-go", "config.json"))
 	if err != nil {
@@ -698,7 +699,7 @@ func TestSaveThemeToConfig_WritesConfig(t *testing.T) {
 
 func TestSaveThemeToConfig_UpdatesExisting(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	testenv.SetHome(t, tmp)
 	configDir := filepath.Join(tmp, ".pi-go")
 	_ = os.MkdirAll(configDir, 0o755)
 	// Pre-write config.

--- a/internal/tui/grounding_display_test.go
+++ b/internal/tui/grounding_display_test.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/logger"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // drainAgentCh collects everything queued on the model's agent channel without
@@ -118,7 +119,7 @@ func TestEmitGroundingEventsIgnoresUngroundedResponses(t *testing.T) {
 // With a logger attached the search is also traced. The log gets the
 // full-fidelity sources (URIs included); the chat still gets labels only.
 func TestEmitGroundingEventsTracesToLog(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := logger.New()
 	if err != nil {

--- a/internal/tui/light_theme_test.go
+++ b/internal/tui/light_theme_test.go
@@ -8,6 +8,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // Before this, every renderer test passed darkPalette, so a hardcoded ANSI
@@ -527,7 +529,7 @@ func TestNewModelBuildsTheRendererFromTheConfiguredTheme(t *testing.T) {
 	t.Run("no saved history", func(t *testing.T) {
 		// A home directory with no history file: loadHistory returns nil and
 		// the model must still start with a usable empty slice.
-		t.Setenv("HOME", t.TempDir())
+		testenv.SetHome(t, t.TempDir())
 		m := newModel(ctx, cancel, Config{WorkDir: t.TempDir()})
 		if m.inputModel.History == nil {
 			t.Error("history should be an empty slice, not nil")

--- a/internal/tui/login_flows_test.go
+++ b/internal/tui/login_flows_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/auth"
 	"github.com/dimetron/pi-go/internal/logger"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // newMockCodexDeviceServer stands in for auth.openai.com's device endpoints.
@@ -63,7 +64,7 @@ func codexDeviceProvider(srvURL string) auth.Provider {
 // record of what a failed authentication did.
 func loggedModel(t *testing.T) (*model, func() string) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := logger.New()
 	if err != nil {
@@ -585,7 +586,7 @@ func TestLoginStart_RoutesManualCode(t *testing.T) {
 // Login events are the only trace a failed authentication leaves, so they have
 // to reach the session log when one is configured.
 func TestLogLogin_WritesToTheSessionLog(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 
 	log, err := logger.New()
 	if err != nil {

--- a/internal/tui/login_test.go
+++ b/internal/tui/login_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/dimetron/pi-go/internal/auth"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // TestMain globally disables real browser opens and process restart for every
@@ -217,9 +218,7 @@ func TestHandleLoginSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	testenv.SetHome(t, tmpDir)
 
 	// codex is the only provider registered since the Anthropic/OpenAI/Gemini
 	// OAuth flows were disabled; handleLoginSave looks up the provider via
@@ -284,9 +283,7 @@ func TestHandleLoginCancel_DevicePhase(t *testing.T) {
 
 func TestHandleLoginSSOResult_Success(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	testenv.SetHome(t, tmpDir)
 
 	m := &model{
 		login: &loginState{phase: "sso", provider: "anthropic"},
@@ -391,9 +388,7 @@ func TestHandleLoginSSOResult_EmptyKey(t *testing.T) {
 
 func TestHandleLoginSSOResult_SaveError(t *testing.T) {
 	// Use an invalid HOME to trigger SaveKey error.
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", "/dev/null/nonexistent")
-	defer os.Setenv("HOME", origHome)
+	testenv.SetUnwritableHome(t)
 
 	m := &model{
 		login: &loginState{phase: "sso", provider: "anthropic"},
@@ -436,9 +431,7 @@ func TestHandleLoginSave_UnknownProvider(t *testing.T) {
 }
 
 func TestHandleLoginSave_SaveError(t *testing.T) {
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", "/dev/null/nonexistent")
-	defer os.Setenv("HOME", origHome)
+	testenv.SetUnwritableHome(t)
 
 	// codex is the currently registered provider; HOME points at an invalid
 	// path so SaveKey's MkdirAll must fail, surfacing "Error saving key".

--- a/internal/tui/refs/validator.go
+++ b/internal/tui/refs/validator.go
@@ -97,6 +97,14 @@ func (v *Validator) isPathTraversal(path, cleaned string) bool {
 		}
 	}
 
+	// A rooted path that filepath.IsAbs does not call absolute still escapes.
+	// On Windows "/etc/passwd" is drive-relative rather than absolute, so the
+	// check above lets it through; filepath.IsLocal rejects it, along with
+	// drive-relative "C:x" and the reserved device names.
+	if !filepath.IsAbs(path) && !filepath.IsLocal(cleaned) {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -1739,7 +1739,10 @@ func listAvailableSpecs(workDir string) ([]string, error) {
 		promptPath := filepath.Join(path, "PROMPT.md")
 		if _, statErr := os.Stat(promptPath); statErr == nil {
 			rel, _ := filepath.Rel(specsDir, path)
-			specs = append(specs, rel)
+			// A spec name is an identifier the user types back into
+			// "/run <spec-name>", not a path to display: keep it slash-form on
+			// every OS. filepath.Join accepts it either way.
+			specs = append(specs, filepath.ToSlash(rel))
 		}
 		return nil
 	})

--- a/internal/tui/run_backup_test.go
+++ b/internal/tui/run_backup_test.go
@@ -24,6 +24,10 @@ func initRunTestRepo(t *testing.T) string {
 		{"git", "config", "user.name", "Test"},
 		{"git", "config", "commit.gpgsign", "false"},
 		{"git", "config", "tag.gpgsign", "false"},
+		// Git for Windows defaults core.autocrlf to true, which would rewrite
+		// every LF these tests write into CRLF on checkout and break the
+		// byte-for-byte content assertions.
+		{"git", "config", "core.autocrlf", "false"},
 		{"git", "commit", "--allow-empty", "-m", "initial commit"},
 	} {
 		cmd := exec.Command(args[0], args[1:]...)

--- a/internal/tui/run_eval_e2e_test.go
+++ b/internal/tui/run_eval_e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dimetron/pi-go/internal/eval"
 	"github.com/dimetron/pi-go/internal/provider"
 	"github.com/dimetron/pi-go/internal/subagent"
+	"github.com/dimetron/pi-go/internal/testenv"
 
 	tea "charm.land/bubbletea/v2"
 	llmmodel "google.golang.org/adk/v2/model"
@@ -64,7 +65,7 @@ func TestEvalRun(t *testing.T) {
 	// that reports FAIL for a run it measured fine is worse than one that
 	// leaves a temp dir behind. Clean it up permissively instead.
 	home := evalHomeDir(t)
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	// Isolating HOME breaks git commit signing: the repo signs commits/tags
 	// with the user's real key (GPG via 1Password), which is not reachable
 	// from the temp HOME, so the run's `git merge --no-ff` fails at

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -249,7 +249,9 @@ func TestListAvailableSpecs_Nested(t *testing.T) {
 	if specs[0] != "flat-spec" {
 		t.Errorf("specs[0] = %q, want %q", specs[0], "flat-spec")
 	}
-	expected := filepath.Join("skills", "skills-audit")
+	// Spec names are slash-form on every OS: they are identifiers the user
+	// types back into "/run <spec-name>", not paths to display.
+	expected := "skills/skills-audit"
 	if specs[1] != expected {
 		t.Errorf("specs[1] = %q, want %q", specs[1], expected)
 	}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/palace"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 func TestRenderSidebar_Minimal(t *testing.T) {
@@ -230,7 +231,7 @@ func TestHandleRestartCommand(t *testing.T) {
 // --- historyPathPlain ---
 
 func TestHistoryPathPlain(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	testenv.SetHome(t, t.TempDir())
 	path := historyPathPlain()
 	// Should return a non-empty path under HOME.
 	if path == "" {

--- a/internal/webserver/voice_static_test.go
+++ b/internal/webserver/voice_static_test.go
@@ -54,9 +54,11 @@ func TestIndexPage_VoiceBarHasTalkMuteEnd(t *testing.T) {
 	}
 }
 
-// The bar sits 3x its original 16px above the bottom edge and the transcript
-// panel stacks above it from the same custom property, so a later nudge
-// cannot separate them.
+// The bar's distance from the bottom edge lives in one custom property and
+// the transcript panel stacks above it from that same property, so a later
+// nudge (the offset has already moved from 16px to 48px to 96px) cannot
+// separate them. The exact pixel value is a design choice and is deliberately
+// not pinned here; only that it is defined and shared.
 func TestVoiceStyles_BarOffsetSharedWithTranscript(t *testing.T) {
 	data, err := embeddedStaticFiles.ReadFile("static/style.css")
 	if err != nil {
@@ -64,8 +66,8 @@ func TestVoiceStyles_BarOffsetSharedWithTranscript(t *testing.T) {
 	}
 	css := string(data)
 
-	if !strings.Contains(css, "--voice-bar-bottom: 48px;") {
-		t.Error("style.css does not define --voice-bar-bottom: 48px")
+	if !regexp.MustCompile(`--voice-bar-bottom:\s*\d+px;`).MatchString(css) {
+		t.Error("style.css does not define --voice-bar-bottom as a px length")
 	}
 	bar := cssRule(css, ".voice-bar")
 	if !strings.Contains(bar, "bottom: var(--voice-bar-bottom)") {

--- a/piagent/complexity_cog_piagent_test.go
+++ b/piagent/complexity_cog_piagent_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"iter"
 	"testing"
+	"time"
 
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session"
@@ -37,6 +38,11 @@ func (r *cogRunner) fn() runner {
 		r.calls++
 		r.lastSess, r.lastMsg = sessionID, message
 		return func(yield func(*session.Event, error) bool) {
+			// observeTurn asserts Duration > 0. Yielding canned pairs takes
+			// well under one tick of Windows' monotonic clock, which would
+			// time the turn at exactly zero; a Sleep advances that clock by
+			// at least the requested amount on every OS.
+			time.Sleep(time.Millisecond)
 			for _, p := range r.pairs {
 				if !yield(p.ev, p.err) {
 					return

--- a/piagent/piagent_internal_test.go
+++ b/piagent/piagent_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // fakeLLM is the seam that makes an embed testable without a network: it
@@ -82,7 +83,7 @@ func (f *fakeLLM) systemPrompt() string {
 func isolate(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 	t.Setenv("USERPROFILE", home) // windows
 	return home
 }


### PR DESCRIPTION
## What

A **tool-coverage eval suite** for the pi coding agent, extending the existing `internal/eval` harness (`make eval-run`) rather than adding a parallel one. It answers: *does the agent actually use every tool it advertises, and does each tool work when it does?*

- **`internal/eval`** (pure, unit-tested)
  - `Inventory()` — enumerates every registrable tool by constructing them through the same constructors the CLI uses (`tools.CoreTools`, `BashControlTools`, `SubagentTools`, `MemoryTools`, `LSPToolsFor(full)`, `LLMSTools`, `A2ATools`, `palace.PalaceTools`, the Gemini grounding tool). Not a hand-kept list: a new tool shows up automatically.
  - `Scenario` / `Check` / `EvaluateScenario` — declarative scenario shape (fixtures, git history, memory seeds, llms sources, extra `pi` flags, prompt, checks) plus the grader: every target tool called with ≥1 non-error result and every check satisfied (`file_exists/absent/contains/not_contains`, `tool_arg_contains`, `tool_result_contains`, `tool_called_at_least`, `subagent_spawned`).
  - `ComputeCoverage` — the matrix: per tool its scenarios or exclusion, calls/results/errors/wasted from the trajectories, status `ok | errors-only | not-called | excluded | unmapped`, plus `gap` and "called but not inventoried" (MCP). `UnmappedTools` / `UnknownTargets` back the mapping test.
  - `ToolsReport` (JSON + Markdown → `eval-reports/eval-tools-<ts>.{json,md}`), `JudgeTools` (advisory LLM grade: outcome_correctness, tool_selection, tools_efficiency, trajectory_quality), `ProviderComplete`.
  - `looksLikeError` now recognizes **structured** tool errors — `{"error": …}` (how the ADK runner reports a tool failure), a non-empty `error` field, bash `exit_code ∉ {0,-1}`. ATIF stores response maps, not strings, so the `/run` report's `errors` column was effectively always 0 before.
- **`internal/eval/scenarios`** — the suite: 14 scenarios (table below), `Exclusions` with reasons, `TestEvalTools` (build tag `e2e`, gated by `PI_EVAL_TOOLS=1`) that runs each scenario headlessly through the real `pi` binary (`pi --mode print "<prompt>"`, isolated `HOME` + seeded `config.json` + workspace per scenario, git signing forced off, parallel subtests), grades, computes coverage over the full inventory, optional judge, writes the report. `README.md` documents it.
- **Coverage gate as a unit test**: `TestScenarios_CoverInventory` (runs in `make test`, no binary/model) fails when a registered tool has neither a scenario nor an exclusion, when a scenario targets a non-existent tool, or when an exclusion is stale.
- Makefile: `eval-tools`, `eval-tools-judge`. Docs: new "Tool-coverage eval" section in `internal/eval/eval.md`.

## Tool → scenario map

| scenario | tools | requires | key assertions |
|---|---|---|---|
| `explore` | `ls`, `tree`, `find`, `grep\|ripgrep` | | grep pattern has the needle; grep result names `notes.md`; find pattern has `.md` |
| `read` | `read` | | read result contains `8471` |
| `write` | `write` | | `hello.txt` contains `hello from pi` |
| `edit` | `read`, `edit` | | `greet.go` has `"Howdy"`, not `"Hello"`, other const untouched |
| `bash` | `bash` | | `count.txt` contains `5`; bash command contains `wc` |
| `bash-background` | `bash`, `bash_wait`, `bash_kill` | | bash_wait result has `FINISHED-OK`; bash_kill called with a handle (≥2 min by design: bash's timeout floor is 60s) |
| `git` | `git-overview`, `git-file-diff`, `git-hunk` | | overview lists `main.go`; diff/hunk called on `main.go`; diff shows `version 2` |
| `subagent` | `subagent` | | nested trajectory linked; result mentions `gamma` |
| `session-stats` | `session-stats` | | called, no error |
| `memory` | `mem-search`, `mem-get`, `mem-timeline` | | mem-search result contains `rotation` (store pre-seeded) |
| `read-image` | `read_image` | vision | called, no error |
| `fetch-docs` | `fetch_docs` | network | url has `llmstxt.org`; result contains `llms.txt` |
| `lsp` | `lsp-symbols`, `lsp-diagnostics` | lsp | symbols contain `Alpha`; diagnostics mention `unusedValue` |
| `lsp-full` | `lsp-hover`, `lsp-definition`, `lsp-references`, `lsp-workspace-symbol`, `lsp-code-action` | lsp (`--lsp full`) | workspace-symbol query `Alpha`; references name `main.go` |

**Excluded** (with reasons, enforced by the mapping test): `a2a` (needs a remote A2A agent server), `palace-*` (11 tools; need a populated memory palace + embedding model, not registered in a fresh HOME), `google_search` (Gemini provider built-in). MCP tools are dynamic per config and are not in the inventory; calls to them are reported as "called but not inventoried".

`fetch_docs` cannot be pointed at a local `httptest` server (the tool enforces `https://` and rejects private hosts), so it fetches a real public `llms.txt` and is tagged `network`; the runner probes the URL first and skips with the cause if unreachable.

## Live run (claude-haiku-4-5, thinking `none`, 2m38s, 362k tokens incl. 241k cached)

**13 passed, 0 failed, 1 skipped** (`fetch-docs`: this host cannot open outbound HTTPS from Go binaries to llmstxt.org — the probe recorded the skip). Coverage: **40 registered tools, 26 exercised ok, 0 errors-only, 1 not called (`fetch_docs`), 13 excluded, 0 unmapped.**

| tool | group | status | calls | results | errors | scenarios / exclusion |
|---|---|---|---|---|---|---|
| `bash` | core | ok | 3 | 3 | 0 | bash, bash-background |
| `bash_kill` | bash-control | ok | 1 | 1 | 0 | bash-background |
| `bash_wait` | bash-control | ok | 2 | 2 | 0 | bash-background |
| `edit` | core | ok | 1 | 1 | 0 | edit |
| `find` | core | ok | 1 | 1 | 0 | explore |
| `git-file-diff` | core | ok | 1 | 1 | 0 | git |
| `git-hunk` | core | ok | 1 | 1 | 0 | git |
| `git-overview` | core | ok | 1 | 1 | 0 | git |
| `ls` | core | ok | 3 | 3 | 0 | explore |
| `read` | core | ok | 3 | 3 | 1 | read, edit |
| `read_image` | core | ok | 2 | 2 | 0 | read-image |
| `ripgrep` (grep) | core | ok | 2 | 2 | 0 | explore |
| `session-stats` | core | ok | 1 | 1 | 0 | session-stats |
| `tree` | core | ok | 1 | 1 | 0 | explore |
| `write` | core | ok | 1 | 1 | 0 | write |
| `subagent` | subagent | ok | 1 | 1 | 0 | subagent |
| `mem-get` / `mem-search` / `mem-timeline` | memory | ok | 1 each | 1 each | 0 | memory |
| `lsp-symbols` / `lsp-diagnostics` | lsp | ok | 1 / 2 | 1 / 2 | 0 | lsp |
| `lsp-hover` / `lsp-definition` / `lsp-references` / `lsp-workspace-symbol` / `lsp-code-action` | lsp | ok | 1 each | 1 each | 0 | lsp-full |
| `fetch_docs` | llms | not-called | 0 | 0 | 0 | fetch-docs (skipped: no outbound network for Go here) |
| `a2a` | a2a | excluded | | | | remote A2A server |
| `palace-*` (11) | palace | excluded | | | | populated palace + embedding model |
| `google_search` | provider | excluded | | | | Gemini built-in |

LLM judge: unavailable in this environment (same outbound-network restriction from the test process); it degrades to a note in the report, as designed.

Two findings the suite surfaced, reported rather than papered over: (1) `lsp-diagnostics` reads gopls's cache right after `didOpen`, so the **first call routinely returns "no problems"** for a file with a real compile error — the scenario prompt asks for a second call, and the report shows the 2 calls; (2) an earlier run showed `write` emitting 1 error-looking result (ledger/path first attempt) — visible in the `errors` column.

## How to run

```bash
make build
make eval-tools                                   # whole suite
PI_EVAL_SCENARIO=git,edit make eval-tools         # subset
go test -tags e2e -run 'TestEvalTools/scenario/explore' ./internal/eval/scenarios/
PI_EVAL_JUDGE_MODEL=claude-sonnet-4-6 make eval-tools-judge
```

Knobs: `PI_EVAL_MODEL`, `PI_EVAL_THINKING` (default `none`), `PI_EVAL_TIMEOUT`, `PI_EVAL_STRICT=1` (fail on scenario FAIL/ERROR and on a coverage gap), `PI_EVAL_SERIAL=1`, `PI_EVAL_OFFLINE=1`, `PI_EVAL_NO_VISION=1`, `PI_EVAL_OUT`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags e2e ./internal/tui/ ./internal/eval/...`
- [x] `go test ./internal/eval/... ./internal/tools/ -count=1` — new unit tests: inventory groups, coverage statuses/gap/unknown/exclusion glob, structured `looksLikeError`, `EvaluateScenario` + every check kind, `SeedWorkspace` (git history, unsigned), `SeedMemory` (FTS searchable), `ScenarioConfig`, tools report render/write, tools judge prompt/parse, mapping gate, scenario seeding and satisfiability
- [x] `make lint` — 0 issues
- [x] Live `make eval-tools` equivalent against `claude-haiku-4-5`: 13 pass / 1 skip, table above
- [x] `codex review` — one P2 finding (a timed-out / non-zero `pi` process could be tallied as pass when its partial trajectory satisfied the checks) — fixed: any process failure now yields `error`.

## CI note: Test (Windows)

Test (Windows) on `main` currently fails on a pre-existing set unrelated to this PR (`cmd/pi-sandbox`, `internal/acp/client{,/cursor,/gemini}`, `internal/acp/server`, `internal/auth`, `internal/browser`, then the job aborts inside an `internal/cli` TUI test — before `internal/eval` is ever reached). #203 (`fix/windows-ci-tests`) fixes exactly that set, so this branch **temporarily merges `origin/fix/windows-ci-tests`** to let Test (Windows) pass now. Separately, `main` at 135bf73 (#214) breaks `internal/webserver` `TestVoiceStyles_BarOffsetSharedWithTranscript` on every platform; #215 (`fix/voice-bar-offset-test`) fixes it, so this branch **also temporarily merges `origin/fix/voice-bar-offset-test`**. Both extra diffs collapse to nothing once #203 and #215 merge.

With the eval tests now actually running on Windows, one portability commit was added: `eval.HomeEnv` sets `USERPROFILE` alongside `HOME` on Windows (the isolated-home redirection for the e2e `pi` process and fixture git commands), and the fixture git env forces `core.autocrlf=false` so LF fixtures are byte-identical on every host.

https://claude.ai/code/session_014XA8pYe34AXYE8sSeRe3WC

