### PR TITLE
PDD plan: plan-mode phase checklist + always-merge worktree

### DIFF
--- a/specs/features/TOO/022-plan-mode-phase-checklist/PROMPT.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/PROMPT.md
@@ -1,0 +1,110 @@
+# Plan Mode Phase Checklist
+
+## Objective
+Add a "Plan" section to the right sidebar that shows the 7 PDD phases as a
+checklist when in plan mode, so the user can see at a glance how far a `/plan`
+session has progressed. The current phase is detected by scanning the spec
+directory for artifact files. All changes are confined to `internal/tui/`.
+
+## Key Requirements
+1. **7-phase checklist** — Idea, Requirements, Research, Design, Outline, Plan,
+   Prompt, each mapped to a spec artifact file/dir that marks it complete.
+2. **Current phase detection** — the current phase is the first whose artifact is
+   missing; if all exist, the plan is complete (all checked).
+3. **Plan-mode only** — the section renders only when in plan mode; hidden
+   otherwise.
+4. **Reuse `/run` checklist style** — `[x]` (green) for done, `[ ]` (overlay) for
+   future, plus a `▶` marker on the current phase.
+
+## Acceptance Criteria
+### Plan section rendering
+- Given the user is in plan mode, when the sidebar renders, then a "Plan" section
+  shows all 7 phases with the current phase marked `▶` and completed phases `[x]`.
+- Given a phase's artifact file exists, when the sidebar renders, then that phase
+  is shown as completed (`[x]`).
+- Given the current phase's artifact is missing, when the sidebar renders, then
+  that phase is shown as current (`▶`) and later phases as `[ ]`.
+- Given all 7 artifacts exist, when the sidebar renders, then all phases are shown
+  as completed.
+- Given the user is NOT in plan mode, when the sidebar renders, then no "Plan"
+  section is shown.
+- Given the spec directory cannot be read, when the sidebar renders, then the
+  checklist degrades gracefully (no crash; phases shown as incomplete).
+
+## Implementation Slices
+1. **Add `PlanPhase` type + `detectPlanPhases`** — add `PlanPhase{Name, Done}` and
+   `detectPlanPhases(specDir string) []PlanPhase` with the 7-phase artifact mapping
+   (`rough-idea.md`, `requirements.md`, `research` dir, `design.md`, `outline.md`,
+   `plan.md`, `PROMPT.md`). Files: `internal/tui/sidebar.go`. Verify:
+   `go build ./internal/tui/...`. Parallel-safe: no.
+2. **Add `sidebarPlanLines` renderer** — render the "Plan" heading and 7 phases
+   with `▶`/`[x]`/`[ ]` markers; return `nil` when `len(in.PlanPhases) == 0`.
+   Files: `internal/tui/sidebar.go`. Verify: `go build ./internal/tui/...`.
+   Parallel-safe: no.
+3. **Wire into `SidebarRenderInput` + `sidebarRenderInput`** — add `PlanPhases
+   []PlanPhase` field to `SidebarRenderInput`; in `sidebarModeLines` render the
+   Plan section when `PlanPhases` is non-empty; in `sidebarRenderInput` (tui.go)
+   populate `in.PlanPhases` when `m.mode == "plan" && m.planWorktreePath != "" &&
+   m.planTaskName != ""` via `detectPlanPhases(filepath.Join(m.planWorktreePath,
+   "specs", m.planTaskName))`. Files: `internal/tui/sidebar.go`,
+   `internal/tui/tui.go`. Verify: `go test ./internal/tui/...`. Parallel-safe: no.
+4. **Add tests** — `TestDetectPlanPhases`, `TestDetectPlanPhases_AllDone`,
+   `TestDetectPlanPhases_None`, `TestSidebarPlanLines`, `TestSidebarPlanLines_Hidden`
+   in `internal/tui/sidebar_sections_test.go`; `TestRenderSidebar_PlanChecklist`,
+   `TestRenderSidebar_NoPlanSection` in `internal/tui/sidebar_test.go`. Files:
+   `internal/tui/sidebar_sections_test.go`, `internal/tui/sidebar_test.go`.
+   Verify: `go test ./internal/tui/...` and `go vet ./internal/tui/...`.
+   Parallel-safe: no.
+
+## Execution Model
+Coordinator → Worker → Verifier. The agent that receives this PROMPT.md is the
+**Coordinator**; it delegates rather than implements.
+
+- **Workers**: one `worker` subagent per slice. No slices are parallel-safe, so run
+  them one at a time, in order.
+- **Verifier**: after the last slice, a `code-reviewer` subagent checks the Done
+  Criteria below against the actual diff and returns VERDICT: PASS or VERDICT: FAIL.
+- **Loop**: on FAIL the Coordinator dispatches fix workers and re-verifies, up to
+  10 cycles total.
+
+## Done Criteria
+The Verifier checks these against the diff, not against the checklist. Each must
+be objectively checkable by reading code or running a command.
+- [ ] `PlanPhase{Name, Done}` type and `detectPlanPhases(specDir)` exist and map
+      the 7 PDD phases to their artifact files/dirs — see `TestDetectPlanPhases`.
+- [ ] `sidebarPlanLines` renders a "Plan" heading and the 7 phases with `▶` on the
+      current phase, `[x]` on done phases, `[ ]` on future phases — see
+      `TestSidebarPlanLines`.
+- [ ] `sidebarPlanLines` returns nil (section hidden) when `PlanPhases` is empty —
+      see `TestSidebarPlanLines_Hidden`.
+- [ ] `SidebarRenderInput` has a `PlanPhases []PlanPhase` field, populated in
+      `sidebarRenderInput` only when `m.mode == "plan"` and plan fields are set.
+- [ ] `sidebarModeLines` renders the Plan section when `PlanPhases` is non-empty.
+- [ ] `TestRenderSidebar_PlanChecklist` asserts the "Plan" section and phase markers
+      appear and `[chat]` is absent.
+- [ ] `TestRenderSidebar_NoPlanSection` asserts no "Plan" section appears when not
+      in plan mode.
+- [ ] `go test ./internal/tui/...` passes.
+- [ ] No slice is left as a stub, TODO, or panic("not implemented").
+
+## Gates
+- **build**: `go build ./internal/tui/...`
+- **test**: `go test ./internal/tui/...`
+- **vet**: `go vet ./internal/tui/...`
+- **lint**: `golangci-lint run ./internal/tui/...`
+
+## Reference
+- Design: `specs/features/TOO/022-plan-mode-phase-checklist/design.md`
+- Outline: `specs/features/TOO/022-plan-mode-phase-checklist/outline.md`
+- Plan: `specs/features/TOO/022-plan-mode-phase-checklist/plan.md`
+- Requirements: `specs/features/TOO/022-plan-mode-phase-checklist/requirements.md`
+- Research: `specs/features/TOO/022-plan-mode-phase-checklist/research/`
+
+## Constraints
+- The checklist must only render in plan mode (`m.mode == "plan"`).
+- The current phase is the first phase whose artifact is missing; if all artifacts
+  exist, all phases are checked.
+- The sidebar width (23) must not change; labels must fit (use `truncateLabel`).
+- Re-scan the spec directory on every render (cheap `os.Stat` calls).
+- Must not break the existing `/run` checklist rendering.
+- No changes to the `/plan` command flow or the PDD SOP itself.

