### PR TITLE
fix(ollama): stop 401ing on cloud models the local daemon can serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Set the API key for your provider as an environment variable. The provider is in
 | Azure OpenAI | `azure/<deployment>` | `AZURE_OPENAI_API_KEY` | — |
 | OpenCode | `opencode/<model>` | `OPENCODE_API_KEY` | `OPENCODE_BASE_URL` |
 | Ollama (local) | `ollama/<model>` | none | `OLLAMA_HOST` (default `http://localhost:11434`) |
-| Ollama Cloud | `<model>:cloud` | `OLLAMA_API_KEY` | `https://api.ollama.com` |
+| Ollama Cloud | `<model>:cloud` | `OLLAMA_API_KEY` | `https://api.ollama.com`, or the local daemon when no key is set |
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
@@ -235,10 +235,17 @@ export MISTRAL_API_KEY="..."     # optional — only if you use Mistral models
 export XAI_API_KEY="..."         # optional — only if you use Grok models
 export OPENROUTER_API_KEY="..."  # optional — only if you use OpenRouter models
 export OPENCODE_API_KEY="..."
-export OLLAMA_API_KEY="..."   # only for Ollama Cloud (:cloud suffix)
+export OLLAMA_API_KEY="..."   # optional — only to reach Ollama Cloud directly
 ```
 
 A name with no recognized prefix is rejected rather than guessed at — reach for the `ollama/` prefix or the `:cloud` suffix to name an Ollama model explicitly.
+
+A `:cloud` tag names a model, not a destination. With `OLLAMA_API_KEY` set the
+request goes straight to `api.ollama.com`; without one it goes to the local
+daemon, which has served cloud models on your `ollama signin` identity since
+Ollama 0.12 — so `pi --model deepseek-v3.1:671b-cloud` works with no key at all.
+The `ollama/` prefix always means the local daemon, tag notwithstanding, and an
+explicit `OLLAMA_HOST` overrides both.
 
 ## Build
 

--- a/internal/acp/server/complexity_runtime_test.go
+++ b/internal/acp/server/complexity_runtime_test.go
@@ -90,11 +90,15 @@ func TestResolveOllamaBaseURL_NonOllamaPassesThrough(t *testing.T) {
 	}
 }
 
-// A cloud-tagged model with no explicit endpoint resolves to ollama.com, and
-// the local-daemon health check must not run against it.
+// A cloud-tagged model with a key and no explicit endpoint resolves to
+// ollama.com, and the local-daemon health check must not run against it.
+//
+// The key matters to the destination here: without one the same model falls
+// back to the local daemon, because api.ollama.com answers an unauthenticated
+// request with 401 before it looks at the model.
 func TestResolveOllamaBaseURL_CloudModelSkipsHealthCheck(t *testing.T) {
 	info := provider.Info{Provider: "ollama", Model: "deepseek-v4-flash:0731-cloud", Ollama: true}
-	got, err := resolveOllamaBaseURL(info, "", "")
+	got, err := resolveOllamaBaseURL(info, "sk-ollama-test", "")
 	if err != nil {
 		t.Fatalf("resolveOllamaBaseURL: %v", err)
 	}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -282,7 +282,12 @@ func resolveOllamaBaseURL(info provider.Info, apiKey, baseURL string) (string, e
 	if !info.Ollama {
 		return baseURL, nil
 	}
-	baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+	baseURL = provider.ResolveOllamaEndpoint(provider.OllamaRouting{
+		Model:      info.Model,
+		BaseURL:    baseURL,
+		APIKey:     apiKey,
+		ForceLocal: info.LocalOllama,
+	})
 	if apiKey == "" && !provider.IsOllamaCloudEndpoint(baseURL) {
 		if err := provider.CheckOllama(baseURL); err != nil {
 			return "", fmt.Errorf("ollama health check: %w", err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -116,6 +116,7 @@ routing you need:
   openrouter/<model>       OpenRouter      OPENROUTER_API_KEY
   ollama/<model>           Ollama, local   none; http://localhost:11434
   <model>:cloud            Ollama Cloud    OLLAMA_API_KEY; https://api.ollama.com
+                                           without a key: the local daemon
   azure/<deployment>       Azure OpenAI    AZURE_OPENAI_API_KEY
   opencode/<model>         OpenCode        OPENCODE_API_KEY
 
@@ -145,7 +146,9 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
   # Ollama against a local daemon — no API key needed
   pi --model ollama/gemma4:e4b "rename this symbol everywhere"
 
-  # Ollama Cloud — the :cloud tag routes to api.ollama.com, needs OLLAMA_API_KEY
+  # Ollama Cloud — the :cloud tag routes to api.ollama.com with OLLAMA_API_KEY
+  # set; without one it falls back to the local daemon, which serves cloud
+  # models on your "ollama signin" identity. The ollama/ prefix forces local.
   pi --model minimax-m3:cloud "port this module to generics"
 
   # Azure OpenAI — the deployment name follows azure/
@@ -333,7 +336,12 @@ func applyRuntimeOllamaEndpoint(info *provider.Info, apiKey, baseURL string) (st
 		// happens to be exported: a key set for some :cloud model used to send
 		// locally pulled names like qwen3.8:27b-mlx to api.ollama.com, which
 		// answers 404 for a model only this machine has.
-		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+		baseURL = provider.ResolveOllamaEndpoint(provider.OllamaRouting{
+			Model:      info.Model,
+			BaseURL:    baseURL,
+			APIKey:     apiKey,
+			ForceLocal: info.LocalOllama,
+		})
 		// Record the endpoint actually chosen so session metadata names the
 		// backend instead of leaving the model name to be interpreted.
 		info.BaseURL = baseURL
@@ -1753,7 +1761,12 @@ func buildCommitMsgFunc(ctx context.Context, cfg config.Config) func(context.Con
 		baseURL = baseURLs[info.Provider]
 	}
 	if info.Ollama {
-		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+		baseURL = provider.ResolveOllamaEndpoint(provider.OllamaRouting{
+			Model:      info.Model,
+			BaseURL:    baseURL,
+			APIKey:     apiKey,
+			ForceLocal: info.LocalOllama,
+		})
 	}
 
 	if info.Ollama && !provider.IsOllamaCloudEndpoint(baseURL) {

--- a/internal/cli/complexity_core_test.go
+++ b/internal/cli/complexity_core_test.go
@@ -238,7 +238,9 @@ func TestApplyRuntimeOllamaEndpoint(t *testing.T) {
 	t.Run("cloud endpoint skips the local health check", func(t *testing.T) {
 		t.Parallel()
 		info := provider.Info{Provider: "ollama", Model: "gpt-oss:120b-cloud", Ollama: true}
-		got, err := applyRuntimeOllamaEndpoint(&info, "", "")
+		// The key is what sends a :cloud model to api.ollama.com; without one
+		// it falls back to the local daemon and the probe does run.
+		got, err := applyRuntimeOllamaEndpoint(&info, "sk-ollama-test", "")
 		if err != nil {
 			t.Fatalf("applyRuntimeOllamaEndpoint: %v", err)
 		}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -81,6 +81,10 @@ func writeRoleSummary(w io.Writer) {
 // A local Ollama daemon is the one provider that needs no credential, so
 // reporting a missing OLLAMA_API_KEY there would be a false alarm — the key is
 // only required once a :cloud tag routes the request to api.ollama.com.
+//
+// A cloud tag with no key is not a missing credential either: the request falls
+// back to the local daemon, which proxies cloud models on the signed-in
+// identity. Calling that MISSING would report a failure that does not happen.
 func credentialStatus(prov, model string, keys map[string]string) string {
 	if prov == "ollama" && !provider.IsOllamaCloudModel(model) {
 		return "none (local daemon)"
@@ -89,6 +93,9 @@ func credentialStatus(prov, model string, keys map[string]string) string {
 	envVar := providerEnvVar(prov)
 	if _, ok := keys[prov]; ok {
 		return envVar + " (set)"
+	}
+	if prov == "ollama" {
+		return envVar + " (unset — using local daemon)"
 	}
 	return envVar + " (MISSING)"
 }

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -83,8 +83,11 @@ func TestWriteRoleSummaryFlagsMissingCredential(t *testing.T) {
 	}
 }
 
-// A local Ollama daemon needs no key, so demanding one would be a false alarm;
-// a :cloud tag reaches api.ollama.com and does.
+// A local Ollama daemon needs no key, so demanding one would be a false alarm.
+// Neither does a :cloud tag on its own: without a key that request falls back
+// to the local daemon rather than failing, so reporting MISSING would announce
+// a breakage that does not happen. The key is reported as what it is — the way
+// to reach api.ollama.com directly.
 func TestWriteRoleSummaryOllamaCredential(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -92,7 +95,7 @@ func TestWriteRoleSummaryOllamaCredential(t *testing.T) {
 		want  string
 	}{
 		{"local daemon needs no key", "ollama/gemma4:e4b", "none (local daemon)"},
-		{"cloud tag needs a key", "minimax-m3:cloud", "OLLAMA_API_KEY (MISSING)"},
+		{"cloud tag without a key falls back to the daemon", "minimax-m3:cloud", "OLLAMA_API_KEY (unset — using local daemon)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -1068,5 +1068,16 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 	tokenTracker.SetContextWindowSize(ctxWindowSize)
 	llm = guardrail.WrapModel(llm, tokenTracker)
 
-	return llm, info.Model, info.Provider, nil
+	// Hand back a name that re-resolves to the same endpoint. Resolve strips
+	// the ollama/ prefix from info.Model, and this answer is what the TUI
+	// stores as the current model and re-resolves on the next switch — so
+	// returning the bare name would drop the one part of the spelling that
+	// says "local", and a cloud-tagged model would move to api.ollama.com
+	// behind the user's back the moment a key was set.
+	switchedName := info.Model
+	if info.LocalOllama {
+		switchedName = "ollama/" + info.Model
+	}
+
+	return llm, switchedName, info.Provider, nil
 }

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -1026,7 +1026,12 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 	apiKey := keys[info.Provider]
 
 	if info.Ollama {
-		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+		baseURL = provider.ResolveOllamaEndpoint(provider.OllamaRouting{
+			Model:      info.Model,
+			BaseURL:    baseURL,
+			APIKey:     apiKey,
+			ForceLocal: info.LocalOllama,
+		})
 	}
 
 	// Record the endpoint actually chosen, after every fallback above has had

--- a/internal/cli/ollama_callsite_test.go
+++ b/internal/cli/ollama_callsite_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/guardrail"
+	"github.com/dimetron/pi-go/internal/provider"
 	"github.com/dimetron/pi-go/internal/testenv"
 )
 
@@ -146,5 +147,49 @@ func TestBuildCommitMsgFunc_OllamaUnreachableDaemonYieldsNil(t *testing.T) {
 	}
 	if fn := buildCommitMsgFunc(context.Background(), cfg); fn != nil {
 		t.Error("expected nil when the local daemon is unreachable")
+	}
+}
+
+// The model name buildSwitchedLLM returns is what the TUI stores and feeds
+// back into the next resolve, so it has to survive a round trip. Resolve
+// strips the ollama/ prefix from info.Model, and that prefix is the only part
+// of the spelling that pins a cloud-tagged model to the local daemon — hand
+// back the bare name and the next switch sends it to api.ollama.com instead.
+func TestBuildSwitchedLLM_OllamaPrefixSurvivesRoundTrip(t *testing.T) {
+	testenv.SetHome(t, t.TempDir())
+	t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+	t.Setenv("OLLAMA_HOST", "")
+
+	origURL := flagURL
+	t.Cleanup(func() { flagURL = origURL })
+	flagURL = ""
+
+	cfg := config.Config{
+		Roles: map[string]config.RoleConfig{
+			"default": {Model: "ollama/deepseek-v4-flash:0731-cloud", Provider: "ollama"},
+		},
+	}
+
+	const requested = "ollama/deepseek-v4-flash:0731-cloud"
+	_, modelName, _, err := buildSwitchedLLM(context.Background(), cfg, guardrail.New(0), requested)
+	if err != nil {
+		t.Fatalf("buildSwitchedLLM: %v", err)
+	}
+	if modelName != requested {
+		t.Fatalf("model = %q, want %q — the prefix must survive to be re-resolved", modelName, requested)
+	}
+
+	// The returned name, resolved again, must still route to the daemon.
+	info, err := provider.Resolve(modelName)
+	if err != nil {
+		t.Fatalf("Resolve(%q): %v", modelName, err)
+	}
+	got := provider.ResolveOllamaEndpoint(provider.OllamaRouting{
+		Model:      info.Model,
+		APIKey:     "sk-ollama-test",
+		ForceLocal: info.LocalOllama,
+	})
+	if provider.IsOllamaCloudEndpoint(got) {
+		t.Errorf("re-resolved endpoint = %q, want the local daemon", got)
 	}
 }

--- a/internal/cli/ollama_routing_test.go
+++ b/internal/cli/ollama_routing_test.go
@@ -10,21 +10,40 @@ import (
 // The bug this pins: OLLAMA_API_KEY exported for a :cloud model used to be read
 // as a destination, so a locally pulled name like qwen3.8:27b-mlx was posted to
 // api.ollama.com and came back "model not found" from a server the user never
-// meant to talk to. Routing follows the model's tag; the key is a credential.
+// meant to talk to. A key never promotes a model to the cloud.
+//
+// The second bug this pins: ollama/ is documented as "Ollama, local", but a
+// cloud-looking tag on the name used to override the prefix, so
+// ollama/deepseek-v4-flash:0731-cloud went to api.ollama.com — and answered 401
+// whenever no key was set, though the local daemon serves that model.
+//
+// Every case here exports a key, because buildRootRuntime health-checks a local
+// daemon only when none is set and CI has no daemon to answer. The no-key
+// fallback is pinned where the decision is actually made, in
+// provider.TestResolveOllamaEndpoint.
 func TestBuildRootRuntime_OllamaKeyDoesNotForceCloud(t *testing.T) {
 	tests := []struct {
 		name    string
 		model   string
+		apiKey  string
 		wantURL string
 	}{
 		{
 			name:    "mlx tag stays on the local daemon",
 			model:   "ollama/qwen3.8:27b-mlx",
+			apiKey:  "sk-ollama-test",
 			wantURL: "http://localhost:11434",
 		},
 		{
-			name:    "cloud tag still routes to the cloud",
+			name:    "ollama/ prefix keeps a cloud-tagged model local",
 			model:   "ollama/deepseek-v4-flash:0731-cloud",
+			apiKey:  "sk-ollama-test",
+			wantURL: "http://localhost:11434",
+		},
+		{
+			name:    "an unprefixed cloud tag with a key routes to the cloud",
+			model:   "deepseek-v4-flash:0731-cloud",
+			apiKey:  "sk-ollama-test",
 			wantURL: "https://api.ollama.com",
 		},
 	}
@@ -33,9 +52,7 @@ func TestBuildRootRuntime_OllamaKeyDoesNotForceCloud(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetGlobalFlags(t)
 			testenv.SetHome(t, t.TempDir())
-			// Set, as it must be for any cloud model — and irrelevant to where
-			// a local model goes.
-			t.Setenv("OLLAMA_API_KEY", "sk-ollama-test")
+			t.Setenv("OLLAMA_API_KEY", tt.apiKey)
 			t.Setenv("OLLAMA_HOST", "")
 
 			flagModel = tt.model

--- a/internal/cli/ping.go
+++ b/internal/cli/ping.go
@@ -291,7 +291,12 @@ func resolvePingModelInfo(cfg config.Config, activeRole string) (provider.Info, 
 func resolvePingCredentials(info provider.Info, baseURL string, explicitBaseURL bool) (string, string, bool) {
 	apiKey := config.APIKeys()[info.Provider]
 	if info.Ollama {
-		baseURL = provider.ResolveOllamaEndpoint(info.Model, baseURL)
+		baseURL = provider.ResolveOllamaEndpoint(provider.OllamaRouting{
+			Model:      info.Model,
+			BaseURL:    baseURL,
+			APIKey:     apiKey,
+			ForceLocal: info.LocalOllama,
+		})
 	}
 	// Azure resolves its endpoint and credential through the same helpers a
 	// real run uses, so a passing ping means the settings a real run would pick
@@ -1034,7 +1039,12 @@ func ollamaPingFull(ctx context.Context, baseURL, modelName, prompt string, isPi
 	}
 
 	// Step 2: Create native Ollama LLM.
-	llm, err := provider.NewOllama(ctx, modelName, "", baseURL, "none", nil)
+	// baseURL is already settled by the caller, so it decides the endpoint on
+	// its own — see rule 1 in ResolveOllamaEndpoint.
+	llm, err := provider.NewOllama(ctx, provider.OllamaRouting{
+		Model:   modelName,
+		BaseURL: baseURL,
+	}, "none", nil)
 	if err != nil {
 		return "", fmt.Errorf("create client: %w", err)
 	}

--- a/internal/provider/complexity_cog_provider_a_test.go
+++ b/internal/provider/complexity_cog_provider_a_test.go
@@ -1269,7 +1269,7 @@ func TestCogPAOllamaChatRequestGoldens(t *testing.T) {
 			}
 			var body map[string]any
 			srv := cogPAOllamaCapture(t, &body)
-			llm, err := NewOllama(context.Background(), tc.model, "", srv.URL, tc.thinking, nil)
+			llm, err := NewOllama(context.Background(), OllamaRouting{Model: tc.model, APIKey: "", BaseURL: srv.URL}, tc.thinking, nil)
 			if err != nil {
 				t.Fatalf("NewOllama: %v", err)
 			}
@@ -1290,7 +1290,7 @@ func TestCogPAOllamaStreamingRequestGolden(t *testing.T) {
 	cogPAClearOllamaEnv(t)
 	var body map[string]any
 	srv := cogPAOllamaCapture(t, &body)
-	llm, err := NewOllama(context.Background(), "llama3", "", srv.URL, "low", nil)
+	llm, err := NewOllama(context.Background(), OllamaRouting{Model: "llama3", APIKey: "", BaseURL: srv.URL}, "low", nil)
 	if err != nil {
 		t.Fatalf("NewOllama: %v", err)
 	}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -31,31 +31,64 @@ const (
 	ollamaCloudURL = "https://api.ollama.com"
 )
 
-// ResolveOllamaEndpoint picks the server a model should be sent to. It is
-// exported because every caller that builds an Ollama client — the CLI, the
-// TUI's /model switch, the ACP server, ping — has to reach the same answer;
-// each one deciding for itself is how the key-as-destination bug survived in
-// three places after this function stopped making that mistake.
+// OllamaRouting carries the facts that decide which Ollama server a model
+// reaches. They travel together because every caller that builds an Ollama
+// client — the CLI, the TUI's /model switch, the ACP server, ping — has to
+// reach the same answer; each one deciding for itself is how the
+// key-as-destination bug survived in three places after ResolveOllamaEndpoint
+// stopped making that mistake.
+type OllamaRouting struct {
+	// Model is the Ollama model name, tag included.
+	Model string
+	// BaseURL is an explicit endpoint (OLLAMA_HOST or --url), empty if unset.
+	BaseURL string
+	// APIKey is OLLAMA_API_KEY, empty if unset.
+	APIKey string
+	// ForceLocal records that the caller named the model with the explicit
+	// ollama/ prefix, which the CLI help documents as "Ollama, local".
+	ForceLocal bool
+}
+
+// ResolveOllamaEndpoint picks the server a model should be sent to.
 //
-// Routing follows the model's cloud tag, which is the rule the CLI help and
-// every other routing check in the tree already state. It used to follow the
-// presence of an API key instead, and that made OLLAMA_API_KEY a global switch:
-// exporting it once for a :cloud model silently sent every *local* model to
-// api.ollama.com too, where a privately pulled name like qwen3.8:27b-mlx does
-// not exist. The key is a credential, not a destination.
+// The order is:
 //
-// An explicit baseURL (OLLAMA_HOST) always wins — that is how someone points at
-// another machine, a container, or an authenticated proxy.
+//  1. An explicit BaseURL (OLLAMA_HOST, --url) always wins — that is how
+//     someone points at another machine, a container, or an authenticated proxy.
+//  2. The ollama/ prefix means the local daemon. The prefix is the one way a
+//     user states the destination outright, so a tag cannot overrule it:
+//     ollama/deepseek-v4-flash:0731-cloud is a request for the model of that
+//     name on localhost, and answering it with api.ollama.com ignores what was
+//     asked for.
+//  3. A cloud-tagged model with a key goes to api.ollama.com.
+//  4. A cloud-tagged model with no key goes to the local daemon, which has
+//     proxied cloud models on the user's `ollama signin` identity since 0.12.
+//     api.ollama.com rejects an unauthenticated request with 401 before it
+//     looks at the model, so the alternative is not a different result but a
+//     guaranteed failure.
+//  5. Everything else is local.
+//
+// Rule 4 is the only one that reads the key, and it only ever routes *away*
+// from the cloud. That is deliberate, and it is not the bug this function was
+// written to kill: routing used to follow the presence of a key in the other
+// direction, which made OLLAMA_API_KEY a global switch — exporting it once for
+// a :cloud model silently sent every *local* model to api.ollama.com too, where
+// a privately pulled name like qwen3.8:27b-mlx does not exist. A key still
+// never promotes an untagged model to the cloud; its absence only declines to
+// send a request that cannot be served.
 //
 // Who receives the key is deliberately not decided here. It still goes to
 // whatever endpoint is chosen whenever one is set, unchanged, because an
 // authenticated daemon may be reached over loopback as easily as over the
 // network and this function cannot tell the two apart.
-func ResolveOllamaEndpoint(modelName, baseURL string) string {
-	if endpoint := normalizeBaseURL(baseURL); endpoint != "" {
+func ResolveOllamaEndpoint(r OllamaRouting) string {
+	if endpoint := normalizeBaseURL(r.BaseURL); endpoint != "" {
 		return endpoint
 	}
-	if IsOllamaCloudModel(modelName) {
+	if r.ForceLocal {
+		return ollamaLocalURL
+	}
+	if IsOllamaCloudModel(r.Model) && r.APIKey != "" {
 		return ollamaCloudURL
 	}
 	return ollamaLocalURL
@@ -81,15 +114,15 @@ func IsOllamaCloudEndpoint(baseURL string) bool {
 }
 
 // NewOllama creates an Ollama model.LLM using the native Ollama Go client.
-// The server is chosen by ResolveOllamaEndpoint: an explicit baseURL if given,
-// otherwise api.ollama.com for a :cloud/-cloud tagged model and localhost for
-// everything else.
+// The server is chosen by ResolveOllamaEndpoint from the routing facts in r.
 // thinkingLevel controls extended thinking: "none", "low", "medium", "high".
-func NewOllama(_ context.Context, modelName, apiKey, baseURL, thinkingLevel string, opts *LLMOptions) (model.LLM, error) {
+func NewOllama(_ context.Context, r OllamaRouting, thinkingLevel string, opts *LLMOptions) (model.LLM, error) {
+	modelName := r.Model
 	if modelName == "" {
 		return nil, fmt.Errorf("model name is required")
 	}
-	baseURL = ResolveOllamaEndpoint(modelName, baseURL)
+	apiKey := r.APIKey
+	baseURL := ResolveOllamaEndpoint(r)
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Ollama URL %q: %w", baseURL, err)

--- a/internal/provider/ollama_endpoint_test.go
+++ b/internal/provider/ollama_endpoint_test.go
@@ -7,14 +7,19 @@ import "testing"
 // api.ollama.com — where a private name like muse-glimmer:30b-mlx does not
 // exist, so the run failed with a model-not-found from a server the user never
 // meant to talk to.
+//
+// The key is read in exactly one direction: its absence keeps a cloud-tagged
+// model on the local daemon, which proxies cloud models on the user's
+// `ollama signin` identity. Its presence never promotes an untagged model.
 func TestResolveOllamaEndpoint(t *testing.T) {
 	const key = "sk-ollama-test"
 
 	tests := []struct {
 		name         string
 		model        string
-		apiKey       string // recorded to document the scenario; routing must not consult it
+		apiKey       string
 		baseURL      string
+		forceLocal   bool
 		wantEndpoint string
 	}{
 		{
@@ -40,6 +45,36 @@ func TestResolveOllamaEndpoint(t *testing.T) {
 			model:        "deepseek-v4-flash:0731-cloud",
 			apiKey:       key,
 			wantEndpoint: ollamaCloudURL,
+		},
+		{
+			// Without a credential api.ollama.com answers 401 before it looks
+			// at the model, so the cloud is not an option — the local daemon
+			// is, and it serves cloud models on the signed-in identity.
+			name:         "cloud tag without a key falls back to the local daemon",
+			model:        "minimax-m3:cloud",
+			wantEndpoint: ollamaLocalURL,
+		},
+		{
+			name:         "sized cloud tag without a key falls back to the local daemon",
+			model:        "deepseek-v4-flash:0731-cloud",
+			wantEndpoint: ollamaLocalURL,
+		},
+		{
+			// ollama/ is the one way to name the destination outright, so a
+			// tag on the name cannot overrule it.
+			name:         "ollama/ prefix keeps a cloud-tagged model local",
+			model:        "deepseek-v4-flash:0731-cloud",
+			apiKey:       key,
+			forceLocal:   true,
+			wantEndpoint: ollamaLocalURL,
+		},
+		{
+			name:         "explicit host still wins over the ollama/ prefix",
+			model:        "deepseek-v4-flash:0731-cloud",
+			apiKey:       key,
+			baseURL:      "http://gpu-box.lan:11434",
+			forceLocal:   true,
+			wantEndpoint: "http://gpu-box.lan:11434",
 		},
 		{
 			name:         "explicit host wins over the cloud tag",
@@ -80,9 +115,14 @@ func TestResolveOllamaEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if endpoint := ResolveOllamaEndpoint(tt.model, tt.baseURL); endpoint != tt.wantEndpoint {
-				t.Errorf("ResolveOllamaEndpoint(%q, %q) = %q, want %q",
-					tt.model, tt.baseURL, endpoint, tt.wantEndpoint)
+			r := OllamaRouting{
+				Model:      tt.model,
+				BaseURL:    tt.baseURL,
+				APIKey:     tt.apiKey,
+				ForceLocal: tt.forceLocal,
+			}
+			if endpoint := ResolveOllamaEndpoint(r); endpoint != tt.wantEndpoint {
+				t.Errorf("ResolveOllamaEndpoint(%+v) = %q, want %q", r, endpoint, tt.wantEndpoint)
 			}
 		})
 	}
@@ -114,7 +154,7 @@ func TestIsOllamaCloudModel(t *testing.T) {
 // NewOllama is the real entry point, so pin that it honors the routing rather
 // than only testing the helper underneath it.
 func TestNewOllamaAcceptsLocalTaggedModel(t *testing.T) {
-	llm, err := NewOllama(t.Context(), "muse-glimmer:30b-mlx", "sk-ollama-test", "", "none", nil)
+	llm, err := NewOllama(t.Context(), OllamaRouting{Model: "muse-glimmer:30b-mlx", APIKey: "sk-ollama-test", BaseURL: ""}, "none", nil)
 	if err != nil {
 		t.Fatalf("NewOllama: %v", err)
 	}

--- a/internal/provider/ollama_test.go
+++ b/internal/provider/ollama_test.go
@@ -389,7 +389,7 @@ func TestOllamaListModels(t *testing.T) {
 
 func TestOllamaGenerateContent(t *testing.T) {
 	// Create a mock-like Ollama model for testing
-	llm, err := NewOllama(context.Background(), "qwen3.5:latest", "", "http://localhost:11434", "none", nil)
+	llm, err := NewOllama(context.Background(), OllamaRouting{Model: "qwen3.5:latest", APIKey: "", BaseURL: "http://localhost:11434"}, "none", nil)
 	if err != nil {
 		t.Skipf("skipping: could not create Ollama model: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestOllamaGenerateContent(t *testing.T) {
 	})
 
 	t.Run("with thinking level", func(t *testing.T) {
-		llmThink, err := NewOllama(context.Background(), "qwen3.5:latest", "", "http://localhost:11434", "medium", nil)
+		llmThink, err := NewOllama(context.Background(), OllamaRouting{Model: "qwen3.5:latest", APIKey: "", BaseURL: "http://localhost:11434"}, "medium", nil)
 		if err != nil {
 			t.Skipf("skipping: could not create Ollama model: %v", err)
 		}
@@ -667,21 +667,21 @@ func TestOllamaListModelsWithMockServer(t *testing.T) {
 
 func TestNewOllamaValidation(t *testing.T) {
 	t.Run("empty model name", func(t *testing.T) {
-		_, err := NewOllama(context.Background(), "", "", "", "none", nil)
+		_, err := NewOllama(context.Background(), OllamaRouting{Model: "", APIKey: "", BaseURL: ""}, "none", nil)
 		if err == nil {
 			t.Fatal("expected error for empty model name")
 		}
 	})
 
 	t.Run("invalid URL", func(t *testing.T) {
-		_, err := NewOllama(context.Background(), "test-model", "", "://bad", "none", nil)
+		_, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "", BaseURL: "://bad"}, "none", nil)
 		if err == nil {
 			t.Fatal("expected error for invalid URL")
 		}
 	})
 
 	t.Run("default base URL", func(t *testing.T) {
-		llm, err := NewOllama(context.Background(), "test-model", "", "", "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "", BaseURL: ""}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -691,7 +691,7 @@ func TestNewOllamaValidation(t *testing.T) {
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		llm, err := NewOllama(context.Background(), "test-model", "", "http://custom:1234", "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "", BaseURL: "http://custom:1234"}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -701,7 +701,7 @@ func TestNewOllamaValidation(t *testing.T) {
 	})
 
 	t.Run("with extra headers", func(t *testing.T) {
-		llm, err := NewOllama(context.Background(), "test-model", "", "", "none", &LLMOptions{
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "", BaseURL: ""}, "none", &LLMOptions{
 			ExtraHeaders: map[string]string{"X-Custom": "value"},
 		})
 		if err != nil {
@@ -717,7 +717,7 @@ func TestNewOllamaValidation(t *testing.T) {
 	})
 
 	t.Run("nil extra headers no transport wrapping", func(t *testing.T) {
-		llm, err := NewOllama(context.Background(), "test-model", "", "", "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "", BaseURL: ""}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -777,7 +777,7 @@ func ollamaChatLine(modelName, role, content, thinking, doneReason string, done 
 // newOllamaModelFromServer creates an ollamaModel whose HTTP client points at srv.
 func newOllamaModelFromServer(t *testing.T, srv *httptest.Server, modelName, thinkingLevel string) model.LLM {
 	t.Helper()
-	llm, err := NewOllama(context.Background(), modelName, "", srv.URL, thinkingLevel, nil)
+	llm, err := NewOllama(context.Background(), OllamaRouting{Model: modelName, APIKey: "", BaseURL: srv.URL}, thinkingLevel, nil)
 	if err != nil {
 		t.Fatalf("NewOllama: %v", err)
 	}
@@ -1574,7 +1574,7 @@ func TestOllamaRunNonStreaming_SystemPrompt(t *testing.T) {
 }
 
 func TestOllamaName(t *testing.T) {
-	llm, err := NewOllama(context.Background(), "my-model", "", "", "none", nil)
+	llm, err := NewOllama(context.Background(), OllamaRouting{Model: "my-model", APIKey: "", BaseURL: ""}, "none", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1585,7 +1585,7 @@ func TestOllamaName(t *testing.T) {
 
 func TestNewOllamaCloudAPIKey(t *testing.T) {
 	t.Run("api key sets cloud base URL", func(t *testing.T) {
-		llm, err := NewOllama(context.Background(), "test-model", "ollama_abc123", "", "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "ollama_abc123", BaseURL: ""}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1595,7 +1595,7 @@ func TestNewOllamaCloudAPIKey(t *testing.T) {
 	})
 
 	t.Run("api key with custom base URL uses custom URL", func(t *testing.T) {
-		llm, err := NewOllama(context.Background(), "test-model", "ollama_abc123", "http://myproxy:11434", "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "ollama_abc123", BaseURL: "http://myproxy:11434"}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1621,7 +1621,7 @@ func TestBearerTransport(t *testing.T) {
 		})
 
 		// Create an Ollama model with an API key pointed at the mock server.
-		llm, err := NewOllama(context.Background(), "test-model", "ollama_secret", srv.URL, "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "ollama_secret", BaseURL: srv.URL}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1650,7 +1650,7 @@ func TestBearerTransport(t *testing.T) {
 			})
 		})
 
-		llm, err := NewOllama(context.Background(), "test-model", "", srv.URL, "none", nil)
+		llm, err := NewOllama(context.Background(), OllamaRouting{Model: "test-model", APIKey: "", BaseURL: srv.URL}, "none", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -149,7 +149,11 @@ type Info struct {
 	Provider string
 	Model    string
 	Ollama   bool // true when model is served by Ollama
-	Custom   bool // true when using an explicit custom OpenAI-compatible endpoint
+	// LocalOllama records that the model was named with the explicit ollama/
+	// prefix, which the CLI help documents as "Ollama, local". It keeps a
+	// cloud-looking tag on such a name from routing to api.ollama.com.
+	LocalOllama bool
+	Custom      bool // true when using an explicit custom OpenAI-compatible endpoint
 	// BaseURL is the endpoint finally selected for this model, recorded so a
 	// session transcript identifies the backend and not just the model name.
 	// The same name served by ollama, by a gateway, and by a vendor API behaves
@@ -333,7 +337,7 @@ func Resolve(modelName string) (Info, error) {
 	// Detect ollama/ prefix → native Ollama provider.
 	// The prefix is stripped; the remainder is the Ollama model name.
 	if strings.HasPrefix(strings.ToLower(modelName), "ollama/") {
-		return Info{Provider: "ollama", Model: modelName[len("ollama/"):], Ollama: true}, nil
+		return Info{Provider: "ollama", Model: modelName[len("ollama/"):], Ollama: true, LocalOllama: true}, nil
 	}
 
 	// Detect azure/ prefix → Azure OpenAI provider.
@@ -475,7 +479,12 @@ func NewLLM(ctx context.Context, info Info, apiKey, baseURL, thinkingLevel strin
 	}
 	switch info.Provider {
 	case "ollama":
-		return NewOllama(ctx, info.Model, apiKey, baseURL, thinkingLevel, opts)
+		return NewOllama(ctx, OllamaRouting{
+			Model:      info.Model,
+			BaseURL:    baseURL,
+			APIKey:     apiKey,
+			ForceLocal: info.LocalOllama,
+		}, thinkingLevel, opts)
 	case "gemini":
 		return NewGemini(ctx, info.Model, baseURL, opts)
 	case "openai":


### PR DESCRIPTION
## The bug

`pi --model ollama/deepseek-v4-flash:0731-cloud` failed with a bare
`error: agent run: 401 Unauthorized` on a machine whose local Ollama daemon
serves that model perfectly.

Two separate defects, both in endpoint routing:

1. **A `:cloud` tag was treated as a destination, not a name.** It routed to
   `api.ollama.com` unconditionally, so without `OLLAMA_API_KEY` the request
   was a guaranteed 401 — `api.ollama.com` rejects an unauthenticated request
   before it looks at the model. Meanwhile the local daemon has proxied cloud
   models on the user's `ollama signin` identity since Ollama 0.12 and answers
   them fine.
2. **The `ollama/` prefix was overruled by the tag.** CLI help documents the
   prefix as "Ollama, local", but `ollama/<name>-cloud` still went to the cloud
   API — the one way a user can state the destination outright was ignored.

## The fix

Routing now reads, in order:

| # | Condition | Endpoint |
|---|---|---|
| 1 | explicit `OLLAMA_HOST` / `--url` | that URL |
| 2 | `ollama/` prefix | local daemon |
| 3 | cloud tag **with** a key | `api.ollama.com` |
| 4 | cloud tag **without** a key | local daemon |
| 5 | anything else | local daemon |

Rule 4 replaces a guaranteed failure, not a working path.

The key is read in exactly one direction — its absence routes *away* from the
cloud. It never promotes an untagged model, so this does not reopen the bug
[#8645cb9](https://github.com/dimetron/pi-go/commit/8645cb9) fixed, where an
exported key sent privately pulled names like `qwen3.8:27b-mlx` to a server
that had never heard of them.

The routing facts now travel as one `provider.OllamaRouting` value, so the five
callers that build an Ollama client cannot drift apart again.

## Codex review

`codex review --base main` found a P1 that the tests, lint and `-race` all
passed over, fixed in the second commit: `Resolve` strips `ollama/` from
`info.Model`, and `buildSwitchedLLM` returned that bare name — which the TUI
stores as the current model and re-resolves on the next switch. The prefix is
the only part of the spelling that pins a cloud-tagged model to the daemon, so
dropping it moved the model to `api.ollama.com` behind the user's back once a
key was set. The switcher now hands back a name that re-resolves to the
endpoint it just chose, pinned by a round-trip test.

## Verification

Live, against Ollama 0.32.15, with `OLLAMA_API_KEY` unset — each of these was
`401 Unauthorized` before:

- `pi --model ollama/deepseek-v4-flash:0731:cloud` → answers
- `pi --model deepseek-v4-flash:cloud` → answers
- same, run from a directory with no project `.pi-go/.env` → answers

Still routed to the cloud when a key *is* set (pinned by
`TestBuildRootRuntime_OllamaKeyDoesNotForceCloud`), and the key itself verified
good against `api.ollama.com` directly.

`go test ./...` — 48 packages pass. `make lint` — 0 issues.
