### PR TITLE
test(webserver): stop pinning the voice bar offset to 48px

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - "cmd/"
+  # Test-only helpers, imported solely from _test.go files; the Windows arms
+  # of these helpers can never execute on the Linux coverage job.
+  - "internal/testenv/"

--- a/internal/cli/memory_model.go
+++ b/internal/cli/memory_model.go
@@ -50,6 +50,11 @@ Use --onnx to specify a specific ONNX file, e.g.:
 	return cmd
 }
 
+// downloadModel is the fetcher runMemoryModelDownload delegates to. A variable
+// so tests can substitute a fake instead of pulling the real weights from
+// Hugging Face into the test HOME.
+var downloadModel = palace.DownloadModel
+
 func runMemoryModelDownload(dest string, onnxFilePath string) error {
 	if dest == "" {
 		home, err := os.UserHomeDir()
@@ -71,7 +76,7 @@ func runMemoryModelDownload(dest string, onnxFilePath string) error {
 
 	fmt.Printf("Downloading embedding model to %s ...\n", dest)
 
-	modelPath, err := palace.DownloadModel(dest, onnxFilePath)
+	modelPath, err := downloadModel(dest, onnxFilePath)
 	if err != nil {
 		return fmt.Errorf("downloading model: %w", err)
 	}

--- a/internal/cli/memory_model_test.go
+++ b/internal/cli/memory_model_test.go
@@ -2,10 +2,13 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/testenv"
 )
 
@@ -136,18 +139,71 @@ func TestRunMemoryModelDownload_ExplicitOnnxPath(t *testing.T) {
 	}
 }
 
+// stubDownloadModel replaces the fetcher for the duration of the test and
+// returns a pointer to the arguments it was last called with.
+//
+// The real fetcher pulls the embedding model from Hugging Face into HOME. This
+// test used to do exactly that and only appeared to pass because an earlier
+// test left HOME unset; with HOME isolated properly the download ran, and two
+// things broke under -race: go-huggingface's parallel download has a data
+// race, and every later palace-backed test in this package then found the
+// weights and ran real inference, where gomlx's AVX2 matmul kernel trips
+// checkptr. A fake fetcher keeps the path covered without any of that.
+func stubDownloadModel(t *testing.T, result string, err error) *struct{ dest, onnx string } {
+	t.Helper()
+	var got struct{ dest, onnx string }
+	orig := downloadModel
+	downloadModel = func(dest, onnx string) (string, error) {
+		got.dest, got.onnx = dest, onnx
+		return result, err
+	}
+	t.Cleanup(func() { downloadModel = orig })
+	return &got
+}
+
 func TestRunMemoryModelDownload_DefaultDest(t *testing.T) {
-	// This downloads the real embedding model from Hugging Face into the
-	// package's shared test HOME. It only ever appeared to pass: an earlier
-	// test used to leave HOME unset, so runMemoryModelDownload failed before
-	// reaching the network. With HOME isolated properly the download runs, and
-	// two things break under -race: go-huggingface's parallel download has a
-	// data race, and every later palace-backed test in this package then finds
-	// the weights and runs real inference, where gomlx's AVX2 matmul kernel
-	// trips checkptr. Skip it like its siblings above.
-	t.Skip("skipping: downloads a real model over the network; go-huggingface races under -race and the weights poison later palace tests")
-	err := runMemoryModelDownload("", "")
-	if err != nil {
-		t.Logf("expected error: %v", err)
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	got := stubDownloadModel(t, "model-path", nil)
+
+	out := captureStdout(t, func() {
+		if err := runMemoryModelDownload("", ""); err != nil {
+			t.Errorf("runMemoryModelDownload: %v", err)
+		}
+	})
+
+	wantDest := filepath.Join(home, ".pi-go", "models")
+	if got.dest != wantDest {
+		t.Errorf("dest = %q, want the default under HOME %q", got.dest, wantDest)
+	}
+	if info, err := os.Stat(wantDest); err != nil || !info.IsDir() {
+		t.Errorf("default model directory was not created: %v", err)
+	}
+	if got.onnx != palace.DetectPlatformOnnxFile() {
+		t.Errorf("onnx = %q, want the auto-detected %q", got.onnx, palace.DetectPlatformOnnxFile())
+	}
+	if !strings.Contains(out, "Model downloaded: model-path") {
+		t.Errorf("output = %q, want the downloaded path reported", out)
+	}
+}
+
+func TestRunMemoryModelDownload_ExplicitDestAndOnnxReachTheFetcher(t *testing.T) {
+	got := stubDownloadModel(t, "", nil)
+	dest := filepath.Join(t.TempDir(), "models")
+
+	if err := runMemoryModelDownload(dest, "onnx/custom.onnx"); err != nil {
+		t.Fatalf("runMemoryModelDownload: %v", err)
+	}
+	if got.dest != dest || got.onnx != "onnx/custom.onnx" {
+		t.Errorf("fetcher got dest=%q onnx=%q, want %q / onnx/custom.onnx", got.dest, got.onnx, dest)
+	}
+}
+
+func TestRunMemoryModelDownload_FetcherErrorIsWrapped(t *testing.T) {
+	stubDownloadModel(t, "", errors.New("offline"))
+
+	err := runMemoryModelDownload(t.TempDir(), "")
+	if err == nil || !strings.Contains(err.Error(), "downloading model: offline") {
+		t.Errorf("err = %v, want the fetcher error wrapped as \"downloading model\"", err)
 	}
 }

--- a/internal/palace/embedder.go
+++ b/internal/palace/embedder.go
@@ -105,13 +105,20 @@ func (e *localEmbedder) Close() {
 	}
 }
 
+// hugotDownloadModel is the fetcher DownloadModel delegates to. It is a
+// variable so tests can stand in a fake: the real one reaches Hugging Face,
+// its parallel download has a data race the race detector flags, and leaving
+// real weights behind makes every later palace test in the same package run
+// real inference.
+var hugotDownloadModel = hugot.DownloadModel
+
 // DownloadModel fetches the all-MiniLM-L6-v2 model to dest and returns the local path.
 func DownloadModel(dest string, onnxFilePath string) (string, error) {
 	opts := hugot.NewDownloadOptions()
 	if onnxFilePath != "" {
 		opts.OnnxFilePath = onnxFilePath
 	}
-	return hugot.DownloadModel(
+	return hugotDownloadModel(
 		context.Background(),
 		"sentence-transformers/all-MiniLM-L6-v2",
 		dest,

--- a/internal/palace/embedder_download_test.go
+++ b/internal/palace/embedder_download_test.go
@@ -1,0 +1,65 @@
+package palace
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/knights-analytics/hugot"
+)
+
+// DownloadModel is a thin shim over hugot; what it owns is the model name, the
+// destination, and whether an explicit ONNX file overrides hugot's default.
+// The fetcher is swapped for a recorder so no network is touched and no real
+// weights land on disk.
+func TestDownloadModel_PassesDestAndOnnxOverrideToTheFetcher(t *testing.T) {
+	type call struct {
+		model, dest string
+		opts        hugot.DownloadOptions
+	}
+	var got []call
+	orig := hugotDownloadModel
+	hugotDownloadModel = func(_ context.Context, model, dest string, opts hugot.DownloadOptions) (string, error) {
+		got = append(got, call{model, dest, opts})
+		return dest + "/resolved", nil
+	}
+	t.Cleanup(func() { hugotDownloadModel = orig })
+
+	path, err := DownloadModel("/models", "")
+	if err != nil {
+		t.Fatalf("DownloadModel: %v", err)
+	}
+	if path != "/models/resolved" {
+		t.Errorf("path = %q, want the fetcher's answer", path)
+	}
+	if _, err := DownloadModel("/models", "onnx/custom.onnx"); err != nil {
+		t.Fatalf("DownloadModel with override: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("fetcher called %d times, want 2", len(got))
+	}
+	for i, c := range got {
+		if c.model != "sentence-transformers/all-MiniLM-L6-v2" || c.dest != "/models" {
+			t.Errorf("call %d: model/dest = %q/%q", i, c.model, c.dest)
+		}
+	}
+	if got[0].opts.OnnxFilePath != hugot.NewDownloadOptions().OnnxFilePath {
+		t.Errorf("empty override changed OnnxFilePath to %q, want hugot's default", got[0].opts.OnnxFilePath)
+	}
+	if got[1].opts.OnnxFilePath != "onnx/custom.onnx" {
+		t.Errorf("OnnxFilePath = %q, want the explicit override", got[1].opts.OnnxFilePath)
+	}
+}
+
+func TestDownloadModel_ReportsFetcherErrors(t *testing.T) {
+	orig := hugotDownloadModel
+	hugotDownloadModel = func(context.Context, string, string, hugot.DownloadOptions) (string, error) {
+		return "", errors.New("offline")
+	}
+	t.Cleanup(func() { hugotDownloadModel = orig })
+
+	if _, err := DownloadModel("/models", ""); err == nil || err.Error() != "offline" {
+		t.Errorf("err = %v, want the fetcher's error passed through", err)
+	}
+}


### PR DESCRIPTION
## Summary
- #214 moved `--voice-bar-bottom` from 48px to 96px, but `TestVoiceStyles_BarOffsetSharedWithTranscript` (from #210) still asserted the 48px literal → **main's Test / Test (Windows) / Coverage jobs fail** on every branch that merges current main (see main run 32592253621 and PR #203 run 32592530943).
- The test now checks the invariant it was written for — the offset is a single px custom property and both `.voice-bar` and `.voice-transcript` derive from it — without pinning the design value.

The webserver change itself is test-only, 1 file (`4b8db6a`).

## Temporarily carries #203

Test (Windows) on main has a pre-existing failure set unrelated to this PR (`cmd/pi-sandbox`, `internal/acp/client{,/cursor,/gemini}`, `internal/acp/server`, `internal/auth`, `internal/browser`, then the job dies in an `internal/cli` TUI test — see run 32593089867 on this PR's original head `4b8db6a`). To let Test (Windows) pass now, this branch has merged `origin/fix/windows-ci-tests` (#203, head `2b6518f`, which already includes main and `4b8db6a`). Once #203 merges, this PR's diff collapses back to the single test file.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/webserver/ -count=1` (outside the sandbox) — ok
- [x] `make lint` — 0 issues
- [x] codex review (of the webserver test change) — no actionable findings
- [ ] CI: Test (Windows) green with #203 carried

https://claude.ai/code/session_014XA8pYe34AXYE8sSeRe3WC
