### PR TITLE
fix(tui): widen subagent prompt line when terminal space allows

### DIFF
--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -822,13 +822,15 @@ func TestAgentToolCallMsg_SetsAgentFields(t *testing.T) {
 	}
 }
 
-func TestAgentToolCallMsg_TruncatesLongTitle(t *testing.T) {
+func TestAgentToolCallMsg_StoresTitleWithinCap(t *testing.T) {
 	m := &model{
 		chatModel: ChatModel{Messages: make([]message, 0)},
 		running:   true,
 		agentCh:   make(chan agentMsg, 64),
 	}
 
+	// 100 runes is within the storage cap, so it is kept whole — the visible
+	// length is decided at render time against the terminal width.
 	longPrompt := strings.Repeat("a", 100)
 	newM, _ := m.Update(agentToolCallMsg{
 		name: "agent",
@@ -839,8 +841,30 @@ func TestAgentToolCallMsg_TruncatesLongTitle(t *testing.T) {
 	})
 	mm := newM.(*model)
 
-	if len(mm.chatModel.Messages[0].agentTitle) > 60 {
-		t.Errorf("expected title <= 60 chars, got %d", len(mm.chatModel.Messages[0].agentTitle))
+	if mm.chatModel.Messages[0].agentTitle != longPrompt {
+		t.Errorf("expected title kept whole within the cap, got %q", mm.chatModel.Messages[0].agentTitle)
+	}
+}
+
+func TestAgentToolCallMsg_TruncatesOverCapTitle(t *testing.T) {
+	m := &model{
+		chatModel: ChatModel{Messages: make([]message, 0)},
+		running:   true,
+		agentCh:   make(chan agentMsg, 64),
+	}
+
+	overCap := strings.Repeat("a", maxStoredAgentTitle+50)
+	newM, _ := m.Update(agentToolCallMsg{
+		name: "agent",
+		args: map[string]any{
+			"type":   "explore",
+			"prompt": overCap,
+		},
+	})
+	mm := newM.(*model)
+
+	if len(mm.chatModel.Messages[0].agentTitle) > maxStoredAgentTitle {
+		t.Errorf("expected title <= %d chars, got %d", maxStoredAgentTitle, len(mm.chatModel.Messages[0].agentTitle))
 	}
 	if !strings.HasSuffix(mm.chatModel.Messages[0].agentTitle, "...") {
 		t.Error("expected '...' suffix for truncated title")

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -1285,14 +1285,23 @@ func findUnassignedAgentCard(messages []message, agentID string) int {
 	return fallback
 }
 
-// truncatePrompt shortens a prompt to a single-line 60-char preview for the
-// agent card header.
+// maxStoredAgentTitle bounds the prompt preview stored on an agent card. It is
+// deliberately generous so a wide terminal can show a longer title — the actual
+// visible length is decided at render time by agentCardHeader against the
+// terminal width. This is only a storage cap, so a pathological prompt cannot
+// bloat the message.
+const maxStoredAgentTitle = 200
+
+// truncatePrompt shortens a prompt to a single-line preview for the agent card
+// header. It strips the prompt to its first line and bounds its length; the
+// precise visible length is fixed at render time so a wide terminal gets a
+// longer line.
 func truncatePrompt(prompt string) string {
 	if idx := strings.IndexByte(prompt, '\n'); idx > 0 {
 		prompt = prompt[:idx]
 	}
-	if len(prompt) > 60 {
-		prompt = prompt[:57] + "..."
+	if len(prompt) > maxStoredAgentTitle {
+		prompt = prompt[:maxStoredAgentTitle-3] + "..."
 	}
 	return prompt
 }

--- a/internal/tui/complexity_render_test.go
+++ b/internal/tui/complexity_render_test.go
@@ -1171,6 +1171,44 @@ func TestAgentCardHeaderRender(t *testing.T) {
 	}
 }
 
+// TestAgentTitleFitPinsTruncation pins the rune-wise title clip: the cut is
+// marked with a single ellipsis rune and the result is never wider than the
+// budget.
+func TestAgentTitleFitPinsTruncation(t *testing.T) {
+	title := strings.Repeat("a", 100)
+	got := agentTitleFit(title, 60)
+	if n := len([]rune(got)); n != 60 {
+		t.Errorf("got %d runes, want 60", n)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix, got %q", got)
+	}
+
+	// A title that fits is returned whole.
+	if got := agentTitleFit("short", 60); got != "short" {
+		t.Errorf("got %q, want 'short'", got)
+	}
+}
+
+// TestAgentCardHeaderWideTruncatesLess pins that a wider terminal shows a
+// longer agent title: the render budget grows with the width, so the same
+// stored title is clipped harder on a narrow card than a wide one.
+func TestAgentCardHeaderWideTruncatesLess(t *testing.T) {
+	title := strings.Repeat("x", 300) // beyond even the wide budget
+	msg := message{agentType: "claude", agentTitle: title, content: "done"}
+
+	narrow := ansi.Strip((&ToolDisplayModel{Width: 80}).agentCardHeader(msg, paletteOrDark(Palette{})))
+	wide := ansi.Strip((&ToolDisplayModel{Width: 200}).agentCardHeader(msg, paletteOrDark(Palette{})))
+
+	if len([]rune(narrow)) >= len([]rune(wide)) {
+		t.Errorf("expected the wider terminal to render a longer header; narrow=%d wide=%d",
+			len([]rune(narrow)), len([]rune(wide)))
+	}
+	if !strings.Contains(narrow, "…") || !strings.Contains(wide, "…") {
+		t.Errorf("a title beyond both budgets must be clipped on both, got narrow=%q wide=%q", narrow, wide)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Status bar fields
 // ---------------------------------------------------------------------------

--- a/internal/tui/coverage_boost_test.go
+++ b/internal/tui/coverage_boost_test.go
@@ -1100,13 +1100,22 @@ func TestFindUnassignedAgentCard_None(t *testing.T) {
 }
 
 func TestTruncatePrompt_Long(t *testing.T) {
-	in := strings.Repeat("a", 100)
+	in := strings.Repeat("a", maxStoredAgentTitle+100)
 	got := truncatePrompt(in)
-	if len(got) > 60 {
-		t.Errorf("expected <=60, got %d", len(got))
+	if len(got) > maxStoredAgentTitle {
+		t.Errorf("expected <=%d, got %d", maxStoredAgentTitle, len(got))
 	}
 	if !strings.HasSuffix(got, "...") {
 		t.Errorf("expected ellipsis, got %q", got)
+	}
+}
+
+func TestTruncatePrompt_PassesThruWithinCap(t *testing.T) {
+	// A prompt within the storage cap is kept whole — the visible length is
+	// decided at render time, not here.
+	in := strings.Repeat("a", 100)
+	if got := truncatePrompt(in); got != in {
+		t.Errorf("expected the prompt kept whole within the cap, got %d runes", len(got))
 	}
 }
 

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -236,7 +236,9 @@ func (t *ToolDisplayModel) renderAgentTool(msg message, dim lipgloss.Style, p Pa
 }
 
 // agentCardHeader renders the card's first row: bullet, "agent", the bracketed
-// agent label, and the title.
+// agent label, and the title. The title is truncated against the available
+// terminal width so a wide terminal shows a longer prompt, with a 60-runer
+// floor for narrow terminals.
 func (t *ToolDisplayModel) agentCardHeader(msg message, p Palette) string {
 	agentBullet := t.toolBullet(lipgloss.NewStyle().Foreground(p.Mauve).Bold(true), msg.content == "")
 	typeStyle := lipgloss.NewStyle().Foreground(p.Mauve).Bold(true)
@@ -245,15 +247,48 @@ func (t *ToolDisplayModel) agentCardHeader(msg message, p Palette) string {
 	var b strings.Builder
 	b.WriteString(agentBullet)
 	b.WriteString(typeStyle.Render("agent"))
-	if label := agentBracketLabel(msg.agentType); label != "" {
+	label := agentBracketLabel(msg.agentType)
+	if label != "" {
 		b.WriteString(typeStyle.Render("[" + label + "]"))
 	}
 	if msg.agentTitle != "" {
 		b.WriteString(" ")
-		b.WriteString(titleStyle.Render(msg.agentTitle))
+		b.WriteString(titleStyle.Render(agentTitleFit(msg.agentTitle, t.titleWidth(label))))
 	}
 	b.WriteString("\n")
 	return b.String()
+}
+
+// titleWidth returns the max runes for the agent card title given the terminal
+// width and the bracketed label that precedes it. The label is counted so a
+// compound "[claude+pi+gemini]" leaves less room for the title than a bare
+// "[pi]", keeping the header within one line. A floor of 60 keeps narrow
+// terminals readable, and the storage cap (maxStoredAgentTitle) bounds what a
+// wide terminal can ever show.
+func (t ToolDisplayModel) titleWidth(label string) int {
+	w := t.Width
+	if w < 40 {
+		w = 80 // sensible default when width unknown
+	}
+	// Reserve the bullet (2), "agent" (5), the bracketed label ("[...]" is
+	// len(label)+2), and the separator space (1).
+	used := 2 + len("agent") + len(label) + 2 + 1
+	if w-used < 60 {
+		return 60
+	}
+	return w - used
+}
+
+// agentTitleFit clips a title to n runes, marking the cut with an ellipsis.
+func agentTitleFit(title string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	r := []rune(title)
+	if len(r) <= n {
+		return title
+	}
+	return string(r[:n-1]) + "…"
 }
 
 // agentEventWindow renders the card's live event stream, newest activity last,


### PR DESCRIPTION
The agent card header ("agent[pi] <prompt>") clipped the prompt to a fixed
60 chars at construction time with no regard for terminal width. Split
storage from rendering: truncatePrompt now enforces only a generous
200-char storage cap, and agentCardHeader clips the title width-aware at
render time (titleWidth + agentTitleFit), so a wide terminal shows a longer
prompt while narrow terminals keep the 60-char floor.

Signed-off-by: dimetron@me.com
Signed-off-by: dimetron <dimetron@me.com>
