### PR TITLE
feat(tools): cache fetch_docs pages with HTTP revalidation

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1262,7 +1262,7 @@ func buildToolsets(cfg config.Config) []adktool.Toolset {
 		toolsets = append(toolsets, tools.NewA2AToolset(cfg.A2A))
 	}
 	if cfg.LLMS != nil && len(cfg.LLMS.Sources) > 0 {
-		toolsets = append(toolsets, tools.NewLLMSToolset(cfg.LLMS))
+		toolsets = append(toolsets, tools.NewLLMSCachedToolset(cfg.LLMS))
 	}
 	return toolsets
 }

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -225,7 +225,7 @@ func deferredInit(
 	// would be live for the model yet invisible in the breakdown, and the MCP
 	// panel would list a non-MCP source.
 	if cfg.LLMS != nil && len(cfg.LLMS.Sources) > 0 {
-		coreTools = append(coreTools, tools.LLMSTools(tools.NewLLMSToolset(cfg.LLMS))...)
+		coreTools = append(coreTools, tools.LLMSTools(tools.NewLLMSCachedToolset(cfg.LLMS))...)
 	}
 	// Gemini search grounding (see agent.GeminiGroundingTool doc).
 	//

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,6 +57,16 @@ const llmsCacheTTL = 1 * time.Hour
 // fails, so a permanently dead or moved page is not served forever.
 const llmsCacheMaxAge = 24 * time.Hour
 
+// llmsCacheMaxEntries and llmsCacheMaxBytes bound the on-disk cache. fetch_docs
+// is model-controlled and every distinct URL on an allowed host creates an
+// entry of up to llmsMaxBytes, so without a budget the shared directory could
+// grow without limit. When either bound is exceeded after a write, the
+// least-recently-written entries are evicted until both hold again.
+const (
+	llmsCacheMaxEntries = 512
+	llmsCacheMaxBytes   = 64 * 1024 * 1024 // 64 MB
+)
+
 // llmsCacheEntry is the on-disk form of one cached page.
 type llmsCacheEntry struct {
 	URL          string `json:"url"`
@@ -63,6 +74,13 @@ type llmsCacheEntry struct {
 	ETag         string `json:"etag,omitempty"`
 	LastModified string `json:"last_modified,omitempty"`
 	FetchedAt    int64  `json:"fetched_at"`
+}
+
+// age reports how long ago the entry was fetched or last revalidated. It is
+// computed from the timestamp stored inside the entry, not the file's mtime,
+// so it does not depend on filesystem timestamp granularity.
+func (e *llmsCacheEntry) age() time.Duration {
+	return time.Since(time.Unix(e.FetchedAt, 0))
 }
 
 // LLMSInput defines the parameters for the fetch_docs tool.
@@ -205,6 +223,10 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 	if u.Host == "" {
 		return LLMSOutput{Error: "url has no host"}, nil
 	}
+	// A fragment (#section) is never sent on the wire, so page.md#a and
+	// page.md#b are the same resource: drop it before the cache lookup and the
+	// request so they share one entry instead of each downloading a copy.
+	u.Fragment, u.RawFragment = "", ""
 
 	// SSRF guard: reject loopback, private, link-local, multicast, and
 	// unspecified destinations before dialing.
@@ -220,11 +242,11 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 	// A cached copy younger than llmsCacheTTL is served straight from disk —
 	// no network, no revalidation.
 	entry := t.cacheRead(u)
-	if entry != nil && time.Since(time.Unix(entry.FetchedAt, 0)) < llmsCacheTTL {
+	if entry != nil && entry.age() < llmsCacheTTL {
 		return LLMSOutput{Content: entry.Body}, nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return LLMSOutput{Error: fmt.Sprintf("build request: %v", err)}, nil
 	}
@@ -255,7 +277,7 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 		// Network failure: fall back to a reasonably fresh cached copy rather
 		// than failing the whole call. An entry older than llmsCacheMaxAge is
 		// not served, so a permanently dead page is not resurrected forever.
-		if entry != nil && time.Since(time.Unix(entry.FetchedAt, 0)) < llmsCacheMaxAge {
+		if entry != nil && entry.age() < llmsCacheMaxAge {
 			return LLMSOutput{Content: entry.Body}, nil
 		}
 		return LLMSOutput{Error: fmt.Sprintf("fetch failed: %v", err)}, nil
@@ -286,7 +308,7 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 		// downloading it again. Caching is best-effort: a write failure just
 		// means the next call re-fetches.
 		t.cacheWrite(&llmsCacheEntry{
-			URL:          rawURL,
+			URL:          u.String(),
 			Body:         string(body),
 			ETag:         resp.Header.Get("ETag"),
 			LastModified: resp.Header.Get("Last-Modified"),
@@ -296,8 +318,11 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 
 	default:
 		// An upstream 5xx is transient; prefer a reasonably fresh cached copy
-		// to the cached error being surfaced to the model.
-		if entry != nil && time.Since(time.Unix(entry.FetchedAt, 0)) < llmsCacheMaxAge {
+		// to the error being surfaced to the model. A 4xx (401/403/404/410,
+		// …) is the origin's verdict on the page itself — removed, moved, or
+		// access revoked — so the cached body must not be passed off as
+		// current; only the status is reported.
+		if resp.StatusCode >= 500 && entry != nil && entry.age() < llmsCacheMaxAge {
 			return LLMSOutput{Content: entry.Body}, nil
 		}
 		return LLMSOutput{Error: fmt.Sprintf("unexpected status %d", resp.StatusCode)}, nil
@@ -305,16 +330,22 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 }
 
 // cachePath maps a documentation URL to its on-disk cache file. The key is a
-// hash of the full URL so paths and query strings are disambiguated while
-// staying filesystem-safe.
+// hash of the full URL (scheme, host, path and query) so distinct pages and
+// query strings are disambiguated while the file name stays filesystem-safe
+// on every platform: lowercase hex plus a fixed extension.
 func (t *LLMSToolset) cachePath(u *url.URL) string {
 	sum := sha256.Sum256([]byte(u.String()))
 	return filepath.Join(t.cacheDir, hex.EncodeToString(sum[:])+".json")
 }
 
 // cacheRead loads a cached entry for u, or nil when caching is disabled or the
-// entry is missing/corrupt. Cache failures degrade to nil so the caller falls
-// through to a network fetch.
+// entry is missing, corrupt, or does not describe u. Cache failures degrade to
+// nil so the caller falls through to a network fetch.
+//
+// The entry's recorded URL must match the requested one and its body must be
+// within llmsMaxBytes: the cache directory is shared and writable by the user,
+// so a stray or tampered file must not be able to answer for a different URL
+// or hand the model an oversized body the network path would have refused.
 func (t *LLMSToolset) cacheRead(u *url.URL) *llmsCacheEntry {
 	if t.cacheDir == "" {
 		return nil
@@ -327,11 +358,20 @@ func (t *LLMSToolset) cacheRead(u *url.URL) *llmsCacheEntry {
 	if err := json.Unmarshal(data, &e); err != nil {
 		return nil
 	}
+	if e.URL != u.String() || len(e.Body) > llmsMaxBytes {
+		return nil
+	}
 	return &e
 }
 
 // cacheWrite persists an entry, creating the cache directory as needed. Cache
 // write failures are ignored: they cost a future re-fetch, not correctness.
+//
+// The entry is written to a temporary file and renamed into place so a
+// concurrent reader in another pi-go process (the directory is shared by every
+// mode) never observes a partially written file. The directory is created
+// 0700 and the files 0600: the content is public documentation, but the
+// directory lives under the user's home and should not be world-readable.
 func (t *LLMSToolset) cacheWrite(e *llmsCacheEntry) {
 	if t.cacheDir == "" {
 		return
@@ -344,10 +384,80 @@ func (t *LLMSToolset) cacheWrite(e *llmsCacheEntry) {
 	if err != nil {
 		return
 	}
-	if err := os.MkdirAll(t.cacheDir, 0o755); err != nil {
+	if err := os.MkdirAll(t.cacheDir, 0o700); err != nil {
 		return
 	}
-	_ = os.WriteFile(t.cachePath(u), data, 0o644)
+	dst := t.cachePath(u)
+	tmp, err := os.CreateTemp(t.cacheDir, filepath.Base(dst)+".*.tmp")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return
+	}
+	_ = os.Chmod(tmpName, 0o600)
+	// os.Rename replaces an existing destination on every platform (on
+	// Windows it uses MoveFileEx with REPLACE_EXISTING), but can still fail
+	// there if another process has the destination open at that instant. The
+	// write is best-effort, so just discard the temp file in that case.
+	if err := os.Rename(tmpName, dst); err != nil {
+		_ = os.Remove(tmpName)
+		return
+	}
+	t.cacheEvict()
+}
+
+// cacheEvict enforces llmsCacheMaxEntries and llmsCacheMaxBytes over the
+// cache directory by deleting the least-recently-written entries first. It
+// runs after every write, which only happens after a network round trip, so
+// the directory scan is cheap relative to the fetch it follows. Removal is
+// best-effort: a file another process holds open (Windows) or has already
+// removed is simply skipped.
+func (t *LLMSToolset) cacheEvict() {
+	dirEntries, err := os.ReadDir(t.cacheDir)
+	if err != nil {
+		return
+	}
+	type cacheFile struct {
+		name  string
+		size  int64
+		mtime time.Time
+	}
+	var files []cacheFile
+	var total int64
+	for _, de := range dirEntries {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		info, err := de.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, cacheFile{name: de.Name(), size: info.Size(), mtime: info.ModTime()})
+		total += info.Size()
+	}
+	if len(files) <= llmsCacheMaxEntries && total <= llmsCacheMaxBytes {
+		return
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].mtime.Before(files[j].mtime) })
+	remaining := len(files)
+	for _, f := range files {
+		if remaining <= llmsCacheMaxEntries && total <= llmsCacheMaxBytes {
+			return
+		}
+		if err := os.Remove(filepath.Join(t.cacheDir, f.name)); err != nil && !os.IsNotExist(err) {
+			continue // still on disk; it keeps counting against the budget
+		}
+		remaining--
+		total -= f.size
+	}
 }
 
 // hostAllowed reports whether hostname hosts one of the configured llms.txt

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -2,11 +2,16 @@ package tools
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -40,6 +45,26 @@ const llmsUserAgent = "pi-go/1.0 (+https://github.com/dimetron/pi-go)"
 // srv.Client() so the test's self-signed cert is trusted.
 var llmsClientOverride *http.Client
 
+// llmsCacheTTL bounds how old a cached page may be before it is considered
+// stale. Revalidation with a 304 keeps a cache hit fast (small round trip, no
+// body download); this TTL is the floor below which no revalidation is
+// attempted at all — a page fetched moments ago is served straight from cache.
+const llmsCacheTTL = 1 * time.Hour
+
+// llmsCacheMaxAge bounds the age of an entry usable as a network-down fallback.
+// A cached page older than this is not returned when the revalidation request
+// fails, so a permanently dead or moved page is not served forever.
+const llmsCacheMaxAge = 24 * time.Hour
+
+// llmsCacheEntry is the on-disk form of one cached page.
+type llmsCacheEntry struct {
+	URL          string `json:"url"`
+	Body         string `json:"body"`
+	ETag         string `json:"etag,omitempty"`
+	LastModified string `json:"last_modified,omitempty"`
+	FetchedAt    int64  `json:"fetched_at"`
+}
+
 // LLMSInput defines the parameters for the fetch_docs tool.
 type LLMSInput struct {
 	// URL is the documentation URL to fetch. It must be an https:// URL on a
@@ -55,13 +80,20 @@ type LLMSOutput struct {
 
 // LLMSToolset implements tool.Toolset for llms.txt documentation sources.
 type LLMSToolset struct {
-	sources []config.LLMSSource
-	client  *http.Client
+	sources  []config.LLMSSource
+	client   *http.Client
+	cacheDir string // directory for the on-disk fetch cache; empty disables caching
 }
 
 // NewLLMSToolset creates a new llms.txt toolset from configuration.
 func NewLLMSToolset(cfg *config.LLMSConfig) *LLMSToolset {
-	ts := &LLMSToolset{}
+	return NewLLMSToolsetWithCache(cfg, "")
+}
+
+// NewLLMSToolsetWithCache creates a new llms.txt toolset that caches fetched
+// pages under dir. When dir is empty, caching is disabled.
+func NewLLMSToolsetWithCache(cfg *config.LLMSConfig, dir string) *LLMSToolset {
+	ts := &LLMSToolset{cacheDir: dir}
 	if cfg != nil {
 		ts.sources = cfg.Sources
 	}
@@ -73,6 +105,28 @@ func NewLLMSToolset(cfg *config.LLMSConfig) *LLMSToolset {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error { return ts.checkRedirectURL(req.URL, via) },
 	}
 	return ts
+}
+
+// NewLLMSCachedToolset creates a new llms.txt toolset whose fetch cache lives
+// under the shared pi-go documentation cache directory (~/.pi-go/llms-cache).
+// Every mode that wires fetch_docs — the piagent, the one-shot CLI, and the
+// interactive TUI (which the voice agent drives) — shares this one directory,
+// so a page fetched by one is a cache hit for the others. Caching degrades to
+// off when no usable home directory exists.
+func NewLLMSCachedToolset(cfg *config.LLMSConfig) *LLMSToolset {
+	return NewLLMSToolsetWithCache(cfg, LLMSDefaultCacheDir())
+}
+
+// LLMSDefaultCacheDir returns the shared directory used to cache fetched
+// documentation pages, or "" when no usable home directory can be found. An
+// empty result disables the fetch cache rather than failing construction: doc
+// fetching is a best effort feature.
+func LLMSDefaultCacheDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pi-go", "llms-cache")
 }
 
 // checkRedirectURL validates one redirect hop. It is the CheckRedirect hook
@@ -163,11 +217,28 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 		return LLMSOutput{Error: fmt.Sprintf("host %q is not an allowed documentation source", u.Hostname())}, nil
 	}
 
+	// A cached copy younger than llmsCacheTTL is served straight from disk —
+	// no network, no revalidation.
+	entry := t.cacheRead(u)
+	if entry != nil && time.Since(time.Unix(entry.FetchedAt, 0)) < llmsCacheTTL {
+		return LLMSOutput{Content: entry.Body}, nil
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return LLMSOutput{Error: fmt.Sprintf("build request: %v", err)}, nil
 	}
 	req.Header.Set("User-Agent", llmsUserAgent)
+	// Revalidate an existing entry with a conditional request: the server
+	// answers 304 and we reuse the cached body, saving the full download.
+	if entry != nil {
+		if entry.ETag != "" {
+			req.Header.Set("If-None-Match", entry.ETag)
+		}
+		if entry.LastModified != "" {
+			req.Header.Set("If-Modified-Since", entry.LastModified)
+		}
+	}
 
 	client := t.client
 	if llmsClientOverride != nil {
@@ -181,24 +252,102 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		// Network failure: fall back to a reasonably fresh cached copy rather
+		// than failing the whole call. An entry older than llmsCacheMaxAge is
+		// not served, so a permanently dead page is not resurrected forever.
+		if entry != nil && time.Since(time.Unix(entry.FetchedAt, 0)) < llmsCacheMaxAge {
+			return LLMSOutput{Content: entry.Body}, nil
+		}
 		return LLMSOutput{Error: fmt.Sprintf("fetch failed: %v", err)}, nil
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		// Server confirms the cached copy is still current.
+		if entry != nil {
+			entry.FetchedAt = time.Now().Unix()
+			t.cacheWrite(entry)
+			return LLMSOutput{Content: entry.Body}, nil
+		}
+		return LLMSOutput{Error: "unexpected 304 without a cached entry"}, nil
+
+	case http.StatusOK:
+		// Read one byte past the cap so an oversized body is detected rather
+		// than silently truncated into a successful-looking result.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, llmsMaxBytes+1))
+		if err != nil {
+			return LLMSOutput{Error: fmt.Sprintf("read body: %v", err)}, nil
+		}
+		if len(body) > llmsMaxBytes {
+			return LLMSOutput{Error: fmt.Sprintf("response exceeds %d byte limit", llmsMaxBytes)}, nil
+		}
+		// Cache the fresh body so the next read revalidates instead of
+		// downloading it again. Caching is best-effort: a write failure just
+		// means the next call re-fetches.
+		t.cacheWrite(&llmsCacheEntry{
+			URL:          rawURL,
+			Body:         string(body),
+			ETag:         resp.Header.Get("ETag"),
+			LastModified: resp.Header.Get("Last-Modified"),
+			FetchedAt:    time.Now().Unix(),
+		})
+		return LLMSOutput{Content: string(body)}, nil
+
+	default:
+		// An upstream 5xx is transient; prefer a reasonably fresh cached copy
+		// to the cached error being surfaced to the model.
+		if entry != nil && time.Since(time.Unix(entry.FetchedAt, 0)) < llmsCacheMaxAge {
+			return LLMSOutput{Content: entry.Body}, nil
+		}
 		return LLMSOutput{Error: fmt.Sprintf("unexpected status %d", resp.StatusCode)}, nil
 	}
+}
 
-	// Read one byte past the cap so an oversized body is detected rather than
-	// silently truncated into a successful-looking result.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, llmsMaxBytes+1))
+// cachePath maps a documentation URL to its on-disk cache file. The key is a
+// hash of the full URL so paths and query strings are disambiguated while
+// staying filesystem-safe.
+func (t *LLMSToolset) cachePath(u *url.URL) string {
+	sum := sha256.Sum256([]byte(u.String()))
+	return filepath.Join(t.cacheDir, hex.EncodeToString(sum[:])+".json")
+}
+
+// cacheRead loads a cached entry for u, or nil when caching is disabled or the
+// entry is missing/corrupt. Cache failures degrade to nil so the caller falls
+// through to a network fetch.
+func (t *LLMSToolset) cacheRead(u *url.URL) *llmsCacheEntry {
+	if t.cacheDir == "" {
+		return nil
+	}
+	data, err := os.ReadFile(t.cachePath(u))
 	if err != nil {
-		return LLMSOutput{Error: fmt.Sprintf("read body: %v", err)}, nil
+		return nil
 	}
-	if len(body) > llmsMaxBytes {
-		return LLMSOutput{Error: fmt.Sprintf("response exceeds %d byte limit", llmsMaxBytes)}, nil
+	var e llmsCacheEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil
 	}
-	return LLMSOutput{Content: string(body)}, nil
+	return &e
+}
+
+// cacheWrite persists an entry, creating the cache directory as needed. Cache
+// write failures are ignored: they cost a future re-fetch, not correctness.
+func (t *LLMSToolset) cacheWrite(e *llmsCacheEntry) {
+	if t.cacheDir == "" {
+		return
+	}
+	u, err := url.Parse(e.URL)
+	if err != nil {
+		return
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(t.cacheDir, 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(t.cachePath(u), data, 0o644)
 }
 
 // hostAllowed reports whether hostname hosts one of the configured llms.txt

--- a/internal/tools/llms_test.go
+++ b/internal/tools/llms_test.go
@@ -7,8 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/tool"
@@ -226,6 +229,131 @@ func TestLLMSToolInvoke(t *testing.T) {
 	content, _ := m["content"].(string)
 	if !strings.Contains(content, "Invoked Docs") {
 		t.Fatalf("expected content to contain 'Invoked Docs', got %q", content)
+	}
+}
+
+// newLLMSCacheTestServer starts a TLS server that counts requests and returns
+// a body on 200, plus a toolset with caching enabled into a temp dir.
+func newLLMSCacheTestServer(t *testing.T) (*httptest.Server, *LLMSToolset, *int32) {
+	t.Helper()
+	var requests int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.Write([]byte("# Cached Docs"))
+	}))
+	t.Cleanup(srv.Close)
+
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{
+			{Name: "test", URL: srv.URL + "/llms.txt"},
+		},
+	}, t.TempDir())
+	return srv, ts, &requests
+}
+
+func TestLLMSFetchDocsCachesSecondFetch(t *testing.T) {
+	srv, ts, requests := newLLMSCacheTestServer(t)
+	u := srv.URL + "/page.md"
+
+	out, err := ts.FetchDocs(context.Background(), u)
+	if err != nil || out.Error != "" {
+		t.Fatalf("first FetchDocs() = (%q, %v), want nil error", out.Error, err)
+	}
+
+	// A second fetch within llmsCacheTTL must be served from disk: no HTTP call.
+	out, err = ts.FetchDocs(context.Background(), u)
+	if err != nil {
+		t.Fatalf("second FetchDocs() error = %v", err)
+	}
+	if !strings.Contains(out.Content, "Cached Docs") {
+		t.Fatalf("expected cached content, got %q", out.Content)
+	}
+	if got := atomic.LoadInt32(requests); got != 1 {
+		t.Fatalf("expected 1 HTTP request on cached hit, got %d", got)
+	}
+}
+
+func TestLLMSFetchCacheRevalidatesStale(t *testing.T) {
+	var requests int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requests, 1)
+		if n == 2 && r.Header.Get("If-None-Match") == `"v1"` {
+			// Revalidation request: server confirms the copy is current.
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", `"v1"`)
+		w.Write([]byte("Revalidated Docs"))
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, t.TempDir())
+	u, err := url.Parse(srv.URL + "/page.md")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	if _, err := ts.FetchDocs(context.Background(), u.String()); err != nil {
+		t.Fatalf("first FetchDocs() error = %v", err)
+	}
+
+	// Age the cached entry past llmsCacheTTL so the next read revalidates.
+	e := ts.cacheRead(u)
+	e.FetchedAt = time.Now().Add(-2 * time.Hour).Unix()
+	ts.cacheWrite(e)
+
+	if _, err := ts.FetchDocs(context.Background(), u.String()); err != nil {
+		t.Fatalf("second FetchDocs() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("expected 2 HTTP requests (initial + revalidate), got %d", got)
+	}
+}
+
+func TestLLMSFetchCacheFallsBackOnNetworkError(t *testing.T) {
+	// First fetch populates the cache; the second uses a transport that always
+	// fails, and must return the cached copy rather than an error.
+	srv, ts, _ := newLLMSCacheTestServer(t)
+	u := srv.URL + "/page.md"
+
+	out, err := ts.FetchDocs(context.Background(), u)
+	if err != nil || out.Error != "" {
+		t.Fatalf("initial FetchDocs() = (%q, %v), want nil error", out.Error, err)
+	}
+
+	withLLMSClient(t, &http.Client{Transport: errorTransport{}})
+	out, err = ts.FetchDocs(context.Background(), u)
+	if err != nil {
+		t.Fatalf("FetchDocs() error = %v", err)
+	}
+	if !strings.Contains(out.Content, "Cached Docs") {
+		t.Fatalf("expected cached content on network failure, got %q", out.Content)
+	}
+}
+
+func TestNewLLMSCachedToolsetUsesDefaultCacheDir(t *testing.T) {
+	// The voice agent, one-shot CLI, and piagent all build the toolset through
+	// NewLLMSCachedToolset, so they must all share one cache directory. Pinning
+	// that here guards against a regression that silently disables the shared
+	// cache for one mode.
+	ts := NewLLMSCachedToolset(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "adk", URL: "https://adk.dev/llms.txt"}},
+	})
+	if ts.cacheDir == "" {
+		t.Fatal("NewLLMSCachedToolset must enable caching")
+	}
+	if ts.cacheDir != LLMSDefaultCacheDir() {
+		t.Fatalf("cacheDir = %q, want %q", ts.cacheDir, LLMSDefaultCacheDir())
+	}
+	if !strings.HasSuffix(ts.cacheDir, filepath.Join(".pi-go", "llms-cache")) {
+		t.Fatalf("cacheDir = %q, want it under ~/.pi-go/llms-cache", ts.cacheDir)
 	}
 }
 

