### PR TITLE
fix: restore session backend on resume

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -290,7 +290,21 @@ func loadRootConfig() (config.Config, error) {
 // consulted, first under the role's provider name and then under the provider
 // the model itself resolved to.
 func resolveRuntimeModel(cfg config.Config, modelName, providerName string) (provider.Info, string, error) {
+	return resolveRuntimeModelForRole(cfg, modelName, providerName, "")
+}
+
+func resolveRuntimeModelForRole(cfg config.Config, modelName, providerName, activeRole string) (provider.Info, string, error) {
 	baseURL := flagURL
+	if baseURL == "" && flagSession != "" && flagModel == "" && activeRole == "default" {
+		if dir, err := sessionsDir(); err == nil {
+			if resumedProvider, resumedURL, ok := pisession.SessionBackend(dir, flagSession); ok {
+				if resumedProvider != "" {
+					providerName = resumedProvider
+				}
+				baseURL = resumedURL
+			}
+		}
+	}
 	if baseURL == "" && providerName != "" {
 		baseURLs := cfg.ResolveBaseURLs()
 		baseURL = baseURLs[providerName]
@@ -399,7 +413,7 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 	}
 
 	mode := resolveMode()
-	info, baseURL, err := resolveRuntimeModel(cfg, modelName, providerName)
+	info, baseURL, err := resolveRuntimeModelForRole(cfg, modelName, providerName, activeRole)
 	if err != nil {
 		return rootRuntime{}, err
 	}

--- a/internal/cli/resume_model_test.go
+++ b/internal/cli/resume_model_test.go
@@ -22,12 +22,58 @@ func writeSessionMeta(t *testing.T, dir, sessionID, model string) {
 	}
 }
 
-// withFlags restores the package-level flag state the CLI resolves through.
+func writeSessionBackendMeta(t *testing.T, dir, sessionID, model, provider, baseURL string) {
+	t.Helper()
+	sessionDir := filepath.Join(dir, ".pi-go", "sessions", sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"id":"` + sessionID + `","appName":"pi-go","userID":"local","model":"` + model + `","provider":"` + provider + `","baseURL":"` + baseURL + `"}`
+	if err := os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func withFlags(t *testing.T, session, model string) {
 	t.Helper()
 	origSession, origModel := flagSession, flagModel
 	t.Cleanup(func() { flagSession, flagModel = origSession, origModel })
 	flagSession, flagModel = session, model
+}
+
+func TestResolveRuntimeModel_RestoresSessionBackend(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	writeSessionBackendMeta(t, home, "sess-ollama", "qwen3:8b", "ollama", "http://session-host:11434")
+	origSession, origModel, origURL := flagSession, flagModel, flagURL
+	t.Cleanup(func() { flagSession, flagModel, flagURL = origSession, origModel, origURL })
+	flagSession, flagModel, flagURL = "sess-ollama", "", ""
+
+	cfg := config.Config{Roles: map[string]config.RoleConfig{"default": {Model: "qwen3:8b", Provider: "openai"}}}
+	info, baseURL, err := resolveRuntimeModelForRole(cfg, "qwen3:8b", "openai", "default")
+	if err != nil {
+		t.Fatalf("resolveRuntimeModelForRole: %v", err)
+	}
+	if info.Provider != "ollama" || baseURL != "http://session-host:11434" {
+		t.Fatalf("resolved backend = %q/%q, want ollama/session endpoint", info.Provider, baseURL)
+	}
+}
+
+func TestResolveRuntimeModel_ExplicitURLWinsResume(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	writeSessionBackendMeta(t, home, "sess", "gpt-5.6-luna", "openai", "https://session.example/v1")
+	origSession, origModel, origURL := flagSession, flagModel, flagURL
+	t.Cleanup(func() { flagSession, flagModel, flagURL = origSession, origModel, origURL })
+	flagSession, flagModel, flagURL = "sess", "", "https://flag.example/v1"
+
+	_, baseURL, err := resolveRuntimeModelForRole(config.Config{}, "gpt-5.6-luna", "openai", "default")
+	if err != nil {
+		t.Fatalf("resolveRuntimeModelForRole: %v", err)
+	}
+	if baseURL != "https://flag.example/v1" {
+		t.Fatalf("baseURL = %q, want explicit URL", baseURL)
+	}
 }
 
 func TestApplyResumedModel(t *testing.T) {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -873,6 +873,19 @@ func writeMeta(sessionDir string, meta *Meta) error {
 	return os.WriteFile(filepath.Join(sessionDir, "meta.json"), data, 0o644)
 }
 
+// SessionBackend returns the provider and endpoint recorded for a session.
+// It returns false when the session metadata is unavailable or predates backend
+// recording.
+func SessionBackend(baseDir, sessionID string) (provider, baseURL string, ok bool) {
+	meta, err := readMeta(filepath.Join(baseDir, sessionID))
+	if err != nil || meta == nil {
+		return "", "", false
+	}
+	provider = strings.TrimSpace(meta.Provider)
+	baseURL = strings.TrimSpace(meta.BaseURL)
+	return provider, baseURL, provider != "" || baseURL != ""
+}
+
 // SessionModel returns the model recorded in a session's metadata, or an empty
 // string when the session is unknown or its model was never recorded.
 //


### PR DESCRIPTION
## Summary\n- restore the recorded provider and base URL when resuming a default session\n- preserve explicit --model and --url overrides\n- keep legacy sessions without backend metadata compatible\n\n## Verification\n- codex-review subagent completed; reported no findings in the resume changes\n- targeted resume tests passed\n- session package compile check passed\n- make build passed\n- golangci-lint passed via commit hook