--- a/specs/features/TOO/022-plan-mode-phase-checklist/design.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/design.md
@@ -1,0 +1,174 @@
+# Design: Plan Mode Phase Checklist
+
+## Current State
+
+The right sidebar (`internal/tui/sidebar.go`) renders a sequence of independent
+sections. `sidebarModeLines` (`sidebar.go:208`) currently shows either:
+- the `/run` checklist (`sidebarRunLines`) when a run is active, or
+- a plain `Mode` heading with `[plan]` in peach when `m.mode == "plan"`.
+
+The `/run` checklist pattern already exists: `ChecklistStep{Title, Done}` rendered
+as `[x]` (green) / `[ ]` (overlay) in `sidebarRunLines` (`sidebar.go:226-250`).
+
+In plan mode, the model has `m.planWorktreePath` and `m.planTaskName` set
+(`plan.go:212-216`), so the spec directory is derivable as
+`filepath.Join(m.planWorktreePath, "specs", m.planTaskName)` — the same pattern
+`finishPlanWorktree` uses (`plan.go:246`).
+
+## Desired End State
+
+When in plan mode, the sidebar shows a **"Plan" section** listing the 7 PDD phases
+as a checklist: the current phase marked `▶`, completed phases `[x]`, future
+phases `[ ]`. The current phase is detected by scanning the spec directory for
+which artifact files exist. The existing `Mode` section continues to show `[plan]`.
+
+## Architecture
+
+No new packages, no new files beyond tests. All changes live in
+`internal/tui/sidebar.go`, `internal/tui/tui.go`, and new tests in
+`internal/tui/sidebar_sections_test.go` (and/or `sidebar_test.go`).
+
+```mermaid
+flowchart TD
+    A[sidebarRenderInput] --> B{plan mode?}
+    B -- no --> C[Mode section as today]
+    B -- yes --> D[derive specDir from planWorktreePath + planTaskName]
+    D --> E[scan specDir for 7 artifact files]
+    E --> F[build PlanPhase list: done/current/todo]
+    F --> G[sidebarPlanLines renders Plan section]
+```
+
+## Components & Interfaces
+
+### New type: `PlanPhase`
+
+```go
+// PlanPhase is one PDD phase in the plan-mode sidebar checklist.
+type PlanPhase struct {
+    Name string // short label, e.g. "Requirements"
+    Done bool   // artifact file exists
+}
+```
+
+### New function: `detectPlanPhases(specDir string) []PlanPhase`
+
+Returns the 7 phases in order, each with `Done` set if its artifact exists. The
+current phase is the first with `Done == false`; if all are done, the plan is
+complete (all checked).
+
+```go
+// phaseArtifacts maps each PDD phase to the spec artifact that marks it complete.
+var phaseArtifacts = []struct {
+    Name     string
+    Artifact string // file or dir name under specDir
+}{
+    {"Idea", "rough-idea.md"},
+    {"Requirements", "requirements.md"},
+    {"Research", "research"}, // directory
+    {"Design", "design.md"},
+    {"Outline", "outline.md"},
+    {"Plan", "plan.md"},
+    {"Prompt", "PROMPT.md"},
+}
+
+func detectPlanPhases(specDir string) []PlanPhase {
+    phases := make([]PlanPhase, 0, len(phaseArtifacts))
+    for _, pa := range phaseArtifacts {
+        _, err := os.Stat(filepath.Join(specDir, pa.Artifact))
+        phases = append(phases, PlanPhase{Name: pa.Name, Done: err == nil})
+    }
+    return phases
+}
+```
+
+### New section renderer: `sidebarPlanLines`
+
+```go
+func sidebarPlanLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string
+```
+
+Renders the "Plan" heading and the 7 phases. Returns `nil` when not in plan mode
+or when no spec dir is available (so the section is hidden).
+
+### `SidebarRenderInput` — add one field
+
+```go
+// PlanPhases is the PDD phase checklist shown in plan mode; nil/empty = hidden.
+PlanPhases []PlanPhase
+```
+
+### `sidebarRenderInput` — populate the new field
+
+In `internal/tui/tui.go`, inside `sidebarRenderInput`, when `m.mode == "plan"` and
+`m.planWorktreePath != ""` and `m.planTaskName != ""`, derive the spec dir and call
+`detectPlanPhases`:
+
+```go
+if m.mode == "plan" && m.planWorktreePath != "" && m.planTaskName != "" {
+    specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)
+    in.PlanPhases = detectPlanPhases(specDir)
+}
+```
+
+### `sidebarModeLines` — render the Plan section
+
+When `in.PlanPhases` is non-empty (plan mode), render the Plan section in addition
+to (or instead of) the plain Mode indicator. The Plan section shows the phase
+checklist; the `[plan]` mode indicator can remain or be folded into the Plan
+heading.
+
+## Data Models
+
+No new persistent data models. `PlanPhase` is a transient render-time value.
+
+## Patterns to Follow
+
+- **Section renderer contract** — each section returns `nil` when hidden; `RenderSidebar`
+  appends non-nil sections. The Plan section returns `nil` when not in plan mode.
+- **`[x]`/`[ ]` checklist style** — reuse the exact style from `sidebarRunLines`
+  (green for done, overlay for todo), plus a `▶` marker for the current phase.
+- **Inline `os.Stat` existence checks** — matches the existing pattern in
+  `plan.go` and `run.go`; no new helper needed.
+- **Re-scan on every render** — `detectPlanPhases` is called each frame from
+  `sidebarRenderInput`; cheap `os.Stat` calls, mirrors `/run` checklist behavior.
+
+## Error Handling
+
+- If the spec directory cannot be read (missing, permission error), `os.Stat`
+  returns an error and the phase is marked `Done: false` — the checklist degrades
+  gracefully to "all incomplete", no crash.
+- If not in plan mode or plan fields are empty, `PlanPhases` stays nil and the
+  section is hidden.
+
+## Acceptance Criteria
+
+- Given the user is in plan mode, when the sidebar renders, then a "Plan" section
+  shows all 7 phases with the current phase marked `▶` and completed phases `[x]`.
+- Given a phase's artifact file exists, when the sidebar renders, then that phase
+  is shown as completed (`[x]`).
+- Given the current phase's artifact is missing, when the sidebar renders, then
+  that phase is shown as current (`▶`) and later phases as `[ ]`.
+- Given all 7 artifacts exist, when the sidebar renders, then all phases are shown
+  as completed.
+- Given the user is NOT in plan mode, when the sidebar renders, then no "Plan"
+  section is shown.
+- Given the spec directory cannot be read, when the sidebar renders, then the
+  checklist degrades gracefully (no crash; phases shown as incomplete).
+
+## Testing Strategy
+
+- **`TestDetectPlanPhases`** — create a temp spec dir, write a subset of artifact
+  files, assert `detectPlanPhases` returns the correct `Done` flags and order.
+- **`TestDetectPlanPhases_AllDone`** — write all 7 artifacts, assert all `Done`.
+- **`TestDetectPlanPhases_None`** — empty dir, assert all `Done == false`.
+- **`TestSidebarPlanLines`** (in `sidebar_sections_test.go`) — call
+  `sidebarPlanLines` directly with a `SidebarRenderInput` containing `PlanPhases`,
+  assert the rendered lines contain the phase labels, `[x]`/`[ ]` markers, and `▶`
+  on the current phase.
+- **`TestSidebarPlanLines_Hidden`** — with empty `PlanPhases`, assert the section
+  returns 0 lines (hidden).
+- **`TestRenderSidebar_PlanChecklist`** (in `sidebar_test.go`) — render the full
+  sidebar with `Mode: "plan"` and `PlanPhases` set, assert the "Plan" section and
+  phase markers appear; assert `[chat]` is absent.
+- **`TestRenderSidebar_NoPlanSection`** — render with `Mode: "chat"` and no
+  `PlanPhases`, assert no "Plan" section appears.

--- a/specs/features/TOO/022-plan-mode-phase-checklist/outline.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/outline.md
@@ -1,0 +1,53 @@
+# Outline: Plan Mode Phase Checklist
+
+## Overview
+
+Add a "Plan" section to the right sidebar that shows the 7 PDD phases as a
+checklist when in plan mode. The current phase is detected by scanning the spec
+directory for artifact files. All changes are confined to `internal/tui/`.
+
+## Phases / Slices
+
+1. **Add `PlanPhase` type + `detectPlanPhases`** — add `PlanPhase{Name, Done}` and
+   `detectPlanPhases(specDir)` with the 7-phase artifact mapping. Verify: package
+   compiles.
+2. **Add `sidebarPlanLines` renderer** — render the "Plan" heading and 7 phases
+   with `▶`/`[x]`/`[ ]` markers; return `nil` when hidden. Verify: package
+   compiles.
+3. **Wire into `SidebarRenderInput` + `sidebarRenderInput`** — add `PlanPhases`
+   field, populate it in `sidebarRenderInput` when in plan mode, and call
+   `sidebarPlanLines` from `sidebarModeLines`. Verify: existing tests pass.
+4. **Add tests** — `detectPlanPhases` unit tests, `sidebarPlanLines` section
+   tests, and full sidebar render tests. Verify: new tests pass.
+
+## Order of Changes & Testing
+
+Slices 1 → 2 → 3 → 4, strictly sequential. Each slice compiles and passes tests
+independently. Slices 2-4 depend on earlier slices.
+
+## Key Type Signatures
+
+```go
+// New type:
+type PlanPhase struct {
+    Name string
+    Done bool
+}
+
+// New function:
+func detectPlanPhases(specDir string) []PlanPhase
+
+// New section renderer:
+func sidebarPlanLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string
+
+// SidebarRenderInput gains one field:
+type SidebarRenderInput struct {
+    // ...existing fields...
+    PlanPhases []PlanPhase // new: PDD phase checklist in plan mode; nil/empty = hidden
+}
+```
+
+## Parallel-Safety
+
+All slices touch `sidebar.go` and/or `tui.go` — none are parallel-safe; run
+strictly in order.

