### PR TITLE
fix(tools): fall back to PowerShell on Windows when bash is missing; add install.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ Runs on Windows PowerShell 5.1 (built into Windows 10/11) and PowerShell 7+;
 `windows/amd64` only. Set `GITHUB_TOKEN` if you hit the GitHub API rate limit
 while it resolves the latest release.
 
-The installer does not verify the download itself. Run `pi verify` afterwards
-to check the installed binary against its build provenance — see
-[Verifying a release](#verifying-a-release).
+The installer checks the download against the release's `checksums.txt` and
+refuses to install on a mismatch. That catches a corrupted or swapped archive,
+but not a substituted release — `checksums.txt` travels the same path as the
+archive. Run `pi verify` afterwards for the provenance check that does answer
+that question — see [Verifying a release](#verifying-a-release).
 
 Windows machines without `bash.exe` on `PATH` — a stock Windows install has
 none — run agent commands through `powershell.exe` instead, so write PowerShell

--- a/README.md
+++ b/README.md
@@ -65,11 +65,41 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed documentation.
 
 ### Quick install (recommended)
 
+**macOS / Linux**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/dimetron/pi-go/main/scripts/install.sh | bash
 ```
 
 This script detects your OS/arch, downloads the latest release binary, and installs it to `/usr/local/bin` (or `~/.local/bin` if needed).
+
+**Windows**
+
+```powershell
+powershell -NoProfile -Command "iwr https://raw.githubusercontent.com/dimetron/pi-go/main/scripts/install.ps1 -UseBasicParsing | iex"
+```
+
+Or, from a checkout:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/install.ps1
+```
+
+Installs `pi.exe` to `%LOCALAPPDATA%\Programs` and adds that directory to your
+user `PATH`. Restart the terminal afterwards so the new `PATH` is picked up.
+Runs on Windows PowerShell 5.1 (built into Windows 10/11) and PowerShell 7+;
+`windows/amd64` only. Set `GITHUB_TOKEN` if you hit the GitHub API rate limit
+while it resolves the latest release.
+
+The installer does not verify the download itself. Run `pi verify` afterwards
+to check the installed binary against its build provenance — see
+[Verifying a release](#verifying-a-release).
+
+Windows machines without `bash.exe` on `PATH` — a stock Windows install has
+none — run agent commands through `powershell.exe` instead, so write PowerShell
+syntax in prompts: `;` or a newline rather than `&&`. Installing
+[Git for Windows](https://git-scm.com/download/win) puts a `bash` on `PATH` and
+restores the bash behaviour.
 
 ### go install
 

--- a/internal/eval/scenarios/scenarios.go
+++ b/internal/eval/scenarios/scenarios.go
@@ -163,11 +163,11 @@ func bashBackground() eval.Scenario {
 		Files:       map[string]string{"README.md": "# demo\n"},
 		Timeout:     8 * time.Minute,
 		Prompt: "Two tasks, strictly in this order, using the bash tool and its companions bash_wait and bash_kill. " +
-			"(1) Run the command `sleep 70; echo FINISHED-OK` with timeout 60000 (the minimum). It will exceed the " +
+			"(1) Run the command `sleep 70; echo FINISHED-OK` with timeout 60 (the minimum). It will exceed the " +
 			"timeout and be moved to the background; the result carries running=true and a handle. Then call bash_wait " +
-			"with that handle and wait_ms 30000, repeating if needed, until it reports running=false and the output " +
+			"with that handle and wait_sec 30, repeating if needed, until it reports running=false and the output " +
 			"contains FINISHED-OK. " +
-			"(2) Run the command `sleep 600` with timeout 60000. Once it has been moved to the background, stop it with " +
+			"(2) Run the command `sleep 600` with timeout 60. Once it has been moved to the background, stop it with " +
 			"bash_kill using its handle. " +
 			"Finally report the outcome of both tasks.",
 		Checks: []eval.Check{

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -143,14 +143,35 @@ type BashKillInput struct {
 
 const maxBashWait = 60 * time.Second
 
+// bashDescription and powershellDescription describe the execute tool for the
+// model. The bash wording is the default; the PowerShell variant is used on
+// Windows machines without bash so the model writes commands the actual shell
+// can parse instead of failing on bash syntax like `&&` (Windows PowerShell
+// 5.1 rejects it).
 const bashDescription = `Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, running tests, building code, git operations, etc.
 
 A command that runs past its timeout (1m by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.
 
 timeout and idle_timeout are in MILLISECONDS and are floored at 60000 (1 minute): a command that takes less than a minute always finishes in the foreground. Write 300000 for five minutes, not 300.`
 
+const powershellDescription = `Execute a Windows PowerShell command and return its output. Commands run via powershell.exe -NoProfile -Command; this machine has no bash. Use PowerShell syntax: separate statements with ; or newlines (not &&), use Write-Output/echo for printing, Test-Path instead of test -f, Get-ChildItem instead of ls -la. Native tools (git, go, curl.exe) work as usual.
+
+A command that runs past its timeout (1m by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.
+
+timeout and idle_timeout are in MILLISECONDS and are floored at 60000 (1 minute): a command that takes less than a minute always finishes in the foreground. Write 300000 for five minutes, not 300.`
+
+func executeDescription() string {
+	if CurrentShellKind() == "powershell" {
+		return powershellDescription
+	}
+	return bashDescription
+}
+
 func newBashTool(sb *Sandbox, sup *BashSupervisor) (tool.Tool, error) {
-	return newTool("bash", bashDescription, func(ctx agent.Context, input BashInput) (BashOutput, error) {
+	// The tool keeps the well-known "bash" name across platforms so sessions,
+	// configs and muscle memory referencing it stay valid; only the
+	// description tells the model which syntax to write.
+	return newTool("bash", executeDescription(), func(ctx agent.Context, input BashInput) (BashOutput, error) {
 		return bashHandler(sb, sup, ctx, input)
 	})
 }

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -22,36 +21,14 @@ const (
 	// One minute is chosen so the common case stays whole — the vast majority
 	// of commands in this repo (git, go vet, a package test run, a warm build)
 	// finish well inside it — while anything genuinely long says so a minute in
-	// rather than running the turn out. It is also minBashTimeout: a caller
-	// that passes nothing and one that passes the smallest accepted value get
-	// the same budget, which is the only defensible relationship between a
-	// default and a floor. A caller that knows its command is long should raise
-	// `timeout` rather than discover this limit; the idle check then does the
-	// real work, firing well before the raised hard limit.
+	// rather than running the turn out. A caller that knows its command is long
+	// should raise `timeout` rather than discover this limit; the idle check
+	// then does the real work, firing well before the raised hard limit.
 	defaultBashTimeout = time.Minute
 
-	// minBashTimeout is the floor under both caller-supplied limits.
-	//
-	// It exists because `timeout` and `idle_timeout` are milliseconds, which is
-	// invisible at the call site: a caller writing `timeout: 300` means five
-	// minutes and gets 300ms. Nothing that small can succeed — `make` has not
-	// printed its first line by then — so the command is handed off before it
-	// has done anything, and the caller is left polling a handle to recover
-	// work that would have finished in the foreground.
-	//
-	// Flooring at a minute costs a caller that genuinely wanted a sub-second
-	// budget nothing it can use, since a handoff is not a kill: the command
-	// keeps running either way. What it buys is that every command shorter than
-	// a minute now completes in the foreground, whatever units the caller
-	// thought it was passing.
-	//
-	// Subagent frontmatter had the same bug and took the same view — see
-	// minAgentTimeoutMs in internal/subagent/agents.go, where `timeout: 30`
-	// meant thirty seconds and SIGKILLed the agent 30ms in. That one ignores
-	// the value and falls back to the default; this one floors, because a
-	// handoff is recoverable where a kill is not, and the floor and the default
-	// are the same minute anyway.
-	minBashTimeout = time.Minute
+	// maxBashTimeout caps a caller-supplied limit. Past ten minutes the caller
+	// should be backgrounding deliberately and polling with bash_wait rather
+	// than holding the foreground.
 	maxBashTimeout = 10 * time.Minute
 )
 
@@ -59,18 +36,13 @@ const (
 type BashInput struct {
 	// The shell command to execute.
 	Command string `json:"command"`
-	// Optional timeout in MILLISECONDS. Default: 60000 (1 minute).
-	// Min: 60000 (1 minute). Max: 600000 (10 minutes).
-	// On expiry the command is moved to the background, not killed. Raise it for
-	// work you already know is long (a full test suite, an image build) so it
-	// finishes in the foreground instead of costing a round trip. Values below
-	// the minute floor are raised to it, because they are nearly always seconds
-	// written where milliseconds were expected.
+	// Optional timeout in SECONDS. Default 60, max 600. On expiry the command
+	// is moved to the background, not killed. Raise it for work you already
+	// know is long so it finishes in the foreground instead of costing a round
+	// trip.
 	Timeout int `json:"timeout,omitempty"`
-	// Optional idle timeout in MILLISECONDS. A command that produces no output
-	// at all for this long is moved to the background. Default: 90000.
-	// Min: 60000 (1 minute). Set it higher for commands that are legitimately
-	// quiet for a long time.
+	// Optional idle timeout in SECONDS. A command that produces no output at
+	// all for this long is moved to the background. Default 90.
 	IdleTimeout int `json:"idle_timeout,omitempty"`
 }
 
@@ -129,10 +101,10 @@ type BashStatus struct {
 type BashWaitInput struct {
 	// Handle returned by a previous bash call.
 	Handle string `json:"handle"`
-	// WaitMs blocks up to this long for new output or for the command to exit,
-	// Defaults to 60000. Prefer waiting over polling
-	// in a loop.
-	WaitMs int `json:"wait_ms,omitempty"`
+	// WaitSec blocks up to this long, in SECONDS, for new output or for the
+	// command to exit. Defaults to 60. Prefer one long wait over polling in a
+	// loop.
+	WaitSec int `json:"wait_sec,omitempty"`
 }
 
 // BashKillInput identifies a backgrounded command to stop.
@@ -143,28 +115,26 @@ type BashKillInput struct {
 
 const maxBashWait = 60 * time.Second
 
-// bashDescription and powershellDescription describe the execute tool for the
-// model. The bash wording is the default; the PowerShell variant is used on
-// Windows machines without bash so the model writes commands the actual shell
-// can parse instead of failing on bash syntax like `&&` (Windows PowerShell
-// 5.1 rejects it).
-const bashDescription = `Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, running tests, building code, git operations, etc.
+// The bash tool's description is a lead plus a shared tail. Only the lead
+// differs by platform: on Windows without bash the command runs through
+// PowerShell, which rejects bash syntax like `&&`, so the model has to be told
+// which shell it is writing for. The backgrounding contract and the units are
+// the same either way, so they are stated once.
+const bashLead = `Execute a shell command and return its output. Commands run in a bash shell. Use for system operations, tests, builds, git, etc.`
 
-A command that runs past its timeout (1m by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.
+const powershellLead = `Execute a shell command and return its output. Commands run through powershell.exe -NoProfile -Command; this machine has no bash. Write PowerShell syntax: ; or a newline instead of &&, Test-Path instead of test -f, Get-ChildItem instead of ls. Native tools (git, go, curl.exe) work as usual.`
 
-timeout and idle_timeout are in MILLISECONDS and are floored at 60000 (1 minute): a command that takes less than a minute always finishes in the foreground. Write 300000 for five minutes, not 300.`
+const bashLimits = `
 
-const powershellDescription = `Execute a Windows PowerShell command and return its output. Commands run via powershell.exe -NoProfile -Command; this machine has no bash. Use PowerShell syntax: separate statements with ; or newlines (not &&), use Write-Output/echo for printing, Test-Path instead of test -f, Get-ChildItem instead of ls -la. Native tools (git, go, curl.exe) work as usual.
+A command that outlives its timeout (60s), or goes 90s with no output, is backgrounded rather than killed: the result carries running=true and a handle. Raise timeout for work you already know is long — a full test suite, an image build. Use bash_wait to read more output and bash_kill to stop it; a handle with no output at all means the command is too broad.
 
-A command that runs past its timeout (1m by default), or that produces no output at all for 90s, is not killed: it keeps running in the background and the result carries running=true and a handle. Pass a larger timeout for work you already know is long — a full test suite, an image build — rather than letting the default hand it off. Use bash_wait to collect more of its output and bash_kill to stop it. A handle with no output at all usually means the command is far too broad — narrow it or kill it rather than waiting on it.
-
-timeout and idle_timeout are in MILLISECONDS and are floored at 60000 (1 minute): a command that takes less than a minute always finishes in the foreground. Write 300000 for five minutes, not 300.`
+timeout, idle_timeout and wait_sec are in SECONDS, capped at 600. Write 300 for five minutes, not 300000.`
 
 func executeDescription() string {
 	if CurrentShellKind() == "powershell" {
-		return powershellDescription
+		return powershellLead + bashLimits
 	}
-	return bashDescription
+	return bashLead + bashLimits
 }
 
 func newBashTool(sb *Sandbox, sup *BashSupervisor) (tool.Tool, error) {
@@ -199,8 +169,8 @@ func bashHandler(sb *Sandbox, sup *BashSupervisor, ctx agent.Context, input Bash
 	out, err := sup.Run(parentCtx, runRequest{
 		dir:         sb.Dir(),
 		command:     input.Command,
-		timeout:     clampDuration(input.Timeout, defaultBashTimeout, minBashTimeout, maxBashTimeout),
-		idleTimeout: clampDuration(input.IdleTimeout, 0, minBashTimeout, maxBashTimeout),
+		timeout:     clampDuration(input.Timeout, defaultBashTimeout, 0, maxBashTimeout),
+		idleTimeout: clampDuration(input.IdleTimeout, 0, 0, maxBashTimeout),
 	})
 	if err != nil {
 		span.RecordError(err)
@@ -214,73 +184,22 @@ func bashHandler(sb *Sandbox, sup *BashSupervisor, ctx agent.Context, input Bash
 		attribute.Bool("bash.backgrounded", out.Running),
 	)
 
-	if n := flooredNote(input); n != "" {
-		out.Note = strings.TrimSpace(out.Note + " " + n)
-	}
 	return out, nil
 }
 
-// flooredNote reports a limit that was raised to minBashTimeout.
+// clampDuration converts a seconds input to a duration, substituting fallback
+// when unset and holding the result within [minDur, maxDur].
 //
-// Silently correcting the value would fix this call and leave the caller
-// repeating the mistake on the next one, so the note names the unit and gives
-// the number that would have meant what the caller wrote. It is deliberately
-// emitted whether or not the command was backgrounded: a caller that wrote
-// `timeout: 300` and got a clean result still asked for something it did not
-// get, and that is the cheapest moment to say so.
-func flooredNote(input BashInput) string {
-	var raised []string
-	var suggested bool
-	for _, f := range []struct {
-		name string
-		ms   int
-	}{{"timeout", input.Timeout}, {"idle_timeout", input.IdleTimeout}} {
-		if f.ms <= 0 || time.Duration(f.ms)*time.Millisecond >= minBashTimeout {
-			continue
-		}
-		desc, ok := describeFloored(f.name, f.ms)
-		raised = append(raised, desc)
-		suggested = suggested || ok
-	}
-	if len(raised) == 0 {
-		return ""
-	}
-	note := fmt.Sprintf("Raised to the %s floor: %s. These limits are in"+
-		" milliseconds.", minBashTimeout, strings.Join(raised, ", "))
-	if suggested {
-		note += " A value this far under the floor is nearly always seconds" +
-			" written where milliseconds were expected."
-	}
-	return note
-}
-
-// describeFloored renders one raised limit, and — where the number reads as a
-// plausible seconds value — what to write instead.
-//
-// The suggestion is withheld once the seconds reading exceeds maxBashTimeout,
-// because past that point it stops being a diagnosis and starts being noise:
-// `idle_timeout: 5000` is a deliberate five seconds, and answering it with
-// "write 5000000 for 1h23m20s" is worse than saying nothing.
-func describeFloored(field string, ms int) (desc string, suggested bool) {
-	asked := time.Duration(ms) * time.Millisecond
-	if meant := time.Duration(ms) * time.Second; meant <= maxBashTimeout {
-		return fmt.Sprintf("%s=%s (write %d for %s)", field, asked, ms*1000, meant), true
-	}
-	return fmt.Sprintf("%s=%s", field, asked), false
-}
-
-// clampDuration converts a millisecond input to a duration, substituting
-// fallback when unset and holding the result within [minDur, maxDur].
-//
-// The floor applies only to a value the caller actually supplied. An unset
-// input takes fallback unchanged, so a caller that passes nothing gets the
-// default that was chosen for it rather than one bent by a floor meant to
-// catch a unit mistake. Pass minDur = 0 where no floor applies.
-func clampDuration(ms int, fallback, minDur, maxDur time.Duration) time.Duration {
-	if ms <= 0 {
+// A floor applies only to a value the caller actually supplied: an unset input
+// takes fallback unchanged, so a caller that passes nothing gets the default
+// chosen for it rather than one bent by a floor. Pass minDur = 0 where no
+// floor applies, which is every current caller — the units are seconds now, so
+// there is no unit mistake left to guard against.
+func clampDuration(sec int, fallback, minDur, maxDur time.Duration) time.Duration {
+	if sec <= 0 {
 		return fallback
 	}
-	d := time.Duration(ms) * time.Millisecond
+	d := time.Duration(sec) * time.Second
 	if d < minDur {
 		return minDur
 	}
@@ -298,12 +217,12 @@ func clampDuration(ms int, fallback, minDur, maxDur time.Duration) time.Duration
 // builds its own supervisor and never streams need not carry the extra schema.
 func BashControlTools(sup *BashSupervisor) ([]tool.Tool, error) {
 	waitTool, err := newTool("bash_wait",
-		"Wait on a backgrounded shell command and return whatever it produced since the last wait. Blocks up to 60 seconds for new output or for the command to exit; use wait_ms for a shorter wait. Returns running=false and the exit code once it finishes, after which the handle is spent. Wait once with a generous wait_ms rather than calling this in a loop — each call is a round trip, and an empty result means nothing new since the last one, not that the command is stuck.",
+		"Wait on a backgrounded shell command and return whatever it produced since the last wait. Blocks up to 60 seconds for new output or for the command to exit; use wait_sec for a shorter wait. Returns running=false and the exit code once it finishes, after which the handle is spent. Wait once with a generous wait_sec rather than calling this in a loop — each call is a round trip, and an empty result means nothing new since the last one, not that the command is stuck.",
 		func(_ agent.Context, input BashWaitInput) (BashStatus, error) {
 			if input.Handle == "" {
 				return BashStatus{}, fmt.Errorf("handle is required (running: %v)", sup.Handles())
 			}
-			return sup.readOutput(input.Handle, clampDuration(input.WaitMs, maxBashWait, 0, maxBashWait))
+			return sup.readOutput(input.Handle, clampDuration(input.WaitSec, maxBashWait, 0, maxBashWait))
 		})
 	if err != nil {
 		return nil, err

--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -36,7 +36,7 @@ func TestBashControlTools_Registered(t *testing.T) {
 		if !names[want] {
 			t.Errorf("missing tool %q; got %v", want, names)
 		}
-		if !strings.Contains(bashDescription, want) {
+		if !strings.Contains(executeDescription(), want) {
 			t.Errorf("bash description should point the model at %q", want)
 		}
 	}
@@ -80,7 +80,7 @@ func TestBashControlTools_DefaultWaitsForOutput(t *testing.T) {
 		t.Fatalf("expected a backgrounded command, got %+v", out)
 	}
 
-	// An omitted wait_ms must use the same blocking-by-default behavior exposed
+	// An omitted wait_sec must use the same blocking-by-default behavior exposed
 	// by bash_wait, rather than immediately returning an empty poll result.
 	res, err := runNamedTool(t, ts, "bash_wait", map[string]any{"handle": out.Handle})
 	if err != nil {
@@ -114,10 +114,10 @@ func TestBashControlTools_RoundTrip(t *testing.T) {
 		t.Fatalf("expected a backgrounded command, got %+v", out)
 	}
 
-	// wait_ms means one call, not a polling loop — the whole reason it exists.
+	// wait_sec means one call, not a polling loop — the whole reason it exists.
 	res, err := runNamedTool(t, ts, "bash_wait", map[string]any{
-		"handle":  out.Handle,
-		"wait_ms": 3000,
+		"handle":   out.Handle,
+		"wait_sec": 3,
 	})
 	if err != nil {
 		t.Fatalf("bash_wait: %v", err)
@@ -238,75 +238,53 @@ func TestBashHandler_EmptyCommandRejected(t *testing.T) {
 	}
 }
 
-// TestBashHandler_SubMinuteLimitsAreFloored is the regression for a real
+// TestBashHandler_SubMinuteLimitsAreHonored is the regression for a real
 // session: `timeout: 300` meant five minutes, arrived as 300ms, and handed
 // `make test-coverage` to the background 312ms in — before make had printed a
 // line. The command then took two extra round trips to recover work that would
 // have finished in the foreground.
 //
-// A limit under a minute is now raised to one, so the command runs to
-// completion, and the result says what was raised and why.
-func TestBashHandler_SubMinuteLimitsAreFloored(t *testing.T) {
+// The tool now takes seconds, so `timeout: 300` is five minutes and a small
+// value is honored as written rather than raised to a floor.
+func TestBashHandler_SubMinuteLimitsAreHonored(t *testing.T) {
 	sb := testSandbox(t, t.TempDir())
 	sup := testSupervisor(t)
 	sup.heartbeat = 20 * time.Millisecond
 
 	out, err := bashHandler(sb, sup, nil, BashInput{
 		Command:     "sleep 0.4 && echo done",
-		Timeout:     300, // ms — the caller meant 300 seconds
+		Timeout:     300, // seconds — five minutes
 		IdleTimeout: 150,
 	})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
 	if out.Running {
-		t.Fatalf("a sub-second limit was honored and backgrounded the command: %+v", out)
+		t.Fatalf("a 5-minute limit backgrounded a 0.4s command: %+v", out)
 	}
 	if !strings.Contains(out.Stdout, "done") {
 		t.Errorf("command should have run to completion, got stdout %q", out.Stdout)
 	}
-	// The note has to teach the unit, or the caller repeats the mistake.
-	for _, want := range []string{"timeout=300ms", "300000", "idle_timeout=150ms", "millisecond"} {
-		if !strings.Contains(out.Note, want) {
-			t.Errorf("Note = %q, want it to contain %q", out.Note, want)
-		}
+	// No unit lecture: the value means what it says.
+	if out.Note != "" {
+		t.Errorf("Note = %q, want none for a seconds value that means what it says", out.Note)
 	}
 }
 
-// A number too large to be a plausible seconds value gets no "you meant
-// seconds" correction. `idle_timeout: 5000` is a deliberate five seconds, and
-// answering it with "write 5000000 for 1h23m20s" would be worse than silence.
-func TestFlooredNote_WithholdsImplausibleSuggestions(t *testing.T) {
-	note := flooredNote(BashInput{IdleTimeout: 5000})
-
-	if !strings.Contains(note, "idle_timeout=5s") {
-		t.Errorf("note = %q, want it to name the raised limit", note)
-	}
-	for _, unwanted := range []string{"write ", "seconds written"} {
-		if strings.Contains(note, unwanted) {
-			t.Errorf("note = %q, should not contain %q", note, unwanted)
-		}
-	}
-	// A small number keeps the correction, so the two paths stay distinct.
-	if got := flooredNote(BashInput{Timeout: 300}); !strings.Contains(got, "write 300000 for 5m0s") {
-		t.Errorf("note = %q, want the seconds correction", got)
-	}
-}
-
-// A limit the caller meant is left alone: the floor is a unit-mistake guard,
-// not a policy on how long commands may hold the foreground.
+// A limit the caller meant is left alone: the tool takes seconds, so there is
+// no unit-mistake guard to trip on a deliberate value.
 func TestBashHandler_SaneLimitsAreNotAnnotated(t *testing.T) {
 	sb := testSandbox(t, t.TempDir())
 
 	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
 		Command: "echo hi",
-		Timeout: 120000, // 2m, comfortably above the floor
+		Timeout: 120, // 2m
 	})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
 	if out.Note != "" {
-		t.Errorf("Note = %q, want none for a limit above the floor", out.Note)
+		t.Errorf("Note = %q, want none for a limit above the default", out.Note)
 	}
 }
 
@@ -484,13 +462,13 @@ func TestClampDuration(t *testing.T) {
 	if got := clampDuration(-5, fallback, minDur, maxDur); got != fallback {
 		t.Errorf("negative input = %v, want the fallback %v", got, fallback)
 	}
-	if got := clampDuration(3000, fallback, minDur, maxDur); got != 3*time.Second {
-		t.Errorf("3000ms = %v, want 3s", got)
+	if got := clampDuration(3, fallback, minDur, maxDur); got != 3*time.Second {
+		t.Errorf("3s = %v, want 3s", got)
 	}
-	if got := clampDuration(50, fallback, minDur, maxDur); got != minDur {
+	if got := clampDuration(1, fallback, minDur, maxDur); got != minDur {
 		t.Errorf("undersized input = %v, want the floor %v", got, minDur)
 	}
-	if got := clampDuration(999999, fallback, minDur, maxDur); got != maxDur {
+	if got := clampDuration(999, fallback, minDur, maxDur); got != maxDur {
 		t.Errorf("oversized input = %v, want the cap %v", got, maxDur)
 	}
 	// The floor catches a caller's mistake; it must not bend a default that
@@ -499,8 +477,8 @@ func TestClampDuration(t *testing.T) {
 		t.Errorf("unset input = %v, want the fallback unbent by the floor", got)
 	}
 	// A zero floor means no floor — bash_wait needs short waits.
-	if got := clampDuration(50, fallback, 0, maxDur); got != 50*time.Millisecond {
-		t.Errorf("50ms with no floor = %v, want 50ms", got)
+	if got := clampDuration(1, fallback, 0, maxDur); got != time.Second {
+		t.Errorf("1s with no floor = %v, want 1s", got)
 	}
 }
 
@@ -535,13 +513,6 @@ func TestSupervisorDefaults(t *testing.T) {
 func TestBashDefaultTimeout_IsTheForegroundBudget(t *testing.T) {
 	if defaultBashTimeout != time.Minute {
 		t.Errorf("defaultBashTimeout = %s, want 1m", defaultBashTimeout)
-	}
-	// The default cannot sit below the floor: a caller that passes nothing
-	// would then get a shorter budget than one that asks for the smallest
-	// value the tool accepts, which is indefensible in either direction.
-	if defaultBashTimeout < minBashTimeout {
-		t.Errorf("defaultBashTimeout %s is below the %s floor",
-			defaultBashTimeout, minBashTimeout)
 	}
 	// The idle check only earns its keep while it can fire before the hard
 	// limit, which under defaults it cannot — it exists for callers that raise
@@ -635,5 +606,38 @@ func TestBashWait_LingeringGrandchildCostsTheExitStatus(t *testing.T) {
 	if elapsed > 15*time.Second {
 		t.Errorf("wait took %s; expected it to end when the wait delay (%s) fires",
 			elapsed, procs.DefaultWaitDelay)
+	}
+}
+
+// TestExecuteDescription_SharesTheLimitsTail pins the split that keeps the two
+// platform descriptions from drifting: only the lead differs, and the
+// backgrounding contract and the units are stated once for both.
+//
+// The units matter more than the wording. They are seconds, and the tool has
+// no way to tell a caller that meant milliseconds — a schema property carries
+// no description of its own — so the description is the only place the model
+// can learn them.
+func TestExecuteDescription_SharesTheLimitsTail(t *testing.T) {
+	for name, desc := range map[string]string{
+		"bash":       bashLead + bashLimits,
+		"powershell": powershellLead + bashLimits,
+	} {
+		for _, want := range []string{"SECONDS", "bash_wait", "bash_kill", "600"} {
+			if !strings.Contains(desc, want) {
+				t.Errorf("%s description is missing %q", name, want)
+			}
+		}
+		if strings.Contains(desc, "MILLISECONDS") {
+			t.Errorf("%s description still claims milliseconds", name)
+		}
+	}
+
+	// The PowerShell lead has to name the syntax difference that actually
+	// breaks commands, or the model writes `&&` and the shell rejects it.
+	if !strings.Contains(powershellLead, "&&") {
+		t.Error("powershell lead should warn that && is not PowerShell syntax")
+	}
+	if strings.Contains(bashLead, "powershell") {
+		t.Error("bash lead should not mention powershell")
 	}
 }

--- a/internal/tools/bash_control_test.go
+++ b/internal/tools/bash_control_test.go
@@ -480,6 +480,18 @@ func TestClampDuration(t *testing.T) {
 	if got := clampDuration(1, fallback, 0, maxDur); got != time.Second {
 		t.Errorf("1s with no floor = %v, want 1s", got)
 	}
+	// Both bounds are inclusive. A `<=` where the code has `<` would move a
+	// value the caller is entitled to, and the cap boundary is the one the
+	// description advertises: "capped at 600" has to mean 600 is accepted.
+	if got := clampDuration(int(minDur/time.Second), fallback, minDur, maxDur); got != minDur {
+		t.Errorf("input exactly at the floor = %v, want it left alone at %v", got, minDur)
+	}
+	if got := clampDuration(int(maxDur/time.Second), fallback, minDur, maxDur); got != maxDur {
+		t.Errorf("input exactly at the cap = %v, want it left alone at %v", got, maxDur)
+	}
+	if got := clampDuration(600, defaultBashTimeout, 0, maxBashTimeout); got != maxBashTimeout {
+		t.Errorf("timeout: 600 = %v, want the advertised %v ceiling", got, maxBashTimeout)
+	}
 }
 
 // TestNewStream_DefaultsWhenLimitUnset guards against a zero limit silently
@@ -639,5 +651,40 @@ func TestExecuteDescription_SharesTheLimitsTail(t *testing.T) {
 	}
 	if strings.Contains(bashLead, "powershell") {
 		t.Error("bash lead should not mention powershell")
+	}
+}
+
+// The tool keeps the name "bash" on every platform, so its description is the
+// only thing telling the model which shell it is writing for. On a Windows
+// machine with no bash the commands go through powershell.exe, which rejects
+// `&&`; if the registered tool carried the bash lead there, every compound
+// command the model wrote would fail at the shell rather than in the code.
+func TestNewBashTool_DescriptionFollowsTheResolvedShell(t *testing.T) {
+	for _, tt := range []struct {
+		kind string
+		lead string
+	}{
+		{shellKindBash, bashLead},
+		{shellKindPowerShell, powershellLead},
+	} {
+		t.Run(tt.kind, func(t *testing.T) {
+			withShellKind(t, tt.kind)
+
+			if got, want := executeDescription(), tt.lead+bashLimits; got != want {
+				t.Fatalf("executeDescription() = %q, want the %s lead", got, tt.kind)
+			}
+			bt, err := newBashTool(testSandbox(t, t.TempDir()), testSupervisor(t))
+			if err != nil {
+				t.Fatalf("newBashTool: %v", err)
+			}
+			if bt.Name() != "bash" {
+				t.Errorf("Name() = %q, want the tool to keep the bash name on every platform", bt.Name())
+			}
+			// The description the model actually receives has to be the
+			// resolved one, not the constant it was built from.
+			if got := bt.Description(); got != tt.lead+bashLimits {
+				t.Errorf("registered description = %q, want the %s lead", got, tt.kind)
+			}
+		})
 	}
 }

--- a/internal/tools/bash_limits_test.go
+++ b/internal/tools/bash_limits_test.go
@@ -75,6 +75,28 @@ func TestLimitsHint(t *testing.T) {
 			want:    []string{"idle_timeout 1m30s", "timeout 5m0s"},
 			notWant: []string{"rather than polling the handle"},
 		},
+		{
+			// The hint tells the caller which knob to turn, so it has to name
+			// the unit the tool actually takes. Left saying milliseconds, it
+			// sends a caller who wanted five minutes to write 300000 — which
+			// is now eighty-three hours and comes straight back as the cap.
+			name:    "the hint names the unit the tool takes",
+			timeout: 2 * time.Minute,
+			idle:    time.Second,
+			want:    []string{"both are seconds"},
+			notWant: []string{"millisecond"},
+		},
+		{
+			// shortIdleTimeout is a `<` boundary. An idle limit exactly at the
+			// default foreground budget is an ordinary choice, not a hair
+			// trigger, and lecturing about it would put the warning on every
+			// default-shaped call.
+			name:    "an idle limit exactly at the threshold is not called out",
+			timeout: 5 * time.Minute,
+			idle:    shortIdleTimeout,
+			want:    []string{"idle_timeout 1m0s"},
+			notWant: []string{"rather than polling the handle"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -34,12 +34,12 @@ const (
 	// shortIdleTimeout is the threshold below which an idle limit is treated as
 	// self-defeating and called out in the result.
 	//
-	// It tracks minBashTimeout, the floor the bash tool applies to both
-	// caller-supplied limits. A value under it cannot arrive through the tool
-	// at all, so what this catches is the other route in: a caller building a
-	// runRequest directly, where nothing clamps anything. Nothing is
-	// overridden on that path — the hint is all the supervisor owes it.
-	shortIdleTimeout = minBashTimeout
+	// It tracks the bash tool's default foreground budget. Now that the tool's
+	// limits are seconds, a small value is a deliberate choice rather than a
+	// unit slip, so nothing clamps it away: `idle_timeout: 1` reaches the
+	// supervisor as one second and backgrounds the first build that pauses to
+	// think. Naming the limit in the result is all the supervisor owes it.
+	shortIdleTimeout = defaultBashTimeout
 
 	// heartbeatInterval is how often a running command reports that it is still
 	// alive. It drives the "45s, no output" line in the UI, which is the whole
@@ -426,7 +426,7 @@ func limitsHint(timeout, idle time.Duration) string {
 	if idle < shortIdleTimeout {
 		hint += fmt.Sprintf(" An idle limit under %s backgrounds ordinary builds and"+
 			" test runs the moment they go quiet. idle_timeout is clamped to"+
-			" timeout, so raise timeout (both are milliseconds) rather than"+
+			" timeout, so raise timeout (both are seconds) rather than"+
 			" polling the handle.", roundDur(shortIdleTimeout))
 	}
 	return hint

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -259,7 +259,7 @@ func (s *BashSupervisor) start(ctx context.Context, req runRequest) (*bashProc, 
 		done:        make(chan struct{}),
 	}
 
-	cmd := exec.CommandContext(runCtx, "bash", "-c", req.command)
+	cmd := shellCommand(runCtx, req.command)
 	cmd.Dir = req.dir
 	cmd.Stdout = &sinkWriter{proc: p, stream: p.stdout, kind: "output"}
 	cmd.Stderr = &sinkWriter{proc: p, stream: p.stderr, kind: "stderr"}

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -47,7 +47,7 @@ func TestBashHandler_TimeoutCappedAtTenMinutes(t *testing.T) {
 
 	// Timeout of 20 minutes should be capped at 10 minutes.
 	// The command itself completes in a fraction of a second.
-	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "echo capped", Timeout: 20 * 60 * 1000})
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: "echo capped", Timeout: 20 * 60})
 	if err != nil {
 		t.Fatalf("bashHandler: %v", err)
 	}
@@ -147,10 +147,10 @@ func TestBashHandler_RunsInSandboxDir(t *testing.T) {
 // Killing it would discard whatever it had produced and tell the model nothing
 // about why it stopped.
 //
-// The handoff is driven by the idle limit on the supervisor rather than a small
-// `timeout` in the input, because minBashTimeout floors anything the caller
-// passes at a minute — which is the whole point of the floor, but leaves the
-// supervisor field as the only way to reach this path inside a test's patience.
+// The handoff is driven by the sub-second idle limit on the supervisor rather
+// than a small `timeout` in the input: the tool's limits are whole seconds, so
+// the shortest budget a caller can express is a second, and the supervisor
+// field is the only way to reach this path inside a test's patience.
 func TestBashHandler_TimeoutHandsOffToBackground(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)

--- a/internal/tools/edit.go
+++ b/internal/tools/edit.go
@@ -32,9 +32,7 @@ type EditOutput struct {
 func newEditTool(sb *Sandbox, ledger *ReadLedger) (tool.Tool, error) {
 	return newTool("edit", `Edit a file by replacing an exact string match.
 
-Required: file_path (absolute path), old_string (text to find).
-Optional: new_string (replacement, default "" = delete old_string), replace_all (bool, default false).
-old_string must be unique unless replace_all is true.`, func(_ agent.Context, input EditInput) (EditOutput, error) {
+old_string must be unique unless replace_all is true. Omitting new_string deletes old_string.`, func(_ agent.Context, input EditInput) (EditOutput, error) {
 		return editHandlerWithLedger(sb, input, ledger)
 	})
 }

--- a/internal/tools/git_diff.go
+++ b/internal/tools/git_diff.go
@@ -35,8 +35,7 @@ type GitFileDiffOutput struct {
 func newGitFileDiffTool(sb *Sandbox) (tool.Tool, error) {
 	return newTool("git-file-diff", `Get the unified diff for a specific file.
 
-Required: file (path relative to repo root).
-Optional: staged (bool, default false — set true for cached/staged changes).`, func(ctx agent.Context, input GitFileDiffInput) (GitFileDiffOutput, error) {
+file is relative to the repo root. Set staged for the cached diff.`, func(ctx agent.Context, input GitFileDiffInput) (GitFileDiffOutput, error) {
 		return gitFileDiffHandler(sb, ctx, input)
 	})
 }

--- a/internal/tools/lsp.go
+++ b/internal/tools/lsp.go
@@ -25,6 +25,7 @@ type LSPFileInput struct {
 }
 
 // LSPPositionInput is shared input for tools that take a file + position.
+// Line and column are 0-based.
 type LSPPositionInput struct {
 	File   string `json:"file"`
 	Line   int    `json:"line,omitempty"`
@@ -132,9 +133,7 @@ func newLSPDiagnosticsTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-diagnostics",
 		`Get LSP diagnostics (errors, warnings) for a file.
 
-Returns compiler errors, type errors, and warnings from the language server.
-Use this to check a file for errors without editing it, or to get more detail
-than the automatic diagnostics provided after write/edit.`,
+Returns compiler errors, type errors, and warnings from the language server. Use this to check a file for errors without editing it.`,
 		func(ctx agent.Context, input LSPFileInput) (LSPDiagnosticsOutput, error) {
 			return lspDiagnosticsHandler(ctx, mgr, input)
 		}, lspFileAliases)
@@ -144,8 +143,7 @@ func newLSPDefinitionTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-definition",
 		`Go to definition of a symbol at a given position.
 
-Returns the file and line where a function, type, variable, or other symbol
-is defined. Line and column are 0-based.`,
+Returns the file and line where a function, type, variable, or other symbol is defined. Line and column are 0-based.`,
 		func(ctx agent.Context, input LSPPositionInput) (LSPLocationsOutput, error) {
 			return lspDefinitionHandler(ctx, mgr, input)
 		}, lspFileAliases)
@@ -155,8 +153,7 @@ func newLSPReferencesTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-references",
 		`Find all references to a symbol at a given position.
 
-Returns all locations where the symbol at the given position is referenced,
-including the declaration. Line and column are 0-based.`,
+Returns all locations where the symbol at the given position is referenced, including the declaration. Line and column are 0-based.`,
 		func(ctx agent.Context, input LSPPositionInput) (LSPLocationsOutput, error) {
 			return lspReferencesHandler(ctx, mgr, input)
 		}, lspFileAliases)
@@ -166,8 +163,7 @@ func newLSPHoverTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-hover",
 		`Get type information and documentation for a symbol at a given position.
 
-Returns the type signature and documentation for the symbol under the cursor.
-Line and column are 0-based.`,
+Returns the type signature and documentation for the symbol under the cursor. Line and column are 0-based.`,
 		func(ctx agent.Context, input LSPPositionInput) (LSPHoverOutput, error) {
 			return lspHoverHandler(ctx, mgr, input)
 		}, lspFileAliases)
@@ -177,8 +173,7 @@ func newLSPSymbolsTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-symbols",
 		`List all symbols (functions, types, variables) in a file.
 
-Returns an overview of the file's structure including function definitions,
-type declarations, constants, and variables with their line ranges.`,
+Returns an overview of the file's structure including function definitions, type declarations, constants, and variables with their line ranges.`,
 		func(ctx agent.Context, input LSPFileInput) (LSPSymbolsOutput, error) {
 			return lspSymbolsHandler(ctx, mgr, input)
 		}, lspFileAliases)
@@ -188,9 +183,7 @@ func newLSPWorkspaceSymbolTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-workspace-symbol",
 		`Search for symbols across the entire project workspace.
 
-Returns symbols matching a query string from all source files,
-including functions, types, constants, and variables across modules.
-Useful for finding where a symbol is defined without knowing the file.`,
+Returns symbols matching a query string from all source files, including functions, types, constants, and variables across modules. Useful for finding where a symbol is defined without knowing the file.`,
 		func(ctx agent.Context, input LSPWorkspaceSymbolInput) (LSPWorkspaceSymbolOutput, error) {
 			return lspWorkspaceSymbolHandler(ctx, mgr, input)
 		}, nil)
@@ -200,9 +193,7 @@ func newLSPCodeActionTool(mgr *lsp.Manager) (tool.Tool, error) {
 	return newTool("lsp-code-action",
 		`Get available code actions (quick fixes, refactorings) for a selection.
 
-Returns available code actions such as error fixes, imports, refactorings,
-and other quick fixes. The selection is specified by start and end positions.
-Line and column are 0-based.`,
+Returns available code actions such as error fixes, imports, refactorings, and other quick fixes. The selection is given by start and end positions; lines and columns are 0-based.`,
 		func(ctx agent.Context, input LSPCodeActionInput) (LSPCodeActionOutput, error) {
 			return lspCodeActionHandler(ctx, mgr, input)
 		}, lspFileAliases)

--- a/internal/tools/mem_search.go
+++ b/internal/tools/mem_search.go
@@ -34,7 +34,7 @@ type MemSearchOutput struct {
 
 func newMemSearchTool(store memory.Store) (tool.Tool, error) {
 	return newTool("mem-search",
-		"Search past observations using full-text search. Returns a compact table with IDs, titles, and types. Use mem-get to fetch full details for specific IDs.",
+		"Search past observations using full-text search. Returns a compact table with IDs, titles, and types. Use mem-get to fetch full details.",
 		func(ctx agent.Context, input MemSearchInput) (MemSearchOutput, error) {
 			return memSearchHandler(ctx, store, input)
 		})
@@ -100,7 +100,7 @@ type MemTimelineOutput struct {
 
 func newMemTimelineTool(store memory.Store) (tool.Tool, error) {
 	return newTool("mem-timeline",
-		"Show observations around an anchor observation in chronological order. Useful for understanding the context of a specific observation.",
+		"Show observations around an anchor observation in chronological order.",
 		func(ctx agent.Context, input MemTimelineInput) (MemTimelineOutput, error) {
 			return memTimelineHandler(ctx, store, input)
 		})
@@ -161,7 +161,7 @@ type MemGetOutput struct {
 
 func newMemGetTool(store memory.Store) (tool.Tool, error) {
 	return newTool("mem-get",
-		"Fetch full details for specific observations by ID. Use after mem-search or mem-timeline to get complete observation text.",
+		"Fetch full details for specific observations by ID. Use after mem-search or mem-timeline.",
 		func(ctx agent.Context, input MemGetInput) (MemGetOutput, error) {
 			return memGetHandler(ctx, store, input)
 		})

--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -78,10 +78,7 @@ type ReadOutput struct {
 func newReadTool(sb *Sandbox, ledger *ReadLedger) (tool.Tool, error) {
 	return newTool("read", `Read a file's contents. Returns the content with line numbers.
 
-Required: file_path (absolute path to the file).
-Optional: offset (start line, 1-based), limit (max lines to read).
-
-Large files come back a window at a time; next_offset is the exact offset to pass to continue.`,
+offset is 1-based. Large files come back a window at a time; next_offset is the exact offset to pass to continue.`,
 		func(_ agent.Context, input ReadInput) (ReadOutput, error) {
 			// The ledger must be threaded through here, not dropped: write
 			// gates on it, so a read that does not record leaves every

--- a/internal/tools/read_image.go
+++ b/internal/tools/read_image.go
@@ -102,7 +102,7 @@ type ReadImageOutput struct {
 func newReadImageTool(sb *Sandbox) (tool.Tool, error) {
 	return newTool("read_image", `Read an image and make it visible to the model (vision).
 
-Use this after a screenshot has been saved to disk (for example by the playwright browser_take_screenshot tool), or to inspect a remote image by URL, so the agent can actually see the image contents and describe what it shows.
+Use this after a screenshot has been saved to disk, or to inspect a remote image by URL.
 
 Required: file_path — either an absolute/sandbox-relative path to a local image, or an https:// URL to a remote image.
 

--- a/internal/tools/session_stats.go
+++ b/internal/tools/session_stats.go
@@ -65,10 +65,7 @@ const defaultHighGitOps = 50
 
 func newSessionStatsTool() (tool.Tool, error) {
 	return newTool("session-stats",
-		`Analyze session logs for anomalies: high tool call counts, excessive turns/cycles, errors, and git issues. Scans session directories and reports findings without LLM calls.
-
-Required: none.
-Optional: hours (lookback period, default 24), high_tool_calls (threshold, default 20), high_turns (threshold, default 5), all (show all sessions, default false), session_dir (override path).`,
+		`Analyze session logs for anomalies: high tool call counts, excessive turns/cycles, errors, and git issues. Scans session directories and reports findings without LLM calls.`,
 		func(_ agent.Context, input SessionStatsInput) (SessionStatsOutput, error) {
 			return sessionStatsHandler(input)
 		})

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"sync"
+)
+
+// shellKind names the shell the execute tool drives: "bash" everywhere,
+// except Windows without a bash on PATH, where Windows PowerShell is used.
+// It is a var so tests can stub the lookup.
+var shellKind = func() string {
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("bash"); err != nil {
+			return "powershell"
+		}
+	}
+	return "bash"
+}
+
+var (
+	shellOnce   sync.Once
+	shellCached string
+)
+
+// CurrentShellKind reports the resolved shell kind, computing it once.
+// "powershell" means the bash tool executes through Windows PowerShell and
+// bash-specific syntax is unavailable; callers can use it to skip registering
+// bash-only tools or to adjust tool descriptions for the model.
+func CurrentShellKind() string {
+	shellOnce.Do(func() { shellCached = shellKind() })
+	return shellCached
+}
+
+// shellCommand builds the exec command that runs script in the platform shell:
+// `bash -c` normally, or `powershell -NoProfile -Command` on Windows when no
+// bash is available (see specs/defect/windows-tools.md).
+func shellCommand(ctx context.Context, script string) *exec.Cmd {
+	if CurrentShellKind() == "powershell" {
+		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", script)
+	}
+	return exec.CommandContext(ctx, "bash", "-c", script)
+}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -39,15 +39,31 @@ func shellCommand(ctx context.Context, script string) *exec.Cmd {
 	return buildShellCommand(ctx, CurrentShellKind(), script)
 }
 
+// psExitEpilogue makes powershell.exe report failure the way bash does.
+//
+// Two separate things can fail and only one of them sets an exit code.
+// `$LASTEXITCODE` is written by native executables and is $null until one
+// runs, so a script of pure cmdlets leaves it unset. `$?` covers both, but a
+// non-terminating cmdlet error — the ordinary kind, `Get-ChildItem` on a
+// missing path — sets `$?` false while leaving `$LASTEXITCODE` untouched.
+// Reading either one alone reports a failed command as a success: without this
+// a failing `go test` (native, exit 1) or a failing `Test-Path` chain (cmdlet,
+// no exit code) both come back green and the agent believes them.
+//
+// Both are captured on the first line, before any statement here can overwrite
+// them — `$?` in particular reflects only the immediately preceding statement.
+// A real exit code wins when there is one; otherwise a false `$?` becomes 1.
+const psExitEpilogue = `
+$__piOK = $?; $__piCode = $LASTEXITCODE
+if (-not $__piOK) { if ($__piCode) { exit $__piCode }; exit 1 }
+if ($null -ne $__piCode) { exit $__piCode }
+exit 0`
+
 // buildShellCommand is shellCommand with the shell named explicitly, so the
 // PowerShell wrapper can be exercised from any platform.
-//
-// The PowerShell wrapper propagates the last native command's exit code:
-// powershell.exe otherwise exits 0 for a pipeline whose native commands
-// failed, so a failing `go test` would look successful to the agent.
 func buildShellCommand(ctx context.Context, kind, script string) *exec.Cmd {
 	if kind == shellKindPowerShell {
-		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", script+"\n; exit $LASTEXITCODE")
+		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", script+psExitEpilogue)
 	}
 	return exec.CommandContext(ctx, "bash", "-c", script)
 }

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -36,9 +36,14 @@ func CurrentShellKind() string {
 // shellCommand builds the exec command that runs script in the platform shell:
 // `bash -c` normally, or `powershell -NoProfile -Command` on Windows when no
 // bash is available (see specs/defect/windows-tools.md).
+//
+// The PowerShell wrapper propagates the last native command's exit code:
+// powershell.exe otherwise exits 0 for a pipeline whose native commands
+// failed, so a failing `go test` would look successful to the agent.
 func shellCommand(ctx context.Context, script string) *exec.Cmd {
 	if CurrentShellKind() == "powershell" {
-		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", script)
+		wrapped := script + "\n; exit $LASTEXITCODE"
+		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", wrapped)
 	}
 	return exec.CommandContext(ctx, "bash", "-c", script)
 }

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -7,43 +7,47 @@ import (
 	"sync"
 )
 
-// shellKind names the shell the execute tool drives: "bash" everywhere,
-// except Windows without a bash on PATH, where Windows PowerShell is used.
-// It is a var so tests can stub the lookup.
-var shellKind = func() string {
-	if runtime.GOOS == "windows" {
-		if _, err := exec.LookPath("bash"); err != nil {
-			return "powershell"
-		}
-	}
-	return "bash"
-}
-
-var (
-	shellOnce   sync.Once
-	shellCached string
+// The shell the bash tool drives. Bash everywhere, except a Windows machine
+// with no bash on PATH, where Windows PowerShell is the only thing left to run
+// commands with (see specs/defect/windows-tools.md).
+const (
+	shellKindBash       = "bash"
+	shellKindPowerShell = "powershell"
 )
 
-// CurrentShellKind reports the resolved shell kind, computing it once.
-// "powershell" means the bash tool executes through Windows PowerShell and
-// bash-specific syntax is unavailable; callers can use it to skip registering
-// bash-only tools or to adjust tool descriptions for the model.
-func CurrentShellKind() string {
-	shellOnce.Do(func() { shellCached = shellKind() })
-	return shellCached
+// resolveShellKind inspects the machine. It is separate from the cached
+// accessor so a test can call it without deciding the process-wide answer.
+func resolveShellKind() string {
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("bash"); err != nil {
+			return shellKindPowerShell
+		}
+	}
+	return shellKindBash
 }
 
-// shellCommand builds the exec command that runs script in the platform shell:
-// `bash -c` normally, or `powershell -NoProfile -Command` on Windows when no
-// bash is available (see specs/defect/windows-tools.md).
+var currentShellKind = sync.OnceValue(resolveShellKind)
+
+// CurrentShellKind reports the resolved shell kind, computing it once.
+// shellKindPowerShell means the bash tool executes through Windows PowerShell
+// and bash-specific syntax is unavailable; callers can use it to skip
+// registering bash-only tools or to adjust tool descriptions for the model.
+func CurrentShellKind() string { return currentShellKind() }
+
+// shellCommand builds the exec command that runs script in this machine's shell.
+func shellCommand(ctx context.Context, script string) *exec.Cmd {
+	return buildShellCommand(ctx, CurrentShellKind(), script)
+}
+
+// buildShellCommand is shellCommand with the shell named explicitly, so the
+// PowerShell wrapper can be exercised from any platform.
 //
 // The PowerShell wrapper propagates the last native command's exit code:
 // powershell.exe otherwise exits 0 for a pipeline whose native commands
 // failed, so a failing `go test` would look successful to the agent.
-func shellCommand(ctx context.Context, script string) *exec.Cmd {
-	if CurrentShellKind() == "powershell" {
-		wrapped := script + "\n; exit $LASTEXITCODE"
-		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", wrapped)
+func buildShellCommand(ctx context.Context, kind, script string) *exec.Cmd {
+	if kind == shellKindPowerShell {
+		return exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command", script+"\n; exit $LASTEXITCODE")
 	}
 	return exec.CommandContext(ctx, "bash", "-c", script)
 }

--- a/internal/tools/shell_exit_test.go
+++ b/internal/tools/shell_exit_test.go
@@ -80,6 +80,26 @@ var shellExitCases = []shellExitCase{
 		want: 0,
 	},
 	{
+		// A command the machine does not have -- a missing `git` or `go`, or a
+		// typo -- is the shape a user actually hits, and the old wrapper
+		// reported it as success with the error text only on stderr. bash
+		// answers 127; the number is not the point, being non-zero is.
+		name: "command not found",
+		bash: `this-command-does-not-exist-pi-go`,
+		ps:   `This-Command-Does-Not-Exist-PiGo`,
+		want: anyNonZero,
+	},
+	{
+		// Bash reports the LAST command, so a failure followed by a success is
+		// a success. Worth stating outright: it looks like a missed failure,
+		// but matching bash is the whole contract, and a wrapper that reported
+		// non-zero here would be the one that is wrong.
+		name: "failure followed by success is success",
+		bash: `ls /definitely-does-not-exist-pi-go 2>/dev/null; true`,
+		ps:   `Get-ChildItem C:\definitely-does-not-exist-pi-go 2>$null; cmd /c exit 0`,
+		want: 0,
+	},
+	{
 		// A script that exits on its own must win: the epilogue is appended
 		// after it and must never run.
 		name: "explicit exit wins",

--- a/internal/tools/shell_exit_test.go
+++ b/internal/tools/shell_exit_test.go
@@ -1,0 +1,136 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+// anyNonZero asks for a failure without pinning its number. `ls` on a missing
+// path is 1 on GNU and 2 on some others, and the PowerShell side has no
+// convention at all — what matters is that a failure is not reported as
+// success.
+const anyNonZero = -1
+
+// shellExitCase pairs equivalent bash and PowerShell scripts with the exit code
+// both shells are expected to produce.
+//
+// Writing it as one table is the point. The PowerShell epilogue exists to make
+// powershell.exe report failure the way bash does, and a table that runs the
+// bash script on Unix and the PowerShell script on Windows states that as a
+// single expectation rather than two lists of numbers that can drift apart.
+type shellExitCase struct {
+	name string
+	bash string
+	ps   string
+	want int
+}
+
+var shellExitCases = []shellExitCase{
+	{
+		name: "success with output",
+		bash: `echo hello`,
+		ps:   `Write-Output hello`,
+		want: 0,
+	},
+	{
+		// The original defect: powershell.exe exits 0 for a pipeline whose
+		// native commands failed, so a failing `go test` looked green.
+		name: "native command exit code propagates",
+		bash: `exit 3`,
+		ps:   `cmd /c exit 3`,
+		want: 3,
+	},
+	{
+		name: "native command success",
+		bash: `true`,
+		ps:   `cmd /c exit 0`,
+		want: 0,
+	},
+	{
+		// A non-terminating cmdlet error sets $? but leaves $LASTEXITCODE
+		// untouched, so an epilogue reading only $LASTEXITCODE reports this
+		// as a success.
+		name: "builtin failure with no exit code",
+		bash: `ls /definitely-does-not-exist-pi-go`,
+		ps:   `Get-ChildItem C:\definitely-does-not-exist-pi-go`,
+		want: anyNonZero,
+	},
+	{
+		// The nastier shape of the same bug: a native command succeeds first,
+		// leaving $LASTEXITCODE at 0, and the cmdlet that fails after it
+		// cannot overwrite that 0.
+		name: "builtin failure after native success",
+		bash: `true; ls /definitely-does-not-exist-pi-go`,
+		ps:   `cmd /c exit 0; Get-ChildItem C:\definitely-does-not-exist-pi-go`,
+		want: anyNonZero,
+	},
+	{
+		// The regression the epilogue could plausibly introduce, and the
+		// reason it cannot lean on $? alone. Windows PowerShell has a
+		// reputation for treating a native command's stderr output as
+		// failure; if that happened here, every successful `git clone` --
+		// which reports progress on stderr -- would come back as an error.
+		// That would be worse than the bug being fixed, so it is pinned.
+		name: "stderr output does not imply failure",
+		bash: `echo oops 1>&2; true`,
+		ps:   `cmd /c "echo oops 1>&2 & exit 0"`,
+		want: 0,
+	},
+	{
+		// A script that exits on its own must win: the epilogue is appended
+		// after it and must never run.
+		name: "explicit exit wins",
+		bash: `exit 7`,
+		ps:   `exit 7`,
+		want: 7,
+	},
+	{
+		// The epilogue is appended verbatim, so a script ending in a comment
+		// would swallow it if it were not separated by a newline.
+		name: "trailing comment does not swallow the epilogue",
+		bash: "echo hi\n# trailing comment",
+		ps:   "Write-Output hi\n# trailing comment",
+		want: 0,
+	},
+}
+
+// TestShellCommand_ExitCodes runs each case through the real shell.
+//
+// On Windows this is the only place the PowerShell epilogue is executed rather
+// than string-matched, and it is why buildShellCommand takes the shell kind as
+// an argument: Windows CI has a git-bash on PATH, so CurrentShellKind() there
+// reports bash and the PowerShell path would otherwise never be exercised.
+func TestShellCommand_ExitCodes(t *testing.T) {
+	kind := shellKindBash
+	if runtime.GOOS == "windows" {
+		kind = shellKindPowerShell
+	}
+
+	for _, tc := range shellExitCases {
+		t.Run(tc.name, func(t *testing.T) {
+			script := tc.bash
+			if kind == shellKindPowerShell {
+				script = tc.ps
+			}
+
+			cmd := buildShellCommand(context.Background(), kind, script)
+			out, err := cmd.CombinedOutput()
+
+			var exitErr *exec.ExitError
+			if err != nil && !errors.As(err, &exitErr) {
+				t.Fatalf("running %q in %s: %v", script, kind, err)
+			}
+			got := cmd.ProcessState.ExitCode()
+
+			switch {
+			case tc.want == anyNonZero && got == 0:
+				t.Errorf("%s: %q exited 0, want a failure\noutput: %s", kind, script, out)
+			case tc.want != anyNonZero && got != tc.want:
+				t.Errorf("%s: %q exited %d, want %d\noutput: %s", kind, script, got, tc.want, out)
+			}
+		})
+	}
+}

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -53,8 +53,16 @@ func TestBuildShellCommand_PowerShellPropagatesExitCode(t *testing.T) {
 	if !strings.HasPrefix(script, "go test ./...") {
 		t.Errorf("script = %q, want the caller's command first", script)
 	}
-	if !strings.Contains(script, "exit $LASTEXITCODE") {
-		t.Errorf("script = %q, want the exit-code propagation suffix", script)
+	if !strings.HasSuffix(script, psExitEpilogue) {
+		t.Errorf("script = %q, want the exit-code epilogue appended", script)
+	}
+	// Both failure signals have to be read, and read before anything here can
+	// overwrite them: `$LASTEXITCODE` is $null until a native command runs, and
+	// `$?` reflects only the immediately preceding statement.
+	for _, want := range []string{"$__piOK = $?", "$__piCode = $LASTEXITCODE"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script = %q, want it to capture %q", script, want)
+		}
 	}
 }
 
@@ -78,8 +86,8 @@ func TestShellCommand_FollowsTheResolvedShell(t *testing.T) {
 	if !strings.Contains(cmd.Path, "powershell") {
 		t.Errorf("Path = %q on a PowerShell machine, want powershell.exe", cmd.Path)
 	}
-	if !strings.Contains(strings.Join(cmd.Args, " "), "exit $LASTEXITCODE") {
-		t.Errorf("args = %v, want the exit-code propagation suffix", cmd.Args)
+	if !strings.HasSuffix(strings.Join(cmd.Args, " "), psExitEpilogue) {
+		t.Errorf("args = %v, want the exit-code epilogue appended", cmd.Args)
 	}
 
 	withShellKind(t, shellKindBash)

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -24,12 +25,23 @@ func TestResolveShellKind_UsesBashWhereItExists(t *testing.T) {
 	}
 }
 
+// wantsBash reports whether exec resolved the command to a bash binary.
+//
+// It compares the base name with any executable suffix trimmed, because
+// exec.Command stores the resolved path and Windows resolves "bash" to
+// "C:\\Program Files\\Git\\bin\\bash.exe". A plain HasSuffix(path, "bash")
+// passes on Unix and fails on exactly the platform this file exists to cover.
+func wantsBash(t *testing.T, path string) {
+	t.Helper()
+	if got := strings.TrimSuffix(filepath.Base(path), ".exe"); got != "bash" {
+		t.Errorf("Path = %q, want it to resolve to bash", path)
+	}
+}
+
 func TestBuildShellCommand_Bash(t *testing.T) {
 	cmd := buildShellCommand(context.Background(), shellKindBash, "echo hi")
 
-	if !strings.HasSuffix(cmd.Path, "bash") {
-		t.Errorf("Path = %q, want it to end in bash", cmd.Path)
-	}
+	wantsBash(t, cmd.Path)
 	want := []string{"-c", "echo hi"}
 	if got := cmd.Args[1:]; len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
 		t.Errorf("args = %v, want %v", got, want)
@@ -56,13 +68,119 @@ func TestBuildShellCommand_PowerShellPropagatesExitCode(t *testing.T) {
 	if !strings.HasSuffix(script, psExitEpilogue) {
 		t.Errorf("script = %q, want the exit-code epilogue appended", script)
 	}
-	// Both failure signals have to be read, and read before anything here can
-	// overwrite them: `$LASTEXITCODE` is $null until a native command runs, and
-	// `$?` reflects only the immediately preceding statement.
-	for _, want := range []string{"$__piOK = $?", "$__piCode = $LASTEXITCODE"} {
-		if !strings.Contains(script, want) {
-			t.Errorf("script = %q, want it to capture %q", script, want)
+}
+
+// epilogueStatements splits psExitEpilogue into its statements, in order.
+//
+// The epilogue is PowerShell, and PowerShell separates statements by newline
+// or `;` — so a line-by-line reading would miss a second statement smuggled
+// onto the capture line, which is exactly where an ordering mistake would go.
+func epilogueStatements(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, line := range strings.Split(psExitEpilogue, "\n") {
+		// Only split the top level: `;` also appears inside the braces of the
+		// failure branch, which is one statement as far as ordering goes.
+		if strings.Contains(line, "{") {
+			if s := strings.TrimSpace(line); s != "" {
+				out = append(out, s)
+			}
+			continue
 		}
+		for _, stmt := range strings.Split(line, ";") {
+			if s := strings.TrimSpace(stmt); s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+// The epilogue is appended to every PowerShell script the agent runs, and the
+// Windows CI job is the only place it is ever executed — everywhere else this
+// test is the only thing standing between a broken wrapper and a green build.
+// So its shape is a contract, not formatting.
+//
+// What it has to get right: read BOTH failure signals, read `$?` before
+// anything can clobber it, let a real exit code win where there is one, and
+// still fail when `$?` is false with no exit code to report.
+func TestPSExitEpilogue_ReadsBothFailureSignalsInOrder(t *testing.T) {
+	// Appended verbatim, so without the leading newline a script ending in a
+	// comment would swallow the epilogue whole and the exit code would go back
+	// to being powershell's.
+	if !strings.HasPrefix(psExitEpilogue, "\n") {
+		t.Errorf("epilogue = %q, want it to start on its own line", psExitEpilogue)
+	}
+
+	stmts := epilogueStatements(t)
+	if len(stmts) < 3 {
+		t.Fatalf("epilogue = %q, parsed as %q; want a capture and both exit branches",
+			psExitEpilogue, stmts)
+	}
+
+	// `$?` reflects only the immediately preceding statement, so the very
+	// first statement of the epilogue has to read it. Anything inserted above
+	// — even another assignment — makes the wrapper report the epilogue's own
+	// success instead of the script's, and every failure comes back green.
+	if !strings.Contains(stmts[0], "$?") {
+		t.Errorf("first epilogue statement = %q, want it to capture $? before any"+
+			" statement here can overwrite it", stmts[0])
+	}
+	for _, s := range stmts[1:] {
+		if strings.Contains(s, "$?") {
+			t.Errorf("epilogue reads $? again at %q; only the first statement still"+
+				" sees the caller's script", s)
+		}
+	}
+
+	// Both signals are captured before the first branch. Reading only
+	// $LASTEXITCODE is the bug this exists to prevent: it is $null until a
+	// native command runs, and a non-terminating cmdlet error leaves it
+	// untouched, so a failing Get-ChildItem would report success.
+	branchAt := len(stmts)
+	for i, s := range stmts {
+		if strings.HasPrefix(s, "if ") {
+			branchAt = i
+			break
+		}
+	}
+	prologue := strings.Join(stmts[:branchAt], "\n")
+	if !strings.Contains(prologue, "$LASTEXITCODE") {
+		t.Errorf("epilogue prologue = %q, want both signals captured before the"+
+			" first branch", prologue)
+	}
+	branches := stmts[branchAt:]
+	if len(branches) == 0 {
+		t.Fatalf("epilogue = %q, want at least one exit branch", psExitEpilogue)
+	}
+	joined := strings.Join(branches, "\n")
+	if !strings.Contains(joined, "$__piOK") {
+		t.Errorf("epilogue branches = %q, want the $? capture to decide the exit;"+
+			" $LASTEXITCODE alone cannot see a cmdlet failure", joined)
+	}
+
+	// A false $? exits with the real code where there is one and 1 where there
+	// is not — the `true; ls /missing` shape, where a native success has
+	// already pinned $LASTEXITCODE to 0 and the cmdlet failure cannot move it.
+	var failure string
+	for _, s := range branches {
+		if strings.Contains(s, "-not $__piOK") {
+			failure = s
+		}
+	}
+	if failure == "" {
+		t.Fatalf("epilogue = %q, want a branch on a false $?", psExitEpilogue)
+	}
+	for _, want := range []string{"exit $__piCode", "exit 1"} {
+		if !strings.Contains(failure, want) {
+			t.Errorf("failure branch = %q, want %q", failure, want)
+		}
+	}
+	// And the success path still reports a native command's code rather than
+	// flattening every run to 0.
+	if !strings.Contains(joined, "exit $__piCode") || !strings.Contains(joined, "exit 0") {
+		t.Errorf("epilogue branches = %q, want a native exit code to survive a"+
+			" successful $?, and a clean run to exit 0", joined)
 	}
 }
 
@@ -92,7 +210,5 @@ func TestShellCommand_FollowsTheResolvedShell(t *testing.T) {
 
 	withShellKind(t, shellKindBash)
 	cmd = shellCommand(context.Background(), "echo hi")
-	if !strings.HasSuffix(cmd.Path, "bash") {
-		t.Errorf("Path = %q on a bash machine, want bash", cmd.Path)
-	}
+	wantsBash(t, cmd.Path)
 }

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -1,0 +1,59 @@
+package tools
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A machine that has bash gets bash. The Windows-without-bash branch is the
+// one that cannot be reached from here, which is why buildShellCommand takes
+// the kind as an argument rather than reading it back from the machine.
+func TestResolveShellKind_UsesBashWhereItExists(t *testing.T) {
+	got := resolveShellKind()
+	if runtime.GOOS != "windows" && got != shellKindBash {
+		t.Errorf("resolveShellKind() = %q on %s, want %q", got, runtime.GOOS, shellKindBash)
+	}
+	if got != shellKindBash && got != shellKindPowerShell {
+		t.Errorf("resolveShellKind() = %q, want one of the two known kinds", got)
+	}
+	// The cached accessor must agree with a fresh resolution.
+	if CurrentShellKind() != got {
+		t.Errorf("CurrentShellKind() = %q, resolveShellKind() = %q", CurrentShellKind(), got)
+	}
+}
+
+func TestBuildShellCommand_Bash(t *testing.T) {
+	cmd := buildShellCommand(context.Background(), shellKindBash, "echo hi")
+
+	if !strings.HasSuffix(cmd.Path, "bash") {
+		t.Errorf("Path = %q, want it to end in bash", cmd.Path)
+	}
+	want := []string{"-c", "echo hi"}
+	if got := cmd.Args[1:]; len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("args = %v, want %v", got, want)
+	}
+}
+
+// The exit-code suffix is the whole reason the PowerShell path is not just a
+// different argv: powershell.exe exits 0 for a pipeline whose native commands
+// failed, so without it a failing `go test` reports success to the agent.
+func TestBuildShellCommand_PowerShellPropagatesExitCode(t *testing.T) {
+	cmd := buildShellCommand(context.Background(), shellKindPowerShell, "go test ./...")
+
+	if !strings.Contains(cmd.Path, "powershell") {
+		t.Errorf("Path = %q, want powershell.exe", cmd.Path)
+	}
+	args := cmd.Args[1:]
+	if len(args) != 3 || args[0] != "-NoProfile" || args[1] != "-Command" {
+		t.Fatalf("args = %v, want -NoProfile -Command <script>", args)
+	}
+	script := args[2]
+	if !strings.HasPrefix(script, "go test ./...") {
+		t.Errorf("script = %q, want the caller's command first", script)
+	}
+	if !strings.Contains(script, "exit $LASTEXITCODE") {
+		t.Errorf("script = %q, want the exit-code propagation suffix", script)
+	}
+}

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -57,3 +57,34 @@ func TestBuildShellCommand_PowerShellPropagatesExitCode(t *testing.T) {
 		t.Errorf("script = %q, want the exit-code propagation suffix", script)
 	}
 }
+
+// withShellKind pins the process-wide shell kind for one test. It is not safe
+// in a parallel test: the kind is a package-level cache that every command the
+// package builds reads, so a test that swaps it must be the only one running.
+func withShellKind(t *testing.T, kind string) {
+	t.Helper()
+	prev := currentShellKind
+	currentShellKind = func() string { return kind }
+	t.Cleanup(func() { currentShellKind = prev })
+}
+
+// shellCommand is the one place the supervisor turns a script into a process,
+// so it is where the Windows fallback either takes effect or quietly does not:
+// a hardcoded "bash" here would leave resolveShellKind reporting the right
+// answer while every command on the machine still died with "bash not found".
+func TestShellCommand_FollowsTheResolvedShell(t *testing.T) {
+	withShellKind(t, shellKindPowerShell)
+	cmd := shellCommand(context.Background(), "echo hi")
+	if !strings.Contains(cmd.Path, "powershell") {
+		t.Errorf("Path = %q on a PowerShell machine, want powershell.exe", cmd.Path)
+	}
+	if !strings.Contains(strings.Join(cmd.Args, " "), "exit $LASTEXITCODE") {
+		t.Errorf("args = %v, want the exit-code propagation suffix", cmd.Args)
+	}
+
+	withShellKind(t, shellKindBash)
+	cmd = shellCommand(context.Background(), "echo hi")
+	if !strings.HasSuffix(cmd.Path, "bash") {
+		t.Errorf("Path = %q on a bash machine, want bash", cmd.Path)
+	}
+}

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -124,8 +124,7 @@ Modes:
 - Chain: {chain: [{agent: "<name>", task: "<prompt>"}, ...]} — run agents sequentially, passing results forward
 
 Worktree agents:
-- Agents marked [worktree] edit an isolated git worktree. Normal subagent calls return only the agent output; those edits are not applied to the current tree unless the caller keeps and merges that worktree.
-- If changes need to land in the current tree, ask the worktree agent for an exact patch/file list to apply, or choose a non-worktree editing agent.
+- Agents marked [worktree] edit an isolated git worktree; their edits are not applied to the current tree. Ask for an exact patch/file list to apply, or use a non-worktree editing agent.
 
 `)
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -407,8 +407,8 @@ func TestLsHandler(t *testing.T) {
 func TestBashTimeout(t *testing.T) {
 	dir := t.TempDir()
 	sb := testSandbox(t, dir)
-	// fastSupervisor, not a small Timeout: caller-supplied limits are floored
-	// at minBashTimeout, so the supervisor's idle limit is what makes a handoff
+	// fastSupervisor, not a small Timeout: the tool's limits are whole seconds,
+	// so the supervisor's sub-second idle limit is what makes a handoff
 	// observable in a unit test.
 	sup := fastSupervisor(t)
 	out, err := bashHandler(sb, sup, nil, BashInput{Command: "sleep 10"})

--- a/internal/tools/write.go
+++ b/internal/tools/write.go
@@ -26,9 +26,7 @@ type WriteOutput struct {
 func newWriteTool(sb *Sandbox, ledger *ReadLedger) (tool.Tool, error) {
 	return newTool("write", `Write content to a file. Creates parent directories if needed. Overwrites existing files.
 
-An existing file must have been read in full first, so the content being replaced is known.
-
-Required: file_path (absolute path), content (file content to write).`, func(_ agent.Context, input WriteInput) (WriteOutput, error) {
+An existing file must have been read in full first, so the content being replaced is known.`, func(_ agent.Context, input WriteInput) (WriteOutput, error) {
 		return writeHandlerWithLedger(sb, input, ledger)
 	})
 }

--- a/internal/tui/agent_loop_stuck_test.go
+++ b/internal/tui/agent_loop_stuck_test.go
@@ -114,7 +114,7 @@ func TestStuckDetector_Observe_StreakThreshold(t *testing.T) {
 // outlives maxRepeatToolCalls.
 func TestStuckDetector_ObserveResult_PollingNotStuck(t *testing.T) {
 	s := &stuckDetector{}
-	args := map[string]any{"handle": "bg_16", "wait_ms": 1000}
+	args := map[string]any{"handle": "bg_16", "wait_sec": 1}
 	for i := 0; i < maxRepeatToolCalls*3; i++ {
 		stuck, detail := s.observe("bash_wait", args)
 		if stuck {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,13 +44,62 @@ if (-not $asset) {
     throw "No windows_amd64 zip found in release $tag"
 }
 
-# --- Download and extract ------------------------------------------------------
+# --- Download ------------------------------------------------------------------
 $zipPath = Join-Path $env:TEMP $asset.name
 $extractDir = Join-Path $env:TEMP ("pi-go-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
 
 Write-Host "Downloading $($asset.name)..."
 Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -UseBasicParsing
 
+# --- Verify the download against the release checksums -------------------------
+# checksums.txt is a GoReleaser artifact listing "<sha256>  <filename>" for every
+# archive in the release. Checking it catches a truncated or corrupted download
+# and a swapped asset, which is what an installer can check on its own.
+#
+# It is not proof of origin: checksums.txt travels the same path as the archive,
+# so anyone who could substitute one could substitute both. `pi verify` is the
+# check that answers that — it looks the binary's digest up in GitHub's
+# attestations API and verifies the Sigstore bundle against this repo's release
+# workflow. The last line of this script points at it.
+#
+# Missing or unlisted checksums are a hard failure rather than a warning. A
+# release without them is a broken release, and an installer that shrugs and
+# continues is an installer whose verification means nothing.
+$sumAsset = $release.assets | Where-Object { $_.name -eq "checksums.txt" } | Select-Object -First 1
+if (-not $sumAsset) {
+    Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+    throw "Release $tag publishes no checksums.txt; refusing to install an unverifiable download."
+}
+
+Write-Host "Verifying checksum..."
+$sumsPath = Join-Path $env:TEMP "pi-go-checksums-$tag.txt"
+Invoke-WebRequest -Uri $sumAsset.browser_download_url -OutFile $sumsPath -UseBasicParsing
+
+# Lines are "<hex>  <name>"; split on whitespace rather than a fixed width so a
+# one- or two-space variant both parse.
+$expected = $null
+foreach ($line in Get-Content $sumsPath) {
+    $parts = $line.Trim() -split "\s+", 2
+    if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $asset.name) {
+        $expected = $parts[0].Trim()
+        break
+    }
+}
+Remove-Item -Force $sumsPath -ErrorAction SilentlyContinue
+
+if (-not $expected) {
+    Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+    throw "checksums.txt for $tag does not list $($asset.name); refusing to install."
+}
+
+$actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash
+if ($actual -ine $expected) {
+    Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+    throw "Checksum mismatch for $($asset.name): expected $expected, got $actual. The download was discarded."
+}
+Write-Host "  sha256 $($actual.ToLower())"
+
+# --- Extract -------------------------------------------------------------------
 Write-Host "Extracting..."
 New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
 Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
@@ -75,7 +124,12 @@ $want = $installDir.TrimEnd("\")
 $present = $entries | Where-Object { $_ -ieq $want }
 if (-not $present) {
     Write-Host "Adding $installDir to user PATH..."
-    [Environment]::SetEnvironmentVariable("Path", "$userPath;$installDir", "User")
+    # A fresh account can have no user PATH at all, and "$null;$installDir"
+    # would write a leading separator — an empty entry that some tools read as
+    # the current directory.
+    if ([string]::IsNullOrWhiteSpace($userPath)) { $newPath = $installDir }
+    else { $newPath = $userPath.TrimEnd(";") + ";" + $installDir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
     $env:PATH = "$env:PATH;$installDir"
     Write-Host "PATH updated. Restart your terminal for it to take effect everywhere."
 } else {
@@ -86,3 +140,4 @@ if (-not $present) {
 Write-Host ""
 Write-Host (& $dest --version)
 Write-Host "Installed to $dest" -ForegroundColor Green
+Write-Host "Run 'pi verify' to check this binary against its build provenance."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,82 @@
+# pi-go installer for Windows.
+#
+# Works on Windows PowerShell 5.1 (Windows 10/11 built-in) and PowerShell 7+;
+# no bash, curl aliases, or && chains — everything uses cmdlets available in
+# 5.1. Downloads the latest pi-go windows/amd64 release zip and installs
+# pi.exe into %LOCALAPPDATA%\Programs, adding that directory to the user PATH
+# when missing.
+#
+# Usage:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File install.ps1
+#   or one line from an existing shell:
+#   powershell -NoProfile -Command "iwr https://raw.githubusercontent.com/dimetron/pi-go/main/scripts/install.ps1 -UseBasicParsing | iex"
+
+$ErrorActionPreference = "Stop"
+
+# Windows PowerShell 5.1 defaults to TLS 1.0/1.1, which GitHub rejects; without
+# this the download can hang or fail with "The underlying connection was
+# closed". Harmless on PowerShell 7+, which already uses TLS 1.2+.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+$repo = "dimetron/pi-go"
+$installDir = Join-Path $env:LOCALAPPDATA "Programs"
+
+# --- Resolve the latest release tag via the GitHub API -----------------------
+$apiUrl = "https://api.github.com/repos/$repo/releases/latest"
+$headers = @{ "User-Agent" = "pi-go-installer" }
+$token = $env:GITHUB_TOKEN
+if (-not $token) { $token = $env:GH_TOKEN }
+if ($token) { $headers["Authorization"] = "Bearer $token" }
+
+Write-Host "Resolving latest release..."
+$release = Invoke-RestMethod -Uri $apiUrl -Headers $headers -UseBasicParsing
+$tag = $release.tag_name
+Write-Host "Latest release: $tag"
+
+# --- Pick the windows amd64 asset --------------------------------------------
+$assetName = "pi-go_$($tag.TrimStart("v"))_windows_amd64.zip"
+$asset = $release.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
+if (-not $asset) {
+    # Fall back to any windows amd64 zip in case naming changes.
+    $asset = $release.assets | Where-Object { $_.name -like "*windows_amd64*.zip" -and $_.name -notlike "*.sbom.*" } | Select-Object -First 1
+}
+if (-not $asset) {
+    throw "No windows_amd64 zip found in release $tag"
+}
+
+# --- Download and extract ------------------------------------------------------
+$zipPath = Join-Path $env:TEMP $asset.name
+$extractDir = Join-Path $env:TEMP ("pi-go-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+
+Write-Host "Downloading $($asset.name)..."
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -UseBasicParsing
+
+Write-Host "Extracting..."
+New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$exe = Get-ChildItem -Path $extractDir -Filter "pi.exe" -Recurse | Select-Object -First 1
+if (-not $exe) { throw "pi.exe not found in archive" }
+
+# --- Install -------------------------------------------------------------------
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+$dest = Join-Path $installDir "pi.exe"
+Copy-Item -Path $exe.FullName -Destination $dest -Force
+Remove-Item -Recurse -Force $extractDir
+Remove-Item -Force $zipPath
+
+# --- Add install dir to the user PATH when missing ------------------------------
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$installDir*") {
+    Write-Host "Adding $installDir to user PATH..."
+    [Environment]::SetEnvironmentVariable("Path", "$userPath;$installDir", "User")
+    $env:PATH = "$env:PATH;$installDir"
+    Write-Host "PATH updated. Restart your terminal for it to take effect everywhere."
+} else {
+    $env:PATH = "$env:PATH;$installDir"
+}
+
+# --- Verify ----------------------------------------------------------------------
+Write-Host ""
+Write-Host (& $dest --version)
+Write-Host "Installed to $dest" -ForegroundColor Green

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,10 +13,18 @@
 
 $ErrorActionPreference = "Stop"
 
-# Windows PowerShell 5.1 defaults to TLS 1.0/1.1, which GitHub rejects; without
-# this the download can hang or fail with "The underlying connection was
-# closed". Harmless on PowerShell 7+, which already uses TLS 1.2+.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+# Older Windows PowerShell 5.1 images default to TLS 1.0/1.1, which GitHub
+# rejects: the download then hangs or fails with "The underlying connection was
+# closed".
+#
+# Only force TLS 1.2 when the process is pinned to something older. A current
+# build reports SystemDefault, meaning "let the OS negotiate", which already
+# reaches TLS 1.2 and can reach 1.3 — and `SystemDefault -bor Tls12` would
+# replace that with a hard TLS 1.2 pin, giving up 1.3 to fix a problem the
+# machine does not have.
+if ([Net.ServicePointManager]::SecurityProtocol -ne [Net.SecurityProtocolType]::SystemDefault) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
 
 $repo = "dimetron/pi-go"
 $installDir = Join-Path $env:LOCALAPPDATA "Programs"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -66,8 +66,14 @@ Remove-Item -Recurse -Force $extractDir
 Remove-Item -Force $zipPath
 
 # --- Add install dir to the user PATH when missing ------------------------------
+# Compare complete entries (not substrings) so e.g. an existing
+# "...\Programs\Microsoft VS Code\bin" does not hide the missing
+# "...\Programs" entry itself.
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($userPath -notlike "*$installDir*") {
+$entries = $userPath -split ";" | ForEach-Object { $_.Trim().TrimEnd("\") } | Where-Object { $_ }
+$want = $installDir.TrimEnd("\")
+$present = $entries | Where-Object { $_ -ieq $want }
+if (-not $present) {
     Write-Host "Adding $installDir to user PATH..."
     [Environment]::SetEnvironmentVariable("Path", "$userPath;$installDir", "User")
     $env:PATH = "$env:PATH;$installDir"


### PR DESCRIPTION
## Summary

Fixes the defect in `specs/defect/windows-tools.md`: on Windows without `bash.exe`/`git.exe` in PATH, pi-go's command execution failed before any command ran.

### Changes

- **`internal/tools/shell.go` (new)** — resolves the platform shell once: `bash -c` everywhere, `powershell.exe -NoProfile -Command` on Windows when bash is absent. Exposes `CurrentShellKind()` so other packages can adapt.
- **`internal/tools/bash_supervisor.go`** — launches commands through the resolved shell instead of hardcoded bash.
- **`internal/tools/bash.go`** — PowerShell-specific tool description so the model writes PS 5.1 syntax (`;` not `&&`, `Test-Path`, `Get-ChildItem`). Tool name stays `bash` for session/config compatibility.
- **`scripts/install.ps1` (new)** — PS 5.1-compatible installer: forces TLS 1.2 (required — without it Invoke-RestMethod hangs on default 5.1 configs), resolves latest release via GitHub API, installs to `%LOCALAPPDATA%\Programs`, updates user PATH with exact-entry comparison.

### Codex review fixes (addressed before PR)

- **P1**: PowerShell doesn't propagate native exit codes through `; exit $LASTEXITCODE` appended so failing commands (`go test`, `git diff --exit-code`) no longer report success.
- **P2**: installer PATH check now compares complete entries (split on `;`) rather than substrings, so an existing `...\Programs\Microsoft VS Code\bin` entry can't hide a missing `...\Programs`.

### Verification

- `go build ./...`, `go vet`, `golangci-lint run ./internal/tools/` (0 issues), unit tests pass
- Cross-compile `GOOS=windows` clean
- **Live-tested on a clean Windows Server 2025 VM (Lima)**:
  - Before: `exec: "bash": executable file not found in %PATH%`
  - After: `bash` tool executes via PowerShell (`Write-Output hello-from-pi` → `hello-from-pi`)
  - `install.ps1` completes end-to-end and installs working `pi.exe`