### PR TITLE
feat(sop): declarative SOPs on ADK 2.x with artifact validation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,6 +19,9 @@ find . -name '*.go' \
 # Stage any formatting changes
 git add -u
 
-# Run linters
+# Run linters. Scoped to repo packages: a bare `./...` also typechecks the
+# gitignored tmp/ scratch area (vendored third-party repos), whose samples
+# never compile standalone and would hard-fail every commit, including the
+# amends made by `git rebase --exec`.
 echo "Running golangci-lint..."
-golangci-lint run ./...
+golangci-lint run ./cmd/... ./internal/... ./hack/...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,14 @@ Agents marked `[worktree]` edit an isolated tree. Their edits do **not** land in
 the caller's tree — ask for an explicit patch or file list to apply, or use a
 non-worktree editing agent (`internal/tools/subagent.go:127-128`).
 
-## Commits: always sign off and sign
+## Commits: all commits must be signed
 
-Every commit must carry both a `Signed-off-by` trailer and a cryptographic
-signature:
+**Rule: every commit must be cryptographically signed and carry a
+`Signed-off-by` trailer.** There is no exception — not for merge commits, not
+for reverts, not for WIP or "just this once". An unsigned commit is a broken
+commit; fix it before pushing (see the pre-push hook below).
+
+The signing command:
 
 ```bash
 git commit -s -S -m "..."     # -s = Signed-off-by trailer, -S = sign
@@ -66,7 +70,9 @@ git commit -s -S -m "..."     # -s = Signed-off-by trailer, -S = sign
 
 `-S` is redundant when config is honoured (`commit.gpgsign` and `tag.gpgsign`
 are already `true`), but pass it explicitly so a commit fails loudly rather than
-landing unsigned when config is missing or overridden.
+landing unsigned when config is missing or overridden. The `pre-push` hook
+hard-fails any push containing an unsigned commit or one missing a matching
+`Signed-off-by` trailer, so an unsigned commit cannot reach the remote.
 
 Signing here is SSH-format, not GPG, through 1Password:
 

--- a/hack/sopcheck/describe.go
+++ b/hack/sopcheck/describe.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// describeSOP prints the compiled shape of a built-in SOP.
+func describeSOP(workDir, name string) int {
+	def, err := sop.LoadDefinition(workDir, name)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	compiled, err := sop.Compile(def, sop.DescribeFactory{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Print(compiled.Describe())
+	return 0
+}

--- a/hack/sopcheck/main.go
+++ b/hack/sopcheck/main.go
@@ -1,0 +1,119 @@
+// Command sopcheck validates the spec directories under specs/ against the
+// SOP artifact contracts, without running /plan or /run.
+//
+// Usage:
+//
+//	go run ./hack/sopcheck <repo-root>            # summary for every spec
+//	go run ./hack/sopcheck <repo-root> <spec>     # findings for one spec
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: sopcheck <repo-root> [spec-name]")
+		os.Exit(2)
+	}
+	root := os.Args[1]
+
+	if len(os.Args) > 2 {
+		os.Exit(reportOne(root, os.Args[2]))
+	}
+	reportAll(root)
+}
+
+func reportOne(root, name string) int {
+	spec, err := specdoc.Load(root, name)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load:", err)
+		return 1
+	}
+	findings := validate.Check(spec, root, validate.PlanContract())
+	for _, f := range findings {
+		fmt.Println(f.String())
+	}
+	if findings.OK() {
+		return 0
+	}
+	return 1
+}
+
+func reportAll(root string) {
+	specs := discover(root)
+	byRule := map[string]int{}
+	var planOK, preflightOK int
+
+	for _, name := range specs {
+		spec, err := specdoc.Load(root, name)
+		if err != nil {
+			continue
+		}
+		plan := validate.Check(spec, root, validate.PlanContract())
+		pre := validate.Check(spec, root, validate.RunPreflightContract())
+		if plan.OK() {
+			planOK++
+		}
+		if pre.OK() {
+			preflightOK++
+		}
+		for _, f := range plan.Errors() {
+			byRule[f.Rule]++
+		}
+		fmt.Printf("%-58s plan=%-4s preflight=%-4s errors=%d\n",
+			name, verdict(plan.OK()), verdict(pre.OK()), len(plan.Errors()))
+	}
+
+	fmt.Printf("\n%d specs — plan contract clean: %d, run preflight clean: %d\n",
+		len(specs), planOK, preflightOK)
+	fmt.Println("\nBlocking findings by rule:")
+	type kv struct {
+		rule string
+		n    int
+	}
+	var rows []kv
+	for r, n := range byRule {
+		rows = append(rows, kv{r, n})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].n > rows[j].n })
+	for _, r := range rows {
+		fmt.Printf("  %4d  %s\n", r.n, r.rule)
+	}
+}
+
+// discover lists every directory under specs/ that holds at least one artifact.
+func discover(root string) []string {
+	var out []string
+	specsDir := filepath.Join(root, "specs")
+	_ = filepath.WalkDir(specsDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil //nolint:nilerr // an unreadable directory is skipped, not fatal
+		}
+		for _, a := range []string{specdoc.Plan, specdoc.Prompt, specdoc.RoughIdea} {
+			if _, statErr := os.Stat(filepath.Join(p, a)); statErr == nil {
+				rel, relErr := filepath.Rel(specsDir, p)
+				if relErr == nil {
+					out = append(out, filepath.ToSlash(rel))
+				}
+				return nil
+			}
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out
+}
+
+func verdict(ok bool) string {
+	if ok {
+		return "OK"
+	}
+	return "FAIL"
+}

--- a/hack/sopcheck/main.go
+++ b/hack/sopcheck/main.go
@@ -19,10 +19,15 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: sopcheck <repo-root> [spec-name]")
+		fmt.Fprintln(os.Stderr, "usage: sopcheck <repo-root> [spec-name | sop:<plan|run>]")
 		os.Exit(2)
 	}
 	root := os.Args[1]
+
+	// `sopcheck <root> sop:<name>` prints the compiled shape of a built-in SOP.
+	if len(os.Args) > 2 && len(os.Args[2]) > 4 && os.Args[2][:4] == "sop:" {
+		os.Exit(describeSOP(root, os.Args[2][4:]))
+	}
 
 	if len(os.Args) > 2 {
 		os.Exit(reportOne(root, os.Args[2]))

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"iter"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -22,6 +21,7 @@ import (
 	piagent "github.com/dimetron/pi-go/internal/agent"
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/gitroot"
 	"github.com/dimetron/pi-go/internal/guardrail"
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/otel"
@@ -570,12 +570,9 @@ func buildMCPToolsetsFromCfg(cfg config.Config) []adktool.Toolset {
 	return ts
 }
 
+// detectGitRoot returns the repository root containing dir. Inside a linked
+// worktree it resolves the main checkout so the subagent sandbox covers the
+// whole repository. See internal/gitroot.
 func detectGitRoot(dir string) string {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	return gitroot.Detect(context.Background(), dir)
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -19,12 +19,14 @@ import (
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/session"
+
 	"google.golang.org/adk/v2/tool"
 	"google.golang.org/adk/v2/util/instructionutil"
 	"google.golang.org/genai"
 
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/logger"
+	pisession "github.com/dimetron/pi-go/internal/session"
 )
 
 // re-export callback types for use by CLI without importing llmagent directly.
@@ -507,6 +509,13 @@ type titleNamer interface {
 	SetSessionTitle(sessionID, title string) error
 }
 
+// agentContextRecorder is implemented by session services that can persist a
+// session's place in an agent tree. Declared here for the same reason as
+// titleNamer: the agent takes the capability, not the concrete service.
+type agentContextRecorder interface {
+	UpdateAgentContext(sessionID string, ctx *pisession.AgentContext) error
+}
+
 // CreateSession creates a new session and returns its ID together with the
 // default title that was applied (git repo name, or CWD basename) — or "" if
 // no title was set. The title is metadata only; the TUI seeds its terminal
@@ -521,6 +530,15 @@ func (a *Agent) CreateSession(ctx context.Context) (sessionID, defaultTitle stri
 		return "", "", fmt.Errorf("creating session: %w", err)
 	}
 	sid := resp.Session.ID()
+	// Record this process's place in an agent tree, if it has one. A spawned
+	// worker knows its coordinator, spec, slice and cycle only through the
+	// environment; writing them here is what makes a run tree a field lookup
+	// instead of an inference from workDir and title prefixes.
+	if ac, ok := a.sessionService.(agentContextRecorder); ok {
+		if actx := pisession.AgentContextFromEnv(); actx != nil {
+			_ = ac.UpdateAgentContext(sid, actx) // best-effort metadata
+		}
+	}
 	if mn, ok := a.sessionService.(modelNamer); ok {
 		modelName := ""
 		if a.config.Model != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	_ "net/http/pprof" // registers pprof HTTP handlers on /debug/pprof
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -26,6 +25,7 @@ import (
 	"github.com/dimetron/pi-go/internal/agent"
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/gitroot"
 	"github.com/dimetron/pi-go/internal/guardrail"
 	"github.com/dimetron/pi-go/internal/httplog"
 	"github.com/dimetron/pi-go/internal/jsonrpc"
@@ -1864,16 +1864,13 @@ const gitCmdTimeout = 5 * time.Second
 
 // detectGitRoot returns the git repository root for the given directory,
 // or empty string if not inside a git repo.
+//
+// Inside a linked worktree this resolves the *main* checkout, not the worktree
+// — the value becomes PI_SANDBOX_ROOT for spawned subagents, and rooting that
+// at a worktree makes every file-tool access to the rest of the repo fail.
+// See internal/gitroot.
 func detectGitRoot(ctx context.Context, dir string) string {
-	ctx, cancel := context.WithTimeout(ctx, gitCmdTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	return gitroot.Detect(ctx, dir)
 }
 
 // LoadDotEnv loads environment variables from ~/.pi-go/.env and the nearest

--- a/internal/codex/process_windows.go
+++ b/internal/codex/process_windows.go
@@ -7,5 +7,5 @@ import "os/exec"
 func setPlatformAttrs(cmd *exec.Cmd) {
 	// On Windows there is no process-group signal mechanism equivalent
 	// to Unix Setpgid + Kill(-pgid). The default CommandContext
-	// behaviour (TerminateProcess) is sufficient.
+	// behavior (TerminateProcess) is sufficient.
 }

--- a/internal/gitroot/gitroot.go
+++ b/internal/gitroot/gitroot.go
@@ -1,0 +1,81 @@
+// Package gitroot resolves the repository root that a sandbox should cover.
+//
+// The distinction this package exists for: `git rev-parse --show-toplevel`
+// run from inside a *linked worktree* returns the worktree directory, not the
+// main checkout. pi-go spawns subagents whose working directory is a linked
+// worktree (`.pi-go/tasks/<id>`, `.worktrees/<branch>`), and each spawned pi
+// process derives its own PI_SANDBOX_ROOT. Using the toplevel there roots the
+// sandbox at the worktree, so every read or edit of a path elsewhere in the
+// repo is rejected as escaping the sandbox — which is what made /run workers
+// fall back to shelling out instead of using the file tools.
+//
+// Detect resolves the main checkout instead, so a worker in a worktree can
+// still reach the whole repository.
+package gitroot
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CmdTimeout bounds every git subprocess this package spawns so a stalled
+// repository (blocked hook, lock contention, unreachable network mount) cannot
+// hang initialization indefinitely.
+const CmdTimeout = 5 * time.Second
+
+// Detect returns the main checkout of the repository containing dir, or "" when
+// dir is not inside a repository.
+//
+// For an ordinary checkout this is the same as `git rev-parse --show-toplevel`.
+// For a linked worktree it is the main checkout the worktree belongs to,
+// resolved through the common git directory.
+func Detect(ctx context.Context, dir string) string {
+	top := revParse(ctx, dir, "--show-toplevel")
+	if top == "" {
+		return ""
+	}
+	if main := mainCheckout(ctx, dir); main != "" {
+		return main
+	}
+	return top
+}
+
+// Toplevel returns the working tree containing dir — the linked worktree itself
+// when dir is inside one. Callers that mean "the directory this checkout owns"
+// rather than "the repository" want this.
+func Toplevel(ctx context.Context, dir string) string {
+	return revParse(ctx, dir, "--show-toplevel")
+}
+
+// mainCheckout derives the main checkout from the common git directory. It
+// returns "" when the layout is anything other than a plain `<checkout>/.git`
+// — a bare repository, a separate GIT_DIR, or a git too old for
+// --path-format — leaving the caller with the toplevel it already has.
+func mainCheckout(ctx context.Context, dir string) string {
+	common := revParse(ctx, dir, "--path-format=absolute", "--git-common-dir")
+	if common == "" || filepath.Base(common) != ".git" {
+		return ""
+	}
+	parent := filepath.Dir(common)
+	st, err := os.Stat(parent)
+	if err != nil || !st.IsDir() {
+		return ""
+	}
+	return parent
+}
+
+func revParse(ctx context.Context, dir string, args ...string) string {
+	ctx, cancel := context.WithTimeout(ctx, CmdTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", append([]string{"rev-parse"}, args...)...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/gitroot/gitroot_test.go
+++ b/internal/gitroot/gitroot_test.go
@@ -1,0 +1,103 @@
+package gitroot
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initRepo makes dir a repository with one commit so worktrees can be added.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run(t, dir, "git", "init", "-q", "-b", "main")
+	run(t, dir, "git", "config", "user.email", "t@example.com")
+	run(t, dir, "git", "config", "user.name", "t")
+	run(t, dir, "git", "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-q", "-m", "init")
+	return dir
+}
+
+func run(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+	}
+}
+
+// resolve normalizes macOS /var -> /private/var symlinking.
+func resolve(t *testing.T, p string) string {
+	t.Helper()
+	r, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", p, err)
+	}
+	return r
+}
+
+func TestDetectPlainCheckout(t *testing.T) {
+	repo := initRepo(t)
+	got := Detect(t.Context(), repo)
+	if got == "" {
+		t.Fatal("Detect() = empty, want the repository root")
+	}
+	if resolve(t, got) != resolve(t, repo) {
+		t.Errorf("Detect() = %q, want %q", got, repo)
+	}
+}
+
+func TestDetectFromSubdirectory(t *testing.T) {
+	repo := initRepo(t)
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if resolve(t, Detect(t.Context(), sub)) != resolve(t, repo) {
+		t.Errorf("Detect(subdir) did not return the repository root")
+	}
+}
+
+// TestDetectFromLinkedWorktree is the regression this package exists for:
+// --show-toplevel returns the worktree, Detect must return the main checkout.
+func TestDetectFromLinkedWorktree(t *testing.T) {
+	repo := initRepo(t)
+	wt := filepath.Join(t.TempDir(), "wt")
+	run(t, repo, "git", "worktree", "add", "-q", "-b", "side", wt)
+
+	top := Toplevel(t.Context(), wt)
+	if resolve(t, top) != resolve(t, wt) {
+		t.Fatalf("Toplevel(worktree) = %q, want the worktree %q", top, wt)
+	}
+
+	got := Detect(t.Context(), wt)
+	if resolve(t, got) != resolve(t, repo) {
+		t.Errorf("Detect(worktree) = %q, want the main checkout %q", got, repo)
+	}
+	if resolve(t, got) == resolve(t, wt) {
+		t.Error("Detect(worktree) returned the worktree — sandbox would be rooted too narrowly")
+	}
+}
+
+func TestDetectNonRepo(t *testing.T) {
+	dir := t.TempDir()
+	// A temp dir may sit inside no repository; if the harness places it inside
+	// one, Detect legitimately finds that one. Only assert the non-repo case.
+	if got := Detect(t.Context(), dir); got != "" {
+		if _, err := os.Stat(filepath.Join(got, ".git")); err != nil {
+			t.Errorf("Detect(non-repo) = %q, which has no .git", got)
+		}
+	}
+}
+
+func TestDetectMissingDir(t *testing.T) {
+	if got := Detect(t.Context(), filepath.Join(t.TempDir(), "nope")); got != "" {
+		t.Errorf("Detect(missing dir) = %q, want empty", got)
+	}
+}

--- a/internal/provider/xai_e2e_test.go
+++ b/internal/provider/xai_e2e_test.go
@@ -16,7 +16,7 @@ import (
 
 // e2eXAIModel is the tier these tests bill against. grok-4.6 is xAI's current
 // flagship and the one whose reasoning_effort tiers are documented, so it is
-// the model whose behaviour these tests are actually meant to pin.
+// the model whose behavior these tests are actually meant to pin.
 const e2eXAIModel = "grok-4.6"
 
 func testGetXAIAPIKey(t *testing.T) string {

--- a/internal/session/agentenv.go
+++ b/internal/session/agentenv.go
@@ -1,0 +1,96 @@
+package session
+
+import (
+	"os"
+	"strconv"
+)
+
+// Environment variables carrying a spawned agent's place in its run tree.
+//
+// They ride the existing PI_ allowlist prefix (internal/subagent/environ.go),
+// so a parent that sets them reaches its child without further plumbing. The
+// child records them on its own session metadata at creation time, which turns
+// every question the 2026-08-10 investigation answered by inference — which
+// coordinator owns this worker, which spec, which slice, is this a retry — into
+// a field lookup.
+const (
+	EnvAgentID       = "PI_AGENT_ID"
+	EnvAgentType     = "PI_AGENT_TYPE"
+	EnvRunID         = "PI_RUN_ID"
+	EnvSpecName      = "PI_SPEC_NAME"
+	EnvSlice         = "PI_RUN_SLICE"
+	EnvCycle         = "PI_RUN_CYCLE"
+	EnvParentSession = "PI_PARENT_SESSION"
+	EnvAgentBranch   = "PI_AGENT_BRANCH"
+	// EnvWorktreeRoot is already set by the orchestrator for path
+	// normalization; the agent context records it too so a worktree on disk
+	// can be traced back to the spec it belongs to.
+	EnvWorktreeRoot = "PI_WORKTREE_ROOT"
+)
+
+// AgentContextFromEnv builds an AgentContext from the spawn environment, or
+// returns nil when this process was not spawned as part of an agent tree.
+//
+// An interactive session sets none of these, so the block stays absent from
+// meta.json exactly as PlanContext does.
+func AgentContextFromEnv() *AgentContext {
+	ctx := &AgentContext{
+		AgentID:   os.Getenv(EnvAgentID),
+		AgentType: os.Getenv(EnvAgentType),
+		RunID:     os.Getenv(EnvRunID),
+		SpecName:  os.Getenv(EnvSpecName),
+		ParentID:  os.Getenv(EnvParentSession),
+		Worktree:  os.Getenv(EnvWorktreeRoot),
+		Branch:    os.Getenv(EnvAgentBranch),
+		Slice:     envInt(EnvSlice),
+		Cycle:     envInt(EnvCycle),
+	}
+	if ctx.isEmpty() {
+		return nil
+	}
+	return ctx
+}
+
+// isEmpty reports whether nothing identifying was set. Worktree alone does not
+// count: the orchestrator sets it for every spawned agent including ones with
+// no run attribution, and a context holding only a path answers none of the
+// questions the block exists for.
+func (a *AgentContext) isEmpty() bool {
+	return a.AgentID == "" && a.AgentType == "" && a.RunID == "" &&
+		a.SpecName == "" && a.ParentID == "" && a.Branch == ""
+}
+
+// Env renders the context as environment assignments for a child process.
+// Empty fields are omitted so a child never inherits a misleading zero.
+func (a *AgentContext) Env() []string {
+	if a == nil {
+		return nil
+	}
+	var out []string
+	add := func(k, v string) {
+		if v != "" {
+			out = append(out, k+"="+v)
+		}
+	}
+	add(EnvAgentID, a.AgentID)
+	add(EnvAgentType, a.AgentType)
+	add(EnvRunID, a.RunID)
+	add(EnvSpecName, a.SpecName)
+	add(EnvParentSession, a.ParentID)
+	add(EnvAgentBranch, a.Branch)
+	if a.Slice > 0 {
+		add(EnvSlice, strconv.Itoa(a.Slice))
+	}
+	if a.Cycle > 0 {
+		add(EnvCycle, strconv.Itoa(a.Cycle))
+	}
+	return out
+}
+
+func envInt(key string) int {
+	n, err := strconv.Atoi(os.Getenv(key))
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}

--- a/internal/session/agentenv_test.go
+++ b/internal/session/agentenv_test.go
@@ -1,0 +1,138 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAgentContextFromEnvAbsentForInteractiveSessions(t *testing.T) {
+	// No PI_AGENT_* variables set: an ordinary session must record nothing, the
+	// same way PlanContext stays absent.
+	for _, k := range []string{EnvAgentID, EnvAgentType, EnvRunID, EnvSpecName, EnvParentSession, EnvAgentBranch, EnvSlice, EnvCycle, EnvWorktreeRoot} {
+		t.Setenv(k, "")
+	}
+	if got := AgentContextFromEnv(); got != nil {
+		t.Errorf("AgentContextFromEnv() = %+v, want nil for an unattributed process", got)
+	}
+}
+
+// A worktree path alone is not attribution: the orchestrator sets it for every
+// spawned agent, and it answers none of the questions the block exists for.
+func TestAgentContextFromEnvIgnoresWorktreeAlone(t *testing.T) {
+	t.Setenv(EnvWorktreeRoot, "/repo/.pi-go/tasks/763098722000")
+	if got := AgentContextFromEnv(); got != nil {
+		t.Errorf("AgentContextFromEnv() = %+v, want nil when only the worktree is set", got)
+	}
+}
+
+func TestAgentContextFromEnv(t *testing.T) {
+	t.Setenv(EnvAgentID, "agent-7")
+	t.Setenv(EnvAgentType, "worker")
+	t.Setenv(EnvRunID, "run-features-x-123")
+	t.Setenv(EnvSpecName, "features/TOO/024-mistral-provider")
+	t.Setenv(EnvParentSession, "260827-0205-03249-00fa4")
+	t.Setenv(EnvSlice, "3")
+	t.Setenv(EnvCycle, "2")
+	t.Setenv(EnvWorktreeRoot, "/repo/.pi-go/tasks/x")
+	t.Setenv(EnvAgentBranch, "run/features-TOO-024")
+
+	got := AgentContextFromEnv()
+	if got == nil {
+		t.Fatal("AgentContextFromEnv() = nil, want a populated context")
+	}
+	want := AgentContext{
+		AgentID: "agent-7", AgentType: "worker", RunID: "run-features-x-123",
+		SpecName: "features/TOO/024-mistral-provider", ParentID: "260827-0205-03249-00fa4",
+		Slice: 3, Cycle: 2, Worktree: "/repo/.pi-go/tasks/x", Branch: "run/features-TOO-024",
+	}
+	if *got != want {
+		t.Errorf("AgentContextFromEnv() = %+v, want %+v", *got, want)
+	}
+}
+
+func TestAgentContextFromEnvIgnoresUnparseableNumbers(t *testing.T) {
+	t.Setenv(EnvAgentID, "agent-7")
+	t.Setenv(EnvSlice, "not-a-number")
+	t.Setenv(EnvCycle, "-3")
+
+	got := AgentContextFromEnv()
+	if got == nil {
+		t.Fatal("nil context")
+	}
+	if got.Slice != 0 || got.Cycle != 0 {
+		t.Errorf("Slice/Cycle = %d/%d, want 0/0 for unparseable values", got.Slice, got.Cycle)
+	}
+}
+
+func TestAgentContextEnvRoundTrip(t *testing.T) {
+	src := &AgentContext{
+		AgentID: "a1", AgentType: "worker", RunID: "r1", SpecName: "features/x",
+		ParentID: "p1", Slice: 4, Cycle: 1, Branch: "run/x",
+	}
+	for _, kv := range src.Env() {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("malformed env entry %q", kv)
+		}
+		t.Setenv(k, v)
+	}
+	// Worktree is set by the orchestrator, not by Env; clear it so the
+	// round-trip compares like with like.
+	t.Setenv(EnvWorktreeRoot, "")
+
+	got := AgentContextFromEnv()
+	if got == nil {
+		t.Fatal("round trip produced nil")
+	}
+	if *got != *src {
+		t.Errorf("round trip = %+v, want %+v", *got, *src)
+	}
+}
+
+func TestAgentContextEnvOmitsEmptyFields(t *testing.T) {
+	got := (&AgentContext{AgentID: "a1"}).Env()
+	if len(got) != 1 || got[0] != EnvAgentID+"=a1" {
+		t.Errorf("Env() = %v, want only the set field", got)
+	}
+	if (*AgentContext)(nil).Env() != nil {
+		t.Error("nil context produced env entries")
+	}
+}
+
+func TestUpdateAndGetAgentContext(t *testing.T) {
+	svc := newTestService(t)
+	sessionID := createTestSession(t, svc)
+
+	want := &AgentContext{
+		AgentID: "agent-7", AgentType: "worker", RunID: "run-1",
+		SpecName: "features/x", Slice: 3, Cycle: 1,
+		Worktree: "/repo/.pi-go/tasks/x", Branch: "run/features-x",
+	}
+	if err := svc.UpdateAgentContext(sessionID, want); err != nil {
+		t.Fatalf("UpdateAgentContext: %v", err)
+	}
+	got, err := svc.GetAgentContext(sessionID)
+	if err != nil {
+		t.Fatalf("GetAgentContext: %v", err)
+	}
+	if got == nil || *got != *want {
+		t.Errorf("GetAgentContext = %+v, want %+v", got, want)
+	}
+
+	if err := svc.UpdateAgentContext(sessionID, nil); err != nil {
+		t.Fatalf("clearing: %v", err)
+	}
+	if got, _ := svc.GetAgentContext(sessionID); got != nil {
+		t.Errorf("context = %+v after clearing, want nil", got)
+	}
+}
+
+func TestAgentContextUnknownSession(t *testing.T) {
+	svc := newTestService(t)
+	if err := svc.UpdateAgentContext("nope", &AgentContext{AgentID: "a"}); err == nil {
+		t.Error("UpdateAgentContext on an unknown session returned no error")
+	}
+	if _, err := svc.GetAgentContext("nope"); err == nil {
+		t.Error("GetAgentContext on an unknown session returned no error")
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -70,6 +70,31 @@ type Meta struct {
 	Host *HostEnv `json:"host,omitempty"`
 
 	PlanContext *PlanContext `json:"planContext,omitempty"`
+
+	// Agent records this session's place in a /run or /plan agent tree. It is
+	// absent for ordinary interactive sessions.
+	Agent *AgentContext `json:"agentContext,omitempty"`
+}
+
+// AgentContext records where a session sits in an agent tree.
+//
+// Reconstructing a run previously meant grouping sessions by workDir and
+// inferring roles from title prefixes; sessions in numerically-named worktrees
+// (.pi-go/tasks/763098722000) could not be attributed to a spec by any recorded
+// field at all, and three such worktrees are still on disk with nothing to say
+// what they were for. Every question that investigation had to answer by
+// inference is a field here.
+type AgentContext struct {
+	AgentID   string `json:"agentID,omitempty"`   // the orchestrator's ID for this agent
+	AgentType string `json:"agentType,omitempty"` // task | worker | quick-task | code-reviewer | explore
+	ParentID  string `json:"parentSessionID,omitempty"`
+	RunID     string `json:"runID,omitempty"` // groups every session of one /run
+	SpecName  string `json:"specName,omitempty"`
+	Slice     int    `json:"slice,omitempty"`
+	Cycle     int    `json:"cycle,omitempty"` // /run retry index
+	Worktree  string `json:"worktree,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	Status    string `json:"status,omitempty"` // terminal status, written when the run ends
 }
 
 // maxCachedSessions is the maximum number of sessions kept in the in-memory
@@ -700,6 +725,37 @@ func (s *FileService) UpdatePlanContext(sessionID string, ctx *PlanContext) erro
 	sess.meta.PlanContext = ctx
 	sessionDir := filepath.Join(s.baseDir, sessionID)
 	return writeMeta(sessionDir, &sess.meta)
+}
+
+// UpdateAgentContext records a session's place in an agent tree.
+// Pass nil to clear it.
+func (s *FileService) UpdateAgentContext(sessionID string, ctx *AgentContext) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	sess.meta.Agent = ctx
+	sessionDir := filepath.Join(s.baseDir, sessionID)
+	return writeMeta(sessionDir, &sess.meta)
+}
+
+// GetAgentContext returns the agent context for a session, or nil if unset.
+func (s *FileService) GetAgentContext(sessionID string) (*AgentContext, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("session not found: %s", sessionID)
+	}
+	sess.mu.RLock()
+	defer sess.mu.RUnlock()
+	return sess.meta.Agent, nil
 }
 
 // GetPlanContext returns the plan context for the given session, or nil if not found.

