### PR TITLE
test(tools): cover fetch_docs cache failure paths and wiring

### DIFF
--- a/internal/acp/client/test_helper_agent_test.go
+++ b/internal/acp/client/test_helper_agent_test.go
@@ -3,71 +3,83 @@ package client
 import (
 	"context"
 	"os"
+	"sync/atomic"
 
 	acp "github.com/coder/acp-go-sdk"
 )
 
-type helperAgent struct{}
+// helperAgent is the in-process ACP agent the test helper subprocess runs.
+// The connection it answers on is published through conn once
+// NewAgentSideConnection has returned: that constructor starts the receive
+// goroutine that calls Prompt, so writing a plain package-level variable
+// after it returns races with Prompt reading it. ready is closed after the
+// store so Prompt can block until the connection exists.
+type helperAgent struct {
+	conn  atomic.Pointer[acp.AgentSideConnection]
+	ready chan struct{}
+}
 
-func (helperAgent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+func (*helperAgent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
 	return acp.AuthenticateResponse{}, nil
 }
 
-func (helperAgent) Logout(context.Context, acp.LogoutRequest) (acp.LogoutResponse, error) {
+func (*helperAgent) Logout(context.Context, acp.LogoutRequest) (acp.LogoutResponse, error) {
 	return acp.LogoutResponse{}, nil
 }
 
-func (helperAgent) Initialize(context.Context, acp.InitializeRequest) (acp.InitializeResponse, error) {
+func (*helperAgent) Initialize(context.Context, acp.InitializeRequest) (acp.InitializeResponse, error) {
 	return acp.InitializeResponse{
 		ProtocolVersion: acp.ProtocolVersion(acp.ProtocolVersionNumber),
 		AgentInfo:       &acp.Implementation{Name: "helper-agent", Version: "test"},
 	}, nil
 }
 
-func (helperAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+func (*helperAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.NewSessionResponse, error) {
 	return acp.NewSessionResponse{SessionId: acp.SessionId("session-1")}, nil
 }
 
-func (helperAgent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+func (*helperAgent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
 	return acp.ResumeSessionResponse{}, nil
 }
 
-func (helperAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
+func (h *helperAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
 	prompt := ""
 	if len(params.Prompt) > 0 && params.Prompt[0].Text != nil {
 		prompt = params.Prompt[0].Text.Text
 	}
-	_ = agentConn.SessionUpdate(ctx, acp.SessionNotification{
+	<-h.ready
+	_ = h.conn.Load().SessionUpdate(ctx, acp.SessionNotification{
 		SessionId: params.SessionId,
 		Update:    acp.UpdateAgentMessageText("echo: " + prompt),
 	})
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 }
 
-func (helperAgent) Cancel(context.Context, acp.CancelNotification) error {
+func (*helperAgent) Cancel(context.Context, acp.CancelNotification) error {
 	return nil
 }
 
-func (helperAgent) CloseSession(context.Context, acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+func (*helperAgent) CloseSession(context.Context, acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
 	return acp.CloseSessionResponse{}, nil
 }
 
-func (helperAgent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+func (*helperAgent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
 	return acp.ListSessionsResponse{}, nil
 }
 
-func (helperAgent) SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+func (*helperAgent) SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
 	return acp.SetSessionConfigOptionResponse{}, nil
 }
 
-func (helperAgent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+func (*helperAgent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
 	return acp.SetSessionModeResponse{}, nil
 }
 
-var agentConn *acp.AgentSideConnection
-
 func runHelperACPAgent() error {
-	agentConn = acp.NewAgentSideConnection(helperAgent{}, os.Stdout, os.Stdin)
-	<-agentConn.Done()
+	h := &helperAgent{ready: make(chan struct{})}
+	conn := acp.NewAgentSideConnection(h, os.Stdout, os.Stdin)
+	h.conn.Store(conn)
+	close(h.ready)
+	<-conn.Done()
 	return nil
 }

--- a/internal/cli/interactive_deferred_test.go
+++ b/internal/cli/interactive_deferred_test.go
@@ -395,3 +395,68 @@ func TestDeferredInit_WithSkillDir(t *testing.T) {
 	}
 	<-done
 }
+
+// runDeferredInitForTest drives deferredInit to completion with memory off
+// and returns the final InitResult.
+func runDeferredInitForTest(t *testing.T, cfg config.Config) *tui.InitResult {
+	t.Helper()
+	tmpHome := t.TempDir()
+	testenv.SetHome(t, tmpHome)
+
+	origMemOff := flagMemoryOff
+	origSystem := flagSystem
+	t.Cleanup(func() {
+		flagMemoryOff = origMemOff
+		flagSystem = origSystem
+	})
+	flagMemoryOff = true
+	flagSystem = "test system prompt"
+
+	llm := &cliMockLLM{name: "test-llm-llms", response: "ok"}
+	tracker := guardrail.New(0)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ch := make(chan tui.InitEvent, 128)
+	var res initResources
+	t.Cleanup(res.cleanup)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
+		close(ch)
+	}()
+	var result *tui.InitResult
+	for ev := range ch {
+		if ev.Err != nil {
+			t.Fatalf("deferredInit reported error: %v", ev.Err)
+		}
+		if ev.Done && ev.Result != nil {
+			result = ev.Result
+		}
+	}
+	<-done
+	if result == nil {
+		t.Fatal("deferredInit did not emit a final Done event with Result")
+	}
+	return result
+}
+
+func TestDeferredInit_WithLLMSSources(t *testing.T) {
+	// llms.txt sources attach the fetch_docs tool to the core tools in the
+	// interactive TUI (the mode the voice agent drives). The tool's
+	// definition must therefore show up in the context breakdown's tool
+	// bytes, on top of what the same init produces without sources.
+	without := runDeferredInitForTest(t, config.Config{})
+	with := runDeferredInitForTest(t, config.Config{
+		LLMS: &config.LLMSConfig{Sources: []config.LLMSSource{{Name: "adk", URL: "https://adk.dev/llms.txt"}}},
+	})
+	if without.ContextBreakdown == nil || with.ContextBreakdown == nil {
+		t.Fatalf("ContextBreakdown missing: without=%v with=%v", without.ContextBreakdown, with.ContextBreakdown)
+	}
+	if with.ContextBreakdown.ToolDefs <= without.ContextBreakdown.ToolDefs {
+		t.Fatalf("ToolDefs with llms sources = %d, want more than %d without (fetch_docs not wired)",
+			with.ContextBreakdown.ToolDefs, without.ContextBreakdown.ToolDefs)
+	}
+}

--- a/internal/cli/wiring_helpers_test.go
+++ b/internal/cli/wiring_helpers_test.go
@@ -207,6 +207,16 @@ func TestBuildToolsets(t *testing.T) {
 			cfg:     config.Config{A2A: &config.A2AConfig{}},
 			wantLen: 0,
 		},
+		{
+			name:    "llms sources add one (cached fetch_docs) toolset",
+			cfg:     config.Config{LLMS: &config.LLMSConfig{Sources: []config.LLMSSource{{Name: "adk", URL: "https://adk.dev/llms.txt"}}}},
+			wantLen: 1,
+		},
+		{
+			name:    "empty llms source list yields nothing",
+			cfg:     config.Config{LLMS: &config.LLMSConfig{}},
+			wantLen: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/bash_supervisor_leak_test.go
+++ b/internal/tools/bash_supervisor_leak_test.go
@@ -37,6 +37,7 @@ func settleGoroutines(t *testing.T) int {
 // in a long session is thousands.
 func TestSupervisor_ForegroundRunsLeakNoGoroutines(t *testing.T) {
 	sup := fastSupervisor(t)
+	allowSlowShellStartup(sup)
 
 	// Warm up so one-time initialization is not counted as growth.
 	run(t, sup, "echo warmup", 5*time.Second)

--- a/internal/tools/bash_supervisor_test.go
+++ b/internal/tools/bash_supervisor_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -19,6 +20,17 @@ func fastSupervisor(t *testing.T) *BashSupervisor {
 	sup.heartbeat = 25 * time.Millisecond
 	t.Cleanup(sup.KillAll)
 	return sup
+}
+
+// allowSlowShellStartup widens the idle threshold on Windows for tests whose
+// command must NOT be backgrounded. Starting Git-for-Windows bash alone can
+// take longer than fastSupervisor's 150ms, so a command was judged idle before
+// it had printed anything (seen in CI: Elapsed 154ms, Idle 150ms+). Tests that
+// expect a handoff keep the short threshold, so the code path is unchanged.
+func allowSlowShellStartup(sup *BashSupervisor) {
+	if runtime.GOOS == "windows" {
+		sup.idleTimeout = 2 * time.Second
+	}
 }
 
 // bashWorkDir returns a working directory for a backgrounded shell command.
@@ -89,6 +101,7 @@ func TestSupervisor_SilentCommandIsBackgrounded(t *testing.T) {
 // long it takes, and must be left alone.
 func TestSupervisor_ChattyCommandIsNotBackgrounded(t *testing.T) {
 	sup := fastSupervisor(t)
+	allowSlowShellStartup(sup)
 
 	// Runs for ~500ms, well past the 150ms idle threshold, but never silent
 	// for longer than 50ms.
@@ -280,6 +293,7 @@ func TestSupervisor_CapEvictsOldest(t *testing.T) {
 // is indistinguishable from a hang.
 func TestSupervisor_SinkStreamsOutput(t *testing.T) {
 	sup := fastSupervisor(t)
+	allowSlowShellStartup(sup)
 
 	var mu sync.Mutex
 	kinds := map[string][]string{}

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -46,6 +46,11 @@ const llmsUserAgent = "pi-go/1.0 (+https://github.com/dimetron/pi-go)"
 // srv.Client() so the test's self-signed cert is trusted.
 var llmsClientOverride *http.Client
 
+// llmsCacheCreateTemp creates the temporary file a cache entry is written to
+// before being renamed into place. It is a variable so tests can hand back a
+// file the write will fail on and check the failure path cleans up.
+var llmsCacheCreateTemp = os.CreateTemp
+
 // llmsCacheTTL bounds how old a cached page may be before it is considered
 // stale. Revalidation with a 304 keeps a cache hit fast (small round trip, no
 // body download); this TTL is the floor below which no revalidation is
@@ -387,7 +392,7 @@ func (t *LLMSToolset) cacheWrite(e *llmsCacheEntry) {
 		return
 	}
 	dst := t.cachePath(u)
-	tmp, err := os.CreateTemp(t.cacheDir, filepath.Base(dst)+".*.tmp")
+	tmp, err := llmsCacheCreateTemp(t.cacheDir, filepath.Base(dst)+".*.tmp")
 	if err != nil {
 		return
 	}

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -380,10 +380,9 @@ func (t *LLMSToolset) cacheWrite(e *llmsCacheEntry) {
 	if err != nil {
 		return
 	}
-	data, err := json.Marshal(e)
-	if err != nil {
-		return
-	}
+	// Marshaling cannot fail here: the entry is plain strings and an int64
+	// (invalid UTF-8 in a body is coerced, not rejected).
+	data, _ := json.Marshal(e)
 	if err := os.MkdirAll(t.cacheDir, 0o700); err != nil {
 		return
 	}
@@ -393,12 +392,8 @@ func (t *LLMSToolset) cacheWrite(e *llmsCacheEntry) {
 		return
 	}
 	tmpName := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return
-	}
-	if err := tmp.Close(); err != nil {
+	_, werr := tmp.Write(data)
+	if cerr := tmp.Close(); werr != nil || cerr != nil {
 		_ = os.Remove(tmpName)
 		return
 	}

--- a/internal/tools/llms_test.go
+++ b/internal/tools/llms_test.go
@@ -334,6 +334,10 @@ func TestLLMSFetchCacheFallsBackOnNetworkError(t *testing.T) {
 	if err != nil || out.Error != "" {
 		t.Fatalf("initial FetchDocs() = (%q, %v), want nil error", out.Error, err)
 	}
+	// Age the entry past llmsCacheTTL: a fresh entry would be served from
+	// disk without ever reaching the failing transport, and the test would
+	// pass without exercising the fallback.
+	ageLLMSCacheEntry(t, ts, u, 2*time.Hour)
 
 	withLLMSClient(t, &http.Client{Transport: errorTransport{}})
 	out, err = ts.FetchDocs(context.Background(), u)
@@ -1022,4 +1026,113 @@ func countLLMSCacheFiles(t *testing.T, dir string) int {
 		t.Fatal(err)
 	}
 	return len(entries)
+}
+
+// requirePOSIXPerms skips tests that rely on permission bits being enforced:
+// Windows ignores them and root bypasses them.
+func requirePOSIXPerms(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits")
+	}
+}
+
+func TestLLMSCacheWriteSkipsUnwritableDir(t *testing.T) {
+	// An existing cache directory that cannot be written to (CreateTemp
+	// fails) is a silent no-op, not an error or a panic.
+	requirePOSIXPerms(t)
+	dir := filepath.Join(t.TempDir(), "llms-cache")
+	if err := os.MkdirAll(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	ts := NewLLMSToolsetWithCache(nil, dir)
+	ts.cacheWrite(&llmsCacheEntry{URL: "https://adk.dev/page.md", Body: "x", FetchedAt: time.Now().Unix()})
+	if n := countLLMSCacheFiles(t, dir); n != 0 {
+		t.Fatalf("%d files written into a read-only cache dir, want 0", n)
+	}
+}
+
+func TestLLMSCacheWriteRenameFailureLeavesNoTempFile(t *testing.T) {
+	// If the entry cannot be renamed into place (here the destination is a
+	// directory), the temp file is removed rather than left to accumulate.
+	dir := filepath.Join(t.TempDir(), "llms-cache")
+	ts := NewLLMSToolsetWithCache(nil, dir)
+	u, _ := url.Parse("https://adk.dev/page.md")
+	if err := os.MkdirAll(ts.cachePath(u), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ts.cacheWrite(&llmsCacheEntry{URL: u.String(), Body: "x", FetchedAt: time.Now().Unix()})
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || !entries[0].IsDir() {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("cache dir = %v, want only the blocking directory (no temp file left)", names)
+	}
+	if ts.cacheRead(u) != nil {
+		t.Fatal("cacheRead returned an entry for a path that is a directory")
+	}
+}
+
+func TestLLMSCacheEvictEdgeCases(t *testing.T) {
+	// A missing cache directory is a no-op; non-entry files and
+	// subdirectories in the cache directory are neither counted nor removed.
+	ts := NewLLMSToolsetWithCache(nil, filepath.Join(t.TempDir(), "never-created"))
+	ts.cacheEvict() // must not panic
+
+	dir := filepath.Join(t.TempDir(), "llms-cache")
+	ts = NewLLMSToolsetWithCache(nil, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "subdir.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stray := filepath.Join(dir, "stray.tmp")
+	if err := os.WriteFile(stray, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ts.cacheWrite(&llmsCacheEntry{URL: "https://adk.dev/page.md", Body: "x", FetchedAt: time.Now().Unix()})
+	if _, err := os.Stat(stray); err != nil {
+		t.Fatalf("stray non-entry file was touched by eviction: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subdir.json")); err != nil {
+		t.Fatalf("subdirectory was touched by eviction: %v", err)
+	}
+	if n := countLLMSCacheFiles(t, dir); n != 3 {
+		t.Fatalf("cache dir has %d entries, want 3 (entry, stray file, subdir)", n)
+	}
+}
+
+func TestLLMSCacheEvictToleratesUnremovableEntries(t *testing.T) {
+	// An entry that cannot be removed (read-only directory) keeps counting
+	// against the budget and eviction moves on without failing.
+	requirePOSIXPerms(t)
+	dir := filepath.Join(t.TempDir(), "llms-cache")
+	ts := NewLLMSToolsetWithCache(nil, dir)
+	for i := 0; i <= llmsCacheMaxEntries; i++ { // one over budget
+		rawURL := fmt.Sprintf("https://adk.dev/p%d.md", i)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		pu, _ := url.Parse(rawURL)
+		// Write directly so the per-write eviction does not run yet.
+		data := mustJSON(t, llmsCacheEntry{URL: rawURL, Body: "x", FetchedAt: time.Now().Unix()})
+		if err := os.WriteFile(ts.cachePath(pu), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	ts.cacheEvict()
+	if n := countLLMSCacheFiles(t, dir); n != llmsCacheMaxEntries+1 {
+		t.Fatalf("%d entries after eviction in a read-only dir, want all %d untouched", n, llmsCacheMaxEntries+1)
+	}
 }

--- a/internal/tools/llms_test.go
+++ b/internal/tools/llms_test.go
@@ -1136,3 +1136,31 @@ func TestLLMSCacheEvictToleratesUnremovableEntries(t *testing.T) {
 		t.Fatalf("%d entries after eviction in a read-only dir, want all %d untouched", n, llmsCacheMaxEntries+1)
 	}
 }
+
+func TestLLMSCacheWriteFailedWriteLeavesNoTempFile(t *testing.T) {
+	// If writing the temp file fails, it is removed and no entry appears.
+	// The seam hands cacheWrite a read-only handle so the write errors.
+	prev := llmsCacheCreateTemp
+	t.Cleanup(func() { llmsCacheCreateTemp = prev })
+	llmsCacheCreateTemp = func(dir, pattern string) (*os.File, error) {
+		f, err := os.CreateTemp(dir, pattern)
+		if err != nil {
+			return nil, err
+		}
+		name := f.Name()
+		if err := f.Close(); err != nil {
+			return nil, err
+		}
+		return os.Open(name) // O_RDONLY: Write fails, Close succeeds
+	}
+	dir := filepath.Join(t.TempDir(), "llms-cache")
+	ts := NewLLMSToolsetWithCache(nil, dir)
+	u, _ := url.Parse("https://adk.dev/page.md")
+	ts.cacheWrite(&llmsCacheEntry{URL: u.String(), Body: "x", FetchedAt: time.Now().Unix()})
+	if n := countLLMSCacheFiles(t, dir); n != 0 {
+		t.Fatalf("%d files left after a failed temp-file write, want 0 (no temp file, no entry)", n)
+	}
+	if ts.cacheRead(u) != nil {
+		t.Fatal("cacheRead returned an entry after a failed write")
+	}
+}

--- a/piagent/build_test.go
+++ b/piagent/build_test.go
@@ -150,6 +150,17 @@ func TestBuildToolsets(t *testing.T) {
 	if got := buildToolsets(cfg); len(got) != 3 {
 		t.Errorf("buildToolsets(mcp+a2a) = %d toolsets, want 3", len(got))
 	}
+
+	// llms.txt sources add the (cached) fetch_docs toolset; building it
+	// touches no network and no disk.
+	cfg.LLMS = &config.LLMSConfig{Sources: []config.LLMSSource{{Name: "adk", URL: "https://adk.dev/llms.txt"}}}
+	got := buildToolsets(cfg)
+	if len(got) != 4 {
+		t.Fatalf("buildToolsets(mcp+a2a+llms) = %d toolsets, want 4", len(got))
+	}
+	if _, ok := got[3].(*tools.LLMSToolset); !ok || got[3].Name() != "llms" {
+		t.Errorf("last toolset = %T %q, want *tools.LLMSToolset %q", got[3], got[3].Name(), "llms")
+	}
 }
 
 func TestBuildInstruction(t *testing.T) {


### PR DESCRIPTION
## Summary
Follow-up to #216, whose `codecov/patch` landed at 78.68% (target 88.26%). Exercises the remaining branches of the `fetch_docs` disk cache and the three call sites that wire `NewLLMSCachedToolset`.

## Changes
- **Vacuous test fixed**: `TestLLMSFetchCacheFallsBackOnNetworkError` populated the cache and refetched immediately — the fresh entry was served from disk, so the failing transport and the fallback branch were never exercised. It now ages the entry past the TTL first.
- **New cache tests**: unwritable cache dir is a silent no-op; a failed rename leaves no temp file; eviction tolerates a missing dir, skips stray files and subdirectories, and moves on past unremovable entries (permission cases skip on Windows and as root).
- **Wiring tests**: `piagent` and `internal/cli` `TestBuildToolsets` gain llms.txt cases (toolset added; not added for an empty source list); `TestDeferredInit_WithLLMSSources` checks the interactive TUI attaches `fetch_docs` by comparing tool-definition bytes with and without sources.
- **`cacheWrite`**: the temp-file write and close failures are folded into one branch; the `json.Marshal` error check is dropped — the entry is plain strings and an int64, so it cannot fail (comment says so). The temp file is created through a package-level `llmsCacheCreateTemp` (defaults to `os.CreateTemp`) so `TestLLMSCacheWriteFailedWriteLeavesNoTempFile` can hand back a read-only handle and check the failed write removes the temp file and leaves no entry — `cacheWrite` is fully covered.

- **Deflake (a7fd334)**: `internal/acp/client`'s test helper agent stored its `*acp.AgentSideConnection` in a package-level variable *after* `acp.NewAgentSideConnection` had already started the receive goroutine that reads it — a pre-existing data race (`-race` → helper exit 66 in `TestRunnerCompletesPromptTurn`) that this PR's CI run hit. The helper now holds the connection in an `atomic.Pointer` and `Prompt` waits on a `ready` channel closed after the store. `go test -race -count=20 ./internal/acp/client/` passes.
- **Windows deflake (6526d2d)**: `fastSupervisor`'s 150 ms idle threshold is shorter than Git-for-Windows bash startup on the CI runner, so `TestSupervisor_ChattyCommandIsNotBackgrounded` / `TestSupervisor_SinkStreamsOutput` were intermittently backgrounded before printing anything. `allowSlowShellStartup` widens the threshold to 2 s on Windows only, for the tests whose command must not be backgrounded; handoff tests keep the short threshold. No product change.
- **Real bug fix (a73bf14, product)**: `internal/lsp` `Client.done` was closed at four sites with a non-atomic check-then-close; `Close()` (after `cmd.Wait`) and `readLoop`'s deferred exit (stdout EOF) can both see it open and both close → `panic: close of closed channel`, hit by this PR's Coverage job. All closes now go through a `sync.Once`-guarded `closeDone()`; lifecycle unchanged. `go test -race -count=30 ./internal/lsp/` passes.

## Coverage
Test-only apart from the two `cacheWrite` simplifications above (called out so they are visible; no behaviour change). Lifts `internal/tools` and overall project coverage after #216 (`codecov/patch` on #216 was 78.68%, `codecov/project` dipped -0.02%). Local added-line coverage of `internal/tools/llms.go` (vs. main before #216): **87.2% → 96.2%** (and `cacheWrite` 100% after ba61b74). The only lines left uncovered are the temp-file write/close failure and `de.Info()` failure, which have no hermetic trigger.

## Verification
- `go build ./...`, `go test ./internal/tools/ -count=1 -race`, `go test ./internal/cli/ -run 'TestBuildToolsets|TestDeferredInit'`, `go test ./piagent/ -run TestBuildToolsets` — ok
- `GOOS=windows go vet` + `go test -c` for `internal/tools`, `internal/cli`, `piagent` — ok
- `make lint` — 0 issues
- `codex review --uncommitted` — no findings

https://claude.ai/code/session_014XA8pYe34AXYE8sSeRe3WC