--- a/internal/tools/llms_test.go
+++ b/internal/tools/llms_test.go
@@ -2,12 +2,16 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -17,6 +21,7 @@ import (
 	"google.golang.org/adk/v2/tool"
 
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/testenv"
 )
 
 // newLLMSTestServer starts an httptest TLS server serving a fixed body and
@@ -246,11 +251,13 @@ func newLLMSCacheTestServer(t *testing.T) (*httptest.Server, *LLMSToolset, *int3
 	withAllowedTestHosts(t, "127.0.0.1", "::1")
 	withLLMSClient(t, srv.Client())
 
+	// A not-yet-existing subdirectory, as ~/.pi-go/llms-cache is on first
+	// use, so the tests exercise the directory creation path too.
 	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
 		Sources: []config.LLMSSource{
 			{Name: "test", URL: srv.URL + "/llms.txt"},
 		},
-	}, t.TempDir())
+	}, filepath.Join(t.TempDir(), "llms-cache"))
 	return srv, ts, &requests
 }
 
@@ -343,6 +350,8 @@ func TestNewLLMSCachedToolsetUsesDefaultCacheDir(t *testing.T) {
 	// NewLLMSCachedToolset, so they must all share one cache directory. Pinning
 	// that here guards against a regression that silently disables the shared
 	// cache for one mode.
+	home := t.TempDir()
+	testenv.SetHome(t, home)
 	ts := NewLLMSCachedToolset(&config.LLMSConfig{
 		Sources: []config.LLMSSource{{Name: "adk", URL: "https://adk.dev/llms.txt"}},
 	})
@@ -352,8 +361,296 @@ func TestNewLLMSCachedToolsetUsesDefaultCacheDir(t *testing.T) {
 	if ts.cacheDir != LLMSDefaultCacheDir() {
 		t.Fatalf("cacheDir = %q, want %q", ts.cacheDir, LLMSDefaultCacheDir())
 	}
-	if !strings.HasSuffix(ts.cacheDir, filepath.Join(".pi-go", "llms-cache")) {
-		t.Fatalf("cacheDir = %q, want it under ~/.pi-go/llms-cache", ts.cacheDir)
+	if want := filepath.Join(home, ".pi-go", "llms-cache"); ts.cacheDir != want {
+		t.Fatalf("cacheDir = %q, want %q (under the test HOME)", ts.cacheDir, want)
+	}
+}
+
+func TestLLMSDefaultCacheDirEmptyWithoutHome(t *testing.T) {
+	// No usable home directory must disable caching rather than point the
+	// cache at a relative path or fail construction.
+	testenv.UnsetHome(t)
+	if got := LLMSDefaultCacheDir(); got != "" {
+		t.Fatalf("LLMSDefaultCacheDir() = %q, want empty without a home directory", got)
+	}
+	ts := NewLLMSCachedToolset(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "adk", URL: "https://adk.dev/llms.txt"}},
+	})
+	if ts.cacheDir != "" {
+		t.Fatalf("cacheDir = %q, want caching disabled without a home directory", ts.cacheDir)
+	}
+}
+
+// ageLLMSCacheEntry rewrites the cached entry for rawURL so it was fetched
+// `by` ago, forcing the next FetchDocs to revalidate (or, past
+// llmsCacheMaxAge, to refuse the entry as a fallback).
+func ageLLMSCacheEntry(t *testing.T, ts *LLMSToolset, rawURL string, by time.Duration) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	e := ts.cacheRead(u)
+	if e == nil {
+		t.Fatalf("no cache entry for %s", rawURL)
+	}
+	e.FetchedAt = time.Now().Add(-by).Unix()
+	ts.cacheWrite(e)
+}
+
+func TestLLMSFetchCacheStaleReplacedBy200(t *testing.T) {
+	// When revalidation returns a fresh 200 the new body must replace the
+	// cached one, and the conditional headers must have been sent.
+	var requests int32
+	var sawConditional atomic.Bool
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requests, 1)
+		if r.Header.Get("If-None-Match") == `"v1"` && r.Header.Get("If-Modified-Since") == "Mon, 02 Jan 2006 15:04:05 GMT" {
+			sawConditional.Store(true)
+		}
+		w.Header().Set("ETag", fmt.Sprintf(`"v%d"`, n))
+		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+		fmt.Fprintf(w, "Docs v%d", n)
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, t.TempDir())
+	u := srv.URL + "/page.md"
+
+	out, _ := ts.FetchDocs(context.Background(), u)
+	if out.Content != "Docs v1" {
+		t.Fatalf("first fetch = %q, want %q", out.Content, "Docs v1")
+	}
+	ageLLMSCacheEntry(t, ts, u, 2*time.Hour)
+
+	out, _ = ts.FetchDocs(context.Background(), u)
+	if out.Content != "Docs v2" {
+		t.Fatalf("revalidated fetch = %q, want the replaced body %q", out.Content, "Docs v2")
+	}
+	if !sawConditional.Load() {
+		t.Fatal("revalidation request did not carry If-None-Match/If-Modified-Since")
+	}
+	// The replacement is what the cache now serves, with no further request.
+	out, _ = ts.FetchDocs(context.Background(), u)
+	if out.Content != "Docs v2" || atomic.LoadInt32(&requests) != 2 {
+		t.Fatalf("third fetch = %q after %d requests, want %q from cache after 2", out.Content, requests, "Docs v2")
+	}
+}
+
+func TestLLMSFetchCacheFallbackRefusedPastMaxAge(t *testing.T) {
+	// An entry older than llmsCacheMaxAge is not a valid network-down
+	// fallback: the caller sees the fetch error instead of a day-old page.
+	srv, ts, _ := newLLMSCacheTestServer(t)
+	u := srv.URL + "/page.md"
+	if out, _ := ts.FetchDocs(context.Background(), u); out.Error != "" {
+		t.Fatalf("initial fetch error: %s", out.Error)
+	}
+	ageLLMSCacheEntry(t, ts, u, 25*time.Hour)
+
+	withLLMSClient(t, &http.Client{Transport: errorTransport{}})
+	out, _ := ts.FetchDocs(context.Background(), u)
+	if !strings.Contains(out.Error, "fetch failed") {
+		t.Fatalf("expected 'fetch failed' past max age, got content=%q error=%q", out.Content, out.Error)
+	}
+}
+
+func TestLLMSFetchCacheFallsBackOn5xx(t *testing.T) {
+	// A transient upstream 5xx on revalidation serves the reasonably fresh
+	// cached copy; without a cached copy the status is reported.
+	var fail atomic.Bool
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.Write([]byte("Good Docs"))
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, t.TempDir())
+	u := srv.URL + "/page.md"
+
+	fail.Store(true)
+	if out, _ := ts.FetchDocs(context.Background(), u); !strings.Contains(out.Error, "unexpected status 502") {
+		t.Fatalf("uncached 5xx: got content=%q error=%q, want unexpected status 502", out.Content, out.Error)
+	}
+
+	fail.Store(false)
+	if out, _ := ts.FetchDocs(context.Background(), u); out.Content != "Good Docs" {
+		t.Fatalf("populate: got content=%q error=%q", out.Content, out.Error)
+	}
+	ageLLMSCacheEntry(t, ts, u, 2*time.Hour)
+
+	fail.Store(true)
+	if out, _ := ts.FetchDocs(context.Background(), u); out.Content != "Good Docs" {
+		t.Fatalf("5xx with cache: got content=%q error=%q, want cached body", out.Content, out.Error)
+	}
+	ageLLMSCacheEntry(t, ts, u, 25*time.Hour)
+	if out, _ := ts.FetchDocs(context.Background(), u); !strings.Contains(out.Error, "unexpected status 502") {
+		t.Fatalf("5xx past max age: got content=%q error=%q, want the status error", out.Content, out.Error)
+	}
+}
+
+func TestLLMSFetchCache304WithoutEntry(t *testing.T) {
+	// A server answering 304 to an unconditional request has nothing to
+	// reuse; that must be an explicit error, not empty content.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, t.TempDir())
+	out, _ := ts.FetchDocs(context.Background(), srv.URL+"/page.md")
+	if !strings.Contains(out.Error, "304") {
+		t.Fatalf("got content=%q error=%q, want a 304-without-cache error", out.Content, out.Error)
+	}
+}
+
+func TestLLMSFetchCacheIgnoresBadEntries(t *testing.T) {
+	// Corrupt JSON, an entry recorded for a different URL, and an oversized
+	// body are all treated as a miss: the page is fetched again and the bad
+	// file replaced.
+	srv, ts, requests := newLLMSCacheTestServer(t)
+	rawURL := srv.URL + "/page.md"
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	path := ts.cachePath(u)
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"corrupt", []byte("{not json")},
+		{"other-url", mustJSON(t, llmsCacheEntry{URL: srv.URL + "/other.md", Body: "Wrong Page", FetchedAt: time.Now().Unix()})},
+		{"oversized", mustJSON(t, llmsCacheEntry{URL: rawURL, Body: strings.Repeat("x", llmsMaxBytes+1), FetchedAt: time.Now().Unix()})},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.MkdirAll(ts.cacheDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, tc.data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := ts.cacheRead(u); got != nil {
+				t.Fatalf("cacheRead returned %+v for a %s entry, want nil", got, tc.name)
+			}
+			out, _ := ts.FetchDocs(context.Background(), rawURL)
+			if out.Content != "# Cached Docs" {
+				t.Fatalf("got content=%q error=%q, want a fresh fetch", out.Content, out.Error)
+			}
+			if got := atomic.LoadInt32(requests); got != int32(i+1) {
+				t.Fatalf("expected %d HTTP requests after refetch, got %d", i+1, got)
+			}
+			if got := ts.cacheRead(u); got == nil || got.Body != "# Cached Docs" {
+				t.Fatalf("bad entry was not replaced by the fresh fetch: %+v", got)
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestLLMSFetchCacheDisabledWritesNothing(t *testing.T) {
+	// NewLLMSToolset (no cache dir) must never touch the disk and must refetch
+	// every time.
+	srv, _, requests := newLLMSCacheTestServer(t)
+	ts := NewLLMSToolset(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	})
+	u := srv.URL + "/page.md"
+	for i := 1; i <= 2; i++ {
+		if out, _ := ts.FetchDocs(context.Background(), u); out.Content != "# Cached Docs" {
+			t.Fatalf("fetch %d: got content=%q error=%q", i, out.Content, out.Error)
+		}
+	}
+	if got := atomic.LoadInt32(requests); got != 2 {
+		t.Fatalf("expected 2 HTTP requests with caching disabled, got %d", got)
+	}
+	pu, _ := url.Parse(u)
+	if got := ts.cacheRead(pu); got != nil {
+		t.Fatalf("cacheRead with caching disabled = %+v, want nil", got)
+	}
+	ts.cacheWrite(&llmsCacheEntry{URL: u, Body: "x"}) // must be a no-op, not a panic
+}
+
+func TestLLMSFetchCacheWriteIsPrivateAndAtomic(t *testing.T) {
+	// The shared cache directory is created 0700 and entries 0600, and no
+	// temp file is left behind after a write.
+	srv, ts, _ := newLLMSCacheTestServer(t)
+	u := srv.URL + "/page.md"
+	if out, _ := ts.FetchDocs(context.Background(), u); out.Error != "" {
+		t.Fatalf("fetch error: %s", out.Error)
+	}
+	entries, err := os.ReadDir(ts.cacheDir)
+	if err != nil {
+		t.Fatalf("read cache dir: %v", err)
+	}
+	if len(entries) != 1 || !strings.HasSuffix(entries[0].Name(), ".json") {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("cache dir = %v, want exactly one .json entry and no temp files", names)
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	di, err := os.Stat(ts.cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := di.Mode().Perm(); got != 0o700 {
+		t.Errorf("cache dir perm = %o, want 0700", got)
+	}
+	fi, err := os.Stat(filepath.Join(ts.cacheDir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("cache file perm = %o, want 0600", got)
+	}
+}
+
+func TestLLMSFetchCacheKeyIncludesQuery(t *testing.T) {
+	// Two URLs that differ only in query string are distinct cache entries.
+	var requests int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		fmt.Fprintf(w, "q=%s", r.URL.RawQuery)
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, t.TempDir())
+
+	a, _ := ts.FetchDocs(context.Background(), srv.URL+"/page.md?v=1")
+	b, _ := ts.FetchDocs(context.Background(), srv.URL+"/page.md?v=2")
+	if a.Content != "q=v=1" || b.Content != "q=v=2" {
+		t.Fatalf("got %q and %q, want distinct bodies per query", a.Content, b.Content)
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("expected 2 HTTP requests for 2 distinct URLs, got %d", got)
 	}
 }
 
@@ -568,4 +865,161 @@ func TestLLMSRedirectLimitEnforced(t *testing.T) {
 	if !strings.Contains(out.Error, "fetch failed") || !strings.Contains(out.Error, "redirects") {
 		t.Fatalf("expected redirect-limit failure, got %q", out.Error)
 	}
+}
+
+func TestLLMSCacheWriteFailuresAreIgnored(t *testing.T) {
+	// Cache writes are best-effort: an unparsable URL or an uncreatable cache
+	// directory (here, a path below a regular file) must neither panic nor
+	// leave anything behind.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ts := NewLLMSToolsetWithCache(nil, filepath.Join(blocker, "llms-cache"))
+	ts.cacheWrite(&llmsCacheEntry{URL: "https://adk.dev/page.md", Body: "x", FetchedAt: time.Now().Unix()})
+	if _, err := os.Stat(ts.cacheDir); err == nil {
+		t.Fatal("cache dir below a file: directory exists, want nothing created")
+	}
+
+	ts = NewLLMSToolsetWithCache(nil, filepath.Join(t.TempDir(), "llms-cache"))
+	ts.cacheWrite(&llmsCacheEntry{URL: "https://adk.dev/\x7f", Body: "x"})
+	if _, err := os.Stat(ts.cacheDir); !os.IsNotExist(err) {
+		t.Fatalf("unparsable URL: cache dir was created (stat err = %v), want nothing written", err)
+	}
+}
+
+func TestLLMSFetchCacheNoFallbackOn4xx(t *testing.T) {
+	// A 4xx on revalidation is the origin's verdict on the page (gone, moved,
+	// access revoked): the cached body must not be served as current.
+	var status atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if code := int(status.Load()); code != 0 {
+			w.WriteHeader(code)
+			return
+		}
+		w.Write([]byte("Good Docs"))
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, filepath.Join(t.TempDir(), "llms-cache"))
+	u := srv.URL + "/page.md"
+	if out, _ := ts.FetchDocs(context.Background(), u); out.Content != "Good Docs" {
+		t.Fatalf("populate: got content=%q error=%q", out.Content, out.Error)
+	}
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusGone} {
+		ageLLMSCacheEntry(t, ts, u, 2*time.Hour)
+		status.Store(int32(code))
+		out, _ := ts.FetchDocs(context.Background(), u)
+		if out.Content != "" || !strings.Contains(out.Error, fmt.Sprintf("unexpected status %d", code)) {
+			t.Fatalf("%d: got content=%q error=%q, want the status error and no cached body", code, out.Content, out.Error)
+		}
+	}
+}
+
+func TestLLMSFetchCacheIgnoresFragment(t *testing.T) {
+	// page.md#a and page.md#b are the same resource on the wire and share one
+	// cache entry; the request itself carries no fragment.
+	var requests int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		if r.URL.Fragment != "" || strings.Contains(r.RequestURI, "#") {
+			t.Errorf("fragment reached the server: %q", r.RequestURI)
+		}
+		w.Write([]byte("Sectioned Docs"))
+	}))
+	t.Cleanup(srv.Close)
+	withAllowedTestHosts(t, "127.0.0.1", "::1")
+	withLLMSClient(t, srv.Client())
+	ts := NewLLMSToolsetWithCache(&config.LLMSConfig{
+		Sources: []config.LLMSSource{{Name: "test", URL: srv.URL + "/llms.txt"}},
+	}, filepath.Join(t.TempDir(), "llms-cache"))
+
+	for _, frag := range []string{"#install", "#usage", ""} {
+		out, _ := ts.FetchDocs(context.Background(), srv.URL+"/page.md"+frag)
+		if out.Content != "Sectioned Docs" {
+			t.Fatalf("%q: got content=%q error=%q", frag, out.Content, out.Error)
+		}
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("expected 1 HTTP request for three fragments of one page, got %d", got)
+	}
+	entries, err := os.ReadDir(ts.cacheDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("cache dir has %d entries (err %v), want exactly 1", len(entries), err)
+	}
+	pu, _ := url.Parse(srv.URL + "/page.md#install")
+	if e := ts.cacheRead(pu); e != nil {
+		t.Fatalf("cacheRead with a fragment found an entry keyed by the fragment: %+v", e)
+	}
+}
+
+func TestLLMSCacheEvictsOldestPastBudget(t *testing.T) {
+	// Past the entry budget the least-recently-written files go first, and
+	// the total-bytes budget is enforced the same way.
+	dir := filepath.Join(t.TempDir(), "llms-cache")
+	ts := NewLLMSToolsetWithCache(nil, dir)
+	base := time.Now().Add(-time.Hour)
+	writeAged := func(i int, body string, age time.Duration) string {
+		t.Helper()
+		rawURL := fmt.Sprintf("https://adk.dev/p%d.md", i)
+		ts.cacheWrite(&llmsCacheEntry{URL: rawURL, Body: body, FetchedAt: time.Now().Unix()})
+		pu, _ := url.Parse(rawURL)
+		when := base.Add(-age)
+		if err := os.Chtimes(ts.cachePath(pu), when, when); err != nil {
+			t.Fatal(err)
+		}
+		return rawURL
+	}
+	// llmsCacheMaxEntries entries, the lowest-numbered the oldest; all fit.
+	for i := 0; i < llmsCacheMaxEntries; i++ {
+		writeAged(i, "x", time.Duration(llmsCacheMaxEntries-i)*time.Second)
+	}
+	if n := countLLMSCacheFiles(t, dir); n != llmsCacheMaxEntries {
+		t.Fatalf("before eviction: %d files, want %d", n, llmsCacheMaxEntries)
+	}
+	// One more (newest) evicts exactly the oldest, p0.
+	newest := writeAged(llmsCacheMaxEntries, "x", 0)
+	if n := countLLMSCacheFiles(t, dir); n != llmsCacheMaxEntries {
+		t.Fatalf("after one over budget: %d files, want %d", n, llmsCacheMaxEntries)
+	}
+	p0, _ := url.Parse("https://adk.dev/p0.md")
+	if ts.cacheRead(p0) != nil {
+		t.Fatal("oldest entry p0 survived eviction")
+	}
+	p1, _ := url.Parse("https://adk.dev/p1.md")
+	if ts.cacheRead(p1) == nil {
+		t.Fatal("second-oldest entry p1 was evicted, want only the oldest gone")
+	}
+	nu, _ := url.Parse(newest)
+	if ts.cacheRead(nu) == nil {
+		t.Fatal("the entry just written was evicted")
+	}
+
+	// Bytes budget: a few large, old entries over llmsCacheMaxBytes in total
+	// get trimmed oldest-first until the total fits, in a fresh directory.
+	dir = filepath.Join(t.TempDir(), "llms-cache")
+	ts = NewLLMSToolsetWithCache(nil, dir)
+	big := strings.Repeat("y", llmsMaxBytes) // 2 MB per entry
+	n := llmsCacheMaxBytes/llmsMaxBytes + 1  // one past the budget
+	for i := 0; i < n; i++ {
+		writeAged(i, big, time.Duration(n-i)*time.Second)
+	}
+	if got := countLLMSCacheFiles(t, dir); got >= n {
+		t.Fatalf("bytes budget: %d files remain of %d, want at least one evicted", got, n)
+	}
+	if ts.cacheRead(p0) != nil {
+		t.Fatal("bytes budget: oldest entry p0 survived eviction")
+	}
+}
+
+func countLLMSCacheFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(entries)
 }