--- a/internal/sop/compile.go
+++ b/internal/sop/compile.go
@@ -1,0 +1,238 @@
+package sop
+
+import (
+	"fmt"
+	"time"
+
+	"google.golang.org/adk/v2/workflow"
+)
+
+// RecheckSignal is the output a looping stage emits to take its loop_back
+// edge. A repair stage that fixes nothing does not emit it, and the loop ends.
+const RecheckSignal = "RECHECK"
+
+// NodeFactory builds the executable body for one stage.
+//
+// The compiler owns the graph — what runs, in what order, how often it retries,
+// and what must be true before an edge is taken. The factory owns what a stage
+// actually does. Splitting them is the point: the scheduling that used to live
+// in a prompt ("Follow these phases in order", "on FAIL dispatch fix workers")
+// becomes edges the scheduler walks, while the part an LLM should decide stays
+// in the node body.
+type NodeFactory interface {
+	// AgentNode builds a node whose body is an LLM turn.
+	AgentNode(stage Stage, cfg workflow.NodeConfig) (workflow.Node, error)
+	// FunctionNode builds a deterministic node: validators, gates, git.
+	FunctionNode(stage Stage, cfg workflow.NodeConfig) (workflow.Node, error)
+	// ReviewNode builds a checkpoint — a human approval or an agent verdict.
+	ReviewNode(stage Stage, review Review, cfg workflow.NodeConfig) (workflow.Node, error)
+}
+
+// Compiled is a SOP definition turned into a runnable graph.
+type Compiled struct {
+	Definition *Definition
+	Edges      []workflow.Edge
+	// Nodes is indexed by stage id, and by "<id>.review" for a stage's
+	// review checkpoint.
+	Nodes map[string]workflow.Node
+	Order []string
+}
+
+// Compile turns a definition into workflow edges using factory for the node
+// bodies. It lints first: compiling a definition with a dangling edge would
+// produce a graph that silently stops early.
+func Compile(def *Definition, factory NodeFactory) (*Compiled, error) {
+	if findings := LintDefinition(def); !findings.OK() {
+		return nil, fmt.Errorf("SOP %q does not lint:\n%s", def.SOP, findings.Format())
+	}
+
+	c := &Compiled{Definition: def, Nodes: map[string]workflow.Node{}}
+	stages := def.AllStages()
+
+	for _, s := range stages {
+		if err := c.buildStage(s, def, factory); err != nil {
+			return nil, err
+		}
+	}
+	if err := c.wire(stages, def); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Compiled) buildStage(s Stage, def *Definition, factory NodeFactory) error {
+	cfg := NodeConfigFor(s, def.Defaults)
+
+	var (
+		node workflow.Node
+		err  error
+	)
+	if s.EffectiveKind() == "agent" {
+		node, err = factory.AgentNode(s, cfg)
+	} else {
+		node, err = factory.FunctionNode(s, cfg)
+	}
+	if err != nil {
+		return fmt.Errorf("stage %q: %w", s.ID, err)
+	}
+	if node == nil {
+		return fmt.Errorf("stage %q: factory returned no node", s.ID)
+	}
+	c.Nodes[s.ID] = node
+	c.Order = append(c.Order, s.ID)
+
+	if s.Review == nil {
+		return nil
+	}
+	// A review is its own node so the verdict can route an edge. Folding it
+	// into the producing stage is what made the prose Verifier advisory.
+	rcfg := NodeConfigFor(Stage{ID: s.ID + ".review", Timeout: s.Timeout}, def.Defaults)
+	rnode, err := factory.ReviewNode(s, *s.Review, rcfg)
+	if err != nil {
+		return fmt.Errorf("stage %q review: %w", s.ID, err)
+	}
+	if rnode != nil {
+		c.Nodes[s.ID+".review"] = rnode
+		c.Order = append(c.Order, s.ID+".review")
+	}
+	return nil
+}
+
+// wire builds the edges. A stage with a review runs stage → review → successor,
+// so the checkpoint sits on the path rather than beside it.
+func (c *Compiled) wire(stages []Stage, def *Definition) error {
+	b := workflow.NewEdgeBuilder()
+
+	// The engine needs an explicit entry edge. The first stage is the entry
+	// point: preflight when the SOP declares one, so a spec that cannot
+	// succeed is rejected before any worktree is created.
+	if len(stages) > 0 {
+		b.Add(workflow.Start, c.Nodes[stages[0].ID])
+	}
+
+	for _, s := range stages {
+		from := c.Nodes[s.ID]
+		if r, ok := c.Nodes[s.ID+".review"]; ok {
+			b.Add(from, r)
+			from = r
+		}
+
+		switch {
+		case len(s.Routes) > 0:
+			routes := make(map[string]workflow.Node, len(s.Routes))
+			for verdict, target := range s.Routes {
+				to, ok := c.Nodes[target]
+				if !ok {
+					return fmt.Errorf("stage %q routes %q to unknown stage %q", s.ID, verdict, target)
+				}
+				routes[verdict] = to
+			}
+			b.AddRoutes(from, routes)
+		case s.LoopBack != "":
+			to, ok := c.Nodes[s.LoopBack]
+			if !ok {
+				return fmt.Errorf("stage %q loops back to unknown stage %q", s.ID, s.LoopBack)
+			}
+			// A loop-back is conditional, not a barrier: the target already has
+			// an unconditional predecessor on the forward path, and a JoinNode
+			// there would wait for the repair branch on every first pass. The
+			// stage emits RecheckSignal when it has something to re-verify.
+			b.AddRoute(from, to, workflow.StringRoute(RecheckSignal))
+		case s.Next != "":
+			to, ok := c.Nodes[s.Next]
+			if !ok {
+				return fmt.Errorf("stage %q advances to unknown stage %q", s.ID, s.Next)
+			}
+			b.Add(from, to)
+		}
+
+		// A failure path that names a stage is an edge too: it is how a gate
+		// failure reaches the repair stage without the coordinator deciding to.
+		if target := s.OnFail; target != "" && target != "abort" && target != "retry" {
+			to, ok := c.Nodes[target]
+			if !ok {
+				return fmt.Errorf("stage %q fails over to unknown stage %q", s.ID, target)
+			}
+			b.AddRoute(from, to, workflow.StringRoute("FAIL"))
+		}
+	}
+
+	c.Edges = b.Build()
+	if len(c.Edges) == 0 && len(stages) > 1 {
+		return fmt.Errorf("SOP %q compiled to no edges: no stage declares next, routes or loop_back", def.SOP)
+	}
+	return nil
+}
+
+// NodeConfigFor derives a node's runtime configuration from its stage and the
+// definition's defaults.
+//
+// This is where the SOP's declared bounds become the engine's: a per-stage
+// timeout instead of one blanket 60-minute spawn timeout, and retry with
+// backoff and jitter instead of a counter that re-sends the whole briefing.
+func NodeConfigFor(s Stage, defaults Defaults) workflow.NodeConfig {
+	cfg := workflow.NodeConfig{}
+
+	timeout := s.Timeout.Duration()
+	if timeout == 0 {
+		timeout = defaults.Timeout.Duration()
+	}
+	cfg.Timeout = timeout
+
+	retry := s.Retry
+	if retry == nil {
+		retry = defaults.Retry
+	}
+	if retry != nil {
+		cfg.RetryConfig = retryConfig(*retry)
+	}
+
+	if s.FanOut != nil {
+		cfg.ParallelWorker = true
+	}
+	return cfg
+}
+
+// retryConfig maps the SOP's retry block onto the engine's, starting from the
+// engine defaults so an unset field keeps a sensible value rather than zero.
+func retryConfig(r Retry) *workflow.RetryConfig {
+	cfg := workflow.DefaultRetryConfig()
+	if r.MaxAttempts > 0 {
+		cfg.MaxAttempts = r.MaxAttempts
+	}
+	if d := r.InitialDelay.Duration(); d > 0 {
+		cfg.InitialDelay = d
+	}
+	if d := r.MaxDelay.Duration(); d > 0 {
+		cfg.MaxDelay = d
+	}
+	if r.Backoff > 0 {
+		cfg.BackoffFactor = r.Backoff
+	}
+	if r.Jitter > 0 {
+		cfg.Jitter = r.Jitter
+	}
+	return cfg
+}
+
+// Workflow assembles the compiled edges into a runnable workflow.
+func (c *Compiled) Workflow() (*workflow.Workflow, error) {
+	opts := []workflow.Option{}
+	if n := c.Definition.Defaults.MaxConcurrency; n > 0 {
+		opts = append(opts, workflow.WithMaxConcurrency(n))
+	}
+	wf, err := workflow.New(c.Definition.SOP, c.Edges, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building workflow %q: %w", c.Definition.SOP, err)
+	}
+	return wf, nil
+}
+
+// Timeouts reports each stage's effective timeout, for inspection and tests.
+func (c *Compiled) Timeouts() map[string]time.Duration {
+	out := map[string]time.Duration{}
+	for _, s := range c.Definition.AllStages() {
+		out[s.ID] = NodeConfigFor(s, c.Definition.Defaults).Timeout
+	}
+	return out
+}

