### PR TITLE
feat(provider): send OpenRouter app-attribution headers on all requests

### DIFF
--- a/internal/provider/list_models.go
+++ b/internal/provider/list_models.go
@@ -245,6 +245,9 @@ func fetchJSON(ctx context.Context, method, url string, opts ListModelsOptions, 
 		if opts.APIKey != "" {
 			req.Header.Set("Authorization", "Bearer "+opts.APIKey)
 		}
+		if providerName == "openrouter" {
+			openrouterAppAttribution(req.Header)
+		}
 	}
 
 	resp, err := opts.httpClient().Do(req)

--- a/internal/provider/list_models_test.go
+++ b/internal/provider/list_models_test.go
@@ -141,6 +141,15 @@ func TestListOpenRouterModels(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer orkey" {
 			t.Errorf("missing bearer token, got %q", r.Header.Get("Authorization"))
 		}
+		for h, want := range map[string]string{
+			"HTTP-Referer":            openrouterHTTPReferer,
+			"X-OpenRouter-Title":      openrouterAppTitle,
+			"X-OpenRouter-Categories": openrouterAppCategories,
+		} {
+			if got := r.Header.Get(h); got != want {
+				t.Errorf("app attribution %s = %q, want %q", h, got, want)
+			}
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": []map[string]any{
 				{"id": "google/gemini-3.7-flash", "owned_by": "openrouter"},

--- a/internal/provider/openrouter.go
+++ b/internal/provider/openrouter.go
@@ -35,6 +35,8 @@ type openrouterModel struct {
 // If baseURL is empty, the default OpenRouter API endpoint is used.
 // thinkingLevel maps to OpenRouter's unified `reasoning.effort` request
 // parameter; empty or "none" leaves reasoning at the model's default.
+// See https://openrouter.ai/docs/app-attribution for the attribution headers
+// sent on every request.
 func NewOpenRouter(_ context.Context, modelName, apiKey, baseURL, thinkingLevel string, llmOpts *LLMOptions) (model.LLM, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("openrouter API key is required (set OPENROUTER_API_KEY)")
@@ -45,6 +47,13 @@ func NewOpenRouter(_ context.Context, modelName, apiKey, baseURL, thinkingLevel 
 	opts := []option.RequestOption{
 		option.WithAPIKey(apiKey),
 		option.WithBaseURL(baseURL),
+		// App attribution: OpenRouter uses these to rank and report usage
+		// under Pi-Go; HTTP-Referer is the required primary identifier.
+		// "cli-agent" categorizes pi-go as a CLI coding agent per the
+		// taxonomy at https://openrouter.ai/docs/app-attribution.
+		option.WithHeader("HTTP-Referer", openrouterHTTPReferer),
+		option.WithHeader("X-OpenRouter-Title", openrouterAppTitle),
+		option.WithHeader("X-OpenRouter-Categories", openrouterAppCategories),
 	}
 	if llmOpts != nil {
 		for k, v := range llmOpts.ExtraHeaders {
@@ -282,6 +291,7 @@ func openrouterFetchModelContextLengths(ctx context.Context, baseURL string) map
 	if err != nil {
 		return nil
 	}
+	openrouterAppAttribution(req.Header)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/provider/openrouter_attribution.go
+++ b/internal/provider/openrouter_attribution.go
@@ -1,0 +1,21 @@
+package provider
+
+import "net/http"
+
+// App-attribution values sent to OpenRouter so usage is ranked under Pi-Go.
+// HTTP-Referer is the required primary identifier — without it no app page is
+// created and usage does not appear in rankings.
+// See https://openrouter.ai/docs/app-attribution.
+const (
+	openrouterHTTPReferer   = "https://github.com/dimetron/pi-go"
+	openrouterAppTitle      = "Pi-Go"
+	openrouterAppCategories = "cli-agent"
+)
+
+// openrouterAppAttribution sets the OpenRouter app-attribution headers on h,
+// for the raw-net/http request paths (model listing, context-window lookup).
+func openrouterAppAttribution(h http.Header) {
+	h.Set("HTTP-Referer", openrouterHTTPReferer)
+	h.Set("X-OpenRouter-Title", openrouterAppTitle)
+	h.Set("X-OpenRouter-Categories", openrouterAppCategories)
+}

--- a/internal/provider/openrouter_test.go
+++ b/internal/provider/openrouter_test.go
@@ -327,7 +327,12 @@ func TestOpenRouterContextWindowSize(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			openrouterResetWindowCache()
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("HTTP-Referer") != openrouterHTTPReferer ||
+					r.Header.Get("X-OpenRouter-Title") != openrouterAppTitle ||
+					r.Header.Get("X-OpenRouter-Categories") != openrouterAppCategories {
+					t.Errorf("missing OpenRouter app-attribution headers: %v", r.Header)
+				}
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(tc.json))
 			}))


### PR DESCRIPTION
Add HTTP-Referer, X-OpenRouter-Title (Pi-Go), and X-OpenRouter-Categories (cli-agent) per https://openrouter.ai/docs/app-attribution, so OpenRouter attributes and ranks pi-go usage. Headers are set on the chat-completions client and on the raw net/http paths (model listing via fetchJSON, and the context-window /models lookup) through a shared helper.