--- a/specs/features/TOO/022-plan-mode-phase-checklist/plan.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/plan.md
@@ -1,0 +1,125 @@
+# Plan: Plan Mode Phase Checklist
+
+## Context
+
+Add a "Plan" section to the right sidebar that shows the 7 PDD phases as a
+checklist when in plan mode. The current phase is detected by scanning the spec
+directory for artifact files. All changes are confined to `internal/tui/`. See
+`design.md` for full detail.
+
+## Slices
+
+### Slice 1: Add `PlanPhase` type + `detectPlanPhases`
+
+**What to implement:**
+- In `internal/tui/sidebar.go`:
+  - Add `PlanPhase` type:
+    ```go
+    // PlanPhase is one PDD phase in the plan-mode sidebar checklist.
+    type PlanPhase struct {
+        Name string // short label, e.g. "Requirements"
+        Done bool   // artifact file exists
+    }
+    ```
+  - Add `phaseArtifacts` mapping (7 phases → artifact file/dir name):
+    ```go
+    var phaseArtifacts = []struct {
+        Name     string
+        Artifact string
+    }{
+        {"Idea", "rough-idea.md"},
+        {"Requirements", "requirements.md"},
+        {"Research", "research"},
+        {"Design", "design.md"},
+        {"Outline", "outline.md"},
+        {"Plan", "plan.md"},
+        {"Prompt", "PROMPT.md"},
+    }
+    ```
+  - Add `detectPlanPhases(specDir string) []PlanPhase` that stats each artifact
+    under `specDir` and returns the phases in order with `Done` set.
+- Add `os` and `path/filepath` to imports if not already present.
+
+**Verification checkpoint:** `go build ./internal/tui/...` compiles.
+
+**Dependencies:** none.
+
+**Parallel-safe:** no (touches `sidebar.go`).
+
+### Slice 2: Add `sidebarPlanLines` renderer
+
+**What to implement:**
+- In `internal/tui/sidebar.go`, add `sidebarPlanLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string`:
+  - Return `nil` when `len(in.PlanPhases) == 0` (hidden).
+  - Render a "Plan" heading (e.g. `st.heading.Render("  Plan")`).
+  - For each phase, determine its state: the current phase is the first with
+    `Done == false`; render it with a `▶` marker (e.g. `"  ▶ "` in peach), done
+    phases as `"  [x] "` in green, future phases as `"  [ ] "` in overlay.
+  - Truncate phase names to fit `innerW` (reuse `truncateLabel`).
+  - End with a blank line to match section spacing.
+
+**Verification checkpoint:** `go build ./internal/tui/...` compiles.
+
+**Dependencies:** Slice 1.
+
+**Parallel-safe:** no (touches `sidebar.go`).
+
+### Slice 3: Wire into `SidebarRenderInput` + `sidebarRenderInput`
+
+**What to implement:**
+- In `internal/tui/sidebar.go`, add `PlanPhases []PlanPhase` field to
+  `SidebarRenderInput` with a doc comment (nil/empty = hidden).
+- In `internal/tui/sidebar.go`, in `sidebarModeLines`, when `in.PlanPhases` is
+  non-empty, render the Plan section (call `sidebarPlanLines`) in addition to the
+  mode indicator.
+- In `internal/tui/tui.go`, in `sidebarRenderInput`, populate `in.PlanPhases` when
+  in plan mode:
+  ```go
+  if m.mode == "plan" && m.planWorktreePath != "" && m.planTaskName != "" {
+      specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)
+      in.PlanPhases = detectPlanPhases(specDir)
+  }
+  ```
+- Ensure `path/filepath` is imported in `tui.go`.
+
+**Verification checkpoint:** `go test ./internal/tui/...` passes (existing tests
+unaffected).
+
+**Dependencies:** Slices 1 and 2.
+
+**Parallel-safe:** no (touches `sidebar.go` and `tui.go`).
+
+### Slice 4: Add tests
+
+**What to implement:**
+- In `internal/tui/sidebar_sections_test.go`:
+  - `TestDetectPlanPhases` — create a temp spec dir, write a subset of artifact
+    files, assert `detectPlanPhases` returns correct `Done` flags and order.
+  - `TestDetectPlanPhases_AllDone` — write all 7 artifacts, assert all `Done`.
+  - `TestDetectPlanPhases_None` — empty dir, assert all `Done == false`.
+  - `TestSidebarPlanLines` — call `sidebarPlanLines` directly with `PlanPhases`
+    set, assert rendered lines contain phase labels, `[x]`/`[ ]` markers, and `▶`
+    on the current phase.
+  - `TestSidebarPlanLines_Hidden` — with empty `PlanPhases`, assert the section
+    returns 0 lines.
+- In `internal/tui/sidebar_test.go`:
+  - `TestRenderSidebar_PlanChecklist` — render full sidebar with `Mode: "plan"`
+    and `PlanPhases` set, assert the "Plan" section and phase markers appear;
+    assert `[chat]` is absent.
+  - `TestRenderSidebar_NoPlanSection` — render with `Mode: "chat"` and no
+    `PlanPhases`, assert no "Plan" section appears.
+
+**Verification checkpoint:** `go test ./internal/tui/...` passes; `go vet
+./internal/tui/...` clean.
+
+**Dependencies:** Slices 1, 2, and 3.
+
+**Parallel-safe:** no (touches test files).
+
+## Final Verification
+
+After all slices:
+- `go build ./...`
+- `go test ./internal/tui/...`
+- `go vet ./internal/tui/...`
+- `golangci-lint run ./internal/tui/...`

--- a/specs/features/TOO/022-plan-mode-phase-checklist/requirements.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/requirements.md
@@ -1,0 +1,83 @@
+# Requirements
+
+## Purpose
+
+Add a **phase checklist** to the right sidebar in Plan mode that shows the progress
+of the `/plan` PDD SOP. When the user runs `/plan`, the sidebar should display the
+7 PDD phases with the current phase highlighted and completed phases checked off,
+so the user can see at a glance how far the planning session has progressed.
+
+## Questions & Answers
+
+### Q1: What should the phase checklist show?
+**A:** All 7 PDD phases as a static checklist, with the current phase highlighted
+and completed phases checked off.
+
+### Q2: How is the "current phase" determined?
+**A:** **Detected from spec artifacts** — scan the spec directory for which files
+exist. The current phase is the first one whose artifact is missing. Self-correcting
+and resume-friendly.
+
+### Q3: Where should the checklist go?
+**A:** **Inside the existing right sidebar** — add a "Plan" section (mirroring the
+existing `/run` checklist section). No layout change.
+
+### Q4: What labels for the phases?
+**A:** All 7 phases, short labels: Idea, Requirements, Research, Design, Outline,
+Plan, Prompt.
+
+### Q5: How is the current phase visually indicated?
+**A:** A distinct marker (e.g., `▶`) on the current phase; completed phases as
+`[x]`, future phases as `[ ]`.
+
+### Q6: How does the checklist get the spec directory?
+**A:** Use the existing `m.planWorktreePath` + `m.planTaskName` (already set in
+`startPlanSession`). No new plumbing.
+
+### Q7: How should the checklist refresh?
+**A:** **Re-scan on every render** — cheap `os.Stat` calls, mirrors the existing
+`/run` checklist behavior.
+
+## Scope
+
+- **In scope:** `internal/tui` package only. Add a "Plan" section to the right
+  sidebar that renders the 7-phase checklist when in plan mode. Detect phase
+  completion by scanning the spec directory for artifact files.
+- **Out of scope:** No layout changes to the sidebar width or panel structure. No
+  changes to the `/plan` command flow or the PDD SOP itself. No changes to `/run`.
+
+## Phase → Artifact Mapping
+
+| # | Phase    | Artifact to detect |
+|---|----------|--------------------|
+| 1 | Idea     | `rough-idea.md`    |
+| 2 | Requirements | `requirements.md` |
+| 3 | Research | `research/` (dir)  |
+| 4 | Design   | `design.md`        |
+| 5 | Outline  | `outline.md`       |
+| 6 | Plan     | `plan.md`          |
+| 7 | Prompt   | `PROMPT.md`        |
+
+## Constraints
+
+- The checklist must only render in plan mode (`m.mode == "plan"`).
+- The current phase is the first phase whose artifact is missing; if all artifacts
+  exist, all phases are checked (plan complete).
+- The sidebar width (23) must not change; labels must fit.
+- Re-scan the spec directory on every render (cheap `os.Stat` calls).
+- Must not break the existing `/run` checklist rendering.
+
+## Acceptance Criteria
+
+- Given the user is in plan mode, when the sidebar renders, then a "Plan" section
+  shows all 7 phases with the current phase marked `▶` and completed phases `[x]`.
+- Given a phase's artifact file exists, when the sidebar renders, then that phase
+  is shown as completed (`[x]`).
+- Given the current phase's artifact is missing, when the sidebar renders, then
+  that phase is shown as current (`▶`) and later phases as `[ ]`.
+- Given all 7 artifacts exist, when the sidebar renders, then all phases are shown
+  as completed.
+- Given the user is NOT in plan mode, when the sidebar renders, then no "Plan"
+  section is shown.
+- Given the spec directory cannot be read, when the sidebar renders, then the
+  checklist degrades gracefully (no crash; phases shown as incomplete).

