### PR TITLE
fix(tui): make loop-detector error streaks args-aware and batch-aware

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -127,15 +127,35 @@ func extractAgentType(args map[string]any) string {
 
 // stuckDetector tracks recent tool calls and detects repetition loops.
 type stuckDetector struct {
-	recent      []string // ring of fingerprints (len <= recentWindowSize)
-	lastPrint   string   // fingerprint of last tool call
-	lastName    string   // tool name behind lastPrint
-	lastResult  string   // fingerprint of the streak's previous result ("" = none yet)
-	streak      int      // consecutive identical tool calls with identical results
-	lastErrTool string   // name of last tool that errored
-	errStreak   int      // consecutive errors for that tool
-	outBuf      string   // rolling tail of the model's own output
-	outSince    int      // bytes of output since the last repetition scan
+	recent     []string // ring of fingerprints (len <= recentWindowSize)
+	lastPrint  string   // fingerprint of last tool call
+	lastName   string   // tool name behind lastPrint
+	lastResult string   // fingerprint of the streak's previous result ("" = none yet)
+	streak     int      // consecutive identical tool calls with identical results
+	// Two error detectors run in parallel. The args-aware streak keys on the
+	// call fingerprint, so only the same tool call failing repeatedly counts;
+	// the name-only streak keys on the tool name and compounds only across
+	// distinct model messages, so a batch of different calls in one message is
+	// a single attempt rather than a streak. See observeError.
+	callInfo       map[string]callRecord // call ID -> fingerprint + message, for response correlation
+	lastCallByName map[string]callRecord // name -> most recent call, fallback when a response carries no/unknown ID
+	msgSeq         int                   // per-event counter; calls in the same event share it
+	lastErrFP      string                // fingerprint of the previous error (args-aware streak)
+	errFPStreak    int                   // consecutive errors of the same call fingerprint
+	lastErrTool    string                // name of last tool that errored
+	errStreak      int                   // consecutive errors of that tool across distinct messages
+	lastErrBatch   int                   // message sequence of the call the last error answered
+	outBuf         string                // rolling tail of the model's own output
+	outSince       int                   // bytes of output since the last repetition scan
+}
+
+// callRecord is what the detector remembers about an observed tool call so a
+// later response can be correlated back to it: the call's fingerprint (for the
+// args-aware error streak) and the message it appeared in (for the name-only
+// cross-batch streak).
+type callRecord struct {
+	fp  string
+	msg int
 }
 
 // volatileToolArgs address a slice of a target rather than the target itself.
@@ -175,9 +195,31 @@ func stableToolArgs(args map[string]any) map[string]any {
 	return stable
 }
 
+// beginEvent advances the message counter so calls in one model event share a
+// batch identity. Responses later use it to tell a single batch of calls from
+// repeated attempts spread across turns.
+func (s *stuckDetector) beginEvent() {
+	s.msgSeq++
+}
+
 // observe records a tool call and returns true if the loop appears stuck.
-func (s *stuckDetector) observe(name string, args map[string]any) (stuck bool, detail string) {
+// id correlates the call to its later response (FunctionCall.ID). Calls with
+// an empty id cannot be correlated by ID, so they are remembered only by name
+// (see lastCallByName); observeError uses that fallback so a batch of ID-less
+// calls still reads as one message.
+func (s *stuckDetector) observe(id, name string, args map[string]any) (stuck bool, detail string) {
 	fp := toolFingerprint(name, args)
+	rec := callRecord{fp: fp, msg: s.msgSeq}
+	if id != "" {
+		if s.callInfo == nil {
+			s.callInfo = make(map[string]callRecord)
+		}
+		s.callInfo[id] = rec
+	}
+	if s.lastCallByName == nil {
+		s.lastCallByName = make(map[string]callRecord)
+	}
+	s.lastCallByName[name] = rec
 
 	// Consecutive identical call detection.
 	if fp == s.lastPrint {
@@ -240,20 +282,77 @@ func (s *stuckDetector) observeResult(name string, response map[string]any) {
 	s.lastResult = fp
 }
 
-// observeError records the outcome of a tool call by name. Consecutive errors
-// of the same tool name — regardless of args — trip the detector once the
-// streak reaches maxToolErrorStreak. A success (isError == false) or a switch
-// to a different tool name resets the streak.
-func (s *stuckDetector) observeError(name string, isError bool) (stuck bool, detail string) {
-	if isError && name == s.lastErrTool {
-		s.errStreak++
-	} else {
-		s.errStreak = 1
-		s.lastErrTool = name
+// observeError records the outcome of a tool call and reports whether the loop
+// is stuck. Two streaks run in parallel, catching different loop shapes:
+//
+//  1. Args-aware (errFPStreak): the same call — same tool and same argument
+//     fingerprint — failing maxToolErrorStreak times. A model stuck re-issuing
+//     one call trips here no matter how many messages pass.
+//
+//  2. Name-only, cross-batch (errStreak): consecutive failures of the same
+//     tool name that come from calls in *different* model messages. A batch of
+//     distinct calls sent in one message (e.g. fetching pricing for ten
+//     models in a single turn) is one attempt, not ten, so it does not
+//     compound; the same tool failing once per message across ten messages is
+//     the flailing pattern and does.
+//
+// A success (isError == false) resets both streaks. id is the FunctionResponse
+// ID, used to look up which call — and therefore which message — this result
+// answers.
+func (s *stuckDetector) observeError(id, name string, isError bool) (stuck bool, detail string) {
+	// Correlate this response to the call it answers. By ID first: a matched
+	// record gives the call's fingerprint and message, and is consumed so the
+	// map stays bounded by outstanding (unanswered) calls. When the response
+	// carries no usable ID, fall back to the most recent call of that name —
+	// responses trail their calls in order, so this is the call being answered.
+	// Only the batch is trusted from the name fallback: without an ID we cannot
+	// pair a response to a specific call's arguments, so the args-aware streak
+	// must not see a fingerprint — a batch of distinct ID-less calls would all
+	// collapse onto the last call's fingerprint and false-abort.
+	fp := ""
+	batch := 0
+	if rec, ok := s.callInfo[id]; ok {
+		fp, batch = rec.fp, rec.msg
+		delete(s.callInfo, id)
+	} else if rec, ok := s.lastCallByName[name]; ok {
+		batch = rec.msg
 	}
-	if s.errStreak >= maxToolErrorStreak {
-		return true, fmt.Sprintf("tool %q failed %d times in a row", name, s.errStreak)
+
+	if isError {
+		if fp != "" && fp == s.lastErrFP {
+			s.errFPStreak++
+		} else {
+			s.errFPStreak = 1
+			s.lastErrFP = fp
+		}
+		if s.errFPStreak >= maxToolErrorStreak {
+			return true, fmt.Sprintf("tool %q failed %d times in a row", name, s.errFPStreak)
+		}
+
+		// Name-only streak. Compound only when this failure answers a call
+		// from a different message than the previous one (or from an
+		// unknown message — treat unobserved calls as new attempts).
+		if name == s.lastErrTool {
+			if s.lastErrBatch == 0 || batch != s.lastErrBatch {
+				s.errStreak++
+				s.lastErrBatch = batch
+			}
+		} else {
+			s.errStreak = 1
+			s.lastErrTool = name
+			s.lastErrBatch = batch
+		}
+		if s.errStreak >= maxToolErrorStreak {
+			return true, fmt.Sprintf("tool %q failed %d times in a row", name, s.errStreak)
+		}
+		return false, ""
 	}
+
+	s.errFPStreak = 0
+	s.lastErrFP = ""
+	s.errStreak = 0
+	s.lastErrTool = ""
+	s.lastErrBatch = 0
 	return false, ""
 }
 
@@ -940,6 +1039,10 @@ func (m *model) emitEventParts(
 	detector *stuckDetector,
 	log *logger.Logger,
 ) error {
+	// Each event is one model message. Calls in the same event share a batch
+	// identity so the error detector treats a batch of distinct calls as one
+	// attempt rather than a streak (see observeError).
+	detector.beginEvent()
 	for _, part := range ev.Content.Parts {
 		if err := m.emitEventPart(ch, ev, dedup, detector, log, part); err != nil {
 			return err
@@ -976,7 +1079,7 @@ func (m *model) emitEventPart(
 		log.ToolCall(ev.Author, fc.Name, fc.Args)
 		ch <- agentToolCallMsg{id: fc.ID, name: fc.Name, args: fc.Args}
 
-		if err := stuckErr(detector.observe(fc.Name, fc.Args)); err != nil {
+		if err := stuckErr(detector.observe(fc.ID, fc.Name, fc.Args)); err != nil {
 			return err
 		}
 	}
@@ -1033,7 +1136,7 @@ func (m *model) emitPartResponse(
 	// map[string]any{"error": ...}. Anything else (including a
 	// missing key) is treated as success and resets the streak.
 	_, isErr := fr.Response["error"]
-	return stuckErr(detector.observeError(fr.Name, isErr))
+	return stuckErr(detector.observeError(fr.ID, fr.Name, isErr))
 }
 
 // stuckError is a loop abort the run can recover from. It is distinguished

--- a/internal/tui/agent_loop_runaway_test.go
+++ b/internal/tui/agent_loop_runaway_test.go
@@ -71,7 +71,7 @@ func TestStuckDetector_Observe_TripsOnPagedRereads(t *testing.T) {
 	s := &stuckDetector{}
 	var stuck bool
 	for i := range maxRepeatToolCalls {
-		stuck, _ = s.observe("read", map[string]any{"file_path": "/repo/chat.go", "offset": i * 40})
+		stuck, _ = s.observe("c", "read", map[string]any{"file_path": "/repo/chat.go", "offset": i * 40})
 	}
 	if !stuck {
 		t.Fatalf("re-reading one file %d times must trip the detector", maxRepeatToolCalls)

--- a/internal/tui/agent_loop_stuck_test.go
+++ b/internal/tui/agent_loop_stuck_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -49,7 +50,7 @@ func TestToolFingerprint_EmptyArgs(t *testing.T) {
 
 func TestStuckDetector_Observe_NotStuck(t *testing.T) {
 	s := &stuckDetector{}
-	stuck, detail := s.observe("read", map[string]any{"path": "/foo"})
+	stuck, detail := s.observe("c", "read", map[string]any{"path": "/foo"})
 	if stuck {
 		t.Errorf("expected not stuck, got stuck: %s", detail)
 	}
@@ -57,7 +58,7 @@ func TestStuckDetector_Observe_NotStuck(t *testing.T) {
 
 func TestStuckDetector_Observe_SingleCall(t *testing.T) {
 	s := &stuckDetector{}
-	s.observe("read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
 	if len(s.recent) != 1 {
 		t.Errorf("recent len = %d, want 1", len(s.recent))
 	}
@@ -68,8 +69,8 @@ func TestStuckDetector_Observe_SingleCall(t *testing.T) {
 
 func TestStuckDetector_Observe_IncrementStreak(t *testing.T) {
 	s := &stuckDetector{}
-	s.observe("read", map[string]any{"path": "/foo"})
-	s.observe("read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
 	if s.streak != 2 {
 		t.Errorf("streak = %d, want 2", s.streak)
 	}
@@ -77,9 +78,9 @@ func TestStuckDetector_Observe_IncrementStreak(t *testing.T) {
 
 func TestStuckDetector_Observe_ResetStreak(t *testing.T) {
 	s := &stuckDetector{}
-	s.observe("read", map[string]any{"path": "/foo"})
-	s.observe("read", map[string]any{"path": "/foo"})
-	s.observe("write", map[string]any{"path": "/bar"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
+	s.observe("c", "write", map[string]any{"path": "/bar"})
 	if s.streak != 1 {
 		t.Errorf("streak = %d, want 1 after different call", s.streak)
 	}
@@ -89,7 +90,7 @@ func TestStuckDetector_Observe_WindowOverflow(t *testing.T) {
 	s := &stuckDetector{}
 	// Add more than recentWindowSize entries
 	for i := 0; i < 20; i++ {
-		s.observe("read", map[string]any{"path": "/foo"})
+		s.observe("c", "read", map[string]any{"path": "/foo"})
 	}
 	if len(s.recent) > recentWindowSize {
 		t.Errorf("recent len = %d, should not exceed %d", len(s.recent), recentWindowSize)
@@ -100,7 +101,7 @@ func TestStuckDetector_Observe_StreakThreshold(t *testing.T) {
 	s := &stuckDetector{}
 	// Trigger stuck detection
 	for i := 0; i < maxRepeatToolCalls; i++ {
-		stuck, _ := s.observe("read", map[string]any{"path": "/foo"})
+		stuck, _ := s.observe("c", "read", map[string]any{"path": "/foo"})
 		if i == maxRepeatToolCalls-1 && !stuck {
 			t.Errorf("expected stuck after %d repeats", maxRepeatToolCalls)
 		}
@@ -116,7 +117,7 @@ func TestStuckDetector_ObserveResult_PollingNotStuck(t *testing.T) {
 	s := &stuckDetector{}
 	args := map[string]any{"handle": "bg_16", "wait_sec": 1}
 	for i := 0; i < maxRepeatToolCalls*3; i++ {
-		stuck, detail := s.observe("bash_wait", args)
+		stuck, detail := s.observe("c", "bash_wait", args)
 		if stuck {
 			t.Fatalf("poll %d flagged stuck: %s", i, detail)
 		}
@@ -133,7 +134,7 @@ func TestStuckDetector_ObserveResult_ChangingTimingDoesNotReset(t *testing.T) {
 	s := &stuckDetector{}
 	args := map[string]any{"handle": "bg_16"}
 	for i := 0; i < maxRepeatToolCalls; i++ {
-		stuck, _ := s.observe("bash_wait", args)
+		stuck, _ := s.observe("c", "bash_wait", args)
 		if i == maxRepeatToolCalls-1 && !stuck {
 			t.Fatalf("timing-only polls should trip after %d repeats", maxRepeatToolCalls)
 		}
@@ -154,7 +155,7 @@ func TestStuckDetector_ObserveResult_IdenticalResultsStillStuck(t *testing.T) {
 	resp := map[string]any{"running": false, "stdout": "done"}
 	tripped := false
 	for i := 0; i < maxRepeatToolCalls; i++ {
-		stuck, _ := s.observe("bash_wait", args)
+		stuck, _ := s.observe("c", "bash_wait", args)
 		tripped = tripped || stuck
 		s.observeResult("bash_wait", resp)
 	}
@@ -165,8 +166,8 @@ func TestStuckDetector_ObserveResult_IdenticalResultsStillStuck(t *testing.T) {
 
 func TestStuckDetector_ObserveResult_OtherToolDoesNotReset(t *testing.T) {
 	s := &stuckDetector{}
-	s.observe("read", map[string]any{"path": "/foo"})
-	s.observe("read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
 	s.observeResult("write", map[string]any{"changed": 1})
 	s.observeResult("write", map[string]any{"changed": 2})
 	if s.streak != 2 {
@@ -176,10 +177,163 @@ func TestStuckDetector_ObserveResult_OtherToolDoesNotReset(t *testing.T) {
 
 func TestStuckDetector_ObserveResult_FirstResultOnlySetsBaseline(t *testing.T) {
 	s := &stuckDetector{}
-	s.observe("read", map[string]any{"path": "/foo"})
+	s.observe("c", "read", map[string]any{"path": "/foo"})
 	s.observeResult("read", map[string]any{"content": "x"})
 	if s.streak != 1 {
 		t.Errorf("streak = %d, want 1: the first result has nothing to compare against", s.streak)
+	}
+}
+
+// TestStuckDetector_ObserveError_SameCallDifferentMessagesStillStuck pins the
+// args-aware streak: the same call (same tool + same args) failing across
+// several messages still trips at maxToolErrorStreak. Regression guard for the
+// pre-hash behavior where distinct args also counted.
+func TestStuckDetector_ObserveError_SameCallDifferentMessagesStillStuck(t *testing.T) {
+	s := &stuckDetector{}
+	args := map[string]any{"request": map[string]any{"author": "stealth", "slug": "ox-alpha"}}
+	tripped := false
+	for i := 0; i < maxToolErrorStreak; i++ {
+		s.beginEvent() // one call per message: repeated attempts
+		id := fmt.Sprintf("call_%d", i)
+		s.observe(id, "get-model", args)
+		stuck, _ := s.observeError(id, "get-model", true)
+		tripped = tripped || stuck
+	}
+	if !tripped {
+		t.Errorf("the same call failing %d times must trip the args-aware streak", maxToolErrorStreak)
+	}
+}
+
+// TestStuckDetector_ObserveError_BatchOfDistinctCallsNotStuck is the regression
+// for session 260826-2200-b99f8-5b94b: the model sent one message with ten
+// get-model calls, each targeting a different model, and every one failed with
+// "Model not found". That is a single sweep over a list — progress — not a
+// loop, so neither error streak may trip.
+func TestStuckDetector_ObserveError_BatchOfDistinctCallsNotStuck(t *testing.T) {
+	s := &stuckDetector{}
+	s.beginEvent() // all ten calls share one message
+	slugs := []string{
+		"stealth/ox-alpha", "deepseek/deepseek-v4-flash-20260731", "xiaomi/mimo-v2.5-20260422",
+		"tencent/hy3-20260706", "deepseek/deepseek-v4-flash-20260423", "google/gemini-3.7-flash-20260813",
+		"openai/gpt-5.6-luna-20260709", "z-ai/glm-5.2-20260616", "deepseek/deepseek-v4-pro-20260423",
+		"openai/gpt-5.6-sol-20260709",
+	}
+	for i, slug := range slugs {
+		parts := strings.SplitN(slug, "/", 2)
+		id := fmt.Sprintf("call_%d", i)
+		s.observe(id, "get-model", map[string]any{"request": map[string]any{"author": parts[0], "slug": parts[1]}})
+	}
+	for i := range slugs {
+		id := fmt.Sprintf("call_%d", i)
+		if stuck, detail := s.observeError(id, "get-model", true); stuck {
+			t.Fatalf("a batch of distinct failing calls tripped the detector: %s", detail)
+		}
+	}
+	if s.errFPStreak >= maxToolErrorStreak {
+		t.Errorf("args-aware streak = %d, want < %d: distinct args must not compound", s.errFPStreak, maxToolErrorStreak)
+	}
+	if s.errStreak >= maxToolErrorStreak {
+		t.Errorf("name-only streak = %d, want < %d: one batch is one attempt", s.errStreak, maxToolErrorStreak)
+	}
+}
+
+// TestStuckDetector_ObserveError_BatchOfDistinctCalls_EmptyIDsNotStuck pins the
+// same regression for providers that leave FunctionCall.ID empty: the name
+// fallback must still attribute the whole batch to one message, so ten
+// distinct ID-less calls in one message do not trip the name-only streak.
+func TestStuckDetector_ObserveError_BatchOfDistinctCalls_EmptyIDsNotStuck(t *testing.T) {
+	s := &stuckDetector{}
+	s.beginEvent()
+	for i := 0; i < maxToolErrorStreak; i++ {
+		s.observe("", "get-model", map[string]any{"request": map[string]any{"author": "a", "slug": fmt.Sprintf("model-%d", i)}})
+	}
+	for i := 0; i < maxToolErrorStreak; i++ {
+		if stuck, detail := s.observeError("", "get-model", true); stuck {
+			t.Fatalf("an ID-less batch of distinct failing calls tripped the detector: %s", detail)
+		}
+	}
+}
+
+// TestStuckDetector_ObserveError_FlailingAcrossMessagesStillStuck pins the
+// name-only cross-batch streak: the same tool failing once per message with
+// different args across maxToolErrorStreak messages is the flailing pattern and
+// must still trip.
+func TestStuckDetector_ObserveError_FlailingAcrossMessagesStillStuck(t *testing.T) {
+	s := &stuckDetector{}
+	tripped := false
+	for i := 0; i < maxToolErrorStreak; i++ {
+		s.beginEvent() // one call per message
+		id := fmt.Sprintf("call_%d", i)
+		s.observe(id, "read", map[string]any{"file_path": fmt.Sprintf("/nonexistent/path/%d", i)})
+		stuck, _ := s.observeError(id, "read", true)
+		tripped = tripped || stuck
+	}
+	if !tripped {
+		t.Errorf("flailing (same tool, distinct args, across %d messages) must trip the name-only streak", maxToolErrorStreak)
+	}
+}
+
+// TestStuckDetector_ObserveError_CallInfoConsumed pins that a matched response
+// consumes its call record: the correlation map stays bounded by outstanding
+// (unanswered) calls, so a long turn does not grow it without bound.
+func TestStuckDetector_ObserveError_CallInfoConsumed(t *testing.T) {
+	s := &stuckDetector{}
+	s.beginEvent()
+	s.observe("c1", "read", map[string]any{"path": "/foo"})
+	s.observe("c2", "write", map[string]any{"path": "/bar"})
+	if len(s.callInfo) != 2 {
+		t.Fatalf("callInfo len = %d, want 2 after two observed calls", len(s.callInfo))
+	}
+	s.observeError("c1", "read", false) // answer c1; the record must be consumed
+	if len(s.callInfo) != 1 {
+		t.Errorf("callInfo len = %d, want 1: answered calls must be consumed", len(s.callInfo))
+	}
+	if _, ok := s.callInfo["c1"]; ok {
+		t.Error("c1 still present after its response; the record was not consumed")
+	}
+	s.observeError("c2", "write", false)
+	if len(s.callInfo) != 0 {
+		t.Errorf("callInfo len = %d, want 0 after all calls answered", len(s.callInfo))
+	}
+}
+
+// TestStuckDetector_ObserveError_SameCall_EmptyIDsStillStuck pins that the
+// same call repeated with an empty ID across different messages still trips
+// the name-only streak: the name fallback supplies the batch, and distinct
+// messages compound.
+func TestStuckDetector_ObserveError_SameCall_EmptyIDsStillStuck(t *testing.T) {
+	s := &stuckDetector{}
+	tripped := false
+	for i := 0; i < maxToolErrorStreak; i++ {
+		s.beginEvent()
+		s.observe("", "get-model", map[string]any{"request": map[string]any{"author": "a", "slug": "b"}})
+		stuck, _ := s.observeError("", "get-model", true)
+		tripped = tripped || stuck
+	}
+	if !tripped {
+		t.Errorf("the same ID-less call failing %d times across messages must trip the name-only streak", maxToolErrorStreak)
+	}
+}
+
+// TestStuckDetector_ObserveError_SuccessResetsBothStreaks pins that a success
+// clears both error streaks, so the model recovering from a bad stretch is not
+// penalized later.
+func TestStuckDetector_ObserveError_SuccessResetsBothStreaks(t *testing.T) {
+	s := &stuckDetector{}
+	for i := 0; i < maxToolErrorStreak-1; i++ {
+		s.beginEvent()
+		id := fmt.Sprintf("call_%d", i)
+		s.observe(id, "get-model", map[string]any{"request": map[string]any{"author": "a", "slug": "b"}})
+		s.observeError(id, "get-model", true)
+	}
+	// A success resets everything.
+	s.beginEvent()
+	s.observe("ok", "get-model", map[string]any{"request": map[string]any{"author": "a", "slug": "b"}})
+	if stuck, _ := s.observeError("ok", "get-model", false); stuck {
+		t.Fatal("a successful call must not trip the detector")
+	}
+	if s.errFPStreak != 0 || s.errStreak != 0 {
+		t.Errorf("streaks not reset by success: errFPStreak=%d errStreak=%d", s.errFPStreak, s.errStreak)
 	}
 }
 


### PR DESCRIPTION
The name-only error streak counted every failure of the same tool name as
repetition, so a model that sent one message with ten get-model calls —
each targeting a different model, each failing with Model not found —
was aborted as a loop (session 260826-2200-b99f8-5b94b). That is a
single sweep over a list, not repetition.

Run two error streaks in parallel:
- args-aware: the same call (tool + argument fingerprint) failing
  maxToolErrorStreak times still trips, whatever message it is in.
- name-only, cross-batch: failures of the same tool name compound only
  when they answer calls from different model messages, so a batch of
  distinct calls in one message is one attempt. The flailing pattern —
  same tool, different args, once per message — still trips.

Calls and responses are correlated by FunctionCall.ID, recorded in
observe() and looked up in observeError(); beginEvent() marks the
message boundary on every event. Calls with an empty ID (synthetic
grounding, old transcripts) fall back to the name-only streak.

Signed-off-by: dimetron <dimetron@me.com>
