### PR TITLE
fix(tools): let $? decide the PowerShell exit code, not the stale native one

### DIFF
--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -52,12 +52,17 @@ func shellCommand(ctx context.Context, script string) *exec.Cmd {
 //
 // Both are captured on the first line, before any statement here can overwrite
 // them — `$?` in particular reflects only the immediately preceding statement.
-// A real exit code wins when there is one; otherwise a false `$?` becomes 1.
+//
+// `$?` decides, and `$LASTEXITCODE` only supplies the number. That order
+// matters: a cmdlet does not reset `$LASTEXITCODE`, so after
+// `cmd /c exit 3; Write-Output recovered` it still reads 3 while `$?` is true.
+// Consulting the code first would report 3 for a script whose last statement
+// succeeded, where bash reports 0 — `(exit 3); echo recovered` is a success.
 const psExitEpilogue = `
 $__piOK = $?; $__piCode = $LASTEXITCODE
-if (-not $__piOK) { if ($__piCode) { exit $__piCode }; exit 1 }
-if ($null -ne $__piCode) { exit $__piCode }
-exit 0`
+if ($__piOK) { exit 0 }
+if ($__piCode) { exit $__piCode }
+exit 1`
 
 // buildShellCommand is shellCommand with the shell named explicitly, so the
 // PowerShell wrapper can be exercised from any platform.

--- a/internal/tools/shell_exit_test.go
+++ b/internal/tools/shell_exit_test.go
@@ -100,6 +100,16 @@ var shellExitCases = []shellExitCase{
 		want: 0,
 	},
 	{
+		// A cmdlet does not reset $LASTEXITCODE, so a failing native command
+		// leaves its code sitting there while a later statement succeeds.
+		// bash reports the last command, so this is a success -- reading the
+		// stale code instead of $? would report 3 for a script that worked.
+		name: "native failure recovered by a later success",
+		bash: `(exit 3); echo recovered`,
+		ps:   `cmd /c exit 3; Write-Output recovered`,
+		want: 0,
+	},
+	{
 		// A script that exits on its own must win: the epilogue is appended
 		// after it and must never run.
 		name: "explicit exit wins",

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -38,6 +38,26 @@ func wantsBash(t *testing.T, path string) {
 	}
 }
 
+// TestResolveShellKind_PowerShellWhenBashIsMissing covers the one line the
+// whole branch exists for: the decision to fall back.
+//
+// Nothing else reaches it. shell_exit_test.go injects the shell kind rather
+// than resolving it, precisely because Windows CI ships a git-bash on PATH --
+// so on that runner LookPath succeeds and the PowerShell return is
+// unreachable. Emptying PATH reproduces the actual defect condition (a Windows
+// machine with no bash), and exec.LookPath re-reads PATH on every call, so no
+// production seam is needed to get there.
+func TestResolveShellKind_PowerShellWhenBashIsMissing(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("the PowerShell fallback only exists on Windows")
+	}
+	t.Setenv("PATH", "")
+
+	if got := resolveShellKind(); got != shellKindPowerShell {
+		t.Errorf("resolveShellKind() with no bash on PATH = %q, want %q", got, shellKindPowerShell)
+	}
+}
+
 func TestBuildShellCommand_Bash(t *testing.T) {
 	cmd := buildShellCommand(context.Background(), shellKindBash, "echo hi")
 

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -179,28 +179,28 @@ func TestPSExitEpilogue_ReadsBothFailureSignalsInOrder(t *testing.T) {
 			" $LASTEXITCODE alone cannot see a cmdlet failure", joined)
 	}
 
-	// A false $? exits with the real code where there is one and 1 where there
-	// is not — the `true; ls /missing` shape, where a native success has
-	// already pinned $LASTEXITCODE to 0 and the cmdlet failure cannot move it.
-	var failure string
-	for _, s := range branches {
-		if strings.Contains(s, "-not $__piOK") {
-			failure = s
-		}
+	// `$?` decides and `$LASTEXITCODE` only supplies the number, so the very
+	// first branch has to be the success branch and it has to exit 0.
+	//
+	// Reversing these two is a real bug, not a style point: a cmdlet does not
+	// reset $LASTEXITCODE, so after `cmd /c exit 3; Write-Output recovered` it
+	// still reads 3 while $? is true. Consulting the code first reports 3 for
+	// a script whose last statement succeeded, where bash reports 0.
+	if !strings.Contains(branches[0], "$__piOK") {
+		t.Errorf("first branch = %q, want $? to decide before the exit code is"+
+			" consulted", branches[0])
 	}
-	if failure == "" {
-		t.Fatalf("epilogue = %q, want a branch on a false $?", psExitEpilogue)
+	if !strings.Contains(branches[0], "exit 0") {
+		t.Errorf("first branch = %q, want a true $? to exit 0", branches[0])
 	}
+	// The code is only reachable once $? is false, and a failure with no code
+	// of its own still has to be non-zero — the `Get-ChildItem C:\missing`
+	// shape, where no native command ever ran to set one.
+	rest := strings.Join(branches[1:], "\n")
 	for _, want := range []string{"exit $__piCode", "exit 1"} {
-		if !strings.Contains(failure, want) {
-			t.Errorf("failure branch = %q, want %q", failure, want)
+		if !strings.Contains(rest, want) {
+			t.Errorf("failure path = %q, want %q", rest, want)
 		}
-	}
-	// And the success path still reports a native command's code rather than
-	// flattening every run to 0.
-	if !strings.Contains(joined, "exit $__piCode") || !strings.Contains(joined, "exit 0") {
-		t.Errorf("epilogue branches = %q, want a native exit code to survive a"+
-			" successful $?, and a clean run to exit 0", joined)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #222, which merged while these two commits were still in review.
Both were pushed to that branch after the merge, so they never reached `main`.

## The bug (in `main` today)

Found by a `codex review` of #222. A cmdlet does not reset `$LASTEXITCODE`, so
after `cmd /c exit 3; Write-Output recovered` it still reads 3 while `$?` is
true. The epilogue consulted the code before `$?`, so it reported **3 for a
script whose last statement succeeded**.

bash disagrees, and bash parity is the whole contract of this wrapper:

```
$ bash -c '(exit 3); echo recovered'   →  0
```

On a Windows machine without bash, that is an agent being told a command failed
when it worked.

## The fix

`$?` decides; `$LASTEXITCODE` only supplies the number. The code is reachable
only once `$?` is false, which also makes the wrapper shorter:

```powershell
$__piOK = $?; $__piCode = $LASTEXITCODE
if ($__piOK) { exit 0 }
if ($__piCode) { exit $__piCode }
exit 1
```

Every case #222 established still holds, because `$?` is false after a native
command that exits non-zero — `cmd /c exit 3` alone still reports 3. That is
the one assumption not checkable off Windows, and
`native_command_exit_code_propagates` in the table is what checks it: if `$?`
did not track native exit codes, that case would come back 0 on the Windows job.

The structure test previously asserted *"a native exit code survives a
successful `$?`"* — the defect written down as a requirement. It now pins the
corrected order.

## Also here

`TestResolveShellKind_PowerShellWhenBashIsMissing` covers the one line the
fallback exists for. Nothing reached it before: `shell_exit_test.go` injects
the shell kind rather than resolving one, because Windows CI ships a git-bash
on PATH — so on that runner `LookPath` succeeds and the PowerShell return is
unreachable. `t.Setenv("PATH", "")` reproduces the real defect condition, and
`exec.LookPath` re-reads PATH per call, so no production seam is needed.

## Not addressed here

`codex` also raised process-tree termination on Windows (P1): killing a
backgrounded `go test ./...` kills `powershell.exe` but not its children.
That is real, but it is **not** introduced by the PowerShell fallback and is
orthogonal to which shell runs — `internal/procs/procs_other.go` implements
Windows terminate as a bare `cmd.Process.Kill()` for bash too, and its own
comment already records job objects as deferred work. It deserves its own
issue, not a shell-fallback PR.