### PR TITLE
docs: add Parallel Search MCP example

### DIFF
--- a/.pi-go/mcp-example.json
+++ b/.pi-go/mcp-example.json
@@ -20,6 +20,9 @@
     "exa": {
       "url": "https://mcp.exa.ai/mcp?exaApiKey=${EXA_API_KEY}"
     },
+    "parallel-search": {
+      "url": "https://search.parallel.ai/mcp"
+    },
     "docs-acp": {
       "url": "https://gitmcp.io/agentclientprotocol/agent-client-protocol"
     },


### PR DESCRIPTION
## Why

Adds an optional web search and URL-fetching MCP server to the checked-in pi-go MCP configuration example. The default endpoint does not require an account or API key. When a user chooses to enable this server, search queries and URLs requested for fetching are sent to Parallel.ai's hosted MCP endpoint.

## Changes

- Add Parallel Search MCP using the example's existing URL-only remote-server shape.
- Preserve all existing example servers and leave active configuration, defaults, dependencies, and authentication unchanged.

## Validation

- `python3 -m json.tool .pi-go/mcp-example.json`: passed.
- Verified the `parallel-search` entry has exactly the expected URL-only shape: passed.
- `git diff --check`: passed.
- Verified `.pi-go/mcp-example.json` is the only changed path: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.