### PR TITLE
fix(mcp): route notices to the TUI, re-login on 401, serve llms.txt via fetch_docs

### DIFF
--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -180,7 +180,7 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 	ag, err := piagent.New(piagent.Config{
 		Model:                llm,
 		Tools:                res.coreTools,
-		Toolsets:             buildMCPToolsetsFromCfg(cfg),
+		Toolsets:             buildToolsetsFromCfg(cfg),
 		Instruction:          instruction,
 		BeforeToolCallbacks:  res.beforeCBs,
 		AfterToolCallbacks:   res.afterCBs,
@@ -525,6 +525,22 @@ func convertHooks(cfgHooks []config.HookConfig) []extension.HookConfig {
 		}
 	}
 	return hooks
+}
+
+// buildToolsetsFromCfg assembles the toolsets an ACP session exposes: the
+// configured MCP servers, plus the llms.txt documentation sources that back
+// fetch_docs.
+//
+// The documentation sources belong here for the same reason they do in the
+// interactive, one-shot and piagent paths. Without them an ACP session would
+// dial an llms.txt entry as MCP, fail on the 405, and never offer the tool
+// that can actually read it. A nil return means nothing is configured.
+func buildToolsetsFromCfg(cfg config.Config) []adktool.Toolset {
+	toolsets := buildMCPToolsetsFromCfg(cfg)
+	if llms := cfg.LLMSSources(); llms != nil {
+		toolsets = append(toolsets, tools.NewLLMSCachedToolset(llms))
+	}
+	return toolsets
 }
 
 // buildMCPToolsetsFromCfg converts cfg.MCP servers into resilient ADK toolsets

--- a/internal/acp/server/runtime_test.go
+++ b/internal/acp/server/runtime_test.go
@@ -313,3 +313,39 @@ func TestDetectGitRootSuccess(t *testing.T) {
 		t.Errorf("detectGitRoot(%q) returned empty, expected a path", dir)
 	}
 }
