### PR TITLE
fix/plan windows taskname

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# commit-msg: guarantee every commit carries a Signed-off-by trailer.
+#
+# CLAUDE.md mandates `git commit -s -S`, but -s is easy to forget and nothing
+# caught it: 5 of the last 20 commits reached main without the trailer. This
+# adds it when missing rather than rejecting the commit, so the invariant holds
+# without turning a forgotten flag into a lost commit message.
+#
+# interpret-trailers is idempotent — --if-exists doNothing means an explicit
+# `-s` is left exactly as the author wrote it, including a trailer naming
+# someone other than the committer.
+set -euo pipefail
+
+MSG_FILE="$1"
+
+# Skip squash/fixup messages: the trailer belongs on the commit they fold into,
+# and rebase would otherwise duplicate it.
+if head -1 "$MSG_FILE" | grep -qE '^(fixup|squash)!'; then
+  exit 0
+fi
+
+if grep -qi '^Signed-off-by:' "$MSG_FILE"; then
+  exit 0
+fi
+
+NAME="$(git config user.name)"
+EMAIL="$(git config user.email)"
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+  echo "commit-msg: user.name or user.email unset; cannot add Signed-off-by." >&2
+  exit 1
+fi
+
+git interpret-trailers --in-place --if-exists doNothing \
+  --trailer "Signed-off-by: $NAME <$EMAIL>" "$MSG_FILE"
+
+echo "commit-msg: added missing Signed-off-by: $NAME <$EMAIL>" >&2

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# post-commit: warn loudly when a commit lands without a signature.
+#
+# commit.gpgsign is true, so this should be unreachable — but op-ssh-sign needs
+# the 1Password agent, which is not reachable from inside the sandbox, and
+# CLAUDE.md records three commits (0714568, a8b243b, bcb6d26) that landed
+# unsigned that way. A full-history scan found 281 unsigned commits; signing
+# only became consistent on 2026-07-29.
+#
+# This runs after the signature would have been applied, so it is the first
+# point at which the outcome is actually knowable. It cannot fail the commit —
+# post-commit's exit code is ignored — so it prints the repair command instead.
+set -euo pipefail
+
+if git cat-file commit HEAD | grep -q '^gpgsig'; then
+  exit 0
+fi
+
+SHA="$(git rev-parse --short HEAD)"
+cat >&2 <<EOF
+
+  ⚠  UNSIGNED COMMIT: $SHA
+
+  commit.gpgsign is set, so signing was attempted and failed — most likely
+  because op-ssh-sign could not reach the 1Password agent from a sandbox.
+
+  Re-sign it before pushing:
+
+      git commit --amend --no-edit -S
+
+  Run that with the sandbox disabled. Do not reach for --no-verify: it skips
+  the signing path too, which is how the unsigned commits already in this
+  history got there.
+
+EOF

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# pre-push: hard-fail when any commit about to be pushed is unsigned or lacks
+# a Signed-off-by trailer.
+#
+# The post-commit hook only warns — it cannot stop an unsigned commit, and
+# AGENTS.md records commits (0714568, a8b243b, bcb6d26) that reached the
+# remote that way. Signature *verification* via %G? is unusable here because
+# gpg.ssh.allowedSignersFile is unset (see AGENTS.md), so this inspects the
+# raw commit object for a gpgsig header instead: presence of the header means
+# signing was attempted and produced a signature; verification happens on the
+# server side.
+#
+# Skipped worktrees (prunable entries) are ignored. Merge commits created by
+# git itself are checked like any other commit.
+set -euo pipefail
+
+remote="$1"
+zero=0000000000000000000000000000000000000000
+
+unsigned=()
+missing_sob=()
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Branch deletion or remote already has the ref with no new commits.
+  [ "$local_sha" = "$zero" ] && continue
+
+  # Determine the range of new commits being pushed.
+  if [ "$remote_sha" = "$zero" ]; then
+    # New ref: everything not reachable from any existing remote branch,
+    # limited to what this push would add. Fall back to the full history
+    # behind local_sha minus existing remotes to avoid re-checking history.
+    range="$(git rev-list "$local_sha" --not --remotes="$remote")"
+  else
+    range="$(git rev-list "$remote_sha..$local_sha")"
+  fi
+
+  for sha in $range; do
+    if ! git cat-file commit "$sha" | grep -q '^gpgsig'; then
+      unsigned+=("$sha")
+    fi
+    trailers="$(git log --format='%(trailers:key=Signed-off-by,valueonly)' -1 "$sha")"
+    committer_email="$(git log --format='%ce' -1 "$sha")"
+    if [ -z "$(echo "$trailers" | tr -d '[:space:]')" ]; then
+      missing_sob+=("$sha")
+    elif ! echo "$trailers" | grep -qi "$committer_email"; then
+      missing_sob+=("$sha")
+    fi
+  done
+done
+
+fail=0
+if [ "${#unsigned[@]}" -gt 0 ]; then
+  echo "pre-push: UNSIGNED commits cannot be pushed:" >&2
+  printf '  %s\n' "${unsigned[@]}" >&2
+  echo "  Re-sign each with:  git rebase --exec 'git commit --amend --no-edit -S' origin/main" >&2
+  fail=1
+fi
+if [ "${#missing_sob[@]}" -gt 0 ]; then
+  echo "pre-push: commits missing a matching Signed-off-by trailer:" >&2
+  printf '  %s\n' "${missing_sob[@]}" >&2
+  echo "  Fix with:          git rebase --exec 'git commit --amend --no-edit -sS' origin/main" >&2
+  fail=1
+fi
+exit $fail

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-unit test-integration test-e2e test-all test-coverage test-ollama check-cve sbom lint vet e2e clean sandbox-run sandbox-log eval-run eval-pin eval-judge eval-tools eval-tools-judge
+.PHONY: build install test test-unit test-integration test-e2e test-all test-coverage test-ollama check-cve sbom lint vet e2e clean sandbox-run sandbox-log eval-run eval-pin eval-judge eval-tools eval-tools-judge hooks
 
 # Go 1.26's simd/archsimd, which gomlx's Go backend uses for its matmul kernels
 # (gomlx/compute internal/gobackend/dot/matmul). Those kernels are gated on
