### PR TITLE
fix(tui): stop re-arming the agent listener for messages it never consumed

### DIFF
--- a/internal/tui/agent_listener_test.go
+++ b/internal/tui/agent_listener_test.go
@@ -1,0 +1,139 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// unclaimedMsg is a message type no handler group in Update claims.
+type unclaimedMsg struct{}
+
+// TestUnclaimedMessageDoesNotArmAgentListener pins the rule that only a message
+// actually consumed from m.agentCh may re-arm the listener.
+//
+// Update used to re-arm for *any* unhandled message while running, on the theory
+// that this kept the listener alive. It could not: every type that travels on
+// m.agentCh is claimed by updateAgentStream, and each of those handlers re-arms
+// exactly once. Re-arming for a message that never came off the channel adds a
+// reader without consuming one, so readers accumulated for the whole turn — 61
+// of them were observed parked on one channel in a live session.
+func TestUnclaimedMessageDoesNotArmAgentListener(t *testing.T) {
+	ch := make(chan agentMsg, 4)
+	m := &model{running: true, agentCh: ch}
+
+	for i := 0; i < 5; i++ {
+		if _, cmd := m.Update(unclaimedMsg{}); cmd != nil {
+			t.Fatalf("unclaimed message #%d armed a listener (cmd %T), want nil", i, cmd)
+		}
+	}
+}
+
+// TestWindowSizeDoesNotArmAgentListener covers the same invariant for a resize,
+// which is handled (so it never reaches Update's fallback) and used to batch a
+// waitForAgent of its own. Every mid-turn resize therefore leaked one reader.
+func TestWindowSizeDoesNotArmAgentListener(t *testing.T) {
+	ch := make(chan agentMsg, 4)
+	m := &model{running: true, agentCh: ch}
+	m.chatModel.Messages = make([]message, 0)
+
+	_, cmd, handled := m.handleWindowSize(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if !handled {
+		t.Fatal("handleWindowSize did not claim the resize")
+	}
+	if cmd == nil {
+		t.Fatal("handleWindowSize returned no command")
+	}
+
+	// The command must be the resize drain tick, not something reading agentCh.
+	// Closing the channel would make any parked reader yield agentDoneMsg.
+	close(ch)
+	got := make(chan tea.Msg, 1)
+	go func() { got <- cmd() }()
+
+	select {
+	case msg := <-got:
+		if _, bad := msg.(agentDoneMsg); bad {
+			t.Fatalf("resize command read from agentCh: got %T", msg)
+		}
+		if _, ok := msg.(resizeDrainDoneMsg); !ok {
+			t.Fatalf("resize command returned %T, want resizeDrainDoneMsg", msg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("resize command did not complete")
+	}
+}
+
+// TestMatrixVisibleMatchesRender pins matrixState.visible to render's own notion
+// of emptiness. messageViewportHeight reserves three rows on visible() while View
+// draws them on render() != "", so the two disagreeing would mis-size the frame.
+func TestMatrixVisibleMatchesRender(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(ms *matrixState)
+	}{
+		{"inactive", func(*matrixState) {}},
+		{"active, empty grid", func(ms *matrixState) { ms.active = true }},
+		{"active, fed", func(ms *matrixState) {
+			ms.active = true
+			ms.feed("hello world", 40)
+		}},
+		{"active, padded", func(ms *matrixState) {
+			ms.active = true
+			ms.feed("hi", 20)
+			ms.fullWidth = ms.width + 10
+		}},
+		{"active, pad rounds to zero", func(ms *matrixState) {
+			ms.active = true
+			ms.width = 10
+			ms.fullWidth = 11
+		}},
+		{"cleared after feed", func(ms *matrixState) {
+			ms.active = true
+			ms.feed("hello", 40)
+			ms.clear()
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ms matrixState
+			tc.setup(&ms)
+			want := ms.render() != ""
+			if got := ms.visible(); got != want {
+				t.Fatalf("visible()=%v but render()!=%q is %v", got, "", want)
+			}
+		})
+	}
+}
+
+// TestClipMessagesToViewportPadding checks the single-allocation padding builds
+// exactly the rows the loop it replaced did: availableHeight rows, the last one
+// materialized as "\n " so the composed frame is not a line short.
+func TestClipMessagesToViewportPadding(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		view            string
+		availableHeight int
+	}{
+		{"pads a short conversation", "one\ntwo", 6},
+		{"pads a single line", "only", 4},
+		{"already full", "a\nb\nc", 3},
+		{"taller than viewport", "a\nb\nc\nd\ne", 3},
+		{"empty view", "", 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			visible, _, _ := clipMessagesToViewport(tc.view, tc.availableHeight, 0)
+			gotRows := strings.Count(visible, "\n") + 1
+			wantRows := tc.availableHeight
+			if gotRows < wantRows {
+				t.Fatalf("got %d rows, want at least %d: %q", gotRows, wantRows, visible)
+			}
+			if strings.HasSuffix(visible, "\n") {
+				t.Fatalf("padding left a bare trailing newline: %q", visible)
+			}
+		})
+	}
+}