+
+// An ACP session must expose fetch_docs for configured llms.txt sources, the
+// same as the interactive, one-shot and piagent paths. Without it a session
+// would dial such an entry as MCP, fail on the 405, and offer nothing that can
+// read the documentation.
+func TestBuildToolsetsFromCfgIncludesLLMSSources(t *testing.T) {
+	cfg := config.Config{
+		LLMS: &config.LLMSConfig{Sources: []config.LLMSSource{
+			{Name: "adk", URL: "https://adk.dev/llms.txt"},
+		}},
+	}
+	ts := buildToolsetsFromCfg(cfg)
+	if len(ts) != 1 {
+		t.Fatalf("got %d toolsets, want 1", len(ts))
+	}
+	if ts[0].Name() != "llms" {
+		t.Errorf("toolset = %q, want the llms toolset", ts[0].Name())
+	}
+}
+
+// Sources inferred from an llms.txt MCP entry reach ACP too — they are not
+// stored in the serialized LLMS field, so only LLMSSources sees them.
+func TestBuildToolsetsFromCfgIncludesInferredSources(t *testing.T) {
+	cfg := config.Config{
+		InferredLLMS: []config.LLMSSource{{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"}},
+	}
+	if ts := buildToolsetsFromCfg(cfg); len(ts) != 1 {
+		t.Fatalf("got %d toolsets, want the inferred source served", len(ts))
+	}
+}
+
+func TestBuildToolsetsFromCfgEmpty(t *testing.T) {
+	if ts := buildToolsetsFromCfg(config.Config{}); ts != nil {
+		t.Errorf("got %v, want nil for an empty config", ts)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1266,8 +1266,8 @@ func buildToolsets(cfg config.Config) []adktool.Toolset {
 	if cfg.A2A != nil && len(cfg.A2A.Agents) > 0 {
 		toolsets = append(toolsets, tools.NewA2AToolset(cfg.A2A))
 	}
-	if cfg.LLMS != nil && len(cfg.LLMS.Sources) > 0 {
-		toolsets = append(toolsets, tools.NewLLMSCachedToolset(cfg.LLMS))
+	if llms := cfg.LLMSSources(); llms != nil {
+		toolsets = append(toolsets, tools.NewLLMSCachedToolset(llms))
 	}
 	return toolsets
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -511,6 +511,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	}
 
 	go checkForUpdate(cmd.Context(), Version)
+	config.NotifyReroutedLLMS(runtime.cfg)
 
 	return runNonInteractive(
 		cmd.Context(),

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -487,14 +487,16 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	// Normally started by the root's PersistentPreRun; harmless if already up.
 	startPprofServer()
 
-	go checkForUpdate(cmd.Context(), Version)
-
 	runtime, err := buildRootRuntime(cmd.Context(), args)
 	if err != nil {
 		return err
 	}
 
 	if runtime.mode == "interactive" {
+		// The update check runs inside runInteractive so its notice is
+		// delivered after the TUI has claimed the notice sink. Started out
+		// here it would race the sink installation and could still land on
+		// os.Stderr, in the middle of the painted frame.
 		return runInteractive(
 			cmd.Context(),
 			runtime.cfg,
@@ -507,6 +509,8 @@ func runRoot(cmd *cobra.Command, args []string) error {
 			runtime.worktreeDir,
 		)
 	}
+
+	go checkForUpdate(cmd.Context(), Version)
 
 	return runNonInteractive(
 		cmd.Context(),

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -112,6 +112,13 @@ func runInteractive(
 	// erased a message written then.
 	config.NotifyReroutedLLMS(cfg)
 
+	// A user is present and a browser is reachable, so an MCP server that
+	// answers 401 can be re-authorized interactively. Headless modes leave
+	// this off and skip the server instead of blocking on an approval nobody
+	// will see.
+	extension.SetInteractiveOAuth(true)
+	defer extension.SetInteractiveOAuth(false)
+
 	var res initResources
 	initDone := make(chan struct{})
 

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -88,20 +88,23 @@ func runInteractive(
 	initCh := make(chan tui.InitEvent, 32)
 
 	// Extension notices — a skipped MCP server, a rerouted docs source, an
-	// OAuth re-login — must land in the chat, not on the terminal. The TUI
-	// paints its frame with direct cursor control, so a stderr write from a
-	// background init goroutine lands inside the layout and stays there until
-	// the next full repaint. The channel is buffered and the send is
-	// non-blocking: a notice raised while the TUI is busy is dropped rather
-	// than stalling the agent turn behind it.
-	noticeCh := make(chan string, 16)
+	// OAuth re-login, a blocked skill — must land in the chat, not on the
+	// terminal. The TUI paints its frame with direct cursor control, so a
+	// stderr write from a background init goroutine lands inside the layout
+	// and stays there until the next full repaint. The send is non-blocking:
+	// a notice raised while the TUI is busy is dropped rather than stalling
+	// the agent turn behind it. The channel is handed to the TUI below as
+	// well as in the InitResult, so it is drained from the first frame and
+	// the buffer does not have to hold every startup notice — a run that
+	// blocks a large number of skills would otherwise lose the tail.
+	noticeCh := make(chan string, 64)
 	prevSink := notice.SetSink(func(msg string) {
 		select {
 		case noticeCh <- msg:
 		default:
 		}
 	})
-	defer notice.SetSink(prevSink)
+	defer func() { notice.SetSink(prevSink) }()
 
 	// Started only now that notices are routed to the TUI: an update banner
 	// written to os.Stderr would land inside the painted frame.
@@ -144,6 +147,7 @@ func runInteractive(
 		TokenTracker:   tokenTracker,
 		LifecycleHooks: convertHooks(cfg.Hooks),
 		DeferredInit:   initCh,
+		SystemNoticeCh: noticeCh,
 		ModelSwitcher: func(switchCtx context.Context, modelName string) (adkmodel.LLM, string, string, error) {
 			return buildSwitchedLLM(switchCtx, cfg, tokenTracker, modelName)
 		},

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dimetron/pi-go/internal/logger"
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/memory"
+	"github.com/dimetron/pi-go/internal/notice"
 	"github.com/dimetron/pi-go/internal/provider"
 	pisession "github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/subagent"
@@ -86,6 +87,26 @@ func runInteractive(
 ) error {
 	initCh := make(chan tui.InitEvent, 32)
 
+	// Extension notices — a skipped MCP server, a rerouted docs source, an
+	// OAuth re-login — must land in the chat, not on the terminal. The TUI
+	// paints its frame with direct cursor control, so a stderr write from a
+	// background init goroutine lands inside the layout and stays there until
+	// the next full repaint. The channel is buffered and the send is
+	// non-blocking: a notice raised while the TUI is busy is dropped rather
+	// than stalling the agent turn behind it.
+	noticeCh := make(chan string, 16)
+	prevSink := notice.SetSink(func(msg string) {
+		select {
+		case noticeCh <- msg:
+		default:
+		}
+	})
+	defer notice.SetSink(prevSink)
+
+	// Started only now that notices are routed to the TUI: an update banner
+	// written to os.Stderr would land inside the painted frame.
+	go checkForUpdate(ctx, Version)
+
 	var res initResources
 	initDone := make(chan struct{})
 
@@ -95,7 +116,7 @@ func runInteractive(
 	go func() {
 		defer close(initDone)
 		defer close(initCh)
-		deferredInit(initCtx, cfg, llm, info.Provider, info.BaseURL, tokenTracker, cwd, sandboxRoot, worktreeDir, initCh, &res)
+		deferredInit(initCtx, cfg, llm, info.Provider, info.BaseURL, tokenTracker, cwd, sandboxRoot, worktreeDir, initCh, noticeCh, &res)
 	}()
 
 	tuiErr := tui.Run(ctx, tui.Config{
@@ -139,6 +160,7 @@ func deferredInit(
 	tokenTracker *guardrail.Tracker,
 	cwd, sandboxRoot, worktreeDir string,
 	ch chan<- tui.InitEvent,
+	noticeCh chan string,
 	res *initResources,
 ) {
 	initTotal := deferredInitTotal(cfg)
@@ -283,9 +305,9 @@ func deferredInit(
 	res.sessionID = sessionID
 
 	// Two-stage auto-compaction, installed as a pre-turn hook so history is
-	// only ever rewritten between turns. Buffered so a compaction notice never
-	// blocks the turn if the TUI is momentarily busy.
-	noticeCh := make(chan string, 8)
+	// only ever rewritten between turns. It shares the caller's notice channel
+	// — a buffered, non-blocking send, so a compaction notice never blocks the
+	// turn if the TUI is momentarily busy.
 	if hook := buildAutoCompactHook(autoCompactDeps{
 		SessionSvc:    sessionSvc,
 		Tracker:       tokenTracker,

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -262,8 +262,8 @@ func deferredInit(
 	// counts *extension.resilientToolset entries, so a local toolset there
 	// would be live for the model yet invisible in the breakdown, and the MCP
 	// panel would list a non-MCP source.
-	if cfg.LLMS != nil && len(cfg.LLMS.Sources) > 0 {
-		coreTools = append(coreTools, tools.LLMSTools(tools.NewLLMSCachedToolset(cfg.LLMS))...)
+	if llms := cfg.LLMSSources(); llms != nil {
+		coreTools = append(coreTools, tools.LLMSTools(tools.NewLLMSCachedToolset(llms))...)
 	}
 	// Gemini search grounding (see agent.GeminiGroundingTool doc).
 	//

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -107,6 +107,11 @@ func runInteractive(
 	// written to os.Stderr would land inside the painted frame.
 	go checkForUpdate(ctx, Version)
 
+	// Likewise for anything config load decided: it ran before the sink
+	// existed, and the terminal reset before the first frame would have
+	// erased a message written then.
+	config.NotifyReroutedLLMS(cfg)
+
 	var res initResources
 	initDone := make(chan struct{})
 

--- a/internal/cli/interactive_deferred_test.go
+++ b/internal/cli/interactive_deferred_test.go
@@ -63,7 +63,7 @@ func TestDeferredInit_MemoryOffBasic(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", "", tracker, cwd, cwd, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, cwd, cwd, "", ch, make(chan string, 8), &res)
 		close(ch)
 	}()
 
@@ -125,7 +125,7 @@ func TestDeferredInit_WithMCP(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, make(chan string, 8), &res)
 		close(ch)
 	}()
 
@@ -163,7 +163,7 @@ func TestDeferredInit_WithMemoryEnabled(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, make(chan string, 8), &res)
 		close(ch)
 	}()
 
@@ -387,7 +387,7 @@ func TestDeferredInit_WithSkillDir(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, config.Config{}, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, config.Config{}, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, make(chan string, 8), &res)
 		close(ch)
 	}()
 
@@ -424,7 +424,7 @@ func runDeferredInitForTest(t *testing.T, cfg config.Config) *tui.InitResult {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, &res)
+		deferredInit(ctx, cfg, llm, "openai", "", tracker, tmpHome, tmpHome, "", ch, make(chan string, 8), &res)
 		close(ch)
 	}()
 	var result *tui.InitResult

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/dimetron/pi-go/internal/notice"
 )
 
 const upgradeScriptURL = "https://raw.githubusercontent.com/dimetron/pi-go/main/scripts/install.sh"
@@ -36,7 +38,7 @@ func checkForUpdate(ctx context.Context, currentVersion string) {
 		return
 	}
 	if isNewerVersion(currentVersion, latest) {
-		fmt.Fprintf(os.Stderr, "pi-go: update available: %s -> %s (run `pi upgrade`)\n", currentVersion, latest)
+		notice.Notifyf("update available: %s -> %s (run `pi upgrade`)", currentVersion, latest)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -720,6 +720,15 @@ func IsLLMSDocsURL(u string) bool {
 	if isPrivateHostLiteral(parsed.Hostname()) {
 		return false
 	}
+	// Never infer from a URL that carries credentials. A source's full URL is
+	// written into the fetch_docs tool description and sent to the model
+	// provider, so inferring one from userinfo or a query string would turn
+	// transport configuration the user kept in mcp.json into something the
+	// model — and its provider — can read. A docs index needs neither; anyone
+	// who genuinely has one can configure it under "llms" deliberately.
+	if parsed.User != nil || parsed.RawQuery != "" {
+		return false
+	}
 	switch strings.ToLower(path.Base(parsed.Path)) {
 	case "llms.txt", "llms-full.txt":
 		return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -758,11 +758,16 @@ func registerLLMSDocsSources(cfg *Config) []string {
 			continue
 		}
 		registered = append(registered, srv.Name)
-		if existing[srv.URL] {
+		// Store the trimmed URL. IsLLMSDocsURL deliberately tolerates
+		// surrounding whitespace, but fetch_docs parses the stored value to
+		// check the host against its sources — an untrimmed URL fails that
+		// parse, so the source it advertises would be unusable.
+		url := strings.TrimSpace(srv.URL)
+		if existing[url] {
 			continue
 		}
-		existing[srv.URL] = true
-		added = append(added, LLMSSource{Name: srv.Name, URL: srv.URL})
+		existing[url] = true
+		added = append(added, LLMSSource{Name: srv.Name, URL: url})
 	}
 	if len(added) > 0 {
 		if cfg.LLMS == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -711,11 +712,32 @@ func IsLLMSDocsURL(u string) bool {
 	if parsed.Scheme != "https" || parsed.Hostname() == "" {
 		return false
 	}
+	if isPrivateHostLiteral(parsed.Hostname()) {
+		return false
+	}
 	switch strings.ToLower(path.Base(parsed.Path)) {
 	case "llms.txt", "llms-full.txt":
 		return true
 	}
 	return false
+}
+
+// isPrivateHostLiteral reports whether a host is a literal IP that fetch_docs
+// refuses as private, so a source it could never fetch is not advertised.
+//
+// Only literal addresses are tested. fetch_docs also resolves host names and
+// rejects those landing on a private address, but doing that here would put a
+// DNS lookup — and its latency and failure modes — inside config loading. The
+// cost of missing that case is one source entry whose fetches are refused with
+// a clear message; the cost of the lookup is paid on every start.
+func isPrivateHostLiteral(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast()
 }
 
 // isLLMSDocsServer reports whether an MCP entry looks like a documentation

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,9 +94,9 @@ type Config struct {
 	Palace        *PalaceConfig      `json:"palace,omitempty"`
 	A2A           *A2AConfig         `json:"a2a,omitempty"`
 	LLMS          *LLMSConfig        `json:"llms,omitempty"`
-	// ReroutedLLMS names the MCP servers that were moved to LLMS.Sources
-	// during load because their URL is an llms.txt index. Not serialized: it
-	// describes what this load did, not what the file said.
+	// ReroutedLLMS names the MCP servers that were also registered under
+	// LLMS.Sources during load because their URL is an llms.txt index. Not
+	// serialized: it describes what this load did, not what the file said.
 	ReroutedLLMS []string `json:"-"`
 }
 
@@ -300,13 +300,14 @@ func LoadFrom(cwd string) (Config, error) {
 		}
 	}
 
-	// An llms.txt index configured as an MCP server is rerouted to the
-	// fetch_docs sources. The names are recorded rather than announced here:
-	// config loads before any front end exists, and the TUI's first act is a
-	// full terminal reset that clears the screen and scrollback, so a notice
-	// raised now would be wiped before it could be read. NotifyReroutedLLMS
-	// delivers it once the caller knows where output goes.
-	cfg.ReroutedLLMS = routeLLMSDocsServers(&cfg)
+	// An llms.txt index configured as an MCP server is also registered as a
+	// fetch_docs source, so the documentation is readable straight away. The
+	// names are recorded rather than announced here: config loads before any
+	// front end exists, and the TUI's first act is a full terminal reset that
+	// clears the screen and scrollback, so a notice raised now would be wiped
+	// before it could be read. NotifyReroutedLLMS delivers it once the caller
+	// knows where output goes.
+	cfg.ReroutedLLMS = registerLLMSDocsSources(&cfg)
 
 	// Migrate deprecated DefaultModel to roles if roles not set.
 	if cfg.DefaultModel != "" && len(cfg.Roles) == 0 {
@@ -709,17 +710,15 @@ func IsLLMSDocsURL(u string) bool {
 	return false
 }
 
-// isLLMSDocsServer reports whether an MCP entry is really a documentation
-// index that was filed under the wrong key.
+// isLLMSDocsServer reports whether an MCP entry looks like a documentation
+// index filed under the wrong key.
 //
-// The URL's base name is the primary signal, and it is a strong one: llms.txt
-// is a reserved file name in an established convention (llmstxt.org) for a
-// plain-text index fetched with GET, not a JSON-RPC endpoint. But the name
-// alone is a heuristic, and rerouting is destructive — the server stops being
-// dialled — so an entry that carries configuration only a real MCP endpoint
-// needs is left alone. A public docs index has no bearer token, no custom
-// headers and no authorization server; anything that declares those is taken
-// at its word.
+// The URL's base name is the signal: llms.txt is a reserved file name in an
+// established convention (llmstxt.org) for a plain-text index fetched with
+// GET. It is only a signal, never proof — MCP endpoint paths are arbitrary —
+// so nothing destructive hangs off it. An entry that carries configuration a
+// public docs index would never need (a command, OAuth, custom headers) is not
+// a docs index at all and is excluded outright.
 func isLLMSDocsServer(srv MCPServer) bool {
 	if srv.URL == "" || srv.Command != "" || srv.OAuth || len(srv.Headers) > 0 {
 		return false
@@ -727,16 +726,21 @@ func isLLMSDocsServer(srv MCPServer) bool {
 	return IsLLMSDocsURL(srv.URL)
 }
 
-// routeLLMSDocsServers moves MCP server entries that actually point at an
-// llms.txt index out of the MCP list and into the llms.txt sources, where the
-// fetch_docs tool serves them. Configuring a docs index under "mcpServers" is
-// a common mix-up — both are "a URL a model reads from" — and left alone it
-// produces a 405 warning on every startup and no documentation tool.
+// registerLLMSDocsSources makes an MCP entry that points at an llms.txt index
+// readable by the fetch_docs tool. Configuring a docs index under "mcpServers"
+// is a common mix-up — both are "a URL a model reads from" — and left alone it
+// yields a 405 on every startup and no documentation tool.
 //
-// Rerouting rather than dropping keeps the user's intent: the docs stay
-// reachable, just through the tool that can actually read them. An entry whose
-// URL is already configured as a source is dropped as a duplicate.
-func routeLLMSDocsServers(cfg *Config) []string {
+// The entry is left in the MCP list. Endpoint paths are arbitrary in MCP, so
+// the base name cannot prove the URL is not a real server, and removing one on
+// a guess would silently strip its tools. Adding a source is additive and
+// reversible: a genuine MCP server keeps every tool it had and merely gains an
+// inert docs source, while a genuine docs index becomes readable immediately
+// and reports its own failure through resilientToolset, which explains what
+// the entry really is once the connection has actually failed.
+//
+// An entry whose URL is already configured as a source is not added twice.
+func registerLLMSDocsSources(cfg *Config) []string {
 	if cfg.MCP == nil || len(cfg.MCP.Servers) == 0 {
 		return nil
 	}
@@ -747,33 +751,26 @@ func routeLLMSDocsServers(cfg *Config) []string {
 		}
 	}
 
-	kept := make([]MCPServer, 0, len(cfg.MCP.Servers))
-	var moved []string
+	var registered []string
 	var added []LLMSSource
 	for _, srv := range cfg.MCP.Servers {
 		if !isLLMSDocsServer(srv) {
-			kept = append(kept, srv)
 			continue
 		}
-		moved = append(moved, srv.Name)
+		registered = append(registered, srv.Name)
 		if existing[srv.URL] {
 			continue
 		}
 		existing[srv.URL] = true
 		added = append(added, LLMSSource{Name: srv.Name, URL: srv.URL})
 	}
-	if len(moved) == 0 {
-		return nil
-	}
-
-	cfg.MCP.Servers = kept
 	if len(added) > 0 {
 		if cfg.LLMS == nil {
 			cfg.LLMS = &LLMSConfig{}
 		}
 		cfg.LLMS.Sources = append(cfg.LLMS.Sources, added...)
 	}
-	return moved
+	return registered
 }
 
 // quoteAll returns the names quoted, for embedding a list in a notice without
@@ -798,7 +795,8 @@ func NotifyReroutedLLMS(cfg Config) {
 	if len(cfg.ReroutedLLMS) == 0 {
 		return
 	}
-	notice.Notifyf("MCP server(s) %s point at an llms.txt index, not an MCP endpoint — "+
-		"served by the fetch_docs tool instead. Move them to \"llms\": {\"sources\": [...]} to silence this.",
+	notice.Notifyf("MCP server(s) %s point at an llms.txt index and are now readable with the "+
+		"fetch_docs tool. If they are not MCP endpoints, move them to \"llms\": {\"sources\": [...]} "+
+		"so they are not dialled on every startup.",
 		strings.Join(quoteAll(cfg.ReroutedLLMS), ", "))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,10 @@ type Config struct {
 	Palace        *PalaceConfig      `json:"palace,omitempty"`
 	A2A           *A2AConfig         `json:"a2a,omitempty"`
 	LLMS          *LLMSConfig        `json:"llms,omitempty"`
+	// ReroutedLLMS names the MCP servers that were moved to LLMS.Sources
+	// during load because their URL is an llms.txt index. Not serialized: it
+	// describes what this load did, not what the file said.
+	ReroutedLLMS []string `json:"-"`
 }
 
 // PalaceConfig holds settings for the MemPalace memory system.
@@ -297,12 +301,12 @@ func LoadFrom(cwd string) (Config, error) {
 	}
 
 	// An llms.txt index configured as an MCP server is rerouted to the
-	// fetch_docs sources; the notice tells the user their entry moved.
-	if moved := routeLLMSDocsServers(&cfg); len(moved) > 0 {
-		notice.Notifyf("MCP server(s) %s point at an llms.txt index, not an MCP endpoint — "+
-			"served by the fetch_docs tool instead. Move them to \"llms\": {\"sources\": [...]} to silence this.",
-			strings.Join(quoteAll(moved), ", "))
-	}
+	// fetch_docs sources. The names are recorded rather than announced here:
+	// config loads before any front end exists, and the TUI's first act is a
+	// full terminal reset that clears the screen and scrollback, so a notice
+	// raised now would be wiped before it could be read. NotifyReroutedLLMS
+	// delivers it once the caller knows where output goes.
+	cfg.ReroutedLLMS = routeLLMSDocsServers(&cfg)
 
 	// Migrate deprecated DefaultModel to roles if roles not set.
 	if cfg.DefaultModel != "" && len(cfg.Roles) == 0 {
@@ -762,4 +766,21 @@ func quoteAll(names []string) []string {
 		out[i] = strconv.Quote(n)
 	}
 	return out
+}
+
+// NotifyReroutedLLMS announces the MCP servers that load-time rerouting moved
+// to the llms.txt sources. It is separate from LoadFrom so the message is
+// raised only once a front end has claimed the notice sink — in the TUI that
+// means after runInteractive installs it, since anything written before the
+// first frame is erased by the terminal reset.
+//
+// It is safe to call more than once only if the caller intends to repeat the
+// message; each call emits.
+func NotifyReroutedLLMS(cfg Config) {
+	if len(cfg.ReroutedLLMS) == 0 {
+		return
+	}
+	notice.Notifyf("MCP server(s) %s point at an llms.txt index, not an MCP endpoint — "+
+		"served by the fetch_docs tool instead. Move them to \"llms\": {\"sources\": [...]} to silence this.",
+		strings.Join(quoteAll(cfg.ReroutedLLMS), ", "))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -709,6 +709,24 @@ func IsLLMSDocsURL(u string) bool {
 	return false
 }
 
+// isLLMSDocsServer reports whether an MCP entry is really a documentation
+// index that was filed under the wrong key.
+//
+// The URL's base name is the primary signal, and it is a strong one: llms.txt
+// is a reserved file name in an established convention (llmstxt.org) for a
+// plain-text index fetched with GET, not a JSON-RPC endpoint. But the name
+// alone is a heuristic, and rerouting is destructive — the server stops being
+// dialled — so an entry that carries configuration only a real MCP endpoint
+// needs is left alone. A public docs index has no bearer token, no custom
+// headers and no authorization server; anything that declares those is taken
+// at its word.
+func isLLMSDocsServer(srv MCPServer) bool {
+	if srv.URL == "" || srv.Command != "" || srv.OAuth || len(srv.Headers) > 0 {
+		return false
+	}
+	return IsLLMSDocsURL(srv.URL)
+}
+
 // routeLLMSDocsServers moves MCP server entries that actually point at an
 // llms.txt index out of the MCP list and into the llms.txt sources, where the
 // fetch_docs tool serves them. Configuring a docs index under "mcpServers" is
@@ -733,7 +751,7 @@ func routeLLMSDocsServers(cfg *Config) []string {
 	var moved []string
 	var added []LLMSSource
 	for _, srv := range cfg.MCP.Servers {
-		if srv.URL == "" || !IsLLMSDocsURL(srv.URL) {
+		if !isLLMSDocsServer(srv) {
 			kept = append(kept, srv)
 			continue
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,10 +95,15 @@ type Config struct {
 	Palace        *PalaceConfig      `json:"palace,omitempty"`
 	A2A           *A2AConfig         `json:"a2a,omitempty"`
 	LLMS          *LLMSConfig        `json:"llms,omitempty"`
-	// ReroutedLLMS names the MCP servers that were also registered under
-	// LLMS.Sources during load because their URL is an llms.txt index. Not
-	// serialized: it describes what this load did, not what the file said.
+	// ReroutedLLMS names the MCP servers whose URL is an llms.txt index and
+	// which were therefore given a fetch_docs source during load.
 	ReroutedLLMS []string `json:"-"`
+	// InferredLLMS holds those generated sources. They are deliberately kept
+	// out of LLMS, which is serialized: Save marshals the whole config, so an
+	// inference drawn from a project's mcp.json would otherwise be written
+	// into the global config file by an unrelated operation such as
+	// SaveDefaultRole. Read both together with LLMSSources.
+	InferredLLMS []LLMSSource `json:"-"`
 }
 
 // PalaceConfig holds settings for the MemPalace memory system.
@@ -799,13 +804,27 @@ func registerLLMSDocsSources(cfg *Config) []string {
 		existing[url] = true
 		added = append(added, LLMSSource{Name: srv.Name, URL: url})
 	}
-	if len(added) > 0 {
-		if cfg.LLMS == nil {
-			cfg.LLMS = &LLMSConfig{}
-		}
-		cfg.LLMS.Sources = append(cfg.LLMS.Sources, added...)
-	}
+	cfg.InferredLLMS = append(cfg.InferredLLMS, added...)
 	return registered
+}
+
+// LLMSSources returns the llms.txt sources to serve, both those the user
+// configured and those inferred from MCP entries during load. It returns nil
+// when there are none, so callers can test it directly to decide whether to
+// register the fetch_docs tool at all.
+//
+// The two are kept apart in the struct and joined only here, so nothing that
+// marshals a Config can persist an inference.
+func (c *Config) LLMSSources() *LLMSConfig {
+	var sources []LLMSSource
+	if c.LLMS != nil {
+		sources = append(sources, c.LLMS.Sources...)
+	}
+	sources = append(sources, c.InferredLLMS...)
+	if len(sources) == 0 {
+		return nil
+	}
+	return &LLMSConfig{Sources: sources}
 }
 
 // quoteAll returns the names quoted, for embedding a list in a notice without

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,13 @@ type A2AConfig struct {
 type LLMSSource struct {
 	Name string `json:"name"`
 	URL  string `json:"url"`
+	// ExactURLOnly restricts fetch_docs to this exact URL rather than any
+	// page on the same host. It is set on sources pi-go inferred rather than
+	// ones the user wrote, and is not serialized: configuring a source is a
+	// deliberate grant of the whole host, whereas an inference drawn from a
+	// file name is a guess, and a guess must not quietly widen what the model
+	// can reach.
+	ExactURLOnly bool `json:"-"`
 }
 
 // LLMSConfig holds configuration for llms.txt documentation sources.
@@ -811,7 +818,7 @@ func registerLLMSDocsSources(cfg *Config) []string {
 			continue
 		}
 		existing[url] = true
-		added = append(added, LLMSSource{Name: srv.Name, URL: url})
+		added = append(added, LLMSSource{Name: srv.Name, URL: url, ExactURLOnly: true})
 	}
 	cfg.InferredLLMS = append(cfg.InferredLLMS, added...)
 	return registered

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
+
+	"github.com/dimetron/pi-go/internal/notice"
 )
 
 // HookConfig defines a shell command hook for tool call events.
@@ -289,6 +294,14 @@ func LoadFrom(cwd string) (Config, error) {
 		if cfg.MCP == nil || len(cfg.MCP.Servers) == 0 {
 			cfg.MCP = &MCPConfig{Servers: mcpServers}
 		}
+	}
+
+	// An llms.txt index configured as an MCP server is rerouted to the
+	// fetch_docs sources; the notice tells the user their entry moved.
+	if moved := routeLLMSDocsServers(&cfg); len(moved) > 0 {
+		notice.Notifyf("MCP server(s) %s point at an llms.txt index, not an MCP endpoint — "+
+			"served by the fetch_docs tool instead. Move them to \"llms\": {\"sources\": [...]} to silence this.",
+			strings.Join(quoteAll(moved), ", "))
 	}
 
 	// Migrate deprecated DefaultModel to roles if roles not set.
@@ -671,4 +684,82 @@ func SaveDefaultRole(model, provider string) error {
 	cfg.Roles["default"] = role
 
 	return cfg.Save()
+}
+
+// IsLLMSDocsURL reports whether u points at an llms.txt documentation index
+// rather than an MCP endpoint. Such a URL serves plain text over GET and
+// answers the MCP "initialize" POST with 405 Method Not Allowed, so treating
+// it as an MCP server can only ever fail.
+//
+// The convention (llmstxt.org) fixes the file name, not the host or path, so
+// the base name is the whole test: "llms.txt" and the expanded "llms-full.txt".
+func IsLLMSDocsURL(u string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(u))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(path.Base(parsed.Path)) {
+	case "llms.txt", "llms-full.txt":
+		return true
+	}
+	return false
+}
+
+// routeLLMSDocsServers moves MCP server entries that actually point at an
+// llms.txt index out of the MCP list and into the llms.txt sources, where the
+// fetch_docs tool serves them. Configuring a docs index under "mcpServers" is
+// a common mix-up — both are "a URL a model reads from" — and left alone it
+// produces a 405 warning on every startup and no documentation tool.
+//
+// Rerouting rather than dropping keeps the user's intent: the docs stay
+// reachable, just through the tool that can actually read them. An entry whose
+// URL is already configured as a source is dropped as a duplicate.
+func routeLLMSDocsServers(cfg *Config) []string {
+	if cfg.MCP == nil || len(cfg.MCP.Servers) == 0 {
+		return nil
+	}
+	existing := make(map[string]bool)
+	if cfg.LLMS != nil {
+		for _, s := range cfg.LLMS.Sources {
+			existing[s.URL] = true
+		}
+	}
+
+	kept := make([]MCPServer, 0, len(cfg.MCP.Servers))
+	var moved []string
+	var added []LLMSSource
+	for _, srv := range cfg.MCP.Servers {
+		if srv.URL == "" || !IsLLMSDocsURL(srv.URL) {
+			kept = append(kept, srv)
+			continue
+		}
+		moved = append(moved, srv.Name)
+		if existing[srv.URL] {
+			continue
+		}
+		existing[srv.URL] = true
+		added = append(added, LLMSSource{Name: srv.Name, URL: srv.URL})
+	}
+	if len(moved) == 0 {
+		return nil
+	}
+
+	cfg.MCP.Servers = kept
+	if len(added) > 0 {
+		if cfg.LLMS == nil {
+			cfg.LLMS = &LLMSConfig{}
+		}
+		cfg.LLMS.Sources = append(cfg.LLMS.Sources, added...)
+	}
+	return moved
+}
+
+// quoteAll returns the names quoted, for embedding a list in a notice without
+// leaving a name like "adk docs" ambiguous against the separator.
+func quoteAll(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = strconv.Quote(n)
+	}
+	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -697,10 +697,18 @@ func SaveDefaultRole(model, provider string) error {
 // it as an MCP server can only ever fail.
 //
 // The convention (llmstxt.org) fixes the file name, not the host or path, so
-// the base name is the whole test: "llms.txt" and the expanded "llms-full.txt".
+// the base name is the deciding test: "llms.txt" and the expanded
+// "llms-full.txt". The URL must also be one fetch_docs could actually read —
+// https with a host — since that is the only tool that would serve it.
 func IsLLMSDocsURL(u string) bool {
 	parsed, err := url.Parse(strings.TrimSpace(u))
 	if err != nil {
+		return false
+	}
+	// fetch_docs serves only https URLs and matches sources by host, so
+	// anything else could never be read through it. Classifying such a URL as
+	// a docs source would advertise a source that rejects every fetch.
+	if parsed.Scheme != "https" || parsed.Hostname() == "" {
 		return false
 	}
 	switch strings.ToLower(path.Base(parsed.Path)) {
@@ -802,6 +810,6 @@ func NotifyReroutedLLMS(cfg Config) {
 	}
 	notice.Notifyf("MCP server(s) %s point at an llms.txt index and are now readable with the "+
 		"fetch_docs tool. If they are not MCP endpoints, move them to \"llms\": {\"sources\": [...]} "+
-		"so they are not dialled on every startup.",
+		"so they are not dialed on every startup.",
 		strings.Join(quoteAll(cfg.ReroutedLLMS), ", "))
 }

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -1,0 +1,105 @@
+package config
+
+import "testing"
+
+func TestIsLLMSDocsURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://adk.dev/llms.txt", true},
+		{"https://adk.dev/llms-full.txt", true},
+		{"https://example.com/docs/LLMS.TXT", true},
+		{"  https://adk.dev/llms.txt  ", true},
+		{"https://mcp.openrouter.ai/mcp", false},
+		{"https://example.com/llms.txt.json", false},
+		{"https://example.com/allms.txt", false},
+		{"", false},
+		{"://nonsense", false},
+	}
+	for _, tc := range tests {
+		if got := IsLLMSDocsURL(tc.url); got != tc.want {
+			t.Errorf("IsLLMSDocsURL(%q) = %v, want %v", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestRouteLLMSDocsServersMovesDocsIndexToSources(t *testing.T) {
+	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
+		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
+		{Name: "openrouter", URL: "https://mcp.openrouter.ai/mcp"},
+		{Name: "local", Command: "some-server"},
+	}}}
+
+	moved := routeLLMSDocsServers(&cfg)
+
+	if len(moved) != 1 || moved[0] != "adk-docs-mcp" {
+		t.Fatalf("moved = %v, want [adk-docs-mcp]", moved)
+	}
+	if len(cfg.MCP.Servers) != 2 {
+		t.Fatalf("MCP servers = %d, want 2 (docs index removed)", len(cfg.MCP.Servers))
+	}
+	for _, srv := range cfg.MCP.Servers {
+		if srv.Name == "adk-docs-mcp" {
+			t.Error("docs index left in the MCP server list; it would 405 on every connect")
+		}
+	}
+	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
+		t.Fatalf("LLMS sources = %+v, want one entry", cfg.LLMS)
+	}
+	src := cfg.LLMS.Sources[0]
+	if src.Name != "adk-docs-mcp" || src.URL != "https://adk.dev/llms.txt" {
+		t.Errorf("source = %+v, want the rerouted server name and URL", src)
+	}
+}
+
+// The same index configured both ways must not register twice: fetch_docs
+// would then list one source under two names.
+func TestRouteLLMSDocsServersSkipsDuplicateSource(t *testing.T) {
+	cfg := Config{
+		MCP:  &MCPConfig{Servers: []MCPServer{{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"}}},
+		LLMS: &LLMSConfig{Sources: []LLMSSource{{Name: "AgentDevelopmentKit", URL: "https://adk.dev/llms.txt"}}},
+	}
+
+	moved := routeLLMSDocsServers(&cfg)
+
+	if len(moved) != 1 {
+		t.Fatalf("moved = %v, want the server reported as rerouted", moved)
+	}
+	if len(cfg.MCP.Servers) != 0 {
+		t.Errorf("MCP servers = %d, want 0", len(cfg.MCP.Servers))
+	}
+	if len(cfg.LLMS.Sources) != 1 {
+		t.Errorf("LLMS sources = %d, want 1 (no duplicate)", len(cfg.LLMS.Sources))
+	}
+	if cfg.LLMS.Sources[0].Name != "AgentDevelopmentKit" {
+		t.Errorf("existing source renamed to %q", cfg.LLMS.Sources[0].Name)
+	}
+}
+
+func TestRouteLLMSDocsServersLeavesRealServersAlone(t *testing.T) {
+	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
+		{Name: "openrouter", URL: "https://mcp.openrouter.ai/mcp"},
+	}}}
+
+	if moved := routeLLMSDocsServers(&cfg); moved != nil {
+		t.Errorf("moved = %v, want nil", moved)
+	}
+	if len(cfg.MCP.Servers) != 1 {
+		t.Errorf("MCP servers = %d, want 1", len(cfg.MCP.Servers))
+	}
+	if cfg.LLMS != nil {
+		t.Errorf("LLMS config created for a plain MCP server: %+v", cfg.LLMS)
+	}
+}
+
+func TestRouteLLMSDocsServersHandlesEmptyConfig(t *testing.T) {
+	var cfg Config
+	if moved := routeLLMSDocsServers(&cfg); moved != nil {
+		t.Errorf("moved = %v, want nil for a config with no MCP section", moved)
+	}
+	cfg.MCP = &MCPConfig{}
+	if moved := routeLLMSDocsServers(&cfg); moved != nil {
+		t.Errorf("moved = %v, want nil for an empty server list", moved)
+	}
+}

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,10 +55,10 @@ func TestRegisterLLMSDocsSourcesRegistersDocsIndex(t *testing.T) {
 	if len(cfg.MCP.Servers) != 3 {
 		t.Fatalf("MCP servers = %d, want all 3 kept", len(cfg.MCP.Servers))
 	}
-	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
-		t.Fatalf("LLMS sources = %+v, want one entry", cfg.LLMS)
+	if len(cfg.InferredLLMS) != 1 {
+		t.Fatalf("inferred sources = %+v, want one entry", cfg.InferredLLMS)
 	}
-	src := cfg.LLMS.Sources[0]
+	src := cfg.InferredLLMS[0]
 	if src.Name != "adk-docs-mcp" || src.URL != "https://adk.dev/llms.txt" {
 		t.Errorf("source = %+v, want the rerouted server name and URL", src)
 	}
@@ -208,10 +209,10 @@ func TestRegisterLLMSDocsSourcesTrimsURL(t *testing.T) {
 	if moved := registerLLMSDocsSources(&cfg); len(moved) != 1 {
 		t.Fatalf("moved = %v, want the whitespace-padded entry recognized", moved)
 	}
-	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
-		t.Fatalf("LLMS = %+v, want one source", cfg.LLMS)
+	if len(cfg.InferredLLMS) != 1 {
+		t.Fatalf("inferred sources = %+v, want one", cfg.InferredLLMS)
 	}
-	if got := cfg.LLMS.Sources[0].URL; got != "https://adk.dev/llms.txt" {
+	if got := cfg.InferredLLMS[0].URL; got != "https://adk.dev/llms.txt" {
 		t.Errorf("stored URL = %q, want it trimmed", got)
 	}
 }
@@ -224,8 +225,8 @@ func TestRegisterLLMSDocsSourcesDedupesAcrossWhitespace(t *testing.T) {
 	}}}
 
 	registerLLMSDocsSources(&cfg)
-	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
-		t.Errorf("LLMS sources = %+v, want one entry", cfg.LLMS)
+	if len(cfg.InferredLLMS) != 1 {
+		t.Errorf("inferred sources = %+v, want one entry", cfg.InferredLLMS)
 	}
 }
 
@@ -248,5 +249,56 @@ func TestIsLLMSDocsURLRejectsPrivateLiteralHosts(t *testing.T) {
 	// A public literal address is still fine.
 	if !IsLLMSDocsURL("https://93.184.216.34/llms.txt") {
 		t.Error("rejected a public literal address")
+	}
+}
+
+// Save marshals the whole config, so an inference drawn from a project's
+// mcp.json must never reach the serialized LLMS field — SaveDefaultRole would
+// otherwise write it into the global config file.
+func TestInferredLLMSSourcesAreNotSerialized(t *testing.T) {
+	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
+		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
+	}}}
+	registerLLMSDocsSources(&cfg)
+
+	if cfg.LLMS != nil {
+		t.Errorf("inference landed in the serialized field: %+v", cfg.LLMS)
+	}
+	if len(cfg.InferredLLMS) != 1 {
+		t.Fatalf("InferredLLMS = %+v, want one entry", cfg.InferredLLMS)
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// The MCP entry itself legitimately carries the URL; what must not appear
+	// is an "llms" section conjured by the load.
+	if strings.Contains(string(data), `"llms"`) {
+		t.Errorf("marshaled config grew an llms section: %s", data)
+	}
+
+	// It is still served: LLMSSources joins both halves.
+	llms := cfg.LLMSSources()
+	if llms == nil || len(llms.Sources) != 1 || llms.Sources[0].URL != "https://adk.dev/llms.txt" {
+		t.Errorf("LLMSSources() = %+v, want the inferred source served", llms)
+	}
+}
+
+func TestLLMSSourcesJoinsConfiguredAndInferred(t *testing.T) {
+	cfg := Config{
+		LLMS:         &LLMSConfig{Sources: []LLMSSource{{Name: "configured", URL: "https://a.example/llms.txt"}}},
+		InferredLLMS: []LLMSSource{{Name: "inferred", URL: "https://b.example/llms.txt"}},
+	}
+	llms := cfg.LLMSSources()
+	if llms == nil || len(llms.Sources) != 2 {
+		t.Fatalf("LLMSSources() = %+v, want both", llms)
+	}
+	if cfg.LLMS.Sources[0].Name != "configured" || len(cfg.LLMS.Sources) != 1 {
+		t.Error("LLMSSources mutated the configured sources")
+	}
+	empty := Config{}
+	if empty.LLMSSources() != nil {
+		t.Error("empty config should yield nil so callers can skip registering fetch_docs")
 	}
 }

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -190,3 +190,35 @@ func TestRegisterLLMSDocsSourcesKeepsConfiguredEndpoints(t *testing.T) {
 		}
 	}
 }
+
+// IsLLMSDocsURL tolerates surrounding whitespace, so the registered source
+// must be trimmed too: fetch_docs parses the stored value to check the host,
+// and an untrimmed URL fails that parse and yields an unusable source.
+func TestRegisterLLMSDocsSourcesTrimsURL(t *testing.T) {
+	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
+		{Name: "adk-docs-mcp", URL: "  https://adk.dev/llms.txt\n"},
+	}}}
+
+	if moved := registerLLMSDocsSources(&cfg); len(moved) != 1 {
+		t.Fatalf("moved = %v, want the whitespace-padded entry recognized", moved)
+	}
+	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
+		t.Fatalf("LLMS = %+v, want one source", cfg.LLMS)
+	}
+	if got := cfg.LLMS.Sources[0].URL; got != "https://adk.dev/llms.txt" {
+		t.Errorf("stored URL = %q, want it trimmed", got)
+	}
+}
+
+// The same URL padded differently must not register twice.
+func TestRegisterLLMSDocsSourcesDedupesAcrossWhitespace(t *testing.T) {
+	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
+		{Name: "a", URL: "https://adk.dev/llms.txt"},
+		{Name: "b", URL: " https://adk.dev/llms.txt "},
+	}}}
+
+	registerLLMSDocsSources(&cfg)
+	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
+		t.Errorf("LLMS sources = %+v, want one entry", cfg.LLMS)
+	}
+}

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -168,3 +168,28 @@ func writeProjectMCPFile(t *testing.T, dir, body string) {
 		t.Fatalf("writing mcp.json: %v", err)
 	}
 }
+
+// The base name is a heuristic and rerouting is destructive, so an entry that
+// declares configuration only a real MCP endpoint needs must be left alone.
+func TestRouteLLMSDocsServersKeepsConfiguredEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		srv  MCPServer
+	}{
+		{"custom headers", MCPServer{Name: "a", URL: "https://x.example/llms.txt", Headers: map[string]string{"Authorization": "Bearer k"}}},
+		{"oauth", MCPServer{Name: "b", URL: "https://x.example/llms.txt", OAuth: true}},
+		{"command wins over url", MCPServer{Name: "c", URL: "https://x.example/llms.txt", Command: "srv"}},
+	}
+	for _, tc := range tests {
+		cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{tc.srv}}}
+		if moved := routeLLMSDocsServers(&cfg); moved != nil {
+			t.Errorf("%s: rerouted %v, want the server kept", tc.name, moved)
+		}
+		if len(cfg.MCP.Servers) != 1 {
+			t.Errorf("%s: server removed from the MCP list", tc.name)
+		}
+		if cfg.LLMS != nil {
+			t.Errorf("%s: registered a docs source for a configured MCP endpoint", tc.name)
+		}
+	}
+}

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -1,6 +1,13 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/notice"
+)
 
 func TestIsLLMSDocsURL(t *testing.T) {
 	tests := []struct {
@@ -101,5 +108,63 @@ func TestRouteLLMSDocsServersHandlesEmptyConfig(t *testing.T) {
 	cfg.MCP = &MCPConfig{}
 	if moved := routeLLMSDocsServers(&cfg); moved != nil {
 		t.Errorf("moved = %v, want nil for an empty server list", moved)
+	}
+}
+
+// The notice must not be raised during load. In the TUI, config is read before
+// any front end exists and the first frame is preceded by a full terminal
+// reset (ESC c) that clears screen and scrollback, so a message written at
+// load time is erased before it can be read.
+func TestLoadDefersReroutedLLMSNotice(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	writeProjectMCPFile(t, dir, `{"mcpServers":{"adk-docs-mcp":{"url":"https://adk.dev/llms.txt"}}}`)
+
+	var raised []string
+	prev := notice.SetSink(func(msg string) { raised = append(raised, msg) })
+	defer notice.SetSink(prev)
+
+	cfg, err := LoadFrom(dir)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if len(raised) != 0 {
+		t.Errorf("LoadFrom raised %v; the notice must wait for a front end", raised)
+	}
+	if len(cfg.ReroutedLLMS) != 1 || cfg.ReroutedLLMS[0] != "adk-docs-mcp" {
+		t.Fatalf("ReroutedLLMS = %v, want [adk-docs-mcp]", cfg.ReroutedLLMS)
+	}
+
+	NotifyReroutedLLMS(cfg)
+	if len(raised) != 1 {
+		t.Fatalf("NotifyReroutedLLMS raised %v, want one notice", raised)
+	}
+	for _, want := range []string{`"adk-docs-mcp"`, "fetch_docs", "llms", "sources"} {
+		if !strings.Contains(raised[0], want) {
+			t.Errorf("notice %q does not mention %q", raised[0], want)
+		}
+	}
+}
+
+func TestNotifyReroutedLLMSSilentWhenNothingMoved(t *testing.T) {
+	var raised []string
+	prev := notice.SetSink(func(msg string) { raised = append(raised, msg) })
+	defer notice.SetSink(prev)
+
+	NotifyReroutedLLMS(Config{})
+	if len(raised) != 0 {
+		t.Errorf("raised %v for a config with nothing rerouted", raised)
+	}
+}
+
+func writeProjectMCPFile(t *testing.T, dir, body string) {
+	t.Helper()
+	piDir := filepath.Join(dir, ".pi-go")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", piDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(piDir, "mcp.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("writing mcp.json: %v", err)
 	}
 }

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -228,3 +228,25 @@ func TestRegisterLLMSDocsSourcesDedupesAcrossWhitespace(t *testing.T) {
 		t.Errorf("LLMS sources = %+v, want one entry", cfg.LLMS)
 	}
 }
+
+// fetch_docs refuses private and loopback hosts, so registering one would
+// advertise a source whose every fetch is rejected.
+func TestIsLLMSDocsURLRejectsPrivateLiteralHosts(t *testing.T) {
+	for _, u := range []string{
+		"https://127.0.0.1/llms.txt",
+		"https://[::1]/llms.txt",
+		"https://10.0.0.5/llms.txt",
+		"https://192.168.1.10/llms-full.txt",
+		"https://172.16.0.1/llms.txt",
+		"https://169.254.1.1/llms.txt",
+		"https://0.0.0.0/llms.txt",
+	} {
+		if IsLLMSDocsURL(u) {
+			t.Errorf("IsLLMSDocsURL(%q) = true; fetch_docs would reject that host", u)
+		}
+	}
+	// A public literal address is still fine.
+	if !IsLLMSDocsURL("https://93.184.216.34/llms.txt") {
+		t.Error("rejected a public literal address")
+	}
+}

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -302,3 +302,36 @@ func TestLLMSSourcesJoinsConfiguredAndInferred(t *testing.T) {
 		t.Error("empty config should yield nil so callers can skip registering fetch_docs")
 	}
 }
+
+// A source's full URL is written into the fetch_docs tool description and sent
+// to the model provider, so inferring one from a URL carrying credentials
+// would leak transport configuration to the model.
+func TestIsLLMSDocsURLRejectsCredentialBearingURLs(t *testing.T) {
+	for _, u := range []string{
+		"https://user:secret@docs.example.com/llms.txt",
+		"https://token@docs.example.com/llms.txt",
+		"https://docs.example.com/llms.txt?api_key=secret",
+		"https://docs.example.com/llms-full.txt?token=abc",
+	} {
+		if IsLLMSDocsURL(u) {
+			t.Errorf("IsLLMSDocsURL(%q) = true; its URL would be sent to the model provider", u)
+		}
+	}
+	// A fragment carries nothing to the server and is not a credential.
+	if !IsLLMSDocsURL("https://docs.example.com/llms.txt#section") {
+		t.Error("rejected a URL whose only extra is a fragment")
+	}
+}
+
+// End to end: a credential-bearing entry must not become an inferred source.
+func TestRegisterLLMSDocsSourcesSkipsCredentialBearingURLs(t *testing.T) {
+	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
+		{Name: "secret-docs", URL: "https://user:pw@docs.example.com/llms.txt"},
+	}}}
+	if moved := registerLLMSDocsSources(&cfg); moved != nil {
+		t.Errorf("registered %v", moved)
+	}
+	if len(cfg.InferredLLMS) != 0 {
+		t.Errorf("inferred %+v", cfg.InferredLLMS)
+	}
+}

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -19,6 +19,12 @@ func TestIsLLMSDocsURL(t *testing.T) {
 		{"https://example.com/docs/LLMS.TXT", true},
 		{"  https://adk.dev/llms.txt  ", true},
 		{"https://mcp.openrouter.ai/mcp", false},
+		// fetch_docs serves only https URLs matched by host, so anything it
+		// could not read is not a docs source however it is named.
+		{"http://docs.example.com/llms.txt", false},
+		{"llms.txt", false},
+		{"file:///tmp/llms.txt", false},
+		{"https:///llms.txt", false},
 		{"https://example.com/llms.txt.json", false},
 		{"https://example.com/allms.txt", false},
 		{"", false},
@@ -120,7 +126,7 @@ func TestLoadDefersReroutedLLMSNotice(t *testing.T) {
 
 	var raised []string
 	prev := notice.SetSink(func(msg string) { raised = append(raised, msg) })
-	defer notice.SetSink(prev)
+	defer func() { notice.SetSink(prev) }()
 
 	cfg, err := LoadFrom(dir)
 	if err != nil {
@@ -147,7 +153,7 @@ func TestLoadDefersReroutedLLMSNotice(t *testing.T) {
 func TestNotifyReroutedLLMSSilentWhenNothingMoved(t *testing.T) {
 	var raised []string
 	prev := notice.SetSink(func(msg string) { raised = append(raised, msg) })
-	defer notice.SetSink(prev)
+	defer func() { notice.SetSink(prev) }()
 
 	NotifyReroutedLLMS(Config{})
 	if len(raised) != 0 {

--- a/internal/config/llms_route_test.go
+++ b/internal/config/llms_route_test.go
@@ -31,25 +31,22 @@ func TestIsLLMSDocsURL(t *testing.T) {
 	}
 }
 
-func TestRouteLLMSDocsServersMovesDocsIndexToSources(t *testing.T) {
+func TestRegisterLLMSDocsSourcesRegistersDocsIndex(t *testing.T) {
 	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
 		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
 		{Name: "openrouter", URL: "https://mcp.openrouter.ai/mcp"},
 		{Name: "local", Command: "some-server"},
 	}}}
 
-	moved := routeLLMSDocsServers(&cfg)
+	moved := registerLLMSDocsSources(&cfg)
 
 	if len(moved) != 1 || moved[0] != "adk-docs-mcp" {
 		t.Fatalf("moved = %v, want [adk-docs-mcp]", moved)
 	}
-	if len(cfg.MCP.Servers) != 2 {
-		t.Fatalf("MCP servers = %d, want 2 (docs index removed)", len(cfg.MCP.Servers))
-	}
-	for _, srv := range cfg.MCP.Servers {
-		if srv.Name == "adk-docs-mcp" {
-			t.Error("docs index left in the MCP server list; it would 405 on every connect")
-		}
+	// The entry stays: a base name cannot prove the URL is not a real MCP
+	// endpoint, and removing one on a guess would silently strip its tools.
+	if len(cfg.MCP.Servers) != 3 {
+		t.Fatalf("MCP servers = %d, want all 3 kept", len(cfg.MCP.Servers))
 	}
 	if cfg.LLMS == nil || len(cfg.LLMS.Sources) != 1 {
 		t.Fatalf("LLMS sources = %+v, want one entry", cfg.LLMS)
@@ -62,19 +59,19 @@ func TestRouteLLMSDocsServersMovesDocsIndexToSources(t *testing.T) {
 
 // The same index configured both ways must not register twice: fetch_docs
 // would then list one source under two names.
-func TestRouteLLMSDocsServersSkipsDuplicateSource(t *testing.T) {
+func TestRegisterLLMSDocsSourcesSkipsDuplicateSource(t *testing.T) {
 	cfg := Config{
 		MCP:  &MCPConfig{Servers: []MCPServer{{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"}}},
 		LLMS: &LLMSConfig{Sources: []LLMSSource{{Name: "AgentDevelopmentKit", URL: "https://adk.dev/llms.txt"}}},
 	}
 
-	moved := routeLLMSDocsServers(&cfg)
+	moved := registerLLMSDocsSources(&cfg)
 
 	if len(moved) != 1 {
 		t.Fatalf("moved = %v, want the server reported as rerouted", moved)
 	}
-	if len(cfg.MCP.Servers) != 0 {
-		t.Errorf("MCP servers = %d, want 0", len(cfg.MCP.Servers))
+	if len(cfg.MCP.Servers) != 1 {
+		t.Errorf("MCP servers = %d, want the entry kept", len(cfg.MCP.Servers))
 	}
 	if len(cfg.LLMS.Sources) != 1 {
 		t.Errorf("LLMS sources = %d, want 1 (no duplicate)", len(cfg.LLMS.Sources))
@@ -84,12 +81,12 @@ func TestRouteLLMSDocsServersSkipsDuplicateSource(t *testing.T) {
 	}
 }
 
-func TestRouteLLMSDocsServersLeavesRealServersAlone(t *testing.T) {
+func TestRegisterLLMSDocsSourcesLeavesRealServersAlone(t *testing.T) {
 	cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{
 		{Name: "openrouter", URL: "https://mcp.openrouter.ai/mcp"},
 	}}}
 
-	if moved := routeLLMSDocsServers(&cfg); moved != nil {
+	if moved := registerLLMSDocsSources(&cfg); moved != nil {
 		t.Errorf("moved = %v, want nil", moved)
 	}
 	if len(cfg.MCP.Servers) != 1 {
@@ -100,13 +97,13 @@ func TestRouteLLMSDocsServersLeavesRealServersAlone(t *testing.T) {
 	}
 }
 
-func TestRouteLLMSDocsServersHandlesEmptyConfig(t *testing.T) {
+func TestRegisterLLMSDocsSourcesHandlesEmptyConfig(t *testing.T) {
 	var cfg Config
-	if moved := routeLLMSDocsServers(&cfg); moved != nil {
+	if moved := registerLLMSDocsSources(&cfg); moved != nil {
 		t.Errorf("moved = %v, want nil for a config with no MCP section", moved)
 	}
 	cfg.MCP = &MCPConfig{}
-	if moved := routeLLMSDocsServers(&cfg); moved != nil {
+	if moved := registerLLMSDocsSources(&cfg); moved != nil {
 		t.Errorf("moved = %v, want nil for an empty server list", moved)
 	}
 }
@@ -171,7 +168,7 @@ func writeProjectMCPFile(t *testing.T, dir, body string) {
 
 // The base name is a heuristic and rerouting is destructive, so an entry that
 // declares configuration only a real MCP endpoint needs must be left alone.
-func TestRouteLLMSDocsServersKeepsConfiguredEndpoints(t *testing.T) {
+func TestRegisterLLMSDocsSourcesKeepsConfiguredEndpoints(t *testing.T) {
 	tests := []struct {
 		name string
 		srv  MCPServer
@@ -182,7 +179,7 @@ func TestRouteLLMSDocsServersKeepsConfiguredEndpoints(t *testing.T) {
 	}
 	for _, tc := range tests {
 		cfg := Config{MCP: &MCPConfig{Servers: []MCPServer{tc.srv}}}
-		if moved := routeLLMSDocsServers(&cfg); moved != nil {
+		if moved := registerLLMSDocsSources(&cfg); moved != nil {
 			t.Errorf("%s: rerouted %v, want the server kept", tc.name, moved)
 		}
 		if len(cfg.MCP.Servers) != 1 {

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -26,6 +27,22 @@ import (
 )
 
 var mcpConnectTimeout = 30 * time.Second
+
+// interactiveOAuth gates the automatic re-login that answers a 401 from a
+// remote MCP server. That flow opens a browser and waits up to
+// mcpOAuthConnectTimeout for a human to approve it, which is only ever
+// appropriate when a human is sitting in front of the process.
+//
+// It defaults to off, so print, JSON, RPC, socket and ACP runs keep the
+// behaviour they had: a rejected server is reported and skipped after the
+// normal connect timeout, and nothing stalls a headless pipeline for ten
+// minutes waiting on a browser nobody will see. runInteractive turns it on.
+var interactiveOAuth atomic.Bool
+
+// SetInteractiveOAuth enables or disables the automatic OAuth re-login for
+// MCP servers that answer 401/403. Only a front end with a user and a browser
+// in reach should enable it.
+func SetInteractiveOAuth(enabled bool) { interactiveOAuth.Store(enabled) }
 
 // mcpOAuthConnectTimeout is used for servers that run the OAuth
 // authorization-code flow on first connect. The browser round-trip (open URL,
@@ -56,7 +73,7 @@ func BuildMCPToolsets(servers []MCPServerConfig) ([]tool.Toolset, error) {
 		// but server lists are also assembled by hand (evals, embedded
 		// agents), so refuse to dial one here rather than emit a 405 warning
 		// on every startup.
-		if srv.URL != "" && config.IsLLMSDocsURL(srv.URL) {
+		if isLLMSDocsServer(srv) {
 			notice.Notifyf("MCP server %q points at an llms.txt index, not an MCP endpoint — "+
 				"configure it under \"llms\": {\"sources\": [...]} and read it with the fetch_docs tool.", srv.Name)
 			continue
@@ -221,11 +238,15 @@ func (r *resilientToolset) listTools(
 }
 
 // canReauthorize reports whether err is worth answering with a fresh OAuth
-// login. Only remote servers qualify — a stdio subprocess has no bearer token
-// to renew — and only genuine authorization failures, so a 404 or a DNS error
-// never opens a browser window.
+// login.
+//
+// Three conditions must hold. A human must be present, since the flow blocks
+// on a browser approval — see interactiveOAuth. Only remote servers qualify,
+// because a stdio subprocess has no bearer token to renew. And the failure
+// must be a genuine authorization failure, so a 404 or a DNS error never opens
+// a browser window.
 func (r *resilientToolset) canReauthorize(err error) bool {
-	return r.srv.URL != "" && isMCPAuthError(err)
+	return interactiveOAuth.Load() && r.srv.URL != "" && isMCPAuthError(err)
 }
 
 // reauthorize answers a 401/403 by running the OAuth authorization-code flow
@@ -442,6 +463,17 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 		transport: tracked,
 		timeout:   timeout,
 	}, nil
+}
+
+// isLLMSDocsServer mirrors the config-load test, so a server list assembled by
+// hand gets the same treatment as one that came from a config file: an entry
+// that declares MCP-only configuration — a command, OAuth, custom headers — is
+// taken at its word and dialled, whatever its URL looks like.
+func isLLMSDocsServer(srv MCPServerConfig) bool {
+	if srv.URL == "" || srv.Command != "" || srv.OAuth || len(srv.Headers) > 0 {
+		return false
+	}
+	return config.IsLLMSDocsURL(srv.URL)
 }
 
 // newMCPToolset builds one MCP connection: the transport for the configured

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -332,6 +332,17 @@ func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, 
 	return tools, nil
 }
 
+// hasAuthorizationHeader reports whether an Authorization header is configured,
+// canonicalizing because HTTP header names are case-insensitive.
+func hasAuthorizationHeader(headers map[string]string) bool {
+	for k, v := range headers {
+		if http.CanonicalHeaderKey(k) == "Authorization" && v != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // withoutAuthorization copies headers without any Authorization entry.
 //
 // The OAuth retry must not carry the static credential that was just refused.
@@ -493,14 +504,14 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 	// there. It cannot turn into a browser prompt: mcpOAuthCodeFetcher refuses
 	// when no user is present, so a revoked token fails fast rather than
 	// stalling the run on an approval nobody will see.
-	if !srv.OAuth && srv.URL != "" && hasCachedMCPOAuthToken(srv.Name, srv.URL) {
+	// An explicit Authorization header is the user's current instruction and
+	// outranks a token cached from an earlier run: replacing a rejected API key
+	// with a working one must take effect now, not after the cache's 24-hour
+	// window. If that credential is refused too, the interactive retry path
+	// clears it and re-authorizes.
+	if !srv.OAuth && srv.URL != "" && !hasAuthorizationHeader(srv.Headers) &&
+		hasCachedMCPOAuthToken(srv.Name, srv.URL) {
 		srv.OAuth = true
-		// The static credential is what was refused when this server was
-		// upgraded, and headerRoundTripper is the outermost transport, so
-		// leaving it in place would overwrite the cached bearer token with the
-		// refused value and produce another 401 — a browser flow every launch
-		// interactively, and no connection at all headlessly.
-		srv.Headers = withoutAuthorization(srv.Headers)
 	}
 	inner, tracked, err := newMCPToolset(srv)
 	if err != nil {
@@ -594,7 +605,7 @@ func newMCPOAuthHandler(name, serverURL string) (auth.OAuthHandler, error) {
 	// without its cached token ever being presented. That token is the whole
 	// reason a handler is installed there.
 	if !interactiveOAuth.Load() {
-		return newMCPOAuthTokenOnlyHandler(name, serverURL)
+		return &mcpTokenOnlyHandler{name: name, ts: loadMCPOAuthTokenSource(name, serverURL)}, nil
 	}
 
 	// Pick a free loopback port for the callback server.
@@ -657,31 +668,39 @@ func mcpDynamicClientRegistration(redirectURL string) *auth.DynamicClientRegistr
 	}
 }
 
-// newMCPOAuthTokenOnlyHandler builds a handler that can present and refresh
-// stored credentials but can never obtain new ones.
+// mcpTokenOnlyHandler presents stored credentials and never obtains new ones.
 //
-// It binds nothing and opens nothing. The redirect URL is a placeholder that is
-// never reached, because the fetcher refuses before any authorization request
-// is made — which is the correct behavior with no user present: a valid cached
-// token still authenticates the connection, and a revoked one fails fast with a
-// message saying to run pi interactively once.
-func newMCPOAuthTokenOnlyHandler(name, serverURL string) (auth.OAuthHandler, error) {
-	const redirectURL = "http://127.0.0.1/callback"
-	handler, err := auth.NewAuthorizationCodeHandler(&auth.AuthorizationCodeHandlerConfig{
-		RedirectURL: redirectURL,
-		// Required by the constructor even though no flow can run here: the
-		// fetcher refuses before registration would ever be attempted.
-		DynamicClientRegistrationConfig: mcpDynamicClientRegistration(redirectURL),
-		AuthorizationCodeFetcher:        mcpOAuthCodeFetcher(name, nil, browser.Open),
-		RequestRefreshToken:             true,
-		InitialTokenSource:              loadMCPOAuthTokenSource(name, serverURL),
-		NewTokenSource:                  mcpOAuthNewTokenSource(name, serverURL),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating OAuth handler: %w", err)
-	}
-	return handler, nil
+// It is what a headless run gets. Wrapping the SDK's authorization-code
+// handler would not do: its Authorize runs protected-resource discovery,
+// authorization-server metadata retrieval and dynamic client registration
+// before it ever reaches the code fetcher, so a missing or revoked token would
+// still produce a round of network calls against the server — and block the
+// run while they happen — before anything could refuse. Implementing the
+// two-method interface directly means the refusal is the first thing that
+// happens.
+type mcpTokenOnlyHandler struct {
+	name string
+	ts   oauth2.TokenSource // nil when nothing usable is cached
 }
+
+// TokenSource hands back the cached credentials, which is the whole point of
+// installing a handler with no user present. A nil source is valid: the
+// transport then sends no authorization header.
+func (h *mcpTokenOnlyHandler) TokenSource(context.Context) (oauth2.TokenSource, error) {
+	return h.ts, nil
+}
+
+// Authorize refuses immediately. The interface makes the caller responsible
+// for closing the response body.
+func (h *mcpTokenOnlyHandler) Authorize(_ context.Context, _ *http.Request, resp *http.Response) error {
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return fmt.Errorf("MCP server %q needs authorization, and there is no user to grant it; "+
+		"run pi interactively once to authorize it", h.name)
+}
+
+var _ auth.OAuthHandler = (*mcpTokenOnlyHandler)(nil)
 
 // mcpOAuthCallbackResult is what the loopback callback hands to the waiting
 // fetcher: either the authorization result or the error the authorization
@@ -744,11 +763,9 @@ func mcpOAuthCodeFetcher(
 	openURL func(string) error,
 ) func(context.Context, *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
 	return func(ctx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
-		// The SDK calls this itself whenever a request comes back 401/403, so
-		// it is the last place that can stop a browser opening with nobody to
-		// see it. A handler is installed in headless runs too — cached
-		// credentials are worth presenting there — but the flow that needs a
-		// human must fail fast instead of blocking the run.
+		// A headless run gets mcpTokenOnlyHandler and never reaches here, so
+		// this is a backstop: it keeps the browser shut if a future change
+		// installs the full handler without a user present.
 		if !interactiveOAuth.Load() {
 			return nil, fmt.Errorf("MCP server %q needs authorization, and there is no user to grant it; "+
 				"run pi interactively once to authorize it", name)

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -495,6 +495,12 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 	// stalling the run on an approval nobody will see.
 	if !srv.OAuth && srv.URL != "" && hasCachedMCPOAuthToken(srv.Name, srv.URL) {
 		srv.OAuth = true
+		// The static credential is what was refused when this server was
+		// upgraded, and headerRoundTripper is the outermost transport, so
+		// leaving it in place would overwrite the cached bearer token with the
+		// refused value and produce another 401 — a browser flow every launch
+		// interactively, and no connection at all headlessly.
+		srv.Headers = withoutAuthorization(srv.Headers)
 	}
 	inner, tracked, err := newMCPToolset(srv)
 	if err != nil {

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -479,6 +479,11 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 	// upgraded it. Install the handler from the start so those credentials are
 	// presented on the first request; without this the connection would go out
 	// unauthenticated, be refused, and re-run the browser flow every launch.
+	//
+	// This applies in headless runs too, so a cached token still gets used
+	// there. It cannot turn into a browser prompt: mcpOAuthCodeFetcher refuses
+	// when no user is present, so a revoked token fails fast rather than
+	// stalling the run on an approval nobody will see.
 	if !srv.OAuth && srv.URL != "" && hasCachedMCPOAuthToken(srv.Name, srv.URL) {
 		srv.OAuth = true
 	}
@@ -486,8 +491,12 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The OAuth budget covers a browser round-trip — open, approve, redirect —
+	// so it applies only when that round-trip can happen. A headless run never
+	// waits on one (mcpOAuthCodeFetcher refuses immediately), so it keeps the
+	// normal connect timeout and fails fast.
 	timeout := mcpConnectTimeout
-	if srv.OAuth {
+	if srv.OAuth && interactiveOAuth.Load() {
 		timeout = mcpOAuthConnectTimeout
 	}
 	return &resilientToolset{
@@ -678,6 +687,15 @@ func mcpOAuthCodeFetcher(
 	openURL func(string) error,
 ) func(context.Context, *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
 	return func(ctx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
+		// The SDK calls this itself whenever a request comes back 401/403, so
+		// it is the last place that can stop a browser opening with nobody to
+		// see it. A handler is installed in headless runs too — cached
+		// credentials are worth presenting there — but the flow that needs a
+		// human must fail fast instead of blocking the run.
+		if !interactiveOAuth.Load() {
+			return nil, fmt.Errorf("MCP server %q needs authorization, and there is no user to grant it; "+
+				"run pi interactively once to authorize it", name)
+		}
 		select {
 		case <-resultChan: // drop stale outcome from a previous flow
 		default:

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -34,7 +34,7 @@ var mcpConnectTimeout = 30 * time.Second
 // appropriate when a human is sitting in front of the process.
 //
 // It defaults to off, so print, JSON, RPC, socket and ACP runs keep the
-// behaviour they had: a rejected server is reported and skipped after the
+// behavior they had: a rejected server is reported and skipped after the
 // normal connect timeout, and nothing stalls a headless pipeline for ten
 // minutes waiting on a browser nobody will see. runInteractive turns it on.
 var interactiveOAuth atomic.Bool
@@ -204,7 +204,7 @@ func (r *resilientToolset) failureNotice(err error) string {
 // The timeout is a separate timer rather than a derived context because the
 // inner toolset needs the caller's agent.ReadonlyContext, and wrapping it in
 // context.WithTimeout would erase that interface. The inner goroutine still
-// honours the original ctx; on timeout we abandon it, close the connection
+// honors the original ctx; on timeout we abandon it, close the connection
 // underneath it so it can unblock, and drain it in the background.
 func (r *resilientToolset) listTools(
 	ctx agent.ReadonlyContext,
@@ -275,11 +275,16 @@ func (r *resilientToolset) canReauthorize(err error) bool {
 func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
 	notice.Notifyf("MCP server %q rejected the connection as unauthorized — re-running OAuth login.", r.name)
 
-	// Drop cached credentials first so the flow re-authorizes instead of
-	// replaying the token that was just refused. A cache that cannot be
-	// cleared is not fatal: the flow still runs, it may just reuse the token.
-	if err := removeMCPOAuthToken(r.srv.Name, r.srv.URL); err != nil {
-		notice.Notifyf("warning: could not clear cached OAuth token for MCP server %q: %v", r.name, err)
+	// Drop cached credentials only when this connection actually presented
+	// them — r.srv.OAuth is set for a configured server and for one buildMCPToolset
+	// upgraded from the cache. Otherwise the refusal says nothing about the
+	// stored token, and discarding it would throw away a working credential
+	// and force a browser round-trip that was not needed. A cache that cannot
+	// be cleared is not fatal: the flow still runs, it may just reuse the token.
+	if r.srv.OAuth {
+		if err := removeMCPOAuthToken(r.srv.Name, r.srv.URL); err != nil {
+			notice.Notifyf("warning: could not clear cached OAuth token for MCP server %q: %v", r.name, err)
+		}
 	}
 
 	srv := r.srv
@@ -469,6 +474,14 @@ func ToolsetStatuses(toolsets []tool.Toolset) []MCPServerStatus {
 }
 
 func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
+	// Credentials cached for this identity mean a previous run authorized this
+	// server, whether the user asked for OAuth or an automatic re-login
+	// upgraded it. Install the handler from the start so those credentials are
+	// presented on the first request; without this the connection would go out
+	// unauthenticated, be refused, and re-run the browser flow every launch.
+	if !srv.OAuth && srv.URL != "" && hasCachedMCPOAuthToken(srv.Name, srv.URL) {
+		srv.OAuth = true
+	}
 	inner, tracked, err := newMCPToolset(srv)
 	if err != nil {
 		return nil, err
@@ -489,7 +502,7 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 // isLLMSDocsServer mirrors the config-load test, so a server list assembled by
 // hand gets the same treatment as one that came from a config file: an entry
 // that declares MCP-only configuration — a command, OAuth, custom headers — is
-// taken at its word and dialled, whatever its URL looks like.
+// taken at its word and dialed, whatever its URL looks like.
 func isLLMSDocsServer(srv MCPServerConfig) bool {
 	if srv.URL == "" || srv.Command != "" || srv.OAuth || len(srv.Headers) > 0 {
 		return false

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -67,17 +67,6 @@ type MCPServerConfig struct {
 func BuildMCPToolsets(servers []MCPServerConfig) ([]tool.Toolset, error) {
 	var toolsets []tool.Toolset
 	for _, srv := range servers {
-		// An llms.txt index is a documentation file, not an MCP endpoint: it
-		// answers the "initialize" POST with 405 and can never yield tools.
-		// config.LoadFrom already reroutes these to the fetch_docs sources,
-		// but server lists are also assembled by hand (evals, embedded
-		// agents), so refuse to dial one here rather than emit a 405 warning
-		// on every startup.
-		if isLLMSDocsServer(srv) {
-			notice.Notifyf("MCP server %q points at an llms.txt index, not an MCP endpoint — "+
-				"configure it under \"llms\": {\"sources\": [...]} and read it with the fetch_docs tool.", srv.Name)
-			continue
-		}
 		ts, err := buildMCPToolset(srv)
 		if err != nil {
 			notice.Notifyf("warning: MCP server %q skipped: %v", srv.Name, err)
@@ -178,7 +167,7 @@ func (r *resilientToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error)
 			tools, err = r.reauthorize(ctx)
 		}
 		if err != nil {
-			notice.Notifyf("warning: MCP server %q unavailable: %v", r.name, err)
+			notice.Notifyf("%s", r.failureNotice(err))
 			r.failed = true
 			return
 		}
@@ -188,6 +177,25 @@ func (r *resilientToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error)
 		return nil, nil
 	}
 	return r.tools, nil
+}
+
+// failureNotice renders the message shown when a server cannot be used.
+//
+// A URL whose base name is llms.txt gets a different message from the raw
+// transport error. That name is a reserved convention (llmstxt.org) for a
+// plain-text documentation index served over GET, so an entry pointing at one
+// is almost certainly a docs source filed under the wrong config key — and the
+// bare "Method Not Allowed" it produces says nothing about how to fix that.
+// The diagnosis is only offered once the connection has actually failed, so a
+// real MCP server that happens to live at such a path is never second-guessed.
+func (r *resilientToolset) failureNotice(err error) string {
+	if isLLMSDocsServer(r.srv) {
+		return fmt.Sprintf("MCP server %q could not be reached (%v). That URL is an llms.txt "+
+			"documentation index, not an MCP endpoint — it is already served by the fetch_docs "+
+			"tool, so the entry can be removed from \"mcpServers\" and kept under "+
+			"\"llms\": {\"sources\": [...]}.", r.name, err)
+	}
+	return fmt.Sprintf("warning: MCP server %q unavailable: %v", r.name, err)
 }
 
 // listTools runs one Tools() attempt under a timeout, so a server that accepts
@@ -286,8 +294,21 @@ func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, 
 		return nil, fmt.Errorf("re-authorizing: %w", err)
 	}
 
+	// The refused connection is finished with either way. Close it before the
+	// replacement takes over, or its HTTP/SSE session and the goroutine
+	// draining it stay alive for the rest of the process.
+	if r.transport != nil {
+		r.transport.closeConn()
+	}
+	r.transport = nil
+
 	tools, err := r.listTools(ctx, inner, transport, mcpOAuthConnectTimeout)
 	if err != nil {
+		// The replacement connected but could not list; it is abandoned here,
+		// so it must be closed too.
+		if transport != nil {
+			transport.closeConn()
+		}
 		return nil, fmt.Errorf("after re-authorizing: %w", err)
 	}
 	// Adopt the authorized connection so later callers — and the timeout path

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -39,6 +39,14 @@ var mcpConnectTimeout = 30 * time.Second
 // minutes waiting on a browser nobody will see. runInteractive turns it on.
 var interactiveOAuth atomic.Bool
 
+// mcpOAuthListen binds the loopback callback server for the interactive
+// authorization flow. It is a variable so tests can make binding fail and
+// check that a headless run does not depend on it — a sandbox or container
+// that forbids loopback listeners is exactly the case that matters.
+var mcpOAuthListen = func() (net.Listener, error) {
+	return net.Listen("tcp", "127.0.0.1:0")
+}
+
 // SetInteractiveOAuth enables or disables the automatic OAuth re-login for
 // MCP servers that answer 401/403. Only a front end with a user and a browser
 // in reach should enable it.
@@ -287,6 +295,15 @@ func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, 
 		}
 	}
 
+	// The refused connection is finished with either way — whether the
+	// replacement connects, fails to list, or cannot be built at all. Close it
+	// first, so no error path below can leave its HTTP/SSE session and the
+	// goroutine draining it alive for the rest of the process.
+	if r.transport != nil {
+		r.transport.closeConn()
+	}
+	r.transport = nil
+
 	srv := r.srv
 	srv.OAuth = true
 	srv.Headers = withoutAuthorization(srv.Headers)
@@ -298,14 +315,6 @@ func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, 
 	if err != nil {
 		return nil, fmt.Errorf("re-authorizing: %w", err)
 	}
-
-	// The refused connection is finished with either way. Close it before the
-	// replacement takes over, or its HTTP/SSE session and the goroutine
-	// draining it stay alive for the rest of the process.
-	if r.transport != nil {
-		r.transport.closeConn()
-	}
-	r.transport = nil
 
 	tools, err := r.listTools(ctx, inner, transport, mcpOAuthConnectTimeout)
 	if err != nil {
@@ -572,8 +581,18 @@ func newMCPToolset(srv MCPServerConfig) (tool.Toolset, *connTrackingTransport, e
 // and reused for the lifetime of the connection, so the flow runs only on the
 // first connect (or after the token expires).
 func newMCPOAuthHandler(name, serverURL string) (auth.OAuthHandler, error) {
+	// A headless run never completes an authorization flow — mcpOAuthCodeFetcher
+	// refuses before a browser opens — so it needs no callback server. Binding
+	// one anyway would make a sandbox or container that forbids loopback
+	// listeners fail handler construction, and the server would be skipped
+	// without its cached token ever being presented. That token is the whole
+	// reason a handler is installed there.
+	if !interactiveOAuth.Load() {
+		return newMCPOAuthTokenOnlyHandler(name, serverURL)
+	}
+
 	// Pick a free loopback port for the callback server.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := mcpOAuthListen()
 	if err != nil {
 		return nil, fmt.Errorf("starting OAuth callback listener: %w", err)
 	}
@@ -602,25 +621,57 @@ func newMCPOAuthHandler(name, serverURL string) (auth.OAuthHandler, error) {
 	cachedTS := loadMCPOAuthTokenSource(name, serverURL)
 
 	handler, err := auth.NewAuthorizationCodeHandler(&auth.AuthorizationCodeHandlerConfig{
-		RedirectURL: redirectURL,
-		DynamicClientRegistrationConfig: &auth.DynamicClientRegistrationConfig{
-			Metadata: &oauthex.ClientRegistrationMetadata{
-				ClientName:              "pi-go",
-				RedirectURIs:            []string{redirectURL},
-				GrantTypes:              []string{"authorization_code"},
-				ResponseTypes:           []string{"code"},
-				TokenEndpointAuthMethod: "none",
-			},
-		},
-		AuthorizationCodeFetcher: fetcher,
-		RequestRefreshToken:      true,
-		InitialTokenSource:       cachedTS,
+		RedirectURL:                     redirectURL,
+		DynamicClientRegistrationConfig: mcpDynamicClientRegistration(redirectURL),
+		AuthorizationCodeFetcher:        fetcher,
+		RequestRefreshToken:             true,
+		InitialTokenSource:              cachedTS,
 		// Persist each freshly authorized token along with the OAuth config
 		// needed to refresh it next session.
 		NewTokenSource: mcpOAuthNewTokenSource(name, serverURL),
 	})
 	if err != nil {
 		_ = srv.Close()
+		return nil, fmt.Errorf("creating OAuth handler: %w", err)
+	}
+	return handler, nil
+}
+
+// mcpDynamicClientRegistration describes pi-go to an authorization server for
+// RFC 7591 dynamic client registration, so no client ID has to be pre-shared.
+func mcpDynamicClientRegistration(redirectURL string) *auth.DynamicClientRegistrationConfig {
+	return &auth.DynamicClientRegistrationConfig{
+		Metadata: &oauthex.ClientRegistrationMetadata{
+			ClientName:              "pi-go",
+			RedirectURIs:            []string{redirectURL},
+			GrantTypes:              []string{"authorization_code"},
+			ResponseTypes:           []string{"code"},
+			TokenEndpointAuthMethod: "none",
+		},
+	}
+}
+
+// newMCPOAuthTokenOnlyHandler builds a handler that can present and refresh
+// stored credentials but can never obtain new ones.
+//
+// It binds nothing and opens nothing. The redirect URL is a placeholder that is
+// never reached, because the fetcher refuses before any authorization request
+// is made — which is the correct behavior with no user present: a valid cached
+// token still authenticates the connection, and a revoked one fails fast with a
+// message saying to run pi interactively once.
+func newMCPOAuthTokenOnlyHandler(name, serverURL string) (auth.OAuthHandler, error) {
+	const redirectURL = "http://127.0.0.1/callback"
+	handler, err := auth.NewAuthorizationCodeHandler(&auth.AuthorizationCodeHandlerConfig{
+		RedirectURL: redirectURL,
+		// Required by the constructor even though no flow can run here: the
+		// fetcher refuses before registration would ever be attempted.
+		DynamicClientRegistrationConfig: mcpDynamicClientRegistration(redirectURL),
+		AuthorizationCodeFetcher:        mcpOAuthCodeFetcher(name, nil, browser.Open),
+		RequestRefreshToken:             true,
+		InitialTokenSource:              loadMCPOAuthTokenSource(name, serverURL),
+		NewTokenSource:                  mcpOAuthNewTokenSource(name, serverURL),
+	})
+	if err != nil {
 		return nil, fmt.Errorf("creating OAuth handler: %w", err)
 	}
 	return handler, nil

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -255,6 +255,7 @@ func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, 
 
 	srv := r.srv
 	srv.OAuth = true
+	srv.Headers = withoutAuthorization(srv.Headers)
 	connect := r.reconnect
 	if connect == nil {
 		connect = newMCPToolset
@@ -273,6 +274,35 @@ func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, 
 	// it replaced.
 	r.inner, r.transport = inner, transport
 	return tools, nil
+}
+
+// withoutAuthorization copies headers without any Authorization entry.
+//
+// The OAuth retry must not carry the static credential that was just refused.
+// headerRoundTripper is the client's outermost transport, so it runs after the
+// SDK has set "Authorization: Bearer <fresh token>" on the request and would
+// overwrite that token with the stale configured value — the retry would be
+// rejected exactly like the first attempt. Every other header is kept: they
+// carry routing and API metadata the server still needs.
+//
+// The comparison is canonicalized because HTTP header names are
+// case-insensitive and http.Header.Set canonicalizes on the way out, so a
+// config that spells the key "authorization" collides all the same.
+func withoutAuthorization(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		if http.CanonicalHeaderKey(k) == "Authorization" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // isMCPAuthError reports whether err is the MCP transport's rendering of an

--- a/internal/extension/mcp.go
+++ b/internal/extension/mcp.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,6 +21,8 @@ import (
 
 	piauth "github.com/dimetron/pi-go/internal/auth" // SDK auth pkg is imported above
 	"github.com/dimetron/pi-go/internal/browser"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/notice"
 )
 
 var mcpConnectTimeout = 30 * time.Second
@@ -48,9 +50,20 @@ type MCPServerConfig struct {
 func BuildMCPToolsets(servers []MCPServerConfig) ([]tool.Toolset, error) {
 	var toolsets []tool.Toolset
 	for _, srv := range servers {
+		// An llms.txt index is a documentation file, not an MCP endpoint: it
+		// answers the "initialize" POST with 405 and can never yield tools.
+		// config.LoadFrom already reroutes these to the fetch_docs sources,
+		// but server lists are also assembled by hand (evals, embedded
+		// agents), so refuse to dial one here rather than emit a 405 warning
+		// on every startup.
+		if srv.URL != "" && config.IsLLMSDocsURL(srv.URL) {
+			notice.Notifyf("MCP server %q points at an llms.txt index, not an MCP endpoint — "+
+				"configure it under \"llms\": {\"sources\": [...]} and read it with the fetch_docs tool.", srv.Name)
+			continue
+		}
 		ts, err := buildMCPToolset(srv)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: warning: MCP server %q skipped: %v\n", srv.Name, err)
+			notice.Notifyf("warning: MCP server %q skipped: %v", srv.Name, err)
 			continue
 		}
 		toolsets = append(toolsets, ts)
@@ -122,8 +135,14 @@ func (t *connTrackingTransport) closeConn() {
 type resilientToolset struct {
 	inner     tool.Toolset
 	name      string
+	srv       MCPServerConfig
 	transport *connTrackingTransport
 	timeout   time.Duration
+
+	// reconnect builds a second connection for the OAuth retry. It defaults
+	// to newMCPToolset; tests replace it so the retry path can be exercised
+	// without an authorization server to talk to.
+	reconnect func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error)
 
 	once   sync.Once
 	tools  []tool.Tool
@@ -134,56 +153,152 @@ func (r *resilientToolset) Name() string { return r.name }
 
 func (r *resilientToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
 	r.once.Do(func() {
-		type result struct {
-			tools []tool.Tool
-			err   error
+		tools, err := r.listTools(ctx, r.inner, r.transport, r.timeout)
+		// A remote server answering 401/403 is not broken, it is
+		// unauthenticated — the one recoverable failure here. Re-authorize
+		// and retry once before writing the server off.
+		if err != nil && r.canReauthorize(err) {
+			tools, err = r.reauthorize(ctx)
 		}
-		ch := make(chan result, 1)
-		// Use a separate cancel channel so we can time out the inner
-		// Tools() call without wrapping ctx (which would lose the
-		// ReadonlyContext interface). The inner goroutine respects the
-		// original ctx; we simply abandon it on timeout and mark the
-		// toolset as failed.
-		timeout := r.timeout
-		if timeout == 0 {
-			timeout = mcpConnectTimeout
-		}
-		timeoutCh := time.After(timeout)
-		go func() {
-			tools, err := r.inner.Tools(ctx)
-			ch <- result{tools, err}
-		}()
-
-		select {
-		case res := <-ch:
-			if res.err != nil {
-				fmt.Fprintf(os.Stderr, "pi-go: warning: MCP server %q unavailable: %v\n", r.name, res.err)
-				r.failed = true
-				return
-			}
-			r.tools = r.deduplicateTools(res.tools)
-		case <-timeoutCh:
-			fmt.Fprintf(os.Stderr, "pi-go: warning: MCP server %q timed out after %v, skipping\n", r.name, timeout)
+		if err != nil {
+			notice.Notifyf("warning: MCP server %q unavailable: %v", r.name, err)
 			r.failed = true
-			// Close the underlying MCP connection to kill any hung
-			// subprocess and free the blocked goroutine.
-			if r.transport != nil {
-				r.transport.closeConn()
-			}
-			// Drain the result in the background so the inner goroutine
-			// can exit after the connection is closed.
-			go func() {
-				select {
-				case <-ch:
-				case <-time.After(2 * time.Second):
-				}
-			}()
+			return
 		}
+		r.tools = r.deduplicateTools(tools)
 	})
 	if r.failed {
 		return nil, nil
 	}
 	return r.tools, nil
+}
+
+// listTools runs one Tools() attempt under a timeout, so a server that accepts
+// the connection but never answers "initialize" cannot stall the turn.
+//
+// The timeout is a separate timer rather than a derived context because the
+// inner toolset needs the caller's agent.ReadonlyContext, and wrapping it in
+// context.WithTimeout would erase that interface. The inner goroutine still
+// honours the original ctx; on timeout we abandon it, close the connection
+// underneath it so it can unblock, and drain it in the background.
+func (r *resilientToolset) listTools(
+	ctx agent.ReadonlyContext,
+	inner tool.Toolset,
+	transport *connTrackingTransport,
+	timeout time.Duration,
+) ([]tool.Tool, error) {
+	type result struct {
+		tools []tool.Tool
+		err   error
+	}
+	if timeout == 0 {
+		timeout = mcpConnectTimeout
+	}
+	ch := make(chan result, 1)
+	timeoutCh := time.After(timeout)
+	go func() {
+		tools, err := inner.Tools(ctx)
+		ch <- result{tools, err}
+	}()
+
+	select {
+	case res := <-ch:
+		return res.tools, res.err
+	case <-timeoutCh:
+		// Close the underlying MCP connection to kill any hung subprocess
+		// and free the blocked goroutine.
+		if transport != nil {
+			transport.closeConn()
+		}
+		go func() {
+			select {
+			case <-ch:
+			case <-time.After(2 * time.Second):
+			}
+		}()
+		return nil, fmt.Errorf("timed out after %v, skipping", timeout)
+	}
+}
+
+// canReauthorize reports whether err is worth answering with a fresh OAuth
+// login. Only remote servers qualify — a stdio subprocess has no bearer token
+// to renew — and only genuine authorization failures, so a 404 or a DNS error
+// never opens a browser window.
+func (r *resilientToolset) canReauthorize(err error) bool {
+	return r.srv.URL != "" && isMCPAuthError(err)
+}
+
+// reauthorize answers a 401/403 by running the OAuth authorization-code flow
+// and retrying the tool listing once.
+//
+// Two cases land here and both need the same treatment. A server configured
+// without OAuth has no handler at all, so the SDK cannot recover on its own:
+// it only re-authorizes when a handler is installed, and otherwise returns the
+// 401 verbatim — which is what produced the bare "Unauthorized" warning. A
+// server configured with OAuth may be replaying a cached token the provider
+// has since revoked; the SDK would re-run the flow, but only after presenting
+// those dead credentials again. Discarding the cached token first makes this a
+// real re-login rather than a replay.
+//
+// The retry runs under mcpOAuthConnectTimeout because it contains a browser
+// round-trip — open the URL, wait for approval, wait for the redirect. The
+// normal 30s connect budget would abort mid-approval.
+func (r *resilientToolset) reauthorize(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
+	notice.Notifyf("MCP server %q rejected the connection as unauthorized — re-running OAuth login.", r.name)
+
+	// Drop cached credentials first so the flow re-authorizes instead of
+	// replaying the token that was just refused. A cache that cannot be
+	// cleared is not fatal: the flow still runs, it may just reuse the token.
+	if err := removeMCPOAuthToken(r.srv.Name, r.srv.URL); err != nil {
+		notice.Notifyf("warning: could not clear cached OAuth token for MCP server %q: %v", r.name, err)
+	}
+
+	srv := r.srv
+	srv.OAuth = true
+	connect := r.reconnect
+	if connect == nil {
+		connect = newMCPToolset
+	}
+	inner, transport, err := connect(srv)
+	if err != nil {
+		return nil, fmt.Errorf("re-authorizing: %w", err)
+	}
+
+	tools, err := r.listTools(ctx, inner, transport, mcpOAuthConnectTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("after re-authorizing: %w", err)
+	}
+	// Adopt the authorized connection so later callers — and the timeout path
+	// that closes a hung transport — act on the live one, not the connection
+	// it replaced.
+	r.inner, r.transport = inner, transport
+	return tools, nil
+}
+
+// isMCPAuthError reports whether err is the MCP transport's rendering of an
+// HTTP 401 or 403.
+//
+// The test is textual because the SDK reports a non-2xx status by formatting
+// http.StatusText into an error string rather than returning a typed error or
+// exposing the status code, so there is nothing for errors.As to match. The
+// OAuth error codes are matched too: a provider that returns a JSON body
+// ({"error":"invalid_token"}) alongside the status puts both in one string.
+func isMCPAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		strings.ToLower(http.StatusText(http.StatusUnauthorized)), // "unauthorized"
+		strings.ToLower(http.StatusText(http.StatusForbidden)),    // "forbidden"
+		"invalid_token",
+		"invalid_grant",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // deduplicateTools returns tools with their original names. When multiple
@@ -282,6 +397,29 @@ func ToolsetStatuses(toolsets []tool.Toolset) []MCPServerStatus {
 }
 
 func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
+	inner, tracked, err := newMCPToolset(srv)
+	if err != nil {
+		return nil, err
+	}
+	timeout := mcpConnectTimeout
+	if srv.OAuth {
+		timeout = mcpOAuthConnectTimeout
+	}
+	return &resilientToolset{
+		inner:     inner,
+		name:      srv.Name,
+		srv:       srv,
+		transport: tracked,
+		timeout:   timeout,
+	}, nil
+}
+
+// newMCPToolset builds one MCP connection: the transport for the configured
+// endpoint, wrapped in connection tracking so a hung one can be closed. It is
+// separate from buildMCPToolset so the OAuth retry can construct a second,
+// authorized connection for a server whose first attempt was refused, without
+// rebuilding the resilient wrapper that owns the once-only listing state.
+func newMCPToolset(srv MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
 	var transport mcp.Transport
 	switch {
 	case srv.URL != "":
@@ -294,7 +432,7 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 		if srv.OAuth {
 			handler, err := newMCPOAuthHandler(srv.Name, srv.URL)
 			if err != nil {
-				return nil, fmt.Errorf("MCP server %q: %w", srv.Name, err)
+				return nil, nil, fmt.Errorf("MCP server %q: %w", srv.Name, err)
 			}
 			t.OAuthHandler = handler
 		}
@@ -305,7 +443,7 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 			args:    srv.Args,
 		}
 	default:
-		return nil, fmt.Errorf("MCP server %q has neither command nor URL", srv.Name)
+		return nil, nil, fmt.Errorf("MCP server %q has neither command nor URL", srv.Name)
 	}
 
 	// Wrap with connection tracking so we can close the connection on timeout.
@@ -315,13 +453,9 @@ func buildMCPToolset(srv MCPServerConfig) (tool.Toolset, error) {
 		Transport: tracked,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("creating MCP toolset: %w", err)
+		return nil, nil, fmt.Errorf("creating MCP toolset: %w", err)
 	}
-	timeout := mcpConnectTimeout
-	if srv.OAuth {
-		timeout = mcpOAuthConnectTimeout
-	}
-	return &resilientToolset{inner: ts, name: srv.Name, transport: tracked, timeout: timeout}, nil
+	return ts, tracked, nil
 }
 
 // newMCPOAuthHandler builds an OAuth authorization-code handler for a remote
@@ -452,9 +586,9 @@ func mcpOAuthCodeFetcher(
 		case <-resultChan: // drop stale outcome from a previous flow
 		default:
 		}
-		fmt.Fprintf(os.Stderr, "pi-go: MCP server %q requires authorization. Opening browser...\n", name)
+		notice.Notifyf("MCP server %q requires authorization. Opening browser...", name)
 		if err := openURL(args.URL); err != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: could not open browser for %q; visit this URL manually:\n%s\n", name, args.URL)
+			notice.Notifyf("could not open browser for %q; visit this URL manually:\n%s", name, args.URL)
 		}
 		select {
 		case r := <-resultChan:
@@ -473,7 +607,7 @@ func mcpOAuthCodeFetcher(
 func mcpOAuthNewTokenSource(name, serverURL string) func(context.Context, *oauth2.Config, *oauth2.Token) (oauth2.TokenSource, error) {
 	return func(ctx context.Context, cfg *oauth2.Config, tok *oauth2.Token) (oauth2.TokenSource, error) {
 		if err := saveMCPOAuthToken(name, serverURL, cfg, tok); err != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: could not cache OAuth token for MCP server %q: %v\n", name, err)
+			notice.Notifyf("could not cache OAuth token for MCP server %q: %v", name, err)
 		}
 		return newPersistingTokenSource(cfg.TokenSource(ctx, tok), nil, func(t *oauth2.Token) error {
 			return saveMCPOAuthToken(name, serverURL, cfg, t)

--- a/internal/extension/mcp_oauth_handler_test.go
+++ b/internal/extension/mcp_oauth_handler_test.go
@@ -231,6 +231,9 @@ func TestMCPOAuthNewTokenSource_CacheFailureIsNonFatal(t *testing.T) {
 }
 
 func TestNewMCPOAuthHandler_UsesCachedToken(t *testing.T) {
+	// The full authorization-code handler is the interactive one; a headless
+	// run gets mcpTokenOnlyHandler instead.
+	allowInteractiveOAuth(t)
 	setTestHome(t)
 	const server, url = "cached-srv", "https://c.example.com/mcp"
 
@@ -265,6 +268,9 @@ func TestNewMCPOAuthHandler_UsesCachedToken(t *testing.T) {
 }
 
 func TestNewMCPOAuthHandler_NoCacheStartsUnauthorized(t *testing.T) {
+	// The full authorization-code handler is the interactive one; a headless
+	// run gets mcpTokenOnlyHandler instead.
+	allowInteractiveOAuth(t)
 	setTestHome(t)
 	h, err := newMCPOAuthHandler("fresh-srv", "https://f.example.com/mcp")
 	if err != nil {

--- a/internal/extension/mcp_oauth_handler_test.go
+++ b/internal/extension/mcp_oauth_handler_test.go
@@ -117,6 +117,8 @@ func TestMCPOAuthCallbackHandler(t *testing.T) {
 }
 
 func TestMCPOAuthCodeFetcher(t *testing.T) {
+	allowInteractiveOAuth(t)
+
 	t.Run("returns callback result and opens browser", func(t *testing.T) {
 		ch := make(chan mcpOAuthCallbackResult, 1)
 		var opened string
@@ -278,5 +280,29 @@ func TestNewMCPOAuthHandler_NoCacheStartsUnauthorized(t *testing.T) {
 	}
 	if ts != nil {
 		t.Errorf("expected no token source before authorization, got %T", ts)
+	}
+}
+
+// The SDK calls the fetcher itself on any 401/403, so it is the last place
+// that can stop a browser opening in a print, JSON, RPC, socket or ACP run.
+// A cached token is still worth presenting there, which is why the handler is
+// installed at all — but the flow that needs a human must fail immediately
+// rather than block the run for the browser timeout.
+func TestMCPOAuthCodeFetcherRefusesWhenNonInteractive(t *testing.T) {
+	opened := false
+	fetcher := mcpOAuthCodeFetcher("srv", make(chan mcpOAuthCallbackResult, 1), func(string) error {
+		opened = true
+		return nil
+	})
+
+	res, err := fetcher(context.Background(), &auth.AuthorizationArgs{URL: "https://as.example.com/authorize"})
+	if err == nil {
+		t.Fatalf("got res=%v, want a refusal", res)
+	}
+	if opened {
+		t.Error("opened a browser with no user present")
+	}
+	if !strings.Contains(err.Error(), "no user to grant it") {
+		t.Errorf("error %q does not explain why", err)
 	}
 }

--- a/internal/extension/mcp_oauth_store.go
+++ b/internal/extension/mcp_oauth_store.go
@@ -214,6 +214,20 @@ func saveMCPOAuthToken(server, serverURL string, cfg *oauth2.Config, tok *oauth2
 	return nil
 }
 
+// hasCachedMCPOAuthToken reports whether usable credentials are already stored
+// for a server identity.
+//
+// It is what lets an automatic OAuth upgrade survive a restart. A server the
+// user configured without oauth: true, that was authorized after answering 401
+// once, would otherwise be rebuilt with no OAuth handler on the next launch:
+// it would send an unauthenticated request, be refused, and run the whole
+// browser flow again every time. Seeing a cached token here means the previous
+// upgrade succeeded, so the handler is installed from the start and the stored
+// credentials are presented instead.
+func hasCachedMCPOAuthToken(server, serverURL string) bool {
+	return loadMCPOAuthTokenSource(server, serverURL) != nil
+}
+
 // removeMCPOAuthToken discards the cached credentials for a server identity,
 // so the next connect runs the authorization flow instead of replaying a token
 // the provider has refused. A missing file is success: the goal is that no

--- a/internal/extension/mcp_oauth_store.go
+++ b/internal/extension/mcp_oauth_store.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+
+	"github.com/dimetron/pi-go/internal/notice"
 )
 
 // mcpOAuthTokenTTL bounds how long a persisted MCP OAuth token is reused.
@@ -144,7 +146,7 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 
 	if changed {
 		if err := p.saveFn(tok); err != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: could not update cached MCP OAuth token: %v\n", err)
+			notice.Notifyf("could not update cached MCP OAuth token: %v", err)
 		}
 	}
 	return tok, nil
@@ -208,6 +210,21 @@ func saveMCPOAuthToken(server, serverURL string, cfg *oauth2.Config, tok *oauth2
 	if err := os.Rename(tmpName, path); err != nil {
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("installing MCP OAuth cache: %w", err)
+	}
+	return nil
+}
+
+// removeMCPOAuthToken discards the cached credentials for a server identity,
+// so the next connect runs the authorization flow instead of replaying a token
+// the provider has refused. A missing file is success: the goal is that no
+// cached token remains, not that one was deleted.
+func removeMCPOAuthToken(server, serverURL string) error {
+	path, err := mcpOAuthTokenFile(server, serverURL)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -728,5 +729,104 @@ func TestBuildMCPToolset_CachedTokenKeepsFastTimeoutWhenHeadless(t *testing.T) {
 	if rt.timeout != mcpConnectTimeout {
 		t.Errorf("timeout = %v, want the fast budget %v; nothing waits on a browser here",
 			rt.timeout, mcpConnectTimeout)
+	}
+}
+
+// A headless run must not depend on binding a loopback listener. A sandbox or
+// container that forbids one would otherwise fail handler construction and
+// skip the server without ever presenting the cached token that is the only
+// reason a handler is installed there at all.
+func TestNewMCPOAuthHandler_HeadlessNeedsNoListener(t *testing.T) {
+	setTestHome(t)
+	// Deliberately no allowInteractiveOAuth.
+	refuseLoopbackListen(t)
+
+	h, err := newMCPOAuthHandler("srv", "https://mcp.example.com/mcp")
+	if err != nil {
+		t.Fatalf("newMCPOAuthHandler: %v", err)
+	}
+	if h == nil {
+		t.Fatal("no handler returned; a cached token could never be presented")
+	}
+}
+
+// The interactive handler does need one — it has to receive the redirect — so
+// a bind failure there is a real error rather than something to paper over.
+func TestNewMCPOAuthHandler_InteractiveRequiresListener(t *testing.T) {
+	setTestHome(t)
+	allowInteractiveOAuth(t)
+	refuseLoopbackListen(t)
+
+	if _, err := newMCPOAuthHandler("srv", "https://mcp.example.com/mcp"); err == nil {
+		t.Fatal("expected an error when the callback listener cannot bind")
+	} else if !strings.Contains(err.Error(), "callback listener") {
+		t.Errorf("error %q does not name the listener", err)
+	}
+}
+
+// A server whose cached token is presented headlessly still builds when
+// loopback binding is impossible.
+func TestBuildMCPToolset_HeadlessCachedTokenSurvivesNoListener(t *testing.T) {
+	setTestHome(t)
+	refuseLoopbackListen(t)
+
+	const (
+		name = "openrouter"
+		url  = "https://mcp.example.com/mcp"
+	)
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "cached", RefreshToken: "r", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(name, url, cfg, tok); err != nil {
+		t.Fatalf("seeding the token cache: %v", err)
+	}
+
+	ts, err := buildMCPToolset(MCPServerConfig{Name: name, URL: url})
+	if err != nil {
+		t.Fatalf("buildMCPToolset: %v; the cached token would never be presented", err)
+	}
+	if !ts.(*resilientToolset).srv.OAuth {
+		t.Error("cached credentials were not presented")
+	}
+}
+
+// refuseLoopbackListen makes the callback listener fail to bind, standing in
+// for a sandbox that forbids loopback servers.
+func refuseLoopbackListen(t *testing.T) {
+	t.Helper()
+	prev := mcpOAuthListen
+	mcpOAuthListen = func() (net.Listener, error) {
+		return nil, fmt.Errorf("operation not permitted")
+	}
+	t.Cleanup(func() { mcpOAuthListen = prev })
+}
+
+// The refused connection must be closed even when the replacement cannot be
+// built at all, not only when it connects and then fails.
+func TestResilientToolset_ReauthorizeClosesRefusedConnectionOnSetupFailure(t *testing.T) {
+	setTestHome(t)
+	allowInteractiveOAuth(t)
+	captureNotices(t)
+
+	old := &connTrackingTransport{}
+	old.conn = &closeCountingConn{}
+	oldConn := old.conn.(*closeCountingConn)
+
+	rt := &resilientToolset{
+		inner:     &unauthorizedToolset{},
+		name:      "openrouter",
+		srv:       MCPServerConfig{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+		transport: old,
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			return nil, nil, fmt.Errorf("starting OAuth callback listener: permission denied")
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if !rt.failed {
+		t.Error("expected the server to be marked failed")
+	}
+	if oldConn.closes() == 0 {
+		t.Error("refused connection leaked when the replacement could not be built")
 	}
 }

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -830,3 +830,44 @@ func TestResilientToolset_ReauthorizeClosesRefusedConnectionOnSetupFailure(t *te
 		t.Error("refused connection leaked when the replacement could not be built")
 	}
 }
+
+// A server upgraded from a static credential must not carry that credential
+// forward on the next launch: headerRoundTripper runs last and would overwrite
+// the cached bearer token, producing another 401 every time.
+func TestBuildMCPToolset_CachedUpgradeDropsStaticAuthorization(t *testing.T) {
+	setTestHome(t)
+	allowInteractiveOAuth(t)
+
+	const (
+		name = "openrouter"
+		url  = "https://mcp.example.com/mcp"
+	)
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "cached", RefreshToken: "r", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(name, url, cfg, tok); err != nil {
+		t.Fatalf("seeding the token cache: %v", err)
+	}
+
+	srv := MCPServerConfig{
+		Name:    name,
+		URL:     url,
+		Headers: map[string]string{"Authorization": "Bearer refused", "X-Title": "pi"},
+	}
+	ts, err := buildMCPToolset(srv)
+	if err != nil {
+		t.Fatalf("buildMCPToolset: %v", err)
+	}
+	rt := ts.(*resilientToolset)
+	if !rt.srv.OAuth {
+		t.Fatal("cached credentials did not enable OAuth")
+	}
+	if _, ok := rt.srv.Headers["Authorization"]; ok {
+		t.Error("carried the refused Authorization header; it would overwrite the cached token")
+	}
+	if rt.srv.Headers["X-Title"] != "pi" {
+		t.Errorf("dropped an unrelated header: %v", rt.srv.Headers)
+	}
+	if srv.Headers["Authorization"] != "Bearer refused" {
+		t.Error("mutated the caller's configured headers")
+	}
+}

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -831,10 +832,10 @@ func TestResilientToolset_ReauthorizeClosesRefusedConnectionOnSetupFailure(t *te
 	}
 }
 
-// A server upgraded from a static credential must not carry that credential
-// forward on the next launch: headerRoundTripper runs last and would overwrite
-// the cached bearer token, producing another 401 every time.
-func TestBuildMCPToolset_CachedUpgradeDropsStaticAuthorization(t *testing.T) {
+// An explicit Authorization header is the user's current instruction and must
+// outrank a token cached from an earlier run — otherwise replacing a rejected
+// API key with a working one has no effect until the cache expires.
+func TestBuildMCPToolset_ExplicitHeaderBeatsCachedToken(t *testing.T) {
 	setTestHome(t)
 	allowInteractiveOAuth(t)
 
@@ -848,26 +849,85 @@ func TestBuildMCPToolset_CachedUpgradeDropsStaticAuthorization(t *testing.T) {
 		t.Fatalf("seeding the token cache: %v", err)
 	}
 
-	srv := MCPServerConfig{
+	ts, err := buildMCPToolset(MCPServerConfig{
 		Name:    name,
 		URL:     url,
-		Headers: map[string]string{"Authorization": "Bearer refused", "X-Title": "pi"},
-	}
-	ts, err := buildMCPToolset(srv)
+		Headers: map[string]string{"Authorization": "Bearer freshly-configured", "X-Title": "pi"},
+	})
 	if err != nil {
 		t.Fatalf("buildMCPToolset: %v", err)
 	}
 	rt := ts.(*resilientToolset)
-	if !rt.srv.OAuth {
-		t.Fatal("cached credentials did not enable OAuth")
+	if rt.srv.OAuth {
+		t.Error("cached token overrode an explicitly configured credential")
 	}
-	if _, ok := rt.srv.Headers["Authorization"]; ok {
-		t.Error("carried the refused Authorization header; it would overwrite the cached token")
-	}
-	if rt.srv.Headers["X-Title"] != "pi" {
-		t.Errorf("dropped an unrelated header: %v", rt.srv.Headers)
-	}
-	if srv.Headers["Authorization"] != "Bearer refused" {
-		t.Error("mutated the caller's configured headers")
+	if rt.srv.Headers["Authorization"] != "Bearer freshly-configured" {
+		t.Errorf("configured credential not sent: %v", rt.srv.Headers)
 	}
 }
+
+func TestHasAuthorizationHeader(t *testing.T) {
+	tests := []struct {
+		in   map[string]string
+		want bool
+	}{
+		{nil, false},
+		{map[string]string{}, false},
+		{map[string]string{"X-Title": "pi"}, false},
+		{map[string]string{"Authorization": "Bearer k"}, true},
+		{map[string]string{"authorization": "Bearer k"}, true},
+		{map[string]string{"Authorization": ""}, false},
+	}
+	for _, tc := range tests {
+		if got := hasAuthorizationHeader(tc.in); got != tc.want {
+			t.Errorf("hasAuthorizationHeader(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The headless handler must refuse before the SDK can run discovery,
+// authorization-server metadata retrieval or dynamic client registration —
+// those are network calls against the server, and they block the run.
+func TestMCPTokenOnlyHandler(t *testing.T) {
+	h := &mcpTokenOnlyHandler{name: "openrouter"}
+
+	ts, err := h.TokenSource(context.Background())
+	if err != nil {
+		t.Fatalf("TokenSource: %v", err)
+	}
+	if ts != nil {
+		t.Errorf("TokenSource = %v, want nil when nothing is cached", ts)
+	}
+
+	body := &closeTrackingBody{}
+	resp := &http.Response{StatusCode: http.StatusUnauthorized, Body: body}
+	err = h.Authorize(context.Background(), nil, resp)
+	if err == nil {
+		t.Fatal("Authorize succeeded; it must refuse with no user present")
+	}
+	if !strings.Contains(err.Error(), "no user to grant it") {
+		t.Errorf("error %q does not explain why", err)
+	}
+	// The interface makes the handler responsible for the response body.
+	if !body.closed {
+		t.Error("Authorize did not close the response body")
+	}
+}
+
+func TestMCPTokenOnlyHandlerReturnsCachedSource(t *testing.T) {
+	want := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "cached"})
+	h := &mcpTokenOnlyHandler{name: "srv", ts: want}
+
+	got, err := h.TokenSource(context.Background())
+	if err != nil {
+		t.Fatalf("TokenSource: %v", err)
+	}
+	if got != want {
+		t.Error("cached credentials were not presented")
+	}
+}
+
+type closeTrackingBody struct{ closed bool }
+
+func (b *closeTrackingBody) Read([]byte) (int, error) { return 0, io.EOF }
+func (b *closeTrackingBody) Close() error             { b.closed = true; return nil }

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -36,6 +36,15 @@ func captureNotices(t *testing.T) func() []string {
 	}
 }
 
+// allowInteractiveOAuth enables the browser re-login for the duration of a
+// test. It is off by default so headless runs are never blocked on an approval
+// nobody will see, which means every test of the retry path must opt in.
+func allowInteractiveOAuth(t *testing.T) {
+	t.Helper()
+	SetInteractiveOAuth(true)
+	t.Cleanup(func() { SetInteractiveOAuth(false) })
+}
+
 func TestIsMCPAuthError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -76,6 +85,7 @@ func (u *unauthorizedToolset) Tools(agent.ReadonlyContext) ([]tool.Tool, error) 
 
 func TestResilientToolset_ReauthorizesOn401(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	notices := captureNotices(t)
 
 	authorized := &successToolset{tools: []tool.Tool{&namedTool{nameVal: "list-benchmarks"}}}
@@ -119,6 +129,7 @@ func TestResilientToolset_ReauthorizesOn401(t *testing.T) {
 // "re-login" replays the same dead credentials.
 func TestResilientToolset_ReauthorizeClearsCachedToken(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	captureNotices(t)
 
 	const (
@@ -159,6 +170,7 @@ func TestResilientToolset_ReauthorizeClearsCachedToken(t *testing.T) {
 // one must never open a browser.
 func TestResilientToolset_NoReauthorizeForCommandServer(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	notices := captureNotices(t)
 
 	reconnected := false
@@ -188,6 +200,7 @@ func TestResilientToolset_NoReauthorizeForCommandServer(t *testing.T) {
 // A non-auth failure must be reported as-is, without a browser round-trip.
 func TestResilientToolset_NoReauthorizeForOtherErrors(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	notices := captureNotices(t)
 
 	reconnected := false
@@ -215,6 +228,7 @@ func TestResilientToolset_NoReauthorizeForOtherErrors(t *testing.T) {
 // rather than looping through the authorization flow again.
 func TestResilientToolset_ReauthorizeFailureIsTerminal(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	notices := captureNotices(t)
 
 	second := &unauthorizedToolset{}
@@ -249,6 +263,7 @@ func TestResilientToolset_ReauthorizeFailureIsTerminal(t *testing.T) {
 
 func TestResilientToolset_ReconnectErrorIsReported(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	notices := captureNotices(t)
 
 	rt := &resilientToolset{
@@ -412,6 +427,7 @@ func TestWithoutAuthorizationDoesNotMutateInput(t *testing.T) {
 // retry would be rejected exactly like the first attempt.
 func TestResilientToolset_ReauthorizeDropsStaleAuthorizationHeader(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 	captureNotices(t)
 
 	var gotSrv MCPServerConfig
@@ -441,5 +457,62 @@ func TestResilientToolset_ReauthorizeDropsStaleAuthorizationHeader(t *testing.T)
 	// The loaded config must be left intact for anything else reading it.
 	if rt.srv.Headers["Authorization"] != "Bearer revoked" {
 		t.Error("re-authorization mutated the server's configured headers")
+	}
+}
+
+// Print, JSON, RPC, socket and ACP runs have no user at a browser. A 401 there
+// must be reported and skipped after the normal connect timeout, exactly as it
+// was before automatic re-login existed — never met with a browser window and
+// a ten-minute wait that would stall a headless pipeline.
+func TestResilientToolset_NoReauthorizeWhenNonInteractive(t *testing.T) {
+	setTestHome(t)
+	notices := captureNotices(t)
+	// Deliberately no allowInteractiveOAuth: this is the default state.
+
+	reconnected := false
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  "openrouter",
+		srv:   MCPServerConfig{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			reconnected = true
+			return nil, nil, nil
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if reconnected {
+		t.Error("opened a browser re-login in a headless run")
+	}
+	if !rt.failed {
+		t.Error("expected the server to be marked failed")
+	}
+	if hasNoticeContaining(notices(), "re-running OAuth login") {
+		t.Errorf("announced an OAuth re-login with no user present; notices: %v", notices())
+	}
+	if !hasNoticeContaining(notices(), "Unauthorized") {
+		t.Errorf("failure was not reported; notices: %v", notices())
+	}
+}
+
+// An entry that declares configuration only a real MCP endpoint needs is
+// dialled whatever its URL looks like, so the llms.txt name heuristic can
+// never silently remove a working server.
+func TestBuildMCPToolsets_KeepsConfiguredServerAtLLMSPath(t *testing.T) {
+	notices := captureNotices(t)
+
+	toolsets, err := BuildMCPToolsets([]MCPServerConfig{
+		{Name: "authed", URL: "https://example.com/llms.txt", Headers: map[string]string{"Authorization": "Bearer k"}},
+		{Name: "oauthed", URL: "https://example.com/llms-full.txt", OAuth: true},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPToolsets: %v", err)
+	}
+	if len(toolsets) != 2 {
+		t.Fatalf("built %d toolsets, want 2; a configured MCP endpoint was rerouted on its path alone", len(toolsets))
+	}
+	if hasNoticeContaining(notices(), "fetch_docs") {
+		t.Errorf("rerouted a server that declares MCP-only config; notices: %v", notices())
 	}
 }

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -1,0 +1,363 @@
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/tool"
+
+	"github.com/dimetron/pi-go/internal/notice"
+)
+
+// captureNotices installs a sink that records notices for the duration of the
+// test, so assertions can check what the user was actually told and nothing
+// leaks to os.Stderr and into a TUI frame.
+func captureNotices(t *testing.T) func() []string {
+	t.Helper()
+	var mu sync.Mutex
+	var got []string
+	prev := notice.SetSink(func(msg string) {
+		mu.Lock()
+		got = append(got, msg)
+		mu.Unlock()
+	})
+	t.Cleanup(func() { notice.SetSink(prev) })
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), got...)
+	}
+}
+
+func TestIsMCPAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			// The shape the streamable client actually produces: the SDK
+			// formats http.StatusText into the message.
+			name: "401 from the transport",
+			err:  fmt.Errorf(`failed to init MCP session: calling "initialize": sending "initialize": Unauthorized`),
+			want: true,
+		},
+		{"403", fmt.Errorf("sending \"initialize\": Forbidden"), true},
+		{"oauth error code", fmt.Errorf(`{"error":"invalid_token"}`), true},
+		{"expired refresh token", fmt.Errorf("oauth2: cannot fetch token: invalid_grant"), true},
+		{"405 is not an auth failure", fmt.Errorf("sending \"initialize\": Method Not Allowed"), false},
+		{"transport failure", fmt.Errorf("dial tcp: connection refused"), false},
+		{"crash", fmt.Errorf("MCP server crashed: EOF"), false},
+	}
+	for _, tc := range tests {
+		if got := isMCPAuthError(tc.err); got != tc.want {
+			t.Errorf("%s: isMCPAuthError(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}
+
+// unauthorizedToolset fails the way a remote MCP server that wants a bearer
+// token does: the transport surfaces the 401 as "Unauthorized".
+type unauthorizedToolset struct{ calls int }
+
+func (u *unauthorizedToolset) Name() string { return "unauthorized" }
+func (u *unauthorizedToolset) Tools(agent.ReadonlyContext) ([]tool.Tool, error) {
+	u.calls++
+	return nil, fmt.Errorf(`failed to init MCP session: calling "initialize": Unauthorized`)
+}
+
+func TestResilientToolset_ReauthorizesOn401(t *testing.T) {
+	setTestHome(t)
+	notices := captureNotices(t)
+
+	authorized := &successToolset{tools: []tool.Tool{&namedTool{nameVal: "list-benchmarks"}}}
+	var gotSrv MCPServerConfig
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  "openrouter",
+		srv:   MCPServerConfig{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+		reconnect: func(srv MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			gotSrv = srv
+			return authorized, nil, nil
+		},
+	}
+
+	tools, err := rt.Tools(nil)
+	if err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name() != "list-benchmarks" {
+		t.Fatalf("tools = %v, want the authorized connection's tools", tools)
+	}
+	if rt.failed {
+		t.Error("toolset marked failed after a successful re-authorization")
+	}
+	if !gotSrv.OAuth {
+		t.Error("retry did not enable OAuth; the SDK only re-authorizes when a handler is installed")
+	}
+	if gotSrv.URL != "https://mcp.example.com/mcp" {
+		t.Errorf("retry targeted %q, want the configured endpoint", gotSrv.URL)
+	}
+	// The live connection must be the authorized one, not the refused one.
+	if rt.inner != tool.Toolset(authorized) {
+		t.Error("toolset did not adopt the authorized connection")
+	}
+	if !hasNoticeContaining(notices(), "re-running OAuth login") {
+		t.Errorf("user was not told a re-login was happening; notices: %v", notices())
+	}
+}
+
+// A cached token the provider has since revoked must be discarded, or the
+// "re-login" replays the same dead credentials.
+func TestResilientToolset_ReauthorizeClearsCachedToken(t *testing.T) {
+	setTestHome(t)
+	captureNotices(t)
+
+	const (
+		name = "openrouter"
+		url  = "https://mcp.example.com/mcp"
+	)
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "revoked", RefreshToken: "r", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(name, url, cfg, tok); err != nil {
+		t.Fatalf("seeding the token cache: %v", err)
+	}
+	path, err := mcpOAuthTokenFile(name, url)
+	if err != nil {
+		t.Fatalf("mcpOAuthTokenFile: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cached token was not written: %v", err)
+	}
+
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  name,
+		srv:   MCPServerConfig{Name: name, URL: url},
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			return &successToolset{tools: []tool.Tool{&namedTool{nameVal: "t"}}}, nil, nil
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("revoked token still cached at %s (stat err %v)", path, err)
+	}
+}
+
+// A stdio server has no bearer token to renew, so a 401-looking message from
+// one must never open a browser.
+func TestResilientToolset_NoReauthorizeForCommandServer(t *testing.T) {
+	setTestHome(t)
+	notices := captureNotices(t)
+
+	reconnected := false
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  "local",
+		srv:   MCPServerConfig{Name: "local", Command: "some-server"},
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			reconnected = true
+			return nil, nil, nil
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if reconnected {
+		t.Error("ran the OAuth flow for a stdio server")
+	}
+	if !rt.failed {
+		t.Error("expected the server to be marked failed")
+	}
+	if hasNoticeContaining(notices(), "re-running OAuth login") {
+		t.Errorf("announced an OAuth re-login for a stdio server; notices: %v", notices())
+	}
+}
+
+// A non-auth failure must be reported as-is, without a browser round-trip.
+func TestResilientToolset_NoReauthorizeForOtherErrors(t *testing.T) {
+	setTestHome(t)
+	notices := captureNotices(t)
+
+	reconnected := false
+	rt := &resilientToolset{
+		inner: &failingToolset{},
+		name:  "broken",
+		srv:   MCPServerConfig{Name: "broken", URL: "https://mcp.example.com/mcp"},
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			reconnected = true
+			return nil, nil, nil
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if reconnected {
+		t.Error("re-authorized a server that failed for a non-auth reason")
+	}
+	if !hasNoticeContaining(notices(), "unavailable") {
+		t.Errorf("failure was not reported; notices: %v", notices())
+	}
+}
+
+// The retry runs once. If it is also refused, the server is reported failed
+// rather than looping through the authorization flow again.
+func TestResilientToolset_ReauthorizeFailureIsTerminal(t *testing.T) {
+	setTestHome(t)
+	notices := captureNotices(t)
+
+	second := &unauthorizedToolset{}
+	calls := 0
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  "openrouter",
+		srv:   MCPServerConfig{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			calls++
+			return second, nil, nil
+		},
+	}
+
+	tools, err := rt.Tools(nil)
+	if err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if len(tools) != 0 {
+		t.Errorf("tools = %v, want none", tools)
+	}
+	if calls != 1 {
+		t.Errorf("reconnect called %d times, want exactly 1", calls)
+	}
+	if !rt.failed {
+		t.Error("expected the server to be marked failed")
+	}
+	if !hasNoticeContaining(notices(), "after re-authorizing") {
+		t.Errorf("failure did not say the retry was the thing that failed; notices: %v", notices())
+	}
+}
+
+func TestResilientToolset_ReconnectErrorIsReported(t *testing.T) {
+	setTestHome(t)
+	notices := captureNotices(t)
+
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  "openrouter",
+		srv:   MCPServerConfig{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			return nil, nil, fmt.Errorf("no authorization server advertised")
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if !rt.failed {
+		t.Error("expected the server to be marked failed")
+	}
+	if !hasNoticeContaining(notices(), "no authorization server advertised") {
+		t.Errorf("reconnect error was swallowed; notices: %v", notices())
+	}
+}
+
+// An llms.txt index answers "initialize" with 405 and can never yield tools;
+// dialing it produces a warning on every startup and nothing else.
+func TestBuildMCPToolsets_SkipsLLMSDocsIndex(t *testing.T) {
+	notices := captureNotices(t)
+
+	toolsets, err := BuildMCPToolsets([]MCPServerConfig{
+		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
+		{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPToolsets: %v", err)
+	}
+	if len(toolsets) != 1 {
+		t.Fatalf("built %d toolsets, want 1 (the docs index skipped)", len(toolsets))
+	}
+	if toolsets[0].Name() != "openrouter" {
+		t.Errorf("kept %q, want the real MCP server", toolsets[0].Name())
+	}
+	if !hasNoticeContaining(notices(), "fetch_docs") {
+		t.Errorf("user was not pointed at fetch_docs; notices: %v", notices())
+	}
+}
+
+// The notice must name the tool and the config key the user has to edit,
+// otherwise it is just another warning with no way to act on it.
+func TestBuildMCPToolsets_LLMSNoticeIsActionable(t *testing.T) {
+	notices := captureNotices(t)
+
+	if _, err := BuildMCPToolsets([]MCPServerConfig{
+		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms-full.txt"},
+	}); err != nil {
+		t.Fatalf("BuildMCPToolsets: %v", err)
+	}
+	msgs := notices()
+	if len(msgs) != 1 {
+		t.Fatalf("notices = %v, want exactly one", msgs)
+	}
+	for _, want := range []string{"adk-docs-mcp", "llms", "sources", "fetch_docs"} {
+		if !strings.Contains(msgs[0], want) {
+			t.Errorf("notice %q does not mention %q", msgs[0], want)
+		}
+	}
+}
+
+func hasNoticeContaining(msgs []string, want string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// Guard against the cache file format drifting out from under
+// removeMCPOAuthToken: it must be removing the same file saveMCPOAuthToken
+// wrote, not a path that happens not to exist.
+func TestRemoveMCPOAuthToken(t *testing.T) {
+	setTestHome(t)
+
+	const (
+		name = "srv"
+		url  = "https://a.example.com/mcp"
+	)
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	if err := saveMCPOAuthToken(name, url, cfg, &oauth2.Token{AccessToken: "a"}); err != nil {
+		t.Fatalf("saveMCPOAuthToken: %v", err)
+	}
+	path, err := mcpOAuthTokenFile(name, url)
+	if err != nil {
+		t.Fatalf("mcpOAuthTokenFile: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the cached token: %v", err)
+	}
+	var stored mcpOAuthToken
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("cached token is not the expected document: %v", err)
+	}
+
+	if err := removeMCPOAuthToken(name, url); err != nil {
+		t.Fatalf("removeMCPOAuthToken: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("token still present after removal (stat err %v)", err)
+	}
+	// Removing again is success: the goal is that nothing remains cached.
+	if err := removeMCPOAuthToken(name, url); err != nil {
+		t.Errorf("removing an absent token returned %v, want nil", err)
+	}
+}

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -1,13 +1,18 @@
 package extension
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"golang.org/x/oauth2"
 	"google.golang.org/adk/v2/agent"
@@ -285,11 +290,61 @@ func TestResilientToolset_ReconnectErrorIsReported(t *testing.T) {
 	}
 }
 
-// An llms.txt index answers "initialize" with 405 and can never yield tools;
-// dialing it produces a warning on every startup and nothing else.
-func TestBuildMCPToolsets_SkipsLLMSDocsIndex(t *testing.T) {
+// A docs index configured as an MCP server is still dialled — the base name
+// cannot prove it is not a real endpoint — but when the connection fails the
+// message must explain what the entry actually is, not just relay a 405.
+func TestResilientToolset_DiagnosesLLMSDocsIndexOnFailure(t *testing.T) {
 	notices := captureNotices(t)
 
+	rt := &resilientToolset{
+		inner: &methodNotAllowedToolset{},
+		name:  "adk-docs-mcp",
+		srv:   MCPServerConfig{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if !rt.failed {
+		t.Error("expected the server to be marked failed")
+	}
+	msgs := notices()
+	if len(msgs) != 1 {
+		t.Fatalf("notices = %v, want exactly one", msgs)
+	}
+	for _, want := range []string{"adk-docs-mcp", "fetch_docs", "llms", "sources", "Method Not Allowed"} {
+		if !strings.Contains(msgs[0], want) {
+			t.Errorf("notice %q does not mention %q", msgs[0], want)
+		}
+	}
+}
+
+// A server that declares MCP-only configuration gets the plain failure
+// message, never the docs-index diagnosis.
+func TestResilientToolset_NoLLMSDiagnosisForConfiguredEndpoint(t *testing.T) {
+	notices := captureNotices(t)
+
+	rt := &resilientToolset{
+		inner: &methodNotAllowedToolset{},
+		name:  "authed",
+		srv: MCPServerConfig{
+			Name:    "authed",
+			URL:     "https://example.com/llms.txt",
+			Headers: map[string]string{"Authorization": "Bearer k"},
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if hasNoticeContaining(notices(), "fetch_docs") {
+		t.Errorf("diagnosed a configured MCP endpoint as a docs index; notices: %v", notices())
+	}
+	if !hasNoticeContaining(notices(), "unavailable") {
+		t.Errorf("failure was not reported; notices: %v", notices())
+	}
+}
+
+// A docs index is dialled like any other server; nothing is skipped on a name.
+func TestBuildMCPToolsets_DialsLLMSDocsIndex(t *testing.T) {
 	toolsets, err := BuildMCPToolsets([]MCPServerConfig{
 		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
 		{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
@@ -297,36 +352,18 @@ func TestBuildMCPToolsets_SkipsLLMSDocsIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildMCPToolsets: %v", err)
 	}
-	if len(toolsets) != 1 {
-		t.Fatalf("built %d toolsets, want 1 (the docs index skipped)", len(toolsets))
-	}
-	if toolsets[0].Name() != "openrouter" {
-		t.Errorf("kept %q, want the real MCP server", toolsets[0].Name())
-	}
-	if !hasNoticeContaining(notices(), "fetch_docs") {
-		t.Errorf("user was not pointed at fetch_docs; notices: %v", notices())
+	if len(toolsets) != 2 {
+		t.Fatalf("built %d toolsets, want 2; nothing may be dropped on a URL base name", len(toolsets))
 	}
 }
 
-// The notice must name the tool and the config key the user has to edit,
-// otherwise it is just another warning with no way to act on it.
-func TestBuildMCPToolsets_LLMSNoticeIsActionable(t *testing.T) {
-	notices := captureNotices(t)
+// methodNotAllowedToolset fails the way an llms.txt index does when something
+// POSTs "initialize" at it.
+type methodNotAllowedToolset struct{}
 
-	if _, err := BuildMCPToolsets([]MCPServerConfig{
-		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms-full.txt"},
-	}); err != nil {
-		t.Fatalf("BuildMCPToolsets: %v", err)
-	}
-	msgs := notices()
-	if len(msgs) != 1 {
-		t.Fatalf("notices = %v, want exactly one", msgs)
-	}
-	for _, want := range []string{"adk-docs-mcp", "llms", "sources", "fetch_docs"} {
-		if !strings.Contains(msgs[0], want) {
-			t.Errorf("notice %q does not mention %q", msgs[0], want)
-		}
-	}
+func (m *methodNotAllowedToolset) Name() string { return "405" }
+func (m *methodNotAllowedToolset) Tools(agent.ReadonlyContext) ([]tool.Tool, error) {
+	return nil, fmt.Errorf(`failed to init MCP session: calling "initialize": Method Not Allowed`)
 }
 
 func hasNoticeContaining(msgs []string, want string) bool {
@@ -515,4 +552,67 @@ func TestBuildMCPToolsets_KeepsConfiguredServerAtLLMSPath(t *testing.T) {
 	if hasNoticeContaining(notices(), "fetch_docs") {
 		t.Errorf("rerouted a server that declares MCP-only config; notices: %v", notices())
 	}
+}
+
+// A connection that is replaced or abandoned must be closed, or its HTTP/SSE
+// session and the goroutine draining it stay alive for the process lifetime.
+func TestResilientToolset_ReauthorizeClosesReplacedConnection(t *testing.T) {
+	setTestHome(t)
+	allowInteractiveOAuth(t)
+	captureNotices(t)
+
+	old := &connTrackingTransport{inner: &countingTransport{}}
+	old.conn = &closeCountingConn{}
+	replacement := &connTrackingTransport{inner: &countingTransport{}}
+	replacement.conn = &closeCountingConn{}
+
+	rt := &resilientToolset{
+		inner:     &unauthorizedToolset{},
+		name:      "openrouter",
+		srv:       MCPServerConfig{Name: "openrouter", URL: "https://mcp.example.com/mcp"},
+		transport: old,
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			// The retry also fails, so its connection is abandoned too.
+			return &unauthorizedToolset{}, replacement, nil
+		},
+	}
+	oldConn := old.conn.(*closeCountingConn)
+	newConn := replacement.conn.(*closeCountingConn)
+
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if oldConn.closes() == 0 {
+		t.Error("the refused connection was replaced without being closed")
+	}
+	if newConn.closes() == 0 {
+		t.Error("the abandoned retry connection was not closed")
+	}
+}
+
+type countingTransport struct{}
+
+func (c *countingTransport) Connect(context.Context) (mcp.Connection, error) {
+	return &closeCountingConn{}, nil
+}
+
+// closeCountingConn is a minimal mcp.Connection that records Close calls.
+type closeCountingConn struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c *closeCountingConn) Read(context.Context) (jsonrpc.Message, error) { return nil, io.EOF }
+func (c *closeCountingConn) Write(context.Context, jsonrpc.Message) error  { return io.EOF }
+func (c *closeCountingConn) SessionID() string                             { return "" }
+func (c *closeCountingConn) Close() error {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	return nil
+}
+func (c *closeCountingConn) closes() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
 }

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -624,6 +624,7 @@ func (c *closeCountingConn) closes() int {
 // unauthenticated, is refused, and the browser flow runs on every launch.
 func TestBuildMCPToolset_UpgradesServerWithCachedToken(t *testing.T) {
 	setTestHome(t)
+	allowInteractiveOAuth(t)
 
 	const (
 		name = "openrouter"
@@ -697,5 +698,35 @@ func TestResilientToolset_ReauthorizeKeepsUnusedCachedToken(t *testing.T) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("discarded a cached token the refused connection never sent: %v", err)
+	}
+}
+
+// A headless run still presents cached credentials — that is the point of the
+// upgrade — but must not adopt the browser budget, since no browser opens.
+func TestBuildMCPToolset_CachedTokenKeepsFastTimeoutWhenHeadless(t *testing.T) {
+	setTestHome(t)
+	// Deliberately no allowInteractiveOAuth.
+
+	const (
+		name = "openrouter"
+		url  = "https://mcp.example.com/mcp"
+	)
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "cached", RefreshToken: "r", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(name, url, cfg, tok); err != nil {
+		t.Fatalf("seeding the token cache: %v", err)
+	}
+
+	ts, err := buildMCPToolset(MCPServerConfig{Name: name, URL: url})
+	if err != nil {
+		t.Fatalf("buildMCPToolset: %v", err)
+	}
+	rt := ts.(*resilientToolset)
+	if !rt.srv.OAuth {
+		t.Error("cached credentials were not presented in a headless run")
+	}
+	if rt.timeout != mcpConnectTimeout {
+		t.Errorf("timeout = %v, want the fast budget %v; nothing waits on a browser here",
+			rt.timeout, mcpConnectTimeout)
 	}
 }

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -361,3 +361,85 @@ func TestRemoveMCPOAuthToken(t *testing.T) {
 		t.Errorf("removing an absent token returned %v, want nil", err)
 	}
 }
+
+func TestWithoutAuthorization(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{"nil", nil, nil},
+		{"empty", map[string]string{}, nil},
+		{"only authorization", map[string]string{"Authorization": "Bearer stale"}, nil},
+		{
+			// HTTP header names are case-insensitive and http.Header.Set
+			// canonicalizes, so a lowercase spelling collides all the same.
+			name: "lowercase spelling",
+			in:   map[string]string{"authorization": "Bearer stale", "X-Title": "pi"},
+			want: map[string]string{"X-Title": "pi"},
+		},
+		{
+			name: "other headers survive",
+			in:   map[string]string{"Authorization": "Bearer stale", "HTTP-Referer": "https://pi.go", "X-Title": "pi"},
+			want: map[string]string{"HTTP-Referer": "https://pi.go", "X-Title": "pi"},
+		},
+	}
+	for _, tc := range tests {
+		got := withoutAuthorization(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+			continue
+		}
+		for k, v := range tc.want {
+			if got[k] != v {
+				t.Errorf("%s: got[%q] = %q, want %q", tc.name, k, got[k], v)
+			}
+		}
+	}
+}
+
+func TestWithoutAuthorizationDoesNotMutateInput(t *testing.T) {
+	in := map[string]string{"Authorization": "Bearer stale", "X-Title": "pi"}
+	withoutAuthorization(in)
+	if in["Authorization"] != "Bearer stale" {
+		t.Error("withoutAuthorization mutated the caller's header map; it is the loaded config")
+	}
+}
+
+// headerRoundTripper is the client's outermost transport, so it runs after the
+// SDK has set the freshly issued bearer token on the request. Carrying the
+// refused static credential into the retry would overwrite that token and the
+// retry would be rejected exactly like the first attempt.
+func TestResilientToolset_ReauthorizeDropsStaleAuthorizationHeader(t *testing.T) {
+	setTestHome(t)
+	captureNotices(t)
+
+	var gotSrv MCPServerConfig
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  "openrouter",
+		srv: MCPServerConfig{
+			Name:    "openrouter",
+			URL:     "https://mcp.example.com/mcp",
+			Headers: map[string]string{"Authorization": "Bearer revoked", "X-Title": "pi"},
+		},
+		reconnect: func(srv MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			gotSrv = srv
+			return &successToolset{tools: []tool.Tool{&namedTool{nameVal: "t"}}}, nil, nil
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+
+	if _, ok := gotSrv.Headers["Authorization"]; ok {
+		t.Error("retry carried the refused Authorization header; it would overwrite the new OAuth token")
+	}
+	if gotSrv.Headers["X-Title"] != "pi" {
+		t.Errorf("retry dropped an unrelated header: %v", gotSrv.Headers)
+	}
+	// The loaded config must be left intact for anything else reading it.
+	if rt.srv.Headers["Authorization"] != "Bearer revoked" {
+		t.Error("re-authorization mutated the server's configured headers")
+	}
+}

--- a/internal/extension/mcp_reauth_test.go
+++ b/internal/extension/mcp_reauth_test.go
@@ -157,7 +157,9 @@ func TestResilientToolset_ReauthorizeClearsCachedToken(t *testing.T) {
 	rt := &resilientToolset{
 		inner: &unauthorizedToolset{},
 		name:  name,
-		srv:   MCPServerConfig{Name: name, URL: url},
+		// OAuth is on because buildMCPToolset upgrades a server with cached
+		// credentials, so this connection presented the revoked token.
+		srv: MCPServerConfig{Name: name, URL: url, OAuth: true},
 		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
 			return &successToolset{tools: []tool.Tool{&namedTool{nameVal: "t"}}}, nil, nil
 		},
@@ -290,7 +292,7 @@ func TestResilientToolset_ReconnectErrorIsReported(t *testing.T) {
 	}
 }
 
-// A docs index configured as an MCP server is still dialled — the base name
+// A docs index configured as an MCP server is still dialed — the base name
 // cannot prove it is not a real endpoint — but when the connection fails the
 // message must explain what the entry actually is, not just relay a 405.
 func TestResilientToolset_DiagnosesLLMSDocsIndexOnFailure(t *testing.T) {
@@ -343,7 +345,7 @@ func TestResilientToolset_NoLLMSDiagnosisForConfiguredEndpoint(t *testing.T) {
 	}
 }
 
-// A docs index is dialled like any other server; nothing is skipped on a name.
+// A docs index is dialed like any other server; nothing is skipped on a name.
 func TestBuildMCPToolsets_DialsLLMSDocsIndex(t *testing.T) {
 	toolsets, err := BuildMCPToolsets([]MCPServerConfig{
 		{Name: "adk-docs-mcp", URL: "https://adk.dev/llms.txt"},
@@ -534,7 +536,7 @@ func TestResilientToolset_NoReauthorizeWhenNonInteractive(t *testing.T) {
 }
 
 // An entry that declares configuration only a real MCP endpoint needs is
-// dialled whatever its URL looks like, so the llms.txt name heuristic can
+// dialed whatever its URL looks like, so the llms.txt name heuristic can
 // never silently remove a working server.
 func TestBuildMCPToolsets_KeepsConfiguredServerAtLLMSPath(t *testing.T) {
 	notices := captureNotices(t)
@@ -615,4 +617,85 @@ func (c *closeCountingConn) closes() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.n
+}
+
+// A cached token means a previous run authorized this server, so the handler
+// must be installed from the start. Without that the connection goes out
+// unauthenticated, is refused, and the browser flow runs on every launch.
+func TestBuildMCPToolset_UpgradesServerWithCachedToken(t *testing.T) {
+	setTestHome(t)
+
+	const (
+		name = "openrouter"
+		url  = "https://mcp.example.com/mcp"
+	)
+	srv := MCPServerConfig{Name: name, URL: url}
+
+	ts, err := buildMCPToolset(srv)
+	if err != nil {
+		t.Fatalf("buildMCPToolset: %v", err)
+	}
+	if rt := ts.(*resilientToolset); rt.srv.OAuth {
+		t.Fatal("enabled OAuth for a server with no cached credentials")
+	}
+
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	tok := &oauth2.Token{AccessToken: "cached", RefreshToken: "r", Expiry: time.Now().Add(time.Hour)}
+	if err := saveMCPOAuthToken(name, url, cfg, tok); err != nil {
+		t.Fatalf("seeding the token cache: %v", err)
+	}
+
+	ts, err = buildMCPToolset(srv)
+	if err != nil {
+		t.Fatalf("buildMCPToolset: %v", err)
+	}
+	rt := ts.(*resilientToolset)
+	if !rt.srv.OAuth {
+		t.Error("cached credentials did not enable OAuth; the browser flow would repeat every launch")
+	}
+	// The browser round-trip budget applies to any OAuth connection, including
+	// one upgraded implicitly, or an approval would be cut off at 30s.
+	if rt.timeout != mcpOAuthConnectTimeout {
+		t.Errorf("timeout = %v, want the OAuth budget %v", rt.timeout, mcpOAuthConnectTimeout)
+	}
+	// The caller's config must not be mutated by the upgrade.
+	if srv.OAuth {
+		t.Error("buildMCPToolset mutated the caller's server config")
+	}
+}
+
+// A server that never presented a cached token learns nothing from a 401 about
+// that token, so a credential stored for it must survive the re-login.
+func TestResilientToolset_ReauthorizeKeepsUnusedCachedToken(t *testing.T) {
+	setTestHome(t)
+	allowInteractiveOAuth(t)
+	captureNotices(t)
+
+	const (
+		name = "openrouter"
+		url  = "https://mcp.example.com/mcp"
+	)
+	cfg := &oauth2.Config{ClientID: "cid", Endpoint: oauth2.Endpoint{TokenURL: "https://as.example.com/token"}}
+	if err := saveMCPOAuthToken(name, url, cfg, &oauth2.Token{AccessToken: "unused"}); err != nil {
+		t.Fatalf("seeding the token cache: %v", err)
+	}
+	path, err := mcpOAuthTokenFile(name, url)
+	if err != nil {
+		t.Fatalf("mcpOAuthTokenFile: %v", err)
+	}
+
+	rt := &resilientToolset{
+		inner: &unauthorizedToolset{},
+		name:  name,
+		srv:   MCPServerConfig{Name: name, URL: url}, // OAuth off: nothing was presented
+		reconnect: func(MCPServerConfig) (tool.Toolset, *connTrackingTransport, error) {
+			return &successToolset{tools: []tool.Tool{&namedTool{nameVal: "t"}}}, nil, nil
+		},
+	}
+	if _, err := rt.Tools(nil); err != nil {
+		t.Fatalf("Tools() returned an error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("discarded a cached token the refused connection never sent: %v", err)
+	}
 }

--- a/internal/extension/mcp_test.go
+++ b/internal/extension/mcp_test.go
@@ -454,6 +454,9 @@ func TestBuildAfterToolCallbacks_WithMatchingTool(t *testing.T) {
 // oauth flag gets an OAuth authorization-code handler attached to its
 // transport, and that the toolset uses the longer OAuth connect timeout.
 func TestBuildMCPToolset_OAuthHandler(t *testing.T) {
+	// The browser budget applies only where a browser can open.
+	allowInteractiveOAuth(t)
+
 	ts, err := buildMCPToolset(MCPServerConfig{
 		Name:  "oauth-server",
 		URL:   "https://mcp.example.com/mcp",

--- a/internal/extension/read_image.go
+++ b/internal/extension/read_image.go
@@ -1,14 +1,12 @@
 package extension
 
 import (
-	"fmt"
-	"os"
-
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/genai"
 
+	"github.com/dimetron/pi-go/internal/notice"
 	"github.com/dimetron/pi-go/internal/tools"
 )
 
@@ -63,7 +61,7 @@ func readImageParts(sb *tools.Sandbox, parts []*genai.Part) []*genai.Part {
 		}
 		data, err := sb.ReadFile(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "pi-go: warning: read_image callback could not read %q: %v\n", path, err)
+			notice.Notifyf("warning: read_image callback could not read %q: %v", path, err)
 			continue
 		}
 		out = append(out, genai.NewPartFromBytes(data, detectImageMIMEType(data, path)))

--- a/internal/extension/skills.go
+++ b/internal/extension/skills.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/dimetron/pi-go/internal/audit"
+	"github.com/dimetron/pi-go/internal/notice"
 )
 
 // Skill represents a loaded skill from a SKILL.md file.
@@ -74,7 +75,7 @@ func LoadSkillsWithOptions(opts LoadOptions, dirs ...string) ([]Skill, error) {
 	}
 
 	if len(blocked) > 0 {
-		fmt.Fprintf(os.Stderr, "pi-go: %d skill(s) blocked due to security audit. Run 'pi audit' for details.\n", len(blocked))
+		notice.Notifyf("%d skill(s) blocked due to security audit. Run 'pi audit' for details.", len(blocked))
 	}
 
 	return skills, nil
@@ -214,7 +215,7 @@ func auditRejects(opts LoadOptions, skillInfo skillCandidate, blocked *[]string)
 	}
 	scanResult, scanErr := audit.ScanFile(skillInfo.path)
 	if scanErr != nil {
-		fmt.Fprintf(os.Stderr, "pi-go: warning: audit scan failed for %s: %v\n", skillInfo.path, scanErr)
+		notice.Notifyf("warning: audit scan failed for %s: %v", skillInfo.path, scanErr)
 		return false
 	}
 	if !scanResult.HasCritical() {
@@ -222,11 +223,11 @@ func auditRejects(opts LoadOptions, skillInfo skillCandidate, blocked *[]string)
 	}
 	if opts.AuditMode == AuditBlock {
 		*blocked = append(*blocked, skillInfo.path)
-		fmt.Fprintf(os.Stderr, "pi-go: BLOCKED skill %s — critical hidden characters detected\n", skillInfo.defaultName)
+		notice.Notifyf("BLOCKED skill %s — critical hidden characters detected", skillInfo.defaultName)
 		return true
 	}
 	// AuditWarn: log but continue loading.
-	fmt.Fprintf(os.Stderr, "pi-go: WARNING: skill %s has critical hidden characters\n", skillInfo.defaultName)
+	notice.Notifyf("WARNING: skill %s has critical hidden characters", skillInfo.defaultName)
 	return false
 }
 

--- a/internal/notice/notice.go
+++ b/internal/notice/notice.go
@@ -1,0 +1,57 @@
+// Package notice carries short, user-facing messages raised while pi-go starts
+// up or reconfigures itself — a skipped MCP server, a rerouted docs source, a
+// blocked skill, an OAuth re-login.
+//
+// These are not diagnostics, and os.Stderr is the wrong place for them once a
+// front end owns the terminal: the TUI paints its frame with direct cursor
+// control, so a stray write lands in the middle of the layout and stays there
+// until the next full repaint, and the ACP server interleaves them with its
+// protocol stream. Routing them through a sink lets the front end render them
+// where the user is already looking.
+//
+// The default sink writes to os.Stderr, which is correct for the
+// non-interactive CLI: nothing else owns the terminal, and a warning that
+// vanished entirely would be worse than one that scrolls past.
+package notice
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	mu   sync.RWMutex
+	sink func(string)
+)
+
+// SetSink routes notices to fn instead of os.Stderr, returning the sink it
+// replaced so a caller can restore it — tests rely on that, and so does a
+// front end that exits before the process does. Passing nil restores the
+// os.Stderr default.
+//
+// fn is called from whichever goroutine raises the notice, including ones deep
+// inside a lazily-connecting MCP toolset, so it must be safe for concurrent
+// use and must not block: a sink that stalls stalls the agent turn behind it.
+func SetSink(fn func(string)) func(string) {
+	mu.Lock()
+	defer mu.Unlock()
+	prev := sink
+	sink = fn
+	return prev
+}
+
+// Notifyf formats a notice and delivers it to the installed sink. The message
+// carries no trailing newline — a sink renders it as a single item, and the
+// stderr fallback supplies the newline itself.
+func Notifyf(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	mu.RLock()
+	fn := sink
+	mu.RUnlock()
+	if fn != nil {
+		fn(msg)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "pi-go: %s\n", msg)
+}

--- a/internal/notice/notice_test.go
+++ b/internal/notice/notice_test.go
@@ -1,0 +1,70 @@
+package notice
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestNotifyfUsesInstalledSink(t *testing.T) {
+	var got []string
+	prev := SetSink(func(msg string) { got = append(got, msg) })
+	defer SetSink(prev)
+
+	Notifyf("MCP server %q unavailable: %v", "openrouter", "Unauthorized")
+
+	if len(got) != 1 {
+		t.Fatalf("sink received %d notices, want 1: %v", len(got), got)
+	}
+	want := `MCP server "openrouter" unavailable: Unauthorized`
+	if got[0] != want {
+		t.Errorf("notice = %q, want %q", got[0], want)
+	}
+	// The sink renders the notice as one item; a trailing newline would show
+	// up as a blank line in the chat.
+	if strings.HasSuffix(got[0], "\n") {
+		t.Errorf("notice %q has a trailing newline", got[0])
+	}
+}
+
+func TestSetSinkReturnsPreviousSink(t *testing.T) {
+	first := func(string) {}
+	prev := SetSink(first)
+	defer SetSink(prev)
+
+	restored := SetSink(nil)
+	if restored == nil {
+		t.Fatal("SetSink did not return the sink it replaced")
+	}
+	// Restoring nil puts the os.Stderr default back; Notifyf must not panic.
+	Notifyf("back to stderr")
+}
+
+// A notice can be raised from a lazily-connecting MCP toolset on any
+// goroutine, so the sink must survive concurrent delivery and replacement.
+func TestNotifyfConcurrent(t *testing.T) {
+	var mu sync.Mutex
+	count := 0
+	prev := SetSink(func(string) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	})
+	defer SetSink(prev)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Notifyf("notice")
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != 32 {
+		t.Errorf("sink saw %d notices, want 32", count)
+	}
+}

--- a/internal/notice/notice_test.go
+++ b/internal/notice/notice_test.go
@@ -9,7 +9,7 @@ import (
 func TestNotifyfUsesInstalledSink(t *testing.T) {
 	var got []string
 	prev := SetSink(func(msg string) { got = append(got, msg) })
-	defer SetSink(prev)
+	defer func() { SetSink(prev) }()
 
 	Notifyf("MCP server %q unavailable: %v", "openrouter", "Unauthorized")
 
@@ -30,7 +30,7 @@ func TestNotifyfUsesInstalledSink(t *testing.T) {
 func TestSetSinkReturnsPreviousSink(t *testing.T) {
 	first := func(string) {}
 	prev := SetSink(first)
-	defer SetSink(prev)
+	defer func() { SetSink(prev) }()
 
 	restored := SetSink(nil)
 	if restored == nil {
@@ -50,7 +50,7 @@ func TestNotifyfConcurrent(t *testing.T) {
 		count++
 		mu.Unlock()
 	})
-	defer SetSink(prev)
+	defer func() { SetSink(prev) }()
 
 	var wg sync.WaitGroup
 	for i := 0; i < 32; i++ {

--- a/internal/subagent/spawner_acp.go
+++ b/internal/subagent/spawner_acp.go
@@ -3,7 +3,6 @@ package subagent
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	sharedacp "github.com/dimetron/pi-go/internal/acp"
@@ -11,6 +10,7 @@ import (
 	"github.com/dimetron/pi-go/internal/acp/client/copilot"
 	"github.com/dimetron/pi-go/internal/acp/client/cursor"
 	"github.com/dimetron/pi-go/internal/acp/client/gemini"
+	"github.com/dimetron/pi-go/internal/notice"
 )
 
 // acpSession is the shared interface implemented by every per-runner
@@ -259,8 +259,11 @@ func sendProcEvent(p *Process, ev Event) {
 	select {
 	case p.events <- ev:
 	default:
-		// Log dropped events to stderr for debugging. This helps identify
-		// when the event consumer (TUI/orchestrator) falls behind the producer.
-		fmt.Fprintf(os.Stderr, "pi-go: dropped event type=%s session=%s\n", ev.Type, ev.SessionID)
+		// Report dropped events so a consumer (TUI/orchestrator) that has
+		// fallen behind the producer is visible rather than silent. It goes
+		// through the notice sink, not os.Stderr: this fires mid-turn, while
+		// the TUI owns the terminal, and a direct write lands inside the
+		// painted frame.
+		notice.Notifyf("dropped event type=%s session=%s", ev.Type, ev.SessionID)
 	}
 }

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -499,14 +499,18 @@ func (t *LLMSToolset) urlAllowed(target *url.URL) bool {
 		if err != nil {
 			continue
 		}
-		// The query is part of the identity: ?resource=other can select a
+		// EscapedPath, not Path: url.Parse decodes %2F to "/" in Path, so
+		// /a%2Fb/llms.txt and /a/b/llms.txt compare equal there while being
+		// different resources on the wire.
+		//
+		// The query is part of the identity too: ?resource=other can select a
 		// different document entirely, so ignoring it would let any variant
 		// of the path through. An inferred source never carries one —
 		// config.IsLLMSDocsURL refuses query-bearing URLs — so in practice
 		// this requires the request to have none either.
 		if strings.EqualFold(u.Hostname(), target.Hostname()) &&
 			u.Scheme == target.Scheme && u.Port() == target.Port() &&
-			u.Path == target.Path && u.RawQuery == target.RawQuery {
+			u.EscapedPath() == target.EscapedPath() && u.RawQuery == target.RawQuery {
 			return true
 		}
 	}

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -499,8 +499,14 @@ func (t *LLMSToolset) urlAllowed(target *url.URL) bool {
 		if err != nil {
 			continue
 		}
+		// The query is part of the identity: ?resource=other can select a
+		// different document entirely, so ignoring it would let any variant
+		// of the path through. An inferred source never carries one —
+		// config.IsLLMSDocsURL refuses query-bearing URLs — so in practice
+		// this requires the request to have none either.
 		if strings.EqualFold(u.Hostname(), target.Hostname()) &&
-			u.Scheme == target.Scheme && u.Port() == target.Port() && u.Path == target.Path {
+			u.Scheme == target.Scheme && u.Port() == target.Port() &&
+			u.Path == target.Path && u.RawQuery == target.RawQuery {
 			return true
 		}
 	}

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -164,7 +164,9 @@ func (t *LLMSToolset) checkRedirectURL(u *url.URL, via []*http.Request) error {
 	if err := rejectPrivateHost(u.Hostname()); err != nil {
 		return fmt.Errorf("url rejected: %w", err)
 	}
-	if !t.hostAllowed(u.Hostname()) {
+	// Redirects are held to the same rule as the original request, so a source
+	// restricted to one URL cannot be widened by a hop the server chooses.
+	if !t.urlAllowed(u) {
 		return fmt.Errorf("host %q is not an allowed documentation source", u.Hostname())
 	}
 	return nil
@@ -239,8 +241,9 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 		return LLMSOutput{Error: fmt.Sprintf("url rejected: %v", err)}, nil
 	}
 
-	// Restrict to hosts that host a configured llms.txt source.
-	if !t.hostAllowed(u.Hostname()) {
+	// Restrict to configured llms.txt sources: a whole host for one the user
+	// configured, the exact URL for one pi-go inferred.
+	if !t.urlAllowed(u) {
 		return LLMSOutput{Error: fmt.Sprintf("host %q is not an allowed documentation source", u.Hostname())}, nil
 	}
 
@@ -465,11 +468,39 @@ func (t *LLMSToolset) cacheEvict() {
 // configured as https://adk.dev/llms.txt allows fetching any page on adk.dev.
 func (t *LLMSToolset) hostAllowed(hostname string) bool {
 	for _, s := range t.sources {
+		if s.ExactURLOnly {
+			continue // widened access is not what such a source grants
+		}
 		u, err := url.Parse(s.URL)
 		if err != nil {
 			continue
 		}
 		if strings.EqualFold(u.Hostname(), hostname) {
+			return true
+		}
+	}
+	return false
+}
+
+// urlAllowed reports whether target may be fetched. A configured source grants
+// its whole host, which is what makes an llms.txt index useful — the index
+// exists to be followed to the pages it links. A source pi-go inferred from a
+// URL's file name grants only that one URL: the name is a guess, and a wrong
+// guess must not hand the model a whole host it was never configured to reach.
+func (t *LLMSToolset) urlAllowed(target *url.URL) bool {
+	if t.hostAllowed(target.Hostname()) {
+		return true
+	}
+	for _, s := range t.sources {
+		if !s.ExactURLOnly {
+			continue
+		}
+		u, err := url.Parse(s.URL)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(u.Hostname(), target.Hostname()) &&
+			u.Scheme == target.Scheme && u.Port() == target.Port() && u.Path == target.Path {
 			return true
 		}
 	}

--- a/internal/tools/llms_exact_test.go
+++ b/internal/tools/llms_exact_test.go
@@ -51,6 +51,8 @@ func TestURLAllowedInferredSourceGrantsOnlyItsURL(t *testing.T) {
 		"https://internal.corp/",
 		"https://internal.corp:8443/llms.txt",
 		"http://internal.corp/llms.txt",
+		// A query can select a different document entirely.
+		"https://internal.corp/llms.txt?resource=other",
 	} {
 		if ts.urlAllowed(mustURL(t, raw)) {
 			t.Errorf("urlAllowed(%q) = true; an inference must not widen host access", raw)
@@ -75,3 +77,14 @@ func TestURLAllowedConfiguredWinsOverInferredOnSameHost(t *testing.T) {
 // exercised here: checkRedirectURL first calls rejectPrivateHost, which
 // resolves the host, and any fixture host either needs DNS or fails for the
 // wrong reason. The rule itself is covered by the urlAllowed tests above.
+
+// A bare trailing "?" carries no parameters, so it addresses the same resource
+// and is not a widening.
+func TestURLAllowedInferredSourceAllowsEmptyQuery(t *testing.T) {
+	ts := NewLLMSToolset(&config.LLMSConfig{Sources: []config.LLMSSource{
+		{Name: "guessed", URL: "https://internal.corp/llms.txt", ExactURLOnly: true},
+	}})
+	if !ts.urlAllowed(mustURL(t, "https://internal.corp/llms.txt?")) {
+		t.Error("refused the same resource spelled with an empty query")
+	}
+}

--- a/internal/tools/llms_exact_test.go
+++ b/internal/tools/llms_exact_test.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", raw, err)
+	}
+	return u
+}
+
+// A source the user configured grants its whole host: an llms.txt index exists
+// to be followed to the pages it links.
+func TestURLAllowedConfiguredSourceGrantsHost(t *testing.T) {
+	ts := NewLLMSToolset(&config.LLMSConfig{Sources: []config.LLMSSource{
+		{Name: "adk", URL: "https://adk.dev/llms.txt"},
+	}})
+	for _, raw := range []string{
+		"https://adk.dev/llms.txt",
+		"https://adk.dev/docs/agents.md",
+		"https://adk.dev/anything/else",
+	} {
+		if !ts.urlAllowed(mustURL(t, raw)) {
+			t.Errorf("urlAllowed(%q) = false, want true", raw)
+		}
+	}
+	if ts.urlAllowed(mustURL(t, "https://elsewhere.example/llms.txt")) {
+		t.Error("allowed an unrelated host")
+	}
+}
+
+// A source pi-go inferred from a file name grants only that URL. The name is a
+// guess, and a wrong guess must not hand the model a whole host.
+func TestURLAllowedInferredSourceGrantsOnlyItsURL(t *testing.T) {
+	ts := NewLLMSToolset(&config.LLMSConfig{Sources: []config.LLMSSource{
+		{Name: "guessed", URL: "https://internal.corp/llms.txt", ExactURLOnly: true},
+	}})
+
+	if !ts.urlAllowed(mustURL(t, "https://internal.corp/llms.txt")) {
+		t.Error("the inferred URL itself was refused")
+	}
+	for _, raw := range []string{
+		"https://internal.corp/secrets",
+		"https://internal.corp/",
+		"https://internal.corp:8443/llms.txt",
+		"http://internal.corp/llms.txt",
+	} {
+		if ts.urlAllowed(mustURL(t, raw)) {
+			t.Errorf("urlAllowed(%q) = true; an inference must not widen host access", raw)
+		}
+	}
+}
+
+// One configured source and one inferred source on the same host: the
+// configured grant wins, because the user made it deliberately.
+func TestURLAllowedConfiguredWinsOverInferredOnSameHost(t *testing.T) {
+	ts := NewLLMSToolset(&config.LLMSConfig{Sources: []config.LLMSSource{
+		{Name: "inferred", URL: "https://adk.dev/llms.txt", ExactURLOnly: true},
+		{Name: "configured", URL: "https://adk.dev/llms-full.txt"},
+	}})
+	if !ts.urlAllowed(mustURL(t, "https://adk.dev/docs/page.md")) {
+		t.Error("a deliberately configured source did not grant its host")
+	}
+}
+
+// checkRedirectURL applies urlAllowed to every hop, so a server cannot widen an
+// inferred source by choosing where to send the client. That path is not
+// exercised here: checkRedirectURL first calls rejectPrivateHost, which
+// resolves the host, and any fixture host either needs DNS or fails for the
+// wrong reason. The rule itself is covered by the urlAllowed tests above.

--- a/internal/tools/llms_exact_test.go
+++ b/internal/tools/llms_exact_test.go
@@ -88,3 +88,26 @@ func TestURLAllowedInferredSourceAllowsEmptyQuery(t *testing.T) {
 		t.Error("refused the same resource spelled with an empty query")
 	}
 }
+
+// url.Parse decodes %2F to "/" in Path, so an encoded separator would compare
+// equal to a real one while addressing a different resource on the wire.
+func TestURLAllowedInferredSourceComparesEscapedPath(t *testing.T) {
+	ts := NewLLMSToolset(&config.LLMSConfig{Sources: []config.LLMSSource{
+		{Name: "guessed", URL: "https://internal.corp/a%2Fb/llms.txt", ExactURLOnly: true},
+	}})
+	if ts.urlAllowed(mustURL(t, "https://internal.corp/a/b/llms.txt")) {
+		t.Error("a decoded separator matched an encoded one; they are different resources")
+	}
+	if !ts.urlAllowed(mustURL(t, "https://internal.corp/a%2Fb/llms.txt")) {
+		t.Error("the source's own URL was refused")
+	}
+
+	// And the other direction: a source with a real separator must not admit
+	// the encoded spelling.
+	ts = NewLLMSToolset(&config.LLMSConfig{Sources: []config.LLMSSource{
+		{Name: "guessed", URL: "https://internal.corp/a/b/llms.txt", ExactURLOnly: true},
+	}})
+	if ts.urlAllowed(mustURL(t, "https://internal.corp/a%2Fb/llms.txt")) {
+		t.Error("an encoded separator matched a real one")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -561,11 +561,20 @@ func (m *model) Init() tea.Cmd {
 	if m.initCh != nil {
 		// Deferred init: start listening for init events.
 		// Heavy initialization runs in a background goroutine (started by cli).
-		return tea.Batch(
+		cmds := []tea.Cmd{
 			requestBg,
 			waitForInitEvent(m.initCh),
 			tea.Tick(300*time.Millisecond, func(t time.Time) tea.Msg { return loadingTickMsg{} }),
-		)
+		}
+		// Drain notices from the first frame. Deferred init is exactly when
+		// they are raised — skipped MCP servers, blocked skills, an OAuth
+		// re-login — and it finishes long after they start arriving, so a
+		// reader armed only from the InitResult would leave the whole startup
+		// run buffered.
+		if m.cfg.SystemNoticeCh != nil {
+			cmds = append(cmds, waitForSystemNotice(m.cfg.SystemNoticeCh))
+		}
+		return tea.Batch(cmds...)
 	}
 
 	// Synchronous init (non-deferred path, used by tests and non-interactive modes).

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2233,6 +2233,11 @@ func (m *model) handleInitEvent(msg initEventMsg) (tea.Model, tea.Cmd) {
 		m.cfg.SkillDirs = r.SkillDirs
 		m.cfg.GenerateCommitMsg = r.GenerateCommitMsg
 		m.cfg.AgentEventCh = r.AgentEventCh
+		// Remembered before the assignment: a front end that handed the same
+		// channel to the initial config already has a reader waiting on it,
+		// and arming a second would leave two goroutines blocked on one
+		// channel for the rest of the session.
+		prevNoticeCh := m.cfg.SystemNoticeCh
 		m.cfg.SystemNoticeCh = r.SystemNoticeCh
 		m.cfg.ContextBreakdown = r.ContextBreakdown
 		m.cfg.TokenTracker = r.TokenTracker
@@ -2257,7 +2262,7 @@ func (m *model) handleInitEvent(msg initEventMsg) (tea.Model, tea.Cmd) {
 		if r.AgentEventCh != nil {
 			cmds = append(cmds, waitForSubEvent(r.AgentEventCh))
 		}
-		if r.SystemNoticeCh != nil {
+		if r.SystemNoticeCh != nil && r.SystemNoticeCh != prevNoticeCh {
 			cmds = append(cmds, waitForSystemNotice(r.SystemNoticeCh))
 		}
 		cmds = append(cmds, memoryTickCmd(m.cwd()))

--- a/piagent/build.go
+++ b/piagent/build.go
@@ -137,8 +137,8 @@ func buildToolsets(cfg config.Config) []adktool.Toolset {
 	if cfg.A2A != nil && len(cfg.A2A.Agents) > 0 {
 		toolsets = append(toolsets, tools.NewA2AToolset(cfg.A2A))
 	}
-	if cfg.LLMS != nil && len(cfg.LLMS.Sources) > 0 {
-		toolsets = append(toolsets, tools.NewLLMSCachedToolset(cfg.LLMS))
+	if llms := cfg.LLMSSources(); llms != nil {
+		toolsets = append(toolsets, tools.NewLLMSCachedToolset(llms))
 	}
 	return toolsets
 }


### PR DESCRIPTION
Three faults showed up together as garbled text painted over the TUI frame:

```
pi-go: warning: MCP server "adk-docs-mcp" unavailable: ... Method Not Allowed
pi-go: warning: MCP server "openrouter" unavailable: ... Unauthorized
```

No config file changes are needed — `.pi-go/mcp.json` is untouched. Both entries in it are handled correctly now.

## 1. Notices reach the TUI, not stderr

The TUI paints with direct cursor control, so a write from a background init goroutine lands inside the layout and stays until the next full repaint.

New `internal/notice` package: a sink that defaults to `os.Stderr` — correct for the non-interactive CLI — which `runInteractive` redirects into the existing `SystemNoticeCh` so notices render as chat messages. Every writer that can fire while the TUI owns the terminal was converted: MCP, skills, `read_image`, the OAuth token store, the ACP dropped-event log, and the update banner. The update check moved inside `runInteractive`, since started where it was it raced the sink installation.

## 2. A 401 re-logins instead of being terminal

The go-sdk only re-authorizes when an OAuth handler is installed, so a server configured without one — `openrouter` — had its 401 returned verbatim and was written off. It now detects the auth failure, discards a cached token *only if this connection presented one*, reconnects with OAuth, and retries once.

Guards, each of which came out of review:

- **Interactive only.** The flow blocks on a browser approval, so print/JSON/RPC/socket/ACP runs never enter it and keep failing fast.
- **Headless still uses cached credentials.** `mcpTokenOnlyHandler` implements the two-method `auth.OAuthHandler` directly, so `Authorize` refuses before the SDK can run discovery, metadata retrieval or dynamic client registration — no network side effects, no loopback listener bound.
- **The upgrade survives a restart**, so the browser flow does not repeat on every launch.
- **Explicit credentials win.** A configured `Authorization` header outranks a cached token, so replacing a rejected API key takes effect immediately rather than after the 24-hour cache window.
- **No stale header on the retry.** `headerRoundTripper` is the outermost transport and would otherwise overwrite the fresh bearer token with the refused value.
- Replaced and abandoned connections are closed on every path.

Verified against OpenRouter's live metadata: it advertises `registration_endpoint`, `token_endpoint_auth_methods_supported: ["none"]` and PKCE S256 — everything pi-go's handler needs.

## 3. An llms.txt index is served by `fetch_docs`

`https://adk.dev/llms.txt` answers the MCP `initialize` POST with 405 and can never yield tools.

Nothing is removed from the MCP list — endpoint paths are arbitrary, and a base name is not proof. The entry is dialled like any other, and only once the connection has actually failed does the notice explain that the URL is a documentation index and name the config key to move it to. Diagnosis on evidence, not on a guess.

The loader separately registers a `fetch_docs` source so the docs are readable straight away, with three constraints:

- **Not serialized.** `Config.Save` marshals the whole struct, so an inference drawn from a project's `mcp.json` would otherwise be written into the global config by an unrelated call such as `SaveDefaultRole`. Inferred sources live in `InferredLLMS`; `Config.LLMSSources()` joins the halves for the four call sites that build the toolset.
- **Never from a credential-bearing URL.** A source's full URL goes into the `fetch_docs` tool description sent to the model provider, so userinfo and query strings are excluded from inference entirely.
- **Grants only its own URL.** A configured source grants its whole host, which is what makes an index useful. An inferred one carries `ExactURLOnly` and matches on scheme, host, port, escaped path and query together — a filename guess must not hand the model a host it was never configured to reach. Redirects go through the same check.

ACP sessions now get the `fetch_docs` toolset too; they were the one path of four without it.

## Review

Nine `codex review` passes, each finding acted on and verified against the code first. Among them: a browser flow blocking headless runs for ten minutes, a stale header overwriting the fresh OAuth token, two leaked MCP connections, the notice reader never being armed in deferred init, and a credential leak into the tool description. Final pass: *"No actionable correctness regressions were identified."*

`go build`, `go vet`, `golangci-lint run ./...` (0 issues) and `go test ./internal/... ./piagent/... -race` all pass.

One pre-existing failure is unrelated and also fails on `main`: `TestNewPromptHandler_NoAPIKey` expects "no API key" but a real key is present in the environment and `claude-3-5-haiku-latest` now 404s.