--- a/piagent/build.go
+++ b/piagent/build.go
@@ -138,7 +138,7 @@ func buildToolsets(cfg config.Config) []adktool.Toolset {
 		toolsets = append(toolsets, tools.NewA2AToolset(cfg.A2A))
 	}
 	if cfg.LLMS != nil && len(cfg.LLMS.Sources) > 0 {
-		toolsets = append(toolsets, tools.NewLLMSToolset(cfg.LLMS))
+		toolsets = append(toolsets, tools.NewLLMSCachedToolset(cfg.LLMS))
 	}
 	return toolsets
 }


### PR DESCRIPTION
## Summary

Cache documentation pages fetched by `fetch_docs` on disk under `~/.pi-go/llms-cache`, keyed by URL hash, using HTTP conditional revalidation.

## Behavior
- **Fresh hit (< 1h)**: served from disk, no network.
- **Stale entry**: revalidated via `If-None-Match` / `If-Modified-Since`; a `304` reuses the cached body (no full download).
- **Network failure / transient 5xx**: falls back to a reasonably fresh cached copy (< 24h) instead of erroring.
- Cache is best-effort: corrupt/missing entries fall through to a network fetch.

## Wiring
Every mode that wires `fetch_docs` now shares one cache directory via `NewLLMSCachedToolset`:
- `piagent/build.go`
- `internal/cli/cli.go` (one-shot)
- `internal/cli/interactive.go` (interactive TUI — what the voice agent drives)