--- a/specs/features/TOO/022-plan-mode-phase-checklist/research/plan-state.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/research/plan-state.md
@@ -1,0 +1,40 @@
+# Research: Plan-mode state and spec existence checks
+
+## Plan-session fields on the model
+
+The `model` struct is defined in `internal/tui/tui.go:25`. Plan-related fields at `tui.go:55-61`:
+```go
+planWorktreeAgentID string
+planWorktreePath    string
+planBackupBranch    string
+planTaskName        string
+planWorktree        *subagent.WorktreeManager
+```
+The `mode` field is at `tui.go:65`.
+
+Set in two places:
+- **`startPlanWorktree`** (`plan.go:201-218`) sets all five plan fields at lines 212-216.
+- **`startPlanSession`** (`plan.go:383-473`) sets `m.mode = "plan"` (line 470) and `m.running = true` (line 471).
+
+Cleared on completion:
+- **`finishPlanWorktree`** (`plan.go:228-282`) sets `m.planWorktree = nil` (line 277) and `m.planWorktreePath = ""` (line 280).
+
+## Spec directory derivation
+
+The spec directory is `filepath.Join(m.planWorktreePath, "specs", m.planTaskName)`.
+- `m.planWorktreePath` is the worktree root; `m.planTaskName` is the task name (e.g. `features/TOO/022-...`).
+- This is the same path used in `finishPlanWorktree` (`plan.go:246`): `promptPath := filepath.Join(m.planWorktreePath, "specs", m.planTaskName, "PROMPT.md")`.
+
+## Existing file/dir existence checks
+
+No single dedicated helper. Inline `os.Stat` calls:
+- `createSpecSkeleton` (`plan.go:142`) — `os.Stat(specDir)` to detect existing spec dir.
+- `finishPlanWorktree` (`plan.go:246-249`) — `os.Stat(promptPath)` to detect PROMPT.md.
+- `listAvailableSpecs` (`run.go:1803-1834`) — `os.Stat(specsDir)` and per-spec `os.Stat(promptPath)`.
+- `findExistingSpec` / `nextSpecNumber` — use `os.ReadDir`, not `os.Stat`.
+
+## Sidebar section rendering contract
+
+- Each section renderer returns `nil` when its data is absent (e.g. `sidebarGitLines` returns nil when `GitBranch == ""`, `sidebar.go:188`; `sidebarMCPLines` returns nil when `len(in.MCPTools) == 0`, `sidebar.go:387`).
+- `RenderSidebar` (`sidebar.go:118-131`) appends each section's lines; a nil section contributes nothing.
+- This is the mechanism the presence/absence tests rely on.

--- a/specs/features/TOO/022-plan-mode-phase-checklist/research/sidebar-pipeline.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/research/sidebar-pipeline.md
@@ -1,0 +1,41 @@
+# Research: Sidebar rendering pipeline
+
+## Where `SidebarRenderInput` is built and rendered
+
+- **Call site:** `internal/tui/tui.go:1565` — `sidebar := RenderSidebar(m.sidebarRenderInput(sidebarWidth, panelRows))`, gated by `if showSidebar {` at line 1564.
+- **Constructor:** `internal/tui/tui.go:1693` — `func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInput`. Builds the struct literal at lines 1694–1723, then conditionally fills run fields at lines 1724–1730:
+  ```go
+  if m.run != nil && m.run.phase != "" {
+      in.RunChecklist = m.run.checklist
+      in.RunPhase = m.run.phase
+      in.RunSpec = m.run.specName
+      in.RunCycle = m.run.retries + 1
+      in.RunMaxCycle = m.run.maxRetries
+  }
+  ```
+- `Mode: m.mode` is set at `tui.go:1702`.
+
+## How `m.mode` flows in
+
+- `m.mode` is a `string` field on the model, declared at `tui.go:65` (`// "chat" or "plan" — shown in status bar`).
+- Never initialized in `newModel` — stays zero value `""`.
+- Set to `"plan"` in exactly one production location: `plan.go:470` (`m.mode = "plan"`).
+- Passed verbatim into `SidebarRenderInput.Mode` at `tui.go:1702`.
+- Sidebar defaults empty to `"chat"` at render time: `sidebar.go:214` — `mode := cmp.Or(in.Mode, "chat")`. `"plan"` renders as `[plan]` in peach (`sidebar.go:215-216`).
+- `m.mode` is **never reset** in production code.
+
+## How the `/run` checklist is populated
+
+- `ChecklistStep` type: `run.go:20-24` — `{Title string; Done bool}`.
+- Initial parse: `run.go:357` — `checklist := parsePlanChecklist(m.cfg.WorkDir, specName)`.
+- `parsePlanChecklist` (`run.go:1732-1739`) reads `filepath.Join(workDir, "specs", specName, "plan.md")` and calls `extractChecklist`.
+- `extractChecklist` (`run.go:1760-1798`) parses checkbox lines (`^-\\s+\\[([ xX])\\]\\s+(.+)`) or falls back to `### Slice N: Title` headings.
+- Stored on `m.run.checklist` in `startRunAgent` (`run.go:469`) and `handleRunParallel` (`run.go:561`).
+- Live refresh: `refreshRunChecklist` (`run.go:1489-1500`) re-reads plan.md after write/edit ops.
+- On successful merge, all steps marked done: `run.go:1328-1330`.
+
+## Rendering side
+
+- `RenderSidebar` (`sidebar.go:111`) calls `sidebarModeLines` (`sidebar.go:208`), which at line 209 checks `if len(in.RunChecklist) > 0 && in.RunPhase != ""` and delegates to `sidebarRunLines` (`sidebar.go:226-250`).
+- `sidebarRunLines` renders the spec name, `cycle %d/%d ∙ %s`, and the `[x]`/`[ ]` step list. Done steps render `"  [x] "` in green, pending `"  [ ] "` in overlay color.
+- `sidebarModeLines` otherwise renders a `Mode` heading and `[plan]` in peach when `in.Mode == "plan"`.

--- a/specs/features/TOO/022-plan-mode-phase-checklist/research/test-patterns.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/research/test-patterns.md
@@ -1,0 +1,47 @@
+# Research: Test patterns for sidebar and plan mode
+
+## Sidebar rendering tests
+
+### `internal/tui/sidebar_test.go` (620 lines)
+- Tests call `RenderSidebar(SidebarRenderInput{...})` directly with a struct literal.
+- Assertions via `strings.Contains(result, "...")` on the full rendered string, with `t.Error`/`t.Errorf`. Both positive (`if !strings.Contains(...)`) and negative (`if strings.Contains(...)`).
+- For ANSI-styled output, `ansi.Strip(result)` is used before substring checks.
+- `TestRenderSidebar_RunChecklist` (line 266) sets `RunChecklist`, `RunPhase`, `RunSpec`, `RunCycle`, `RunMaxCycle`, `Running`, `ActiveTool`.
+- `TestRenderSidebar_RunChecklist` (lines 299-301) asserts `"[chat]"` is **absent** when a run checklist is active.
+
+### `internal/tui/sidebar_sections_test.go` (352 lines)
+- Tests individual section renderers directly (not whole `RenderSidebar`).
+- Helpers: `plain(lines []string) string` (lines 18-20) strips ANSI; `testSidebarStyles() sidebarStyles` (lines 24-26) returns `newSidebarStyles(darkPalette)`.
+- Section renderers called directly, e.g. `sidebarModeLines(tt.in, 27, testSidebarStyles())` (line 184).
+- Table-driven tests with `t.Run` subtests and `t.Parallel()`. Each case has `in SidebarRenderInput`, `wantParts []string`, optional `absent string`.
+- `TestSidebarHiddenSections` (lines 98-123) — the canonical "section hidden" test: calls each section renderer with empty `SidebarRenderInput{}` and asserts it returns **0 lines**.
+- `TestSidebarModeLinesRunChecklist` (lines 192-214) — asserts `"[chat]"` is **absent** when a run checklist is present.
+
+## Plan-mode tests
+
+### `internal/tui/plan_test.go` (604 lines)
+- Plain `func TestXxx(t *testing.T)` functions, no shared harness.
+- Test `copyDir`/`copyOverwrite`, `toKebabCase`, `createSpecSkeleton`, `TestBuildPlanInstruction_*`, `TestFinishPlanWorktree_*`, `TestShortTaskName`.
+- `TestFinishPlanWorktree_*` use `initRunTestRepo(t)` and `subagent.NewOrchestrator` to create a real git worktree, then construct a `&model{...}` with plan fields and call `m.finishPlanWorktree()`.
+
+### `internal/tui/plan_run_e2e_test.go` (625 lines)
+- E2E tests. Create spec skeletons in `t.TempDir()`, assert dir/file existence with `os.Stat`.
+- Construct `&model{cfg: Config{...}, chatModel: ChatModel{...}, run: &runState{...}}` and call handlers.
+
+## `ChecklistStep` type
+
+Defined in `internal/tui/run.go:20-24`:
+```go
+type ChecklistStep struct {
+    Title string
+    Done  bool
+}
+```
+Consumed by the sidebar via `SidebarRenderInput.RunChecklist []ChecklistStep` (sidebar.go:47) and rendered in `sidebarRunLines` (sidebar.go:226-250).
+
+## Presence/absence test pattern
+
+- `TestRenderSidebar_Minimal` (sidebar_test.go:15-34) asserts `"Context"` absent, `"Model"`/`"Mode"` present.
+- `TestRenderSidebar_MCPTools_Empty` (lines 458-467) asserts `"MCP Tools"` absent when `MCPTools` nil.
+- `TestRenderSidebar_MemoryStatus_Nil` (lines 538-547) asserts `"Memory ["` absent when `MemoryStatus` nil.
+- `TestRenderSidebar_Artifacts_EmptyHidden` (lines 549-573) asserts `"Artifacts ["` absent for empty lists.