@@ -30,6 +30,16 @@ build:
 install:
 	go install $(GO_BUILD_FLAGS) -ldflags "$(GO_LDFLAGS)" ./cmd/pi
 	go install $(GO_BUILD_FLAGS) ./cmd/pi-sandbox
+
+# hooks: point core.hooksPath at the versioned .githooks/ directory.
+#
+# The hooks enforce AGENTS.md's signing rules: commit-msg adds a missing
+# Signed-off-by, post-commit warns on unsigned commits, and pre-push
+# HARD-FAILS any push containing unsigned or unsigned-off commits.
+# Run once per clone: `make hooks`.
+hooks:
+	git config core.hooksPath .githooks
+	@echo "hooks installed: commit-msg, post-commit, pre-push (.githooks/)"
 
 # Accelerated build: ONNX Runtime + CoreML (Apple GPU / Neural Engine).
 #

--- a/internal/tui/coverage_boost_test.go
+++ b/internal/tui/coverage_boost_test.go
@@ -188,7 +188,9 @@ func TestFindExistingSpec_Found(t *testing.T) {
 	base := filepath.Join(tmp, "specs", "tools")
 	_ = os.MkdirAll(filepath.Join(base, "003-my-feature"), 0o755)
 	got := findExistingSpec(tmp, "tools", "my-feature")
-	want := filepath.Join("tools", "003-my-feature")
+	// findExistingSpec returns slash-separated paths so the name is safe in
+	// git refs (a Windows filepath.Join result would break branch creation).
+	want := "tools/003-my-feature"
 	if got != want {
 		t.Errorf("expected %q, got %q", want, got)
 	}

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -126,7 +126,7 @@ func findExistingSpec(workDir, category, baseName string) string {
 		}
 		stripped := numPrefix.ReplaceAllString(e.Name(), "")
 		if stripped == baseName {
-			return filepath.Join(category, e.Name())
+			return filepath.ToSlash(filepath.Join(category, e.Name()))
 		}
 	}
 	return ""
@@ -166,14 +166,46 @@ func createSpecSkeleton(workDir, taskName, roughIdea string) (string, error) {
 	return specDir, nil
 }
 