--- a/internal/sop/describe.go
+++ b/internal/sop/describe.go
@@ -1,0 +1,116 @@
+package sop
+
+import (
+	"fmt"
+	"iter"
+	"sort"
+	"strings"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/workflow"
+)
+
+// DescribeFactory builds a graph whose nodes carry each stage's identity and
+// configuration but do no work.
+//
+// It exists so a SOP can be compiled, linted and inspected without a provider,
+// a worktree or a running agent — which is what makes the definitions testable
+// and what lets `pi` report the shape of a SOP before executing one. Phase 3
+// supplies the factory that runs real agents; the graph it produces is the
+// same graph.
+type DescribeFactory struct{}
+
+func (DescribeFactory) AgentNode(s Stage, cfg workflow.NodeConfig) (workflow.Node, error) {
+	return newDescribeNode(s.ID, describeStage(s, "agent"), cfg), nil
+}
+
+func (DescribeFactory) FunctionNode(s Stage, cfg workflow.NodeConfig) (workflow.Node, error) {
+	return newDescribeNode(s.ID, describeStage(s, "function"), cfg), nil
+}
+
+func (DescribeFactory) ReviewNode(s Stage, r Review, cfg workflow.NodeConfig) (workflow.Node, error) {
+	what := "human approval: " + r.Prompt
+	if r.Kind == "agent" {
+		what = "agent review by " + r.Agent
+	}
+	return newDescribeNode(s.ID+".review", what, cfg), nil
+}
+
+// describeStage renders one stage in a line, naming the things that used to be
+// prose the model could decline: what it dispatches to, what it must produce,
+// and what gate proves it.
+func describeStage(s Stage, kind string) string {
+	var parts []string
+	parts = append(parts, kind)
+	if a := s.AgentName(); a != "" {
+		parts = append(parts, "agent="+a)
+	}
+	if s.FanOut != nil {
+		parts = append(parts, fmt.Sprintf("fan_out over %s (max %d)", s.FanOut.Over, s.FanOut.MaxConcurrency))
+	}
+	for _, p := range s.Produces {
+		parts = append(parts, "produces "+p.Path+" ["+strings.Join(p.Validate, ", ")+"]")
+	}
+	if s.Gate != "" {
+		parts = append(parts, "gate="+s.Gate)
+	}
+	if s.Description != "" {
+		parts = append(parts, s.Description)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// describeNode is a workflow.Node that reports itself and completes.
+type describeNode struct {
+	workflow.BaseNode
+}
+
+func newDescribeNode(name, description string, cfg workflow.NodeConfig) workflow.Node {
+	return &describeNode{BaseNode: workflow.NewBaseNode(name, description, cfg)}
+}
+
+func (n *describeNode) Run(ctx agent.Context, input any) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(nil, fmt.Errorf("node %q is a description only; compile with a real NodeFactory to execute", n.Name()))
+	}
+}
+
+// Describe renders a compiled SOP as text: the stages in order, their bounds,
+// and the edges between them.
+func (c *Compiled) Describe() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "SOP %q v%d — %s\n", c.Definition.SOP, c.Definition.Version, c.Definition.Description)
+	fmt.Fprintf(&b, "workspace: worktree=%s branch=%s merge_on=%s cleanup=%s\n",
+		c.Definition.Workspace.Worktree, c.Definition.Workspace.Branch,
+		c.Definition.Workspace.MergeOn, c.Definition.Workspace.Cleanup)
+	fmt.Fprintf(&b, "max concurrency: %d\n\n", c.Definition.Defaults.MaxConcurrency)
+
+	b.WriteString("Stages:\n")
+	timeouts := c.Timeouts()
+	for _, s := range c.Definition.AllStages() {
+		fmt.Fprintf(&b, "  %-14s %-9s timeout=%s", s.ID, s.EffectiveKind(), timeouts[s.ID])
+		cfg := NodeConfigFor(s, c.Definition.Defaults)
+		if cfg.RetryConfig != nil {
+			fmt.Fprintf(&b, " retry=%dx", cfg.RetryConfig.MaxAttempts)
+		}
+		if s.FanOut != nil {
+			fmt.Fprintf(&b, " fan_out=%s", s.FanOut.Over)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\nEdges:\n")
+	lines := make([]string, 0, len(c.Edges))
+	for _, e := range c.Edges {
+		label := ""
+		if e.Route != nil {
+			label = fmt.Sprintf(" [%v]", e.Route)
+		}
+		lines = append(lines, fmt.Sprintf("  %s -> %s%s", e.From.Name(), e.To.Name(), label))
+	}
+	sort.Strings(lines)
+	b.WriteString(strings.Join(lines, "\n"))
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/sop/load.go
+++ b/internal/sop/load.go
@@ -1,0 +1,71 @@
+package sop
+
+import (
+	_ "embed"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+//go:embed plan.sop.yaml
+var defaultPlanSOP []byte
+
+//go:embed run.sop.yaml
+var defaultRunSOP []byte
+
+// LoadDefinition returns the declarative SOP named `name` ("plan" or "run").
+//
+// Resolution mirrors LoadPDD: project .pi-go/sops/<name>.sop.yaml → global
+// ~/.pi-go/sops/<name>.sop.yaml → embedded default. An override that fails to
+// parse or lint is reported rather than silently ignored — a SOP that does not
+// compile is a SOP that would schedule nothing.
+func LoadDefinition(workDir, name string) (*Definition, error) {
+	data, source := resolveDefinition(workDir, name)
+	def, err := ParseDefinition(data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", source, err)
+	}
+	if findings := LintDefinition(def); !findings.OK() {
+		return nil, fmt.Errorf("%s is not a valid SOP:\n%s", source, findings.Format())
+	}
+	slog.Debug("loaded declarative SOP", "name", name, "source", source, "stages", len(def.Stages))
+	return def, nil
+}
+
+// LintDefinitionFile parses and lints a SOP file without installing it, so a
+// user editing an override can check it.
+func LintDefinitionFile(path string) (validate.Findings, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	def, err := ParseDefinition(data)
+	if err != nil {
+		return nil, err
+	}
+	return LintDefinition(def), nil
+}
+
+func resolveDefinition(workDir, name string) (data []byte, source string) {
+	file := name + ".sop.yaml"
+
+	projectPath := filepath.Join(workDir, ".pi-go", "sops", file)
+	if b, err := os.ReadFile(projectPath); err == nil {
+		return b, projectPath
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		globalPath := filepath.Join(home, ".pi-go", "sops", file)
+		if b, err := os.ReadFile(globalPath); err == nil {
+			return b, globalPath
+		}
+	}
+	switch name {
+	case "run":
+		return defaultRunSOP, "embedded run.sop.yaml"
+	default:
+		return defaultPlanSOP, "embedded plan.sop.yaml"
+	}
+}

--- a/internal/sop/manifest.go
+++ b/internal/sop/manifest.go
@@ -1,0 +1,107 @@
+package sop
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// ManifestName is the machine-readable record a validated spec carries.
+const ManifestName = ".sop-manifest.json"
+
+// SOPVersion is the contract version this build writes and understands. A spec
+// planned under a newer version must fail loudly rather than be executed on
+// assumptions that no longer hold.
+const SOPVersion = 2
+
+// Manifest records what was checked, by which contract, and with what result.
+// /run reads it instead of re-deriving whether a spec is sound, and a spec
+// whose manifest is absent or stale is revalidated rather than trusted.
+type Manifest struct {
+	SOPVersion  int                `json:"sopVersion"`
+	Spec        string             `json:"spec"`
+	Contract    string             `json:"contract"`
+	ValidatedAt time.Time          `json:"validatedAt"`
+	Artifacts   []ArtifactRecord   `json:"artifacts"`
+	Rules       []string           `json:"rules"`
+	Findings    []validate.Finding `json:"findings,omitempty"`
+	Valid       bool               `json:"valid"`
+}
+
+// ArtifactRecord is one artifact's state at validation time.
+type ArtifactRecord struct {
+	Name    string `json:"name"`
+	Present bool   `json:"present"`
+	Lines   int    `json:"lines,omitempty"`
+	Slices  int    `json:"slices,omitempty"`
+}
+
+// BuildManifest validates spec against contract and returns the record.
+func BuildManifest(spec *specdoc.Spec, repoRoot string, contract validate.Contract, now time.Time) *Manifest {
+	findings := validate.Check(spec, repoRoot, contract)
+
+	m := &Manifest{
+		SOPVersion:  SOPVersion,
+		Spec:        spec.Name,
+		Contract:    contract.Name,
+		ValidatedAt: now.UTC(),
+		Findings:    findings,
+		Valid:       findings.OK(),
+	}
+	for _, ac := range contract.Artifacts {
+		m.Rules = append(m.Rules, ac.Rules...)
+		rec := ArtifactRecord{Name: ac.Artifact, Present: spec.Has(ac.Artifact)}
+		if rec.Present {
+			content := spec.Files[ac.Artifact]
+			rec.Lines = specdoc.CountLines(content)
+			switch ac.Artifact {
+			case specdoc.Plan:
+				rec.Slices = len(specdoc.ParsePlanSlices(content))
+			case specdoc.Prompt:
+				rec.Slices = len(specdoc.ParsePromptSlices(content))
+			}
+		}
+		m.Artifacts = append(m.Artifacts, rec)
+	}
+	return m
+}
+
+// WriteManifest writes the manifest into the spec directory.
+func WriteManifest(specDir string, m *Manifest) error {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding manifest: %w", err)
+	}
+	path := filepath.Join(specDir, ManifestName)
+	if err := os.WriteFile(path, append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", ManifestName, err)
+	}
+	return nil
+}
+
+// ReadManifest loads the manifest from a spec directory. A missing manifest is
+// reported as an error so the caller can choose to revalidate rather than
+// silently treat an unvalidated spec as valid.
+func ReadManifest(specDir string) (*Manifest, error) {
+	b, err := os.ReadFile(filepath.Join(specDir, ManifestName))
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", ManifestName, err)
+	}
+	return &m, nil
+}
+
+// Compatible reports whether a manifest was written by a contract version this
+// build can rely on. A newer manifest is not compatible: it may assert rules
+// this build does not implement.
+func (m *Manifest) Compatible() bool {
+	return m != nil && m.SOPVersion > 0 && m.SOPVersion <= SOPVersion
+}

--- a/internal/sop/manifest_test.go
+++ b/internal/sop/manifest_test.go
@@ -1,0 +1,191 @@
+package sop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// writeSpec lays down a spec directory and returns the work dir and spec name.
+func writeSpec(t *testing.T, files map[string]string) (string, string) {
+	t.Helper()
+	work := t.TempDir()
+	name := "features/x"
+	dir := filepath.Join(work, "specs", "features", "x")
+	if err := os.MkdirAll(filepath.Join(dir, "research"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return work, name
+}
+
+// validSpec is a spec that satisfies the full plan contract. It doubles as the
+// worked example of what the contract actually demands.
+func validSpec() map[string]string {
+	return map[string]string{
+		"rough-idea.md": "# Rough Idea\n\nAdd a thing.\n",
+		"requirements.md": "# Requirements\n\n## Questions & Answers\n\n" +
+			"Q1: What is in scope?\nA: The thing.\n\n" +
+			"Q2: What are the edge cases?\nA: Empty input.\n\n" +
+			"Q3: What are the acceptance criteria?\nA: Below.\n",
+		"design.md": "# Design\n\n## Current State\nx\n\n## Desired End State\ny\n\n" +
+			"## Acceptance Criteria\n\n- Given no thing, when added, then it exists.\n\n" +
+			"## Testing Strategy\n\nTable tests.\n",
+		"research/a.md": "# A\n\nThe code does x.\n",
+		"research/b.md": "# B\n\nThe code does y.\n",
+		"outline.md":    "# Outline\n\n1. Add the type\n2. Wire it up\n",
+		"plan.md": "# Plan\n\n## Progress\n\n" +
+			"- [ ] Step 1: Add the type\n" +
+			"- [ ] Step 2: Wire it up\n",
+		"PROMPT.md": "# Thing\n\n## Objective\nAdd a thing.\n\n" +
+			"## Acceptance Criteria\n- Given no thing, when added, then it exists.\n\n" +
+			"## Implementation Slices\n\n" +
+			"1. **Add the type** — define it, files: `a.go`, verify: `go build ./...`, parallel-safe: no\n" +
+			"2. **Wire it up** — call it, files: `b.go`, verify: `go build ./...`, parallel-safe: yes\n\n" +
+			"## Done Criteria\n- [ ] the type exists\n- [ ] it is called\n- [ ] no stubs remain\n\n" +
+			"## Gates\n- **build**: `go build ./...`\n",
+	}
+}
+
+func TestBuildManifestValidSpec(t *testing.T) {
+	work, name := writeSpec(t, validSpec())
+	spec, err := specdoc.Load(work, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := BuildManifest(spec, work, validate.PlanContract(), time.Now())
+	if !m.Valid {
+		t.Fatalf("valid spec reported invalid:\n%s", validate.Findings(m.Findings).Format())
+	}
+	if m.SOPVersion != SOPVersion {
+		t.Errorf("SOPVersion = %d, want %d", m.SOPVersion, SOPVersion)
+	}
+	if len(m.Artifacts) != len(validate.PlanContract().Artifacts) {
+		t.Errorf("got %d artifact records, want %d", len(m.Artifacts), len(validate.PlanContract().Artifacts))
+	}
+	for _, a := range m.Artifacts {
+		if !a.Present {
+			t.Errorf("artifact %s recorded absent", a.Name)
+		}
+		if a.Name == specdoc.Plan && a.Slices != 2 {
+			t.Errorf("plan.md slices = %d, want 2", a.Slices)
+		}
+		if a.Name == specdoc.Prompt && a.Slices != 2 {
+			t.Errorf("PROMPT.md slices = %d, want 2", a.Slices)
+		}
+	}
+}
+
+// The gap that motivated this package: a spec whose PROMPT.md exists but is
+// hollow used to pass the single os.Stat check.
+func TestBuildManifestCatchesHollowPrompt(t *testing.T) {
+	files := validSpec()
+	files["PROMPT.md"] = "# Thing\n\n## Objective\nAdd a thing.\n\n" +
+		"## Gates\n- **build**: `<build command discovered during research>`\n"
+	work, name := writeSpec(t, files)
+	spec, _ := specdoc.Load(work, name)
+
+	m := BuildManifest(spec, work, validate.PlanContract(), time.Now())
+	if m.Valid {
+		t.Fatal("a PROMPT.md with placeholder gates and no Done Criteria was reported valid")
+	}
+	rules := map[string]bool{}
+	for _, f := range m.Findings {
+		rules[f.Rule] = true
+	}
+	for _, want := range []string{"gates_are_executable", "done_criteria", "has_headings"} {
+		if !rules[want] {
+			t.Errorf("expected a %s finding; got %v", want, rules)
+		}
+	}
+}
+
+func TestBuildManifestMissingOutlineBlocks(t *testing.T) {
+	files := validSpec()
+	delete(files, "outline.md")
+	work, name := writeSpec(t, files)
+	spec, _ := specdoc.Load(work, name)
+
+	m := BuildManifest(spec, work, validate.PlanContract(), time.Now())
+	if m.Valid {
+		t.Fatal("a spec missing outline.md was reported valid")
+	}
+	var found bool
+	for _, f := range m.Findings {
+		if f.Artifact == specdoc.Outline && f.Rule == "required" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no required-artifact finding for outline.md: %v", m.Findings)
+	}
+}
+
+func TestManifestRoundTrip(t *testing.T) {
+	work, name := writeSpec(t, validSpec())
+	spec, _ := specdoc.Load(work, name)
+	m := BuildManifest(spec, work, validate.PlanContract(), time.Now())
+
+	if err := WriteManifest(spec.Dir, m); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadManifest(spec.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec != m.Spec || got.Valid != m.Valid || got.Contract != m.Contract {
+		t.Errorf("round trip mismatch: %+v vs %+v", got, m)
+	}
+	if !got.Compatible() {
+		t.Error("a manifest this build wrote is reported incompatible")
+	}
+}
+
+func TestManifestCompatibility(t *testing.T) {
+	if (&Manifest{SOPVersion: SOPVersion + 1}).Compatible() {
+		t.Error("a manifest from a newer SOP version was accepted")
+	}
+	if (&Manifest{SOPVersion: 0}).Compatible() {
+		t.Error("a manifest with no version was accepted")
+	}
+	var nilManifest *Manifest
+	if nilManifest.Compatible() {
+		t.Error("a nil manifest was accepted")
+	}
+}
+
+func TestReadManifestMissing(t *testing.T) {
+	if _, err := ReadManifest(t.TempDir()); err == nil {
+		t.Error("ReadManifest on a directory with no manifest returned no error")
+	}
+}
+
+// RunPreflightContract must be narrower than PlanContract: a hand-written spec
+// with only plan.md and PROMPT.md should still be runnable.
+func TestRunPreflightAcceptsMinimalSpec(t *testing.T) {
+	files := validSpec()
+	for _, drop := range []string{"rough-idea.md", "requirements.md", "design.md", "outline.md", "research/a.md", "research/b.md"} {
+		delete(files, drop)
+	}
+	work, name := writeSpec(t, files)
+	spec, _ := specdoc.Load(work, name)
+
+	if f := validate.Check(spec, work, validate.PlanContract()); f.OK() {
+		t.Fatal("PlanContract accepted a spec missing most artifacts")
+	}
+	if f := validate.Check(spec, work, validate.RunPreflightContract()); !f.OK() {
+		t.Errorf("RunPreflightContract rejected a runnable spec:\n%s", f.Format())
+	}
+}

--- a/internal/sop/plan.sop.yaml
+++ b/internal/sop/plan.sop.yaml
@@ -1,0 +1,122 @@
+sop: plan
+version: 2
+description: Prompt-Driven Development planning — produces a spec /run can execute
+
+workspace:
+  worktree: per-run
+  branch: "specs/{{.TaskName}}"
+  merge_on: success
+  cleanup: always
+
+defaults:
+  timeout: 20m
+  max_concurrency: 4
+  on_rate_limit: throttle
+  retry:
+    max_attempts: 3
+    initial_delay: 5s
+    max_delay: 60s
+    backoff: 2.0
+    jitter: 1.0
+
+stages:
+  - id: clarify
+    description: Clarify requirements with the user, one question at a time
+    agent: plan
+    produces:
+      - path: requirements.md
+        validate:
+          - non_empty
+          - "min_qa(min: 3)"
+    review:
+      kind: human
+      prompt: "Requirements captured. Approve to continue to research?"
+    next: research
+
+  - id: research
+    description: Establish how the code works today, in parallel, without reading it into this context
+    fan_out:
+      over: research_angles
+      agent: explore
+      max_concurrency: 4
+      isolation: sub_branch
+    produces:
+      - path: "research/*.md"
+        validate:
+          - non_empty
+          - no_solution_language
+    join: research_summary
+    next: design
+
+  - id: design
+    description: Write the standalone design document
+    agent: plan
+    inputs: [requirements, research_summary]
+    produces:
+      - path: design.md
+        validate:
+          - non_empty
+          - "max_lines(max: 2000)"
+          - 'has_headings(["Acceptance Criteria", "Testing Strategy"])'
+          - acceptance_criteria_are_given_when_then
+          - "research_at_least(min: 2)"
+    review:
+      kind: human
+      prompt: "Approve the design?"
+    next: outline
+
+  - id: outline
+    description: The cheap review checkpoint before the full plan
+    agent: plan
+    produces:
+      - path: outline.md
+        validate:
+          - non_empty
+          - "max_lines(max: 120)"
+          - "lists_slices(min: 2)"
+    review:
+      kind: human
+      prompt: "Approve the outline before expanding it into the plan?"
+    next: plan
+
+  - id: plan
+    description: Expand the outline into vertical slices
+    agent: plan
+    produces:
+      - path: plan.md
+        validate:
+          - non_empty
+          - "max_lines(max: 2000)"
+          - slices_are_checkboxes
+          - "slice_count(min: 1, max: 25)"
+          - outline_slices_match_plan_slices
+    review:
+      kind: agent
+      agent: spec-reviewer
+      verdict_schema: Verdict
+    routes:
+      FAIL: plan
+      PASS: prompt
+    max_cycles: 3
+
+  - id: prompt
+    description: Compress the plan into the execution briefing /run consumes
+    agent: plan
+    produces:
+      - path: PROMPT.md
+        validate:
+          - non_empty
+          - 'has_headings(["Objective", "Acceptance Criteria", "Implementation Slices", "Done Criteria", "Gates"])'
+          - 'every_slice_has(["files", "verify", "parallel_safe"])'
+          - "slice_budget(max_files: 10)"
+          - gates_are_executable
+          - "done_criteria(min: 3, no_placeholders: true)"
+          - references_exist
+          - plan_slices_match_prompt_slices
+    next: manifest
+
+  - id: manifest
+    description: Record what was checked, by which contract, at which SOP version
+    kind: function
+    produces:
+      - path: .sop-manifest.json

--- a/internal/sop/run.sop.yaml
+++ b/internal/sop/run.sop.yaml
@@ -1,0 +1,93 @@
+sop: run
+version: 2
+description: Execute a validated spec — Coordinator, Workers, Verifier as a graph
+
+workspace:
+  worktree: per-run
+  branch: "run/{{.SpecName}}"
+  merge_on: success
+  cleanup: always
+
+defaults:
+  timeout: 30m
+  max_concurrency: 3
+  on_rate_limit: throttle
+  retry:
+    max_attempts: 3
+    initial_delay: 10s
+    max_delay: 5m
+    backoff: 2.0
+    jitter: 1.0
+
+preflight:
+  - id: validate_spec
+    description: Refuse to start a spec that cannot succeed
+    kind: function
+    validate:
+      - sop_manifest_valid
+      - gates_are_executable
+      - "slice_budget(max_files: 10)"
+    on_fail: abort
+    next: slices
+
+stages:
+  - id: slices
+    description: One worker per slice; slices marked parallel-safe run together
+    fan_out:
+      over: plan.slices
+      agent: worker
+      group_by: parallel_safe
+      max_concurrency: 3
+      isolation: sub_branch
+      output_schema: SliceResult
+    gate: "{{ .Slice.Verify }}"
+    timeout: 30m
+    retry:
+      max_attempts: 3
+      initial_delay: 10s
+      max_delay: 5m
+      backoff: 2.0
+      jitter: 1.0
+    on_fail: repair
+    join: slice_results
+    next: gates
+
+  - id: gates
+    description: Run the spec's gates; a hang is neither a pass nor a fail
+    kind: function
+    gates_from: PROMPT.md
+    timeout: 10m
+    on_fail: repair
+    next: verify
+
+  - id: verify
+    description: Check the diff against the Done Criteria
+    agent: code-reviewer
+    inputs: [diff, done_criteria, slice_results]
+    output_schema: Verdict
+    routes:
+      FAIL: repair
+      PASS: merge
+
+  - id: repair
+    description: Dispatch fix workers for the unmet criteria, then verify again
+    fan_out:
+      over: verdict.unmet
+      agent: worker
+      max_concurrency: 2
+      output_schema: SliceResult
+    loop_back: verify
+    max_cycles: 3
+
+  - id: merge
+    description: Merge the run worktree into the invoking branch
+    kind: function
+    next: summary
+
+  - id: summary
+    description: Write the run report
+    kind: function
+    produces:
+      - path: summary.md
+        validate:
+          - non_empty

--- a/internal/sop/schema.go
+++ b/internal/sop/schema.go
@@ -1,0 +1,216 @@
+package sop
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// A Definition is a Standard Operating Procedure expressed as data.
+//
+// The prose SOPs it replaces — DefaultPDDSOP and the /run coordinator contract
+// — stated their rules in a Go string constant, which made every rule
+// advisory. The session corpus is a catalog of those rules being declined:
+// research delegated to subagents 4 times across 69 planning sessions, slices
+// implemented inline by coordinators 302 bash calls to 8 worker spawns, and a
+// Verifier whose verdict was PASS in 9 of 9 runs because nothing read it.
+//
+// Here the sequencing is a graph the scheduler walks, the review verdicts are
+// edges, and the artifact rules are validators. What stays in prose is each
+// node's own instruction, which is the part an LLM should be deciding.
+type Definition struct {
+	SOP         string    `yaml:"sop"`
+	Version     int       `yaml:"version"`
+	Description string    `yaml:"description"`
+	Workspace   Workspace `yaml:"workspace"`
+	Defaults    Defaults  `yaml:"defaults"`
+	Preflight   []Stage   `yaml:"preflight"`
+	Stages      []Stage   `yaml:"stages"`
+}
+
+// Workspace declares where a run's work lands and who cleans it up.
+type Workspace struct {
+	// Worktree is "per-run" or "none". Per-run means the graph owns one
+	// worktree; slices get branches inside it rather than nested worktrees.
+	Worktree string `yaml:"worktree"`
+	Branch   string `yaml:"branch"`
+	MergeOn  string `yaml:"merge_on"` // "success" | "never"
+	// Cleanup is "always" or "on_success". "always" is a terminal node
+	// reached from every exit path — the reason orphaned worktrees stop
+	// accumulating.
+	Cleanup string `yaml:"cleanup"`
+}
+
+// Defaults apply to any stage that does not override them.
+type Defaults struct {
+	Timeout     Duration `yaml:"timeout"`
+	Retry       *Retry   `yaml:"retry"`
+	OnRateLimit string   `yaml:"on_rate_limit"` // "throttle" | "fail"
+	// MaxConcurrency bounds the whole graph. It is separate from the
+	// per-process subagent pool, which multiplies rather than shares when
+	// runs nest.
+	MaxConcurrency int `yaml:"max_concurrency"`
+}
+
+// Retry is the per-stage retry policy. It maps onto workflow.RetryConfig.
+type Retry struct {
+	MaxAttempts  int      `yaml:"max_attempts"`
+	InitialDelay Duration `yaml:"initial_delay"`
+	MaxDelay     Duration `yaml:"max_delay"`
+	Backoff      float64  `yaml:"backoff"`
+	Jitter       float64  `yaml:"jitter"`
+}
+
+// Stage is one node, or one fan-out group, in the SOP graph.
+type Stage struct {
+	ID          string `yaml:"id"`
+	Description string `yaml:"description"`
+
+	// Kind is "agent" (an LLM does the work) or "function" (deterministic Go:
+	// validators, gates, git). Empty means "agent" when Agent is set and
+	// "function" otherwise.
+	Kind  string `yaml:"kind"`
+	Agent string `yaml:"agent"`
+
+	Inputs   []string   `yaml:"inputs"`
+	Produces []Produces `yaml:"produces"`
+
+	// Validate holds stage-level rules that are not tied to one artifact —
+	// preflight checks, for instance.
+	Validate []string `yaml:"validate"`
+
+	FanOut *FanOut `yaml:"fan_out"`
+	Join   string  `yaml:"join"`
+
+	Review *Review `yaml:"review"`
+
+	// Routes maps an output value to the stage it advances to. This is what
+	// turns a verdict into control flow instead of a sentence in a prompt.
+	Routes   map[string]string `yaml:"routes"`
+	LoopBack string            `yaml:"loop_back"`
+	MaxCycle int               `yaml:"max_cycles"`
+
+	// OnFail is "abort", "retry" or the id of a stage to jump to.
+	OnFail string `yaml:"on_fail"`
+
+	Timeout Duration `yaml:"timeout"`
+	Retry   *Retry   `yaml:"retry"`
+
+	// Gate is a shell command the engine runs after the stage body. Running it
+	// here rather than asking the LLM to is what makes a "verified" slice
+	// verified.
+	Gate         string `yaml:"gate"`
+	GatesFrom    string `yaml:"gates_from"`
+	OutputSchema string `yaml:"output_schema"`
+	Next         string `yaml:"next"`
+}
+
+// Produces declares an artifact a stage must write, and the rules it must
+// satisfy. A failing rule keeps the graph on this stage.
+type Produces struct {
+	Path     string   `yaml:"path"`
+	Validate []string `yaml:"validate"`
+}
+
+// FanOut declares that a stage runs once per item of a collection.
+type FanOut struct {
+	Over           string `yaml:"over"`
+	Agent          string `yaml:"agent"`
+	GroupBy        string `yaml:"group_by"`
+	MaxConcurrency int    `yaml:"max_concurrency"`
+	// Isolation is "sub_branch" or "none". Sub-branch keeps parallel workers
+	// from seeing each other's event history.
+	Isolation    string `yaml:"isolation"`
+	OutputSchema string `yaml:"output_schema"`
+}
+
+// Review is a checkpoint between stages: a human approval or an agent verdict.
+type Review struct {
+	Kind          string `yaml:"kind"` // "human" | "agent"
+	Prompt        string `yaml:"prompt"`
+	Agent         string `yaml:"agent"`
+	VerdictSchema string `yaml:"verdict_schema"`
+}
+
+// Duration is a YAML-friendly time.Duration accepting "20m", "5s", "1h30m".
+type Duration time.Duration
+
+// UnmarshalYAML parses a duration string.
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return fmt.Errorf("duration must be a string like \"20m\": %w", err)
+	}
+	if s == "" {
+		*d = 0
+		return nil
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("parsing duration %q: %w", s, err)
+	}
+	*d = Duration(parsed)
+	return nil
+}
+
+// Duration returns the value as a time.Duration.
+func (d Duration) Duration() time.Duration { return time.Duration(d) }
+
+// MarshalYAML renders the duration back as a string.
+func (d Duration) MarshalYAML() (any, error) {
+	if d == 0 {
+		return "", nil
+	}
+	return time.Duration(d).String(), nil
+}
+
+// ParseDefinition decodes a SOP definition. It rejects unknown fields: a typo
+// in a stage key would otherwise silently disable the behavior it names.
+func ParseDefinition(data []byte) (*Definition, error) {
+	var def Definition
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&def); err != nil {
+		return nil, fmt.Errorf("parsing SOP: %w", err)
+	}
+	return &def, nil
+}
+
+// Stage returns the stage with the given id.
+func (d *Definition) Stage(id string) (Stage, bool) {
+	for _, s := range d.AllStages() {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return Stage{}, false
+}
+
+// AllStages returns preflight stages followed by the main stages.
+func (d *Definition) AllStages() []Stage {
+	out := make([]Stage, 0, len(d.Preflight)+len(d.Stages))
+	out = append(out, d.Preflight...)
+	return append(out, d.Stages...)
+}
+
+// EffectiveKind resolves a stage's kind, defaulting by whether an agent is set.
+func (s Stage) EffectiveKind() string {
+	switch {
+	case s.Kind != "":
+		return s.Kind
+	case s.Agent != "" || s.FanOut != nil:
+		return "agent"
+	default:
+		return "function"
+	}
+}
+
+// AgentName returns the agent this stage (or its fan-out) dispatches to.
+func (s Stage) AgentName() string {
+	if s.FanOut != nil && s.FanOut.Agent != "" {
+		return s.FanOut.Agent
+	}
+	return s.Agent
+}

--- a/internal/sop/schema_test.go
+++ b/internal/sop/schema_test.go
@@ -1,0 +1,351 @@
+package sop
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// The shipped definitions must parse, lint and compile. If they do not, the
+// declarative SOPs are decoration.
+func TestEmbeddedDefinitionsCompile(t *testing.T) {
+	for _, name := range []string{"plan", "run"} {
+		t.Run(name, func(t *testing.T) {
+			def, err := LoadDefinition(t.TempDir(), name)
+			if err != nil {
+				t.Fatalf("LoadDefinition(%q): %v", name, err)
+			}
+			if def.SOP != name {
+				t.Errorf("sop = %q, want %q", def.SOP, name)
+			}
+			if def.Version != SOPVersion {
+				t.Errorf("version = %d, want %d", def.Version, SOPVersion)
+			}
+
+			compiled, err := Compile(def, DescribeFactory{})
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", name, err)
+			}
+			if len(compiled.Edges) == 0 {
+				t.Error("compiled to no edges")
+			}
+			if _, err := compiled.Workflow(); err != nil {
+				t.Fatalf("Workflow(): %v", err)
+			}
+		})
+	}
+}
+
+// The plan SOP must schedule the outline stage. It is the phase the prose SOP
+// asked for and 70% of specs skipped; making it a graph node is the fix.
+func TestPlanSOPSchedulesOutline(t *testing.T) {
+	def, err := LoadDefinition(t.TempDir(), "plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outline, ok := def.Stage("outline")
+	if !ok {
+		t.Fatal("plan SOP has no outline stage")
+	}
+	if outline.Review == nil || outline.Review.Kind != "human" {
+		t.Error("outline stage has no human review checkpoint")
+	}
+	if len(outline.Produces) == 0 {
+		t.Fatal("outline stage produces nothing")
+	}
+
+	// Every stage must be reachable: an unreachable outline is the same as no
+	// outline.
+	compiled, err := Compile(def, DescribeFactory{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reached := map[string]bool{}
+	for _, e := range compiled.Edges {
+		reached[e.To.Name()] = true
+	}
+	for _, s := range def.Stages[1:] { // the first stage is the entry point
+		if !reached[s.ID] {
+			t.Errorf("stage %q is unreachable", s.ID)
+		}
+	}
+}
+
+// The run SOP must route the verifier's verdict. An unrouted verdict is why
+// the prose Verifier reported PASS in 9 of 9 runs and nothing acted on it.
+func TestRunSOPRoutesTheVerdict(t *testing.T) {
+	def, err := LoadDefinition(t.TempDir(), "run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verify, ok := def.Stage("verify")
+	if !ok {
+		t.Fatal("run SOP has no verify stage")
+	}
+	for _, want := range []string{"PASS", "FAIL"} {
+		if _, ok := verify.Routes[want]; !ok {
+			t.Errorf("verify stage does not route %s", want)
+		}
+	}
+	if verify.Routes["FAIL"] == verify.Routes["PASS"] {
+		t.Error("PASS and FAIL route to the same stage")
+	}
+
+	repair, ok := def.Stage("repair")
+	if !ok {
+		t.Fatal("run SOP has no repair stage")
+	}
+	if repair.LoopBack != "verify" {
+		t.Errorf("repair loops back to %q, want verify", repair.LoopBack)
+	}
+	if repair.MaxCycle <= 0 {
+		t.Error("repair loop is unbounded")
+	}
+}
+
+func TestLintRejectsWorktreeAgent(t *testing.T) {
+	def := mustParse(t, `
+sop: run
+version: 2
+stages:
+  - id: build
+    agent: designer
+    next: done
+  - id: done
+    kind: function
+`)
+	findings := LintDefinition(def)
+	if findings.OK() {
+		t.Fatal("a stage dispatching to a [worktree] agent was accepted")
+	}
+	if !hasRule(findings, "worktree_agent") {
+		t.Errorf("no worktree_agent finding: %s", findings.Format())
+	}
+	if !strings.Contains(findings.Format(), "never merged") {
+		t.Errorf("finding does not explain the consequence:\n%s", findings.Format())
+	}
+}
+
+func TestLintRejectsDanglingEdge(t *testing.T) {
+	def := mustParse(t, `
+sop: run
+version: 2
+stages:
+  - id: a
+    kind: function
+    next: nowhere
+`)
+	if findings := LintDefinition(def); !hasRule(findings, "dangling_edge") {
+		t.Errorf("a next: pointing at no stage was accepted: %s", findings.Format())
+	}
+}
+
+func TestLintRejectsUnboundedLoop(t *testing.T) {
+	def := mustParse(t, `
+sop: run
+version: 2
+stages:
+  - id: a
+    kind: function
+    next: b
+  - id: b
+    kind: function
+    loop_back: a
+`)
+	if findings := LintDefinition(def); !hasRule(findings, "unbounded_loop") {
+		t.Errorf("a loop with no max_cycles was accepted: %s", findings.Format())
+	}
+}
+
+func TestLintRejectsUnknownValidator(t *testing.T) {
+	def := mustParse(t, `
+sop: plan
+version: 2
+stages:
+  - id: a
+    agent: plan
+    produces:
+      - path: plan.md
+        validate: [no_such_rule]
+`)
+	if findings := LintDefinition(def); !hasRule(findings, "unknown_rule") {
+		t.Errorf("an unknown validator was accepted: %s", findings.Format())
+	}
+}
+
+func TestLintRejectsUnroutedAgentVerdict(t *testing.T) {
+	def := mustParse(t, `
+sop: plan
+version: 2
+stages:
+  - id: a
+    agent: plan
+    review:
+      kind: agent
+      agent: spec-reviewer
+`)
+	if findings := LintDefinition(def); !hasRule(findings, "unrouted_verdict") {
+		t.Errorf("an agent review with no routes was accepted: %s", findings.Format())
+	}
+}
+
+func TestLintRejectsDuplicateStageID(t *testing.T) {
+	def := mustParse(t, `
+sop: plan
+version: 2
+stages:
+  - id: a
+    kind: function
+    next: b
+  - id: b
+    kind: function
+  - id: a
+    kind: function
+`)
+	if findings := LintDefinition(def); !hasRule(findings, "stage_id") {
+		t.Errorf("a duplicate stage id was accepted: %s", findings.Format())
+	}
+}
+
+func TestParseDefinitionRejectsUnknownField(t *testing.T) {
+	_, err := ParseDefinition([]byte("sop: plan\nversion: 2\nstagez: []\n"))
+	if err == nil {
+		t.Fatal("an unknown top-level field was accepted; a typo would silently disable behavior")
+	}
+}
+
+func TestNodeConfigInheritsDefaults(t *testing.T) {
+	defaults := Defaults{
+		Timeout: Duration(20 * time.Minute),
+		Retry:   &Retry{MaxAttempts: 3, InitialDelay: Duration(5 * time.Second), Backoff: 2, Jitter: 1},
+	}
+
+	inherited := NodeConfigFor(Stage{ID: "a"}, defaults)
+	if inherited.Timeout != 20*time.Minute {
+		t.Errorf("timeout = %s, want the default 20m", inherited.Timeout)
+	}
+	if inherited.RetryConfig == nil || inherited.RetryConfig.MaxAttempts != 3 {
+		t.Errorf("retry not inherited: %+v", inherited.RetryConfig)
+	}
+
+	override := NodeConfigFor(Stage{
+		ID:      "b",
+		Timeout: Duration(90 * time.Second),
+		Retry:   &Retry{MaxAttempts: 7},
+	}, defaults)
+	if override.Timeout != 90*time.Second {
+		t.Errorf("timeout = %s, want the stage override 90s", override.Timeout)
+	}
+	if override.RetryConfig.MaxAttempts != 7 {
+		t.Errorf("MaxAttempts = %d, want 7", override.RetryConfig.MaxAttempts)
+	}
+	// Unset fields fall back to the engine defaults, not to zero.
+	if override.RetryConfig.MaxDelay == 0 {
+		t.Error("MaxDelay = 0; an unset retry field should keep the engine default")
+	}
+}
+
+func TestFanOutStageIsParallelWorker(t *testing.T) {
+	cfg := NodeConfigFor(Stage{ID: "slices", FanOut: &FanOut{Over: "plan.slices"}}, Defaults{})
+	if !cfg.ParallelWorker {
+		t.Error("a fan_out stage did not compile to a ParallelWorker node")
+	}
+}
+
+func TestDurationParsing(t *testing.T) {
+	def := mustParse(t, "sop: plan\nversion: 2\ndefaults:\n  timeout: 90s\nstages:\n  - id: a\n    kind: function\n")
+	if got := def.Defaults.Timeout.Duration(); got != 90*time.Second {
+		t.Errorf("timeout = %s, want 90s", got)
+	}
+	if _, err := ParseDefinition([]byte("sop: plan\nversion: 2\ndefaults:\n  timeout: banana\n")); err == nil {
+		t.Error("an unparseable duration was accepted")
+	}
+}
+
+func TestCompiledDescribeNamesStagesAndEdges(t *testing.T) {
+	def, err := LoadDefinition(t.TempDir(), "run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled, err := Compile(def, DescribeFactory{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := compiled.Describe()
+	for _, want := range []string{"slices", "verify", "repair", "merge", "->"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("description omits %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestLoadDefinitionPrefersProjectOverride(t *testing.T) {
+	work := t.TempDir()
+	writeOverride(t, work, "plan.sop.yaml", `
+sop: plan
+version: 2
+description: project override
+stages:
+  - id: only
+    kind: function
+`)
+	def, err := LoadDefinition(work, "plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Description != "project override" {
+		t.Errorf("description = %q, want the project override", def.Description)
+	}
+}
+
+func TestLoadDefinitionRejectsBrokenOverride(t *testing.T) {
+	work := t.TempDir()
+	writeOverride(t, work, "plan.sop.yaml", `
+sop: plan
+version: 2
+stages:
+  - id: a
+    kind: function
+    next: nowhere
+`)
+	_, err := LoadDefinition(work, "plan")
+	if err == nil {
+		t.Fatal("a project override with a dangling edge was accepted")
+	}
+	if !strings.Contains(err.Error(), "not a stage") {
+		t.Errorf("error does not name the problem: %v", err)
+	}
+}
+
+func hasRule(fs validate.Findings, rule string) bool {
+	for _, f := range fs {
+		if f.Rule == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func mustParse(t *testing.T, src string) *Definition {
+	t.Helper()
+	def, err := ParseDefinition([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseDefinition: %v", err)
+	}
+	return def
+}
+
+func writeOverride(t *testing.T, workDir, name, body string) {
+	t.Helper()
+	dir := filepath.Join(workDir, ".pi-go", "sops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/sop/schema_validate.go
+++ b/internal/sop/schema_validate.go
@@ -1,0 +1,215 @@
+package sop
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dimetron/pi-go/internal/sop/validate"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// LintDefinition statically checks a SOP definition before anything runs.
+//
+// The checks that matter most are the ones the prose SOPs could only ask for:
+// a stage that dispatches to a [worktree] agent produces edits in a nested
+// worktree that is never merged, so the slice silently produces nothing. The
+// prose warns about this in two places, in bold. Here it is a compile error.
+func LintDefinition(def *Definition) validate.Findings {
+	var out validate.Findings
+	add := func(rule, msg, fix string) {
+		out = append(out, validate.Finding{
+			Artifact: def.SOP + ".sop.yaml", Rule: rule,
+			Severity: validate.SeverityError, Message: msg, Fix: fix,
+		})
+	}
+
+	if def.SOP == "" {
+		add("sop", "definition has no `sop:` name", "name it `plan` or `run`")
+	}
+	if def.Version != SOPVersion {
+		add("version",
+			fmt.Sprintf("SOP version %d, but this build implements %d", def.Version, SOPVersion),
+			"a definition from another version may assert rules this build does not have")
+	}
+	if len(def.Stages) == 0 {
+		add("stages", "definition has no stages", "a SOP with no stages schedules nothing")
+	}
+
+	out = append(out, lintStageIDs(def)...)
+	out = append(out, lintReferences(def)...)
+	out = append(out, lintAgents(def)...)
+	out = append(out, lintRules(def)...)
+	out = append(out, lintWorkspace(def)...)
+	return out
+}
+
+func lintStageIDs(def *Definition) validate.Findings {
+	var out validate.Findings
+	seen := map[string]bool{}
+	for _, s := range def.AllStages() {
+		switch {
+		case s.ID == "":
+			out = append(out, stageFinding(def, s, "stage_id", "stage has no id",
+				"every stage needs an id; edges and routes address stages by it"))
+		case seen[s.ID]:
+			out = append(out, stageFinding(def, s, "stage_id",
+				fmt.Sprintf("duplicate stage id %q", s.ID),
+				"ids must be unique: a duplicate silently shadows the earlier stage"))
+		}
+		seen[s.ID] = true
+	}
+	return out
+}
+
+// lintReferences catches an edge pointing at a stage that does not exist. A
+// dangling `next`, `routes` target or `loop_back` is a graph that stops early
+// — the failure mode of the 36-second coordinator that spawned one worker and
+// stopped, but detectable before the run rather than after it.
+func lintReferences(def *Definition) validate.Findings {
+	var out validate.Findings
+	for _, s := range def.AllStages() {
+		refs := map[string]string{}
+		if s.Next != "" {
+			refs["next"] = s.Next
+		}
+		if s.LoopBack != "" {
+			refs["loop_back"] = s.LoopBack
+		}
+		if s.OnFail != "" && s.OnFail != "abort" && s.OnFail != "retry" {
+			refs["on_fail"] = s.OnFail
+		}
+		if s.Join != "" {
+			// A join names the collected output, not a stage; nothing to check.
+			delete(refs, "join")
+		}
+		for verdict, target := range s.Routes {
+			refs["routes."+verdict] = target
+		}
+		for field, target := range refs {
+			if _, ok := def.Stage(target); !ok {
+				out = append(out, stageFinding(def, s, "dangling_edge",
+					fmt.Sprintf("stage %q has %s: %q, which is not a stage", s.ID, field, target),
+					"an edge to a nonexistent stage ends the graph early"))
+			}
+		}
+		if s.LoopBack != "" && s.MaxCycle <= 0 {
+			out = append(out, stageFinding(def, s, "unbounded_loop",
+				fmt.Sprintf("stage %q loops back to %q with no max_cycles", s.ID, s.LoopBack),
+				"an unbounded repair loop cannot terminate; set max_cycles"))
+		}
+	}
+	return out
+}
+
+// lintAgents rejects unknown agents and, critically, [worktree] agents.
+func lintAgents(def *Definition) validate.Findings {
+	bundled, err := subagent.LoadBundledAgents()
+	if err != nil {
+		return nil // cannot check; not a reason to reject the definition
+	}
+	byName := make(map[string]subagent.AgentConfig, len(bundled))
+	names := make([]string, 0, len(bundled))
+	for _, a := range bundled {
+		byName[a.Name] = a
+		names = append(names, a.Name)
+	}
+	sort.Strings(names)
+
+	var out validate.Findings
+	for _, s := range def.AllStages() {
+		name := s.AgentName()
+		if name == "" {
+			if s.Review != nil && s.Review.Kind == "agent" {
+				name = s.Review.Agent
+			}
+			if name == "" {
+				continue
+			}
+		}
+		cfg, ok := byName[name]
+		if !ok {
+			out = append(out, stageFinding(def, s, "unknown_agent",
+				fmt.Sprintf("stage %q dispatches to unknown agent %q", s.ID, name),
+				"known agents: "+strings.Join(names, ", ")))
+			continue
+		}
+		if cfg.Worktree {
+			out = append(out, stageFinding(def, s, "worktree_agent",
+				fmt.Sprintf("stage %q dispatches to %q, which runs in its own worktree", s.ID, name),
+				"a [worktree] agent's edits land in a nested worktree that is never merged, "+
+					"so the stage silently produces nothing — use `worker` or `quick-task`, "+
+					"which edit the current directory"))
+		}
+		if s.Review != nil && s.Review.Kind == "agent" && s.Review.Agent != "" && len(s.Routes) == 0 {
+			out = append(out, stageFinding(def, s, "unrouted_verdict",
+				fmt.Sprintf("stage %q has an agent review but no routes", s.ID),
+				"a verdict nothing routes on is a verdict nothing acts on — this is why "+
+					"the prose Verifier reported PASS in 9 of 9 runs"))
+		}
+	}
+	return out
+}
+
+// lintRules checks every validator named in the definition is registered.
+func lintRules(def *Definition) validate.Findings {
+	var out validate.Findings
+	check := func(s Stage, specs []string, where string) {
+		for _, spec := range specs {
+			name, _, err := validate.ParseRule(spec)
+			if err != nil {
+				out = append(out, stageFinding(def, s, "bad_rule",
+					fmt.Sprintf("stage %q %s: %v", s.ID, where, err), ""))
+				continue
+			}
+			if _, ok := validate.Lookup(name); !ok {
+				out = append(out, stageFinding(def, s, "unknown_rule",
+					fmt.Sprintf("stage %q %s names unknown validator %q", s.ID, where, name),
+					"registered validators: "+strings.Join(sortedRules(), ", ")))
+			}
+		}
+	}
+	for _, s := range def.AllStages() {
+		check(s, s.Validate, "validate")
+		for _, p := range s.Produces {
+			check(s, p.Validate, "produces "+p.Path)
+		}
+	}
+	return out
+}
+
+func lintWorkspace(def *Definition) validate.Findings {
+	var out validate.Findings
+	w := def.Workspace
+	if w.Worktree != "" && w.Worktree != "per-run" && w.Worktree != "none" {
+		out = append(out, validate.Finding{
+			Artifact: def.SOP + ".sop.yaml", Rule: "workspace", Severity: validate.SeverityError,
+			Message: fmt.Sprintf("workspace.worktree = %q, want \"per-run\" or \"none\"", w.Worktree),
+		})
+	}
+	if w.Worktree == "per-run" && w.Cleanup != "always" {
+		out = append(out, validate.Finding{
+			Artifact: def.SOP + ".sop.yaml", Rule: "workspace", Severity: validate.SeverityWarn,
+			Message: fmt.Sprintf("workspace.cleanup = %q with a per-run worktree", w.Cleanup),
+			Fix: "cleanup: always makes teardown a terminal node reached from every exit path; " +
+				"anything else leaks a worktree whenever a run does not end cleanly",
+		})
+	}
+	return out
+}
+
+func stageFinding(def *Definition, s Stage, rule, msg, fix string) validate.Finding {
+	return validate.Finding{
+		Artifact: def.SOP + ".sop.yaml",
+		Rule:     rule,
+		Severity: validate.SeverityError,
+		Message:  msg,
+		Fix:      fix,
+	}
+}
+
+func sortedRules() []string {
+	names := validate.RuleNames()
+	sort.Strings(names)
+	return names
+}

--- a/internal/sop/specdoc/specdoc.go
+++ b/internal/sop/specdoc/specdoc.go
@@ -1,0 +1,402 @@
+// Package specdoc parses the Markdown artifacts a /plan session produces.
+//
+// It exists so that /plan, /run and the validators all read a spec the same
+// way. Before it, gate parsing lived only in the TUI, slice parsing existed in
+// two shapes that disagreed, and nothing read PROMPT.md's slice list at all —
+// so a PROMPT.md describing a different set of slices than plan.md was
+// undetectable.
+package specdoc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Artifact names a /plan phase output. The order is the order the PDD SOP
+// produces them in.
+const (
+	RoughIdea    = "rough-idea.md"
+	Requirements = "requirements.md"
+	Design       = "design.md"
+	Outline      = "outline.md"
+	Plan         = "plan.md"
+	Prompt       = "PROMPT.md"
+	Summary      = "summary.md"
+)
+
+// Artifacts lists every artifact the PDD SOP defines, in phase order.
+var Artifacts = []string{RoughIdea, Requirements, Design, Outline, Plan, Prompt, Summary}
+
+// Gate is a validation command declared in PROMPT.md's "## Gates" section.
+type Gate struct {
+	Name    string
+	Command string
+	Line    int
+}
+
+// Slice is one unit of implementable work. It is parsed from plan.md's
+// checklist (or slice headings) and from PROMPT.md's "## Implementation
+// Slices" list, which is why Files/Verify may be empty: plan.md carries the
+// checkbox, PROMPT.md carries the execution detail.
+type Slice struct {
+	Index        int
+	Title        string
+	Done         bool
+	Files        []string
+	Verify       string
+	ParallelSafe bool
+	HasParallel  bool // whether parallel-safe was stated at all
+	Line         int
+	Body         string
+}
+
+// Spec is a loaded spec directory.
+type Spec struct {
+	Name     string            // "features/TOO/024-mistral-provider"
+	Dir      string            // absolute path
+	Files    map[string]string // artifact name -> content, only for files present
+	Research []string          // basenames under research/
+}
+
+// Load reads every artifact present in <workDir>/specs/<name>. A missing
+// artifact is simply absent from Files — that is a validation finding, not a
+// load error, so the caller can report all of them at once.
+func Load(workDir, name string) (*Spec, error) {
+	dir := filepath.Join(workDir, "specs", filepath.FromSlash(name))
+	st, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("spec %q: %w", name, err)
+	}
+	if !st.IsDir() {
+		return nil, fmt.Errorf("spec %q: not a directory", name)
+	}
+
+	spec := &Spec{Name: name, Dir: dir, Files: map[string]string{}}
+	for _, a := range Artifacts {
+		b, err := os.ReadFile(filepath.Join(dir, a))
+		if err != nil {
+			continue
+		}
+		spec.Files[a] = string(b)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, "research"))
+	if err == nil {
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+				spec.Research = append(spec.Research, e.Name())
+			}
+		}
+	}
+	return spec, nil
+}
+
+// Has reports whether the artifact is present and holds anything but whitespace.
+func (s *Spec) Has(artifact string) bool {
+	return strings.TrimSpace(s.Files[artifact]) != ""
+}
+
+// --- headings ---
+
+var headingRe = regexp.MustCompile(`(?m)^(#{1,6})\s+(.+?)\s*$`)
+
+// Headings returns every Markdown heading's text, in document order, with the
+// leading hashes and any trailing punctuation stripped.
+func Headings(content string) []string {
+	var out []string
+	for _, m := range headingRe.FindAllStringSubmatch(content, -1) {
+		out = append(out, strings.TrimSpace(m[2]))
+	}
+	return out
+}
+
+// HasHeading reports whether any heading contains want, case-insensitively.
+// Containment rather than equality: real specs write "## Gates" but also
+// "## Acceptance Criteria (Given/When/Then)".
+func HasHeading(content, want string) bool {
+	want = strings.ToLower(want)
+	for _, h := range Headings(content) {
+		if strings.Contains(strings.ToLower(h), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// Section returns the lines under the first heading containing name, up to the
+// next heading at the same or shallower depth. The heading line is excluded.
+func Section(content, name string) string {
+	lines := strings.Split(content, "\n")
+	want := strings.ToLower(name)
+
+	start, depth := -1, 0
+	for i, line := range lines {
+		m := headingRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if start == -1 {
+			if strings.Contains(strings.ToLower(m[2]), want) {
+				start, depth = i+1, len(m[1])
+			}
+			continue
+		}
+		if len(m[1]) <= depth {
+			return strings.Join(lines[start:i], "\n")
+		}
+	}
+	if start == -1 {
+		return ""
+	}
+	return strings.Join(lines[start:], "\n")
+}
+
+// --- gates ---
+
+// gateRe matches "- **name**: `command`" and "- name: `command`".
+var gateRe = regexp.MustCompile("^-\\s+\\*{0,2}([^*:]+?)\\*{0,2}\\s*:\\s*`([^`]+)`")
+
+// ParseGates extracts the gates declared in PROMPT.md's "## Gates" section.
+func ParseGates(promptMD string) []Gate {
+	body := Section(promptMD, "Gates")
+	if body == "" {
+		return nil
+	}
+	offset := strings.Index(promptMD, body)
+	base := 1
+	if offset >= 0 {
+		base = strings.Count(promptMD[:offset], "\n") + 1
+	}
+
+	var gates []Gate
+	for i, line := range strings.Split(body, "\n") {
+		m := gateRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		gates = append(gates, Gate{
+			Name:    strings.TrimSpace(m[1]),
+			Command: strings.TrimSpace(m[2]),
+			Line:    base + i,
+		})
+	}
+	return gates
+}
+
+// --- slices ---
+
+var (
+	checkboxRe = regexp.MustCompile(`^-\s+\[([ xX])\]\s+(.+)$`)
+	// numberedSliceRe matches an explicitly numbered slice heading at any depth:
+	// real plans write "## Slice 1 — Title" as often as "### Slice 1: Title".
+	numberedSliceRe = regexp.MustCompile(`^#{2,4}\s+(?:Slice|Step)\s+(\d+)\s*[:—–-]?\s*(.*)$`)
+	// sliceHeadingRe is the older fallback: any H3 is a slice.
+	sliceHeadingRe = regexp.MustCompile(`^###\s+(?:Slice\s+(\d+):?\s*)?(.+)$`)
+	stepPrefixRe   = regexp.MustCompile(`^(?:Step|Slice)\s+\d+\s*[:.]\s*`)
+	promptSliceRe  = regexp.MustCompile(`^(\d+)\.\s+(.+)$`)
+	verifyRe       = regexp.MustCompile("(?i)verify\\s*:\\s*`([^`]+)`")
+	filesRe        = regexp.MustCompile("(?i)files\\s*:\\s*((?:\\s*`[^`]+`\\s*,?)+)")
+	backtickRe     = regexp.MustCompile("`([^`]+)`")
+	parallelRe     = regexp.MustCompile(`(?i)parallel[- ]safe\s*:\s*(yes|no|true|false)`)
+)
+
+// ParsePlanSlices extracts slices from plan.md. Checkbox lines are
+// authoritative; "### Slice N" headings are the fallback for plans written
+// before the checklist convention.
+func ParsePlanSlices(planMD string) []Slice {
+	lines := strings.Split(planMD, "\n")
+
+	var boxes []Slice
+	for i, line := range lines {
+		m := checkboxRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		title := stepPrefixRe.ReplaceAllString(strings.TrimSpace(m[2]), "")
+		boxes = append(boxes, Slice{
+			Index: len(boxes) + 1,
+			Title: title,
+			Done:  strings.EqualFold(m[1], "x"),
+			Line:  i + 1,
+		})
+	}
+	if len(boxes) > 0 {
+		return boxes
+	}
+
+	// Explicitly numbered slice headings come next: they are unambiguous, and
+	// counting them at any depth avoids reading "## Gates" or "## Constraints"
+	// as slices the way a depth-only rule would.
+	var numbered []Slice
+	for i, line := range lines {
+		m := numberedSliceRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		numbered = append(numbered, Slice{
+			Index: len(numbered) + 1,
+			Title: strings.TrimSpace(m[2]),
+			Line:  i + 1,
+		})
+	}
+	if len(numbered) > 0 {
+		return numbered
+	}
+
+	var heads []Slice
+	for i, line := range lines {
+		m := sliceHeadingRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		heads = append(heads, Slice{
+			Index: len(heads) + 1,
+			Title: strings.TrimSpace(m[2]),
+			Line:  i + 1,
+		})
+	}
+	return heads
+}
+
+// SliceHeadings counts explicitly numbered slice headings. outline.md states
+// its slices as headings rather than as a list, so a rule that only counts
+// list items reads a perfectly good outline as empty.
+func SliceHeadings(content string) int {
+	n := 0
+	for _, line := range strings.Split(content, "\n") {
+		if numberedSliceRe.MatchString(strings.TrimSpace(line)) {
+			n++
+		}
+	}
+	return n
+}
+
+// ParsePromptSlices extracts the numbered list under PROMPT.md's
+// "## Implementation Slices". Each entry runs until the next numbered item, so
+// a slice whose detail wraps across lines is read whole.
+func ParsePromptSlices(promptMD string) []Slice {
+	body := Section(promptMD, "Implementation Slices")
+	if body == "" {
+		return nil
+	}
+	offset := strings.Index(promptMD, body)
+	base := 1
+	if offset >= 0 {
+		base = strings.Count(promptMD[:offset], "\n") + 1
+	}
+
+	var slices []Slice
+	var cur *Slice
+	var buf []string
+
+	flush := func() {
+		if cur == nil {
+			return
+		}
+		cur.Body = strings.Join(buf, "\n")
+		applySliceDetail(cur)
+		slices = append(slices, *cur)
+		cur, buf = nil, nil
+	}
+
+	for i, line := range strings.Split(body, "\n") {
+		m := promptSliceRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m != nil {
+			flush()
+			cur = &Slice{Index: len(slices) + 1, Title: sliceTitle(m[2]), Line: base + i}
+			buf = []string{m[2]}
+			continue
+		}
+		if cur != nil {
+			buf = append(buf, line)
+		}
+	}
+	flush()
+	return slices
+}
+
+// sliceTitle takes the first bolded run as the name, falling back to the text
+// up to the first em-dash or the whole line.
+func sliceTitle(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, "**"); i >= 0 {
+		if j := strings.Index(s[i+2:], "**"); j >= 0 {
+			return strings.TrimSpace(s[i+2 : i+2+j])
+		}
+	}
+	for _, sep := range []string{" — ", " – ", " - "} {
+		if i := strings.Index(s, sep); i > 0 {
+			return strings.TrimSpace(s[:i])
+		}
+	}
+	return s
+}
+
+func applySliceDetail(s *Slice) {
+	if m := verifyRe.FindStringSubmatch(s.Body); m != nil {
+		s.Verify = strings.TrimSpace(m[1])
+	}
+	if m := filesRe.FindStringSubmatch(s.Body); m != nil {
+		for _, f := range backtickRe.FindAllStringSubmatch(m[1], -1) {
+			s.Files = append(s.Files, strings.TrimSpace(f[1]))
+		}
+	}
+	if m := parallelRe.FindStringSubmatch(s.Body); m != nil {
+		s.HasParallel = true
+		v := strings.ToLower(m[1])
+		s.ParallelSafe = v == "yes" || v == "true"
+	}
+}
+
+// --- done criteria ---
+
+var doneItemRe = regexp.MustCompile(`^-\s+(?:\[[ xX]\]\s+)?(.+)$`)
+
+// DoneCriteria returns the bullet items under "## Done Criteria".
+func DoneCriteria(promptMD string) []string {
+	body := Section(promptMD, "Done Criteria")
+	if body == "" {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		m := doneItemRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		if t := strings.TrimSpace(m[1]); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// References returns the backticked paths listed under "## Reference".
+func References(promptMD string) []string {
+	body := Section(promptMD, "Reference")
+	if body == "" {
+		return nil
+	}
+	var out []string
+	for _, m := range backtickRe.FindAllStringSubmatch(body, -1) {
+		if p := strings.TrimSpace(m[1]); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// CountLines reports the number of lines in content.
+func CountLines(content string) int {
+	if content == "" {
+		return 0
+	}
+	n := strings.Count(content, "\n")
+	if !strings.HasSuffix(content, "\n") {
+		n++
+	}
+	return n
+}

--- a/internal/sop/specdoc/specdoc_test.go
+++ b/internal/sop/specdoc/specdoc_test.go
@@ -1,0 +1,199 @@
+package specdoc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const samplePrompt = "# Mistral Provider\n" +
+	"\n" +
+	"## Objective\n" +
+	"Add a Mistral provider.\n" +
+	"\n" +
+	"## Implementation Slices\n" +
+	"\n" +
+	"1. **Slice 1 — Routing fix** — repair provider routing, files: `internal/provider/route.go`, `internal/provider/route_test.go`,\n" +
+	"   verify: `go test ./internal/provider/...`, parallel-safe: no\n" +
+	"\n" +
+	"2. **Slice 2 — Model catalog** — add the catalog entries.\n" +
+	"   files: `internal/provider/catalog.go`\n" +
+	"   verify: `go build ./...`\n" +
+	"   parallel-safe: yes\n" +
+	"\n" +
+	"## Done Criteria\n" +
+	"- [ ] `pi --provider mistral` streams a response\n" +
+	"- [ ] No slice is left as a stub\n" +
+	"\n" +
+	"## Gates\n" +
+	"- **build**: `make build`\n" +
+	"- **test**: `make test`\n" +
+	"- vet: `make vet`\n" +
+	"\n" +
+	"## Reference\n" +
+	"- Plan: `specs/x/plan.md`\n" +
+	"- Design: `specs/x/design.md`\n"
+
+func TestParseGates(t *testing.T) {
+	gates := ParseGates(samplePrompt)
+	if len(gates) != 3 {
+		t.Fatalf("got %d gates, want 3: %+v", len(gates), gates)
+	}
+	want := map[string]string{"build": "make build", "test": "make test", "vet": "make vet"}
+	for _, g := range gates {
+		if want[g.Name] != g.Command {
+			t.Errorf("gate %q command = %q, want %q", g.Name, g.Command, want[g.Name])
+		}
+		if g.Line == 0 {
+			t.Errorf("gate %q has no line number", g.Name)
+		}
+	}
+}
+
+func TestParseGatesStopsAtNextSection(t *testing.T) {
+	// The Reference section also matches the gate pattern; it must not leak in.
+	for _, g := range ParseGates(samplePrompt) {
+		if g.Name == "Plan" || g.Name == "Design" {
+			t.Errorf("Reference entry %q leaked into gates", g.Name)
+		}
+	}
+}
+
+func TestParsePromptSlices(t *testing.T) {
+	slices := ParsePromptSlices(samplePrompt)
+	if len(slices) != 2 {
+		t.Fatalf("got %d slices, want 2: %+v", len(slices), slices)
+	}
+
+	s1 := slices[0]
+	if s1.Title != "Slice 1 — Routing fix" {
+		t.Errorf("slice 1 title = %q", s1.Title)
+	}
+	if len(s1.Files) != 2 {
+		t.Errorf("slice 1 files = %v, want 2 entries", s1.Files)
+	}
+	if s1.Verify != "go test ./internal/provider/..." {
+		t.Errorf("slice 1 verify = %q", s1.Verify)
+	}
+	if !s1.HasParallel || s1.ParallelSafe {
+		t.Errorf("slice 1 parallel-safe = (%v,%v), want stated=true safe=false", s1.HasParallel, s1.ParallelSafe)
+	}
+
+	// Slice 2's detail wraps across lines; it must still be read whole.
+	s2 := slices[1]
+	if s2.Verify != "go build ./..." {
+		t.Errorf("slice 2 verify = %q, want the wrapped value", s2.Verify)
+	}
+	if !s2.ParallelSafe {
+		t.Errorf("slice 2 parallel-safe = false, want true")
+	}
+}
+
+func TestDoneCriteria(t *testing.T) {
+	got := DoneCriteria(samplePrompt)
+	if len(got) != 2 {
+		t.Fatalf("got %d criteria, want 2: %v", len(got), got)
+	}
+}
+
+func TestReferences(t *testing.T) {
+	got := References(samplePrompt)
+	if len(got) != 2 {
+		t.Fatalf("got %d references, want 2: %v", len(got), got)
+	}
+}
+
+func TestParsePlanSlicesCheckboxes(t *testing.T) {
+	plan := "# Plan\n\n## Progress\n\n" +
+		"- [x] Step 1: Model Roles — Config\n" +
+		"- [ ] Step 2: Git Tools — git-overview\n" +
+		"- [ ] Slice 3: Subagent pool\n"
+	got := ParsePlanSlices(plan)
+	if len(got) != 3 {
+		t.Fatalf("got %d slices, want 3", len(got))
+	}
+	if !got[0].Done || got[1].Done {
+		t.Errorf("done flags wrong: %v %v", got[0].Done, got[1].Done)
+	}
+	if got[0].Title != "Model Roles — Config" {
+		t.Errorf("title = %q, want the Step prefix stripped", got[0].Title)
+	}
+	if got[2].Title != "Subagent pool" {
+		t.Errorf("title = %q, want the Slice prefix stripped", got[2].Title)
+	}
+}
+
+func TestParsePlanSlicesFallsBackToHeadings(t *testing.T) {
+	plan := "# Plan\n\n### Slice 1: PairingManager\n\ntext\n\n### Slice 2: Wire it up\n"
+	got := ParsePlanSlices(plan)
+	if len(got) != 2 {
+		t.Fatalf("got %d slices, want 2", len(got))
+	}
+	if got[0].Title != "PairingManager" {
+		t.Errorf("title = %q", got[0].Title)
+	}
+}
+
+func TestSectionStopsAtSameDepth(t *testing.T) {
+	md := "## A\nalpha\n### A1\nnested\n## B\nbeta\n"
+	got := Section(md, "A")
+	if want := "alpha\n### A1\nnested"; got != want {
+		t.Errorf("Section(A) = %q, want %q", got, want)
+	}
+}
+
+func TestHasHeading(t *testing.T) {
+	if !HasHeading(samplePrompt, "done criteria") {
+		t.Error("HasHeading should match case-insensitively")
+	}
+	if HasHeading(samplePrompt, "Execution Model") {
+		t.Error("HasHeading matched a heading that is absent")
+	}
+}
+
+func TestLoadReadsPresentArtifactsOnly(t *testing.T) {
+	work := t.TempDir()
+	dir := filepath.Join(work, "specs", "features", "x")
+	if err := os.MkdirAll(filepath.Join(dir, "research"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(rel, body string) {
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("plan.md", "# Plan\n")
+	write("PROMPT.md", samplePrompt)
+	write(filepath.Join("research", "a.md"), "notes\n")
+
+	spec, err := Load(work, "features/x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !spec.Has(Plan) || !spec.Has(Prompt) {
+		t.Error("present artifacts not loaded")
+	}
+	if spec.Has(Design) {
+		t.Error("absent artifact reported as present")
+	}
+	if len(spec.Research) != 1 {
+		t.Errorf("research = %v, want 1 entry", spec.Research)
+	}
+}
+
+func TestLoadMissingSpec(t *testing.T) {
+	if _, err := Load(t.TempDir(), "nope"); err == nil {
+		t.Error("Load(missing) = nil error, want an error")
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	for _, tt := range []struct {
+		in   string
+		want int
+	}{{"", 0}, {"a", 1}, {"a\n", 1}, {"a\nb", 2}, {"a\nb\n", 2}} {
+		if got := CountLines(tt.in); got != tt.want {
+			t.Errorf("CountLines(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/sop/validate/contract.go
+++ b/internal/sop/validate/contract.go
@@ -1,0 +1,200 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+)
+
+// ArtifactContract binds an artifact to the rules it must satisfy.
+type ArtifactContract struct {
+	Artifact string   `json:"artifact"`
+	Required bool     `json:"required"`
+	Rules    []string `json:"rules"`
+}
+
+// Contract is the full set of checks for one gate in the pipeline.
+type Contract struct {
+	Name      string             `json:"name"`
+	Artifacts []ArtifactContract `json:"artifacts"`
+}
+
+// PlanContract is what a finished /plan session must satisfy. It is the prose
+// PDD SOP's own rules, made checkable: every phase produces its artifact, the
+// plan's slices are sized and self-describing, and PROMPT.md carries gates and
+// Done Criteria that are real rather than template text.
+func PlanContract() Contract {
+	return Contract{
+		Name: "pdd-plan",
+		Artifacts: []ArtifactContract{
+			{Artifact: specdoc.RoughIdea, Required: true, Rules: []string{"non_empty"}},
+			{Artifact: specdoc.Requirements, Required: true, Rules: []string{
+				"non_empty",
+				"min_qa(min: 3)",
+			}},
+			{Artifact: specdoc.Design, Required: true, Rules: []string{
+				"non_empty",
+				"max_lines(max: 2000)",
+				`has_headings(["Acceptance Criteria", "Testing Strategy"])`,
+				"acceptance_criteria_are_given_when_then",
+				"research_at_least(min: 2)",
+			}},
+			{Artifact: specdoc.Outline, Required: true, Rules: []string{
+				"non_empty",
+				"max_lines(max: 120)",
+				"lists_slices(min: 2)",
+			}},
+			{Artifact: specdoc.Plan, Required: true, Rules: []string{
+				"non_empty",
+				"max_lines(max: 2000)",
+				"slices_are_checkboxes",
+				"slice_count(min: 1, max: 25)",
+				"outline_slices_match_plan_slices",
+			}},
+			{Artifact: specdoc.Prompt, Required: true, Rules: []string{
+				"non_empty",
+				`has_headings(["Objective", "Acceptance Criteria", "Implementation Slices", "Done Criteria", "Gates"])`,
+				"every_slice_has([\"files\", \"verify\", \"parallel_safe\"])",
+				"slice_budget(max_files: 10)",
+				"gates_are_executable",
+				"done_criteria(min: 3, no_placeholders: true)",
+				"references_exist",
+				"plan_slices_match_prompt_slices",
+			}},
+		},
+	}
+}
+
+// RunPreflightContract is what /run requires before it will start. It is
+// deliberately narrower than PlanContract: a spec written by hand, or planned
+// under an older SOP, should still run if the two artifacts a run actually
+// consumes are sound.
+func RunPreflightContract() Contract {
+	return Contract{
+		Name: "run-preflight",
+		Artifacts: []ArtifactContract{
+			{Artifact: specdoc.Plan, Required: true, Rules: []string{
+				"non_empty",
+				"max_lines(max: 2000)",
+				"slice_count(min: 1, max: 25)",
+			}},
+			{Artifact: specdoc.Prompt, Required: true, Rules: []string{
+				"non_empty",
+				"gates_are_executable",
+				"slice_budget(max_files: 10)",
+			}},
+		},
+	}
+}
+
+// Check runs a contract over a loaded spec. repoRoot is the checkout the spec
+// lives in; rules that resolve paths or probe commands need it, and pass when
+// it is empty.
+func Check(spec *specdoc.Spec, repoRoot string, c Contract) Findings {
+	var out Findings
+	for _, ac := range c.Artifacts {
+		content := spec.Files[ac.Artifact]
+		if !spec.Has(ac.Artifact) {
+			if ac.Required {
+				out = append(out, Finding{
+					Artifact: ac.Artifact,
+					Rule:     "required",
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("%s is missing", ac.Artifact),
+					Fix:      "this phase of the SOP did not produce its artifact; complete it before continuing",
+				})
+			}
+			continue
+		}
+		t := Target{Artifact: ac.Artifact, Content: content, Spec: spec, RepoRoot: repoRoot}
+		for _, r := range ac.Rules {
+			out = append(out, Apply(r, t)...)
+		}
+	}
+	return out
+}
+
+// Describe renders the contract as instruction text for the agent that must
+// satisfy it.
+//
+// This is the half that makes validation a loop rather than a gate: the
+// planner is told the exact rules its artifacts are checked against, in the
+// same session where the findings come back. A contract the producer cannot
+// see is just a way to fail late.
+func (c Contract) Describe() string {
+	var b strings.Builder
+	b.WriteString("## Artifact Contract (machine-checked)\n\n")
+	b.WriteString("Every artifact below is validated by code before the plan is accepted.\n")
+	b.WriteString("A failing check keeps the planning session open and returns the finding to you.\n\n")
+	for _, ac := range c.Artifacts {
+		req := "optional"
+		if ac.Required {
+			req = "required"
+		}
+		fmt.Fprintf(&b, "- `%s` (%s)\n", ac.Artifact, req)
+		for _, r := range ac.Rules {
+			fmt.Fprintf(&b, "  - %s\n", describeRule(r))
+		}
+	}
+	return b.String()
+}
+
+// describeRule renders one rule spec in prose, falling back to the spec itself
+// for rules with no gloss so a newly registered rule is still shown.
+func describeRule(spec string) string {
+	name, args, err := ParseRule(spec)
+	if err != nil {
+		return spec
+	}
+	switch name {
+	case "non_empty":
+		return "must exist and hold content"
+	case "max_lines":
+		return fmt.Sprintf("at most %d lines (the read tool's window — a longer file reaches a worker one page at a time)", args.Int("max", 2000))
+	case "has_headings":
+		return "must have these sections: " + strings.Join(quoteAll(args.Items()), ", ")
+	case "min_qa":
+		return fmt.Sprintf("record at least %d clarifying questions and their answers (warning only)", args.Int("min", 3))
+	case "research_at_least":
+		return fmt.Sprintf("at least %d files under research/ — dispatch parallel `explore` subagents rather than reading the codebase into this session", args.Int("min", 2))
+	case "lists_slices":
+		return fmt.Sprintf("list at least %d slices", args.Int("min", 2))
+	case "slices_are_checkboxes":
+		return "slices must be `- [ ] Step N: <title>` checkboxes, not headings — /run ticks these to track progress"
+	case "slice_count":
+		return fmt.Sprintf("between %d and %d slices; a longer plan means the feature must be split into sequential specs", args.Int("min", 1), args.Int("max", 25))
+	case "every_slice_has":
+		return "every slice must state " + strings.Join(quoteAll(args.Items()), ", ") + " — a worker cannot see this conversation"
+	case "slice_budget":
+		return fmt.Sprintf("no slice may name more than %d files; oversized slices exhaust a worker's context mid-slice", args.Int("max_files", 10))
+	case "gates_present":
+		return fmt.Sprintf("at least %d gate command(s)", args.Int("min", 1))
+	case "gates_are_executable":
+		return "gate commands must be this project's real commands: no `<placeholders>`, and the program must exist"
+	case "done_criteria":
+		return fmt.Sprintf("at least %d Done Criteria, each an outcome checkable by reading code or running a command — no template text", args.Int("min", 3))
+	case "no_placeholders":
+		return "no unfilled `<template>` text"
+	case "references_exist":
+		return "every path under `## Reference` must exist"
+	case "plan_slices_match_prompt_slices":
+		return "plan.md and PROMPT.md must describe the same slices — PROMPT.md is what /run executes"
+	case "outline_slices_match_plan_slices":
+		return "plan.md must not drop slices the outline approved"
+	case "acceptance_criteria_are_given_when_then":
+		return "acceptance criteria phrased as Given / When / Then"
+	case "no_solution_language":
+		return "research states facts about the code as it is, not proposals (warning only)"
+	default:
+		return spec
+	}
+}
+
+func quoteAll(items []string) []string {
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = "`" + s + "`"
+	}
+	return out
+}

--- a/internal/sop/validate/rules.go
+++ b/internal/sop/validate/rules.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -593,4 +594,54 @@ func ruleNoSolutionLanguage(t Target, _ Args) Findings {
 		}
 	}
 	return out
+}
+
+// --- manifest ---
+
+// manifestShape is the subset of the SOP manifest this package reads. The
+// manifest is written by package sop, which imports this one, so the rule
+// decodes the file directly rather than importing back.
+type manifestShape struct {
+	SOPVersion int    `json:"sopVersion"`
+	Contract   string `json:"contract"`
+	Valid      bool   `json:"valid"`
+}
+
+// ManifestName duplicates sop.ManifestName for the same reason.
+const ManifestName = ".sop-manifest.json"
+
+func init() { Register("sop_manifest_valid", ruleManifestValid) }
+
+// ruleManifestValid checks the spec carries a validation record this build can
+// rely on. A missing manifest is a warning, not a block: specs written by hand
+// or planned before manifests existed are still runnable, and the preflight
+// rules re-derive what matters. A manifest that records a failed validation, or
+// one from a newer SOP version, does block.
+func ruleManifestValid(t Target, a Args) Findings {
+	if t.Spec == nil || t.Spec.Dir == "" {
+		return nil
+	}
+	maxVersion := a.Int("max_version", 0)
+
+	b, err := os.ReadFile(filepath.Join(t.Spec.Dir, ManifestName))
+	if err != nil {
+		return warn("spec has no "+ManifestName+" — it has not been validated by /plan",
+			"run the preflight rules directly, or re-plan the spec to produce a manifest")
+	}
+	var m manifestShape
+	if err := json.Unmarshal(b, &m); err != nil {
+		return finding(ManifestName+" is unreadable: "+err.Error(),
+			"delete it; the spec is revalidated from its artifacts")
+	}
+	if maxVersion > 0 && m.SOPVersion > maxVersion {
+		return finding(
+			fmt.Sprintf("%s records SOP version %d, newer than this build's %d", ManifestName, m.SOPVersion, maxVersion),
+			"a spec planned under a newer SOP may rely on rules this build does not implement")
+	}
+	if !m.Valid {
+		return finding(
+			fmt.Sprintf("%s records a failed validation (contract %q)", ManifestName, m.Contract),
+			"the spec did not satisfy its contract when it was planned; fix the findings or re-plan it")
+	}
+	return nil
 }

--- a/internal/sop/validate/rules.go
+++ b/internal/sop/validate/rules.go
@@ -1,0 +1,596 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+)
+
+// Target is what a rule is asked about: one artifact, plus the spec it belongs
+// to so cross-artifact rules can reach its siblings.
+type Target struct {
+	Artifact string // "plan.md"
+	Content  string
+	Spec     *specdoc.Spec
+	RepoRoot string // for rules that resolve paths or probe commands
+}
+
+// Rule checks one property of a Target.
+type Rule func(Target, Args) Findings
+
+var registry = map[string]Rule{}
+
+// Register adds a rule under name. It panics on a duplicate: a silently
+// shadowed rule would validate nothing while appearing to pass.
+func Register(name string, r Rule) {
+	if _, dup := registry[name]; dup {
+		panic("validate: duplicate rule " + name)
+	}
+	registry[name] = r
+}
+
+// Lookup returns the rule registered under name.
+func Lookup(name string) (Rule, bool) {
+	r, ok := registry[name]
+	return r, ok
+}
+
+// RuleNames lists every registered rule.
+func RuleNames() []string {
+	out := make([]string, 0, len(registry))
+	for n := range registry {
+		out = append(out, n)
+	}
+	return out
+}
+
+// Apply runs one rule spec against a target.
+func Apply(spec string, t Target) Findings {
+	name, args, err := ParseRule(spec)
+	if err != nil {
+		return Findings{{Artifact: t.Artifact, Rule: spec, Severity: SeverityError, Message: err.Error()}}
+	}
+	rule, ok := Lookup(name)
+	if !ok {
+		return Findings{{
+			Artifact: t.Artifact, Rule: name, Severity: SeverityError,
+			Message: fmt.Sprintf("unknown validator %q", name),
+			Fix:     "use one of: " + strings.Join(RuleNames(), ", "),
+		}}
+	}
+	out := rule(t, args)
+	for i := range out {
+		if out[i].Artifact == "" {
+			out[i].Artifact = t.Artifact
+		}
+		if out[i].Rule == "" {
+			out[i].Rule = name
+		}
+		if out[i].Severity == "" {
+			out[i].Severity = SeverityError
+		}
+	}
+	return out
+}
+
+func finding(msg, fix string) Findings {
+	return Findings{{Severity: SeverityError, Message: msg, Fix: fix}}
+}
+
+func warn(msg, fix string) Findings {
+	return Findings{{Severity: SeverityWarn, Message: msg, Fix: fix}}
+}
+
+func init() {
+	Register("non_empty", ruleNonEmpty)
+	Register("max_lines", ruleMaxLines)
+	Register("has_headings", ruleHasHeadings)
+	Register("min_qa", ruleMinQA)
+	Register("research_at_least", ruleResearchAtLeast)
+	Register("lists_slices", ruleListsSlices)
+	Register("slices_are_checkboxes", ruleSlicesAreCheckboxes)
+	Register("slice_count", ruleSliceCount)
+	Register("every_slice_has", ruleEverySliceHas)
+	Register("slice_budget", ruleSliceBudget)
+	Register("gates_present", ruleGatesPresent)
+	Register("gates_are_executable", ruleGatesAreExecutable)
+	Register("done_criteria", ruleDoneCriteria)
+	Register("no_placeholders", ruleNoPlaceholders)
+	Register("references_exist", ruleReferencesExist)
+	Register("plan_slices_match_prompt_slices", rulePlanMatchesPrompt)
+	Register("outline_slices_match_plan_slices", ruleOutlineMatchesPlan)
+	Register("acceptance_criteria_are_given_when_then", ruleGivenWhenThen)
+	Register("no_solution_language", ruleNoSolutionLanguage)
+}
+
+// --- shape ---
+
+func ruleNonEmpty(t Target, _ Args) Findings {
+	if strings.TrimSpace(t.Content) == "" {
+		return finding(t.Artifact+" is missing or empty",
+			"write "+t.Artifact+" before this phase can complete")
+	}
+	return nil
+}
+
+func ruleMaxLines(t Target, a Args) Findings {
+	maxLines := a.Int("max", 2000)
+	if n := specdoc.CountLines(t.Content); n > maxLines {
+		return finding(
+			fmt.Sprintf("%s is %d lines, over the %d-line limit", t.Artifact, n, maxLines),
+			"the read tool returns at most 2000 lines per call, so a worker sent to read this "+
+				"sees only part of it — split the feature into sequential specs rather than shrinking the prose")
+	}
+	return nil
+}
+
+func ruleHasHeadings(t Target, a Args) Findings {
+	var out Findings
+	for _, want := range a.Items() {
+		if !specdoc.HasHeading(t.Content, want) {
+			out = append(out, Finding{
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("required section %q is missing", want),
+				Fix:      fmt.Sprintf("add a `## %s` section", want),
+			})
+		}
+	}
+	return out
+}
+
+var qaMarkerRe = regexp.MustCompile(`(?im)^\s*(?:[-*>]\s*)?(?:#{1,6}\s*)?(?:\*\*)?q(?:uestion)?\s*\d*\s*[:.]|^\s*.*\?\s*$`)
+
+func ruleMinQA(t Target, a Args) Findings {
+	minQA := a.Int("min", 3)
+	if n := len(qaMarkerRe.FindAllString(t.Content, -1)); n < minQA {
+		// A warning, not a block: requirements.md written as a scope document
+		// rather than a Q&A transcript still captures the requirements. The
+		// finding is worth surfacing because unasked questions are where
+		// rework comes from, but it is not a correctness property.
+		return warn(
+			fmt.Sprintf("only %d clarifying questions recorded, want at least %d", n, minQA),
+			"ask the user about scope, constraints, edge cases and acceptance criteria, "+
+				"appending each answer to requirements.md")
+	}
+	return nil
+}
+
+func ruleResearchAtLeast(t Target, a Args) Findings {
+	minRes := a.Int("min", 2)
+	if t.Spec == nil {
+		return nil
+	}
+	if n := len(t.Spec.Research); n < minRes {
+		return Findings{{
+			Artifact: "research/", Severity: SeverityError,
+			Message: fmt.Sprintf("%d research files, want at least %d", n, minRes),
+			Fix: "split the question into independent angles and dispatch them in one parallel " +
+				"`subagent` call; each agent writes its findings to research/<topic>.md",
+		}}
+	}
+	return nil
+}
+
+// --- slices ---
+
+var listItemRe = regexp.MustCompile(`(?m)^\s*(?:\d+\.|[-*])\s+\S`)
+
+func ruleListsSlices(t Target, a Args) Findings {
+	minItems := a.Int("min", 2)
+	n := len(listItemRe.FindAllString(t.Content, -1))
+	if h := specdoc.SliceHeadings(t.Content); h > n {
+		n = h
+	}
+	if n < minItems {
+		return finding(
+			fmt.Sprintf("%s lists %d items, want at least %d slices", t.Artifact, n, minItems),
+			"the outline is the cheap review checkpoint: list the slices and their order "+
+				"before expanding into the full plan")
+	}
+	return nil
+}
+
+func ruleSlicesAreCheckboxes(t Target, _ Args) Findings {
+	slices := specdoc.ParsePlanSlices(t.Content)
+	if len(slices) == 0 {
+		return finding("plan.md declares no slices",
+			"write each slice as `- [ ] Step N: <title>` so progress is machine-readable")
+	}
+	if !strings.Contains(t.Content, "- [ ]") && !strings.Contains(t.Content, "- [x]") &&
+		!strings.Contains(t.Content, "- [X]") {
+		return finding("plan.md slices are headings, not checkboxes",
+			"add a `## Progress` checklist of `- [ ] Step N: <title>` lines; /run ticks these to track completion")
+	}
+	return nil
+}
+
+func ruleSliceCount(t Target, a Args) Findings {
+	maxSlices := a.Int("max", 25)
+	minSlices := a.Int("min", 1)
+	n := len(specdoc.ParsePlanSlices(t.Content))
+	if n == 0 {
+		n = len(specdoc.ParsePromptSlices(t.Content))
+	}
+	switch {
+	case n < minSlices:
+		return finding(fmt.Sprintf("%d slices, want at least %d", n, minSlices),
+			"break the work into verifiable vertical slices")
+	case n > maxSlices:
+		return finding(
+			fmt.Sprintf("%d slices, over the %d-slice limit", n, maxSlices),
+			"a run drives one slice per worker within a bounded retry budget; split the feature "+
+				"into sequential specs and note the running order in each one's Constraints")
+	}
+	return nil
+}
+
+func ruleEverySliceHas(t Target, a Args) Findings {
+	want := a.Items()
+	if len(want) == 0 {
+		want = []string{"files", "verify", "parallel_safe"}
+	}
+	slices := specdoc.ParsePromptSlices(t.Content)
+	if len(slices) == 0 {
+		return finding("no implementation slices found",
+			"list slices under `## Implementation Slices` as `1. **<name>** — <what>, files: `<paths>`, verify: `<cmd>`, parallel-safe: <yes|no>`")
+	}
+	var out Findings
+	for _, s := range slices {
+		var missing []string
+		for _, w := range want {
+			switch strings.ToLower(strings.ReplaceAll(w, "-", "_")) {
+			case "files":
+				if len(s.Files) == 0 {
+					missing = append(missing, "files")
+				}
+			case "verify":
+				if s.Verify == "" {
+					missing = append(missing, "verify")
+				}
+			case "parallel_safe":
+				if !s.HasParallel {
+					missing = append(missing, "parallel-safe")
+				}
+			}
+		}
+		if len(missing) > 0 {
+			out = append(out, Finding{
+				Severity: SeverityError, Line: s.Line,
+				Message: fmt.Sprintf("slice %d (%s) does not state: %s", s.Index, s.Title, strings.Join(missing, ", ")),
+				Fix: "a worker cannot see the plan; each slice must name its files, its verify command, " +
+					"and whether it is parallel-safe",
+			})
+		}
+	}
+	return out
+}
+
+func ruleSliceBudget(t Target, a Args) Findings {
+	maxFiles := a.Int("max_files", 10)
+	var out Findings
+	for _, s := range specdoc.ParsePromptSlices(t.Content) {
+		if len(s.Files) > maxFiles {
+			out = append(out, Finding{
+				Severity: SeverityError, Line: s.Line,
+				Message: fmt.Sprintf("slice %d (%s) names %d files, over the %d-file budget",
+					s.Index, s.Title, len(s.Files), maxFiles),
+				Fix: "size each slice to one worker's context — an oversized slice grows the worker " +
+					"past the model limit and the provider drops the stream mid-slice",
+			})
+		}
+	}
+	return out
+}
+
+// --- gates ---
+
+func ruleGatesPresent(t Target, a Args) Findings {
+	minGates := a.Int("min", 1)
+	if n := len(specdoc.ParseGates(t.Content)); n < minGates {
+		return finding(
+			fmt.Sprintf("%d gates declared, want at least %d", n, minGates),
+			"add a `## Gates` section with the project's real build and test commands")
+	}
+	return nil
+}
+
+// placeholderRe catches template text left unfilled: <build command>, TBD, ...
+var placeholderRe = regexp.MustCompile(`(?i)<[^>]*(command|paths?|name|title|description|what|outcome|cmd)[^>]*>|\bTBD\b|\bFIXME\b|\bXXX\b|^\s*\.\.\.\s*$`)
+
+func ruleGatesAreExecutable(t Target, _ Args) Findings {
+	gates := specdoc.ParseGates(t.Content)
+	if len(gates) == 0 {
+		return finding("no gates to check",
+			"add a `## Gates` section; /run has nothing to verify the tree with otherwise")
+	}
+	var out Findings
+	for _, g := range gates {
+		if placeholderRe.MatchString(g.Command) {
+			out = append(out, Finding{
+				Severity: SeverityError, Line: g.Line,
+				Message: fmt.Sprintf("gate %q is still a template placeholder: %s", g.Name, g.Command),
+				Fix:     "discover the project's real build and test commands during research and put them here",
+			})
+			continue
+		}
+		if f := probeCommand(g, t.RepoRoot); f != nil {
+			out = append(out, *f)
+		}
+	}
+	return out
+}
+
+// probeCommand checks that a gate's leading program exists. It resolves the
+// binary rather than running the gate: running it here would be a build, and
+// the point is to catch an unrunnable gate at plan time cheaply.
+func probeCommand(g specdoc.Gate, repoRoot string) *Finding {
+	fields := strings.Fields(g.Command)
+	if len(fields) == 0 {
+		return &Finding{Severity: SeverityError, Line: g.Line,
+			Message: fmt.Sprintf("gate %q has an empty command", g.Name)}
+	}
+	prog := fields[0]
+	// Shell builtins and assignments are not resolvable binaries; accept them.
+	switch prog {
+	case "cd", "set", "export", "if", "for", "while", "true", "false", "[", "test":
+		return nil
+	}
+	if strings.ContainsAny(prog, "=$(){}") {
+		return nil
+	}
+	if strings.Contains(prog, "/") {
+		if _, err := os.Stat(filepath.Join(repoRoot, prog)); err == nil {
+			return nil
+		}
+	}
+	if _, err := exec.LookPath(prog); err != nil {
+		return &Finding{
+			Severity: SeverityError, Line: g.Line,
+			Message: fmt.Sprintf("gate %q runs %q, which is not on PATH", g.Name, prog),
+			Fix:     "use a command that exists in this project — check the Makefile targets",
+		}
+	}
+	if prog == "make" && len(fields) > 1 && repoRoot != "" {
+		if f := probeMakeTarget(g, fields[1], repoRoot); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+func probeMakeTarget(g specdoc.Gate, target, repoRoot string) *Finding {
+	if strings.HasPrefix(target, "-") {
+		return nil
+	}
+	body, err := os.ReadFile(filepath.Join(repoRoot, "Makefile"))
+	if err != nil {
+		return nil // no Makefile to check against; not this rule's business
+	}
+	targetRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(target) + `\s*:`)
+	if targetRe.Match(body) {
+		return nil
+	}
+	return &Finding{
+		Severity: SeverityWarn, Line: g.Line,
+		Message: fmt.Sprintf("gate %q runs `make %s`, but the Makefile has no such target", g.Name, target),
+		Fix:     "check `make help` for the real target name",
+	}
+}
+
+// --- done criteria and placeholders ---
+
+func ruleDoneCriteria(t Target, a Args) Findings {
+	minCrit := a.Int("min", 3)
+	noPlaceholders := a.Bool("no_placeholders", true)
+
+	crit := specdoc.DoneCriteria(t.Content)
+	if len(crit) < minCrit {
+		return finding(
+			fmt.Sprintf("%d Done Criteria, want at least %d", len(crit), minCrit),
+			"without Done Criteria the Verifier falls back to counting checkboxes, "+
+				"which cannot tell an implemented slice from a stubbed one")
+	}
+	if !noPlaceholders {
+		return nil
+	}
+	var out Findings
+	for _, c := range crit {
+		if placeholderRe.MatchString(c) {
+			out = append(out, Finding{
+				Severity: SeverityError,
+				Message:  "Done Criterion is still a template placeholder: " + c,
+				Fix:      "state an outcome checkable by reading code or running a command",
+			})
+		}
+	}
+	return out
+}
+
+func ruleNoPlaceholders(t Target, _ Args) Findings {
+	var out Findings
+	for i, line := range strings.Split(t.Content, "\n") {
+		if placeholderRe.MatchString(line) {
+			out = append(out, Finding{
+				Severity: SeverityError, Line: i + 1,
+				Message: "unfilled template placeholder: " + strings.TrimSpace(line),
+				Fix:     "replace it with the real value discovered during research",
+			})
+		}
+	}
+	return out
+}
+
+// --- cross-artifact ---
+
+func ruleReferencesExist(t Target, _ Args) Findings {
+	if t.RepoRoot == "" {
+		return nil
+	}
+	var out Findings
+	for _, ref := range specdoc.References(t.Content) {
+		if !isRepoPath(ref) {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(t.RepoRoot, filepath.FromSlash(ref))); err != nil {
+			out = append(out, Finding{
+				Severity: SeverityError,
+				Message:  "Reference points at a path that does not exist: " + ref,
+				Fix:      "write the referenced artifact, or correct the path",
+			})
+		}
+	}
+	return out
+}
+
+// isRepoPath reports whether a Reference entry names a path inside this
+// checkout. It filters out commands, globs, and external module paths such as
+// `google.golang.org/adk/v2@v2.2.0/agent/context.go`, which are legitimate
+// references that will never resolve against the repo root.
+func isRepoPath(ref string) bool {
+	if !strings.Contains(ref, "/") || strings.ContainsAny(ref, " $*@") {
+		return false
+	}
+	if strings.HasPrefix(ref, "~") || strings.HasPrefix(ref, "/") {
+		return false // outside the checkout: a home path or an absolute one
+	}
+	head, _, _ := strings.Cut(ref, "/")
+	return !strings.Contains(head, ".") // a domain-like first segment means a module path
+}
+
+func rulePlanMatchesPrompt(t Target, _ Args) Findings {
+	if t.Spec == nil {
+		return nil
+	}
+	plan := specdoc.ParsePlanSlices(t.Spec.Files[specdoc.Plan])
+	prompt := specdoc.ParsePromptSlices(t.Spec.Files[specdoc.Prompt])
+	return compareSlices(plan, prompt, "plan.md", "PROMPT.md",
+		"PROMPT.md is what /run executes; a mismatch means the run drives a different set of slices than the plan tracks")
+}
+
+func ruleOutlineMatchesPlan(t Target, _ Args) Findings {
+	if t.Spec == nil {
+		return nil
+	}
+	outlineMD := t.Spec.Files[specdoc.Outline]
+	outline := len(listItemRe.FindAllString(outlineMD, -1))
+	if h := specdoc.SliceHeadings(outlineMD); h > 0 {
+		outline = h
+	}
+	plan := len(specdoc.ParsePlanSlices(t.Spec.Files[specdoc.Plan]))
+	if outline == 0 || plan == 0 {
+		return nil // covered by the presence rules
+	}
+	if plan < outline {
+		return warn(
+			fmt.Sprintf("outline lists %d items but plan.md has %d slices — the plan dropped work the outline approved", outline, plan),
+			"expand every outlined slice into the plan, or revise the outline and re-approve it")
+	}
+	return nil
+}
+
+// compareSlices reports a count mismatch as an error and unmatched titles as
+// warnings. Titles are compared by token overlap: the two documents legitimately
+// phrase the same slice differently, so exact equality would be noise.
+func compareSlices(a, b []specdoc.Slice, aName, bName, why string) Findings {
+	if len(a) == 0 || len(b) == 0 {
+		return nil // absence is another rule's finding
+	}
+	var out Findings
+	if len(a) != len(b) {
+		out = append(out, Finding{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("%s has %d slices but %s has %d", aName, len(a), bName, len(b)),
+			Fix:      why,
+		})
+	}
+	for _, s := range a {
+		if !anyMatch(s.Title, b) {
+			out = append(out, Finding{
+				Severity: SeverityWarn, Line: s.Line,
+				Message: fmt.Sprintf("slice %q in %s has no counterpart in %s", s.Title, aName, bName),
+				Fix:     why,
+			})
+		}
+	}
+	return out
+}
+
+func anyMatch(title string, in []specdoc.Slice) bool {
+	for _, s := range in {
+		if overlap(title, s.Title) >= 0.5 {
+			return true
+		}
+	}
+	return false
+}
+
+var wordRe = regexp.MustCompile(`[a-z0-9]+`)
+
+// overlap is the fraction of a's significant words that also appear in b.
+func overlap(a, b string) float64 {
+	aw := wordRe.FindAllString(strings.ToLower(a), -1)
+	bw := map[string]bool{}
+	for _, w := range wordRe.FindAllString(strings.ToLower(b), -1) {
+		bw[w] = true
+	}
+	var total, hit int
+	for _, w := range aw {
+		if len(w) < 3 || w == "the" || w == "and" || w == "for" || w == "slice" || w == "step" {
+			continue
+		}
+		total++
+		if bw[w] {
+			hit++
+		}
+	}
+	if total == 0 {
+		return 1
+	}
+	return float64(hit) / float64(total)
+}
+
+// --- prose quality ---
+
+// gwtRe accepts an arrow in place of the literal "then": specs write
+// `Given no goal, when "/goal x" -> chat shows ...` and mean the same thing.
+var gwtRe = regexp.MustCompile(`(?i)\bgiven\b.*\bwhen\b.*(?:\bthen\b|→|->)`)
+
+func ruleGivenWhenThen(t Target, a Args) Findings {
+	body := specdoc.Section(t.Content, "Acceptance Criteria")
+	if strings.TrimSpace(body) == "" {
+		return finding("no Acceptance Criteria section",
+			"add `## Acceptance Criteria` with Given/When/Then statements")
+	}
+	// Criteria wrap across lines in real specs, so match against the section
+	// with newlines folded into spaces rather than line by line.
+	folded := strings.Join(strings.Fields(body), " ")
+	minCrit := a.Int("min", 1)
+	if n := len(gwtRe.FindAllString(folded, -1)); n < minCrit {
+		return finding(
+			fmt.Sprintf("%d Given/When/Then criteria, want at least %d", n, minCrit),
+			"phrase each criterion as \"Given <precondition>, when <action>, then <expected outcome>\"")
+	}
+	return nil
+}
+
+var solutionRe = regexp.MustCompile(`(?im)^\s*(?:[-*]\s*)?(?:we should|we could|i (?:suggest|propose|recommend)|the fix is|my recommendation|proposed (?:solution|design|approach))\b`)
+
+func ruleNoSolutionLanguage(t Target, _ Args) Findings {
+	var out Findings
+	for i, line := range strings.Split(t.Content, "\n") {
+		if solutionRe.MatchString(line) {
+			out = append(out, Finding{
+				Severity: SeverityWarn, Line: i + 1,
+				Message: "research states a proposal rather than a fact: " + strings.TrimSpace(line),
+				Fix: "research must compress how the code works today; proposals belong in design.md, " +
+					"where they can be reviewed against the facts",
+			})
+		}
+	}
+	return out
+}

--- a/internal/sop/validate/validate.go
+++ b/internal/sop/validate/validate.go
@@ -1,0 +1,220 @@
+// Package validate checks the artifacts a /plan session produces against a
+// machine-readable contract.
+//
+// Before it, the only check on a whole plan was a single os.Stat on PROMPT.md
+// (internal/tui/plan.go). Everything else the PDD SOP asks for — an outline,
+// slices that name their files and verify command, gates that actually run,
+// Done Criteria that are not template placeholders — was prose the model could
+// decline. Across 53 spec directories, 3 had a complete artifact set and
+// outline.md was missing from 70%.
+//
+// A rule here returns Findings rather than a bool, because a Finding is fed
+// back to the agent that produced the artifact: Message says what is wrong and
+// Fix says what to do about it.
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Severity distinguishes a finding that blocks the pipeline from one that is
+// only worth saying.
+type Severity string
+
+const (
+	// SeverityError blocks: /plan will not finish and /run will not start.
+	SeverityError Severity = "error"
+	// SeverityWarn is reported and recorded but blocks nothing.
+	SeverityWarn Severity = "warn"
+)
+
+// Finding is one rule violation.
+type Finding struct {
+	Artifact string   `json:"artifact"`
+	Rule     string   `json:"rule"`
+	Severity Severity `json:"severity"`
+	Line     int      `json:"line,omitempty"`
+	Message  string   `json:"message"`
+	Fix      string   `json:"fix,omitempty"`
+}
+
+func (f Finding) String() string {
+	loc := f.Artifact
+	if f.Line > 0 {
+		loc = fmt.Sprintf("%s:%d", f.Artifact, f.Line)
+	}
+	return fmt.Sprintf("[%s] %s (%s): %s", f.Severity, loc, f.Rule, f.Message)
+}
+
+// Findings is a rule result set.
+type Findings []Finding
+
+// Errors returns only the blocking findings.
+func (fs Findings) Errors() Findings {
+	var out Findings
+	for _, f := range fs {
+		if f.Severity == SeverityError {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// OK reports whether nothing blocking was found.
+func (fs Findings) OK() bool { return len(fs.Errors()) == 0 }
+
+// Format renders findings as a Markdown list, errors first.
+func (fs Findings) Format() string {
+	if len(fs) == 0 {
+		return "No findings."
+	}
+	sorted := append(Findings(nil), fs...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Severity == SeverityError && sorted[j].Severity != SeverityError
+	})
+	var b strings.Builder
+	for _, f := range sorted {
+		loc := f.Artifact
+		if f.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", f.Artifact, f.Line)
+		}
+		fmt.Fprintf(&b, "- **%s** `%s` — %s", strings.ToUpper(string(f.Severity)), loc, f.Message)
+		if f.Fix != "" {
+			fmt.Fprintf(&b, "\n  - fix: %s", f.Fix)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// --- rule arguments ---
+
+// Args holds a rule invocation's arguments. The three shapes cover every rule
+// the SOP schema needs: `max_lines(2000)`, `has_headings(["A","B"])`, and
+// `slice_budget(max_files: 10, max_changed_lines: 400)`.
+type Args struct {
+	Positional []string
+	List       []string
+	Named      map[string]string
+}
+
+// Int returns the named argument, or the first positional one when name is
+// empty or absent, falling back to def.
+func (a Args) Int(name string, def int) int {
+	if v, ok := a.Named[name]; ok {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return n
+		}
+	}
+	for _, p := range a.Positional {
+		if n, err := strconv.Atoi(strings.TrimSpace(p)); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// Bool returns the named boolean argument, or def.
+func (a Args) Bool(name string, def bool) bool {
+	if v, ok := a.Named[name]; ok {
+		b, err := strconv.ParseBool(strings.TrimSpace(v))
+		if err == nil {
+			return b
+		}
+	}
+	return def
+}
+
+// Items returns the list argument, falling back to the positional strings.
+func (a Args) Items() []string {
+	if len(a.List) > 0 {
+		return a.List
+	}
+	return a.Positional
+}
+
+var (
+	ruleCallRe = regexp.MustCompile(`^\s*([a-z0-9_]+)\s*(?:\((.*)\)\s*)?$`)
+	quotedRe   = regexp.MustCompile(`"([^"]*)"|'([^']*)'`)
+)
+
+// ParseRule splits a rule spec such as `slice_budget(max_files: 10)` into its
+// name and arguments.
+func ParseRule(spec string) (string, Args, error) {
+	m := ruleCallRe.FindStringSubmatch(spec)
+	if m == nil {
+		return "", Args{}, fmt.Errorf("malformed rule %q", spec)
+	}
+	name := m[1]
+	args := Args{Named: map[string]string{}}
+	body := strings.TrimSpace(m[2])
+	if body == "" {
+		return name, args, nil
+	}
+
+	// A bracketed list is the whole argument: has_headings(["A","B"]).
+	if strings.HasPrefix(body, "[") && strings.HasSuffix(body, "]") {
+		for _, q := range quotedRe.FindAllStringSubmatch(body, -1) {
+			args.List = append(args.List, firstNonEmpty(q[1], q[2]))
+		}
+		if len(args.List) == 0 {
+			for _, part := range splitTop(strings.Trim(body, "[]")) {
+				if p := strings.TrimSpace(part); p != "" {
+					args.List = append(args.List, p)
+				}
+			}
+		}
+		return name, args, nil
+	}
+
+	for _, part := range splitTop(body) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if k, v, ok := strings.Cut(part, ":"); ok && !strings.HasPrefix(part, `"`) {
+			args.Named[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+			continue
+		}
+		args.Positional = append(args.Positional, strings.Trim(part, `"'`))
+	}
+	return name, args, nil
+}
+
+// splitTop splits on commas that are not inside brackets or quotes.
+func splitTop(s string) []string {
+	var out []string
+	depth, quote := 0, rune(0)
+	start := 0
+	for i, r := range s {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			}
+		case r == '"' || r == '\'':
+			quote = r
+		case r == '[' || r == '(':
+			depth++
+		case r == ']' || r == ')':
+			depth--
+		case r == ',' && depth == 0:
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, s[start:])
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/sop/validate/validate_test.go
+++ b/internal/sop/validate/validate_test.go
@@ -1,0 +1,339 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+)
+
+func TestParseRule(t *testing.T) {
+	tests := []struct {
+		spec     string
+		wantName string
+		check    func(*testing.T, Args)
+	}{
+		{"non_empty", "non_empty", func(t *testing.T, a Args) {
+			if len(a.Positional) != 0 || len(a.List) != 0 {
+				t.Errorf("bare rule got args: %+v", a)
+			}
+		}},
+		{"max_lines(2000)", "max_lines", func(t *testing.T, a Args) {
+			if got := a.Int("max", 0); got != 2000 {
+				t.Errorf("Int = %d, want 2000", got)
+			}
+		}},
+		{"max_lines(max: 500)", "max_lines", func(t *testing.T, a Args) {
+			if got := a.Int("max", 0); got != 500 {
+				t.Errorf("Int = %d, want 500", got)
+			}
+		}},
+		{`has_headings(["Objective", "Gates"])`, "has_headings", func(t *testing.T, a Args) {
+			if got := a.Items(); len(got) != 2 || got[0] != "Objective" || got[1] != "Gates" {
+				t.Errorf("Items = %v", got)
+			}
+		}},
+		{"slice_budget(max_files: 10, max_changed_lines: 400)", "slice_budget", func(t *testing.T, a Args) {
+			if got := a.Int("max_files", 0); got != 10 {
+				t.Errorf("max_files = %d, want 10", got)
+			}
+			if got := a.Int("max_changed_lines", 0); got != 400 {
+				t.Errorf("max_changed_lines = %d, want 400", got)
+			}
+		}},
+		{"done_criteria(min: 3, no_placeholders: true)", "done_criteria", func(t *testing.T, a Args) {
+			if !a.Bool("no_placeholders", false) {
+				t.Error("no_placeholders = false, want true")
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.spec, func(t *testing.T) {
+			name, args, err := ParseRule(tt.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name != tt.wantName {
+				t.Fatalf("name = %q, want %q", name, tt.wantName)
+			}
+			tt.check(t, args)
+		})
+	}
+}
+
+func TestParseRuleMalformed(t *testing.T) {
+	if _, _, err := ParseRule("Not A Rule!"); err == nil {
+		t.Error("ParseRule accepted malformed input")
+	}
+}
+
+func TestApplyUnknownRuleIsAnError(t *testing.T) {
+	got := Apply("no_such_rule", Target{Artifact: "plan.md", Content: "x"})
+	if got.OK() {
+		t.Fatal("unknown rule did not produce a blocking finding")
+	}
+	if !strings.Contains(got[0].Message, "unknown validator") {
+		t.Errorf("message = %q", got[0].Message)
+	}
+}
+
+func TestRuleNonEmpty(t *testing.T) {
+	if got := Apply("non_empty", Target{Artifact: "plan.md", Content: "  \n\t "}); got.OK() {
+		t.Error("whitespace-only content passed non_empty")
+	}
+	if got := Apply("non_empty", Target{Artifact: "plan.md", Content: "# Plan"}); !got.OK() {
+		t.Errorf("real content failed non_empty: %v", got)
+	}
+}
+
+func TestRuleMaxLines(t *testing.T) {
+	long := strings.Repeat("line\n", 2500)
+	got := Apply("max_lines(max: 2000)", Target{Artifact: "plan.md", Content: long})
+	if got.OK() {
+		t.Fatal("a 2500-line plan passed max_lines(2000)")
+	}
+	if !strings.Contains(got[0].Fix, "2000 lines per call") {
+		t.Errorf("fix does not explain the read window: %q", got[0].Fix)
+	}
+}
+
+func TestRuleHasHeadings(t *testing.T) {
+	content := "# T\n\n## Objective\nx\n\n## Gates\ny\n"
+	if got := Apply(`has_headings(["Objective","Gates"])`, Target{Content: content}); !got.OK() {
+		t.Errorf("present headings reported missing: %v", got)
+	}
+	got := Apply(`has_headings(["Objective","Done Criteria"])`, Target{Content: content})
+	if got.OK() {
+		t.Fatal("missing heading was not reported")
+	}
+	if !strings.Contains(got[0].Message, "Done Criteria") {
+		t.Errorf("message = %q", got[0].Message)
+	}
+}
+
+func TestRuleSlicesAreCheckboxes(t *testing.T) {
+	headingOnly := "# Plan\n\n### Slice 1: A\n\n### Slice 2: B\n"
+	if got := Apply("slices_are_checkboxes", Target{Content: headingOnly}); got.OK() {
+		t.Error("a heading-only plan passed slices_are_checkboxes")
+	}
+	withBoxes := "# Plan\n\n- [ ] Step 1: A\n- [x] Step 2: B\n"
+	if got := Apply("slices_are_checkboxes", Target{Content: withBoxes}); !got.OK() {
+		t.Errorf("a checkbox plan failed: %v", got)
+	}
+	if got := Apply("slices_are_checkboxes", Target{Content: "# Plan\n\ntext\n"}); got.OK() {
+		t.Error("a plan with no slices passed")
+	}
+}
+
+func TestRuleSliceCountUpperBound(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("# Plan\n\n")
+	for i := 1; i <= 50; i++ {
+		b.WriteString("- [ ] Step 1: thing\n")
+	}
+	got := Apply("slice_count(min: 1, max: 25)", Target{Artifact: "plan.md", Content: b.String()})
+	if got.OK() {
+		t.Fatal("a 50-slice plan passed slice_count(max: 25)")
+	}
+	if !strings.Contains(got[0].Message, "50 slices") {
+		t.Errorf("message = %q", got[0].Message)
+	}
+}
+
+const promptWithSlices = "# T\n\n## Implementation Slices\n\n" +
+	"1. **A** — do a, files: `x.go`, verify: `go test ./...`, parallel-safe: no\n" +
+	"2. **B** — do b\n"
+
+func TestRuleEverySliceHas(t *testing.T) {
+	got := Apply(`every_slice_has(["files","verify","parallel_safe"])`,
+		Target{Artifact: "PROMPT.md", Content: promptWithSlices})
+	if got.OK() {
+		t.Fatal("a slice missing files/verify/parallel-safe passed")
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1 (only slice 2 is incomplete): %v", len(got), got)
+	}
+	for _, want := range []string{"files", "verify", "parallel-safe"} {
+		if !strings.Contains(got[0].Message, want) {
+			t.Errorf("message %q does not name missing %q", got[0].Message, want)
+		}
+	}
+}
+
+func TestRuleSliceBudget(t *testing.T) {
+	var files []string
+	for i := 0; i < 14; i++ {
+		files = append(files, "`f"+string(rune('a'+i))+".go`")
+	}
+	content := "## Implementation Slices\n\n1. **Big** — files: " + strings.Join(files, ", ") + ", verify: `go build ./...`\n"
+	got := Apply("slice_budget(max_files: 10)", Target{Artifact: "PROMPT.md", Content: content})
+	if got.OK() {
+		t.Fatal("a 14-file slice passed a 10-file budget")
+	}
+}
+
+func TestRuleGatesAreExecutable(t *testing.T) {
+	t.Run("placeholder", func(t *testing.T) {
+		content := "## Gates\n- **build**: `<build command discovered during research>`\n"
+		got := Apply("gates_are_executable", Target{Artifact: "PROMPT.md", Content: content})
+		if got.OK() {
+			t.Fatal("a template placeholder gate passed")
+		}
+		if !strings.Contains(got[0].Message, "template placeholder") {
+			t.Errorf("message = %q", got[0].Message)
+		}
+	})
+	t.Run("missing binary", func(t *testing.T) {
+		content := "## Gates\n- **build**: `definitely-not-a-real-binary-xyz build`\n"
+		got := Apply("gates_are_executable", Target{Artifact: "PROMPT.md", Content: content})
+		if got.OK() {
+			t.Fatal("a gate running a nonexistent binary passed")
+		}
+	})
+	t.Run("real binary", func(t *testing.T) {
+		content := "## Gates\n- **build**: `go build ./...`\n"
+		if got := Apply("gates_are_executable", Target{Artifact: "PROMPT.md", Content: content}); !got.OK() {
+			t.Errorf("`go build` reported unrunnable: %v", got)
+		}
+	})
+	t.Run("no gates", func(t *testing.T) {
+		if got := Apply("gates_are_executable", Target{Artifact: "PROMPT.md", Content: "# T\n"}); got.OK() {
+			t.Error("a PROMPT.md with no gates passed")
+		}
+	})
+}
+
+func TestRuleGatesMakeTargetWarnsOnly(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "Makefile"), []byte("build:\n\techo hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	content := "## Gates\n- **test**: `make no-such-target`\n"
+	got := Apply("gates_are_executable", Target{Artifact: "PROMPT.md", Content: content, RepoRoot: repo})
+	if !got.OK() {
+		t.Errorf("an unknown make target should warn, not block: %v", got)
+	}
+	if len(got) != 1 || got[0].Severity != SeverityWarn {
+		t.Errorf("want one warning, got %v", got)
+	}
+}
+
+func TestRuleDoneCriteria(t *testing.T) {
+	t.Run("too few", func(t *testing.T) {
+		content := "## Done Criteria\n- [ ] one thing\n"
+		got := Apply("done_criteria(min: 3)", Target{Artifact: "PROMPT.md", Content: content})
+		if got.OK() {
+			t.Fatal("1 criterion passed a minimum of 3")
+		}
+	})
+	t.Run("placeholders", func(t *testing.T) {
+		content := "## Done Criteria\n- [ ] <observable outcome>\n- [ ] <observable outcome>\n- [ ] real thing works\n"
+		got := Apply("done_criteria(min: 3, no_placeholders: true)", Target{Artifact: "PROMPT.md", Content: content})
+		if got.OK() {
+			t.Fatal("template placeholders passed")
+		}
+		if len(got) != 2 {
+			t.Errorf("got %d findings, want 2 placeholders: %v", len(got), got)
+		}
+	})
+	t.Run("valid", func(t *testing.T) {
+		content := "## Done Criteria\n- [ ] a works\n- [ ] b works\n- [ ] c works\n"
+		if got := Apply("done_criteria(min: 3)", Target{Content: content}); !got.OK() {
+			t.Errorf("valid criteria failed: %v", got)
+		}
+	})
+}
+
+func TestRuleGivenWhenThen(t *testing.T) {
+	wrapped := "## Acceptance Criteria\n\n### Area\n\n- Given no goal set, when `/goal x`,\n  then chat shows the goal.\n"
+	if got := Apply("acceptance_criteria_are_given_when_then", Target{Content: wrapped}); !got.OK() {
+		t.Errorf("a criterion wrapped across lines was rejected: %v", got)
+	}
+	prose := "## Acceptance Criteria\n\n- It should work nicely.\n"
+	if got := Apply("acceptance_criteria_are_given_when_then", Target{Content: prose}); got.OK() {
+		t.Error("prose criteria passed the Given/When/Then rule")
+	}
+}
+
+func TestRuleReferencesExist(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "specs", "x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "specs", "x", "plan.md"), []byte("p"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	content := "## Reference\n- Plan: `specs/x/plan.md`\n- Design: `specs/x/design.md`\n"
+	got := Apply("references_exist", Target{Artifact: "PROMPT.md", Content: content, RepoRoot: repo})
+	if got.OK() {
+		t.Fatal("a Reference to a nonexistent path passed")
+	}
+	if len(got) != 1 || !strings.Contains(got[0].Message, "design.md") {
+		t.Errorf("findings = %v", got)
+	}
+}
+
+func TestRulePlanMatchesPrompt(t *testing.T) {
+	spec := &specdoc.Spec{Files: map[string]string{
+		specdoc.Plan:   "- [ ] Step 1: Routing fix\n- [ ] Step 2: Model catalog\n- [ ] Step 3: Thinking cache\n",
+		specdoc.Prompt: promptWithSlices,
+	}}
+	got := Apply("plan_slices_match_prompt_slices", Target{Artifact: "PROMPT.md", Spec: spec})
+	if got.OK() {
+		t.Fatal("a 3-slice plan against a 2-slice PROMPT passed")
+	}
+	if !strings.Contains(got.Errors()[0].Message, "3 slices") {
+		t.Errorf("message = %q", got.Errors()[0].Message)
+	}
+}
+
+func TestRulePlanMatchesPromptAcceptsRephrasedTitles(t *testing.T) {
+	spec := &specdoc.Spec{Files: map[string]string{
+		specdoc.Plan: "- [ ] Step 1: Routing fix for provider\n- [ ] Step 2: Model catalog entries\n",
+		specdoc.Prompt: "## Implementation Slices\n\n" +
+			"1. **Routing fix** — provider routing, files: `a.go`, verify: `go build ./...`, parallel-safe: no\n" +
+			"2. **Model catalog** — catalog entries, files: `b.go`, verify: `go build ./...`, parallel-safe: yes\n",
+	}}
+	if got := Apply("plan_slices_match_prompt_slices", Target{Artifact: "PROMPT.md", Spec: spec}); !got.OK() {
+		t.Errorf("rephrased but matching titles were rejected: %v", got)
+	}
+}
+
+func TestRuleNoSolutionLanguageWarnsOnly(t *testing.T) {
+	content := "# Findings\n\nThe router dispatches by prefix.\n\nWe should replace it with a map.\n"
+	got := Apply("no_solution_language", Target{Artifact: "research/a.md", Content: content})
+	if !got.OK() {
+		t.Error("solution language should warn, not block")
+	}
+	if len(got) != 1 || got[0].Severity != SeverityWarn {
+		t.Errorf("want one warning, got %v", got)
+	}
+}
+
+func TestFindingsFormatPutsErrorsFirst(t *testing.T) {
+	fs := Findings{
+		{Artifact: "a.md", Rule: "r1", Severity: SeverityWarn, Message: "warn thing"},
+		{Artifact: "b.md", Rule: "r2", Severity: SeverityError, Message: "error thing", Fix: "do x"},
+	}
+	out := fs.Format()
+	if strings.Index(out, "error thing") > strings.Index(out, "warn thing") {
+		t.Errorf("errors not listed first:\n%s", out)
+	}
+	if !strings.Contains(out, "fix: do x") {
+		t.Errorf("fix not rendered:\n%s", out)
+	}
+}
+
+func TestFindingsOK(t *testing.T) {
+	if !(Findings{{Severity: SeverityWarn}}).OK() {
+		t.Error("warnings should not block")
+	}
+	if (Findings{{Severity: SeverityError}}).OK() {
+		t.Error("errors should block")
+	}
+	if !(Findings{}).OK() {
+		t.Error("empty findings should be OK")
+	}
+}

--- a/internal/sop/verdict.go
+++ b/internal/sop/verdict.go
@@ -1,0 +1,150 @@
+package sop
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Verdict is a review stage's structured result.
+//
+// The prose contract asked the Verifier to "End your reply with exactly one
+// line: VERDICT: PASS or VERDICT: FAIL", and nothing read the answer back into
+// control flow. Across the coordinator sessions in the corpus the verdict was
+// PASS 9 times out of 9 — not because the work was sound, but because a
+// verdict nobody routes on cannot fail.
+//
+// Parsing it into a value is the first half of the fix; routing an edge on it
+// is the second.
+type Verdict struct {
+	Result string  `json:"verdict"` // VerdictPass | VerdictFail
+	Unmet  []Unmet `json:"unmet,omitempty"`
+	// Stated is false when no verdict line was found at all. An absent verdict
+	// is not a pass: it means the Verifier never ran, or never finished.
+	Stated bool `json:"stated"`
+}
+
+// Unmet is one Done Criterion the Verifier judged not met.
+type Unmet struct {
+	Criterion string `json:"criterion"`
+	File      string `json:"file,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	Why       string `json:"why,omitempty"`
+}
+
+// Verdict results.
+const (
+	VerdictPass = "PASS"
+	VerdictFail = "FAIL"
+)
+
+// Passed reports whether the review may advance. An unstated verdict never
+// passes.
+func (v Verdict) Passed() bool { return v.Stated && v.Result == VerdictPass }
+
+// Reason explains a non-passing verdict for the retry briefing.
+func (v Verdict) Reason() string {
+	switch {
+	case !v.Stated:
+		return "the Verifier produced no VERDICT line, so the review did not complete"
+	case v.Result == VerdictFail && len(v.Unmet) > 0:
+		items := make([]string, 0, len(v.Unmet))
+		for _, u := range v.Unmet {
+			entry := "- " + u.Criterion
+			if u.File != "" {
+				entry += fmt.Sprintf(" (%s", u.File)
+				if u.Line > 0 {
+					entry += fmt.Sprintf(":%d", u.Line)
+				}
+				entry += ")"
+			}
+			if u.Why != "" {
+				entry += " — " + u.Why
+			}
+			items = append(items, entry)
+		}
+		return "the Verifier reported these criteria NOT MET:\n" + strings.Join(items, "\n")
+	case v.Result == VerdictFail:
+		return "the Verifier returned VERDICT: FAIL"
+	default:
+		return ""
+	}
+}
+
+var (
+	verdictRe = regexp.MustCompile(`(?im)^\s*\**\s*VERDICT\s*\**\s*:\s*\**\s*(PASS|FAIL)\b`)
+	unmetRe   = regexp.MustCompile(`(?im)^\s*[-*]?\s*(.+?)\s*[-—:]\s*NOT\s+MET\b\s*(.*)$`)
+	fileRefRe = regexp.MustCompile("`?([\\w./-]+\\.[a-zA-Z]+)`?(?::(\\d+))?")
+)
+
+// ParseVerdict extracts a verdict from a review agent's reply.
+//
+// The last VERDICT line wins: a Verifier that reasons aloud may echo the word
+// while explaining, and its conclusion is what counts.
+func ParseVerdict(text string) Verdict {
+	matches := verdictRe.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return Verdict{Stated: false}
+	}
+	v := Verdict{
+		Result: strings.ToUpper(matches[len(matches)-1][1]),
+		Stated: true,
+	}
+	if v.Result == VerdictFail {
+		v.Unmet = parseUnmet(text)
+	}
+	return v
+}
+
+func parseUnmet(text string) []Unmet {
+	var out []Unmet
+	for _, m := range unmetRe.FindAllStringSubmatch(text, -1) {
+		criterion := strings.TrimSpace(strings.Trim(m[1], "*`"))
+		if criterion == "" {
+			continue
+		}
+		u := Unmet{Criterion: criterion, Why: strings.TrimSpace(m[2])}
+		if ref := fileRefRe.FindStringSubmatch(m[2]); ref != nil {
+			u.File = ref[1]
+			if ref[2] != "" {
+				u.Line = atoi(ref[2])
+			}
+		}
+		out = append(out, u)
+	}
+	return out
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// SliceResult is a worker's structured report on one slice.
+//
+// VerifyPassed is set by whoever ran the verify command, not by the worker
+// claiming it. That distinction is the whole point: plan.md checkboxes in the
+// corpus read 0/50, 0/41 and 6/41 because ticking one was an instruction
+// rather than a consequence.
+type SliceResult struct {
+	Slice        int      `json:"slice"`
+	Title        string   `json:"title,omitempty"`
+	Status       string   `json:"status"` // done | blocked | partial
+	FilesChanged []string `json:"files_changed,omitempty"`
+	VerifyCmd    string   `json:"verify_cmd,omitempty"`
+	VerifyPassed bool     `json:"verify_passed"`
+	Blockers     []string `json:"blockers,omitempty"`
+	Notes        string   `json:"notes,omitempty"`
+}
+
+// Done reports whether the slice may be ticked: it must claim completion and
+// its verify command must have actually passed.
+func (r SliceResult) Done() bool {
+	return r.Status == "done" && r.VerifyPassed
+}

--- a/internal/sop/verdict_test.go
+++ b/internal/sop/verdict_test.go
@@ -1,0 +1,114 @@
+package sop
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseVerdict(t *testing.T) {
+	tests := []struct {
+		name       string
+		text       string
+		wantResult string
+		wantStated bool
+		wantPassed bool
+	}{
+		{"plain pass", "All good.\n\nVERDICT: PASS\n", VerdictPass, true, true},
+		{"plain fail", "Two criteria unmet.\n\nVERDICT: FAIL\n", VerdictFail, true, false},
+		{"bolded", "**VERDICT: PASS**\n", VerdictPass, true, true},
+		{"lowercase key", "verdict: pass\n", VerdictPass, true, true},
+		{"leading whitespace", "   VERDICT:   FAIL  \n", VerdictFail, true, false},
+		{"no verdict", "I checked the diff and it looks fine.\n", "", false, false},
+		{"empty", "", "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseVerdict(tt.text)
+			if got.Result != tt.wantResult {
+				t.Errorf("Result = %q, want %q", got.Result, tt.wantResult)
+			}
+			if got.Stated != tt.wantStated {
+				t.Errorf("Stated = %v, want %v", got.Stated, tt.wantStated)
+			}
+			if got.Passed() != tt.wantPassed {
+				t.Errorf("Passed() = %v, want %v", got.Passed(), tt.wantPassed)
+			}
+		})
+	}
+}
+
+// An absent verdict must never read as a pass. This is the specific failure the
+// type exists to prevent: the prose contract asked for the line and nothing
+// checked whether it arrived.
+func TestUnstatedVerdictIsNotAPass(t *testing.T) {
+	v := ParseVerdict("The implementation looks complete to me.")
+	if v.Passed() {
+		t.Fatal("a reply with no VERDICT line was treated as a pass")
+	}
+	if !strings.Contains(v.Reason(), "no VERDICT line") {
+		t.Errorf("Reason() = %q, want it to name the missing verdict", v.Reason())
+	}
+}
+
+// A Verifier that reasons aloud may echo the word before concluding; the last
+// line is the conclusion.
+func TestParseVerdictTakesTheLastLine(t *testing.T) {
+	text := "I will end with VERDICT: PASS if all criteria are met.\n" +
+		"Criterion 2 - NOT MET: the handler is a stub in `internal/api/handler.go:42`\n" +
+		"VERDICT: FAIL\n"
+	got := ParseVerdict(text)
+	if got.Result != VerdictFail {
+		t.Fatalf("Result = %q, want FAIL (the concluding line)", got.Result)
+	}
+	if got.Passed() {
+		t.Error("a FAIL verdict passed")
+	}
+}
+
+func TestParseVerdictExtractsUnmetCriteria(t *testing.T) {
+	text := "Review:\n" +
+		"- POST /api/x returns 202 - NOT MET: handler returns 500, see `internal/api/handler.go:42`\n" +
+		"- No stubs remain - NOT MET: panic(\"not implemented\") in `internal/api/job.go`\n" +
+		"VERDICT: FAIL\n"
+	got := ParseVerdict(text)
+	if len(got.Unmet) != 2 {
+		t.Fatalf("got %d unmet criteria, want 2: %+v", len(got.Unmet), got.Unmet)
+	}
+	if got.Unmet[0].File != "internal/api/handler.go" || got.Unmet[0].Line != 42 {
+		t.Errorf("first unmet file/line = %q:%d", got.Unmet[0].File, got.Unmet[0].Line)
+	}
+	reason := got.Reason()
+	for _, want := range []string{"POST /api/x", "No stubs remain", "handler.go"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("Reason() omits %q:\n%s", want, reason)
+		}
+	}
+}
+
+func TestPassingVerdictHasNoReason(t *testing.T) {
+	if got := ParseVerdict("VERDICT: PASS").Reason(); got != "" {
+		t.Errorf("Reason() = %q, want empty for a pass", got)
+	}
+}
+
+// A slice is done when it says so AND its verify command actually passed. The
+// second half is what the corpus was missing.
+func TestSliceResultDone(t *testing.T) {
+	tests := []struct {
+		name string
+		r    SliceResult
+		want bool
+	}{
+		{"done and verified", SliceResult{Status: "done", VerifyPassed: true}, true},
+		{"done but unverified", SliceResult{Status: "done", VerifyPassed: false}, false},
+		{"verified but partial", SliceResult{Status: "partial", VerifyPassed: true}, false},
+		{"blocked", SliceResult{Status: "blocked"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.Done(); got != tt.want {
+				t.Errorf("Done() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/subagent/complexity_subagent_test.go
+++ b/internal/subagent/complexity_subagent_test.go
@@ -21,6 +21,7 @@ import (
 
 	sharedacp "github.com/dimetron/pi-go/internal/acp"
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/testenv"
 )
 
@@ -1045,7 +1046,7 @@ func TestSpawnEnv(t *testing.T) {
 	t.Run("no worktree manager leaves env untouched", func(t *testing.T) {
 		o := &Orchestrator{}
 		in := []string{"A=1"}
-		got := o.spawnEnv(in, "/some/dir")
+		got := o.spawnEnv(in, "/some/dir", nil)
 		if len(got) != 1 || got[0] != "A=1" {
 			t.Errorf("env = %v, want [A=1]", got)
 		}
@@ -1054,7 +1055,7 @@ func TestSpawnEnv(t *testing.T) {
 	t.Run("adds sandbox and worktree roots", func(t *testing.T) {
 		o := &Orchestrator{worktree: NewWorktreeManager("/repo")}
 		in := []string{"A=1"}
-		got := o.spawnEnv(in, "/repo/.pi-go/tasks/x")
+		got := o.spawnEnv(in, "/repo/.pi-go/tasks/x", nil)
 
 		want := []string{"A=1", "PI_SANDBOX_ROOT=/repo", "PI_WORKTREE_ROOT=/repo/.pi-go/tasks/x"}
 		if len(got) != len(want) {
@@ -1073,11 +1074,76 @@ func TestSpawnEnv(t *testing.T) {
 
 	t.Run("empty workDir omits the worktree root", func(t *testing.T) {
 		o := &Orchestrator{worktree: NewWorktreeManager("/repo")}
-		got := o.spawnEnv(nil, "")
+		got := o.spawnEnv(nil, "", nil)
 		if len(got) != 1 || got[0] != "PI_SANDBOX_ROOT=/repo" {
 			t.Errorf("env = %v, want [PI_SANDBOX_ROOT=/repo]", got)
 		}
 	})
+
+	t.Run("attribution is forwarded to the child", func(t *testing.T) {
+		o := &Orchestrator{worktree: NewWorktreeManager("/repo")}
+		got := o.spawnEnv(nil, "/repo/.pi-go/tasks/x", &session.AgentContext{
+			AgentID: "worker-3", AgentType: "worker", RunID: "run-1",
+			SpecName: "features/x", Slice: 3, Cycle: 2, ParentID: "sess-parent",
+		})
+		want := map[string]string{
+			"PI_AGENT_ID":       "worker-3",
+			"PI_AGENT_TYPE":     "worker",
+			"PI_RUN_ID":         "run-1",
+			"PI_SPEC_NAME":      "features/x",
+			"PI_RUN_SLICE":      "3",
+			"PI_RUN_CYCLE":      "2",
+			"PI_PARENT_SESSION": "sess-parent",
+		}
+		have := map[string]string{}
+		for _, kv := range got {
+			if k, v, ok := strings.Cut(kv, "="); ok {
+				have[k] = v
+			}
+		}
+		for k, v := range want {
+			if have[k] != v {
+				t.Errorf("%s = %q, want %q (env: %v)", k, have[k], v, got)
+			}
+		}
+	})
+
+	t.Run("no attribution adds no attribution vars", func(t *testing.T) {
+		o := &Orchestrator{worktree: NewWorktreeManager("/repo")}
+		for _, kv := range o.spawnEnv(nil, "/repo", nil) {
+			if strings.HasPrefix(kv, "PI_AGENT_ID=") || strings.HasPrefix(kv, "PI_RUN_ID=") {
+				t.Errorf("unattributed spawn got %q", kv)
+			}
+		}
+	})
+}
+
+// attributionFor must not let a caller's run-level fields be overwritten by the
+// orchestrator's defaults, and must fill in what only it knows.
+func TestAttributionFor(t *testing.T) {
+	in := SpawnInput{
+		Agent:       AgentConfig{Name: "worker"},
+		Attribution: &session.AgentContext{RunID: "run-1", SpecName: "features/x", Slice: 4},
+	}
+	got := attributionFor(in, "agent-77", "/repo/.pi-go/tasks/x")
+
+	if got.RunID != "run-1" || got.SpecName != "features/x" || got.Slice != 4 {
+		t.Errorf("caller fields were lost: %+v", got)
+	}
+	if got.AgentID != "agent-77" {
+		t.Errorf("AgentID = %q, want the orchestrator's id", got.AgentID)
+	}
+	if got.AgentType != "worker" {
+		t.Errorf("AgentType = %q, want worker", got.AgentType)
+	}
+	if got.Worktree != "/repo/.pi-go/tasks/x" {
+		t.Errorf("Worktree = %q", got.Worktree)
+	}
+
+	// The caller's struct must not be mutated in place.
+	if in.Attribution.AgentID != "" {
+		t.Error("attributionFor mutated the caller's AgentContext")
+	}
 }
 
 func TestResolveWorkDir(t *testing.T) {

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/session"
 )
 
 // DefaultPoolSize is the default maximum number of concurrent subagents.
@@ -469,7 +470,7 @@ func (o *Orchestrator) Spawn(ctx context.Context, input SpawnInput) (<-chan Even
 		Prompt:      input.Prompt,
 		Instruction: agent.Instruction,
 		Timeout:     timeout,
-		Env:         o.spawnEnv(input.Env, workDir),
+		Env:         o.spawnEnv(input.Env, workDir, attributionFor(input, agentID, workDir)),
 		BaseURL:     o.BaseURL,
 		Insecure:    o.Insecure,
 		Headers:     o.Headers,
@@ -530,15 +531,40 @@ func (o *Orchestrator) resolveWorkDir(agentID string, input SpawnInput, useWorkt
 // spawnEnv extends the caller's env with the roots the subagent needs: the repo
 // root so its sandbox covers the full repo and not just the worktree directory,
 // and the worktree path so it can normalize relative paths.
-func (o *Orchestrator) spawnEnv(env []string, workDir string) []string {
-	if o.worktree == nil {
-		return env
+// attributionFor fills in the fields the orchestrator knows — the agent's ID,
+// its type, and the worktree it was given — over whatever the caller supplied.
+// The caller owns the run-level fields (run ID, spec, slice, cycle) because
+// only it knows them.
+func attributionFor(input SpawnInput, agentID, workDir string) *session.AgentContext {
+	var ctx session.AgentContext
+	if input.Attribution != nil {
+		ctx = *input.Attribution
 	}
-	env = append(append([]string(nil), env...), "PI_SANDBOX_ROOT="+o.worktree.RepoRoot())
-	if workDir != "" {
-		env = append(env, "PI_WORKTREE_ROOT="+workDir)
+	if ctx.AgentID == "" {
+		ctx.AgentID = agentID
 	}
-	return env
+	if ctx.AgentType == "" {
+		ctx.AgentType = input.Agent.Name
+	}
+	if ctx.Worktree == "" {
+		ctx.Worktree = workDir
+	}
+	return &ctx
+}
+
+func (o *Orchestrator) spawnEnv(env []string, workDir string, attribution *session.AgentContext) []string {
+	out := append([]string(nil), env...)
+	if o.worktree != nil {
+		out = append(out, "PI_SANDBOX_ROOT="+o.worktree.RepoRoot())
+		if workDir != "" {
+			out = append(out, "PI_WORKTREE_ROOT="+workDir)
+		}
+	}
+	// Attribution rides the same channel. The child records it on its own
+	// session so the run tree is recoverable from meta.json rather than by
+	// grouping sessions by working directory and guessing at roles.
+	out = append(out, attribution.Env()...)
+	return out
 }
 
 // dispatchSpawn launches the agent through the right runner. ACP-bundled agents

--- a/internal/subagent/process_windows.go
+++ b/internal/subagent/process_windows.go
@@ -7,5 +7,5 @@ import "os/exec"
 func setPlatformAttrs(cmd *exec.Cmd) {
 	// On Windows there is no process-group signal mechanism equivalent
 	// to Unix Setpgid + Kill(-pgid). The default CommandContext
-	// behaviour (TerminateProcess) is sufficient.
+	// behavior (TerminateProcess) is sufficient.
 }

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -3,6 +3,8 @@ package subagent
 import (
 	"fmt"
 	"time"
+
+	"github.com/dimetron/pi-go/internal/session"
 )
 
 // SpawnInput is the input to spawn a subagent with an AgentConfig.
@@ -17,6 +19,11 @@ type SpawnInput struct {
 	Env          []string    `json:"env,omitempty"`           // Additional environment variables
 	MaxRetries   int         `json:"max_retries,omitempty"`   // Max retry attempts on crash (default 0, max 3)
 	Timeout      int         `json:"timeout,omitempty"`       // Absolute timeout override in milliseconds
+
+	// Attribution records where the spawned agent sits in a run tree. The
+	// orchestrator forwards it through the environment; the child writes it
+	// onto its own session metadata. Nil for spawns that are not part of one.
+	Attribution *session.AgentContext `json:"attribution,omitempty"`
 }
 
 // AgentInput is the legacy input to spawn a subagent (deprecated, use SpawnInput).
@@ -31,6 +38,9 @@ type AgentInput struct {
 	Background   bool   `json:"background,omitempty"`    // Run in background
 	SkipCleanup  bool   `json:"skip_cleanup,omitempty"`  // Deprecated: worktree cleanup is always deferred to the caller or shutdown
 	Timeout      int    `json:"timeout,omitempty"`       // Absolute timeout override in milliseconds
+
+	// Attribution records where the spawned agent sits in a run tree.
+	Attribution *session.AgentContext `json:"attribution,omitempty"`
 }
 
 // ToSpawnInput converts a legacy AgentInput to the new SpawnInput format.
@@ -64,6 +74,7 @@ func (a AgentInput) ToSpawnInput() (SpawnInput, error) {
 		Background:   a.Background,
 		SkipCleanup:  a.SkipCleanup,
 		Timeout:      a.Timeout,
+		Attribution:  a.Attribution,
 	}, nil
 }
 

--- a/internal/tui/complexity_commands_test.go
+++ b/internal/tui/complexity_commands_test.go
@@ -736,23 +736,27 @@ func TestCplxParseRunArgs(t *testing.T) {
 		args         []string
 		wantSpec     string
 		wantParallel bool
+		wantForce    bool
 	}{
-		{"empty", nil, "", false},
-		{"spec only", []string{"my-spec"}, "my-spec", false},
-		{"long flag", []string{"my-spec", "--parallel"}, "my-spec", true},
-		{"short flag", []string{"my-spec", "-p"}, "my-spec", true},
-		{"flag first", []string{"-p", "my-spec"}, "my-spec", true},
+		{"empty", nil, "", false, false},
+		{"spec only", []string{"my-spec"}, "my-spec", false, false},
+		{"long flag", []string{"my-spec", "--parallel"}, "my-spec", true, false},
+		{"short flag", []string{"my-spec", "-p"}, "my-spec", true, false},
+		{"flag first", []string{"-p", "my-spec"}, "my-spec", true, false},
 		// The first non-flag argument wins; later ones are ignored.
-		{"extra positional ignored", []string{"first", "second"}, "first", false},
-		{"flag only", []string{"--parallel"}, "", true},
-		{"repeated flags", []string{"-p", "--parallel", "spec"}, "spec", true},
+		{"extra positional ignored", []string{"first", "second"}, "first", false, false},
+		{"flag only", []string{"--parallel"}, "", true, false},
+		{"repeated flags", []string{"-p", "--parallel", "spec"}, "spec", true, false},
+		{"force long", []string{"my-spec", "--force"}, "my-spec", false, true},
+		{"force short", []string{"my-spec", "-f"}, "my-spec", false, true},
+		{"force and parallel", []string{"-f", "-p", "my-spec"}, "my-spec", true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec, parallel := parseRunArgs(tt.args)
-			if spec != tt.wantSpec || parallel != tt.wantParallel {
-				t.Errorf("parseRunArgs(%v) = (%q, %v), want (%q, %v)",
-					tt.args, spec, parallel, tt.wantSpec, tt.wantParallel)
+			spec, parallel, force := parseRunArgs(tt.args)
+			if spec != tt.wantSpec || parallel != tt.wantParallel || force != tt.wantForce {
+				t.Errorf("parseRunArgs(%v) = (%q, %v, %v), want (%q, %v, %v)",
+					tt.args, spec, parallel, force, tt.wantSpec, tt.wantParallel, tt.wantForce)
 			}
 		})
 	}
@@ -784,7 +788,7 @@ func TestCplxHandleRunCommand_NoArgsShowsUsage(t *testing.T) {
 	if len(m.chatModel.Messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(m.chatModel.Messages))
 	}
-	if !strings.Contains(m.chatModel.Messages[0].content, "Usage: `/run <spec-name> [--parallel]`") {
+	if !strings.Contains(m.chatModel.Messages[0].content, "Usage: `/run <spec-name> [--parallel] [--force]`") {
 		t.Errorf("usage message = %q", m.chatModel.Messages[0].content)
 	}
 }

--- a/internal/tui/plan.go
+++ b/internal/tui/plan.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/validate"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -248,6 +249,14 @@ func (m *model) finishPlanWorktree() error {
 		return nil
 	}
 
+	// PROMPT.md existing is not the same as the plan being sound. Validate the
+	// whole artifact set against the PDD contract before merging: a spec that
+	// fails here is one /run could not have executed, and the worktree is kept
+	// so the next planning turn can fix it in place.
+	if !m.validatePlanArtifacts() {
+		return nil
+	}
+
 	// Merge the worktree branch into the invoking branch. This brings the spec
 	// files into <workDir>/specs/<task>/ as tracked files.
 	if _, err := m.planWorktree.MergeBack(m.planWorktreeAgentID); err != nil {
@@ -396,7 +405,8 @@ func (m *model) startPlanSession(taskName, roughIdea, specDir string) (tea.Model
 		return m, nil
 	}
 
-	instruction := sopText + "\n\n## Current Task\n" +
+	instruction := sopText + "\n\n" + validate.PlanContract().Describe() +
+		"\n## Current Task\n" +
 		"- Task name: " + taskName + "\n" +
 		"- Spec directory: " + specDir + "/\n" +
 		"- Rough idea: " + roughIdea + "\n\n" +

--- a/internal/tui/plan_run_e2e_test.go
+++ b/internal/tui/plan_run_e2e_test.go
@@ -211,6 +211,7 @@ func TestE2E_GatePassTriggersMerge(t *testing.T) {
 		passed: true,
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunGateResult(msg)
 
 	if m.run.phase != "merging" {
@@ -265,6 +266,7 @@ func TestE2E_GateFailTriggersRetry(t *testing.T) {
 		passed: false,
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunGateResult(msg)
 
 	// Should attempt retry (retry count incremented).
@@ -611,6 +613,7 @@ func TestE2E_AgentDoneGatePassMergeFlow(t *testing.T) {
 		},
 		passed: true,
 	}
+	seedPassVerdict(m.run)
 	m.handleRunGateResult(gateMsg)
 	if m.run.phase != "merging" {
 		t.Fatalf("phase after gates = %q, want %q", m.run.phase, "merging")

--- a/internal/tui/plan_test.go
+++ b/internal/tui/plan_test.go
@@ -341,18 +341,9 @@ func TestFinishPlanWorktree_CopiesSpecIntoInvokingCheckout(t *testing.T) {
 		t.Fatalf("creating plan worktree: %v", err)
 	}
 	wtSpec := filepath.Join(wtPath, "specs", taskName)
-	if err := os.MkdirAll(filepath.Join(wtSpec, "research"), 0o755); err != nil {
-		t.Fatalf("mkdir research: %v", err)
-	}
-	for name, content := range map[string]string{
-		"PROMPT.md":         "# Feature\n\n## Objective\nDo it.\n",
-		"requirements.md":   "# Requirements\n",
-		"research/notes.md": "notes\n",
-	} {
-		if err := os.WriteFile(filepath.Join(wtSpec, name), []byte(content), 0o644); err != nil {
-			t.Fatalf("writing %s: %v", name, err)
-		}
-	}
+	// The spec must satisfy the PDD contract: finishPlanWorktree validates
+	// before it merges, so a stub spec would be held back rather than copied.
+	writeValidPlanSpec(t, wtSpec)
 
 	m := &model{
 		cfg:                 Config{WorkDir: repo, Orchestrator: orch},
@@ -532,10 +523,11 @@ func TestFinishPlanWorktree_MergeFailureStillCopiesSpec(t *testing.T) {
 		t.Fatalf("creating plan worktree: %v", err)
 	}
 	wtSpec := filepath.Join(wtPath, "specs", taskName)
-	if err := os.MkdirAll(wtSpec, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(wtSpec, "PROMPT.md"), []byte("# Prompt\n"), 0o644); err != nil {
+	// A contract-conforming spec: validation must pass so the merge is
+	// attempted at all, which is what this test is about.
+	writeValidPlanSpec(t, wtSpec)
+	promptWant, err := os.ReadFile(filepath.Join(wtSpec, "PROMPT.md"))
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -569,8 +561,8 @@ func TestFinishPlanWorktree_MergeFailureStillCopiesSpec(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("spec not preserved on merge failure: %v", readErr)
 	}
-	if string(got) != "# Prompt\n" {
-		t.Errorf("spec content = %q, want the worktree's copy %q", got, "# Prompt\n")
+	if string(got) != string(promptWant) {
+		t.Errorf("spec content = %q, want the worktree's copy %q", got, promptWant)
 	}
 }
 

--- a/internal/tui/plan_validate.go
+++ b/internal/tui/plan_validate.go
@@ -1,0 +1,81 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// validatePlanArtifacts checks the spec against the PDD contract and records
+// the result as a manifest in the spec directory.
+//
+// It returns true when the plan may be merged. On failure it appends the
+// findings to the conversation — phrased as work for the planner, since the
+// planning session is still live and the next turn can act on them — and keeps
+// the worktree so that fix lands in the same branch.
+//
+// This replaces the single os.Stat that used to be the whole check. Across the
+// 53 specs planned before it, 3 had a complete artifact set: the SOP asked for
+// the rest in prose, and prose does not block a merge.
+func (m *model) validatePlanArtifacts() bool {
+	workDir := m.cfg.WorkDir
+	if m.planWorktreePath != "" {
+		workDir = m.planWorktreePath
+	}
+
+	spec, err := specdoc.Load(workDir, m.planTaskName)
+	if err != nil {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: fmt.Sprintf("Could not read the spec for validation: %v", err),
+		})
+		return false
+	}
+
+	manifest := sop.BuildManifest(spec, workDir, validate.PlanContract(), time.Now())
+	if err := sop.WriteManifest(spec.Dir, manifest); err != nil {
+		// A manifest that cannot be written is not a reason to lose the plan.
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: fmt.Sprintf("Warning: could not write %s: %v", sop.ManifestName, err),
+		})
+	}
+
+	findings := validate.Findings(manifest.Findings)
+	if manifest.Valid {
+		if len(findings) > 0 {
+			m.chatModel.Messages = append(m.chatModel.Messages, message{
+				role:    "assistant",
+				content: "**Plan validated** with warnings:\n\n" + findings.Format(),
+			})
+		} else {
+			m.chatModel.Messages = append(m.chatModel.Messages, message{
+				role:    "assistant",
+				content: "**Plan validated** — all artifacts satisfy the PDD contract.",
+			})
+		}
+		return true
+	}
+
+	m.chatModel.Messages = append(m.chatModel.Messages, message{
+		role:    "assistant",
+		content: formatPlanValidationFailure(m.planTaskName, findings),
+	})
+	return false
+}
+
+// formatPlanValidationFailure renders blocking findings as the planner's next
+// task rather than as an error report: the session is still open, and every
+// finding carries the fix that clears it.
+func formatPlanValidationFailure(taskName string, findings validate.Findings) string {
+	errs := findings.Errors()
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Plan not yet complete** — %d artifact check(s) failed for `%s`.\n\n", len(errs), taskName)
+	b.WriteString(findings.Format())
+	b.WriteString("\nThe planning worktree is kept. Address these and the plan merges on the next turn.\n")
+	return b.String()
+}

--- a/internal/tui/plan_validate_test.go
+++ b/internal/tui/plan_validate_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// writeTestSpec lays down a spec under workDir/specs/<name>.
+func writeTestSpec(t *testing.T, workDir, name string, files map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(workDir, "specs", filepath.FromSlash(name))
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func runnableSpec() map[string]string {
+	return map[string]string{
+		"plan.md": "# Plan\n\n- [ ] Step 1: Add the type\n- [ ] Step 2: Wire it up\n",
+		"PROMPT.md": "# Thing\n\n## Objective\nAdd a thing.\n\n" +
+			"## Implementation Slices\n\n" +
+			"1. **Add the type** — define it, files: `a.go`, verify: `go build ./...`, parallel-safe: no\n" +
+			"2. **Wire it up** — call it, files: `b.go`, verify: `go build ./...`, parallel-safe: yes\n\n" +
+			"## Gates\n- **build**: `go build ./...`\n",
+	}
+}
+
+func TestRunPreflightAcceptsRunnableSpec(t *testing.T) {
+	work := t.TempDir()
+	writeTestSpec(t, work, "features/x", runnableSpec())
+
+	m := &model{cfg: Config{WorkDir: work}}
+	findings, ok := m.runPreflight("features/x")
+	if !ok {
+		t.Fatalf("preflight rejected a runnable spec:\n%s", findings.Format())
+	}
+}
+
+func TestRunPreflightRejectsPlaceholderGates(t *testing.T) {
+	work := t.TempDir()
+	files := runnableSpec()
+	files["PROMPT.md"] = strings.Replace(files["PROMPT.md"],
+		"- **build**: `go build ./...`",
+		"- **build**: `<build command discovered during research>`", 1)
+	writeTestSpec(t, work, "features/x", files)
+
+	m := &model{cfg: Config{WorkDir: work}}
+	findings, ok := m.runPreflight("features/x")
+	if ok {
+		t.Fatal("preflight accepted a spec whose gate is still template text")
+	}
+	if !strings.Contains(findings.Format(), "template placeholder") {
+		t.Errorf("findings do not name the placeholder:\n%s", findings.Format())
+	}
+}
+
+func TestRunPreflightRejectsMissingSpec(t *testing.T) {
+	m := &model{cfg: Config{WorkDir: t.TempDir()}}
+	if _, ok := m.runPreflight("nope"); ok {
+		t.Fatal("preflight accepted a spec that does not exist")
+	}
+}
+
+func TestRunPreflightRejectsOversizedSlice(t *testing.T) {
+	work := t.TempDir()
+	files := runnableSpec()
+	var paths []string
+	for i := 0; i < 14; i++ {
+		paths = append(paths, "`f"+string(rune('a'+i))+".go`")
+	}
+	files["PROMPT.md"] = "# T\n\n## Implementation Slices\n\n1. **Big** — files: " +
+		strings.Join(paths, ", ") + ", verify: `go build ./...`, parallel-safe: no\n\n" +
+		"## Gates\n- **build**: `go build ./...`\n"
+	files["plan.md"] = "# Plan\n\n- [ ] Step 1: Big\n"
+	writeTestSpec(t, work, "features/x", files)
+
+	m := &model{cfg: Config{WorkDir: work}}
+	findings, ok := m.runPreflight("features/x")
+	if ok {
+		t.Fatal("preflight accepted a slice naming 14 files")
+	}
+	if !strings.Contains(findings.Format(), "file budget") {
+		t.Errorf("findings do not name the budget:\n%s", findings.Format())
+	}
+}
+
+func TestWriteRunManifestRecordsResult(t *testing.T) {
+	work := t.TempDir()
+	dir := writeTestSpec(t, work, "features/x", runnableSpec())
+
+	m := &model{cfg: Config{WorkDir: work}}
+	m.writeRunManifest("features/x")
+
+	manifest, err := sop.ReadManifest(dir)
+	if err != nil {
+		t.Fatalf("no manifest written: %v", err)
+	}
+	if !manifest.Valid {
+		t.Errorf("manifest reports invalid for a runnable spec: %+v", manifest.Findings)
+	}
+	if manifest.Contract != "run-preflight" {
+		t.Errorf("contract = %q, want run-preflight", manifest.Contract)
+	}
+	if !manifest.Compatible() {
+		t.Error("freshly written manifest is not compatible")
+	}
+}
+
+func TestFormatPreflightBlockNamesTheOverride(t *testing.T) {
+	out := formatPreflightBlock("features/x", validate.Findings{
+		{Artifact: "PROMPT.md", Rule: "gates_are_executable", Severity: validate.SeverityError, Message: "bad gate"},
+	})
+	if !strings.Contains(out, "--force") {
+		t.Errorf("block message does not mention the override:\n%s", out)
+	}
+	if !strings.Contains(out, "bad gate") {
+		t.Errorf("block message does not include the finding:\n%s", out)
+	}
+}
+
+// The planner must be shown the contract it is held to, or validation is a
+// late failure rather than a loop.
+func TestPlanContractDescribeIsInstructional(t *testing.T) {
+	got := validate.PlanContract().Describe()
+	for _, want := range []string{"outline.md", "PROMPT.md", "Done Criteria", "parallel_safe", "research/"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("contract description omits %q:\n%s", want, got)
+		}
+	}
+}
+
+// writeValidPlanSpec writes a spec satisfying the full PDD contract into
+// specDir. Tests that drive the end-of-plan teardown need one, because
+// finishPlanWorktree now validates before it merges.
+func writeValidPlanSpec(t *testing.T, specDir string) {
+	t.Helper()
+	files := map[string]string{
+		"rough-idea.md": "# Rough Idea\n\nDo it.\n",
+		"requirements.md": "# Requirements\n\n## Questions & Answers\n\n" +
+			"Q1: What is in scope?\nA: The feature.\n\n" +
+			"Q2: What are the edge cases?\nA: Empty input.\n\n" +
+			"Q3: How is it verified?\nA: go build.\n",
+		"design.md": "# Design\n\n## Current State\nNone.\n\n## Desired End State\nIt exists.\n\n" +
+			"## Acceptance Criteria\n\n- Given no feature, when added, then it exists.\n\n" +
+			"## Testing Strategy\n\nTable tests.\n",
+		"research/notes.md":    "# Notes\n\nThe code does x today.\n",
+		"research/patterns.md": "# Patterns\n\nThe repo uses functional options.\n",
+		"outline.md":           "# Outline\n\n1. Add the type\n2. Wire it up\n",
+		"plan.md":              "# Plan\n\n## Progress\n\n- [ ] Step 1: Add the type\n- [ ] Step 2: Wire it up\n",
+		"PROMPT.md": "# Feature\n\n## Objective\nDo it.\n\n" +
+			"## Acceptance Criteria\n- Given no feature, when added, then it exists.\n\n" +
+			"## Implementation Slices\n\n" +
+			"1. **Add the type** — define it, files: `a.go`, verify: `go build ./...`, parallel-safe: no\n" +
+			"2. **Wire it up** — call it, files: `b.go`, verify: `go build ./...`, parallel-safe: yes\n\n" +
+			"## Done Criteria\n- [ ] the type exists\n- [ ] it is called\n- [ ] no stubs remain\n\n" +
+			"## Gates\n- **build**: `go build ./...`\n",
+	}
+	for rel, body := range files {
+		full := filepath.Join(specDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestFinishPlanWorktreeHoldsBackInvalidSpec is the behavior change: a
+// PROMPT.md that merely exists used to be enough to merge. Now a spec that
+// fails the contract keeps the worktree so the next planning turn can fix it.
+func TestValidatePlanArtifactsHoldsBackInvalidSpec(t *testing.T) {
+	work := t.TempDir()
+	const taskName = "features/x"
+	specDir := writeTestSpec(t, work, taskName, map[string]string{
+		"PROMPT.md": "# Feature\n\n## Objective\nDo it.\n",
+	})
+
+	m := &model{cfg: Config{WorkDir: work}, planTaskName: taskName}
+	if m.validatePlanArtifacts() {
+		t.Fatal("a spec with only a stub PROMPT.md was accepted")
+	}
+
+	msg := m.chatModel.Messages[len(m.chatModel.Messages)-1].content
+	if !strings.Contains(msg, "Plan not yet complete") {
+		t.Errorf("message does not frame the findings as remaining work:\n%s", msg)
+	}
+	for _, want := range []string{"outline.md", "plan.md", "Done Criteria"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message omits the missing %q:\n%s", want, msg)
+		}
+	}
+
+	// The manifest is written even for an invalid plan, so the failure is a
+	// record rather than only a chat message.
+	manifest, err := sop.ReadManifest(specDir)
+	if err != nil {
+		t.Fatalf("no manifest written for an invalid plan: %v", err)
+	}
+	if manifest.Valid {
+		t.Error("manifest reports an invalid plan as valid")
+	}
+}
+
+func TestValidatePlanArtifactsAcceptsConformingSpec(t *testing.T) {
+	work := t.TempDir()
+	const taskName = "features/x"
+	specDir := filepath.Join(work, "specs", filepath.FromSlash(taskName))
+	writeValidPlanSpec(t, specDir)
+
+	m := &model{cfg: Config{WorkDir: work}, planTaskName: taskName}
+	if !m.validatePlanArtifacts() {
+		t.Fatalf("a conforming spec was rejected:\n%s",
+			m.chatModel.Messages[len(m.chatModel.Messages)-1].content)
+	}
+
+	manifest, err := sop.ReadManifest(specDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.Valid || manifest.Contract != "pdd-plan" {
+		t.Errorf("manifest = %+v, want a valid pdd-plan record", manifest)
+	}
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -370,16 +370,25 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	specName, parallel := parseRunArgs(args)
+	specName, parallel, force := parseRunArgs(args)
 	if specName == "" {
 		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: "Missing spec name."})
 		return m, nil
 	}
 
-	// Read PROMPT.md.
+	// Read PROMPT.md. A spec that is absent entirely gets the "not found"
+	// message and the list of specs that do exist — a more useful answer than
+	// a validation report about a directory the user mistyped.
 	promptMD, err := readPromptMD(m.cfg.WorkDir, specName)
 	if err != nil {
 		m.showRunSpecError(err)
+		return m, nil
+	}
+
+	// Preflight: a spec that cannot succeed should fail here, in a second,
+	// rather than as a worker with an unrunnable verify command forty minutes
+	// in. --force keeps the decision the user's.
+	if !m.preflightAllows(specName, force) {
 		return m, nil
 	}
 
@@ -414,7 +423,7 @@ func (m *model) handleRunCommand(args []string) (tea.Model, tea.Cmd) {
 // available to run when there are any.
 func (m *model) showRunUsage() {
 	specs, _ := listAvailableSpecs(m.cfg.WorkDir)
-	msg := "Usage: `/run <spec-name> [--parallel]`\n\nExecutes a spec's PROMPT.md using an isolated task agent.\nUse `--parallel` to split independent slices across 2 agents."
+	msg := "Usage: `/run <spec-name> [--parallel] [--force]`\n\nExecutes a spec's PROMPT.md using an isolated task agent.\nUse `--parallel` to split independent slices across 2 agents.\nUse `--force` to start despite preflight validation errors."
 	if len(specs) > 0 {
 		msg += "\n\n" + formatAvailableRunSpecsTable(specs)
 	}
@@ -434,18 +443,20 @@ func (m *model) showRunSpecError(err error) {
 
 // parseRunArgs splits /run arguments into the spec name and the parallel flag.
 // The first non-flag argument wins; later ones are ignored.
-func parseRunArgs(args []string) (specName string, parallel bool) {
+func parseRunArgs(args []string) (specName string, parallel, force bool) {
 	for _, arg := range args {
 		switch arg {
 		case "--parallel", "-p":
 			parallel = true
+		case "--force", "-f":
+			force = true
 		default:
 			if specName == "" {
 				specName = arg
 			}
 		}
 	}
-	return specName, parallel
+	return specName, parallel, force
 }
 
 // formatRunGateInfo renders gate names for the spawn announcement.

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dimetron/pi-go/internal/procs"
+	"github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/sop"
 	"github.com/dimetron/pi-go/internal/subagent"
 
@@ -65,6 +66,12 @@ type runState struct {
 	// it, retrying a parallel run silently drops every worktree but the one
 	// the retry resumed in.
 	carried []mergeTarget
+
+	// runID groups every session this run spawns, at any depth. Without it the
+	// only way to reconstruct a run tree is to group sessions by working
+	// directory and infer roles from title prefixes — which cannot attribute
+	// an agent that ran in a numerically-named worktree at all.
+	runID string
 
 	// transcript accumulates the coordinator's streamed text for this cycle so
 	// the Verifier's verdict can be read out of it. Without this the verdict
@@ -505,6 +512,7 @@ func (m *model) startRunAgent(
 	specName, promptMD string, gates []Gate, checklist []ChecklistStep, gateInfo string,
 ) (tea.Model, tea.Cmd) {
 	prompt := buildRunPrompt(specName, promptMD, checklist)
+	runID := newRunID(specName)
 
 	events, agentID, err := m.cfg.Orchestrator.SpawnWithInput(m.ctx, subagent.AgentInput{
 		Type:         "task",
@@ -513,6 +521,7 @@ func (m *model) startRunAgent(
 		WorktreeName: runWorktreeName(specName, ""),
 		SkipCleanup:  true,
 		Timeout:      int((60 * time.Minute) / time.Millisecond),
+		Attribution:  runAttribution(runID, specName, m.cfg.SessionID, 0, 0),
 	})
 	if err != nil {
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -532,6 +541,7 @@ func (m *model) startRunAgent(
 		promptMD: promptMD,
 		gates:    gates,
 		agentID:  agentID,
+		runID:    runID,
 		// The spawning agent owns the worktree; retries resume inside it.
 		worktreeAgentID: agentID,
 		phase:           "running",
@@ -566,6 +576,7 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 	prompt2 := buildParallelPrompt(specName, promptMD, checklist, mid, len(checklist))
 
 	useWorktree := true
+	runID := newRunID(specName)
 
 	// Spawn agent 1.
 	events1, agentID1, err := m.cfg.Orchestrator.SpawnWithInput(m.ctx, subagent.AgentInput{
@@ -575,6 +586,7 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 		WorktreeName: runWorktreeName(specName, "part-1"),
 		SkipCleanup:  true,
 		Timeout:      int((60 * time.Minute) / time.Millisecond),
+		Attribution:  runAttribution(runID, specName, m.cfg.SessionID, 1, 0),
 	})
 	if err != nil {
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -592,6 +604,7 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 		WorktreeName: runWorktreeName(specName, "part-2"),
 		SkipCleanup:  true,
 		Timeout:      int((60 * time.Minute) / time.Millisecond),
+		Attribution:  runAttribution(runID, specName, m.cfg.SessionID, mid+1, 0),
 	})
 	if err != nil {
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -624,6 +637,7 @@ func (m *model) handleRunParallel(specName, promptMD string, gates []Gate, check
 		specName: specName,
 		promptMD: promptMD,
 		gates:    gates,
+		runID:    runID,
 		agentID:  agentID1, // primary agent for fallback
 		// Gates and verification run in the first agent's worktree.
 		worktreeAgentID: agentID1,
@@ -1037,6 +1051,7 @@ func (m *model) retryRun(reason, extraContext string) tea.Cmd {
 		WorkDir:     wtPath,
 		SkipCleanup: true,
 		Timeout:     int((60 * time.Minute) / time.Millisecond),
+		Attribution: runAttribution(m.run.runID, m.run.specName, m.cfg.SessionID, 0, m.run.retries),
 	})
 	if err != nil {
 		m.run.phase = "failed"
@@ -1564,6 +1579,7 @@ func writeRunSummaryMetadata(b *strings.Builder, rs *runState, outcome string) {
 	b.WriteString("| Field | Value |\n")
 	b.WriteString("|-------|-------|\n")
 	fmt.Fprintf(b, "| Spec | `%s` |\n", rs.specName)
+	b.WriteString(rs.attributionSummary())
 	fmt.Fprintf(b, "| Agent | `%s` |\n", rs.agentID)
 	fmt.Fprintf(b, "| Outcome | **%s** |\n", outcome)
 	fmt.Fprintf(b, "| Retries | %d / %d |\n", rs.retries, rs.maxRetries)
@@ -2064,4 +2080,35 @@ func (m *model) verificationContext(pending []string) string {
 	b.WriteString("\n\nAddress these before ticking anything further. ")
 	b.WriteString("End the cycle with the Verifier's `VERDICT:` line — a cycle with no verdict cannot merge.\n")
 	return b.String()
+}
+
+// newRunID returns an identifier that groups every session of one /run.
+func newRunID(specName string) string {
+	return fmt.Sprintf("run-%s-%d", runWorktreeName(specName, ""), time.Now().UnixMilli())
+}
+
+// runAttribution builds the attribution handed to a spawned agent. The
+// orchestrator fills in the agent's own ID, type and worktree; the run-level
+// fields are ours because only we know them.
+//
+// It takes the run identity as arguments rather than reading m.run, because the
+// first agent of a run is spawned before the run state exists.
+func runAttribution(runID, specName, parentSession string, slice, cycle int) *session.AgentContext {
+	return &session.AgentContext{
+		AgentType: "task",
+		RunID:     runID,
+		SpecName:  specName,
+		Slice:     slice,
+		Cycle:     cycle,
+		ParentID:  parentSession,
+	}
+}
+
+// runAttributionSummary renders the run's identity for the summary report, so
+// a spec's SUMMARY.md names the sessions and worktrees that produced it.
+func (rs *runState) attributionSummary() string {
+	if rs.runID == "" {
+		return ""
+	}
+	return fmt.Sprintf("| Run ID | `%s` |\n", rs.runID)
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -149,18 +150,50 @@ type runAgentDoneMsg struct {
 	status  string // authoritative terminal status from the subagent
 }
 
+// GateStatus is the outcome of one gate command. It is three-valued on
+// purpose: a gate that never returns is not a gate that passed.
+//
+// pi-go has a documented case of this — tests that bind a local listener hang
+// under the sandbox (CLAUDE.md, "Two environment traps"). Session trajectories
+// show coordinators backgrounding such a run, killing it, and reporting
+// success. Collapsing "hang" into either "pass" or "fail" is what let that
+// happen: reported as a pass it merges unverified work, reported as a fail it
+// burns the retry budget re-running something that will hang again.
+type GateStatus string
+
+const (
+	GatePass GateStatus = "pass"
+	GateFail GateStatus = "fail"
+	GateHang GateStatus = "hang"
+)
+
 // GateResult holds the result of running a single gate command.
 type GateResult struct {
 	Name    string
 	Command string
-	Passed  bool
+	Passed  bool // true only for GatePass; kept as the summary predicate
+	Status  GateStatus
 	Output  string
+	Elapsed time.Duration
+}
+
+// status reports the gate's status, defaulting to the Passed field for results
+// built before Status existed (tests, persisted eval fixtures).
+func (r GateResult) status() GateStatus {
+	if r.Status != "" {
+		return r.Status
+	}
+	if r.Passed {
+		return GatePass
+	}
+	return GateFail
 }
 
 // runGateResultMsg carries the result of running all gate commands.
 type runGateResultMsg struct {
 	results []GateResult
 	passed  bool // true if all gates passed
+	hung    bool // a gate exceeded its timeout — distinct from failing
 }
 
 // runMergeResultMsg carries the result of merging the worktree branch.
@@ -1101,44 +1134,86 @@ func (m *model) runGatesCmd() tea.Cmd {
 	}
 }
 
-// runGates executes gate commands sequentially in the given directory.
+// defaultGateTimeout bounds a single gate command. A gate is a build, test or
+// vet run; anything still going after this is hung, not slow.
+const defaultGateTimeout = 10 * time.Minute
+
+// runGates executes gate commands sequentially in the given directory, each
+// bounded by defaultGateTimeout.
 func runGates(ctx context.Context, workDir string, gates []Gate) runGateResultMsg {
+	return runGatesTimeout(ctx, workDir, gates, defaultGateTimeout)
+}
+
+// runGatesTimeout is runGates with an explicit per-gate bound, so tests need
+// not wait out the production timeout.
+func runGatesTimeout(ctx context.Context, workDir string, gates []Gate, timeout time.Duration) runGateResultMsg {
 	var results []GateResult
 	allPassed := true
+	hung := false
 
 	for _, gate := range gates {
-		cmd := procs.CommandContext(ctx, "sh", "-c", gate.Command)
-		cmd.Dir = workDir
+		res := runOneGate(ctx, workDir, gate, timeout)
+		results = append(results, res)
 
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-
-		err := cmd.Run()
-		passed := err == nil
-
-		output := stdout.String()
-		if stderr.Len() > 0 {
-			if output != "" {
-				output += "\n"
-			}
-			output += stderr.String()
-		}
-
-		results = append(results, GateResult{
-			Name:    gate.Name,
-			Command: gate.Command,
-			Passed:  passed,
-			Output:  output,
-		})
-
-		if !passed {
+		if res.Status != GatePass {
 			allPassed = false
-			break // Stop at first failure.
+			hung = res.Status == GateHang
+			break // Stop at the first gate that does not pass.
 		}
 	}
 
-	return runGateResultMsg{results: results, passed: allPassed}
+	return runGateResultMsg{results: results, passed: allPassed, hung: hung}
+}
+
+// runOneGate runs a single gate under its own deadline and classifies the
+// outcome. A gate whose own deadline fired is GateHang; one the caller
+// canceled is GateFail, because the run is being torn down rather than the
+// command misbehaving.
+func runOneGate(ctx context.Context, workDir string, gate Gate, timeout time.Duration) GateResult {
+	gctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := procs.CommandContext(gctx, "sh", "-c", gate.Command)
+	cmd.Dir = workDir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(start)
+
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += stderr.String()
+	}
+
+	status := GatePass
+	switch {
+	case err == nil:
+		// passed
+	case errors.Is(gctx.Err(), context.DeadlineExceeded) && ctx.Err() == nil:
+		status = GateHang
+		if output != "" {
+			output += "\n"
+		}
+		output += fmt.Sprintf("gate did not return within %s and was killed", timeout)
+	default:
+		status = GateFail
+	}
+
+	return GateResult{
+		Name:    gate.Name,
+		Command: gate.Command,
+		Passed:  status == GatePass,
+		Status:  status,
+		Output:  output,
+		Elapsed: elapsed,
+	}
 }
 
 // handleRunGateResult processes gate validation results.
@@ -1154,10 +1229,7 @@ func (m *model) handleRunGateResult(msg runGateResultMsg) (tea.Model, tea.Cmd) {
 	var summary strings.Builder
 	summary.WriteString("**Gate Results:**\n")
 	for _, r := range msg.results {
-		status := "PASS"
-		if !r.Passed {
-			status = "FAIL"
-		}
+		status := strings.ToUpper(string(r.status()))
 		fmt.Fprintf(&summary, "- **%s** (`%s`): %s\n", r.Name, r.Command, status)
 		if !r.Passed && r.Output != "" {
 			// Include truncated output for failed gates.
@@ -1181,6 +1253,14 @@ func (m *model) handleRunGateResult(msg runGateResultMsg) (tea.Model, tea.Cmd) {
 			content: "All gates passed — verifying plan completeness...",
 		})
 		return m.verifyRunComplete()
+	}
+
+	// A hung gate is not a failed gate. Retrying it re-runs a command that
+	// already proved it does not return, which spends the whole retry budget
+	// on the same hang; and merging over it would ship unverified work. Stop
+	// and say what to re-run by hand instead.
+	if msg.hung {
+		return m.reportGateHang(msg.results)
 	}
 
 	// Gates failed — attempt retry or give up.
@@ -1209,6 +1289,43 @@ func (m *model) handleRunGateResult(msg runGateResultMsg) (tea.Model, tea.Cmd) {
 		})
 	}
 
+	return m, nil
+}
+
+// reportGateHang ends the run on a gate that never returned, naming the gate
+// and the worktree so the command can be re-run by hand. pi-go's own test
+// suite hangs under the sandbox (CLAUDE.md), so "re-run outside the sandbox"
+// is the usual resolution rather than a code fix.
+func (m *model) reportGateHang(results []GateResult) (tea.Model, tea.Cmd) {
+	m.run.phase = "failed"
+
+	var hung []GateResult
+	for _, r := range results {
+		if r.status() == GateHang {
+			hung = append(hung, r)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("**Gate hung** — not merging, and not retrying.\n\n")
+	for _, r := range hung {
+		fmt.Fprintf(&b, "- **%s** (`%s`) did not return within %s.\n", r.Name, r.Command, r.Elapsed.Round(time.Second))
+	}
+	if wt := m.runWorktreePath(m.run.worktreeAgentID); wt != "" {
+		fmt.Fprintf(&b, "\nWorktree preserved at: `%s`\n", wt)
+	}
+	b.WriteString("\nA hang is not a failure the agent can fix by re-running it. " +
+		"Run the gate yourself — outside the sandbox if it binds a local listener — " +
+		"then `/run` the spec again.")
+
+	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: b.String()})
+
+	if report, err := m.writeRunSummary("gate_hang"); err == nil {
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: fmt.Sprintf("Summary report: `%s`", report),
+		})
+	}
 	return m, nil
 }
 
@@ -1423,28 +1540,40 @@ func writeRunSummaryGates(b *strings.Builder, rs *runState) {
 		return
 	}
 	allPassed := true
+	anyHung := false
 	for _, r := range rs.gateResults {
-		if !r.Passed {
+		switch r.status() {
+		case GatePass:
+		case GateHang:
+			allPassed = false
+			anyHung = true
+		default:
 			allPassed = false
 		}
 		writeRunSummaryGateResult(b, r)
 	}
 	b.WriteString("\n")
-	if allPassed {
+	switch {
+	case allPassed:
 		b.WriteString("All gates **passed**.\n\n")
-		return
+	case anyHung:
+		b.WriteString("A gate **hung** — it never returned and was killed. " +
+			"This is not a failure the run can retry away; re-run the gate by hand, " +
+			"outside the sandbox if it binds a local listener.\n\n")
+	default:
+		b.WriteString("Some gates **failed**.\n\n")
 	}
-	b.WriteString("Some gates **failed**.\n\n")
 }
 
 // writeRunSummaryGateResult writes one gate's verdict, with its output block
 // when it failed and produced any.
 func writeRunSummaryGateResult(b *strings.Builder, r GateResult) {
-	status := "PASS"
-	if !r.Passed {
-		status = "FAIL"
+	status := strings.ToUpper(string(r.status()))
+	if r.Elapsed > 0 {
+		fmt.Fprintf(b, "- **%s** (`%s`): **%s** (%s)\n", r.Name, r.Command, status, r.Elapsed.Round(time.Second))
+	} else {
+		fmt.Fprintf(b, "- **%s** (`%s`): **%s**\n", r.Name, r.Command, status)
 	}
-	fmt.Fprintf(b, "- **%s** (`%s`): **%s**\n", r.Name, r.Command, status)
 	if r.Passed || r.Output == "" {
 		return
 	}
@@ -1459,6 +1588,10 @@ func writeRunSummaryGateResult(b *strings.Builder, r GateResult) {
 func writeRunSummaryResult(b *strings.Builder, rs *runState, outcome string) {
 	b.WriteString("## Result\n\n")
 	switch outcome {
+	case "gate_hang":
+		b.WriteString("A gate command never returned and was killed at its timeout. " +
+			"Nothing was merged. A hang carries no information about whether the code is correct, " +
+			"so it is reported rather than retried or treated as a pass.\n")
 	case "completed":
 		b.WriteString("All gates passed, the plan checklist was complete, and changes were merged successfully.\n")
 	case "gate_failed":

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dimetron/pi-go/internal/procs"
+	"github.com/dimetron/pi-go/internal/sop"
 	"github.com/dimetron/pi-go/internal/subagent"
 
 	tea "charm.land/bubbletea/v2"
@@ -64,6 +65,16 @@ type runState struct {
 	// it, retrying a parallel run silently drops every worktree but the one
 	// the retry resumed in.
 	carried []mergeTarget
+
+	// transcript accumulates the coordinator's streamed text for this cycle so
+	// the Verifier's verdict can be read out of it. Without this the verdict
+	// is only ever displayed, never acted on — which is why the corpus holds
+	// nine PASS verdicts and no FAIL.
+	transcript strings.Builder
+
+	// verdict is the review result parsed from transcript at the end of a
+	// cycle. An unstated verdict is not a pass.
+	verdict sop.Verdict
 
 	// ownerBackup is the backup branch the worktree owner was given at spawn
 	// time. It is recorded on collapse because the owner keeps its parallel
@@ -258,6 +269,23 @@ Spawn the Verifier and act on its verdict:
   Repeat up to 10 cycles.
 - **VERDICT: PASS** — report the changed files and stop. Do not commit or merge;
   /run handles gates and the merge.
+
+### Ending the cycle
+
+The last line of your own reply must repeat the Verifier's verdict verbatim:
+
+    VERDICT: PASS
+
+or
+
+    VERDICT: FAIL
+
+/run reads that line and acts on it: PASS is what permits the merge, FAIL sends
+the run into another cycle with the NOT MET items as its brief. **A cycle that
+ends with no VERDICT line does not merge** — it is treated as an incomplete
+review, because a verdict nobody can read is the same as no review at all. Do
+not write the line before the Verifier has returned, and do not write PASS when
+it returned FAIL.
 `
 
 // buildRunPrompt constructs the augmented prompt for the task subagent.
@@ -713,6 +741,9 @@ func (m *model) handleRunAgentEvent(msg runAgentEventMsg) (tea.Model, tea.Cmd) {
 // folds it into the trailing LLM trace entry.
 func (m *model) applyRunTextDelta(ev subagent.Event) {
 	m.chatModel.Streaming += ev.Content
+	if m.run != nil {
+		m.run.transcript.WriteString(ev.Content)
+	}
 	// Update the last assistant message with accumulated text.
 	for i := len(m.chatModel.Messages) - 1; i >= 0; i-- {
 		if m.chatModel.Messages[i].role == "assistant" {
@@ -911,38 +942,46 @@ func (m *model) unfinishedSlicesContext() string {
 func (m *model) verifyRunComplete() (tea.Model, tea.Cmd) {
 	m.run.phase = "verifying"
 	m.refreshRunChecklist()
+	m.run.verdict = sop.ParseVerdict(m.run.transcript.String())
 
 	pending := m.run.unfinishedSlices()
-	if len(pending) == 0 {
+
+	// Two independent signals must agree before a merge. The checklist says
+	// the coordinator believes every slice landed; the verdict says a reviewer
+	// checked the diff against the Done Criteria. Ticking a box is cheap and
+	// the corpus shows it done without verification, so the checklist alone is
+	// not enough — and a verdict that was never stated is not a pass.
+	if len(pending) == 0 && m.run.verdict.Passed() {
 		done := len(m.run.checklist)
-		msg := "**Verifier: PASS** — no plan checklist to verify."
+		msg := "**Verifier: PASS** — reviewer confirmed the Done Criteria."
 		if done > 0 {
-			msg = fmt.Sprintf("**Verifier: PASS** — all %d slices complete.", done)
+			msg = fmt.Sprintf("**Verifier: PASS** — all %d slices complete and the reviewer confirmed the Done Criteria.", done)
 		}
 		m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: msg})
 		m.run.phase = "merging"
 		return m, m.mergeWorktreeCmd()
 	}
 
+	reason, detail := m.verificationFailure(pending)
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
-		role: "assistant",
-		content: fmt.Sprintf("**Verifier: FAIL** — %d of %d slices still unchecked in plan.md.",
-			len(pending), len(m.run.checklist)),
+		role:    "assistant",
+		content: "**Verifier: FAIL** — " + detail,
 	})
 
-	if cmd := m.retryRun("plan incomplete", m.unfinishedSlicesContext()); cmd != nil {
+	if cmd := m.retryRun(reason, m.verificationContext(pending)); cmd != nil {
 		return m, cmd
 	}
 
 	// Cycles exhausted with work still outstanding — do not merge.
 	m.run.phase = "failed"
 	wtPath := m.runWorktreePath(m.run.worktreeAgentID)
+	_, detail = m.verificationFailure(pending)
 	m.chatModel.Messages = append(m.chatModel.Messages, message{
 		role: "assistant",
 		content: fmt.Sprintf(
-			"**Verification failed** for spec `%s` after %d retries — %d slices never completed.\n"+
+			"**Verification failed** for spec `%s` after %d retries — %s\n"+
 				"Not merging. Worktree preserved at: `%s`",
-			m.run.specName, m.run.maxRetries, len(pending), wtPath),
+			m.run.specName, m.run.maxRetries, detail, wtPath),
 	})
 	if report, err := m.writeRunSummary("verify_failed"); err == nil {
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
@@ -1016,6 +1055,10 @@ func (m *model) retryRun(reason, extraContext string) tea.Cmd {
 	m.run.events = events
 	m.run.status = ""
 	m.run.phase = "running"
+	// Each cycle gets its own transcript. Carrying the previous cycle's text
+	// forward would let a stale PASS satisfy the next verification.
+	m.run.transcript.Reset()
+	m.run.verdict = sop.Verdict{}
 
 	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: ""})
 	m.chatModel.Streaming = ""
@@ -1975,4 +2018,50 @@ func listAvailableSpecs(workDir string) ([]string, error) {
 
 	sort.Strings(specs)
 	return specs, nil
+}
+
+// verificationFailure explains why the run may not merge, distinguishing the
+// two signals so the retry briefing addresses the right one.
+//
+// The distinction matters: unchecked slices mean work is outstanding, while a
+// FAIL verdict over a fully-ticked checklist means the work is claimed done
+// but does not satisfy the Done Criteria. Sending "finish the remaining
+// slices" for the second case is what makes a retry cycle repeat itself.
+func (m *model) verificationFailure(pending []string) (reason, detail string) {
+	total := len(m.run.checklist)
+	switch {
+	case len(pending) > 0 && !m.run.verdict.Passed():
+		return "plan incomplete and review not passed",
+			fmt.Sprintf("%d of %d slices still unchecked in plan.md, and %s.",
+				len(pending), total, m.run.verdict.Reason())
+	case len(pending) > 0:
+		return "plan incomplete",
+			fmt.Sprintf("%d of %d slices still unchecked in plan.md.", len(pending), total)
+	case !m.run.verdict.Stated:
+		return "review did not complete",
+			"every slice is ticked, but the Verifier produced no VERDICT line. " +
+				"A checked box is a claim; without a review it is unverified."
+	default:
+		return "review failed", "every slice is ticked, but " + m.run.verdict.Reason()
+	}
+}
+
+// verificationContext renders the state the next cycle needs: which slices are
+// outstanding, and which Done Criteria the reviewer rejected.
+func (m *model) verificationContext(pending []string) string {
+	var b strings.Builder
+	if len(pending) > 0 {
+		b.WriteString(m.unfinishedSlicesContext())
+	}
+	if m.run.verdict.Passed() {
+		return b.String()
+	}
+	if b.Len() > 0 {
+		b.WriteString("\n")
+	}
+	b.WriteString("## Review\n")
+	b.WriteString(m.run.verdict.Reason())
+	b.WriteString("\n\nAddress these before ticking anything further. ")
+	b.WriteString("End the cycle with the Verifier's `VERDICT:` line — a cycle with no verdict cannot merge.\n")
+	return b.String()
 }

--- a/internal/tui/run_backup_test.go
+++ b/internal/tui/run_backup_test.go
@@ -192,7 +192,7 @@ func TestHandleRunCommand_SpawnFailure(t *testing.T) {
 	writeRunSpec(t, workDir, "my-spec", "# My Spec\n\n## Gates\n\n- **build**: `go build ./...`\n", "")
 
 	m := runTestModel(t, workDir)
-	m.handleRunCommand([]string{"my-spec"})
+	m.handleRunCommand([]string{"my-spec", "--force"})
 
 	if got := lastMessage(t, m); !strings.Contains(got, "Failed to spawn task agent") {
 		t.Errorf("message %q does not report the spawn failure", got)
@@ -220,7 +220,7 @@ func TestHandleRunCommand_ParallelSpawnFailure(t *testing.T) {
 	writeRunSpec(t, workDir, "my-spec", "# My Spec\n", plan)
 
 	m := runTestModel(t, workDir)
-	m.handleRunCommand([]string{"my-spec", "--parallel"})
+	m.handleRunCommand([]string{"my-spec", "--parallel", "--force"})
 
 	got := lastMessage(t, m)
 	if !strings.Contains(got, "Failed to spawn agent 1") {
@@ -239,7 +239,7 @@ func TestHandleRunCommand_ParallelFallsBackToSingleAgent(t *testing.T) {
 	writeRunSpec(t, workDir, "my-spec", "# My Spec\n", "# Plan\n\n- [ ] Step 1: the only slice\n")
 
 	m := runTestModel(t, workDir)
-	m.handleRunCommand([]string{"my-spec", "--parallel"})
+	m.handleRunCommand([]string{"my-spec", "--parallel", "--force"})
 
 	if got := lastMessage(t, m); !strings.Contains(got, "Failed to spawn task agent") {
 		t.Errorf("message %q suggests the parallel path ran with a single slice", got)

--- a/internal/tui/run_gate_status_test.go
+++ b/internal/tui/run_gate_status_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunGatesClassifiesPassFailHang(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    GateStatus
+	}{
+		{"pass", "true", GatePass},
+		{"fail", "exit 3", GateFail},
+		{"hang", "sleep 30", GateHang},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := runGatesTimeout(t.Context(), t.TempDir(),
+				[]Gate{{Name: tt.name, Command: tt.command}}, 150*time.Millisecond)
+
+			if len(msg.results) != 1 {
+				t.Fatalf("got %d results, want 1", len(msg.results))
+			}
+			got := msg.results[0]
+			if got.Status != tt.want {
+				t.Errorf("Status = %q, want %q", got.Status, tt.want)
+			}
+			if wantPassed := tt.want == GatePass; got.Passed != wantPassed {
+				t.Errorf("Passed = %v, want %v", got.Passed, wantPassed)
+			}
+			if msg.hung != (tt.want == GateHang) {
+				t.Errorf("msg.hung = %v, want %v", msg.hung, tt.want == GateHang)
+			}
+			if msg.passed != (tt.want == GatePass) {
+				t.Errorf("msg.passed = %v, want %v", msg.passed, tt.want == GatePass)
+			}
+		})
+	}
+}
+
+// A hang must not be reported as a pass. This is the specific laundering the
+// three-valued status exists to prevent.
+func TestRunGatesHangIsNotAPass(t *testing.T) {
+	msg := runGatesTimeout(t.Context(), t.TempDir(),
+		[]Gate{{Name: "test", Command: "sleep 30"}}, 100*time.Millisecond)
+
+	if msg.passed {
+		t.Fatal("a hung gate was reported as passed")
+	}
+	if !strings.Contains(msg.results[0].Output, "did not return within") {
+		t.Errorf("hang output does not explain the timeout: %q", msg.results[0].Output)
+	}
+}
+
+// A caller-canceled gate is a teardown, not a misbehaving command: it must be
+// classified FAIL so the hang path is reserved for commands that really hang.
+func TestRunGatesCallerCancelIsFailNotHang(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+	msg := runGatesTimeout(ctx, t.TempDir(),
+		[]Gate{{Name: "test", Command: "sleep 30"}}, 10*time.Second)
+
+	if msg.results[0].Status != GateFail {
+		t.Errorf("Status = %q, want %q for a caller-canceled gate", msg.results[0].Status, GateFail)
+	}
+	if msg.hung {
+		t.Error("caller cancellation was misreported as a hang")
+	}
+}
+
+func TestRunGatesStopsAtFirstNonPass(t *testing.T) {
+	msg := runGatesTimeout(t.Context(), t.TempDir(), []Gate{
+		{Name: "build", Command: "true"},
+		{Name: "test", Command: "exit 1"},
+		{Name: "vet", Command: "true"},
+	}, time.Second)
+
+	if len(msg.results) != 2 {
+		t.Fatalf("got %d results, want 2 (should stop at the failing gate)", len(msg.results))
+	}
+}
+
+// status() must keep working for GateResults built before Status existed.
+func TestGateResultStatusFallsBackToPassed(t *testing.T) {
+	if got := (GateResult{Passed: true}).status(); got != GatePass {
+		t.Errorf("status() = %q, want %q", got, GatePass)
+	}
+	if got := (GateResult{Passed: false}).status(); got != GateFail {
+		t.Errorf("status() = %q, want %q", got, GateFail)
+	}
+	if got := (GateResult{Passed: false, Status: GateHang}).status(); got != GateHang {
+		t.Errorf("status() = %q, want %q", got, GateHang)
+	}
+}
+
+func TestWriteRunSummaryGatesReportsHangDistinctly(t *testing.T) {
+	var b strings.Builder
+	writeRunSummaryGates(&b, &runState{
+		gateResults: []GateResult{
+			{Name: "build", Command: "make build", Passed: true, Status: GatePass},
+			{Name: "test", Command: "make test", Status: GateHang, Elapsed: 10 * time.Minute},
+		},
+	})
+	out := b.String()
+	if !strings.Contains(out, "HANG") {
+		t.Errorf("summary does not mark the gate HANG:\n%s", out)
+	}
+	if strings.Contains(out, "Some gates **failed**") {
+		t.Errorf("a hang was described as a failure:\n%s", out)
+	}
+	if !strings.Contains(out, "never returned") {
+		t.Errorf("summary does not explain the hang:\n%s", out)
+	}
+}

--- a/internal/tui/run_preflight.go
+++ b/internal/tui/run_preflight.go
@@ -1,0 +1,90 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/specdoc"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// runPreflight checks a spec before /run spawns anything.
+//
+// It exists because the only pre-run check used to be "PROMPT.md exists". A
+// spec with placeholder gates, slices that name no files, or a PROMPT.md
+// describing a different set of slices than plan.md tracks would start a run
+// that could not succeed — and the failure surfaced forty minutes later as a
+// worker with an unrunnable verify command rather than as a planning defect.
+//
+// It returns the findings and whether the run may proceed. Warnings are
+// reported and do not block.
+func (m *model) runPreflight(specName string) (validate.Findings, bool) {
+	spec, err := specdoc.Load(m.cfg.WorkDir, specName)
+	if err != nil {
+		return validate.Findings{{
+			Artifact: specName, Rule: "spec", Severity: validate.SeverityError,
+			Message: err.Error(),
+		}}, false
+	}
+	findings := validate.Check(spec, m.cfg.WorkDir, validate.RunPreflightContract())
+	return findings, findings.OK()
+}
+
+// formatPreflightBlock renders the message shown when preflight refuses to
+// start a run. It names the override so the decision stays the user's.
+func formatPreflightBlock(specName string, findings validate.Findings) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Preflight failed** for spec `%s` — not starting the run.\n\n", specName)
+	b.WriteString(findings.Format())
+	b.WriteString("\nFix the spec (or re-plan it) and run again. " +
+		"To start anyway, use `/run " + specName + " --force`.\n")
+	return b.String()
+}
+
+// formatPreflightWarnings renders non-blocking findings.
+func formatPreflightWarnings(findings validate.Findings) string {
+	var b strings.Builder
+	b.WriteString("**Preflight warnings** — starting anyway:\n\n")
+	b.WriteString(findings.Format())
+	return b.String()
+}
+
+// writeRunManifest records the preflight result in the spec directory so a
+// later run, or a human, can see what was checked and when.
+func (m *model) writeRunManifest(specName string) {
+	spec, err := specdoc.Load(m.cfg.WorkDir, specName)
+	if err != nil {
+		return
+	}
+	manifest := sop.BuildManifest(spec, m.cfg.WorkDir, validate.RunPreflightContract(), time.Now())
+	_ = sop.WriteManifest(spec.Dir, manifest)
+}
+
+// preflightAllows runs preflight, reports the outcome, records the manifest,
+// and reports whether the run may start. force downgrades a blocking result to
+// a warning so the user keeps the final say.
+func (m *model) preflightAllows(specName string, force bool) bool {
+	findings, ok := m.runPreflight(specName)
+	switch {
+	case !ok && !force:
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: formatPreflightBlock(specName, findings),
+		})
+		return false
+	case !ok:
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: "**Preflight failed but `--force` was given** — starting anyway.\n\n" + findings.Format(),
+		})
+	case len(findings) > 0:
+		m.chatModel.Messages = append(m.chatModel.Messages, message{
+			role:    "assistant",
+			content: formatPreflightWarnings(findings),
+		})
+	}
+	m.writeRunManifest(specName)
+	return true
+}

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -467,6 +467,7 @@ func TestHandleRunCommand_StreamingEvents(t *testing.T) {
 	}
 
 	// Process done — with no gates defined, it transitions to merging.
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{})
 	if m.running {
 		t.Error("model should not be running after done")
@@ -685,6 +686,7 @@ func TestHandleRunGateResult_AllPass(t *testing.T) {
 		passed: true,
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunGateResult(msg)
 
 	if m.run.phase != "merging" {
@@ -839,6 +841,7 @@ func TestHandleRunAgentDone_NoGatesSkipsToMerge(t *testing.T) {
 		},
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{})
 
 	if m.run.phase != "merging" {
@@ -876,6 +879,7 @@ func TestHandleRunAgentDone_WithGatesTriggersGating(t *testing.T) {
 		},
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{})
 
 	if m.run.phase != "gating" {
@@ -1415,6 +1419,7 @@ func TestHandleRunAgentDone_ParallelAllDone(t *testing.T) {
 	}
 
 	// Agent 2 finishes — now all done.
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{agentID: "a-2"})
 
 	if !m.run.allAgentsDone() {
@@ -1520,6 +1525,7 @@ func TestHandleRunAgentDone_CompletedStatus_ProceedsToGatesOrMerge(t *testing.T)
 		},
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-1"})
 
 	if m.run.phase != "merging" {
@@ -1685,6 +1691,7 @@ func TestHandleRunAgentDone_ParallelAllCompleted_ProceedsToGates(t *testing.T) {
 		},
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{agentID: "a-2"})
 
 	if m.run.phase != "gating" {
@@ -1707,6 +1714,7 @@ func TestHandleRunAgentDone_UsesTerminalStatusAfterOrchestratorEviction(t *testi
 
 	// The terminal event is authoritative even though the bounded orchestrator
 	// status map no longer contains the completed agent.
+	seedPassVerdict(m.run)
 	m.handleRunAgentDone(runAgentDoneMsg{agentID: "task-evicted", status: "completed"})
 
 	if m.run.phase != "merging" {
@@ -1782,6 +1790,7 @@ func TestVerifier_CompletePlanProceedsToMerge(t *testing.T) {
 		},
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunGateResult(runGateResultMsg{
 		results: []GateResult{{Name: "build", Command: "go build ./...", Passed: true}},
 		passed:  true,
@@ -1809,6 +1818,7 @@ func TestVerifier_NoChecklistProceedsToMerge(t *testing.T) {
 		},
 	}
 
+	seedPassVerdict(m.run)
 	m.handleRunGateResult(runGateResultMsg{passed: true})
 
 	if m.run.phase != "merging" {
@@ -2552,4 +2562,15 @@ func TestMergeTargets_NeverParallelUsesBareBackup(t *testing.T) {
 	if want := runBackupBranchName("spec", ""); got[0].backup != want {
 		t.Errorf("backup = %q, want %q", got[0].backup, want)
 	}
+}
+
+// seedPassVerdict writes the Verifier's PASS line into a run's transcript.
+//
+// verifyRunComplete requires two agreeing signals before a merge: a fully
+// ticked checklist and a stated PASS verdict. Fixtures below that mean to reach
+// the merge therefore have to state one; tests that exercise the verification
+// gate itself set the transcript explicitly instead.
+func seedPassVerdict(rs *runState) {
+	rs.transcript.Reset()
+	rs.transcript.WriteString("All Done Criteria met.\n\nVERDICT: PASS\n")
 }

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -1474,8 +1474,9 @@ func TestHandleRunCommand_ParallelFlag(t *testing.T) {
 	}
 
 	// With --parallel flag, spawn will fail (no task agent config) but
-	// we can verify the parallel path was taken.
-	m.handleRunCommand([]string{"test-spec", "--parallel"})
+	// we can verify the parallel path was taken. --force gets the minimal
+	// fixture past preflight, which is not what this test is about.
+	m.handleRunCommand([]string{"test-spec", "--parallel", "--force"})
 
 	found := false
 	for _, msg := range m.chatModel.Messages {

--- a/internal/tui/run_verdict_test.go
+++ b/internal/tui/run_verdict_test.go
@@ -147,3 +147,51 @@ func messageContents(m *model) []string {
 	}
 	return out
 }
+
+// A run must give every agent it spawns the same run ID, so the tree is
+// recoverable from meta.json rather than by grouping sessions by working
+// directory and guessing at roles.
+func TestRunAttributionCarriesRunIdentity(t *testing.T) {
+	got := runAttribution("run-1", "features/x", "sess-parent", 3, 2)
+	if got.RunID != "run-1" || got.SpecName != "features/x" || got.ParentID != "sess-parent" {
+		t.Errorf("attribution = %+v", got)
+	}
+	if got.Slice != 3 || got.Cycle != 2 {
+		t.Errorf("slice/cycle = %d/%d, want 3/2", got.Slice, got.Cycle)
+	}
+	if got.AgentType != "task" {
+		t.Errorf("AgentType = %q, want task", got.AgentType)
+	}
+	// The agent's own ID and worktree are the orchestrator's to fill in.
+	if got.AgentID != "" || got.Worktree != "" {
+		t.Errorf("run-level attribution should not guess the agent's id or worktree: %+v", got)
+	}
+}
+
+func TestNewRunIDIsSpecScopedAndUnique(t *testing.T) {
+	a := newRunID("features/TOO/024-mistral-provider")
+	if !strings.Contains(a, "features-TOO-024-mistral-provider") {
+		t.Errorf("run id %q does not name the spec", a)
+	}
+	if !strings.HasPrefix(a, "run-") {
+		t.Errorf("run id %q has no run- prefix", a)
+	}
+}
+
+func TestRunSummaryRecordsTheRunID(t *testing.T) {
+	rs := &runState{specName: "features/x", runID: "run-features-x-42", agentID: "a1"}
+	var b strings.Builder
+	writeRunSummaryMetadata(&b, rs, "completed")
+	if !strings.Contains(b.String(), "run-features-x-42") {
+		t.Errorf("summary omits the run id:\n%s", b.String())
+	}
+}
+
+func TestRunSummaryOmitsRunIDWhenAbsent(t *testing.T) {
+	rs := &runState{specName: "features/x", agentID: "a1"}
+	var b strings.Builder
+	writeRunSummaryMetadata(&b, rs, "completed")
+	if strings.Contains(b.String(), "Run ID") {
+		t.Errorf("summary shows an empty Run ID row:\n%s", b.String())
+	}
+}

--- a/internal/tui/run_verdict_test.go
+++ b/internal/tui/run_verdict_test.go
@@ -1,0 +1,149 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// verdictModel builds a model whose run is at the verification step with the
+// given checklist state and coordinator transcript.
+func verdictModel(t *testing.T, transcript string, done ...bool) *model {
+	t.Helper()
+	rs := &runState{specName: "features/x", maxRetries: 0}
+	for i, d := range done {
+		rs.checklist = append(rs.checklist, ChecklistStep{
+			Title: "slice " + string(rune('A'+i)), Done: d,
+		})
+	}
+	rs.transcript.WriteString(transcript)
+	return &model{run: rs, chatModel: ChatModel{Messages: make([]message, 0)}}
+}
+
+// The corpus failure this guards: every box ticked, no review, merged anyway.
+func TestVerifyRunCompleteRefusesToMergeWithoutAVerdict(t *testing.T) {
+	m := verdictModel(t, "I finished all the slices and everything builds.", true, true)
+	_, cmd := m.verifyRunComplete()
+
+	if m.run.phase == "merging" {
+		t.Fatal("a fully-ticked checklist with no verdict reached the merge")
+	}
+	if cmd != nil {
+		t.Error("retry budget was 0, so no retry command should have been issued")
+	}
+	msg := strings.Join(messageContents(m), "\n")
+	if !strings.Contains(msg, "no VERDICT line") {
+		t.Errorf("failure does not name the missing verdict:\n%s", msg)
+	}
+	if !strings.Contains(msg, "A checked box is a claim") {
+		t.Errorf("failure does not explain why ticks are not enough:\n%s", msg)
+	}
+}
+
+func TestVerifyRunCompleteMergesOnTickedChecklistAndPass(t *testing.T) {
+	m := verdictModel(t, "All criteria met.\n\nVERDICT: PASS\n", true, true)
+	_, _ = m.verifyRunComplete()
+
+	if m.run.phase != "merging" {
+		t.Fatalf("phase = %q, want merging", m.run.phase)
+	}
+	msg := strings.Join(messageContents(m), "\n")
+	if !strings.Contains(msg, "Verifier: PASS") {
+		t.Errorf("no PASS message:\n%s", msg)
+	}
+}
+
+func TestVerifyRunCompleteRefusesOnFailVerdict(t *testing.T) {
+	m := verdictModel(t,
+		"- No stubs remain - NOT MET: panic(\"not implemented\") in `internal/api/job.go`\nVERDICT: FAIL\n",
+		true, true)
+	_, _ = m.verifyRunComplete()
+
+	if m.run.phase == "merging" {
+		t.Fatal("a FAIL verdict reached the merge")
+	}
+	msg := strings.Join(messageContents(m), "\n")
+	if !strings.Contains(msg, "No stubs remain") {
+		t.Errorf("failure does not carry the unmet criterion:\n%s", msg)
+	}
+}
+
+func TestVerifyRunCompleteReportsBothSignals(t *testing.T) {
+	m := verdictModel(t, "VERDICT: FAIL\n", true, false)
+	_, _ = m.verifyRunComplete()
+
+	msg := strings.Join(messageContents(m), "\n")
+	if !strings.Contains(msg, "unchecked in plan.md") {
+		t.Errorf("failure omits the checklist signal:\n%s", msg)
+	}
+	if !strings.Contains(msg, "VERDICT: FAIL") && !strings.Contains(msg, "returned VERDICT") {
+		t.Errorf("failure omits the review signal:\n%s", msg)
+	}
+}
+
+// The retry briefing must address the right signal: telling a coordinator to
+// "finish the remaining slices" when every slice is ticked and the review
+// failed is what makes a cycle repeat itself.
+func TestVerificationContextTargetsTheFailingSignal(t *testing.T) {
+	t.Run("review failure", func(t *testing.T) {
+		m := verdictModel(t, "- Criterion one - NOT MET: still a stub\nVERDICT: FAIL\n", true, true)
+		m.run.verdict = sop.ParseVerdict(m.run.transcript.String())
+
+		got := m.verificationContext(nil)
+		if !strings.Contains(got, "Criterion one") {
+			t.Errorf("context omits the unmet criterion:\n%s", got)
+		}
+		if strings.Contains(got, "unfinished") {
+			t.Errorf("context talks about unfinished slices when none are:\n%s", got)
+		}
+	})
+
+	t.Run("incomplete plan", func(t *testing.T) {
+		m := verdictModel(t, "VERDICT: PASS\n", true, false)
+		m.run.verdict = sop.ParseVerdict(m.run.transcript.String())
+
+		got := m.verificationContext(m.run.unfinishedSlices())
+		if !strings.Contains(got, "unfinished") {
+			t.Errorf("context omits the outstanding slices:\n%s", got)
+		}
+	})
+}
+
+// A PASS from an earlier cycle must not satisfy a later one.
+func TestRetryResetsTheVerdict(t *testing.T) {
+	m := verdictModel(t, "VERDICT: PASS\n", true)
+	m.run.verdict = sop.ParseVerdict(m.run.transcript.String())
+	if !m.run.verdict.Passed() {
+		t.Fatal("fixture did not parse a PASS")
+	}
+
+	// retryRun resets both; simulate the reset it performs.
+	m.run.transcript.Reset()
+	m.run.verdict = sop.Verdict{}
+
+	if m.run.verdict.Passed() {
+		t.Error("a stale PASS survived into the next cycle")
+	}
+	if m.run.transcript.Len() != 0 {
+		t.Error("transcript was not reset between cycles")
+	}
+}
+
+// The coordinator must be told to emit the line the runtime reads.
+func TestCoordinatorContractRequiresTheVerdictLine(t *testing.T) {
+	contract := buildRunPrompt("features/x", "# Spec\n", nil)
+	for _, want := range []string{"VERDICT: PASS", "VERDICT: FAIL", "does not merge"} {
+		if !strings.Contains(contract, want) {
+			t.Errorf("coordinator contract omits %q", want)
+		}
+	}
+}
+
+func messageContents(m *model) []string {
+	out := make([]string, 0, len(m.chatModel.Messages))
+	for _, msg := range m.chatModel.Messages {
+		out = append(out, msg.content)
+	}
+	return out
+}

--- a/piagent/build.go
+++ b/piagent/build.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	adktool "google.golang.org/adk/v2/tool"
@@ -15,6 +13,7 @@ import (
 	"github.com/dimetron/pi-go/internal/agent"
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
+	"github.com/dimetron/pi-go/internal/gitroot"
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/memory"
 	"github.com/dimetron/pi-go/internal/palace"
@@ -63,17 +62,11 @@ func resolveSessionDir(dir string) (string, error) {
 }
 
 // detectGitRoot returns the repository root containing dir, or "" when dir is
-// not in a repository. Subagent worktrees are created relative to it.
+// not in a repository. Subagent worktrees are created relative to it, and it
+// becomes the sandbox root, so inside a linked worktree this resolves the main
+// checkout rather than the worktree. See internal/gitroot.
 func detectGitRoot(ctx context.Context, dir string) string {
-	ctx, cancel := context.WithTimeout(ctx, gitCmdTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	return gitroot.Detect(ctx, dir)
 }
 
 // buildSandbox roots the file tools at workDir and grants the extra


### PR DESCRIPTION
Turns pi-go's `/plan` and `/run` SOPs from prose into data, and adds the machine checks the prose could only ask for. Design and evidence: `specs/workflows/declarative-sop-design.md`.

## Why

Both SOPs live in a Go string constant — `DefaultPDDSOP` (190 lines) and `coordinatorContract` (55). An instruction the model may decline is not a control-flow construct, and the session corpus is a record of them being declined. Measured across 69 `/plan` sessions, 57 `/run` coordinator sessions, and all 55 spec directories in this repo:

| Finding | Evidence |
|---|---|
| Artifacts are optional in practice | 3 of 53 specs have a complete set; `outline.md` and `summary.md` each missing from 70% |
| Delegation is ignored | planners: 100 `bash` vs **4** `subagent`; coordinators: 302 `bash` vs **8** worker spawns |
| The Verifier never fails | `VERDICT: PASS` in 9 of 9 runs, 0 FAIL — nothing read the line |
| Checkboxes are unearned | `memory-fixes` 0/50, `memory/002` 0/41, `TOO/002` 6/41 |
| Fan-out has no backpressure | 30 sessions with exactly 2 events created in 3 minutes on 2026-08-10 |
| Workers could not write | `detectGitRoot` runs `--show-toplevel`, which inside a linked worktree returns the worktree, so spawned coordinators gave their workers a `PI_SANDBOX_ROOT` that rejected edits to `internal/` |
| Worktrees leak | 7 orphans on disk, 3 of them anonymous and unattributable to any spec |

The only machine-enforced checks were: `PROMPT.md` exists (one `os.Stat`), gates exit zero, and a checkbox count.

## What this changes

**Phase 0 — unblock workers.** `internal/gitroot` resolves the main checkout via `--git-common-dir`, falling back to the toplevel for bare repos and older git; all three duplicate `detectGitRoot` implementations delegate to it. `GateStatus` becomes `pass | fail | hang` with a per-gate timeout — a hang ends the run on its own path instead of spending the retry budget re-running a command that already proved it does not return.

**Phase 1 — validate the artifacts.** `internal/sop/specdoc` is one parser for gates, plan slices, PROMPT slices, Done Criteria and references. `internal/sop/validate` holds 20 rules and two contracts; a rule returns `Finding`s carrying the fix, which is fed back to the agent that produced the artifact. `Contract.Describe` renders the rules into the planner's own instructions — a contract the producer cannot see is only a way to fail late. `.sop-manifest.json` records what was checked, by which contract, at which SOP version. `finishPlanWorktree` validates before merging and keeps the worktree when a spec fails; `/run` preflights and refuses to start, with `--force` leaving the decision to the user.

**Phase 2 — compile the SOPs.** `plan.sop.yaml` and `run.sop.yaml` declare stages, artifacts, validators, review checkpoints, retry/timeout bounds and edges. `Compile` turns them into `[]workflow.Edge` against `adk/v2 v2.2.0` — already a dependency, previously unused by `/run`. Per-stage `NodeConfig.Timeout` replaces one blanket 60-minute spawn timeout; `RetryConfig` with backoff and jitter replaces a counter that re-sent the whole briefing; `fan_out` compiles to a `ParallelWorker`; a verdict compiles to `AddRoutes`. `LintDefinition` statically rejects a `[worktree]` agent, a dangling edge, an unbounded loop, an unknown validator, and an agent review whose verdict nothing routes on.

**Verdict routing.** `sop.Verdict` parses the line, with the deliberate property that an *unstated* verdict is not a pass. `verifyRunComplete` now requires two agreeing signals before merging — a ticked checklist and a stated PASS — and `verificationFailure` distinguishes them so the retry brief addresses the one that failed.

**Attribution.** `session.AgentContext` records agent id/type, parent session, run id, spec, slice, cycle, worktree and branch, forwarded through the spawn environment on the existing `PI_` prefix. `/run` mints one run id per invocation and gives it to every agent it spawns.

## Not in this PR

Phase 3 (execute the compiled graph, deleting `runState`/`retryRun`/`buildResumePrompt`) is the load-bearing remainder; Phase 4 and Phase 5's HITL depend on it. `DescribeFactory` exists so that work has a target to build against. The run lease and worktree reaping are independent and still outstanding — the design doc says why.

## Verification

`make build`, `make vet`, `make lint` (0 issues) and `make test` all pass. The contracts were calibrated against every spec directory in the repo with `hack/sopcheck`; the parser fixes for `## Slice N` headings, module paths in Reference sections, and arrow-form Given/When/Then all came from that pass.

`go run ./hack/sopcheck . sop:run` prints the compiled graph.