A page fetched by any mode is a cache hit for the others.

## Verification
- `go build ./...` — ok
- `go vet ./...` — ok
- `go test ./internal/tools/ ./piagent/` — ok (new cache tests pass)
- `golangci-lint run ./...` — 0 issues

New tests:
- `TestLLMSFetchDocsCachesSecondFetch`
- `TestLLMSFetchCacheRevalidatesStale`
- `TestLLMSFetchCacheFallsBackOnNetworkError`
- `TestNewLLMSCachedToolsetUsesDefaultCacheDir`

## Hardening (d73d5d2, after codex review)
- Cache dir created `0700`, entries `0600`; entries written via temp file + rename (safe for concurrent pi-go processes; Windows rename failure just skips the write).
- A cached entry is ignored unless its recorded URL matches the request and its body is within `llmsMaxBytes`.
- URL fragments are stripped before lookup/request (`page.md#a` and `page.md#b` share one entry).
- Stale fallback only for 5xx; a 4xx (401/403/404/410) is reported, never papered over with a cached body.
- Cache bounded at 512 entries / 64 MB, least-recently-written evicted after each write.
- Additional tests for all of the above plus stale→200 replacement, >24h fallback refusal, 304 without entry, corrupt/foreign/oversized entries, query-string keying, caching-disabled path, and hermetic default-dir resolution (`testenv.SetHome`/`UnsetHome`).

## CI note (temporary)
This branch carries a merge of `origin/fix/windows-ci-tests` (#203, which itself includes #215) plus current `main` (0dc3f42, #213) so Test / Test (Windows) / Coverage can pass now — on first run they failed only on `main`'s pre-existing `internal/webserver` voice-bar-offset test and the Windows-only test set, not on anything in `internal/tools`. The merge collapses to nothing once #203/#215 land in `main`.

