### PR TITLE
fix/bash wait tool name pasted

### DIFF
--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -3,7 +3,9 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/adk/v2/agent"
@@ -150,6 +152,11 @@ func bashHandler(sb *Sandbox, sup *BashSupervisor, ctx agent.Context, input Bash
 	if input.Command == "" {
 		return BashOutput{}, fmt.Errorf("command is required")
 	}
+	if name := controlToolName(input.Command); name != "" {
+		return BashOutput{}, fmt.Errorf(
+			"%q is a tool name, not a shell command — call the %s tool directly instead of typing it into the bash tool",
+			name, name)
+	}
 
 	// Use background context if agent.Context is nil (e.g. in unit tests)
 	var parentCtx context.Context
@@ -207,6 +214,25 @@ func clampDuration(sec int, fallback, minDur, maxDur time.Duration) time.Duratio
 		return maxDur
 	}
 	return d
+}
+
+// controlToolName reports which bash control tool (bash_wait, bash_kill) a
+// command string is trying to invoke, or "" when the command does not look
+// like one. It exists because backgrounding results embed the control tools'
+// names, and models occasionally paste the suggested call — e.g.
+// bash_wait(handle="bg_1") — into the bash tool as shell text, where it fails
+// with an unhelpful bash syntax error. Matching only at the start of the
+// command keeps ordinary shell lines that merely mention these names working.
+func controlToolName(command string) string {
+	for _, name := range []string{"bash_wait", "bash_kill"} {
+		if rest, ok := strings.CutPrefix(command, name); ok {
+			trimmed := strings.TrimLeftFunc(rest, unicode.IsSpace)
+			if strings.HasPrefix(trimmed, "(") {
+				return name
+			}
+		}
+	}
+	return ""
 }
 
 // BashControlTools returns the tools for inspecting and stopping commands that

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -227,9 +227,15 @@ func controlToolName(command string) string {
 	for _, name := range []string{"bash_wait", "bash_kill"} {
 		if rest, ok := strings.CutPrefix(command, name); ok {
 			trimmed := strings.TrimLeftFunc(rest, unicode.IsSpace)
-			if strings.HasPrefix(trimmed, "(") {
-				return name
+			if !strings.HasPrefix(trimmed, "(") {
+				continue
 			}
+			// `name(...)` is also valid shell function-definition syntax
+			// (`bash_wait() { ... }`); a pasted tool call has no space there.
+			if strings.HasPrefix(trimmed, "()") {
+				continue
+			}
+			return name
 		}
 	}
 	return ""

--- a/internal/tools/bash_supervisor.go
+++ b/internal/tools/bash_supervisor.go
@@ -380,8 +380,8 @@ func (s *BashSupervisor) background(p *bashProc, reason string) BashOutput {
 
 	note := fmt.Sprintf(
 		"Command %s and was moved to the background; it is still running. "+
-			"Read more with bash_wait(handle=%q) or stop it with bash_kill(handle=%q). "+
-			"Output above is everything produced so far.",
+			"Call the bash_wait tool with handle %q to read more output, or the bash_kill tool with handle %q to stop it. "+
+			"Do not type these as shell commands — they are tool names, not shell syntax.",
 		reason, p.id, p.id)
 	if strings.TrimSpace(stdout) == "" && strings.TrimSpace(stderr) == "" {
 		note += " It has produced no output at all — if that is unexpected, the command is probably too broad (a filesystem-wide scan, or a prompt waiting for input) and should be killed and narrowed."

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -319,3 +319,38 @@ func TestBashHandler_BothStreamsAndExitCode(t *testing.T) {
 		t.Errorf("Stderr = %q, want 'err-line'", out.Stderr)
 	}
 }
+
+// TestBashHandler_RejectsControlToolCall covers the guard against models
+// pasting a suggested control-tool invocation — e.g. bash_wait(handle="bg_1")
+// from the backgrounding note — into the bash tool as shell text.
+func TestBashHandler_RejectsControlToolCall(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sb := testSandbox(t, dir)
+
+	for _, cmd := range []string{
+		`bash_wait(handle="bg_12", wait_sec=5)`,
+		`bash_kill(handle="bg_3")`,
+		"bash_wait( handle=\"bg_1\")",
+	} {
+		_, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: cmd})
+		if err == nil {
+			t.Errorf("command %q should be rejected as a control-tool call", cmd)
+			continue
+		}
+		if !strings.Contains(err.Error(), "tool name") {
+			t.Errorf("command %q error should name the confusion, got %v", cmd, err)
+		}
+	}
+
+	// Shell that merely mentions the tools still runs normally.
+	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
+		Command: `echo "use bash_wait to poll"`,
+	})
+	if err != nil {
+		t.Fatalf("echo mentioning bash_wait: %v", err)
+	}
+	if !strings.Contains(out.Stdout, "bash_wait") {
+		t.Errorf("Stdout = %q, want mention of bash_wait", out.Stdout)
+	}
+}

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -343,14 +343,18 @@ func TestBashHandler_RejectsControlToolCall(t *testing.T) {
 		}
 	}
 
-	// Shell that merely mentions the tools still runs normally.
-	out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{
-		Command: `echo "use bash_wait to poll"`,
-	})
-	if err != nil {
-		t.Fatalf("echo mentioning bash_wait: %v", err)
-	}
-	if !strings.Contains(out.Stdout, "bash_wait") {
-		t.Errorf("Stdout = %q, want mention of bash_wait", out.Stdout)
+	// Shell that merely mentions the tools still runs normally, and so does a
+	// valid function definition that shares the name prefix.
+	for _, cmd := range []string{
+		`echo "use bash_wait to poll"`,
+		`bash_wait() { echo ok; }; bash_wait`,
+	} {
+		out, err := bashHandler(sb, testSupervisor(t), nil, BashInput{Command: cmd})
+		if err != nil {
+			t.Fatalf("valid shell %q should not be rejected: %v", cmd, err)
+		}
+		if out.ExitCode != 0 {
+			t.Errorf("command %q ExitCode = %d, want 0 (Stdout %q, Stderr %q)", cmd, out.ExitCode, out.Stdout, out.Stderr)
+		}
 	}
 }


### PR DESCRIPTION
- **fix(tools): stop models pasting bash_wait/bash_kill calls as shell text**
- **fix(tools): exempt function definitions from the control-tool guard**