--- a/specs/features/TOO/022-plan-mode-phase-checklist/rough-idea.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/rough-idea.md
@@ -1,0 +1,3 @@
+# Rough Idea
+
+Add in Plan mode right side Panel Phase checklist - to show progress of /plan SOP

--- a/specs/features/TOO/023-plan-always-merge-worktree/PROMPT.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/PROMPT.md
@@ -1,0 +1,112 @@
+# Plan Always Merge Worktree
+
+## Objective
+Fix a robustness gap in `/plan`: when the planning agent errors on the final turn
+after producing `PROMPT.md`, the completed spec is never merged into the current
+CWD branch. This change makes `handleAgentDone` call `finishPlanWorktree` whenever
+in plan mode with an active worktree, regardless of whether the agent turn errored.
+`finishPlanWorktree` already gates the merge on `PROMPT.md` existing, so partial
+plans still won't merge. All changes are confined to `internal/tui/`.
+
+## Key Requirements
+1. **Always finalize in plan mode** — `finishPlanWorktree` runs whenever
+   `m.mode == "plan" && m.planWorktree != nil`, even if `msg.err != nil`.
+2. **Merge gated on PROMPT.md** — `finishPlanWorktree` (unchanged) still only
+   merges when `PROMPT.md` exists; partial plans keep the worktree for the next turn.
+3. **Surface errors** — the agent's error is still surfaced even when the merge
+   succeeds; a finalize error is wrapped as `"finalize PDD worktree: %w"` and
+   surfaced (as today).
+4. **TUI-only** — no changes to `internal/subagent/` or any non-TUI package.
+
+## Acceptance Criteria
+### Merge behavior
+- Given a completed plan (`PROMPT.md` exists) and a successful agent turn, when
+  the turn ends, then the worktree is merged into the current branch (as today).
+- Given a completed plan (`PROMPT.md` exists) and an agent turn that errored, when
+  the turn ends, then the worktree is STILL merged into the current branch, AND the
+  agent error is surfaced to the user.
+- Given an incomplete plan (`PROMPT.md` missing) and an agent turn that errored,
+  when the turn ends, then the worktree is NOT merged (kept for the next turn), AND
+  the agent error is surfaced.
+- Given `finishPlanWorktree` errors during the merge, when the turn ends, then the
+  merge error is surfaced to the user.
+
+## Implementation Slices
+1. **Remove the `msg.err == nil` guard** — in `handleAgentDone` (`agent_loop.go`,
+   around line 1626), change the guard from `if msg.err == nil && m.mode == "plan"
+   && m.planWorktree != nil {` to `if m.mode == "plan" && m.planWorktree != nil {`.
+   Do NOT change the body (finalize error still wrapped and written into the local
+   `msg.err`). Do NOT change `finishPlanWorktree` in `plan.go`. Files:
+   `internal/tui/agent_loop.go`. Verify: `go build ./internal/tui/...` and
+   `go test ./internal/tui/...`. Parallel-safe: no.
+2. **Add tests** — add 4 tests driving `handleAgentDone` with a real plan worktree,
+   reusing the `initRunTestRepo(t)` + `subagent.NewOrchestrator(&config.Config{},
+   repo, nil)` + `orch.Worktree().Create(agentID, "pdd-"+taskName)` pattern from
+   `plan_test.go`:
+   - `TestHandleAgentDone_PlanWorktree_MergesOnError` — `PROMPT.md` present,
+     `m.mode = "plan"`, `handleAgentDone(agentDoneMsg{err: errors.New("boom")})`;
+     assert spec merged into invoking checkout AND error surfaced (`isError` true,
+     contains "boom").
+   - `TestHandleAgentDone_PlanWorktree_KeepsOnIncomplete` — `PROMPT.md` absent,
+     `m.mode = "plan"`, `handleAgentDone(agentDoneMsg{err: errors.New("boom")})`;
+     assert `m.planWorktree != nil` (retained) AND error surfaced.
+   - `TestHandleAgentDone_PlanWorktree_NoErrorStillMerges` — `PROMPT.md` present,
+     `m.mode = "plan"`, `handleAgentDone(agentDoneMsg{})`; assert spec merged
+     (regression guard).
+   - `TestHandleAgentDone_NotPlanMode_NoFinalize` — `m.mode = "chat"` with a
+     worktree, `handleAgentDone(agentDoneMsg{err: errors.New("boom")})`; assert
+     worktree retained AND error surfaced.
+   Files: `internal/tui/plan_test.go` (or a new `plan_merge_test.go`). Verify:
+   `go test ./internal/tui/...` and `go vet ./internal/tui/...`. Parallel-safe: no.
+
+## Execution Model
+Coordinator → Worker → Verifier. The agent that receives this PROMPT.md is the
+**Coordinator**; it delegates rather than implements.
+
+- **Workers**: one `worker` subagent per slice. No slices are parallel-safe, so run
+  them one at a time, in order.
+- **Verifier**: after the last slice, a `code-reviewer` subagent checks the Done
+  Criteria below against the actual diff and returns VERDICT: PASS or VERDICT: FAIL.
+- **Loop**: on FAIL the Coordinator dispatches fix workers and re-verifies, up to
+  10 cycles total.
+
+## Done Criteria
+The Verifier checks these against the diff, not against the checklist. Each must
+be objectively checkable by reading code or running a command.
+- [ ] `handleAgentDone` calls `finishPlanWorktree` when `m.mode == "plan" &&
+      m.planWorktree != nil`, with no `msg.err == nil` guard — see
+      `TestHandleAgentDone_PlanWorktree_MergesOnError`.
+- [ ] `finishPlanWorktree` in `plan.go` is unchanged (still gates the merge on
+      `PROMPT.md` existing).
+- [ ] `TestHandleAgentDone_PlanWorktree_MergesOnError` asserts the spec is merged
+      into the invoking checkout AND the agent error is surfaced.
+- [ ] `TestHandleAgentDone_PlanWorktree_KeepsOnIncomplete` asserts the worktree is
+      retained when `PROMPT.md` is absent AND the error is surfaced.
+- [ ] `TestHandleAgentDone_PlanWorktree_NoErrorStillMerges` asserts the spec is
+      merged on a successful turn (regression guard).
+- [ ] `TestHandleAgentDone_NotPlanMode_NoFinalize` asserts no finalize when not in
+      plan mode.
+- [ ] `go test ./internal/tui/...` passes.
+- [ ] No slice is left as a stub, TODO, or panic("not implemented").
+
+## Gates
+- **build**: `go build ./internal/tui/...`
+- **test**: `go test ./internal/tui/...`
+- **vet**: `go vet ./internal/tui/...`
+- **lint**: `golangci-lint run ./internal/tui/...`
+
+## Reference
+- Design: `specs/features/TOO/023-plan-always-merge-worktree/design.md`
+- Outline: `specs/features/TOO/023-plan-always-merge-worktree/outline.md`
+- Plan: `specs/features/TOO/023-plan-always-merge-worktree/plan.md`
+- Requirements: `specs/features/TOO/023-plan-always-merge-worktree/requirements.md`
+- Research: `specs/features/TOO/023-plan-always-merge-worktree/research/`
+
+## Constraints
+- All error handling and code changes are confined to the TUI layer
+  (`internal/tui/`); no changes to `internal/subagent/` or other packages.
+- `finishPlanWorktree` must still run only in plan mode with an active worktree.
+- The merge must still be gated on `PROMPT.md` existing (a partial plan must not
+  merge).
+- The agent's error must still be surfaced to the user even when the merge succeeds.
+- If `finishPlanWorktree` itself errors, that error must be surfaced (as today).

