### PR TITLE
chore(lint): exclude tmp/ from golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,12 @@ linters:
     # Built-in exclusion presets (e.g. test helpers, generated code).
     presets:
       - std-error-handling
+    # tmp/ is a scratch area for vendored third-party repos (SDK copies,
+    # claude-mem, …) kept for reference. Not our code — never lint it.
+    # Unanchored on purpose: golangci-lint cache entries can carry paths from
+    # sibling worktrees (same caveat as the hack/ exclusion below).
+    paths:
+      - tmp/
     rules:
       # Test files: relax errcheck, bodyclose, nilerr, unusedwrite, SA5011.
       - path: _test\.go


### PR DESCRIPTION
## Summary

Exclude `tmp/` from golangci-lint via `linters.exclusions.paths`.

`tmp/` is a scratch area holding vendored third-party repos (SDK copies, claude-mem) kept for reference. Linting it surfaces pre-existing upstream issues that block every commit through the pre-commit hook.

### Notes

- golangci-lint v2 does not accept `run.exclude-dirs` (`config verify` rejects it); directory exclusions belong in `linters.exclusions.paths`.
- The pattern is unanchored (`tmp/`), matching the existing `hack/` exclusion, so cache hits recorded from sibling worktrees are suppressed too.

## Verification

- `golangci-lint config verify` — OK
- Proved effectiveness: `tmp/sdk/openai-go/packages/ssestream/` produces 1 staticcheck issue under the current config, 0 with this change
- Full-module `golangci-lint run ./...` — 0 issues