+// shortTaskName derives a compact identifier from a task name for use in
+// worktree paths, branch names, and agent IDs. It drops the category prefix
+// ("features/TOO/001-my-long-feature-name" -> "001-my-long-feature") and
+// truncates to maxShortTaskLen characters at a hyphen boundary. The full
+// task name stays in use for spec directories and the backup branch.
+func shortTaskName(taskName string) string {
+	const maxLen = 40
+	name := taskName
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	if len(name) <= maxLen {
+		return name
+	}
+	if i := strings.LastIndex(name[:maxLen+1], "-"); i > maxLen/2 {
+		name = name[:i]
+	} else {
+		// No useful hyphen boundary in range: keep a meaningful prefix by
+		// dropping any leading NNN- number instead of cutting mid-word.
+		if j := strings.Index(name, "-"); j >= 0 && j < 4 && j+1 < maxLen {
+			name = name[j+1:]
+			if len(name) > maxLen {
+				name = name[:maxLen]
+			}
+			return strings.Trim(name, "-")
+		}
+		name = name[:maxLen]
+	}
+	return strings.Trim(name, "-")
+}
+
 // startPlanWorktree creates the isolated branch used by /plan.
 func (m *model) startPlanWorktree(taskName string) (string, error) {
 	if m.cfg.Orchestrator == nil || m.cfg.Orchestrator.Worktree() == nil {
 		return "", fmt.Errorf("/plan requires a git worktree manager")
 	}
 	wm := m.cfg.Orchestrator.Worktree()
-	agentID := "plan-" + taskName
-	wtPath, err := wm.Create(agentID, "pdd-"+taskName)
+	short := shortTaskName(taskName)
+	agentID := "plan-" + short
+	wtPath, err := wm.Create(agentID, short)
 	if err != nil {
 		return "", fmt.Errorf("create PDD worktree: %w", err)
 	}
@@ -284,6 +316,13 @@ func copyOverwrite(src, dst string) error {
 	return os.CopyFS(dst, os.DirFS(src))
 }
 
+// newTaskName builds the spec task name "<category>/<NNN>-<base>".
+// It always uses forward slashes: the name flows into git refs (backup
+// branch) and agent IDs, where a backslash is invalid (exit 128 on Windows).
+func newTaskName(category, num, base string) string {
+	return filepath.ToSlash(filepath.Join(category, num+"-"+base))
+}
+
 // handlePlanCommand processes "/plan <rough idea>" input.
 // Creates the spec skeleton in an isolated worktree, loads the PDD SOP,
 // injects it as the system instruction, clears the conversation, and sends
@@ -308,7 +347,7 @@ func (m *model) handlePlanCommand(parts []string) (tea.Model, tea.Cmd) {
 		taskName = existing
 	} else {
 		num := nextSpecNumber(workDir, category)
-		taskName = filepath.Join(category, num+"-"+baseName)
+		taskName = newTaskName(category, num, baseName)
 	}
 
 	if m.planWorktree == nil {

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -573,3 +573,32 @@ func TestFinishPlanWorktree_MergeFailureStillCopiesSpec(t *testing.T) {
 		t.Errorf("spec content = %q, want the worktree's copy %q", got, "# Prompt\n")
 	}
 }
+
+func TestShortTaskName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// Category prefix dropped.
+		{"features/TOO/001-my-feature", "001-my-feature"},
+		{"memory/002-remember-things", "002-remember-things"},
+		// No category.
+		{"003-bare-name", "003-bare-name"},
+		// Long name truncated at a hyphen boundary, under 40 chars.
+		{
+			"features/TOO/001-create-new-screen-with-summary-of-the-ride-at-the",
+			"001-create-new-screen-with-summary-of",
+		},
+		// No hyphen in range: hard cut at 40.
+		{
+			"features/TOO/001-" + strings.Repeat("x", 60),
+			strings.Repeat("x", 40),
+		},
+	}
+	for _, c := range cases {
+		got := shortTaskName(c.in)
+		if got != c.want {
+			t.Errorf("shortTaskName(%q) = %q, want %q", c.in, got, c.want)
+		}
+		if len(got) > 40 {
+			t.Errorf("shortTaskName(%q) = %q, longer than 40 chars", c.in, got)
+		}
+	}
+}