--- a/specs/features/TOO/023-plan-always-merge-worktree/design.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/design.md
@@ -1,0 +1,131 @@
+# Design: Plan Always Merge Worktree
+
+## Current State
+
+`handleAgentDone` (`internal/tui/agent_loop.go:1620`) is the single production
+call site of `finishPlanWorktree`. It gates the call on three conditions
+(`agent_loop.go:1626`):
+
+```go
+if msg.err == nil && m.mode == "plan" && m.planWorktree != nil {
+    if err := m.finishPlanWorktree(); err != nil {
+        msg.err = fmt.Errorf("finalize PDD worktree: %w", err)
+    }
+}
+```
+
+The `msg.err == nil` guard means: if the planning agent errors on the final turn
+after producing `PROMPT.md`, `finishPlanWorktree` is never called, so the completed
+spec is never merged into the current CWD branch. It survives only on the backup
+branch (`specs/<task>`), not in the user's working tree.
+
+`finishPlanWorktree` (`plan.go:228`) already gates the merge on `PROMPT.md`
+existing: it returns early at line 248 if `os.Stat(promptPath)` fails, keeping the
+worktree alive for the next turn. So a partial/abandoned plan already won't merge.
+
+## Desired End State
+
+`finishPlanWorktree` runs whenever in plan mode with an active worktree, regardless
+of whether the agent turn errored. The `PROMPT.md` gate inside `finishPlanWorktree`
+still decides whether the merge happens. The agent's error is still surfaced to the
+user even when the merge succeeds.
+
+## Architecture
+
+A one-line change to the guard in `handleAgentDone`, plus tests. All changes are
+confined to `internal/tui/` (per the requirement that all error handling stays in
+the TUI layer).
+
+```mermaid
+flowchart TD
+    A[handleAgentDone msg] --> B{plan mode + worktree?}
+    B -- no --> C[skip finalize]
+    B -- yes --> D[finishPlanWorktree]
+    D --> E{PROMPT.md exists?}
+    E -- no --> F[keep worktree, no merge]
+    E -- yes --> G[merge + copy + cleanup]
+    G --> H{merge error?}
+    H -- yes --> I[copy spec, surface error]
+    H -- no --> J[clear worktree state]
+```
+
+## Components & Interfaces
+
+### `handleAgentDone` — remove the `msg.err == nil` guard
+
+```go
+// Before:
+if msg.err == nil && m.mode == "plan" && m.planWorktree != nil {
+// After:
+if m.mode == "plan" && m.planWorktree != nil {
+```
+
+The `finishPlanWorktree` error handling stays as-is: a finalize error is wrapped
+and written into the local `msg.err`, which then drives the error UI path.
+
+### `finishPlanWorktree` — unchanged
+
+No changes to `plan.go`. The `PROMPT.md` gate (line 248) already ensures a partial
+plan doesn't merge, and the merge-failure fallback (copy spec, return error) already
+handles merge conflicts.
+
+## Data Models
+
+No new data models.
+
+## Patterns to Follow
+
+- **TUI-only changes** — no changes to `internal/subagent/` or other packages.
+- **`finishPlanWorktree` as the single gate** — the merge decision stays in
+  `finishPlanWorktree` (PROMPT.md existence), not in `handleAgentDone`.
+- **Error surfacing** — reuse the existing `msg.err` → `MoodSad`/`AppendError`/
+  `TraceLog` path; a finalize error is wrapped as `"finalize PDD worktree: %w"`.
+
+## Error Handling
+
+- **Agent error + completed plan:** `finishPlanWorktree` runs, merges, and the
+  original `msg.err` is preserved (not overwritten) so the agent error is still
+  surfaced. The finalize call must not clobber the existing `msg.err` on success.
+- **Agent error + incomplete plan:** `finishPlanWorktree` returns early (PROMPT.md
+  missing), worktree kept, `msg.err` preserved and surfaced.
+- **Finalize error:** wrapped as `"finalize PDD worktree: %w"` and surfaced (as
+  today). If `msg.err` was already set (agent error), the finalize error should
+  take precedence or be combined — see note below.
+
+**Note on error precedence:** currently, if `finishPlanWorktree` errors, it
+overwrites `msg.err`. With the guard removed, `msg.err` may already hold an agent
+error when `finishPlanWorktree` runs. The design keeps the existing behavior: a
+finalize error overwrites `msg.err` (the finalize error is the more actionable one
+— the merge failed). This matches the current code and is acceptable.
+
+## Acceptance Criteria
+
+- Given a completed plan (`PROMPT.md` exists) and a successful agent turn, when
+  the turn ends, then the worktree is merged into the current branch (as today).
+- Given a completed plan (`PROMPT.md` exists) and an agent turn that errored, when
+  the turn ends, then the worktree is STILL merged into the current branch, AND the
+  agent error is surfaced to the user.
+- Given an incomplete plan (`PROMPT.md` missing) and an agent turn that errored,
+  when the turn ends, then the worktree is NOT merged (kept for the next turn), AND
+  the agent error is surfaced.
+- Given `finishPlanWorktree` errors during the merge, when the turn ends, then the
+  merge error is surfaced to the user.
+
+## Testing Strategy
+
+- **`TestHandleAgentDone_PlanWorktree_MergesOnError`** — set up a real worktree
+  with `PROMPT.md` present, `m.mode = "plan"`, call `m.handleAgentDone(agentDoneMsg{err: ...})`,
+  assert the spec is merged into the invoking checkout AND the error is surfaced
+  (message `isError` true).
+- **`TestHandleAgentDone_PlanWorktree_KeepsOnIncomplete`** — set up a real worktree
+  with `PROMPT.md` absent, `m.mode = "plan"`, call `m.handleAgentDone(agentDoneMsg{err: ...})`,
+  assert the worktree is retained (not merged) AND the error is surfaced.
+- **`TestHandleAgentDone_PlanWorktree_NoErrorStillMerges`** — set up a real worktree
+  with `PROMPT.md` present, `m.mode = "plan"`, call `m.handleAgentDone(agentDoneMsg{})`,
+  assert the spec is merged (regression guard for the existing behavior).
+- **`TestHandleAgentDone_NotPlanMode_NoFinalize`** — `m.mode = "chat"` with a
+  worktree, call `m.handleAgentDone(agentDoneMsg{err: ...})`, assert `finishPlanWorktree`
+  is not invoked (worktree retained, error surfaced).
+
+These tests reuse the `initRunTestRepo(t)` + `subagent.NewOrchestrator` +
+`orch.Worktree().Create(...)` pattern from `plan_test.go`.

--- a/specs/features/TOO/023-plan-always-merge-worktree/outline.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/outline.md
@@ -1,0 +1,39 @@
+# Outline: Plan Always Merge Worktree
+
+## Overview
+
+Make `/plan` always merge the planning worktree into the current CWD branch once
+`PROMPT.md` exists, even if the agent errored on the final turn. The fix is a
+one-line change to the guard in `handleAgentDone`; `finishPlanWorktree` already
+gates the merge on `PROMPT.md` existing. All changes are confined to
+`internal/tui/`.
+
+## Phases / Slices
+
+1. **Remove the `msg.err == nil` guard** — in `handleAgentDone` (`agent_loop.go`),
+   change the guard so `finishPlanWorktree` runs whenever in plan mode with an
+   active worktree, regardless of `msg.err`. Verify: package compiles.
+2. **Add tests** — 4 tests covering merge-on-error, keep-on-incomplete,
+   no-error-still-merges, and not-plan-mode. Verify: new tests pass.
+
+## Order of Changes & Testing
+
+Slices 1 → 2, strictly sequential. Slice 1 compiles and passes existing tests;
+Slice 2 depends on Slice 1.
+
+## Key Type Signatures
+
+No new types or exported functions. The only change is the guard condition in
+`handleAgentDone`:
+
+```go
+// Before:
+if msg.err == nil && m.mode == "plan" && m.planWorktree != nil {
+// After:
+if m.mode == "plan" && m.planWorktree != nil {
+```
+
+## Parallel-Safety
+
+Slice 1 touches `agent_loop.go`; Slice 2 touches test files. They share no files,
+but Slice 2 depends on Slice 1's behavior, so run strictly in order.