--- a/internal/tui/coverage_boost_test.go
+++ b/internal/tui/coverage_boost_test.go
@@ -1532,13 +1532,17 @@ func TestUpdate_UnknownMsg_NotRunning(t *testing.T) {
 	}
 }
 
+// TestUpdate_UnknownMsg_Running asserts an unknown message arms nothing, even
+// mid-turn. This test previously required the opposite — a waitForAgent cmd —
+// which is what let surplus readers pile up on m.agentCh for a whole turn. See
+// TestUnclaimedMessageDoesNotArmAgentListener for the reasoning.
 func TestUpdate_UnknownMsg_Running(t *testing.T) {
 	m := newTestModelFull(t)
 	m.running = true
 	m.agentCh = make(chan agentMsg, 1)
 	_, cmd := m.Update(unknownMsgType{})
-	if cmd == nil {
-		t.Error("expected waitForAgent cmd when running")
+	if cmd != nil {
+		t.Errorf("unknown msg while running armed a listener (%T), want nil", cmd)
 	}
 }
 

--- a/internal/tui/matrix.go
+++ b/internal/tui/matrix.go
@@ -201,6 +201,28 @@ func (ms *matrixState) feed(tokenText string, width int) {
 	}
 }
 
+// visible reports whether render would return a non-empty bar, without building
+// it. View reserves the three matrix rows (rule, bar, rule) only when render is
+// non-empty, so messageViewportHeight has to agree with render exactly — testing
+// ms.active alone over-reserves in the window between activation and the first
+// feed, when the grid is still empty. TestMatrixVisibleMatchesRender pins the
+// two together.
+func (ms *matrixState) visible() bool {
+	if !ms.active {
+		return false
+	}
+	// render prefixes every row with pad spaces; a pad of zero adds nothing.
+	if ms.fullWidth > ms.width && (ms.fullWidth-ms.width)/2 > 0 {
+		return true
+	}
+	for row := range ms.grid {
+		if len(ms.grid[row]) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // render returns the matrix rain string centered at 60% width, or empty if inactive.
 func (ms *matrixState) render() string {
 	if !ms.active {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -630,10 +630,14 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Keep the agent listener alive for any unhandled message types.
-	if m.running {
-		return m, waitForAgent(m.agentCh)
-	}
+	// Deliberately no waitForAgent re-arm here. Every message that arrives on
+	// m.agentCh is claimed by updateAgentStream, and each of those handlers
+	// re-arms exactly once, so a single reader is always parked on the channel.
+	// Re-arming for messages that did *not* come from the channel adds a reader
+	// without consuming one: the readers then accumulate for the whole turn, and
+	// on close(agentCh) every one of them delivers its own agentDoneMsg, running
+	// handleAgentDone — lifecycle hooks, startNextPrompt — once per surplus
+	// reader. See TestAgentListenerStaysSingle.
 	return m, nil
 }
 
@@ -746,23 +750,20 @@ func (m *model) handleMatrixTick() (tea.Model, tea.Cmd, bool) {
 	return m, matrixTickCmd(), true
 }
 
-// handleWindowSize re-lays out the frame, and keeps the agent listener alive
-// so a resize mid-turn does not drop the stream.
+// handleWindowSize re-lays out the frame. It does not touch the agent listener:
+// a tea.WindowSizeMsg never came off m.agentCh, so re-arming here would leave an
+// extra reader parked on the channel for every resize taken mid-turn.
 func (m *model) handleWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd, bool) {
 	m.resizeAt = time.Now()
 	m.width, m.height = msg.Width, msg.Height
 	m.applyResize()
 
-	cmd := resizeDrainDoneCmd(m.resizeAt)
-	if m.running {
-		return m, tea.Batch(cmd, waitForAgent(m.agentCh)), true
-	}
-	return m, cmd, true
+	return m, resizeDrainDoneCmd(m.resizeAt), true
 }
 
 // handlePaste inserts pasted text into the prompt, ignoring pastes that arrive
 // while the agent runs or that are really resize noise. Outside a resize drain
-// the message is left unhandled so the agent listener stays alive.
+// the message is left unhandled so later handler groups still get a look at it.
 func (m *model) handlePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd, bool) {
 	if !m.resizeDraining() && isUserPaste(msg.Content) {
 		m.inputModel.InsertText(msg.Content)
@@ -1666,13 +1667,15 @@ func clipMessagesToViewport(messagesView string, availableHeight, scroll int) (v
 
 	// Pad to fill the viewport. availableHeight is message rows only — the blank
 	// rows that inset the block from the rules are budgeted separately.
-	visibleLineCount := strings.Count(visible, "\n") + 1
-	for visibleLineCount < availableHeight {
-		// Keep the final padding row materialized. A trailing newline only
-		// terminates the preceding row; treating its trailing empty string as a
-		// row made the composed frame one line shorter than the terminal.
-		visible += "\n "
-		visibleLineCount++
+	// Keep the final padding row materialized. A trailing newline only
+	// terminates the preceding row; treating its trailing empty string as a row
+	// made the composed frame one line shorter than the terminal.
+	//
+	// Built in one allocation: `visible += "\n "` in a loop recopies the whole
+	// viewport per padding row, which on a tall terminal with a short
+	// conversation made this the second-largest allocation site in the process.
+	if visibleLineCount := strings.Count(visible, "\n") + 1; visibleLineCount < availableHeight {
+		visible += strings.Repeat("\n ", availableHeight-visibleLineCount)
 	}
 	return visible, startLine, endLine
 }
@@ -1893,8 +1896,11 @@ func (m *model) messageViewportHeight() int {
 	// the panel one row taller than the terminal, so the terminal scrolled the
 	// frame and tore the panel away from the sidebar.
 	availableHeight := m.height - statusLines - inputLines - 3 - 2
-	if m.matrix.render() != "" {
+	if m.matrix.visible() {
 		// The matrix bar adds three rows above the messages (rule, bar, rule).
+		// visible() answers the same question as render() != "" without building
+		// the bar: render() assembled the whole animation purely for this check,
+		// and View renders it again a few lines later.
 		availableHeight -= 3
 	}
 	if m.branchPopup != nil {

--- a/internal/tui/tui_update_test.go
+++ b/internal/tui/tui_update_test.go
@@ -322,22 +322,29 @@ func TestUpdateRestartMsg(t *testing.T) {
 	_ = mm // model state doesn't change for restart
 }
 
-func TestUpdateAgentListenerAlive(t *testing.T) {
+// TestUpdateUnknownMsgLeavesListenerUntouched replaces TestUpdateAgentListenerAlive,
+// which asserted that an unknown message re-armed the agent listener. That was the
+// bug, not the contract: nothing was consumed from m.agentCh, so the re-arm added a
+// reader that never went away. The listener stays alive because every type carried
+// on m.agentCh is claimed by updateAgentStream and re-armed there exactly once.
+func TestUpdateUnknownMsgLeavesListenerUntouched(t *testing.T) {
 	m := &model{
 		running:   true,
 		agentCh:   make(chan agentMsg, 1),
 		chatModel: ChatModel{Messages: make([]message, 0)},
 	}
 
-	// Unknown message type while running should keep listener alive
 	newM, cmd := m.Update("unknown message type")
 	mm := newM.(*model)
 
 	if mm != m {
 		t.Error("unknown message should return the same model")
 	}
-	if cmd == nil {
-		t.Error("should return command to keep agent listener alive")
+	if cmd != nil {
+		t.Errorf("unknown message armed a listener (%T), want nil", cmd)
+	}
+	if m.agentCh == nil {
+		t.Error("unknown message must not clear the agent channel")
 	}
 }
 


### PR DESCRIPTION
## What

Live profiling of `pi --pprof true` turned up a goroutine accumulation in the TUI agent listener, plus two allocation hot spots in the render path. This fixes all three.

## The goroutine bug

Goroutines climbed **19 → 48 → 74 → 150 → 167** over ~7 minutes and did not drain. At the top, `tui.waitForAgent.func1` sat at **61 readers parked on a single `agentCh`** with one agent running. Each surplus reader also holds a bubbletea `execBatchMsg` wrapper blocked on a `WaitGroup`, so ~121 of 166 goroutines (73%) came from this one pattern. RSS tracked it, 78 → 89 MB.

Two sites re-armed `waitForAgent` for messages that never came off `agentCh`, adding a reader without consuming one:

- **`Update`** — a fallback that re-armed for *any* unhandled message while `m.running`. Bubbletea pumps a lot of message types; each one leaked a reader.
- **`handleWindowSize`** — `tea.Batch(cmd, waitForAgent(...))`, so every mid-turn resize leaked one.

Both carried a comment about "keeping the agent listener alive". It cannot die that way: the listener is a goroutine already parked on the channel, and an unrelated message never consumes it.

### The goroutine count is the smaller half

`runAgentLoop` does `defer close(ch)`, and `waitForAgent` returns `agentDoneMsg{}` on close. So **every parked reader delivers its own `agentDoneMsg`**, and `handleAgentDone` runs once per surplus reader. Each run:

- fires `runLifecycleHooks("turn_complete")` and `("user_input_required")` — `hookQueueDepth` is 32, so with 61 readers × 2 events the queue overflows and genuine hooks get dropped;
- calls `startNextPrompt()` when prompts are queued, so a queue of pending prompts would all start at once.

### Why removing them is safe

Exactly 7 message types travel on `agentCh` (`agentText`, `agentThinking`, `agentToolCall`, `agentToolResult`, `agentUsage`, `agentWarning`, `agentDone`). All are claimed by `updateAgentStream`, and **every return path in all 6 re-arming handlers re-arms exactly once** — including the three separate returns in `handleAgentToolCall`. `handleAgentDone` correctly does not re-arm. `agentSubEventMsg` implements `agentMsg()` but is only ever produced by `waitForSubEvent` on a *different* channel, and re-arms that one. Each path was read, not assumed.

## Also fixed, from the same profiles

**`messageViewportHeight` rendered the matrix bar just to test emptiness** — `m.matrix.render() != ""` built the whole animation and discarded it, then `View` rendered it again a few lines later.

Worth flagging for review: `m.matrix.active` is **not** an equivalent predicate. `render()` returns `""` when the grid is empty even while `active` is true (`matrixLines == 1`), and `View` reserves the three matrix rows on `matrixBar != ""` — so testing `active` would over-reserve three rows between activation and the first `feed`. Added `matrixState.visible()`, pinned to `render()`'s own emptiness by `TestMatrixVisibleMatchesRender`.

**`clipMessagesToViewport` padded with `visible += "\n "` in a loop**, recopying the whole viewport per padding row. At **11.03 MB flat it was the second-largest allocation site in the process**, worst on a tall terminal with a short conversation — i.e. at startup. Now one `strings.Repeat`.

## Tests

- `TestUnclaimedMessageDoesNotArmAgentListener`, `TestWindowSizeDoesNotArmAgentListener` — both **verified to fail against the pre-fix code** (`armed a listener (cmd tea.Cmd), want nil` / `returned tea.BatchMsg, want resizeDrainDoneMsg`), so they are not vacuous.
- `TestMatrixVisibleMatchesRender` — table over inactive / active+empty / fed / padded / pad-rounds-to-zero / cleared, asserting `visible() == (render() != "")`. Also catches a future `matrixLines` bump.
- `TestClipMessagesToViewportPadding` — row counts and no bare trailing newline.
- Two existing tests (`TestUpdate_UnknownMsg_Running`, `TestUpdateAgentListenerAlive`) asserted the old behavior. Rewritten to pin the corrected invariant rather than deleted; the second is renamed to `TestUpdateUnknownMsgLeavesListenerUntouched` because its old name asserted the wrong contract.

## Gates

- `go test ./internal/tui/` — pass
- `go test -race ./internal/tui/` — pass
- `make lint` — 0 issues
- `codex review --base main` — no findings
- `make test` — one failure, `internal/acp/server TestNewPromptHandler_NoAPIKey`, **pre-existing on main** (verified at `f0e1240`, identical error). The test expects "no API key" but this machine has one set, so it reaches a real `api.anthropic.com` call and gets a 404 for `claude-3-5-haiku-latest`. Unrelated to this change.

## Deliberately not in this PR

`(*model).View` is ~87% of all allocation (~263 MB/min idle, ~580 MB/min with subagents). The remaining big lines — `lipgloss.JoinHorizontal` 71.7 MB, three `padLinesTo` passes per frame at ~54 MB, the final concat at 20.3 MB — need layout changes with real visual regression risk, so they are tracked separately rather than rushed in here.

For the record: **live heap was flat in every run** (~9–12 MB, sub-1 MB drift over minutes). There was never a memory leak; the cost is churn and goroutines.