--- a/internal/tui/plan_windows_test.go
+++ b/internal/tui/plan_windows_test.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression test for Windows: task names built with filepath.Join contain
+// backslashes, which leak into git refs (backup branch "specs/<taskName>")
+// and make git fail with exit status 128. Task names must always use
+// forward slashes.
+func TestNewTaskName_NoBackslashes(t *testing.T) {
+	got := newTaskName(`features\TOO`, "001", "my-feature")
+	if strings.ContainsRune(got, '\\') {
+		t.Errorf("task name contains backslash: %q", got)
+	}
+	if want := "features/TOO/001-my-feature"; got != want {
+		t.Errorf("newTaskName() = %q, want %q", got, want)
+	}
+}
+
+func TestFindExistingSpec_NoBackslashes(t *testing.T) {
+	dir := t.TempDir()
+	specDir := filepath.Join(dir, "specs", "features", "TOO", "001-existing-spec")
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got := findExistingSpec(dir, `features\TOO`, "existing-spec")
+	if got == "" {
+		t.Fatal("findExistingSpec() returned empty")
+	}
+	if strings.ContainsRune(got, '\\') {
+		t.Errorf("existing spec path contains backslash: %q", got)
+	}
+}

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/PROMPT.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/PROMPT.md
@@ -1,0 +1,62 @@
+# TUI: open URL in browser on click
+
+## Objective
+Add click-to-open-URL support to the pi-go TUI chat output. Hovering an http(s) URL underlines it; a left click without drag opens it in the system browser via `internal/browser.Open`. Errors are silently ignored; scope is chat output only.
+
+## Key Requirements
+1. **Frame link resolution** — parse OSC 8 hyperlink spans out of the composed frame string to resolve which URL (if any) sits under a given cell; derived on demand from `lastFrame`, no cached index.
+2. **Hover underline** — mouse motion over a link sets hover state; View renders SGR underline over exactly that span.
+3. **Click-to-open with drag suppression** — release opens the URL only when selection ended empty ("click without drag") and press/release resolve to the same URL.
+4. **Silent failure** — `browser.Open` errors ignored (`_ = openChatLink(url)`); injectable var for tests.
+
+## Acceptance Criteria
+### Link resolution
+- Given a frame line containing an OSC 8 hyperlink, when `frameLinks` runs, then it returns the URL with correct display-column Start/End (BEL and ST terminator forms, styled inner text, multiple links per line).
+- Given out-of-range row/col or non-link cells, when `frameLinkAt` runs, then it returns nil.
+
+### Hover
+- Given chat output containing `https://example.com`, when the mouse moves onto it, then the next frame underlines that span only; moving off clears it.
+
+### Click-to-open
+- Given press and release on the same link cell without motion between, when handled, then `openChatLink` is called once with the URL.
+- Given press on a link followed by motion/drag, then no open occurs and text selection works as before.
+- Given click on non-link text, then `openChatLink` is never called.
+- Given `openChatLink` returns an error, then nothing visible changes.
+
+## Implementation Slices
+1. **Frame link resolution** — pure functions + unit tests, files: `internal/tui/framelinks.go`, `internal/tui/framelinks_test.go`, verify: `go build ./... && go test ./internal/tui/ -run 'FrameLink' -v`, parallel-safe: yes
+2. **Hover underline rendering** — `applyHoverUnderline`, model hover fields, motion handler + View wiring, files: `internal/tui/framelinks.go`, `internal/tui/framelinks_test.go`, `internal/tui/tui.go`, verify: `go test ./internal/tui/ -v`, parallel-safe: no
+3. **Click-to-open on release** — `openChatLink` hook, press/release handling, handler tests, files: `internal/tui/tui.go`, verify: `go build ./... && go test ./internal/tui/... -v && go test ./...`, parallel-safe: no
+
+## Execution Model
+Coordinator → Worker → Verifier. The agent that receives this PROMPT.md is the **Coordinator**; it delegates rather than implements.
+
+- **Workers**: one `worker` subagent per slice. Slices are sequential (2 and 3 share tui.go with each other's context); run one at a time in order.
+- **Verifier**: after the last slice, a `code-reviewer` subagent checks the Done Criteria below against the actual diff and returns VERDICT: PASS or VERDICT: FAIL.
+- **Loop**: on FAIL the Coordinator dispatches fix workers and re-verifies, up to 10 cycles total.
+
+## Done Criteria
+The Verifier checks these against the diff, not against the checklist:
+- [ ] `internal/tui/framelinks.go` exports `frameLinks`, `frameLinkAt`, `applyHoverUnderline` with working OSC 8 parsing (both BEL and ST terminators), covered by tests in `framelinks_test.go`
+- [ ] Motion over a link in the message viewport produces an underlined span in the composed frame (hover wiring present in handleMouseMotion and View)
+- [ ] Release on a link after dragless click calls the injected browser opener exactly once; drags suppress opening; non-link clicks never call it — see handler tests
+- [ ] `browser.Open` errors are silently discarded (no user-facing error path added)
+- [ ] No slice is left as a stub, TODO, or panic("not implemented")
+- [ ] `go build ./...` and `go test ./...` pass; existing mouse/selection behavior unchanged (selection.go unmodified)
+
+## Gates
+- **build**: `make build`
+- **test**: `go test ./...`
+- **vet/lint**: `make vet lint`
+
+## Reference
+- Design: `specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/design.md`
+- Outline: `specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/outline.md`
+- Plan: `specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/plan.md`
+- Requirements: `specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/requirements.md`
+- Research: `specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/research/`
+
+## Constraints
+- Do not modify `chat.go` rendering pipeline or `selection.go` semantics
+- No new dependencies; reuse `charmbracelet/x/ansi`, `lipgloss`, `internal/browser`
+- Keep all source changes within `internal/tui/`

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/design.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/design.md
@@ -1,0 +1,107 @@
+# Design: Click-to-open URL in TUI chat
+
+## Current State
+
+- Chat output is rendered to a single frame string with embedded ANSI + OSC 8 hyperlink escapes (`internal/tui/chat.go`: `hyperlinkRenderedURLs` / `hyperlinkRenderedLine`). Column ranges are computed at render time and discarded; no position→URL map exists.
+- `model.View()` (tui.go:1451) renders, clips via `clipMessagesToViewport`, saves `lastFrame` (composed full frame) and `frameRows`; sets `msgTop/msgBottom` selectable rows.
+- Mouse: `handleMouse` dispatches Click/Motion/Release/Wheel with terminal cell coords. `clampToChat` maps absolute Y → frame row (`y - m.frameTop()`), X → chat columns. Drag-selection state lives in `selection` (selection.go); `empty()` distinguishes click-without-drag.
+- `internal/browser.Open(url)` opens a URL in the system browser; errors include `ErrNoHandler`.
+
+## Desired End State
+
+Hovering an http(s) URL in the chat message viewport underlines it; clicking it without dragging opens it in the browser. All other mouse behavior unchanged. Failures silently ignored.
+
+## Architecture Overview
+
+Single source of truth remains the frame string. At click/motion time we resolve the cell under the pointer by parsing OSC 8 spans out of the relevant line of `lastFrame`.
+
+```mermaid
+flowchart LR
+    M[Mouse msg] --> C[clampToChat x,y]
+    C --> L[frameLinkAt lastFrame, row, col]
+    L -->|url| U[browser.Open url]
+    L -->|none| S[existing selection path]
+    Motion -.hover over link.-> H[underline render flag]
+```
+
+New file `internal/tui/framelinks.go` owns all position→URL logic; tui.go handlers call into it.
+
+## Components & Interfaces
+
+```go
+// framelinks.go
+
+// LinkSpan is a clickable URL within one frame line.
+type LinkSpan struct {
+    URL   string
+    Start int // display column, inclusive
+    End   int // display column, exclusive
+}
+
+// frameLinks extracts clickable link spans from a single frame line.
+// Parses OSC 8 sequences (both BEL and ST terminated); returns nil if none.
+func frameLinks(line string) []LinkSpan
+
+// frameLinkAt resolves the link under (row, col) in frame coordinates,
+// or nil. row indexes lines of frame; col is a 0-based display column
+// clamped to the line's visible width.
+func frameLinkAt(frame string, row, col int) *LinkSpan
+```
+
+Model additions (tui.go):
+
+```go
+type model struct {
+    // ...existing...
+    hoverLink string // URL currently hovered ("" = none)
+}
+```
+
+Rendering of hover underline: when `hoverLink != ""`, View post-processes only the message-viewport rows of the frame, adding SGR underline around the hovered span's cells for its row(s). Implemented as `applyHoverUnderline(frame string, hover hoverInfo) string` in framelinks.go, where `hoverInfo{row, startCol, endCol int}` is recomputed each View from `hoverLink` + pointer position stored in model (`hoverX, hoverY int`). If the link no longer exists at that position (scroll/render change), skip.
+
+## Data Models
+
+No persistent structures beyond two ints (`hoverX/hoverY`) and `hoverLink`. Everything else derived from `lastFrame` on demand — no invalidation problem across scroll/re-render.
+
+## Patterns Followed
+
+- Frame-string post-processing like existing selection highlight (`selectedText(m.lastFrame, ...)`) — derive from saved frame, don't cache.
+- Small focused files in internal/tui with table-driven tests (see `terminal_hyperlink_test.go`).
+- Browser opening via injected var for testability: mirror login.go's `openBrowser` pattern — `var openChatLink = browser.Open` in tui.go.
+
+## Error Handling Strategy
+
+Per requirements: `browser.Open` error is silently ignored (`_ = openChatLink(url)`). Malformed/unparseable frame content simply yields no link → normal behavior. No user-visible failures.
+
+## Behavior Specification
+
+1. **Motion**: update `hoverX/hoverY`; resolve `frameLinkAt(lastFrame, row, col)` after clampToChat mapping; set/clear `hoverLink`. Trigger re-render (View already runs per event).
+2. **Click (left)**: record anchor as today but also remember press-point link (`pressLink`); proceed with existing selection-start logic unchanged so drag still works.
+3. **Release**: after existing logic, if selection ended empty (click-without-drag, `m.sel.empty()` path) AND the release cell resolves to the same URL as press (`frameLinkAt` equality), open it. This gives drag suppression for free: drags produce non-empty selection → no open.
+4. **Non-left buttons**: untouched.
+5. **Scope**: only cells within `[msgTop, msgBottom)` message viewport rows resolve links (clampToChat already restricts there).
+
+Edge cases:
+- Link spanning wrapped lines (glamour soft-wraps long URLs): OSC 8 wraps each visual line separately already (hyperlinkRenderedLine is per-line), so per-line lookup handles this naturally; clicking any visual segment opens the same href.
+- Hover while scrolled/typing: recompute each View; stale hover auto-clears since resolution fails.
+- Click inside an existing text-selection highlight that is also a link: preserve current copy-on-click behavior (check sel.contains first, as today).
+
+## Acceptance Criteria
+
+Given/When/Then:
+- Given chat contains `https://example.com`, when mouse moves onto it, then the span renders underlined next frame.
+- When mouse leaves, underline clears.
+- Given left press then release on the same link cell with no motion between, then `openChatLink` is called once with the link's URL.
+- Given left press on a link followed by motion (drag), then no open occurs and selection works as today.
+- Given a click on non-link text, then `openChatLink` is never called.
+- Given `openChatLink` returns an error, then nothing is displayed and state is unaffected.
+
+## Testing Strategy
+
+Unit tests in `internal/tui/framelinks_test.go`:
+- `frameLinks`: parses OSC 8 (BEL + ST forms), ignores non-link text, handles styled inner text, multiple links per line.
+- `frameLinkAt`: hits inside/outside spans, out-of-range row/col, multi-line frame.
+- Handler tests (extend existing tui tests): simulate MouseClickMsg→MouseReleaseMsg on a crafted frame containing a link; assert stubbed `openChatLink` called with expected URL; drag variant asserts not called; error variant asserts silent.
+- Underline: assert `applyHoverUnderline` output contains SGR underline exactly over the span columns, preserves other bytes.
+
+Existing suites must stay green: `go test ./...`.

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/outline.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/outline.md
@@ -1,0 +1,25 @@
+# Outline: Click-to-open URL in TUI chat
+
+## Slices (vertical, each independently verifiable)
+
+1. **Slice 1: Frame link resolution** — `internal/tui/framelinks.go` with `LinkSpan`, `frameLinks(line)`, `frameLinkAt(frame, row, col)` + `framelinks_test.go` unit tests. Pure functions, no wiring. Depends on: none. Parallel-safe: yes.
+2. **Slice 2: Hover underline rendering** — `applyHoverUnderline` in framelinks.go + tests; model fields `hoverX/hoverY/hoverLink`; motion handler sets/clears hover; View applies underline to message rows. Verify: underline tests + existing tui tests green. Depends on Slice 1. Parallel-safe: no.
+3. **Slice 3: Click-to-open on release** — injectable `var openChatLink = browser.Open`; release handler opens when selection empty and press/release resolve to same link; click handler records press-point link; handler tests (open, drag-suppressed, error-silent). Verify: `go test ./internal/tui/...`. Depends on Slices 1–2 (hover state exists; but logic only needs Slice 1 — order after 2 for file-conflict avoidance). Parallel-safe: no.
+
+## Key signatures
+
+```go
+// framelinks.go
+type LinkSpan struct { URL string; Start, End int }
+func frameLinks(line string) []LinkSpan
+func frameLinkAt(frame string, row, col int) *LinkSpan
+func applyHoverUnderline(frame string, row, startCol, endCol int) string
+
+// tui.go
+var openChatLink = browser.Open // injected for tests
+// model: hoverX, hoverY int; hoverLink string
+```
+
+## Order & testing
+
+Slices strictly sequential (1 → 2 → 3); each ends with `go build ./... && go test ./internal/tui/...`. Final gate: `go test ./...`.

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/plan.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/plan.md
@@ -1,0 +1,46 @@
+# Plan: TUI click-to-open URL in browser
+
+Feature: hovering an http(s) URL in the TUI chat message viewport underlines it; a left click without drag on it opens it via `internal/browser.Open`. Errors silently ignored. Scope: chat output only.
+
+Read `design.md` for full context before starting. All work in `/Users/dimetron/p6s/pi-dev/pi-go`.
+
+- [ ] Slice 1: Frame link resolution (`internal/tui/framelinks.go` + tests)
+  - Create `internal/tui/framelinks.go`:
+    - `type LinkSpan struct { URL string; Start, End int }` — display columns, half-open.
+    - `func frameLinks(line string) []LinkSpan` — parse OSC 8 hyperlink sequences (form `\x1b]8;params;URI\x07text\x1b]8;;\x07`, and ST (`\x1b\\`) terminators) out of one frame line. Compute Start/End as display columns of the inner text using existing conventions in chat.go's `hyperlinkRenderedLine` (see how it converts byte offsets to columns with `lipgloss.Width`/`ansi.Cut`). Return nil when no links.
+    - `func frameLinkAt(frame string, row, col int) *LinkSpan` — split frame on `\n`, index row (return nil if out of range), strip nothing; use `frameLinks`; match col within `[Start, End)`; nil otherwise.
+  - Create `internal/tui/framelinks_test.go`: table-driven tests covering: BEL-terminated and ST-terminated OSC 8; plain line → nil; multiple links per line; styled inner text (SGR bytes inside link text); hit inside/outside span; out-of-range row/col; multi-line frame. Model test fixtures on real output from `hyperlinkRenderedURLs` in chat.go (see `terminal_hyperlink_test.go`).
+  - Verify: `go build ./... && go test ./internal/tui/ -run 'FrameLink' -v`
+
+- [ ] Slice 2: Hover underline rendering + motion wiring
+  - In framelinks.go add `func applyHoverUnderline(frame string, row, startCol, endCol int) string` — returns frame with SGR underline (`\x1b[4m` … `\x1b[24m`) inserted around exactly those display columns of that line; must not disturb other escape bytes; no-op if row/cols out of range or span already underlined by style bytes (check for existing SGR at boundaries; simplest safe rule: only apply when the target cells carry no SGR styling of their own — document this limitation).
+  - Add `applyHoverUnderline` tests to framelinks_test.go (exact span coverage, adjacent escapes preserved, out-of-range no-op).
+  - In tui.go model struct add fields: `hoverX, hoverY int` (frame coords), `hoverLink string`.
+  - Extend `handleMouseMotion` (tui.go:980): after existing drag logic, map msg coords via `clampToChat` to `(x, y)`; resolve `frameLinkAt(m.lastFrame, y, x)`; set/clear `hoverX/hoverY/hoverLink` accordingly. Motion during active drag should clear hoverLink (drag = selecting, not hovering).
+  - In View (around where lastFrame is saved, tui.go:1597): if `hoverLink != ""` re-resolve its span at `(hoverX, hoverY)`; if found, apply `applyHoverUnderline` to the composed message rows before saving lastFrame ordering per current code (apply after composition, before assignment — keep `frameRows` consistent since underline adds no lines). If re-resolution fails, clear hoverLink.
+  - Verify: `go build ./... && go test ./internal/tui/ -v`
+
+- [ ] Slice 3: Click-to-open on release
+  - In tui.go add injectable hook near login.go's pattern: `var openChatLink = browser.Open` (import `internal/browser`).
+  - Add model field `pressLink string`.
+  - In `handleMouseClick` (tui.go:921): for left-button presses inside the message viewport, before existing selection-start logic, record `m.pressLink = frameLinkAt(m.lastFrame, y, x)` result (nil if none). Do NOT alter existing selection behavior.
+  - In `handleMouseRelease` (tui.go:995): capture press-link first; after the existing empty-selection reset branch (the "click without drag" path), if selection ended empty AND release cell resolves via `frameLinkAt` to a LinkSpan whose URL equals `pressLink.URL`, call `_ = openChatLink(url)`. Clear `pressLink` and `hoverLink` on any release. Drags produce non-empty selection → suppressed automatically.
+  - Tests (new file or extend existing mouse handler tests): craft a model with a lastFrame containing an OSC 8 link (use `hyperlinkRenderedURLs` to build it); stub `openChatLink` with a recorder; cases:
+    1. press+release same cell on link, no motion → called once with URL;
+    2. press on link, motion to another cell, release → not called, selection non-empty;
+    3. press+release on non-link cell → not called;
+    4. stub returns error → no panic, no visible state change;
+    5. press on link A, release over link B (different URL) → not called.
+  - Verify: `go build ./... && go test ./internal/tui/... -v`, then full gate `go test ./...`
+
+## Gates
+
+- build: `make build`
+- test: `go test ./...`
+- vet/lint: `make vet lint`
+
+## Constraints
+
+- Do not modify chat.go rendering pipeline or selection.go semantics.
+- No new dependencies; reuse `charmbracelet/x/ansi`, `lipgloss`, `internal/browser`.
+- Keep all changes within `internal/tui/`.

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/requirements.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/requirements.md
@@ -1,0 +1,4 @@
+# Requirements
+
+## Questions & Answers
+

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/requirements.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/requirements.md
@@ -2,3 +2,36 @@
 
 ## Questions & Answers
 
+**Q1: Click behavior — open immediately on left-click?**
+A: Yes, plain left-click opens the URL (no modifier keys, no menu).
+
+**Q2: What about clicks on non-link text?**
+A: Click only opens when the cursor is over a hyperlink; otherwise normal text-selection behavior.
+
+**Q3: Visual feedback on hover?**
+A: Yes if simple — underline the hovered URL; click opens.
+
+**Q4: Behavior when `browser.Open()` fails?**
+A: Silently ignore (no error message).
+
+**Q5: Interaction with copy-on-release drag selection?**
+A: Open only on a click without drag — suppress opening if the click turned into a drag/selection.
+
+## Summary
+
+Add click-to-open-URL support to the TUI chat output:
+
+1. **Hover underline**: when the mouse pointer rests over an http(s) URL in rendered chat output, show that URL underlined.
+2. **Click-to-open**: a left mouse click (press + release without significant movement/drag) on a URL opens it in the system browser via `internal/browser.Open()`.
+3. **Non-link clicks unchanged**: clicking non-hyperlink text keeps existing selection behavior.
+4. **Drag suppression**: if the click starts a drag/selection, do not open the URL.
+5. **Failure handling**: `browser.Open()` errors are silently ignored.
+6. **Scope**: chat output only (where OSC 8 / URL regex rendering already lives in `internal/tui/chat.go`); no other TUI surfaces in v1.
+
+## Acceptance Criteria
+
+- Given chat output containing `https://example.com`, when the user hovers over it, then the URL renders underlined.
+- When the user left-clicks (no drag) on the URL, then it is opened via `browser.Open` and no error is surfaced.
+- When the user left-clicks and drags starting on the URL, then it is NOT opened and normal selection occurs.
+- When the user clicks on non-URL text, then behavior is identical to today (selection).
+- Given an environment with no browser handler, when a URL is clicked, then nothing visible happens (no crash, no error message).

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/research/mouse-handling.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/research/mouse-handling.md
@@ -1,0 +1,41 @@
+# Research: Mouse handling & coordinate spaces (tui.go, selection.go)
+
+## Dispatcher
+
+`handleMouse(msg tea.MouseMsg)` (tui.go:787), reached from Update at tui.go:670-671. Dispatches to:
+- `handleMouseClick(msg tea.MouseClickMsg)` — tui.go:921
+- `handleMouseMotion(msg tea.MouseMotionMsg)` — tui.go:980
+- `handleMouseRelease(msg tea.MouseReleaseMsg)` — tui.go:995
+- `handleMouseWheel(msg tea.MouseWheelMsg)` — tui.go:1049
+
+All use `msg.Mouse()` → bubbletea v2 `tea.Mouse{X, Y int; Button MouseButton; Mod KeyMod}`. **X/Y are terminal cell coordinates.**
+
+## Coordinate mapping
+
+Y is absolute terminal row (no alt-screen). `clampToChat` (tui.go:1023-1036): frame row = `y - m.frameTop()` where `frameTop() = max(0, m.height - m.frameRows)` (tui.go:1039-1046); clamps to `[msgTop, msgBottom-1]`. X clamped to `[0, chatWidth()-1]`.
+
+## Drag selection (`selection` type, selection.go:19-29)
+
+Fields: `dragging bool`, `anchorX/anchorY`, `cursorX/cursorY`, `present bool` (set only by Motion).
+
+Flow:
+- Click (tui.go:921): non-left ignored; hitContextClear check; click right of panel deselects; click inside existing highlight re-copies (tui.go:945-947); otherwise starts `selection{dragging: true, anchor=cursor=(x,y)}`.
+- Motion: updates cursor, sets `present = true`.
+- Release (tui.go:995): sets `dragging = false`; if `m.sel.empty()` (selection.go:71-73 — `!present || anchor == cursor`) resets and does nothing; else copies via `copyAndFlash` (OSC 52 + clipboard).
+
+**"Click without drag" notion already exists**: `selection.empty()`.
+
+## Relevant model state
+
+- `sel selection` (tui.go:85), `lastFrame string` (:86, saved in View :1597), `frameRows int` (:87).
+- `msgTop, msgBottom int` (:103) — half-open selectable rows, set in View at :1600.
+- `chatModel.ChatModel` — custom model: `Scroll int // offset from bottom` (chat.go:267), `Width int`; `ScrollUp/ScrollDown/MaxScroll(height)`.
+- Dimensions: `m.width/m.height`, `chatWidth()`, `messageViewportHeight()` (tui.go:1894).
+
+## MouseMode
+
+tui.go:1634: `v.MouseMode = tea.MouseModeCellMotion`, `v.AltScreen = false` (:1633). Asserted in history_key_test.go:201-202.
+
+## Browser helper
+
+`internal/browser/browser.go`: `browser.Open(url string) error` returning `ErrNoHandler`. Tries `$BROWSER`, then platform commands. Already used by login flows.

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/research/url-rendering.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/research/url-rendering.md
@@ -1,0 +1,28 @@
+# Research: URL rendering pipeline (chat.go)
+
+## Regexes (chat.go:462-463)
+
+```go
+var markdownLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((file://[^)]+|http://[^)]+|https://[^)]+)\)`)
+var httpURLRe      = regexp.MustCompile(`https?://[^\s<>()[\]{}"']+`)
+```
+
+## Functions
+
+- `hyperlinkURLs(text string) string` (chat.go:473-485): wraps `https?://` matches in OSC 8; trims trailing punctuation, validates via `url.Parse`. Constants chat.go:466-467.
+- `hyperlinkRenderedURLs(text string) string` (chat.go:490-496): per-line → `hyperlinkRenderedLine` (chat.go:498-529): strips SGR with `ansi.Strip`, finds URLs in plain text, converts byte offsets to display columns (`lipgloss.Width`, `ansi.Cut`), splices OSC 8 around visible span preserving style bytes.
+- Column ranges (`start`, `end`, `rawEnd`) computed then **discarded** after rendering.
+
+## Render pipeline
+
+`RenderMarkdown` (chat.go:557-571): `expandLinks` (flattens `[text](url)` to `"text (url)"`, chat.go:534-552) → glamour → `hyperlinkRenderedURLs`.
+
+Called from `assistantBody` (:808) → `renderAssistantBlock` → `renderMessageBlock` → `renderMessages(running bool) (string, []blockKind)` (chat.go:629).
+
+## Output structure — key constraint
+
+Rendered output is a single Go `string` with embedded ANSI/OSC 8 escapes. Per-message cache: `message.renderCache string` (+key/bool, chat.go:144-146). View calls `clipMessagesToViewport(messagesView, availableHeight, m.chatModel.Scroll)` returning `(visibleMessages, startLine, endLine)` (tui.go:1483).
+
+**No position→URL mapping exists.** The only retained artifacts are: the full rendered string, the viewport start/end line offsets, and `lastFrame` (composed frame saved at tui.go:1597). Any click→URL lookup must be derived from these (e.g., parse OSC 8 sequences out of the target frame line/column) or built fresh during render.
+
+Tests: `terminal_hyperlink_test.go`, `chat_test.go`.

--- a/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/rough-idea.md
+++ b/specs/features/TOO/020-tui-allow-open-url-in-browser-on-click/rough-idea.md
@@ -1,0 +1,3 @@
+# Rough Idea
+
+tui allow open URL in browser on click


### PR DESCRIPTION
- **PDD plan: features/TOO/020-tui-allow-open-url-in-browser-on-click**
- **PDD plan: features/TOO/020-tui-allow-open-url-in-browser-on-click**
- **PDD plan: features/TOO/020-tui-allow-open-url-in-browser-on-click**
- **PDD plan: features/TOO/020-tui-allow-open-url-in-browser-on-click**
- **PDD plan: features/TOO/020-tui-allow-open-url-in-browser-on-click**
- **PDD plan: features/TOO/020-tui-allow-open-url-in-browser-on-click**
- **fix(tui): normalize /plan task names to forward slashes and shorten worktree names**