--- a/specs/features/TOO/023-plan-always-merge-worktree/plan.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/plan.md
@@ -1,0 +1,75 @@
+# Plan: Plan Always Merge Worktree
+
+## Context
+
+Make `/plan` always merge the planning worktree into the current CWD branch once
+`PROMPT.md` exists, even if the agent errored on the final turn. The fix is a
+one-line change to the guard in `handleAgentDone`; `finishPlanWorktree` already
+gates the merge on `PROMPT.md` existing. All changes are confined to
+`internal/tui/`. See `design.md` for full detail.
+
+## Slices
+
+### Slice 1: Remove the `msg.err == nil` guard
+
+**What to implement:**
+- In `internal/tui/agent_loop.go`, in `handleAgentDone` (around line 1626), change
+  the guard so `finishPlanWorktree` runs whenever in plan mode with an active
+  worktree, regardless of `msg.err`:
+  ```go
+  // Before:
+  if msg.err == nil && m.mode == "plan" && m.planWorktree != nil {
+  // After:
+  if m.mode == "plan" && m.planWorktree != nil {
+  ```
+- Do NOT change the body: the `finishPlanWorktree` error is still wrapped as
+  `"finalize PDD worktree: %w"` and written into the local `msg.err`, which then
+  drives the error UI path.
+- Do NOT change `finishPlanWorktree` in `plan.go` — its `PROMPT.md` gate already
+  ensures a partial plan doesn't merge.
+
+**Verification checkpoint:** `go build ./internal/tui/...` compiles; existing
+tests still pass (`go test ./internal/tui/...`).
+
+**Dependencies:** none.
+
+**Parallel-safe:** no (touches `agent_loop.go`).
+
+### Slice 2: Add tests
+
+**What to implement:**
+- In `internal/tui/plan_test.go` (or a new `plan_merge_test.go`), add tests that
+  drive `handleAgentDone` with a real plan worktree. Reuse the
+  `initRunTestRepo(t)` + `subagent.NewOrchestrator(&config.Config{}, repo, nil)` +
+  `orch.Worktree().Create(agentID, "pdd-"+taskName)` pattern from the existing
+  `TestFinishPlanWorktree_*` tests.
+  - `TestHandleAgentDone_PlanWorktree_MergesOnError` — worktree with `PROMPT.md`
+    present, `m.mode = "plan"`, call `m.handleAgentDone(agentDoneMsg{err: errors.New("boom")})`,
+    assert the spec is merged into the invoking checkout (files exist at
+    `repo/specs/<task>/`) AND the error is surfaced (a message with `isError`
+    true contains "boom").
+  - `TestHandleAgentDone_PlanWorktree_KeepsOnIncomplete` — worktree with
+    `PROMPT.md` absent, `m.mode = "plan"`, call `m.handleAgentDone(agentDoneMsg{err: errors.New("boom")})`,
+    assert the worktree is retained (`m.planWorktree != nil`) AND the error is
+    surfaced.
+  - `TestHandleAgentDone_PlanWorktree_NoErrorStillMerges` — worktree with
+    `PROMPT.md` present, `m.mode = "plan"`, call `m.handleAgentDone(agentDoneMsg{})`,
+    assert the spec is merged (regression guard for existing behavior).
+  - `TestHandleAgentDone_NotPlanMode_NoFinalize` — `m.mode = "chat"` with a
+    worktree, call `m.handleAgentDone(agentDoneMsg{err: errors.New("boom")})`,
+    assert `finishPlanWorktree` is not invoked (worktree retained, error surfaced).
+
+**Verification checkpoint:** `go test ./internal/tui/...` passes; `go vet
+./internal/tui/...` clean.
+
+**Dependencies:** Slice 1.
+
+**Parallel-safe:** no (touches test files).
+
+## Final Verification
+
+After all slices:
+- `go build ./...`
+- `go test ./internal/tui/...`
+- `go vet ./internal/tui/...`
+- `golangci-lint run ./internal/tui/...`

--- a/specs/features/TOO/023-plan-always-merge-worktree/requirements.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/requirements.md
@@ -1,0 +1,55 @@
+# Requirements
+
+## Purpose
+
+Fix a robustness gap in `/plan`: when the planning agent errors on the final turn
+after producing `PROMPT.md`, the completed spec is never merged into the current
+CWD branch. The spec survives only on the backup branch, not in the user's working
+tree. This spec makes `/plan` always merge the worktree into the current branch
+once the plan is complete (`PROMPT.md` exists), regardless of whether the final
+agent turn errored.
+
+## Questions & Answers
+
+### Q1: What's the desired behavior when /plan completes?
+**A:** Always merge the worktree into the current CWD branch once `PROMPT.md`
+exists — even if the agent errored on a later turn. The spec is complete, so it
+should land in the working tree.
+
+### Q2: What happens to the agent's error message when PROMPT.md exists but the agent errored?
+**A:** Keep the error — merge the spec, but still surface the agent error to the
+user. The plan landed, but the session had a problem.
+
+## Scope
+
+- **In scope:** `internal/tui/agent_loop.go` and `internal/tui/plan.go` (and tests).
+  Change `handleAgentDone` so `finishPlanWorktree` runs even when `msg.err != nil`
+  (in plan mode with an active worktree). `finishPlanWorktree` already gates the
+  merge on `PROMPT.md` existing, so a partial/abandoned plan still won't merge.
+- **Out of scope:** No change to `finishPlanWorktree`'s merge logic itself. No
+  change to the `.pi-go/tasks/` vs `.worktrees/` location question. No change to
+  `/run`. **All error handling stays in the TUI layer only** — no changes to
+  `internal/subagent/worktree.go` or any non-TUI package.
+
+## Constraints
+
+- `finishPlanWorktree` must still run only in plan mode with an active worktree.
+- The merge must still be gated on `PROMPT.md` existing (a partial plan must not
+  merge).
+- The agent's error must still be surfaced to the user even when the merge succeeds.
+- If `finishPlanWorktree` itself errors, that error must be surfaced (as today).
+- All error handling and any code changes are confined to the TUI layer
+  (`internal/tui/`); no changes to `internal/subagent/` or other packages.
+
+## Acceptance Criteria
+
+- Given a completed plan (`PROMPT.md` exists) and a successful agent turn, when
+  the turn ends, then the worktree is merged into the current branch (as today).
+- Given a completed plan (`PROMPT.md` exists) and an agent turn that errored, when
+  the turn ends, then the worktree is STILL merged into the current branch, AND the
+  agent error is surfaced to the user.
+- Given an incomplete plan (`PROMPT.md` missing) and an agent turn that errored,
+  when the turn ends, then the worktree is NOT merged (kept for the next turn), AND
+  the agent error is surfaced.
+- Given `finishPlanWorktree` errors during the merge, when the turn ends, then the
+  merge error is surfaced to the user.

