### PR TITLE
refactor/llms fetchdocs complexity

### DIFF
--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -991,12 +991,36 @@ func buildMCPServerConfigs(cfg config.Config) []extension.MCPServerConfig {
 // the model, creates the LLM, updates the token tracker's context window size,
 // and wraps it with the guardrail. Used by the TUI /model <name> command.
 func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guardrail.Tracker, modelName string) (adkmodel.LLM, string, string, error) {
-	// Try to auto-detect provider from config's default role.
 	providerName := ""
 	if rc, ok := cfg.Roles["default"]; ok && rc.Provider != "" {
 		providerName = rc.Provider
 	}
 
+	info, baseURL, apiKey, err := resolveSwitchedModel(cfg, modelName, providerName)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	llmOpts := &provider.LLMOptions{
+		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),
+	}
+	applyTransportOptions(llmOpts, cfg)
+	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, llmOpts)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("creating LLM: %w", err)
+	}
+
+	tokenTracker.SetContextWindowSize(switchContextWindowSize(ctx, cfg, info, baseURL))
+	llm = guardrail.WrapModel(llm, tokenTracker)
+
+	return llm, switchedModelName(info), info.Provider, nil
+}
+
+// resolveSwitchedModel resolves modelName to a validated model info plus the
+// endpoint and API key to reach it: provider auto-detection from config's
+// default role, base URL resolution, model validation, and Ollama endpoint
+// fallback all happen here.
+func resolveSwitchedModel(cfg config.Config, modelName, providerName string) (provider.Info, string, string, error) {
 	baseURL := flagURL
 	if baseURL == "" && providerName != "" {
 		baseURLs := cfg.ResolveBaseURLs()
@@ -1005,7 +1029,7 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 
 	info, err := provider.ResolveWithBaseURL(modelName, baseURL)
 	if err != nil {
-		return nil, "", "", fmt.Errorf("resolving model: %w", err)
+		return provider.Info{}, "", "", fmt.Errorf("resolving model: %w", err)
 	}
 	if providerName != "" {
 		info.Provider = providerName
@@ -1019,11 +1043,10 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 		}
 	}
 	if err := provider.ValidateModel(info); err != nil {
-		return nil, "", "", fmt.Errorf("model validation: %w", err)
+		return provider.Info{}, "", "", fmt.Errorf("model validation: %w", err)
 	}
 
-	keys := config.APIKeys()
-	apiKey := keys[info.Provider]
+	apiKey := config.APIKeys()[info.Provider]
 
 	if info.Ollama {
 		baseURL = provider.ResolveOllamaEndpoint(provider.OllamaRouting{
@@ -1038,17 +1061,13 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 	// its say, so session metadata names the backend rather than leaving the
 	// model name to be interpreted.
 	info.BaseURL = baseURL
+	return info, baseURL, apiKey, nil
+}
 
-	llmOpts := &provider.LLMOptions{
-		ExtraHeaders: mergeExtraHeaders(cfg.ExtraHeaders, flagHeaders),
-	}
-	applyTransportOptions(llmOpts, cfg)
-	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, llmOpts)
-	if err != nil {
-		return nil, "", "", fmt.Errorf("creating LLM: %w", err)
-	}
-
-	// Update context window size on the existing token tracker.
+// switchContextWindowSize determines the context window for the switched
+// model: embedded catalog first, then live queries for Ollama and OpenRouter,
+// then an explicit config value wins over both.
+func switchContextWindowSize(ctx context.Context, cfg config.Config, info provider.Info, baseURL string) int64 {
 	ctxWindowSize := provider.ContextWindowSizeFor(info.Provider, info.Model)
 	if info.Ollama {
 		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
@@ -1065,19 +1084,18 @@ func buildSwitchedLLM(ctx context.Context, cfg config.Config, tokenTracker *guar
 	if cfg.ContextWindow > 0 {
 		ctxWindowSize = cfg.ContextWindow
 	}
-	tokenTracker.SetContextWindowSize(ctxWindowSize)
-	llm = guardrail.WrapModel(llm, tokenTracker)
+	return ctxWindowSize
+}
 
-	// Hand back a name that re-resolves to the same endpoint. Resolve strips
-	// the ollama/ prefix from info.Model, and this answer is what the TUI
-	// stores as the current model and re-resolves on the next switch — so
-	// returning the bare name would drop the one part of the spelling that
-	// says "local", and a cloud-tagged model would move to api.ollama.com
-	// behind the user's back the moment a key was set.
-	switchedName := info.Model
+// switchedModelName hands back a name that re-resolves to the same endpoint.
+// Resolve strips the ollama/ prefix from info.Model, and this answer is what
+// the TUI stores as the current model and re-resolves on the next switch — so
+// returning the bare name would drop the one part of the spelling that says
+// "local", and a cloud-tagged model would move to api.ollama.com behind the
+// user's back the moment a key was set.
+func switchedModelName(info provider.Info) string {
 	if info.LocalOllama {
-		switchedName = "ollama/" + info.Model
+		return "ollama/" + info.Model
 	}
-
-	return llm, switchedName, info.Provider, nil
+	return info.Model
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,18 +298,8 @@ func Load() (Config, error) {
 func LoadFrom(cwd string) (Config, error) {
 	cfg := Defaults()
 
-	home, err := os.UserHomeDir()
-	if err == nil {
-		globalPath := filepath.Join(home, ".pi-go", "config.json")
-		if err := loadFile(globalPath, &cfg); err != nil && !os.IsNotExist(err) {
-			return cfg, err
-		}
-	}
-
-	if projectPath := findNearestProjectFile(cwd, filepath.Join(".pi-go", "config.json")); projectPath != "" {
-		if err := loadFile(projectPath, &cfg); err != nil && !os.IsNotExist(err) {
-			return cfg, err
-		}
+	if err := loadConfigFiles(&cfg, cwd); err != nil {
+		return cfg, err
 	}
 
 	// Load MCP config from separate mcp.json files if present and merge with
@@ -317,45 +307,73 @@ func LoadFrom(cwd string) (Config, error) {
 	// config.json; mcp.json-only servers are appended so a project can add
 	// servers without redefining the global set. Appended entries keep the
 	// standalone marker so Save never copies them into config.json.
-	mcpServers := LoadMCPServersFrom(cwd)
-	if len(mcpServers) > 0 {
-		if cfg.MCP == nil {
-			cfg.MCP = &MCPConfig{}
-		}
-		known := make(map[string]bool, len(cfg.MCP.Servers))
-		for _, s := range cfg.MCP.Servers {
-			known[s.Name] = true
-		}
-		for _, s := range mcpServers {
-			if !known[s.Name] {
-				s.fromStandaloneFile = true
-				cfg.MCP.Servers = append(cfg.MCP.Servers, s)
-			}
-		}
-	}
+	mergeStandaloneMCPServers(&cfg, LoadMCPServersFrom(cwd))
 
 	// An llms.txt index configured as an MCP server is also registered as a
-	// fetch_docs source, so the documentation is readable straight away. The
-	// names are recorded rather than announced here: config loads before any
-	// front end exists, and the TUI's first act is a full terminal reset that
-	// clears the screen and scrollback, so a notice raised now would be wiped
-	// before it could be read. NotifyReroutedLLMS delivers it once the caller
-	// knows where output goes.
+	// fetch_docs source, so the documentation is readable straight away.
 	cfg.ReroutedLLMS = registerLLMSDocsSources(&cfg)
 
-	// Migrate deprecated DefaultModel to roles if roles not set.
-	if cfg.DefaultModel != "" && len(cfg.Roles) == 0 {
+	migrateDefaultModelRoles(&cfg)
+
+	return cfg, nil
+}
+
+// loadConfigFiles overlays the nearest project .pi-go/config.json onto the
+// global ~/.pi-go/config.json on top of cfg. A missing file is not an error;
+// any other read or parse failure is.
+func loadConfigFiles(cfg *Config, cwd string) error {
+	if home, err := os.UserHomeDir(); err == nil {
+		globalPath := filepath.Join(home, ".pi-go", "config.json")
+		if err := loadFile(globalPath, cfg); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if projectPath := findNearestProjectFile(cwd, filepath.Join(".pi-go", "config.json")); projectPath != "" {
+		if err := loadFile(projectPath, cfg); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// mergeStandaloneMCPServers appends standalone mcp.json servers that config.json
+// does not already declare. Existing names win; appended entries keep the
+// standalone marker so Save never copies them into config.json.
+func mergeStandaloneMCPServers(cfg *Config, mcpServers []MCPServer) {
+	if len(mcpServers) == 0 {
+		return
+	}
+	if cfg.MCP == nil {
+		cfg.MCP = &MCPConfig{}
+	}
+	known := make(map[string]bool, len(cfg.MCP.Servers))
+	for _, s := range cfg.MCP.Servers {
+		known[s.Name] = true
+	}
+	for _, s := range mcpServers {
+		if !known[s.Name] {
+			s.fromStandaloneFile = true
+			cfg.MCP.Servers = append(cfg.MCP.Servers, s)
+		}
+	}
+}
+
+// migrateDefaultModelRoles migrates the deprecated DefaultModel field into
+// Roles: as the default role when none exist, otherwise filling in just the
+// default role if roles are set but leave it unset.
+func migrateDefaultModelRoles(cfg *Config) {
+	if cfg.DefaultModel == "" {
+		return
+	}
+	if len(cfg.Roles) == 0 {
 		cfg.Roles = map[string]RoleConfig{
 			"default": {Model: cfg.DefaultModel},
 		}
-	} else if cfg.DefaultModel != "" && cfg.Roles != nil {
-		// If DefaultModel is set alongside roles, update the default role if not already set.
+	} else if cfg.Roles != nil {
 		if _, ok := cfg.Roles["default"]; !ok {
 			cfg.Roles["default"] = RoleConfig{Model: cfg.DefaultModel}
 		}
 	}
-
-	return cfg, nil
 }
 
 // mcpServerFile represents the JSON structure of a standalone mcp.json file.

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -245,7 +245,7 @@ func conditionalHeaders(req *http.Request, entry *llmsCacheEntry) {
 	}
 }
 
-// handleLLMSResponse converts an HTTP response into a tool output, using the
+// fetchLLMSURL builds, sends, and converts the response of a documentation fetch
 // cached entry for revalidation (304) and stale-while-error fallback.
 //
 // A cached copy younger than llmsCacheMaxAge is served on network failure or
@@ -253,7 +253,7 @@ func conditionalHeaders(req *http.Request, entry *llmsCacheEntry) {
 // origin's verdict on the page itself — removed, moved, or access revoked —
 // so the cached body must not be passed off as current; only the status is
 // reported.
-func (t *LLMSToolset) handleLLMSResponse(ctx context.Context, u *url.URL, entry *llmsCacheEntry) (LLMSOutput, error) {
+func (t *LLMSToolset) fetchLLMSURL(ctx context.Context, u *url.URL, entry *llmsCacheEntry) (LLMSOutput, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return LLMSOutput{Error: fmt.Sprintf("build request: %v", err)}, nil
@@ -350,7 +350,7 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 		return LLMSOutput{Content: entry.Body}, nil
 	}
 
-	return t.handleLLMSResponse(ctx, u, entry)
+	return t.fetchLLMSURL(ctx, u, entry)
 }
 
 // cachePath maps a documentation URL to its on-disk cache file. The key is a

--- a/internal/tools/llms.go
+++ b/internal/tools/llms.go
@@ -207,68 +207,59 @@ func NewLLMSToolFromSet(ts *LLMSToolset) (tool.Tool, error) {
 	)
 }
 
-// FetchDocs fetches a documentation URL, restricted to hosts that host one of
-// the configured llms.txt sources. The response is returned as-is (llms.txt
-// and its linked pages are markdown, so no HTML conversion is needed).
-//
-// It is exported so the voice agent can drive the same allow-list and SSRF
-// guards for its own fetch_docs tool rather than reimplementing them; it is
-// otherwise the body behind the ADK fetch_docs tool.
-func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput, error) {
+// parseLLMSURL validates and normalizes a fetch_docs URL: https only, must
+// have a host, and the fragment (#section) is dropped — it is never sent on
+// the wire, so page.md#a and page.md#b are the same resource and should share
+// one cache entry instead of each downloading a copy.
+func parseLLMSURL(rawURL string) (*url.URL, error) {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
-		return LLMSOutput{Error: "url is required"}, nil
+		return nil, errors.New("url is required")
 	}
 
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return LLMSOutput{Error: fmt.Sprintf("parse url: %v", err)}, nil
+		return nil, fmt.Errorf("parse url: %w", err)
 	}
 	if u.Scheme != "https" {
-		return LLMSOutput{Error: "only https:// URLs are allowed"}, nil
+		return nil, errors.New("only https:// URLs are allowed")
 	}
 	if u.Host == "" {
-		return LLMSOutput{Error: "url has no host"}, nil
+		return nil, errors.New("url has no host")
 	}
-	// A fragment (#section) is never sent on the wire, so page.md#a and
-	// page.md#b are the same resource: drop it before the cache lookup and the
-	// request so they share one entry instead of each downloading a copy.
 	u.Fragment, u.RawFragment = "", ""
+	return u, nil
+}
 
-	// SSRF guard: reject loopback, private, link-local, multicast, and
-	// unspecified destinations before dialing.
-	if err := rejectPrivateHost(u.Hostname()); err != nil {
-		return LLMSOutput{Error: fmt.Sprintf("url rejected: %v", err)}, nil
+// conditionalHeaders sets revalidation headers on req for entry: the server
+// answers 304 and we reuse the cached body, saving the full download.
+func conditionalHeaders(req *http.Request, entry *llmsCacheEntry) {
+	if entry == nil {
+		return
 	}
-
-	// Restrict to configured llms.txt sources: a whole host for one the user
-	// configured, the exact URL for one pi-go inferred.
-	if !t.urlAllowed(u) {
-		return LLMSOutput{Error: fmt.Sprintf("host %q is not an allowed documentation source", u.Hostname())}, nil
+	if entry.ETag != "" {
+		req.Header.Set("If-None-Match", entry.ETag)
 	}
-
-	// A cached copy younger than llmsCacheTTL is served straight from disk —
-	// no network, no revalidation.
-	entry := t.cacheRead(u)
-	if entry != nil && entry.age() < llmsCacheTTL {
-		return LLMSOutput{Content: entry.Body}, nil
+	if entry.LastModified != "" {
+		req.Header.Set("If-Modified-Since", entry.LastModified)
 	}
+}
 
+// handleLLMSResponse converts an HTTP response into a tool output, using the
+// cached entry for revalidation (304) and stale-while-error fallback.
+//
+// A cached copy younger than llmsCacheMaxAge is served on network failure or
+// an upstream 5xx: both are transient. A 4xx (401/403/404/410, …) is the
+// origin's verdict on the page itself — removed, moved, or access revoked —
+// so the cached body must not be passed off as current; only the status is
+// reported.
+func (t *LLMSToolset) handleLLMSResponse(ctx context.Context, u *url.URL, entry *llmsCacheEntry) (LLMSOutput, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return LLMSOutput{Error: fmt.Sprintf("build request: %v", err)}, nil
 	}
 	req.Header.Set("User-Agent", llmsUserAgent)
-	// Revalidate an existing entry with a conditional request: the server
-	// answers 304 and we reuse the cached body, saving the full download.
-	if entry != nil {
-		if entry.ETag != "" {
-			req.Header.Set("If-None-Match", entry.ETag)
-		}
-		if entry.LastModified != "" {
-			req.Header.Set("If-Modified-Since", entry.LastModified)
-		}
-	}
+	conditionalHeaders(req, entry)
 
 	client := t.client
 	if llmsClientOverride != nil {
@@ -282,9 +273,6 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		// Network failure: fall back to a reasonably fresh cached copy rather
-		// than failing the whole call. An entry older than llmsCacheMaxAge is
-		// not served, so a permanently dead page is not resurrected forever.
 		if entry != nil && entry.age() < llmsCacheMaxAge {
 			return LLMSOutput{Content: entry.Body}, nil
 		}
@@ -325,16 +313,44 @@ func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput,
 		return LLMSOutput{Content: string(body)}, nil
 
 	default:
-		// An upstream 5xx is transient; prefer a reasonably fresh cached copy
-		// to the error being surfaced to the model. A 4xx (401/403/404/410,
-		// …) is the origin's verdict on the page itself — removed, moved, or
-		// access revoked — so the cached body must not be passed off as
-		// current; only the status is reported.
 		if resp.StatusCode >= 500 && entry != nil && entry.age() < llmsCacheMaxAge {
 			return LLMSOutput{Content: entry.Body}, nil
 		}
 		return LLMSOutput{Error: fmt.Sprintf("unexpected status %d", resp.StatusCode)}, nil
 	}
+}
+
+// FetchDocs fetches a documentation URL, restricted to hosts that host one of
+// the configured llms.txt sources. The response is returned as-is (llms.txt
+// and its linked pages are markdown, so no HTML conversion is needed).
+//
+// It is exported so the voice agent can drive the same allow-list and SSRF
+// guards for its own fetch_docs tool rather than reimplementing them; it is
+// otherwise the body behind the ADK fetch_docs tool.
+func (t *LLMSToolset) FetchDocs(ctx context.Context, rawURL string) (LLMSOutput, error) {
+	u, err := parseLLMSURL(rawURL)
+	if err != nil {
+		return LLMSOutput{Error: err.Error()}, nil
+	}
+
+	// SSRF guard: reject loopback, private, link-local, multicast, and
+	// unspecified destinations before dialing.
+	if err := rejectPrivateHost(u.Hostname()); err != nil {
+		return LLMSOutput{Error: fmt.Sprintf("url rejected: %v", err)}, nil
+	}
+
+	// Restrict to configured llms.txt sources: a whole host for one the user
+	// configured, the exact URL for one pi-go inferred.
+	if !t.urlAllowed(u) {
+		return LLMSOutput{Error: fmt.Sprintf("host %q is not an allowed documentation source", u.Hostname())}, nil
+	}
+
+	entry := t.cacheRead(u)
+	if entry != nil && entry.age() < llmsCacheTTL {
+		return LLMSOutput{Content: entry.Body}, nil
+	}
+
+	return t.handleLLMSResponse(ctx, u, entry)
 }
 
 // cachePath maps a documentation URL to its on-disk cache file. The key is a


### PR DESCRIPTION
- **refactor(tools): split FetchDocs into parse/guard/respond phases**
- **refactor(cli): extract resolve/context-window/name helpers from buildSwitchedLLM**
- **refactor(config): split LoadFrom into file-load/MCP-merge/roles-migrate phases**