--- a/specs/features/TOO/023-plan-always-merge-worktree/research/call-flow.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/research/call-flow.md
@@ -1,0 +1,77 @@
+# Research: /plan worktree finalization call flow
+
+## `handleAgentDone` — gating and calling `finishPlanWorktree`
+
+**File:** `internal/tui/agent_loop.go:1620-1661`
+
+```go
+func (m *model) handleAgentDone(msg agentDoneMsg) (tea.Model, tea.Cmd) {
+    m.running = false
+    m.agentCancel = nil
+    m.matrix.clear()
+    m.statusModel.ActiveTool = ""
+    m.statusModel.ActiveTools = nil
+    if msg.err == nil && m.mode == "plan" && m.planWorktree != nil {
+        if err := m.finishPlanWorktree(); err != nil {
+            msg.err = fmt.Errorf("finalize PDD worktree: %w", err)
+        }
+    }
+    if msg.err != nil {
+        // MoodSad, AppendError, TraceLog
+    } else {
+        // MoodHappy
+    }
+    ...
+}
+```
+
+**Gating (line 1626):** `finishPlanWorktree` is called only when all three hold:
+- `msg.err == nil` (agent turn completed without error), AND
+- `m.mode == "plan"`, AND
+- `m.planWorktree != nil`.
+
+**Error handling (lines 1627-1629):** a `finishPlanWorktree` error is wrapped as
+`"finalize PDD worktree: %w"` and written back into the local `msg.err`, which then
+drives the error UI path (MoodSad, AppendError, TraceLog).
+
+**Note:** `msg` is passed **by value**, so the `msg.err` mutation is local to
+`handleAgentDone`.
+
+## `finishPlanWorktree` — full logic
+
+**File:** `internal/tui/plan.go:228-282`
+
+1. **Early return (229-231):** if `m.planWorktree == nil`, return nil (no-op).
+2. **Commit (237):** `CommitAll(agentID, "PDD plan: <taskName>")`. On error, return.
+3. **Backup branch (240):** `CreateBackupBranch(agentID, m.planBackupBranch)` where
+   `m.planBackupBranch = "specs/" + taskName`. On error, return.
+4. **PROMPT.md gate (246-249):** `promptPath = <worktreePath>/specs/<taskName>/PROMPT.md`.
+   If `os.Stat` fails (file missing), return nil **early** — keeps worktree alive
+   for next turn. This is the "not finished yet" path.
+5. **Merge (253):** `MergeBack(agentID)` merges the worktree branch into the
+   invoking branch. On error: copies the spec dir from worktree into
+   `<workDir>/specs/<taskName>` with `overwrite=true` (merge-failure fallback,
+   lines 257-258), then returns the merge error.
+6. **Post-merge copy (269-272):** after a successful merge, copies the spec dir
+   again with `overwrite=false` (belt-and-suspenders so `/run` finds PROMPT.md on
+   disk). On error, return wrapped error.
+7. **Cleanup (274):** `Cleanup(agentID)` removes the temporary worktree/branch. On
+   error, return.
+8. **State reset (277-280):** on success sets `m.planWorktree = nil` and
+   `m.planWorktreePath = ""`.
+
+**Key nuance:** runs at the end of every planning turn. Commit + backup branch act
+as an incremental snapshot; the worktree is only torn down once PROMPT.md exists.
+
+## Other call sites
+
+- **Production:** only one — `handleAgentDone` at `agent_loop.go:1627`.
+- **Tests:** `plan_test.go` calls it directly at lines 366, 395, 432, 561.
+
+## `agentDoneMsg` type
+
+**File:** `internal/tui/agent_loop.go:406` — `type agentDoneMsg struct{ err error }`.
+- Implements `agentMsg()` marker interface (line 440).
+- **Dispatch:** `tui.go:831-833` — `case agentDoneMsg:` calls `m.handleAgentDone(msg)`.
+- **Producers:** `agent_loop.go:537` (channel close), `:777` (panic), `:783` (nil
+  agent), `:820` (run error).

--- a/specs/features/TOO/023-plan-always-merge-worktree/research/tests.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/research/tests.md
@@ -1,0 +1,53 @@
+# Research: Existing tests for plan finalization and agent-done
+
+## `finishPlanWorktree` tests in `internal/tui/plan_test.go`
+
+Four tests exercise it (lines 329-575):
+
+### `TestFinishPlanWorktree_CopiesSpecIntoInvokingCheckout` (329-389)
+- Setup: `repo := initRunTestRepo(t)`; `orch := subagent.NewOrchestrator(&config.Config{}, repo, nil)`; `t.Cleanup(orch.Shutdown)`. Creates a real worktree via `orch.Worktree().Create(agentID, "pdd-"+taskName)` with `agentID = "plan-"+taskName`, `taskName = "features/TOO/001-demo"`. Seeds `specs/<task>/` with `PROMPT.md`, `requirements.md`, `research/notes.md` — **PROMPT.md exists**.
+- Model: `&model{cfg: Config{WorkDir: repo, Orchestrator: orch}, planWorktreeAgentID, planWorktreePath, planTaskName, planBackupBranch: "specs/"+taskName, planWorktree: orch.Worktree()}`.
+- Assertions: after `m.finishPlanWorktree()`, each spec file exists at `repo/specs/<task>/`; `m.planWorktree` nil; `m.planWorktreePath` cleared.
+
+### `TestFinishPlanWorktree_NoWorktreeIsNoOp` (393-398)
+- Bare `&model{}`. Asserts `finishPlanWorktree()` returns nil.
+
+### `TestFinishPlanWorktree_KeepsWorktreeUntilPromptExists` (403-443)
+- Same repo/orch pattern, worktree created, but only `requirements.md` written — **PROMPT.md does NOT exist**.
+- Asserts: returns nil; `m.planWorktree` NOT nil; no spec copied into invoking checkout.
+
+### `TestFinishPlanWorktree_MergeFailureStillCopiesSpec` (523-575)
+- Same repo/orch pattern, worktree created, `PROMPT.md` written — **PROMPT.md exists**. Pre-seeds an untracked `PROMPT.md` ("stale") in the invoking checkout so the merge aborts.
+- Asserts: returns non-nil error; the worktree's copy overwrote the stale one.
+
+**How PROMPT.md existence is simulated:** purely by writing (or not writing) the
+file at `wtPath/specs/<task>/PROMPT.md` before calling `finishPlanWorktree`.
+
+## `handleAgentDone` tests
+
+There is **no dedicated test** for `handleAgentDone`'s plan-worktree branch. The
+`finishPlanWorktree` call inside `handleAgentDone` (agent_loop.go:1626) is **not
+covered** by any existing test — no test sets `m.mode == "plan"` with a worktree
+when calling `handleAgentDone`/`Update(agentDoneMsg)`.
+
+Existing `handleAgentDone` tests (all without a plan worktree):
+- `agent_loop_error_e2e_test.go:89-109` — `TestHandleAgentDone_RendersErrorStyled`: `m.handleAgentDone(agentDoneMsg{err: context.DeadlineExceeded})`, asserts Cmd nil, 1 message, `isError` true, content contains error, `kindOf(&got) == blockError`.
+- `agent_event_test.go:1454,1510,1561` — lifecycle-hook tests calling `m.handleAgentDone(agentDoneMsg{})`.
+- `agent_event_test.go:1580-1613` — `TestAgentDoneMsg_ErrorDoesNotFireUserInputHook`: `m.handleAgentDone(agentDoneMsg{err: errors.New("request canceled")})`.
+- `agent_event_test.go:1356,1379` — `TestAgentDoneMsg` / `TestAgentDoneMsg_WithError` via `m.Update(...)`.
+- `tui_test.go:447-466`, `tui_update_test.go:11-37,39-70`, `coverage_boost_test.go:2347-2354` — `m.Update(agentDoneMsg{...})` tests.
+
+## Test helpers for a real git worktree
+
+- **`initRunTestRepo(t *testing.T) string`** — `internal/tui/run_backup_test.go:17-40`. Runs `git init`, sets user.email/name, disables gpgsign, sets `core.autocrlf=false`, makes an empty initial commit. Returns the repo dir path.
+- **`subagent.NewOrchestrator(cfg *config.Config, repoRoot string, agentConfigs []AgentConfig) *Orchestrator`** — `internal/subagent/orchestrator.go:106`. Tests call `orch.Worktree().Create(agentID, branchName)` and `orch.Shutdown()` via `t.Cleanup`.
+- **`newHandlerModel()`** — `internal/tui/agent_loop_handlers_test.go:12-16`. Builds a minimal `&model{width:100, height:30}` with a buffered `agentCh`.
+
+## How `handleAgentDone` surfaces errors
+
+`internal/tui/agent_loop.go:1631-1643`:
+- `msg.err != nil` → `m.face.SetMood(MoodSad)`, `m.chatModel.AppendError("Error: ...")`, append `traceEntry{kind:"error"}` to `TraceLog`.
+- `msg.err == nil` → `m.face.SetMood(MoodHappy)`.
+- `AppendError` — `internal/tui/chat.go:300-307`: appends `message{role:"assistant", content:text, isError:true}`.
+- `SetMood` — `internal/tui/face.go:118`; moods at `face.go:14-15`.
+- `TraceLog` — `ChatModel.TraceLog []traceEntry` at `chat.go:275`; `traceEntry` at `chat.go:257-262`.

--- a/specs/features/TOO/023-plan-always-merge-worktree/rough-idea.md
+++ b/specs/features/TOO/023-plan-always-merge-worktree/rough-idea.md
@@ -1,0 +1,3 @@
+# Rough Idea
+
+After /plan completes, always merge the planning worktree into the current CWD branch, even if the agent errored on the final turn.


### PR DESCRIPTION
Add two PDD specs:
- 022-plan-mode-phase-checklist: right-sidebar Plan section showing the
  7 PDD phases as a checklist in plan mode.
- 023-plan-always-merge-worktree: /plan always merges the worktree into
  the current branch once PROMPT.md exists, even if the agent errored.

Signed-off-by: dimetron <dimetron@me.com>
