### PR TITLE
feat(sop): execute SOPs through the ADK workflow engine

### DIFF
--- a/internal/sop/compile.go
+++ b/internal/sop/compile.go
@@ -117,6 +117,14 @@ func (c *Compiled) wire(stages []Stage, def *Definition) error {
 			from = r
 		}
 
+		// A stage that can fail over needs its forward edge to be conditional.
+		// The engine fires every unconditional edge regardless of routing
+		// ("Edges with no Route always fire" — workflow.findSuccessors), so an
+		// unconditional next alongside a FAIL route would schedule the
+		// successor AND the repair stage on a failure. Default fires only when
+		// no concrete route matched, which is exactly "next unless it failed".
+		failsOver := failoverTarget(s) != ""
+
 		switch {
 		case len(s.Routes) > 0:
 			routes := make(map[string]workflow.Node, len(s.Routes))
@@ -143,12 +151,16 @@ func (c *Compiled) wire(stages []Stage, def *Definition) error {
 			if !ok {
 				return fmt.Errorf("stage %q advances to unknown stage %q", s.ID, s.Next)
 			}
-			b.Add(from, to)
+			if failsOver {
+				b.AddRoute(from, to, workflow.Default)
+			} else {
+				b.Add(from, to)
+			}
 		}
 
 		// A failure path that names a stage is an edge too: it is how a gate
 		// failure reaches the repair stage without the coordinator deciding to.
-		if target := s.OnFail; target != "" && target != "abort" && target != "retry" {
+		if target := failoverTarget(s); target != "" {
 			to, ok := c.Nodes[target]
 			if !ok {
 				return fmt.Errorf("stage %q fails over to unknown stage %q", s.ID, target)
@@ -162,6 +174,15 @@ func (c *Compiled) wire(stages []Stage, def *Definition) error {
 		return fmt.Errorf("SOP %q compiled to no edges: no stage declares next, routes or loop_back", def.SOP)
 	}
 	return nil
+}
+
+// failoverTarget returns the stage a failure routes to, or "" when the stage
+// aborts, retries in place, or declares no failure path.
+func failoverTarget(s Stage) string {
+	if s.OnFail == "" || s.OnFail == "abort" || s.OnFail == "retry" {
+		return ""
+	}
+	return s.OnFail
 }
 
 // NodeConfigFor derives a node's runtime configuration from its stage and the
@@ -187,6 +208,13 @@ func NodeConfigFor(s Stage, defaults Defaults) workflow.NodeConfig {
 		cfg.RetryConfig = retryConfig(*retry)
 	}
 
+	// NOTE: as of adk v2.2.0 the scheduler never reads cfg.ParallelWorker — the
+	// field is declared in workflow.NodeConfig and consumed only by the YAML
+	// plumbing in internal/configurable. Setting it records the stage's intent
+	// and costs nothing, but it does NOT make the stage run in parallel. Real
+	// parallelism needs a workflow.NewParallelWorker node wrapping the body,
+	// and that constructor rejects a wrapped node carrying a RetryConfig — so a
+	// factory building one must move the retry policy onto the parent.
 	if s.FanOut != nil {
 		cfg.ParallelWorker = true
 	}

--- a/internal/sop/describe.go
+++ b/internal/sop/describe.go
@@ -104,7 +104,10 @@ func (c *Compiled) Describe() string {
 	lines := make([]string, 0, len(c.Edges))
 	for _, e := range c.Edges {
 		label := ""
-		if e.Route != nil {
+		switch {
+		case e.Route == workflow.Default:
+			label = " [default]"
+		case e.Route != nil:
 			label = fmt.Sprintf(" [%v]", e.Route)
 		}
 		lines = append(lines, fmt.Sprintf("  %s -> %s%s", e.From.Name(), e.To.Name(), label))

--- a/internal/sop/embedded_test.go
+++ b/internal/sop/embedded_test.go
@@ -1,0 +1,124 @@
+package sop
+
+import (
+	"strings"
+	"testing"
+)
+
+// The TUI renders the compiled graph and maps run phases onto stage ids. If a
+// SOP edit renames or drops a stage, the sidebar would silently highlight
+// nothing — so the embedded id set is pinned here. Updating a SOP means
+// updating this test and the renderer together, on purpose.
+func TestEmbeddedStageIDsArePinned(t *testing.T) {
+	want := map[string][]string{
+		"run":  {"validate_spec", "slices", "gates", "verify", "repair", "merge", "summary"},
+		"plan": {"clarify", "research", "design", "outline", "plan", "prompt", "manifest"},
+	}
+
+	for name, ids := range want {
+		t.Run(name, func(t *testing.T) {
+			def, err := LoadEmbeddedDefinition(name)
+			if err != nil {
+				t.Fatalf("LoadEmbeddedDefinition(%q): %v", name, err)
+			}
+			compiled, err := Compile(def, DescribeFactory{})
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", name, err)
+			}
+
+			var got []string
+			for _, id := range compiled.Order {
+				if !strings.HasSuffix(id, ".review") {
+					got = append(got, id)
+				}
+			}
+			if len(got) != len(ids) {
+				t.Fatalf("stage ids = %v, want %v", got, ids)
+			}
+			for i, id := range ids {
+				if got[i] != id {
+					t.Errorf("stage %d = %q, want %q", i, got[i], id)
+				}
+			}
+		})
+	}
+}
+
+// Three of the plan SOP's four checkpoints are human approvals. They are what
+// turns "Approve the design?" from a sentence the model may skip into a
+// scheduler state, so their kind is pinned rather than left to a later edit.
+func TestPlanReviewKinds(t *testing.T) {
+	def, err := LoadEmbeddedDefinition("plan")
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefinition: %v", err)
+	}
+
+	want := map[string]string{
+		"clarify": "human",
+		"design":  "human",
+		"outline": "human",
+		"plan":    "agent",
+	}
+
+	got := map[string]string{}
+	for _, s := range def.AllStages() {
+		if s.Review != nil {
+			got[s.ID] = s.Review.Kind
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("stages with reviews = %v, want %v", got, want)
+	}
+	for id, kind := range want {
+		if got[id] != kind {
+			t.Errorf("%s review kind = %q, want %q", id, got[id], kind)
+		}
+	}
+}
+
+// The run SOP has no review checkpoints: its verdict rides the verify stage's
+// routes instead.
+func TestRunSOPHasNoReviews(t *testing.T) {
+	def, err := LoadEmbeddedDefinition("run")
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefinition: %v", err)
+	}
+	for _, s := range def.AllStages() {
+		if s.Review != nil {
+			t.Errorf("stage %q unexpectedly declares a review", s.ID)
+		}
+	}
+}
+
+// The engine fires every unconditional edge regardless of routing, so a stage
+// that can fail over must not also carry an unconditional forward edge — it
+// would schedule the successor and the repair stage at once on a failure.
+func TestFailoverStagesHaveNoUnconditionalForwardEdge(t *testing.T) {
+	for _, name := range []string{"run", "plan"} {
+		t.Run(name, func(t *testing.T) {
+			def, err := LoadEmbeddedDefinition(name)
+			if err != nil {
+				t.Fatalf("LoadEmbeddedDefinition: %v", err)
+			}
+			compiled, err := Compile(def, DescribeFactory{})
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+
+			failsOver := map[string]bool{}
+			for _, s := range def.AllStages() {
+				if failoverTarget(s) != "" {
+					failsOver[s.ID] = true
+				}
+			}
+
+			for _, e := range compiled.Edges {
+				if e.Route == nil && failsOver[e.From.Name()] {
+					t.Errorf("%s -> %s is unconditional, but %s declares a failover target",
+						e.From.Name(), e.To.Name(), e.From.Name())
+				}
+			}
+		})
+	}
+}

--- a/internal/sop/exec/agent.go
+++ b/internal/sop/exec/agent.go
@@ -1,0 +1,38 @@
+package exec
+
+import (
+	"fmt"
+
+	adkagent "google.golang.org/adk/v2/agent"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// Agent compiles a SOP definition with f and returns it as an ADK agent, ready
+// to hand to runner.Config.Agent.
+//
+// It deliberately does not use agent/workflowagent.New, which looks like the
+// obvious entry point. That constructor calls workflow.New(name, edges) with no
+// options, so the SOP's defaults.max_concurrency would be silently dropped, and
+// it keeps the *workflow.Workflow in an unexported wrapper. Building the
+// workflow here keeps both the options and the handle; agent.Config.Run is the
+// sanctioned hook for wrapping any Run function as an agent.
+func Agent(def *sop.Definition, f sop.NodeFactory) (adkagent.Agent, *sop.Compiled, error) {
+	compiled, err := sop.Compile(def, f)
+	if err != nil {
+		return nil, nil, err
+	}
+	wf, err := compiled.Workflow()
+	if err != nil {
+		return nil, nil, err
+	}
+	ag, err := adkagent.New(adkagent.Config{
+		Name:        def.SOP,
+		Description: def.Description,
+		Run:         wf.Run,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("wrapping SOP %q as an agent: %w", def.SOP, err)
+	}
+	return ag, compiled, nil
+}

--- a/internal/sop/exec/exec.go
+++ b/internal/sop/exec/exec.go
@@ -1,0 +1,252 @@
+// Package exec supplies the executable NodeFactory the SOP compiler has been
+// waiting for.
+//
+// The compiler owns the graph — what runs, in what order, how often it retries,
+// what must be true before an edge is taken. This package owns the mechanics of
+// being a node in that graph: emitting the routing event the scheduler reads,
+// bounding loops the engine will not bound itself, and reporting the lifecycle
+// a UI needs. What a stage actually *does* is a StageRunner, injected by the
+// caller, so the graph can be exercised without a provider, a worktree, or a
+// running agent.
+//
+// Three engine facts shape everything here, all verified against adk v2.2.0:
+//
+//   - Routing matches session.Event.Routes, never a node's return value. A body
+//     that returns "PASS" sets Event.Output and matches no edge at all.
+//   - A returned error does not take the on_fail edge. It marks the node failed,
+//     applies RetryConfig, then fails the whole workflow. Failure that the SOP
+//     models as a route must therefore be reported as a value, not an error.
+//   - Nothing counts loop activations, so max_cycles is ours to enforce.
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/adk/v2/workflow"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// StageRunner performs one stage's work.
+//
+// It returns the route the stage produced rather than an error, because the
+// engine treats an error as fatal to the whole run: a gate that fails is a
+// FAIL route, not a Go error. Reserve the error return for a stage that could
+// not be attempted at all.
+type StageRunner interface {
+	RunStage(ctx context.Context, req StageRequest) (StageOutcome, error)
+}
+
+// StageRequest is what a runner is asked to do.
+type StageRequest struct {
+	Stage sop.Stage
+	// Review is set when this activation is a stage's review checkpoint
+	// rather than the stage body itself.
+	Review *sop.Review
+	// Input is the predecessor's output, or the workflow input for the entry
+	// stage.
+	Input any
+	// Cycle is 1 on a stage's first activation and increments each time the
+	// graph routes back to it.
+	Cycle int
+}
+
+// StageOutcome is what a runner produced.
+type StageOutcome struct {
+	// Route is the value the scheduler matches against this stage's outgoing
+	// edges: "PASS", "FAIL", sop.RecheckSignal. Empty means "take the forward
+	// path", which the compiler wires as the Default route for any stage that
+	// can also fail over.
+	Route string
+	// Output is handed to the successor as its input.
+	Output any
+}
+
+// RunnerFunc adapts a function to StageRunner.
+type RunnerFunc func(ctx context.Context, req StageRequest) (StageOutcome, error)
+
+func (f RunnerFunc) RunStage(ctx context.Context, req StageRequest) (StageOutcome, error) {
+	return f(ctx, req)
+}
+
+// Factory builds executable nodes. It implements sop.NodeFactory.
+type Factory struct {
+	Runner StageRunner
+
+	mu sync.Mutex
+	// cycles counts activations per (invocation, node) so a loop can be
+	// bounded. It cannot live on the node or in a plain field: one factory
+	// serves concurrent invocations, and the engine resets NodeState.Attempt
+	// on success, so retries and loop activations are different things.
+	cycles map[cycleKey]int
+}
+
+type cycleKey struct {
+	invocation string
+	node       string
+}
+
+// NewFactory returns a factory whose nodes run r.
+func NewFactory(r StageRunner) *Factory {
+	return &Factory{Runner: r, cycles: map[cycleKey]int{}}
+}
+
+// CycleBudgetError is returned when a stage is activated more times than its
+// max_cycles allows. It is deliberately fatal: a loop that will not converge
+// must stop the run rather than spin.
+type CycleBudgetError struct {
+	Stage string
+	Max   int
+}
+
+func (e *CycleBudgetError) Error() string {
+	return fmt.Sprintf("stage %q exceeded max_cycles (%d): the loop is not converging", e.Stage, e.Max)
+}
+
+func (f *Factory) AgentNode(s sop.Stage, cfg workflow.NodeConfig) (workflow.Node, error) {
+	return f.node(s.ID, s, nil, cfg), nil
+}
+
+func (f *Factory) FunctionNode(s sop.Stage, cfg workflow.NodeConfig) (workflow.Node, error) {
+	return f.node(s.ID, s, nil, cfg), nil
+}
+
+func (f *Factory) ReviewNode(s sop.Stage, r sop.Review, cfg workflow.NodeConfig) (workflow.Node, error) {
+	review := r
+	return f.node(s.ID+".review", s, &review, cfg), nil
+}
+
+// node builds one dynamic node. Dynamic rather than function-typed because the
+// body needs `emit`: it publishes the lifecycle event a UI reads and the
+// routing event the scheduler reads, and only a dynamic (or emitting) node can
+// publish more than its return value.
+func (f *Factory) node(name string, s sop.Stage, review *sop.Review, cfg workflow.NodeConfig) workflow.Node {
+	body := func(ctx agent.Context, in any, emit func(*session.Event) error) (any, error) {
+		cycle, err := f.enter(ctx, name, s)
+		if err != nil {
+			return nil, err
+		}
+
+		// Node start is not an engine event, so a UI cannot see a stage begin
+		// unless the node says so. This is the sidebar's "running" signal.
+		if err := emit(lifecycleEvent(ctx, name, cycle)); err != nil {
+			return nil, err
+		}
+
+		out, err := f.Runner.RunStage(ctx, StageRequest{
+			Stage: s, Review: review, Input: in, Cycle: cycle,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("stage %q: %w", name, err)
+		}
+
+		// The routing event. At most one per activation — a second is
+		// ErrMultipleRoutingEvents and fails the node.
+		ev := session.NewEvent(ctx, ctx.InvocationID())
+		if out.Route != "" {
+			ev.Routes = []string{out.Route}
+		}
+		ev.Output = out.Output
+		if err := emit(ev); err != nil {
+			return nil, err
+		}
+
+		// nil suppresses the node's own terminal event; the emitted one above
+		// already carries the output and the route.
+		return nil, nil
+	}
+
+	return workflow.NewDynamicNode[any, any](name, body, refuseToRetryBudget(cfg))
+}
+
+// refuseToRetryBudget stops the engine retrying a cycle-budget refusal.
+//
+// Without it a non-converging loop costs the SOP's whole retry policy before
+// the run fails — for the run SOP, three attempts with a 10s initial delay and
+// 2x backoff, so ~40 seconds of waiting to re-learn what the first refusal
+// already established. The budget is deterministic per activation: retrying
+// re-runs the same refusal.
+func refuseToRetryBudget(cfg workflow.NodeConfig) workflow.NodeConfig {
+	if cfg.RetryConfig == nil {
+		return cfg
+	}
+	rc := *cfg.RetryConfig
+	prev := rc.ShouldRetry
+	rc.ShouldRetry = func(err error) bool {
+		var budget *CycleBudgetError
+		if errors.As(err, &budget) {
+			return false
+		}
+		if prev != nil {
+			return prev(err)
+		}
+		// Mirror the engine's default: input validation is deterministic per
+		// activation too.
+		return !errors.Is(err, workflow.ErrInputValidation)
+	}
+	cfg.RetryConfig = &rc
+	return cfg
+}
+
+// enter records an activation and enforces the stage's cycle budget.
+func (f *Factory) enter(ctx agent.Context, node string, s sop.Stage) (int, error) {
+	key := cycleKey{invocation: ctx.InvocationID(), node: node}
+
+	f.mu.Lock()
+	f.cycles[key]++
+	n := f.cycles[key]
+	f.mu.Unlock()
+
+	if s.MaxCycle > 0 && n > s.MaxCycle {
+		return n, &CycleBudgetError{Stage: node, Max: s.MaxCycle}
+	}
+	return n, nil
+}
+
+// Forget releases the cycle counters for one invocation. A long-lived process
+// that never calls it leaks one small entry per node per run.
+func (f *Factory) Forget(invocationID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for k := range f.cycles {
+		if k.invocation == invocationID {
+			delete(f.cycles, k)
+		}
+	}
+}
+
+// LifecycleAuthor is the author stamped on the "stage started" events this
+// package emits, so a consumer can tell them from model output.
+const LifecycleAuthor = "sop.stage"
+
+// lifecycleEvent announces that a stage has begun. It carries no Routes, so it
+// is not a routing event and cannot be mistaken for one.
+func lifecycleEvent(ctx agent.Context, node string, cycle int) *session.Event {
+	ev := session.NewEvent(ctx, ctx.InvocationID())
+	ev.Author = LifecycleAuthor
+	ev.Branch = node
+	if cycle > 1 {
+		ev.Branch = fmt.Sprintf("%s#%d", node, cycle)
+	}
+	return ev
+}
+
+// StageStarted reports the stage a lifecycle event announces, and whether ev is
+// one at all. A UI switches its "running" marker on this.
+func StageStarted(ev *session.Event) (stage string, ok bool) {
+	if ev == nil || ev.Author != LifecycleAuthor {
+		return "", false
+	}
+	name := ev.Branch
+	for i := range name {
+		if name[i] == '#' {
+			return name[:i], true
+		}
+	}
+	return name, true
+}

--- a/internal/sop/exec/exec_test.go
+++ b/internal/sop/exec/exec_test.go
@@ -1,0 +1,201 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/session"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/exec"
+)
+
+// script drives the stages: routes[stage] is the route each activation of that
+// stage returns, consumed one per activation so a stage can answer differently
+// the second time round the loop. A stage with no entry takes the forward path.
+type script struct {
+	routes  map[string][]string
+	visited []string
+}
+
+func (s *script) run(_ context.Context, req exec.StageRequest) (exec.StageOutcome, error) {
+	id := req.Stage.ID
+	if req.Review != nil {
+		id += ".review"
+	}
+	s.visited = append(s.visited, id)
+
+	route := ""
+	if queued := s.routes[id]; len(queued) > 0 {
+		route = queued[0]
+		s.routes[id] = queued[1:]
+	}
+	return exec.StageOutcome{Route: route, Output: id}, nil
+}
+
+// execute runs the named embedded SOP end to end through a real ADK runner and
+// returns the stages that were activated, in order.
+func execute(t *testing.T, name string, s *script) ([]string, error) {
+	t.Helper()
+
+	def, err := sop.LoadEmbeddedDefinition(name)
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefinition: %v", err)
+	}
+	ag, _, err := exec.Agent(def, exec.NewFactory(exec.RunnerFunc(s.run)))
+	if err != nil {
+		t.Fatalf("Agent: %v", err)
+	}
+
+	r, err := runner.New(runner.Config{
+		AppName:           "pi-sop-test",
+		Agent:             ag,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+
+	var runErr error
+	for _, err := range r.Run(context.Background(), "u", "sess-"+name,
+		genai.NewContentFromText("start", genai.RoleUser), adkagent.RunConfig{}) {
+		if err != nil {
+			runErr = err
+			break
+		}
+	}
+	return s.visited, runErr
+}
+
+// The happy path: the graph walks the forward edges and the verifier's PASS
+// routes to merge. This is the proof that a compiled SOP executes at all.
+func TestRunSOPExecutesHappyPath(t *testing.T) {
+	s := &script{routes: map[string][]string{"verify": {"PASS"}}}
+	visited, err := execute(t, "run", s)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want := []string{"validate_spec", "slices", "gates", "verify", "merge", "summary"}
+	if strings.Join(visited, ",") != strings.Join(want, ",") {
+		t.Errorf("visited = %v, want %v", visited, want)
+	}
+}
+
+// The regression this whole design turned on: because the engine fires every
+// unconditional edge regardless of routing, a FAIL used to schedule the repair
+// stage AND the forward successor. A failing `slices` must reach `repair` and
+// must NOT reach `gates`.
+func TestFailRouteDoesNotAlsoTakeForwardEdge(t *testing.T) {
+	s := &script{routes: map[string][]string{"slices": {"FAIL"}}}
+	visited, err := execute(t, "run", s)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if !contains(visited, "repair") {
+		t.Errorf("FAIL did not reach repair: %v", visited)
+	}
+	if contains(visited, "gates") {
+		t.Errorf("FAIL also took the forward edge to gates: %v", visited)
+	}
+}
+
+// A gate failure repairs, re-verifies, and merges — the loop the prose SOP
+// could only ask for.
+func TestGateFailureRepairsThenMerges(t *testing.T) {
+	s := &script{routes: map[string][]string{
+		"gates":  {"FAIL"},
+		"repair": {sop.RecheckSignal},
+		"verify": {"PASS"},
+	}}
+	visited, err := execute(t, "run", s)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want := []string{"validate_spec", "slices", "gates", "repair", "verify", "merge", "summary"}
+	if strings.Join(visited, ",") != strings.Join(want, ",") {
+		t.Errorf("visited = %v, want %v", visited, want)
+	}
+}
+
+// Nothing in the engine bounds a conditional cycle, so the factory must. A
+// verifier that never passes has to stop the run rather than spin.
+func TestCycleBudgetStopsANonConvergingLoop(t *testing.T) {
+	always := func(route string) []string {
+		out := make([]string, 40)
+		for i := range out {
+			out[i] = route
+		}
+		return out
+	}
+	s := &script{routes: map[string][]string{
+		"gates":  always("FAIL"),
+		"repair": always(sop.RecheckSignal),
+		"verify": always("FAIL"),
+	}}
+
+	visited, err := execute(t, "run", s)
+	if err == nil {
+		t.Fatalf("a non-converging loop completed successfully: %v", visited)
+	}
+
+	var budget *exec.CycleBudgetError
+	if !errors.As(err, &budget) {
+		t.Fatalf("error = %v, want CycleBudgetError", err)
+	}
+	if budget.Max != 10 {
+		t.Errorf("max = %d, want 10 (repair's max_cycles)", budget.Max)
+	}
+
+	repairs := 0
+	for _, v := range visited {
+		if v == "repair" {
+			repairs++
+		}
+	}
+	if repairs > 11 { // 10 allowed activations, the 11th is refused
+		t.Errorf("repair ran %d times despite max_cycles: 10", repairs)
+	}
+}
+
+// The plan SOP routes through four review checkpoints; plan.review FAIL sends
+// the graph back to `plan`, PASS advances to `prompt`.
+func TestPlanSOPRoutesThroughReview(t *testing.T) {
+	s := &script{routes: map[string][]string{
+		"plan.review": {"FAIL", "PASS"},
+	}}
+	visited, err := execute(t, "plan", s)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for _, want := range []string{"clarify", "clarify.review", "research", "design", "plan", "prompt", "manifest"} {
+		if !contains(visited, want) {
+			t.Errorf("stage %q never ran: %v", want, visited)
+		}
+	}
+	if n := count(visited, "plan"); n != 2 {
+		t.Errorf("plan ran %d times, want 2 (one FAIL round trip): %v", n, visited)
+	}
+}
+
+func contains(xs []string, want string) bool { return count(xs, want) > 0 }
+
+func count(xs []string, want string) int {
+	n := 0
+	for _, x := range xs {
+		if x == want {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/sop/graph.go
+++ b/internal/sop/graph.go
@@ -1,0 +1,49 @@
+package sop
+
+import (
+	"sort"
+
+	"google.golang.org/adk/v2/workflow"
+)
+
+// GraphEdge is one compiled edge flattened to plain strings.
+//
+// It exists so a UI can draw the graph without importing the workflow package
+// or type-switching on its Route interface: the renderer needs three strings,
+// not three node objects.
+type GraphEdge struct {
+	From string
+	To   string
+	// Route is the value that must be produced for this edge to be taken —
+	// "PASS", "FAIL", RecheckSignal — and empty for an unconditional edge or
+	// the default forward edge of a stage that can fail over.
+	Route string
+}
+
+// GraphEdges returns the compiled edges in a deterministic order: by source
+// stage, unconditional edge first, then by route. Rendering order must not
+// depend on map iteration, or the sidebar would redraw differently each frame.
+func (c *Compiled) GraphEdges() []GraphEdge {
+	out := make([]GraphEdge, 0, len(c.Edges))
+	for _, e := range c.Edges {
+		route := ""
+		if sr, ok := e.Route.(workflow.StringRoute); ok {
+			route = string(sr)
+		}
+		out = append(out, GraphEdge{From: e.From.Name(), To: e.To.Name(), Route: route})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].From != out[j].From {
+			return out[i].From < out[j].From
+		}
+		if out[i].Route != out[j].Route {
+			return out[i].Route < out[j].Route
+		}
+		return out[i].To < out[j].To
+	})
+	return out
+}
+
+// StartNodeName is the name of the graph's entry sentinel. Edges out of it are
+// scaffolding, not a stage transition, so renderers skip them.
+var StartNodeName = workflow.Start.Name()

--- a/internal/sop/load.go
+++ b/internal/sop/load.go
@@ -35,6 +35,26 @@ func LoadDefinition(workDir, name string) (*Definition, error) {
 	return def, nil
 }
 
+// LoadEmbeddedDefinition returns the SOP built into the binary, ignoring project
+// and global overrides.
+//
+// The graph is compiled to be shown and executed, and an override describes a
+// pipeline that the engine is not running yet — drawing it would be drawing a
+// lie. Overrides are honored again once the compiled graph is the only
+// executor; that is a one-line change at the call site, back to
+// LoadDefinition.
+func LoadEmbeddedDefinition(name string) (*Definition, error) {
+	data, source := embeddedDefinition(name)
+	def, err := ParseDefinition(data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", source, err)
+	}
+	if findings := LintDefinition(def); !findings.OK() {
+		return nil, fmt.Errorf("%s is not a valid SOP:\n%s", source, findings.Format())
+	}
+	return def, nil
+}
+
 // LintDefinitionFile parses and lints a SOP file without installing it, so a
 // user editing an override can check it.
 func LintDefinitionFile(path string) (validate.Findings, error) {
@@ -62,6 +82,11 @@ func resolveDefinition(workDir, name string) (data []byte, source string) {
 			return b, globalPath
 		}
 	}
+	return embeddedDefinition(name)
+}
+
+// embeddedDefinition returns the SOP compiled into the binary.
+func embeddedDefinition(name string) (data []byte, source string) {
 	switch name {
 	case "run":
 		return defaultRunSOP, "embedded run.sop.yaml"

--- a/internal/sop/run.sop.yaml
+++ b/internal/sop/run.sop.yaml
@@ -77,7 +77,7 @@ stages:
       max_concurrency: 2
       output_schema: SliceResult
     loop_back: verify
-    max_cycles: 3
+    max_cycles: 10
 
   - id: merge
     description: Merge the run worktree into the invoking branch

--- a/internal/sop/schema_test.go
+++ b/internal/sop/schema_test.go
@@ -252,7 +252,7 @@ func TestNodeConfigInheritsDefaults(t *testing.T) {
 func TestFanOutStageIsParallelWorker(t *testing.T) {
 	cfg := NodeConfigFor(Stage{ID: "slices", FanOut: &FanOut{Over: "plan.slices"}}, Defaults{})
 	if !cfg.ParallelWorker {
-		t.Error("a fan_out stage did not compile to a ParallelWorker node")
+		t.Error("a fan_out stage did not set NodeConfig.ParallelWorker")
 	}
 }
 

--- a/internal/tui/.pi-go/skills/test-new-skill/SKILL.md
+++ b/internal/tui/.pi-go/skills/test-new-skill/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: test-new-skill
+description: 
+---
+
+# test-new-skill
+
+[Instructions for this skill]
+
+## Examples
+
+- Example usage 1
+- Example usage 2
+
+## Guidelines
+
+- Guideline 1
+- Guideline 2

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -1411,6 +1411,7 @@ func truncatePrompt(prompt string) string {
 
 // handleAgentToolResult processes an agentToolResultMsg.
 func (m *model) handleAgentToolResult(msg agentToolResultMsg) (tea.Model, tea.Cmd) {
+	m.invalidatePlanPhases()
 	if m.face != nil {
 		m.face.SetMood(MoodProcessing)
 	}
@@ -1675,6 +1676,7 @@ func findUnassignedBashCard(messages []message, command string) int {
 
 // handleAgentSubEvent processes an agentSubEventMsg.
 func (m *model) handleAgentSubEvent(msg agentSubEventMsg) (tea.Model, tea.Cmd) {
+	m.invalidatePlanPhases()
 	if strings.HasPrefix(msg.kind, bashEventPrefix) {
 		return m.handleBashEvent(msg)
 	}
@@ -1721,6 +1723,7 @@ func (m *model) handleAgentSubEvent(msg agentSubEventMsg) (tea.Model, tea.Cmd) {
 
 // handleAgentDone processes an agentDoneMsg.
 func (m *model) handleAgentDone(msg agentDoneMsg) (tea.Model, tea.Cmd) {
+	m.invalidatePlanPhases()
 	m.running = false
 	m.agentCancel = nil
 	m.matrix.clear()

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"image/color"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -49,6 +50,7 @@ type SidebarRenderInput struct {
 	RunSpec      string                   // spec name during /run
 	RunCycle     int                      // current retry cycle
 	RunMaxCycle  int                      // max retries
+	PlanPhases   []PlanPhase              // PDD phase checklist shown in plan mode; nil/empty = hidden
 	MatrixLines  string                   // pre-rendered matrix rain (2 lines)
 	StatusLine   string                   // status text shown above matrix
 	Orchestrator *subagent.Orchestrator   // may be nil — for agents section
@@ -68,6 +70,38 @@ type ArtifactEntry struct {
 	Filename string
 	Size     int64
 	Mime     string
+}
+
+// PlanPhase is one PDD phase in the plan-mode sidebar checklist.
+type PlanPhase struct {
+	Name string // short label, e.g. "Requirements"
+	Done bool   // artifact file exists
+}
+
+// phaseArtifacts maps each PDD phase to the spec artifact that marks it complete.
+var phaseArtifacts = []struct {
+	Name     string
+	Artifact string // file or dir name under specDir
+}{
+	{"Idea", "rough-idea.md"},
+	{"Requirements", "requirements.md"},
+	{"Research", "research"}, // directory
+	{"Design", "design.md"},
+	{"Outline", "outline.md"},
+	{"Plan", "plan.md"},
+	{"Prompt", "PROMPT.md"},
+}
+
+// detectPlanPhases stats each PDD phase artifact under specDir and returns the
+// phases in order with Done set when the artifact exists. A missing or unreadable
+// specDir degrades gracefully to all-incomplete (no crash).
+func detectPlanPhases(specDir string) []PlanPhase {
+	phases := make([]PlanPhase, 0, len(phaseArtifacts))
+	for _, pa := range phaseArtifacts {
+		_, err := os.Stat(filepath.Join(specDir, pa.Artifact))
+		phases = append(phases, PlanPhase{Name: pa.Name, Done: err == nil})
+	}
+	return phases
 }
 
 // sidebarStyles bundles the resolved styles the sidebar draws with, derived
@@ -218,6 +252,9 @@ func sidebarModeLines(in SidebarRenderInput, innerW int, st sidebarStyles) []str
 		lines = append(lines, st.dim.Render("  ["+mode+"]"))
 	}
 	lines = append(lines, sidebarActivityLines(in, st)...)
+	if len(in.PlanPhases) > 0 {
+		lines = append(lines, sidebarPlanLines(in, innerW, st)...)
+	}
 	return append(lines, "")
 }
 
@@ -247,6 +284,31 @@ func sidebarRunLines(in SidebarRenderInput, innerW int, st sidebarStyles) []stri
 		lines = append(lines, sidebarActivityLines(in, st)...)
 	}
 	return lines
+}
+
+// sidebarPlanLines renders the PDD phase checklist for plan mode. It returns nil
+// (hidden) when no PlanPhases are present. The current phase is the first with
+// Done == false and is marked with ▶; done phases show [x] in green, future
+// phases show [ ] in overlay.
+func sidebarPlanLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
+	if len(in.PlanPhases) == 0 {
+		return nil
+	}
+	lines := []string{st.heading.Render("  Plan")}
+	current := true
+	for _, p := range in.PlanPhases {
+		title := truncateLabel(p.Name, max(innerW-5, 10)) // room for "  [x] " prefix
+		switch {
+		case p.Done:
+			lines = append(lines, st.green.Render("  [x] "+title))
+		case current:
+			lines = append(lines, st.peach.Render("  ▶ "+title))
+			current = false
+		default:
+			lines = append(lines, st.overlay.Render("  [ ] "+title))
+		}
+	}
+	return append(lines, "")
 }
 
 // sidebarActivityLines shows the running tool, or a thinking indicator when the

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"bufio"
 	"cmp"
 	"fmt"
 	"image/color"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/palace"
+	"github.com/dimetron/pi-go/internal/sop"
 	"github.com/dimetron/pi-go/internal/subagent"
 )
 
@@ -51,6 +54,7 @@ type SidebarRenderInput struct {
 	RunCycle     int                      // current retry cycle
 	RunMaxCycle  int                      // max retries
 	PlanPhases   []PlanPhase              // PDD phase checklist shown in plan mode; nil/empty = hidden
+	Graph        *SOPGraph                // compiled SOP drawn under the stage list; nil = hidden
 	MatrixLines  string                   // pre-rendered matrix rain (2 lines)
 	StatusLine   string                   // status text shown above matrix
 	Orchestrator *subagent.Orchestrator   // may be nil — for agents section
@@ -72,10 +76,19 @@ type ArtifactEntry struct {
 	Mime     string
 }
 
+// SOPGraph is the compiled SOP the sidebar draws underneath the stage list:
+// the stages in order, the edges between them, and each stage's status. Nil
+// hides the diagram.
+type SOPGraph struct {
+	Order  []string
+	Edges  []sop.GraphEdge
+	Status map[string]stageStatus
+}
+
 // PlanPhase is one PDD phase in the plan-mode sidebar checklist.
 type PlanPhase struct {
 	Name string // short label, e.g. "Requirements"
-	Done bool   // artifact file exists
+	Done bool   // the artifact carries real content, not just a skeleton
 }
 
 // phaseArtifacts maps each PDD phase to the spec artifact that marks it complete.
@@ -92,16 +105,71 @@ var phaseArtifacts = []struct {
 	{"Prompt", "PROMPT.md"},
 }
 
-// detectPlanPhases stats each PDD phase artifact under specDir and returns the
-// phases in order with Done set when the artifact exists. A missing or unreadable
-// specDir degrades gracefully to all-incomplete (no crash).
+// detectPlanPhases inspects each PDD phase artifact under specDir and returns
+// the phases in order, with Done set when the artifact carries real content. A
+// missing or unreadable specDir degrades gracefully to all-incomplete (no
+// crash).
+//
+// Existence is not enough. createSpecSkeleton writes the skeleton up front — an
+// empty research/ directory and a requirements.md holding only its two headings
+// — so a "does the file exist" test ticked Requirements and Research before a
+// single question had been asked.
 func detectPlanPhases(specDir string) []PlanPhase {
 	phases := make([]PlanPhase, 0, len(phaseArtifacts))
 	for _, pa := range phaseArtifacts {
-		_, err := os.Stat(filepath.Join(specDir, pa.Artifact))
-		phases = append(phases, PlanPhase{Name: pa.Name, Done: err == nil})
+		phases = append(phases, PlanPhase{
+			Name: pa.Name,
+			Done: hasSubstance(filepath.Join(specDir, pa.Artifact)),
+		})
 	}
 	return phases
+}
+
+// artifactScanLimit bounds how far hasSubstance reads looking for a body line.
+// This runs on every frame, so it must not grow with the size of plan.md; a
+// real document says something well inside the first few KB.
+const artifactScanLimit = 4 << 10
+
+// hasSubstance reports whether a phase artifact holds more than its skeleton: a
+// directory with at least one non-empty file in it, or a file with at least one
+// line that is neither blank nor a markdown heading.
+func hasSubstance(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	if info.IsDir() {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return false
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if fi, err := e.Info(); err == nil && fi.Size() > 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(io.LimitReader(f, artifactScanLimit))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // sidebarStyles bundles the resolved styles the sidebar draws with, derived
@@ -148,23 +216,70 @@ func RenderSidebar(in SidebarRenderInput) string {
 
 	st := newSidebarStyles(paletteOrDark(in.Palette))
 
-	var lines []string
+	var head []string
 	for _, section := range [][]string{
 		sidebarMoodLines(in, st),
 		sidebarModelLines(in, innerW, st),
 		sidebarArtifactLines(in, innerW, st),
 		sidebarGitLines(in, innerW, st),
 		sidebarModeLines(in, innerW, st),
+	} {
+		head = append(head, section...)
+	}
+
+	var tail []string
+	for _, section := range [][]string{
 		sidebarAgentLines(in, innerW, st),
 		sidebarSkillLines(in, st),
 		sidebarMemoryLines(in, st),
 		sidebarMCPLines(in, innerW, st),
 		sidebarLoadingLines(in, st),
 	} {
-		lines = append(lines, section...)
+		tail = append(tail, section...)
 	}
 
+	// The diagram belongs directly under the stage list it annotates, so it is
+	// spliced between the two rather than appended after everything else.
+	lines := append(head, graphSection(in, len(head)+len(tail), innerW, st)...)
+	lines = append(lines, tail...)
+
 	return sidebarFrame(in, lines, w, st)
+}
+
+// graphSection renders the SOP diagram, or nothing when it will not fit.
+//
+// All or nothing, on purpose: sidebarFrame clips from the bottom, so a diagram
+// that overruns the panel would be cut mid-branch — half a graph, with no sign
+// that the rest exists. Dropping it whole leaves the stage list, which always
+// fits.
+func graphSection(in SidebarRenderInput, used, innerW int, st sidebarStyles) []string {
+	if in.Graph == nil {
+		return nil
+	}
+	graph := sidebarGraphLines(in.Graph.Order, in.Graph.Edges, in.Graph.Status, innerW, st)
+	if len(graph) == 0 {
+		return nil
+	}
+	if used+len(graph)+1 > sidebarContentHeight(in) {
+		return nil
+	}
+	return append(graph, "")
+}
+
+// sidebarContentHeight is how many rows sidebarFrame keeps before it clips. It
+// mirrors the frame's own reservation; the two must agree or the fit test above
+// is a guess.
+func sidebarContentHeight(in SidebarRenderInput) int {
+	matrixH, statusH := 0, 0
+	if in.MatrixLines != "" {
+		matrixH = matrixLines
+		statusH = 1
+	}
+	ruleH := 0
+	if in.Height > 0 {
+		ruleH = 1
+	}
+	return max(0, in.Height-matrixH-statusH-ruleH)
 }
 
 // sidebarMoodLines renders the mascot face or the eyes at the top of the
@@ -253,7 +368,11 @@ func sidebarModeLines(in SidebarRenderInput, innerW int, st sidebarStyles) []str
 	}
 	lines = append(lines, sidebarActivityLines(in, st)...)
 	if len(in.PlanPhases) > 0 {
-		lines = append(lines, sidebarPlanLines(in, innerW, st)...)
+		// Every other section is separated by a blank row; the plan checklist
+		// read as part of the Mode block without one. sidebarPlanLines already
+		// closes with its own blank, so this section ends there.
+		lines = append(lines, "")
+		return append(lines, sidebarPlanLines(in, innerW, st)...)
 	}
 	return append(lines, "")
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -48,21 +48,25 @@ type SidebarRenderInput struct {
 	Messages     []message
 	ActiveTool   string
 	LoadingItems map[string]bool
-	RunChecklist []ChecklistStep          // steps from plan.md during /run
-	RunPhase     string                   // current /run phase (empty if not running)
-	RunSpec      string                   // spec name during /run
-	RunCycle     int                      // current retry cycle
-	RunMaxCycle  int                      // max retries
-	PlanPhases   []PlanPhase              // PDD phase checklist shown in plan mode; nil/empty = hidden
-	Graph        *SOPGraph                // compiled SOP drawn under the stage list; nil = hidden
-	MatrixLines  string                   // pre-rendered matrix rain (2 lines)
-	StatusLine   string                   // status text shown above matrix
-	Orchestrator *subagent.Orchestrator   // may be nil — for agents section
-	Skills       []extension.Skill        // skills section; nil = hidden
-	MCPTools     []extension.MCPToolEntry // MCP tools section; nil = hidden
-	MemoryStatus *palace.PalaceStatus     // memory palace status; nil = hidden
-	Artifacts    []ArtifactEntry          // artifacts section; nil/empty = hidden
-	Palette      Palette                  // resolved theme palette; zero = dark default
+	RunChecklist []ChecklistStep // steps from plan.md during /run
+	RunPhase     string          // current /run phase (empty if not running)
+	RunSpec      string          // spec name during /run
+	RunCycle     int             // current retry cycle
+	RunMaxCycle  int             // max retries
+	PlanPhases   []PlanPhase     // PDD phase checklist shown in plan mode; nil/empty = hidden
+	Graph        *SOPGraph       // compiled SOP drawn under the stage list; nil = hidden
+	// mergePlanGraph draws the plan section as the graph alone rather than as a
+	// checklist plus a graph saying the same thing twice. Set by RenderSidebar
+	// once it knows the graph will fit.
+	mergePlanGraph bool
+	MatrixLines    string                   // pre-rendered matrix rain (2 lines)
+	StatusLine     string                   // status text shown above matrix
+	Orchestrator   *subagent.Orchestrator   // may be nil — for agents section
+	Skills         []extension.Skill        // skills section; nil = hidden
+	MCPTools       []extension.MCPToolEntry // MCP tools section; nil = hidden
+	MemoryStatus   *palace.PalaceStatus     // memory palace status; nil = hidden
+	Artifacts      []ArtifactEntry          // artifacts section; nil/empty = hidden
+	Palette        Palette                  // resolved theme palette; zero = dark default
 }
 
 // ArtifactEntry is one row in the Artifacts sidebar section.
@@ -216,7 +220,34 @@ func RenderSidebar(in SidebarRenderInput) string {
 
 	st := newSidebarStyles(paletteOrDark(in.Palette))
 
-	var head []string
+	tail := sidebarTailLines(in, innerW, st)
+
+	// Prefer the merged plan view: one section carrying both the progress and
+	// the shape. It is tried first and kept only if the whole thing fits, since
+	// the checklist alone is what a short panel can still show usefully.
+	if in.Graph != nil && len(in.PlanPhases) > 0 {
+		merged := in
+		merged.mergePlanGraph = true
+		head := sidebarHeadLines(merged, innerW, st)
+		if len(head)+len(tail) <= sidebarContentHeight(in) {
+			return sidebarFrame(in, append(head, tail...), w, st)
+		}
+	}
+
+	head := sidebarHeadLines(in, innerW, st)
+
+	// Outside plan mode the diagram annotates the list above it rather than
+	// replacing it — a /run slice checklist is per-slice progress, which the
+	// stage graph does not duplicate — so it is spliced between head and tail.
+	lines := append(head, graphSection(in, len(head)+len(tail), innerW, st)...)
+	lines = append(lines, tail...)
+
+	return sidebarFrame(in, lines, w, st)
+}
+
+// sidebarHeadLines renders the sections above the SOP diagram.
+func sidebarHeadLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
+	var out []string
 	for _, section := range [][]string{
 		sidebarMoodLines(in, st),
 		sidebarModelLines(in, innerW, st),
@@ -224,10 +255,14 @@ func RenderSidebar(in SidebarRenderInput) string {
 		sidebarGitLines(in, innerW, st),
 		sidebarModeLines(in, innerW, st),
 	} {
-		head = append(head, section...)
+		out = append(out, section...)
 	}
+	return out
+}
 
-	var tail []string
+// sidebarTailLines renders the sections below the SOP diagram.
+func sidebarTailLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
+	var out []string
 	for _, section := range [][]string{
 		sidebarAgentLines(in, innerW, st),
 		sidebarSkillLines(in, st),
@@ -235,15 +270,9 @@ func RenderSidebar(in SidebarRenderInput) string {
 		sidebarMCPLines(in, innerW, st),
 		sidebarLoadingLines(in, st),
 	} {
-		tail = append(tail, section...)
+		out = append(out, section...)
 	}
-
-	// The diagram belongs directly under the stage list it annotates, so it is
-	// spliced between the two rather than appended after everything else.
-	lines := append(head, graphSection(in, len(head)+len(tail), innerW, st)...)
-	lines = append(lines, tail...)
-
-	return sidebarFrame(in, lines, w, st)
+	return out
 }
 
 // graphSection renders the SOP diagram, or nothing when it will not fit.
@@ -253,8 +282,8 @@ func RenderSidebar(in SidebarRenderInput) string {
 // that the rest exists. Dropping it whole leaves the stage list, which always
 // fits.
 func graphSection(in SidebarRenderInput, used, innerW int, st sidebarStyles) []string {
-	if in.Graph == nil {
-		return nil
+	if in.Graph == nil || len(in.PlanPhases) > 0 {
+		return nil // plan mode draws the graph inside its own section, or not at all
 	}
 	graph := sidebarGraphLines(in.Graph.Order, in.Graph.Edges, in.Graph.Status, innerW, st)
 	if len(graph) == 0 {
@@ -368,10 +397,13 @@ func sidebarModeLines(in SidebarRenderInput, innerW int, st sidebarStyles) []str
 	}
 	lines = append(lines, sidebarActivityLines(in, st)...)
 	if len(in.PlanPhases) > 0 {
-		// Every other section is separated by a blank row; the plan checklist
-		// read as part of the Mode block without one. sidebarPlanLines already
-		// closes with its own blank, so this section ends there.
+		// Every other section is separated by a blank row; the plan section
+		// read as part of the Mode block without one. Both plan renderers close
+		// with their own blank, so the section ends there.
 		lines = append(lines, "")
+		if in.mergePlanGraph && in.Graph != nil {
+			return append(lines, sidebarPlanGraphLines(in, innerW, st)...)
+		}
 		return append(lines, sidebarPlanLines(in, innerW, st)...)
 	}
 	return append(lines, "")
@@ -403,6 +435,35 @@ func sidebarRunLines(in SidebarRenderInput, innerW int, st sidebarStyles) []stri
 		lines = append(lines, sidebarActivityLines(in, st)...)
 	}
 	return lines
+}
+
+// sidebarPlanGraphLines renders the plan section as a single view: the compiled
+// SOP with each stage's status, headed by the progress the checklist used to
+// carry.
+//
+// The checklist and the diagram were two vocabularies for one thing —
+// "Requirements" and "clarify" are the same stage — stacked on top of each
+// other, which cost about twenty of the sidebar's rows to say everything twice.
+func sidebarPlanGraphLines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
+	graph := sidebarGraphLines(in.Graph.Order, in.Graph.Edges, in.Graph.Status, innerW, st)
+	if len(graph) == 0 {
+		return nil
+	}
+
+	done := 0
+	for _, p := range in.PlanPhases {
+		if p.Done {
+			done++
+		}
+	}
+	progress := fmt.Sprintf("%d/%d", done, len(in.PlanPhases))
+	pad := max(1, innerW-len("Plan")-len(progress))
+	head := st.heading.Render("  Plan") + strings.Repeat(" ", pad) + st.dim.Render(progress)
+
+	lines := make([]string, 0, len(graph)+3)
+	lines = append(lines, head, "")
+	lines = append(lines, graph...)
+	return append(lines, "")
 }
 
 // sidebarPlanLines renders the PDD phase checklist for plan mode. It returns nil

--- a/internal/tui/sidebar_sections_test.go
+++ b/internal/tui/sidebar_sections_test.go
@@ -364,6 +364,11 @@ func TestDetectPlanPhases(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(dir, "research"), 0o755); err != nil {
 		t.Fatalf("creating research dir: %v", err)
 	}
+	// A research phase is done when it has produced something; the plan flow
+	// creates the directory itself, up front.
+	if err := os.WriteFile(filepath.Join(dir, "research", "angle.md"), []byte("findings"), 0o644); err != nil {
+		t.Fatalf("writing research file: %v", err)
+	}
 
 	phases := detectPlanPhases(dir)
 	if len(phases) != 7 {
@@ -394,6 +399,9 @@ func TestDetectPlanPhases_AllDone(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(dir, "research"), 0o755); err != nil {
 		t.Fatalf("creating research dir: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, "research", "angle.md"), []byte("findings"), 0o644); err != nil {
+		t.Fatalf("writing research file: %v", err)
+	}
 
 	phases := detectPlanPhases(dir)
 	if len(phases) != 7 {
@@ -402,6 +410,59 @@ func TestDetectPlanPhases_AllDone(t *testing.T) {
 	for _, p := range phases {
 		if !p.Done {
 			t.Errorf("phase %q should be Done, got Done=%v", p.Name, p.Done)
+		}
+	}
+}
+
+// The skeleton /plan writes up front must not tick a single checkbox beyond
+// Idea: requirements.md holds only its headings and research/ is empty, so
+// marking them done claimed work that had not happened yet.
+func TestDetectPlanPhases_SkeletonIsNotProgress(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Exactly what createSpecSkeleton produces.
+	if err := os.WriteFile(filepath.Join(dir, "rough-idea.md"),
+		[]byte("# Rough Idea\n\nmake the thing\n"), 0o644); err != nil {
+		t.Fatalf("writing rough-idea.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "requirements.md"),
+		[]byte("# Requirements\n\n## Questions & Answers\n\n"), 0o644); err != nil {
+		t.Fatalf("writing requirements.md: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "research"), 0o755); err != nil {
+		t.Fatalf("creating research dir: %v", err)
+	}
+
+	phases := detectPlanPhases(dir)
+	done := map[string]bool{}
+	for _, p := range phases {
+		done[p.Name] = p.Done
+	}
+
+	if !done["Idea"] {
+		t.Error("Idea should be done: rough-idea.md carries the user's idea")
+	}
+	if done["Requirements"] {
+		t.Error("Requirements ticked on a headings-only skeleton file")
+	}
+	if done["Research"] {
+		t.Error("Research ticked on an empty research directory")
+	}
+}
+
+// Once the agent actually records a Q&A, Requirements is done.
+func TestDetectPlanPhases_RequirementsDoneOnceAnswered(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	body := "# Requirements\n\n## Questions & Answers\n\n### Q1. Scope?\n**A.** The sidebar only.\n"
+	if err := os.WriteFile(filepath.Join(dir, "requirements.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing requirements.md: %v", err)
+	}
+
+	for _, p := range detectPlanPhases(dir) {
+		if p.Name == "Requirements" && !p.Done {
+			t.Error("Requirements should be done once a Q&A has been recorded")
 		}
 	}
 }

--- a/internal/tui/sidebar_sections_test.go
+++ b/internal/tui/sidebar_sections_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -349,4 +351,95 @@ func TestSidebarLoadingLinesEmptyMapStillShowsHeading(t *testing.T) {
 // hasExact reports whether names contains an exact match for want.
 func hasExact(names []string, want string) bool {
 	return slices.Contains(names, want)
+}
+
+func TestDetectPlanPhases(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, name := range []string{"rough-idea.md", "requirements.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "research"), 0o755); err != nil {
+		t.Fatalf("creating research dir: %v", err)
+	}
+
+	phases := detectPlanPhases(dir)
+	if len(phases) != 7 {
+		t.Fatalf("expected 7 phases, got %d", len(phases))
+	}
+	wantNames := []string{"Idea", "Requirements", "Research", "Design", "Outline", "Plan", "Prompt"}
+	for i, want := range wantNames {
+		if phases[i].Name != want {
+			t.Errorf("phase %d name = %q, want %q", i, phases[i].Name, want)
+		}
+	}
+	wantDone := []bool{true, true, true, false, false, false, false}
+	for i, want := range wantDone {
+		if phases[i].Done != want {
+			t.Errorf("phase %q Done = %v, want %v", phases[i].Name, phases[i].Done, want)
+		}
+	}
+}
+
+func TestDetectPlanPhases_AllDone(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, name := range []string{"rough-idea.md", "requirements.md", "design.md", "outline.md", "plan.md", "PROMPT.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "research"), 0o755); err != nil {
+		t.Fatalf("creating research dir: %v", err)
+	}
+
+	phases := detectPlanPhases(dir)
+	if len(phases) != 7 {
+		t.Fatalf("expected 7 phases, got %d", len(phases))
+	}
+	for _, p := range phases {
+		if !p.Done {
+			t.Errorf("phase %q should be Done, got Done=%v", p.Name, p.Done)
+		}
+	}
+}
+
+func TestDetectPlanPhases_None(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	phases := detectPlanPhases(dir)
+	if len(phases) != 7 {
+		t.Fatalf("expected 7 phases, got %d", len(phases))
+	}
+	for _, p := range phases {
+		if p.Done {
+			t.Errorf("phase %q should not be Done in an empty dir, got Done=%v", p.Name, p.Done)
+		}
+	}
+}
+
+func TestSidebarPlanLines(t *testing.T) {
+	t.Parallel()
+	in := SidebarRenderInput{PlanPhases: []PlanPhase{
+		{Name: "Idea", Done: true},
+		{Name: "Requirements", Done: false},
+		{Name: "Research", Done: false},
+	}}
+	out := plain(sidebarPlanLines(in, 27, testSidebarStyles()))
+	for _, want := range []string{"Plan", "[x] Idea", "▶ Requirements", "[ ] Research"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestSidebarPlanLines_Hidden(t *testing.T) {
+	t.Parallel()
+	got := sidebarPlanLines(SidebarRenderInput{}, 27, testSidebarStyles())
+	if len(got) != 0 {
+		t.Errorf("expected 0 lines when no PlanPhases, got %d: %q", len(got), plain(got))
+	}
 }

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -618,3 +618,44 @@ func TestRenderSidebar_Artifacts_Populated(t *testing.T) {
 		t.Error("did not expect untruncated 'screenshot.png' — sidebar too narrow")
 	}
 }
+
+func TestRenderSidebar_PlanChecklist(t *testing.T) {
+	result := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 30,
+		Mode:   "plan",
+		PlanPhases: []PlanPhase{
+			{Name: "Idea", Done: true},
+			{Name: "Requirements", Done: false},
+			{Name: "Research", Done: false},
+			{Name: "Design", Done: false},
+			{Name: "Outline", Done: false},
+			{Name: "Plan", Done: false},
+			{Name: "Prompt", Done: false},
+		},
+	})
+	stripped := ansi.Strip(result)
+	for _, want := range []string{"Plan", "[x] Idea", "▶ Requirements", "[ ] Research"} {
+		if !strings.Contains(stripped, want) {
+			t.Errorf("expected %q in rendered output:\n%s", want, stripped)
+		}
+	}
+	if strings.Contains(stripped, "[chat]") {
+		t.Error("did not expect [chat] mode in plan-mode sidebar")
+	}
+}
+
+func TestRenderSidebar_NoPlanSection(t *testing.T) {
+	result := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 20,
+		Mode:   "chat",
+	})
+	stripped := ansi.Strip(result)
+	if strings.Contains(stripped, "▶ ") {
+		t.Error("did not expect a current-phase marker when no PlanPhases are present")
+	}
+	if strings.Contains(stripped, "[x] Idea") {
+		t.Error("did not expect a plan checklist row when no PlanPhases are present")
+	}
+}

--- a/internal/tui/sop_graph.go
+++ b/internal/tui/sop_graph.go
@@ -21,6 +21,19 @@ const (
 	stageWaiting // parked on a human approval
 )
 
+// Layout of one stage group. The diagram is a waterfall: each stage starts one
+// column right of the one before it, so the order of the flow is legible from
+// the shape alone, without a drawn spine.
+const (
+	graphBaseIndent  = 2 // first stage
+	graphStagePitch  = 1 // added per stage down the waterfall
+	graphChildIndent = 2 // a review under its stage, an edge under its owner
+	// graphMaxIndent stops the waterfall walking off a 23-column sidebar. A SOP
+	// long enough to reach it keeps its remaining stages in one column, which
+	// still reads in order.
+	graphMaxIndent = 8
+)
+
 // routeMark renders an edge's condition. The graph is 20 columns wide, so the
 // condition has to be a glyph rather than the word.
 func routeMark(route string) string {
@@ -36,13 +49,22 @@ func routeMark(route string) string {
 	}
 }
 
-// sidebarGraphLines draws the compiled SOP as a vertical diagram: one line per
-// stage down the spine, with conditional edges hanging off it.
+// sidebarGraphLines draws the compiled SOP as a waterfall of stage groups: the
+// stage, the review checkpoint that guards it, and the conditional edges that
+// leave either, with a blank row between groups.
 //
-//	✔ validate_spec
-//	│
-//	▶ slices
-//	├─✗→ repair
+//	✔ clarify
+//	  └ ✔ review
+//
+//	 ▶ research
+//
+//	  ○ design
+//	    └ ○ review
+//
+// Sequence is carried by the stagger and the spacing, not by a drawn spine. An
+// earlier version put a │ between every pair of stages, which doubled the
+// height of a diagram sharing 23 columns with everything else and read as noise
+// once the groups were spaced apart.
 //
 // It returns nil when there is nothing to draw, so the caller can drop the
 // whole section rather than emit an empty box.
@@ -54,8 +76,8 @@ func sidebarGraphLines(
 		return nil
 	}
 
-	// Conditional edges only. An unconditional or default edge is the spine
-	// itself, drawn as the connector between consecutive stages.
+	// Conditional edges only. An unconditional or default edge is the forward
+	// path, which the waterfall already shows.
 	branches := map[string][]sop.GraphEdge{}
 	for _, e := range edges {
 		if e.From == sop.StartNodeName || e.Route == "" {
@@ -64,40 +86,70 @@ func sidebarGraphLines(
 		branches[e.From] = append(branches[e.From], e)
 	}
 
-	lines := make([]string, 0, len(order)*2)
+	var lines []string
+	depth := 0
 	for i, id := range order {
-		lines = append(lines, stageLine(id, status[id], innerW, st))
-
-		outgoing := branches[id]
-		for j, e := range outgoing {
-			connector := "├─"
-			if j == len(outgoing)-1 {
-				connector = "└─"
-			}
-			label := truncateLabel(e.To, max(innerW-8, 6))
-			lines = append(lines, st.overlay.Render(
-				"  "+connector+routeMark(e.Route)+"→ "+label))
+		if isReview(id) {
+			continue // drawn as part of its stage's group
+		}
+		if len(lines) > 0 {
+			lines = append(lines, "")
 		}
 
-		// No connector between a stage and its own review: the review hangs
-		// off the stage, it is not the next step down the spine.
-		if i < len(order)-1 && order[i+1] != id+".review" {
-			lines = append(lines, st.overlay.Render("  │"))
+		indent := stageIndent(depth)
+		depth++
+
+		lines = append(lines, nodeLine(id, status[id], indent, innerW, st))
+
+		// A review checkpoint always immediately follows its stage in Order.
+		owner, ownerIndent := id, indent
+		if review := id + ".review"; i+1 < len(order) && order[i+1] == review {
+			lines = append(lines, branchLines(branches[id], indent+graphChildIndent, innerW, st)...)
+			ownerIndent = indent + graphChildIndent
+			lines = append(lines, nodeLine(review, status[review], ownerIndent, innerW, st))
+			owner = review
 		}
+		lines = append(lines, branchLines(branches[owner], ownerIndent+graphChildIndent, innerW, st)...)
 	}
 	return lines
 }
 
-// stageLine renders one node. A review checkpoint is drawn as a child of the
-// stage it belongs to — that is how the compiler keys it ("<id>.review"), and
-// showing it inline would read as a stage of its own.
-func stageLine(id string, s stageStatus, innerW int, st sidebarStyles) string {
-	if _, ok := strings.CutSuffix(id, ".review"); ok {
-		label := truncateLabel("review", max(innerW-6, 6))
-		return statusStyle(s, st).Render("  └ " + statusGlyph(s) + " " + label)
+// stageIndent returns the left offset of the nth stage in the waterfall.
+func stageIndent(n int) int {
+	return graphBaseIndent + min(n*graphStagePitch, graphMaxIndent)
+}
+
+// isReview reports whether id names a stage's review checkpoint, which the
+// compiler keys as "<stage>.review".
+func isReview(id string) bool {
+	return strings.HasSuffix(id, ".review")
+}
+
+// nodeLine renders one node of the graph. A review checkpoint is drawn as a
+// child of the stage it guards — that is how the compiler keys it, and giving
+// it a step of its own in the waterfall would overstate it.
+func nodeLine(id string, s stageStatus, indent, innerW int, st sidebarStyles) string {
+	label := id
+	prefix := ""
+	if isReview(id) {
+		label, prefix = "review", "└ "
 	}
-	label := truncateLabel(id, max(innerW-4, 8))
-	return statusStyle(s, st).Render("  " + statusGlyph(s) + " " + label)
+	room := max(innerW-indent-len(prefix)-2, 6)
+	return statusStyle(s, st).Render(
+		strings.Repeat(" ", indent) + prefix + statusGlyph(s) + " " + truncateLabel(label, room))
+}
+
+// branchLines renders the conditional edges leaving one node, indented under
+// the node they belong to so they read as its outcomes rather than as steps of
+// their own.
+func branchLines(edges []sop.GraphEdge, indent, innerW int, st sidebarStyles) []string {
+	lines := make([]string, 0, len(edges))
+	pad := strings.Repeat(" ", indent)
+	for _, e := range edges {
+		label := truncateLabel(e.To, max(innerW-indent-4, 6))
+		lines = append(lines, st.overlay.Render(pad+routeMark(e.Route)+"→ "+label))
+	}
+	return lines
 }
 
 func statusGlyph(s stageStatus) string {

--- a/internal/tui/sop_graph.go
+++ b/internal/tui/sop_graph.go
@@ -1,0 +1,131 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// stageStatus is what the sidebar draws for one node of the SOP graph. It
+// mirrors the engine's node lifecycle rather than anything the TUI infers: the
+// scheduler is the only thing that knows what is running.
+type stageStatus uint8
+
+const (
+	stageInactive stageStatus = iota
+	stageRunning
+	stageCompleted
+	stageFailed
+	stageWaiting // parked on a human approval
+)
+
+// routeMark renders an edge's condition. The graph is 20 columns wide, so the
+// condition has to be a glyph rather than the word.
+func routeMark(route string) string {
+	switch route {
+	case "PASS":
+		return "✓"
+	case "FAIL":
+		return "✗"
+	case sop.RecheckSignal:
+		return "↺"
+	default:
+		return "→"
+	}
+}
+
+// sidebarGraphLines draws the compiled SOP as a vertical diagram: one line per
+// stage down the spine, with conditional edges hanging off it.
+//
+//	✔ validate_spec
+//	│
+//	▶ slices
+//	├─✗→ repair
+//
+// It returns nil when there is nothing to draw, so the caller can drop the
+// whole section rather than emit an empty box.
+func sidebarGraphLines(
+	order []string, edges []sop.GraphEdge, status map[string]stageStatus,
+	innerW int, st sidebarStyles,
+) []string {
+	if len(order) == 0 {
+		return nil
+	}
+
+	// Conditional edges only. An unconditional or default edge is the spine
+	// itself, drawn as the connector between consecutive stages.
+	branches := map[string][]sop.GraphEdge{}
+	for _, e := range edges {
+		if e.From == sop.StartNodeName || e.Route == "" {
+			continue
+		}
+		branches[e.From] = append(branches[e.From], e)
+	}
+
+	lines := make([]string, 0, len(order)*2)
+	for i, id := range order {
+		lines = append(lines, stageLine(id, status[id], innerW, st))
+
+		outgoing := branches[id]
+		for j, e := range outgoing {
+			connector := "├─"
+			if j == len(outgoing)-1 {
+				connector = "└─"
+			}
+			label := truncateLabel(e.To, max(innerW-8, 6))
+			lines = append(lines, st.overlay.Render(
+				"  "+connector+routeMark(e.Route)+"→ "+label))
+		}
+
+		// No connector between a stage and its own review: the review hangs
+		// off the stage, it is not the next step down the spine.
+		if i < len(order)-1 && order[i+1] != id+".review" {
+			lines = append(lines, st.overlay.Render("  │"))
+		}
+	}
+	return lines
+}
+
+// stageLine renders one node. A review checkpoint is drawn as a child of the
+// stage it belongs to — that is how the compiler keys it ("<id>.review"), and
+// showing it inline would read as a stage of its own.
+func stageLine(id string, s stageStatus, innerW int, st sidebarStyles) string {
+	if _, ok := strings.CutSuffix(id, ".review"); ok {
+		label := truncateLabel("review", max(innerW-6, 6))
+		return statusStyle(s, st).Render("  └ " + statusGlyph(s) + " " + label)
+	}
+	label := truncateLabel(id, max(innerW-4, 8))
+	return statusStyle(s, st).Render("  " + statusGlyph(s) + " " + label)
+}
+
+func statusGlyph(s stageStatus) string {
+	switch s {
+	case stageCompleted:
+		return "✔"
+	case stageRunning:
+		return "▶"
+	case stageFailed:
+		return "✗"
+	case stageWaiting:
+		return "⏸"
+	default:
+		return "○"
+	}
+}
+
+func statusStyle(s stageStatus, st sidebarStyles) lipgloss.Style {
+	switch s {
+	case stageCompleted:
+		return st.green
+	case stageRunning:
+		return st.peach
+	case stageFailed:
+		return st.red
+	case stageWaiting:
+		return st.yellow
+	default:
+		return st.overlay
+	}
+}

--- a/internal/tui/sop_graph.go
+++ b/internal/tui/sop_graph.go
@@ -21,17 +21,19 @@ const (
 	stageWaiting // parked on a human approval
 )
 
-// Layout of one stage group. The diagram is a waterfall: each stage starts one
-// column right of the one before it, so the order of the flow is legible from
-// the shape alone, without a drawn spine.
+// Layout of the diagram. Every stage after the first hangs off one vertical
+// line, so the flow reads as a single sequence at a glance.
+//
+// An earlier version stepped each stage one column right of the last. It looked
+// better on paper, but the panel is 20 columns wide, so the stagger had to stop
+// after four stages — and once it did, the remaining stages shared a column and
+// read as siblings of the stage above rather than as steps after it. A straight
+// spine says the true thing in fewer rows.
 const (
-	graphBaseIndent  = 2 // first stage
-	graphStagePitch  = 1 // added per stage down the waterfall
-	graphChildIndent = 2 // a review under its stage, an edge under its owner
-	// graphMaxIndent stops the waterfall walking off a 23-column sidebar. A SOP
-	// long enough to reach it keeps its remaining stages in one column, which
-	// still reads in order.
-	graphMaxIndent = 8
+	graphSpineCol   = 2 // the vertical line, and the first stage's glyph
+	graphStageCol   = 5 // every stage hanging off the line
+	graphReviewCol  = 5 // the elbow of a review checkpoint
+	graphEdgeIndent = 1 // an edge sits one column right of the node it leaves
 )
 
 // routeMark renders an edge's condition. The graph is 20 columns wide, so the
@@ -49,22 +51,21 @@ func routeMark(route string) string {
 	}
 }
 
-// sidebarGraphLines draws the compiled SOP as a waterfall of stage groups: the
-// stage, the review checkpoint that guards it, and the conditional edges that
-// leave either, with a blank row between groups.
+// sidebarGraphLines draws the compiled SOP as a single spine: the first stage
+// heads it, every later stage hangs off it, and each stage's review checkpoint
+// and conditional edges hang under the stage itself.
 //
-//	✔ clarify
-//	  └ ✔ review
+//	▶ clarify
+//	│  └ ✔ review
+//	├─ ○ research
+//	├─ ○ plan
+//	│  └ ○ review
+//	│     ✗→ plan
+//	│     ✓→ prompt
+//	└─ ○ manifest
 //
-//	 ▶ research
-//
-//	  ○ design
-//	    └ ○ review
-//
-// Sequence is carried by the stagger and the spacing, not by a drawn spine. An
-// earlier version put a │ between every pair of stages, which doubled the
-// height of a diagram sharing 23 columns with everything else and read as noise
-// once the groups were spaced apart.
+// The line closes with └ on the last stage, so the end of the flow is visible
+// rather than implied by running out of rows.
 //
 // It returns nil when there is nothing to draw, so the caller can drop the
 // whole section rather than emit an empty box.
@@ -77,7 +78,7 @@ func sidebarGraphLines(
 	}
 
 	// Conditional edges only. An unconditional or default edge is the forward
-	// path, which the waterfall already shows.
+	// path, which the spine itself shows.
 	branches := map[string][]sop.GraphEdge{}
 	for _, e := range edges {
 		if e.From == sop.StartNodeName || e.Route == "" {
@@ -86,37 +87,56 @@ func sidebarGraphLines(
 		branches[e.From] = append(branches[e.From], e)
 	}
 
+	var stages []string
+	for _, id := range order {
+		if !isReview(id) {
+			stages = append(stages, id)
+		}
+	}
+
+	hasReview := map[string]bool{}
+	for _, id := range order {
+		if stage, ok := strings.CutSuffix(id, ".review"); ok {
+			hasReview[stage] = true
+		}
+	}
+
 	var lines []string
-	depth := 0
-	for i, id := range order {
-		if isReview(id) {
-			continue // drawn as part of its stage's group
-		}
-		if len(lines) > 0 {
-			lines = append(lines, "")
-		}
+	for i, id := range stages {
+		// The line carries on below this stage only while another follows it.
+		more := i < len(stages)-1
 
-		indent := stageIndent(depth)
-		depth++
+		lines = append(lines, stageLine(id, status[id], i == 0, more, innerW, st))
 
-		lines = append(lines, nodeLine(id, status[id], indent, innerW, st))
-
-		// A review checkpoint always immediately follows its stage in Order.
-		owner, ownerIndent := id, indent
-		if review := id + ".review"; i+1 < len(order) && order[i+1] == review {
-			lines = append(lines, branchLines(branches[id], indent+graphChildIndent, innerW, st)...)
-			ownerIndent = indent + graphChildIndent
-			lines = append(lines, nodeLine(review, status[review], ownerIndent, innerW, st))
-			owner = review
+		owner, ownerCol := id, stageGlyphCol(i == 0)
+		if hasReview[id] {
+			lines = append(lines, edgeLines(branches[id], ownerCol+graphEdgeIndent, more, innerW, st)...)
+			review := id + ".review"
+			lines = append(lines, reviewLine(status[review], more, innerW, st))
+			owner, ownerCol = review, graphReviewCol+2
 		}
-		lines = append(lines, branchLines(branches[owner], ownerIndent+graphChildIndent, innerW, st)...)
+		lines = append(lines, edgeLines(branches[owner], ownerCol+graphEdgeIndent, more, innerW, st)...)
 	}
 	return lines
 }
 
-// stageIndent returns the left offset of the nth stage in the waterfall.
-func stageIndent(n int) int {
-	return graphBaseIndent + min(n*graphStagePitch, graphMaxIndent)
+// stageGlyphCol is the column a stage's status glyph sits in: the first stage
+// heads the line, the rest hang off it.
+func stageGlyphCol(first bool) int {
+	if first {
+		return graphSpineCol
+	}
+	return graphStageCol
+}
+
+// spinePad returns width columns with the vertical line drawn at the spine when
+// the flow continues below this row.
+func spinePad(width int, more bool) string {
+	out := []rune(strings.Repeat(" ", max(width, 0)))
+	if more && graphSpineCol < len(out) {
+		out[graphSpineCol] = '│'
+	}
+	return string(out)
 }
 
 // isReview reports whether id names a stage's review checkpoint, which the
@@ -125,29 +145,37 @@ func isReview(id string) bool {
 	return strings.HasSuffix(id, ".review")
 }
 
-// nodeLine renders one node of the graph. A review checkpoint is drawn as a
-// child of the stage it guards — that is how the compiler keys it, and giving
-// it a step of its own in the waterfall would overstate it.
-func nodeLine(id string, s stageStatus, indent, innerW int, st sidebarStyles) string {
-	label := id
-	prefix := ""
-	if isReview(id) {
-		label, prefix = "review", "└ "
+// stageLine draws one stage: the first heads the line, the rest hang off it
+// with ├, and the last closes it with └.
+func stageLine(id string, s stageStatus, first, more bool, innerW int, st sidebarStyles) string {
+	col := stageGlyphCol(first)
+	room := max(innerW-col-2, 6)
+	body := statusStyle(s, st).Render(statusGlyph(s) + " " + truncateLabel(id, room))
+
+	if first {
+		return strings.Repeat(" ", graphSpineCol) + body
 	}
-	room := max(innerW-indent-len(prefix)-2, 6)
-	return statusStyle(s, st).Render(
-		strings.Repeat(" ", indent) + prefix + statusGlyph(s) + " " + truncateLabel(label, room))
+	elbow := "└─ "
+	if more {
+		elbow = "├─ "
+	}
+	return st.overlay.Render(strings.Repeat(" ", graphSpineCol)+elbow) + body
 }
 
-// branchLines renders the conditional edges leaving one node, indented under
-// the node they belong to so they read as its outcomes rather than as steps of
-// their own.
-func branchLines(edges []sop.GraphEdge, indent, innerW int, st sidebarStyles) []string {
+// reviewLine draws a stage's review checkpoint under it.
+func reviewLine(s stageStatus, more bool, innerW int, st sidebarStyles) string {
+	room := max(innerW-graphReviewCol-4, 6)
+	return st.overlay.Render(spinePad(graphReviewCol, more)+"└ ") +
+		statusStyle(s, st).Render(statusGlyph(s)+" "+truncateLabel("review", room))
+}
+
+// edgeLines renders the conditional edges leaving one node, indented under it
+// so they read as its outcomes rather than as steps of their own.
+func edgeLines(edges []sop.GraphEdge, indent int, more bool, innerW int, st sidebarStyles) []string {
 	lines := make([]string, 0, len(edges))
-	pad := strings.Repeat(" ", indent)
 	for _, e := range edges {
 		label := truncateLabel(e.To, max(innerW-indent-4, 6))
-		lines = append(lines, st.overlay.Render(pad+routeMark(e.Route)+"→ "+label))
+		lines = append(lines, st.overlay.Render(spinePad(indent, more)+routeMark(e.Route)+"→ "+label))
 	}
 	return lines
 }

--- a/internal/tui/sop_graph_test.go
+++ b/internal/tui/sop_graph_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -153,5 +155,44 @@ func TestRunStageStatusProjectsThePhase(t *testing.T) {
 	}
 	if _, set := got["merge"]; set {
 		t.Errorf("a later stage should be untouched: %v", got)
+	}
+}
+
+// The checklist is cached between agent events, so the cache must not be able
+// to go stale silently — that would reproduce the frozen checklist the content
+// check was meant to fix.
+func TestPlanPhasesRefreshOnEvents(t *testing.T) {
+	dir := t.TempDir()
+	specDir := filepath.Join(dir, "specs", "demo")
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "rough-idea.md"),
+		[]byte("# Rough Idea\n\nbuild it\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m := &model{mode: "plan", planWorktreePath: dir, planTaskName: "demo"}
+
+	before := m.currentPlanPhases()
+	if !before[0].Done {
+		t.Fatal("Idea should be done")
+	}
+	if before[3].Done {
+		t.Fatal("Design should not be done yet")
+	}
+
+	// The agent writes design.md. Without an event the cache still answers.
+	if err := os.WriteFile(filepath.Join(specDir, "design.md"),
+		[]byte("# Design\n\nthe shape of it\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if m.currentPlanPhases()[3].Done {
+		t.Error("cache should hold until an event invalidates it")
+	}
+
+	m.invalidatePlanPhases()
+	if !m.currentPlanPhases()[3].Done {
+		t.Error("Design should be done once the cache is invalidated")
 	}
 }

--- a/internal/tui/sop_graph_test.go
+++ b/internal/tui/sop_graph_test.go
@@ -196,3 +196,22 @@ func TestPlanPhasesRefreshOnEvents(t *testing.T) {
 		t.Error("Design should be done once the cache is invalidated")
 	}
 }
+
+// A finished stage should not sit beside a review checkpoint that still reads
+// as untouched, and a running stage has not reached its review yet.
+func TestPlanStageStatusCarriesReviewCheckpoints(t *testing.T) {
+	got := planStageStatus([]PlanPhase{
+		{"Idea", true}, {"Requirements", true}, {"Research", false},
+		{"Design", false}, {"Outline", false}, {"Plan", false}, {"Prompt", false},
+	})
+
+	if got["clarify"] != stageCompleted {
+		t.Errorf("clarify = %v, want completed", got["clarify"])
+	}
+	if got["clarify.review"] != stageCompleted {
+		t.Errorf("a completed stage's review = %v, want completed", got["clarify.review"])
+	}
+	if _, set := got["research.review"]; set {
+		t.Error("a running stage's review should not be marked; it has not been reached")
+	}
+}

--- a/internal/tui/sop_graph_test.go
+++ b/internal/tui/sop_graph_test.go
@@ -1,0 +1,95 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// compileEmbedded gives a test the real compiled graph. The diagram is only
+// worth testing against the SOPs that ship, not a fixture that can drift.
+func compileEmbedded(t *testing.T, name string) *sop.Compiled {
+	t.Helper()
+	def, err := sop.LoadEmbeddedDefinition(name)
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefinition(%q): %v", name, err)
+	}
+	c, err := sop.Compile(def, sop.DescribeFactory{})
+	if err != nil {
+		t.Fatalf("Compile(%q): %v", name, err)
+	}
+	return c
+}
+
+func TestSidebarGraphLines_Run(t *testing.T) {
+	c := compileEmbedded(t, "run")
+	got := plain(sidebarGraphLines(c.Order, c.GraphEdges(), map[string]stageStatus{
+		"validate_spec": stageCompleted,
+		"slices":        stageRunning,
+	}, 20, testSidebarStyles()))
+
+	for _, want := range []string{
+		"✔ validate_spec", // completed
+		"▶ slices",        // running
+		"○ gates",         // not started
+		"✗→ repair",       // FAIL branch
+		"✓→ merge",        // PASS branch
+		"│",               // spine connector
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("graph missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// repair loops back to verify. The loop is the reason the diagram exists at
+// all — a flat list cannot show it.
+func TestSidebarGraphLines_ShowsLoopBack(t *testing.T) {
+	c := compileEmbedded(t, "run")
+	got := plain(sidebarGraphLines(c.Order, c.GraphEdges(), nil, 20, testSidebarStyles()))
+	if !strings.Contains(got, "↺→ verify") {
+		t.Errorf("loop-back edge not drawn:\n%s", got)
+	}
+}
+
+// A review checkpoint is a node of its own in the compiled graph, but it reads
+// as part of the stage it guards.
+func TestSidebarGraphLines_ReviewIsAChild(t *testing.T) {
+	c := compileEmbedded(t, "plan")
+	got := plain(sidebarGraphLines(c.Order, c.GraphEdges(), map[string]stageStatus{
+		"clarify.review": stageWaiting,
+	}, 20, testSidebarStyles()))
+
+	if !strings.Contains(got, "└ ⏸ review") {
+		t.Errorf("waiting review not drawn as a child:\n%s", got)
+	}
+	if strings.Contains(got, "clarify.review") {
+		t.Errorf("review node drawn as a top-level stage:\n%s", got)
+	}
+}
+
+// The sidebar is a fixed 23 columns. A line that overflows would break the
+// frame, which the render-integrity tests pin globally — catch it here first.
+func TestSidebarGraphLines_FitsSidebarWidth(t *testing.T) {
+	const innerW = SidebarWidth - 3
+	for _, name := range []string{"run", "plan"} {
+		t.Run(name, func(t *testing.T) {
+			c := compileEmbedded(t, name)
+			for _, line := range sidebarGraphLines(c.Order, c.GraphEdges(), nil, innerW, testSidebarStyles()) {
+				if w := runewidth.StringWidth(ansi.Strip(line)); w > SidebarWidth {
+					t.Errorf("line %q is %d cells wide, sidebar is %d", ansi.Strip(line), w, SidebarWidth)
+				}
+			}
+		})
+	}
+}
+
+func TestSidebarGraphLines_EmptyIsHidden(t *testing.T) {
+	if got := sidebarGraphLines(nil, nil, nil, 20, testSidebarStyles()); got != nil {
+		t.Errorf("expected no lines for an empty graph, got %d", len(got))
+	}
+}

--- a/internal/tui/sop_graph_test.go
+++ b/internal/tui/sop_graph_test.go
@@ -93,3 +93,65 @@ func TestSidebarGraphLines_EmptyIsHidden(t *testing.T) {
 		t.Errorf("expected no lines for an empty graph, got %d", len(got))
 	}
 }
+
+// The diagram has to actually reach the panel: it was implemented and tested in
+// isolation for a while without being wired into RenderSidebar at all.
+func TestRenderSidebar_DrawsTheGraphUnderThePlanList(t *testing.T) {
+	c := compileEmbedded(t, "plan")
+	phases := []PlanPhase{
+		{"Idea", true}, {"Requirements", true}, {"Research", false},
+		{"Design", false}, {"Outline", false}, {"Plan", false}, {"Prompt", false},
+	}
+	in := SidebarRenderInput{
+		Width: SidebarWidth, Height: 44, Mode: "plan", PlanPhases: phases,
+		Graph: &SOPGraph{Order: c.Order, Edges: c.GraphEdges(), Status: planStageStatus(phases)},
+	}
+
+	got := ansi.Strip(RenderSidebar(in))
+	for _, want := range []string{
+		"[x] Requirements", // the list
+		"▶ Research",       // the list's current phase
+		"✔ clarify",        // the diagram, projected from the same phases
+		"▶ research",
+		"└─✓→ prompt", // a routed edge only the diagram can show
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("sidebar missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// A short panel keeps the list and drops the diagram whole. sidebarFrame clips
+// from the bottom, so the alternative is half a tree with no sign of the rest.
+func TestRenderSidebar_DropsTheGraphWhenItCannotFit(t *testing.T) {
+	c := compileEmbedded(t, "plan")
+	phases := []PlanPhase{{"Idea", true}, {"Requirements", false}}
+	in := SidebarRenderInput{
+		Width: SidebarWidth, Height: 20, Mode: "plan", PlanPhases: phases,
+		Graph: &SOPGraph{Order: c.Order, Edges: c.GraphEdges(), Status: planStageStatus(phases)},
+	}
+
+	got := ansi.Strip(RenderSidebar(in))
+	if !strings.Contains(got, "[x] Idea") {
+		t.Errorf("the stage list must survive a short panel:\n%s", got)
+	}
+	if strings.Contains(got, "clarify") {
+		t.Errorf("the diagram should have been dropped whole:\n%s", got)
+	}
+}
+
+// The run diagram follows the imperative phase until the engine drives it.
+func TestRunStageStatusProjectsThePhase(t *testing.T) {
+	c := compileEmbedded(t, "run")
+	got := runStageStatus(c.Order, "gating")
+
+	if got["validate_spec"] != stageCompleted || got["slices"] != stageCompleted {
+		t.Errorf("stages before the current one should be complete: %v", got)
+	}
+	if got["gates"] != stageRunning {
+		t.Errorf("gates status = %v, want running", got["gates"])
+	}
+	if _, set := got["merge"]; set {
+		t.Errorf("a later stage should be untouched: %v", got)
+	}
+}

--- a/internal/tui/sop_graph_test.go
+++ b/internal/tui/sop_graph_test.go
@@ -40,11 +40,16 @@ func TestSidebarGraphLines_Run(t *testing.T) {
 		"○ gates",         // not started
 		"✗→ repair",       // FAIL branch
 		"✓→ merge",        // PASS branch
-		"│",               // spine connector
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("graph missing %q:\n%s", want, got)
 		}
+	}
+
+	// The waterfall carries the order: each stage starts one column right of
+	// the one before it, which is what replaced the drawn spine.
+	if !strings.Contains(got, "  ✔ validate_spec") || !strings.Contains(got, "   ▶ slices") {
+		t.Errorf("stages are not staggered:\n%s", got)
 	}
 }
 
@@ -111,14 +116,23 @@ func TestRenderSidebar_DrawsTheGraphUnderThePlanList(t *testing.T) {
 
 	got := ansi.Strip(RenderSidebar(in))
 	for _, want := range []string{
-		"[x] Requirements", // the list
-		"▶ Research",       // the list's current phase
-		"✔ clarify",        // the diagram, projected from the same phases
+		"Plan",      // the section heading
+		"2/7",       // the progress the checklist used to carry
+		"✔ clarify", // the stages themselves
 		"▶ research",
-		"└─✓→ prompt", // a routed edge only the diagram can show
+		"└ ✔ review", // a checkpoint, drawn under the stage it guards
+		"✓→ prompt",  // a routed edge only the diagram can show
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("sidebar missing %q:\n%s", want, got)
+		}
+	}
+
+	// The checklist and the diagram were two vocabularies for one thing. When
+	// the diagram fits, it replaces the checklist rather than sitting under it.
+	for _, gone := range []string{"[x] Requirements", "[ ] Outline"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("the phase checklist should have been replaced by the diagram, found %q:\n%s", gone, got)
 		}
 	}
 }
@@ -135,7 +149,7 @@ func TestRenderSidebar_DropsTheGraphWhenItCannotFit(t *testing.T) {
 
 	got := ansi.Strip(RenderSidebar(in))
 	if !strings.Contains(got, "[x] Idea") {
-		t.Errorf("the stage list must survive a short panel:\n%s", got)
+		t.Errorf("the checklist must survive a short panel:\n%s", got)
 	}
 	if strings.Contains(got, "clarify") {
 		t.Errorf("the diagram should have been dropped whole:\n%s", got)

--- a/internal/tui/sop_graph_test.go
+++ b/internal/tui/sop_graph_test.go
@@ -46,10 +46,17 @@ func TestSidebarGraphLines_Run(t *testing.T) {
 		}
 	}
 
-	// The waterfall carries the order: each stage starts one column right of
-	// the one before it, which is what replaced the drawn spine.
-	if !strings.Contains(got, "  ✔ validate_spec") || !strings.Contains(got, "   ▶ slices") {
-		t.Errorf("stages are not staggered:\n%s", got)
+	// One vertical line carries the whole flow: the first stage heads it, the
+	// rest hang off it, and the last closes it so the end is visible rather
+	// than implied by running out of rows.
+	if !strings.Contains(got, "  ✔ validate_spec") {
+		t.Errorf("the first stage should head the line:\n%s", got)
+	}
+	if !strings.Contains(got, "├─ ▶ slices") {
+		t.Errorf("later stages should hang off the line:\n%s", got)
+	}
+	if !strings.Contains(got, "└─ ○ summary") {
+		t.Errorf("the last stage should close the line:\n%s", got)
 	}
 }
 

--- a/internal/tui/sop_status.go
+++ b/internal/tui/sop_status.go
@@ -74,3 +74,83 @@ func (t *stageTracker) finish() {
 func (t *stageTracker) statuses() map[string]stageStatus {
 	return t.status
 }
+
+// Until the workflow engine drives /plan and /run, the diagram takes its status
+// from the same evidence the stage list uses: artifacts on disk for /plan, the
+// run state machine for /run. The projections below are the bridge, and they
+// exist so the list and the diagram can never disagree — they are two views of
+// one fact, not two independent guesses. When the engine lands, stageTracker
+// replaces both.
+
+// planPhaseStage maps a PDD phase label to the plan SOP's stage id. "Idea" has
+// no stage: it is the input to the SOP, not a step in it.
+var planPhaseStage = map[string]string{
+	"Requirements": "clarify",
+	"Research":     "research",
+	"Design":       "design",
+	"Outline":      "outline",
+	"Plan":         "plan",
+	"Prompt":       "prompt",
+}
+
+// planStageStatus projects the phase checklist onto plan SOP stage ids: every
+// finished phase is complete, and the first unfinished one is running.
+func planStageStatus(phases []PlanPhase) map[string]stageStatus {
+	out := make(map[string]stageStatus, len(phases))
+	current := true
+	for _, p := range phases {
+		id, ok := planPhaseStage[p.Name]
+		if !ok {
+			continue
+		}
+		switch {
+		case p.Done:
+			out[id] = stageCompleted
+		case current:
+			out[id] = stageRunning
+			current = false
+		}
+	}
+	return out
+}
+
+// runPhaseStage maps a runState phase to the run SOP's stage id.
+var runPhaseStage = map[string]string{
+	"running":   "slices",
+	"gating":    "gates",
+	"verifying": "verify",
+	"retrying":  "repair",
+	"merging":   "merge",
+	"done":      "summary",
+	"failed":    "",
+}
+
+// runStageStatus projects the imperative run phase onto run SOP stage ids:
+// everything before the current stage is complete, the current one is running,
+// and a failed run marks where it stopped.
+func runStageStatus(order []string, phase string) map[string]stageStatus {
+	out := make(map[string]stageStatus, len(order))
+	current, ok := runPhaseStage[phase]
+	if !ok {
+		return out
+	}
+
+	// A failed run has no stage of its own; the last one reached is the one
+	// that failed, and we cannot tell which from the phase alone.
+	if current == "" {
+		return out
+	}
+
+	for _, id := range order {
+		if id == current {
+			out[id] = stageRunning
+			if phase == "done" {
+				out[id] = stageCompleted
+			}
+			break
+		}
+		// validate_spec always ran: the run would not have started otherwise.
+		out[id] = stageCompleted
+	}
+	return out
+}

--- a/internal/tui/sop_status.go
+++ b/internal/tui/sop_status.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"google.golang.org/adk/v2/session"
+
+	"github.com/dimetron/pi-go/internal/sop/exec"
+)
+
+// stageTracker turns the workflow engine's event stream into the status map the
+// sidebar diagram draws.
+//
+// It exists because the engine does not offer the obvious thing. RunState lives
+// on an unexported scheduler and is never handed to a caller, and node *start*
+// is not an event at all. What is observable is the stream: our node bodies
+// announce themselves on entry (exec.StageStarted), a paused node carries
+// RequestedInput, and a failure arrives as an error. Completion is inferred —
+// a node has finished once the next one begins, which the scheduler guarantees
+// by only scheduling a successor after its predecessor completes.
+type stageTracker struct {
+	status  map[string]stageStatus
+	current string
+}
+
+func newStageTracker() *stageTracker {
+	return &stageTracker{status: map[string]stageStatus{}}
+}
+
+// observe folds one event into the tracker.
+func (t *stageTracker) observe(ev *session.Event) {
+	if ev == nil {
+		return
+	}
+
+	if stage, ok := exec.StageStarted(ev); ok {
+		// The previous stage is done: the scheduler does not start a successor
+		// until its predecessor has completed. A stage the graph loops back to
+		// is re-marked running below, which is what we want — it is running
+		// again, not still finished.
+		if t.current != "" && t.current != stage {
+			t.status[t.current] = stageCompleted
+		}
+		t.status[stage] = stageRunning
+		t.current = stage
+		return
+	}
+
+	// A node asking for human input is parked, not working. This is the only
+	// status the artifact-stat approach could never show.
+	if ev.RequestedInput != nil && t.current != "" {
+		t.status[t.current] = stageWaiting
+	}
+}
+
+// fail marks the stage that was running as failed. The engine reports a node
+// failure as an error on the stream rather than as an event, so the caller
+// passes it in separately.
+func (t *stageTracker) fail() {
+	if t.current != "" {
+		t.status[t.current] = stageFailed
+	}
+}
+
+// finish marks the stage that was running as completed, for the end of a run
+// that no successor follows.
+func (t *stageTracker) finish() {
+	if t.current != "" {
+		t.status[t.current] = stageCompleted
+		t.current = ""
+	}
+}
+
+// statuses returns the map the renderer reads. The zero value of stageStatus is
+// stageInactive, so stages never seen simply render as not started.
+func (t *stageTracker) statuses() map[string]stageStatus {
+	return t.status
+}

--- a/internal/tui/sop_status.go
+++ b/internal/tui/sop_status.go
@@ -106,6 +106,14 @@ func planStageStatus(phases []PlanPhase) map[string]stageStatus {
 		switch {
 		case p.Done:
 			out[id] = stageCompleted
+			// A stage's review checkpoint is a node of its own in the graph.
+			// Artifact evidence cannot tell us a human approved anything, but a
+			// finished artifact means the flow moved past that checkpoint —
+			// whereas leaving it inactive draws a permanent ○ beside a ✔ stage.
+			// Only completion is inherited: a running stage has not reached its
+			// review yet. When the engine drives /plan, review nodes report
+			// their own status and none of this applies.
+			out[id+".review"] = stageCompleted
 		case current:
 			out[id] = stageRunning
 			current = false

--- a/internal/tui/sop_status_test.go
+++ b/internal/tui/sop_status_test.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+
+	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/session"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/exec"
+)
+
+// runEmbeddedSOP executes a SOP through a real ADK runner and returns every
+// event it emitted, plus the compiled graph the sidebar draws.
+func runEmbeddedSOP(t *testing.T, name string, routes map[string][]string) ([]*session.Event, *sop.Compiled) {
+	t.Helper()
+
+	def, err := sop.LoadEmbeddedDefinition(name)
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefinition: %v", err)
+	}
+
+	run := func(_ context.Context, req exec.StageRequest) (exec.StageOutcome, error) {
+		id := req.Stage.ID
+		if req.Review != nil {
+			id += ".review"
+		}
+		route := ""
+		if queued := routes[id]; len(queued) > 0 {
+			route = queued[0]
+			routes[id] = queued[1:]
+		}
+		return exec.StageOutcome{Route: route, Output: id}, nil
+	}
+
+	ag, compiled, err := exec.Agent(def, exec.NewFactory(exec.RunnerFunc(run)))
+	if err != nil {
+		t.Fatalf("Agent: %v", err)
+	}
+
+	r, err := runner.New(runner.Config{
+		AppName:           "pi-tui-test",
+		Agent:             ag,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+
+	var events []*session.Event
+	for ev, err := range r.Run(context.Background(), "u", "sess-"+name,
+		genai.NewContentFromText("start", genai.RoleUser), adkagent.RunConfig{}) {
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		events = append(events, ev)
+	}
+	return events, compiled
+}
+
+// The whole point of the feature: what the sidebar draws is what the engine did.
+// This drives a real workflow and renders the real diagram from its events.
+func TestSidebarGraphFollowsRealExecution(t *testing.T) {
+	events, compiled := runEmbeddedSOP(t, "run", map[string][]string{"verify": {"PASS"}})
+
+	tracker := newStageTracker()
+	var atGates string
+
+	for _, ev := range events {
+		tracker.observe(ev)
+		// Snapshot the frame the user would see the moment gates begins.
+		if stage, ok := exec.StageStarted(ev); ok && stage == "gates" {
+			atGates = plain(sidebarGraphLines(
+				compiled.Order, compiled.GraphEdges(), tracker.statuses(), 20, testSidebarStyles()))
+		}
+	}
+	tracker.finish()
+
+	if atGates == "" {
+		t.Fatal("gates never started; the workflow did not run as expected")
+	}
+	for _, want := range []string{"✔ validate_spec", "✔ slices", "▶ gates", "○ verify", "○ merge"} {
+		if !strings.Contains(atGates, want) {
+			t.Errorf("mid-run frame missing %q:\n%s", want, atGates)
+		}
+	}
+
+	final := plain(sidebarGraphLines(
+		compiled.Order, compiled.GraphEdges(), tracker.statuses(), 20, testSidebarStyles()))
+	for _, want := range []string{"✔ validate_spec", "✔ slices", "✔ gates", "✔ verify", "✔ merge", "✔ summary"} {
+		if !strings.Contains(final, want) {
+			t.Errorf("final frame missing %q:\n%s", want, final)
+		}
+	}
+	// repair never ran, so it must still read as not started.
+	if !strings.Contains(final, "○ repair") {
+		t.Errorf("repair should be inactive on a clean run:\n%s", final)
+	}
+}
+
+// A stage the graph loops back to reads as running again, not as still finished.
+func TestStageTrackerReMarksALoopedStage(t *testing.T) {
+	events, compiled := runEmbeddedSOP(t, "run", map[string][]string{
+		"gates":  {"FAIL"},
+		"repair": {sop.RecheckSignal},
+		"verify": {"PASS"},
+	})
+
+	tracker := newStageTracker()
+	for _, ev := range events {
+		tracker.observe(ev)
+	}
+	tracker.finish()
+
+	got := tracker.statuses()
+	if got["repair"] != stageCompleted {
+		t.Errorf("repair status = %v, want completed", got["repair"])
+	}
+	if got["verify"] != stageCompleted {
+		t.Errorf("verify status = %v, want completed after the recheck", got["verify"])
+	}
+
+	final := plain(sidebarGraphLines(compiled.Order, compiled.GraphEdges(), got, 20, testSidebarStyles()))
+	if !strings.Contains(final, "✔ repair") {
+		t.Errorf("repair ran but is not marked complete:\n%s", final)
+	}
+}
+
+// A failing run marks the stage that was running, not the whole graph.
+func TestStageTrackerMarksTheFailingStage(t *testing.T) {
+	tracker := newStageTracker()
+	tracker.status["validate_spec"] = stageCompleted
+	tracker.current = "slices"
+	tracker.fail()
+
+	if got := tracker.statuses()["slices"]; got != stageFailed {
+		t.Errorf("slices status = %v, want failed", got)
+	}
+	if got := tracker.statuses()["validate_spec"]; got != stageCompleted {
+		t.Errorf("a completed stage was disturbed by a later failure: %v", got)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -59,6 +59,8 @@ type model struct {
 	planWorktreeAgentID string
 	planWorktreePath    string
 	sopGraphs           map[string]*sop.Compiled // compiled SOPs for the sidebar diagram, per name
+	planPhases          []PlanPhase              // cached phase checklist; recomputed when planPhasesStale
+	planPhasesStale     bool                     // an agent event may have changed the spec artifacts
 	planBackupBranch    string
 	planTaskName        string
 	planWorktree        *subagent.WorktreeManager
@@ -1732,8 +1734,7 @@ func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInp
 		in.RunMaxCycle = m.run.maxRetries
 	}
 	if m.mode == "plan" && m.planWorktreePath != "" && m.planTaskName != "" {
-		specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)
-		in.PlanPhases = detectPlanPhases(specDir)
+		in.PlanPhases = m.currentPlanPhases()
 		if g := m.sopGraph("plan"); g != nil {
 			in.Graph = &SOPGraph{
 				Order:  g.Order,
@@ -1752,6 +1753,30 @@ func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInp
 		}
 	}
 	return in
+}
+
+// currentPlanPhases returns the phase checklist, re-reading the spec artifacts
+// only when an agent event may have changed them.
+//
+// The artifacts on disk stay the source of truth — they survive a resumed plan
+// and a restarted TUI, which an event log alone would not — but stat-ing seven
+// paths and reading their opening bytes on every keystroke is work the render
+// path should not do. Events decide *when* to look, not *what* is true.
+func (m *model) currentPlanPhases() []PlanPhase {
+	if m.planPhasesStale || m.planPhases == nil {
+		specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)
+		m.planPhases = detectPlanPhases(specDir)
+		m.planPhasesStale = false
+	}
+	return m.planPhases
+}
+
+// invalidatePlanPhases marks the checklist for recomputation. It is called from
+// every event that can precede an artifact write — a tool result, a subagent
+// event, the end of a turn — because missing one would freeze the checklist,
+// which is the bug this whole area just came from.
+func (m *model) invalidatePlanPhases() {
+	m.planPhasesStale = true
 }
 
 // sopGraph returns the compiled SOP named name, compiling it once per session.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dimetron/pi-go/internal/auth"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/palace"
+	"github.com/dimetron/pi-go/internal/sop"
 	"github.com/dimetron/pi-go/internal/subagent"
 )
 
@@ -57,6 +58,7 @@ type model struct {
 	// planner completes, then the branch is merged and the backup ref retained.
 	planWorktreeAgentID string
 	planWorktreePath    string
+	sopGraphs           map[string]*sop.Compiled // compiled SOPs for the sidebar diagram, per name
 	planBackupBranch    string
 	planTaskName        string
 	planWorktree        *subagent.WorktreeManager
@@ -1732,8 +1734,48 @@ func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInp
 	if m.mode == "plan" && m.planWorktreePath != "" && m.planTaskName != "" {
 		specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)
 		in.PlanPhases = detectPlanPhases(specDir)
+		if g := m.sopGraph("plan"); g != nil {
+			in.Graph = &SOPGraph{
+				Order:  g.Order,
+				Edges:  g.GraphEdges(),
+				Status: planStageStatus(in.PlanPhases),
+			}
+		}
+	}
+	if in.Graph == nil && in.RunPhase != "" {
+		if g := m.sopGraph("run"); g != nil {
+			in.Graph = &SOPGraph{
+				Order:  g.Order,
+				Edges:  g.GraphEdges(),
+				Status: runStageStatus(g.Order, in.RunPhase),
+			}
+		}
 	}
 	return in
+}
+
+// sopGraph returns the compiled SOP named name, compiling it once per session.
+//
+// Compiling parses and lints the embedded YAML, which is far too much work for
+// a function the render path calls on every keystroke — hence the cache. A SOP
+// that fails to compile caches nothing and simply hides the diagram; the stage
+// list still renders.
+func (m *model) sopGraph(name string) *sop.Compiled {
+	if m.sopGraphs == nil {
+		m.sopGraphs = map[string]*sop.Compiled{}
+	}
+	if g, ok := m.sopGraphs[name]; ok {
+		return g
+	}
+
+	var compiled *sop.Compiled
+	if def, err := sop.LoadEmbeddedDefinition(name); err == nil {
+		if c, err := sop.Compile(def, sop.DescribeFactory{}); err == nil {
+			compiled = c
+		}
+	}
+	m.sopGraphs[name] = compiled // nil is cached too: do not retry every frame
+	return compiled
 }
 
 // drainTerminalResponses discards any pending terminal response sequences

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -7,6 +7,7 @@ import (
 	"image/color"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -1727,6 +1728,10 @@ func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInp
 		in.RunSpec = m.run.specName
 		in.RunCycle = m.run.retries + 1
 		in.RunMaxCycle = m.run.maxRetries
+	}
+	if m.mode == "plan" && m.planWorktreePath != "" && m.planTaskName != "" {
+		specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)
+		in.PlanPhases = detectPlanPhases(specDir)
 	}
 	return in
 }

--- a/specs/features/TOO/022-plan-mode-phase-checklist/plan.md
+++ b/specs/features/TOO/022-plan-mode-phase-checklist/plan.md
@@ -123,3 +123,10 @@ After all slices:
 - `go test ./internal/tui/...`
 - `go vet ./internal/tui/...`
 - `golangci-lint run ./internal/tui/...`
+
+## Progress
+
+- [x] Step 1: Add `PlanPhase` type + `detectPlanPhases`
+- [x] Step 2: Add `sidebarPlanLines` renderer
+- [x] Step 3: Wire into `SidebarRenderInput` + `sidebarRenderInput`
+- [x] Step 4: Add tests

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/design.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/design.md
@@ -1,0 +1,352 @@
+# Design: /plan and /run as ADK 2.x workflow agents, with live TUI visualization
+
+Status: design verified by an independent review (codex) plus two source-level
+verifications (ADK engine semantics; pi-go feasibility). Every claim below that
+concerns the engine was read from `google.golang.org/adk/v2@v2.2.0` source.
+
+**The executor exists.** `internal/sop/exec` supplies the `NodeFactory` the
+compiler was waiting for, and `exec.Agent` wraps a compiled SOP as an ADK
+`agent.Agent`. Both embedded SOPs now execute end to end through a real
+`runner.Runner` under test: the forward path, a FAIL routing to `repair`
+without also taking the forward edge, a gate failure repairing and merging, a
+non-converging loop stopped by the cycle budget, and the plan SOP's
+`plan.review` FAIL round trip. What remains is the *work* inside the stages —
+the `StageRunner` that spawns subagents, runs gates, and merges worktrees — plus
+the TUI wiring.
+
+## Decision
+
+Execute `/plan` and `/run` **through the compiled SOP graph**, hosted as an ADK
+workflow agent, and render that same graph in the sidebar with stage status
+driven by the engine rather than by anything the TUI or an LLM reports.
+
+Two problems collapse into one solution:
+
+- The graph in `internal/sop` is compiled, linted, and never executed
+  (`research/execution-path.md`). Supplying the missing `NodeFactory` runs it.
+- The sidebar needs to know the active stage. With the engine executing, that
+  comes from the run itself — no `stage_start` marker emitted by a model, no
+  mapping of the imperative `phase` field, no drift between picture and reality.
+
+This supersedes the marker-based approach in the original requirements: markers
+were a workaround for the absent factory.
+
+## Architecture
+
+```
+  plan.sop.yaml / run.sop.yaml
+        │  sop.LoadEmbeddedDefinition        (added)
+        ▼
+   *sop.Definition
+        │  sop.Compile(def, factory)         (exists — the factory is the gap)
+        ▼
+   *sop.Compiled {Edges, Nodes, Order}
+        │  compiled.Workflow()               (exists; keeps WithMaxConcurrency)
+        ▼
+   *workflow.Workflow
+        │  adkagent.New{Run: wf.Run}         (~20 lines; see "Own the workflow")
+        ▼
+     agent.Agent  →  runner.New{Agent: …}    (exists — agent.go:407)
+        ▼
+   iter.Seq2[*session.Event, error]  ──► chat stream
+                                     └──► node status ──► sidebar diagram
+```
+
+### Own the workflow, don't use `workflowagent`
+
+`workflowagent.New` looks like the obvious entry point and is the wrong one:
+it calls `workflow.New(cfg.Name, cfg.Edges)` with **no options**, silently
+dropping `defaults.max_concurrency` (4 for plan, 3 for run), and it keeps the
+`*workflow.Workflow` in an unexported wrapper. Building the workflow ourselves
+and wrapping it with `agent.New(agent.Config{Run: wf.Run})` — `agent.Config.Run`
+is the sanctioned public hook — keeps the options and keeps the handle.
+
+## The node contract
+
+This is the part the first draft got wrong, and it governs every node body.
+
+1. **Routing matches `session.Event.Routes`, never the node's return value.**
+   `StringRoute.Matches` → `matchRoute` scans `event.Routes` only
+   (`workflow/workflow.go:66-80`). A node that returns `"PASS"` sets
+   `Event.Output` and matches nothing.
+2. **A node emits exactly one routing event per activation.** A second sets
+   `ErrMultipleRoutingEvents` and fails the node (`scheduler.go:765`).
+3. **An error never takes the `on_fail` edge.** It marks the node failed,
+   applies `RetryConfig`, then fails the whole workflow — there is no
+   per-node continue-on-failure. **Failure is a value a stage reports, not an
+   error it returns.**
+4. **No match and no Default is a silent dead-end**, explicitly "not an error"
+   (`scheduler.go:966`). Every routing node needs a Default edge.
+5. **Unconditional edges always fire**, regardless of what matched
+   (`scheduler.go:998`). See the compiler fix below.
+
+Two supported body shapes: a `FunctionNode` whose fn returns a `*session.Event`
+directly, or `NewEmittingFunctionNode` / `NewDynamicNode` that `emit`s the
+routing event. The canonical ADK example sets **both** `ev.Routes` (picks the
+successor) and `ev.Output` (feeds the successor's typed input).
+
+## Compiler fix already landed
+
+`wire()` added the `on_fail` edge outside the `switch` that adds `next`, so
+`slices` carried an unconditional edge to `gates` **and** a FAIL edge to
+`repair`. Because unconditional edges always fire, a failing stage would have
+scheduled both — proceeding to verification of work that had just failed.
+
+Fixed: a stage whose `on_fail` names another stage now gets its forward edge as
+`workflow.Default`, which fires only when no concrete route matched — exactly
+"next unless it failed". Pinned by
+`TestFailoverStagesHaveNoUnconditionalForwardEdge`; `sopcheck` now prints
+`slices -> gates [default]` beside `slices -> repair [FAIL]`.
+
+Latent until now precisely because nothing executed the graph.
+
+## Stage inventory
+
+### run.sop.yaml — 7 stages, no reviews
+
+| stage | node | body | routing |
+|---|---|---|---|
+| `validate_spec` | function | preflight validators (`run_preflight.go`) | `on_fail: abort` ⇒ no edge |
+| `slices` | dynamic + `RunNode` per item | one `worker` per slice; `group_by: parallel_safe`, `max_concurrency: 3`, `isolation: sub_branch`, `output_schema: SliceResult`, `join` | FAIL → `repair`, else default → `gates` |
+| `gates` | function | gate runner (`gates_from: PROMPT.md`, timeout 10m) | FAIL → `repair`, else default → `verify` |
+| `verify` | agent (`code-reviewer`) | reviews the diff; `output_schema: Verdict` | PASS → `merge`, FAIL → `repair` |
+| `repair` | dynamic fan-out over `verdict.unmet` | fix workers, `max_concurrency: 2` | `RECHECK` ⇒ `loop_back: verify`, `max_cycles: 10` |
+| `merge` | function | worktree merge | → `summary` |
+| `summary` | function | `SUMMARY.md` | terminal |
+
+### plan.sop.yaml — 7 stages + 4 review checkpoints
+
+| stage | node | body | routing |
+|---|---|---|---|
+| `clarify` | agent (`plan`) | → `requirements.md`; `min_qa(min:3)` | → `research` |
+| `clarify.review` | **`kind: human`** | "Approve to continue to research?" | HITL pause |
+| `research` | **dynamic fan-out** over `research_angles`, agent `explore`, `max_concurrency: 4`, `isolation: sub_branch`, `join: research_summary` | → `research/*.md`; `no_solution_language` | → `design` |
+| `design` | agent (`plan`), `inputs: [requirements, research_summary]` | → `design.md`; `acceptance_criteria_are_given_when_then`, `research_at_least(min:2)` | → `outline` |
+| `design.review` | **`kind: human`** | "Approve the design?" | HITL pause |
+| `outline` | agent (`plan`) | → `outline.md`; `max_lines(120)`, `lists_slices(min:2)` | → `plan` |
+| `outline.review` | **`kind: human`** | "Approve the outline?" | HITL pause |
+| `plan` | agent (`plan`) | → `plan.md`; `slice_count(1..25)` | — |
+| `plan.review` | `kind: agent` (`spec-reviewer`) | verdict | FAIL → `plan`, PASS → `prompt`, `max_cycles: 3` |
+| `prompt` | agent (`plan`) | → `PROMPT.md`; gates executable, `done_criteria(min:3)` | → `manifest` |
+| `manifest` | function | `.sop-manifest.json` | terminal |
+
+**Three of the four reviews are `kind: human`**, so HITL is critical path, not a
+later refinement.
+
+## Visualization
+
+Fixed 23-column sidebar (`SidebarWidth`), inner width 20. **Stage list on top,
+text workflow diagram underneath**, for both commands — the list from
+`Compiled.Order`, the diagram from `Compiled.GraphEdges()`.
+
+```
+ Run: my-spec              Plan: 024-tui-…
+ ────────────────          ────────────────
+ [x] validate_spec         [x] clarify
+ [▶] slices                [x]  └ approved
+ [ ] gates                 [x] research
+ [ ] verify                [▶] design
+ [ ] repair                [ ]  └ review
+ [ ] merge                 …
+ [ ] summary
+ ────────────────          ────────────────
+ ✔ validate_spec           ✔ clarify
+ │                         └ ✔ review
+ ▶ slices                  │
+ └─✗→ repair               ✔ research
+ │                         │
+ ○ gates                   ▶ design
+ └─✗→ repair               └ ⏸ review
+ │                         │
+ ○ verify                  ○ outline
+ ├─✗→ repair               └ ○ review
+ └─✓→ merge                │
+ │                         ○ plan
+ ○ repair                  └ ○ review
+ └─↺→ verify               ├─✗→ plan
+ │                         └─✓→ prompt
+ ○ merge                   │
+ │                         ○ prompt
+ ○ summary                 │
+                           ○ manifest
+```
+
+Glyphs: `✔` completed · `▶` running · `○` inactive · `✗` failed · `⏸` waiting
+(HITL) · `↺` loop-back edge. Implemented in `internal/tui/sop_graph.go`, with
+width pinned against the real `SidebarWidth`.
+
+### Where status comes from
+
+**Live `RunState` is not readable.** It is created inside `newScheduler` and
+held on the unexported scheduler; `Run`/`RunNode` never expose it, and
+`ReconstructRunState` re-scans session history for a *paused* run only.
+
+So the sidebar consumes the **event stream**: `NodeInfo.Path` identifies the
+node, `Output`/`OutputFor` its result, `RequestedInput` a pause. **Node start is
+not an event** — "running" is inferred from a node's first emitted event, or
+from our own graph edges once the predecessor completes. Node bodies are ours,
+and a body runs only when the scheduler activates it, so a lifecycle event
+emitted at entry is engine truth.
+
+### Degradation, in priority order — the list always wins
+
+1. Not enough rows ⇒ drop the diagram **whole**. `sidebarFrame` clips from the
+   bottom (`sidebar.go:517`), so the caller must measure and drop; the renderer
+   cannot self-limit.
+2. SOP fails to compile ⇒ list only, plus one dim line; no crash.
+3. Below 80 columns the sidebar is hidden entirely (`mainWidth`, tui.go:1958) —
+   the width-based "too narrow" case needs no handling.
+
+## Graph source: embedded only
+
+Compiled from the **embedded** SOPs via `sop.LoadEmbeddedDefinition` (added;
+`resolveDefinition` is unexported and always probes `~/.pi-go/sops/`). Overrides
+stay off until the engine is the only executor — until then an override would
+draw a pipeline that is not running. Flipping back to `LoadDefinition` is a
+one-line change at one call site.
+
+## Engine constraints the factory must respect
+
+| # | Constraint | Consequence |
+|---|---|---|
+| E1 | `NodeConfig.ParallelWorker` is a **dead field** — the scheduler never reads it | Real parallelism needs a `NewParallelWorker` node. `compile.go` now documents this |
+| E2 | `NewParallelWorker` rejects a wrapped node carrying `RetryConfig`, and `NodeConfigFor` always sets one from `defaults.retry` | Every fan-out stage (`slices`, `repair`, `research`) fails to construct unless retry moves to the parent — or fan-out is hand-rolled with `DynamicNode` + `RunNode` |
+| E3 | `NewParallelWorker` suppresses intermediate events and emits one aggregate | Worker output would vanish from the TUI. **Decision: `DynamicNode` + `RunNode`**, factory-enforced concurrency, `emit` for streaming |
+| E4 | `ParallelWorker` input must be an actual Go slice | The factory assembles `plan.slices` / `research_angles` / `verdict.unmet` itself; nothing resolves them |
+| E5 | `ErrDuplicateEdge` is `(From,To)`-keyed regardless of route | Two route values at one target must merge into one `MultiRoute` edge |
+| E6 | HITL handoff resumes with `event = nil`, so no concrete route can fire | An approval gate that routes on the answer needs `RerunOnResume: &true` |
+| E7 | `startNode` overwrites `runsByName` with no in-flight check | `repair` has three conditional predecessors; two matching concurrently double-activate it. Routes into a shared target must be provably exclusive, or the target must be a `JoinNode` |
+| E8 | No run-time cycle cap exists; `NodeState.Attempt` is retry-only and resets on success | `max_cycles` must be enforced by us, in **invocation-scoped, resume-safe** state — not on the factory struct, which serves concurrent sessions |
+| E9 | At most one terminal output per run (`ErrMultipleTerminalOutputs`) | A graph whose several terminal nodes all produce output fails at finalize |
+
+`ErrUnsupportedFanIn` is **not** a blocker: `validateFanIn` counts only
+unconditional incoming edges, and every back-edge the compiler builds carries a
+route. That is why `Workflow()` already succeeds for both SOPs.
+
+## Feasibility of reusing the imperative code
+
+| Area | Verdict | Note |
+|---|---|---|
+| Gates | feasible | `runGates`/`runGatesTimeout`/`runOneGate` are already package-level and `tea`-free. Put them in a leaf `internal/sop/gates`, not in `exec`, so the retained imperative path doesn't drag `agent`+`subagent` into the TUI. No cycle: `internal/sop` already imports `internal/subagent`; neither imports `internal/tui` |
+| Preflight | feasible | Needs only `workDir`. Gap: `--force` has no graph equivalent — it becomes node *input* |
+| Merge | needs refactor | `mergeRunTargets` reusable verbatim; `mergeTargets()` is not — it encodes three worktree shapes, and a `repair` loop adding trees per cycle is a fourth |
+| Summary | feasible, caveat | Helpers are package-level, but `*runState` **is** the report's data model |
+| Sidebar | feasible | One production call site (`tui.go:1732`) |
+| Flag | feasible | Follow `PI_NO_GROUNDING` (`agent/grounding.go:186`). Branch `/run` at `run.go:449`, `/plan` inside `startPlanSession` |
+| **/plan** | blocked as designed | see below |
+
+### /plan is the hard half
+
+The small half is ~100 lines: split `buildRunner` into `buildLLMAgent` + the
+runner wrapper (the `llmagent` is currently a discarded local), add a
+`StageAgent(name, description, instruction, tools)` constructor, and add a
+`RunStreamingContent` entry point — resuming a paused workflow means submitting
+a `FunctionResponse` targeting the interrupt id, which today's text-only
+`RunStreaming` cannot express. Doing this also retires
+`RebuildWithInstruction`, which today discards and rebuilds the whole runner
+mid-session.
+
+What blocks it:
+
+1. **pi-go has no HITL machinery at all** — zero production references to
+   `ResumeOrRequestInput`, `Workflow.Resume`, or `ReconstructRunState`.
+2. **`finishPlanWorktree` fires on every turn boundary** (`agent_loop.go:1729`),
+   so each HITL resume would fire it while the graph is parked at a review.
+3. **The plan session is write-only w.r.t. resume**: `PlanContext.Phase` is the
+   constant `"plan"`, `GetPlanContext` has no production caller, and
+   `handlePlanCommand` "resumes" by re-entering `startPlanSession` from scratch.
+4. **`preTurn` compaction spans the wrong unit** — once per `RunStreaming` turn,
+   while a workflow turn spans many stage calls.
+
+## Migration
+
+- `PI_SOP_ENGINE=1` selects the engine; default stays imperative.
+- **`/run` first, `/plan` second.** They are not the same size of problem.
+- Parity gate: the same spec through both paths produces the same artifacts,
+  verdict, and merge decision — and **the parity test must cover all six
+  terminal outcomes** (`agent_failed`, `verify_failed`, `gate_failed`,
+  `gate_hang`, `merge_failed`, `completed`), not just the happy path. The engine
+  collapses them to one error unless the factory attributes each failure, and
+  `SUMMARY.md` would silently degrade to a generic message.
+- **No behaviour change on cycles:** `repair`'s `max_cycles` is now 10, the same
+  budget `runState.maxRetries` gives today.
+
+## Test plan
+
+- **Factory unit tests** — each body with a fake orchestrator: gates FAIL routes
+  to `repair`, verdict PASS routes to `merge`, `repair` emits `RECHECK`,
+  `max_cycles` terminates the loop.
+- **Graph traversal** — stub factory whose nodes record their names; assert the
+  visited order for happy path, gate failure, verdict FAIL, loop exhaustion.
+- **Routing contract** — a node that returns a verdict *without* emitting
+  `Routes` must be caught by a test, since the engine's response is a silent
+  dead-end.
+- **Sidebar renders** — per status glyph, loop-back present, diagram dropped
+  (not clipped) when rows are short, list-only when compile fails. *(done)*
+- **Guard tests** — embedded stage ids, plan review kinds, no unconditional
+  forward edge on a failover stage. *(done)*
+- **Parity** — one fixture spec through both paths, all six outcomes.
+
+## Decisions taken
+
+### `repair` keeps a budget of 10, not 3
+
+`run.sop.yaml` now declares `max_cycles: 10`, matching today's
+`runState.maxRetries = 10`. The SOP's original `3` would have silently cut the
+repair budget on migration; raising it makes the engine path a port rather than
+a behaviour change, and the parity gate can compare like with like.
+
+### One worktree per run, owned by the workspace — not one per agent
+
+This is what `workspace.worktree: per-run` already declares, and it is the
+better model. Today the spawner creates a worktree **per agent**
+(`Worktree: new(true)` at each spawn site, `SkipCleanup: true`), which is what
+forces the surrounding machinery: `mergeTargets()` handling three shapes,
+`collapseParallel` / `carried` / `ownerBackup` moving trees around on retry, one
+backup ref per agent, and `worktreeAgentID` bookkeeping to remember which tree
+gates and merge belong to.
+
+Under one tree per run:
+
+- the factory creates the worktree once at run start; every stage — slice
+  workers, repair workers, gates, verify, merge — works inside it, and workers
+  spawn with `WorkDir: <run worktree>` and no `Worktree` flag of their own;
+- `mergeTargets()`'s three shapes collapse to one tree to merge, and the
+  retry-shuffling machinery has nothing left to do;
+- **the repair loop stops being a problem.** Per-agent trees meant every repair
+  cycle spawned workers with new trees the merge step had never heard of — the
+  "fourth shape" that had no equivalent in the current merge logic. Sharing one
+  tree removes the question;
+- gates run where the work is, with no agent-id lookup, and one backup ref
+  covers the run;
+- `WorktreeManager.Create` serialises on a mutex and stashes the primary
+  checkout on every call, so creating one tree instead of N also removes that
+  per-agent round trip.
+
+**The cost, stated plainly:** parallel slice workers now share a working tree,
+so isolation moves from "separate checkouts" to "disjoint file sets". That
+precondition is already declared and validated — `parallel_safe` on each slice,
+`every_slice_has(["files", "verify", "parallel_safe"])`, and
+`slice_budget(max_files: 10)` — but it is now load-bearing rather than advisory.
+Two consequences to design for: concurrent workers can contend on the git index,
+and a failed worker's partial edits can no longer be discarded by dropping its
+tree.
+
+Mitigation: keep `fan_out.max_concurrency`, but gate concurrent dispatch on the
+slices' declared file sets actually being disjoint, and fall back to sequential
+dispatch within the tree when they intersect. That is a check the coordinator
+prompt used to ask for in prose and nobody enforced.
+
+## Open questions
+
+1. ~~Worktrees vs engine branches.~~ **Resolved above** — one worktree per run,
+   owned by the workspace. Note the ADK half is unchanged: `WithUseSubBranch`
+   scopes session event history and `WithIsolationScope` scopes LLM history;
+   **neither creates a git worktree**, so `WorktreeManager` still runs. `WithUseSubBranch` scopes session event
+   history and `WithIsolationScope` scopes LLM history; **neither creates a git
+   worktree**. `isolation: sub_branch` cannot replace `WorktreeManager` — both
+   must run. Ownership, merge order, repair placement, conflict handling, and
+   cleanup after partial failure are unresolved, and `collapseParallel` /
+   `carried` / `ownerBackup` is retry state with no engine equivalent.
+2. **Where the cycle budget lives** so it is invocation-scoped and resume-safe.
+3. **Per-node token accounting** — nice-to-have, not required for parity.

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/requirements.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/requirements.md
@@ -1,0 +1,4 @@
+# Requirements
+
+## Questions & Answers
+

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/requirements.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/requirements.md
@@ -59,3 +59,63 @@
 - Given a SOP with a loop-back (e.g. run `repair → verify`), when rendered, then the compact graph shows the loop with connector glyphs.
 - Given a terminal too narrow for the graph, when rendering, then the compact graph is hidden without breaking the layout.
 - Given a SOP that cannot be compiled, when rendering, then the sidebar degrades to the linear stage list without crashing.
+
+---
+
+# Post-Research Revisions
+
+Research (Phase 3) disproved the assumption behind Q5 and changed Q3, Q4 and Q6.
+The answers above are the original record; these supersede them.
+
+### Q5 (revised). Does this include migrating /run and /plan to the compiled workflow?
+**Yes — that is now the feature.** The compiled graph is never executed: the
+only `NodeFactory` is the non-executing `DescribeFactory` and
+`Compiled.Workflow()` has no production caller. `/plan` and `/run` are to run as
+ADK 2.x workflow agents with the missing executable factory supplied.
+
+### Q4 (revised). How does the TUI determine the active stage?
+**From the run itself, via the engine's event stream** — `NodeInfo.Path`,
+`Output`/`OutputFor`, `RequestedInput`. Not an LLM-emitted marker, and not the
+imperative `phase` field. Note that live `RunState` is *not* readable and node
+start is *not* an event; see `research/adk-workflow-agent.md`.
+
+### Q6 (revised). How does the TUI receive stage transitions?
+**On the workflow agent's own event stream.** `/run` and `/plan` converge on one
+`iter.Seq2[*session.Event, error]`. The earlier plan — new `stage_start` /
+`stage_end` types on the subagent channel — is dropped: it was unimplementable,
+since the child `pi --mode json` emitter writes a closed set of event types and
+`/plan` has no subagent channel at all.
+
+### Q3 (revised). Derived from the compiled graph, or hand-authored?
+**Derived, from the EMBEDDED SOP only.** Overrides stay disabled until the engine
+is the only executor. Added `sop.LoadEmbeddedDefinition` for this.
+
+### Q2 / Q7 (confirmed)
+Vertical layout in the 23-column sidebar: the stage list on top, a text workflow
+diagram underneath, for both commands. For `/plan` the list becomes the real
+stage ids from `Compiled.Order`, replacing the seven hardcoded PDD artifact
+phases in `phaseArtifacts`.
+
+## Scope (revised)
+
+- **In scope:** an executable `NodeFactory`; hosting the compiled graph as a
+  workflow agent behind `PI_SOP_ENGINE=1`; closing the declared-but-inert gaps
+  (fan-out width/grouping/isolation, `max_cycles` enforcement, artifact
+  validators, typed outputs, workspace ownership); human-in-the-loop review
+  checkpoints; the sidebar list + diagram; tests including a both-paths parity
+  test covering all six terminal outcomes.
+- **Out of scope:** SOP overrides; per-node token accounting.
+
+## Constraints (revised)
+
+- Sidebar fixed at 23 columns; the diagram is dropped whole when rows are short,
+  never clipped — `sidebarFrame` clips from the bottom.
+- Stage status comes from the engine, never from parsed model output.
+- A stage reports failure as a **routed value**, never as a returned error: any
+  node error fails the entire workflow.
+- `max_cycles` must be enforced by the factory in invocation-scoped state.
+  `repair` is set to 10 cycles, matching today's `maxRetries`, so migrating the
+  loop bound is a port rather than a behaviour change.
+- One worktree per run, owned by the workspace rather than one per agent — see
+  the decision in `design.md`.
+- The imperative path stays until parity is demonstrated.

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/requirements.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/requirements.md
@@ -2,3 +2,60 @@
 
 ## Questions & Answers
 
+### Q1. What should the visual workflow be based on — the compiled SOP graph or the imperative state machine?
+**A.** Both. Use sidebar space to show the workflow during `/plan` and `/run`.
+
+### Q2. How should the workflow be represented in the 23-column sidebar?
+**A.** Keep the existing linear stage list as it is, and show a compact graph underneath it to show branching/loops.
+
+### Q3. Should the sidebar graph be derived from the compiled SOP graph, or hand-authored?
+**A.** Derived from the compiled SOP graph (`internal/sop` compiles `plan.sop.yaml` / `run.sop.yaml` into `*sop.Compiled` with Nodes/Edges/Order). A custom SOP override changes the graph.
+
+### Q4. How should the TUI determine which graph stage is active?
+**A.** Instrument actual execution — emit stage events from the executing workflow, not map the imperative `phase`/artifact state onto stage IDs.
+
+### Q5. Does this feature include migrating /run and /plan to execute through the compiled ADK workflow?
+**A.** Assumption to verify in research: the compiled workflow execution is already wired in; only the TUI visualization part is missing. (To be confirmed during Phase 3.)
+
+### Q6. How should the TUI receive stage-transition events?
+**A.** Reuse the existing subagent event channel — surface stage events as new event types on the same channel the /run and /plan subagents already stream into the TUI.
+
+### Q7. What style for the compact graph?
+**A.** Vertical tree with connector glyphs (`│ ├ └ →`) showing the forward path and loop-back arrows.
+
+### Q8. How should /plan produce stage transitions (it is a multi-turn LLM flow, not a single execution)?
+**A.** Emit from the plan agent — the plan agent is instructed to emit stage events as it moves between PDD phases.
+
+### Q9. Should /run use the same stage-event mechanism, or map the existing phase field?
+**A.** Both /run and /plan use the same mechanism — stage events on the existing channel. The run coordinator contract and the plan agent's PDD SOP instruction both emit stage events.
+
+### Q10. What is the full scope?
+**A.** Full scope in-scope: (a) event emission plumbing (run coordinator contract + plan agent PDD SOP instruction emit stage events), and (b) TUI rendering (compile SOP graph, render linear stage list + vertical-tree compact graph, highlight active stage from emitted events). Include tests (sidebar render, event parsing, graph layout) following existing patterns. Degrade gracefully when the terminal is too narrow or the SOP cannot be compiled.
+
+## Scope
+
+- **In scope:**
+  - Stage-event emission from the run coordinator contract (`coordinatorContract` in `internal/tui/run.go`) and the plan agent's PDD SOP instruction (`internal/sop/pdd_default.go`).
+  - New subagent event types for stage transitions (`stage_start` / `stage_end`), surfaced on the existing event channel.
+  - TUI sidebar rendering: compile the SOP graph, render the existing linear stage list, add a vertical-tree compact graph showing branching/loops, highlight the active stage from emitted events.
+  - Graceful degradation: hide the compact graph when the terminal is too narrow or the SOP cannot be compiled.
+  - Tests: sidebar render, event parsing, graph layout, following existing patterns.
+
+- **Out of scope (unless research shows otherwise):**
+  - Migrating /run and /plan to execute through the compiled ADK workflow (assumed already wired; verify in research).
+
+## Constraints
+
+- Sidebar width is fixed at 23 columns (`SidebarWidth` in `internal/tui/sidebar.go`).
+- The compact graph must fit within the sidebar's inner width.
+- Stage events must ride the existing subagent event channel — no new side-channels.
+- The graph is derived from the compiled SOP graph, so a custom SOP override changes the visualization.
+- Must degrade gracefully (narrow terminal, un-compilable SOP).
+
+## Acceptance Criteria (draft — refined in design)
+
+- Given a `/run` in progress, when the coordinator emits a stage event, then the sidebar highlights the corresponding stage in the run graph.
+- Given a `/plan` in progress, when the plan agent emits a stage event, then the sidebar highlights the corresponding stage in the plan graph.
+- Given a SOP with a loop-back (e.g. run `repair → verify`), when rendered, then the compact graph shows the loop with connector glyphs.
+- Given a terminal too narrow for the graph, when rendering, then the compact graph is hidden without breaking the layout.
+- Given a SOP that cannot be compiled, when rendering, then the sidebar degrades to the linear stage list without crashing.

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/adk-workflow-agent.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/adk-workflow-agent.md
@@ -1,0 +1,131 @@
+# Research: ADK 2.x workflow engine — verified API surface
+
+Module `google.golang.org/adk/v2 v2.2.0`. Every fact below was read from module
+source, not inferred. Paths are relative to the module root.
+
+## A workflow can be an agent — two ways
+
+`agent/workflowagent.New(Config{Name, Description, SubAgents, Edges})` returns an
+`agent.Agent`: it calls `workflow.New(cfg.Name, cfg.Edges)` then
+`agent.New(agent.Config{… Run: wa.run})` (workflow.go:47-62).
+
+`agent.Agent` has an unexported method (`agent/agent.go:43-52`), so it cannot be
+implemented outside the ADK; `agent.Config.Run` is the sanctioned hook.
+`*workflow.Workflow` alone is **not** an `agent.Agent` — no `SubAgents`,
+`FindAgent`, or `Description`.
+
+**Caveat that decides our design:** `workflowagent.New` passes **no**
+`workflow.Option`, so `WithMaxConcurrency` and `WithStateSchema` are
+unreachable through it. Building the `*Workflow` ourselves and wrapping it with
+`agent.New(agent.Config{Run: wf.Run})` (~20 lines) keeps both.
+
+`runner.Config.Agent` accepts any `agent.Agent`, so `internal/agent`'s
+`buildRunner` (agent.go:407) already has the right shape.
+
+## Routing — the load-bearing detail
+
+- `StringRoute.Matches` → `matchRoute` iterates **`event.Routes`** only
+  (workflow.go:66-80). `Event.Output` is never consulted. `IntRoute`,
+  `BoolRoute`, `MultiRoute` all funnel through the same function.
+- The routing event is recorded at `scheduler.go:765` (`if it.ev.Routes != nil`).
+  **At most one per activation** — a second yields `ErrMultipleRoutingEvents`
+  and fails the node.
+- `findSuccessors` (scheduler.go:986-1032):
+  - `Route == nil` → **always fires**, and does not count as a concrete match.
+  - `Route == Default` → held aside; fires only if no concrete route matched
+    (`defaultRoute.Matches` always returns false — it is structural).
+  - concrete route → fires iff `event != nil && Route.Matches(event)`.
+  - duplicate `To` targets are deduplicated.
+- **No match and no Default → silent dead-end**, documented as "a deliberate
+  decision not to continue, not an error" (scheduler.go:966).
+
+So a node must **emit an event with `ev.Routes = []string{"PASS"}`**. Returning
+the string sets only `Event.Output` and matches nothing. Supported shapes: a
+`FunctionNode` fn returning `*session.Event`, or `NewEmittingFunctionNode` /
+`NewDynamicNode` emitting it. The ADK example sets both `Routes` and `Output`.
+
+## Errors, retries, failure
+
+- A returned error marks the node failed, applies `RetryConfig`
+  (scheduler.go:856-872, `Attempt++` then `ShouldRetry` → `CalculateDelay`),
+  and then **fails the whole workflow** — `handleCompletion` cancels all and
+  drains. There is no per-node continue-on-failure.
+- `NodeConfig.Timeout` is honoured per activation (scheduler.go:388-392).
+- Default retry: 5 attempts / 1s / 60s cap / 2.0× / full jitter.
+
+## Fan-out
+
+- **`NodeConfig.ParallelWorker` is a dead field** — declared in config.go:56,
+  consumed only by `internal/configurable` YAML plumbing; the scheduler never
+  reads it.
+- The real mechanism is the `ParallelWorker` **node type**
+  (`NewParallelWorker(name, wrapped, maxConcurrency, cfg)`,
+  parallel_worker.go:39): input must be a Go slice; one goroutine per item with
+  a per-item sub-branch; **one aggregate output event** (intermediate events are
+  suppressed); `maxConcurrency <= 0` means unlimited; first failure cancels
+  siblings. **The wrapped node must not carry a `RetryConfig`** (constructor
+  errors) — the parent's retry is applied per item instead.
+- `RunNode[OUT](ctx, child, input, opts…)` works only inside a `NewDynamicNode`
+  body, using that body's ctx (it carries the sub-scheduler). Children are
+  awaited inline and are **not** subject to `WithMaxConcurrency`.
+  `WithUseSubBranch` scopes session event history; `WithIsolationScope` /
+  `…FromNodePath` scope LLM prompt history by exact match. **Neither creates a
+  git worktree.**
+
+## Cycles
+
+No run-time cap exists. `ErrUnconditionalCycle` is build-time and walks only
+`Route == nil` edges (Default counts as conditional). Nothing in the scheduler
+counts activations; `NodeState.Attempt` is the retry counter and resets to 0 on
+completion. `NodeCompleted` is explicitly re-triggerable — "this is what enables
+loops as graph cycles". ADK's own loop test bounds itself with a counter inside
+the node body. **`max_cycles` must be enforced by the caller**, in
+invocation-scoped, resume-safe state.
+
+## Fan-in
+
+`validateFanIn` (validation.go:369-386, build time) rejects a non-`JoinNode`
+target with **two or more unconditional** incoming edges; conditional and
+loop-back edges are deliberately excluded. Neither SOP violates this — which is
+why `Compiled.Workflow()` already succeeds for both.
+
+Two separate traps:
+- `validateUniqueEdges` (validation.go:254) rejects two edges with the same
+  `(From, To)` **regardless of route** — multiple route values at one target
+  must become a single `MultiRoute` edge.
+- At run time, `startNode` (scheduler.go:395) overwrites `runsByName` with no
+  in-flight check. Two conditionally-routed predecessors that match concurrently
+  double-activate the target and corrupt bookkeeping.
+
+## HITL
+
+`ResumeOrRequestInput` (request_input.go:123) returns the reply if already
+resumed, else emits a request event carrying a synthetic FunctionCall named
+`adk_request_input` whose ID is the interrupt id, and returns
+`ErrNodeInterrupted`; the scheduler parks the node `NodeWaiting`.
+
+`workflowAgent.run` detects the matching `FunctionResponse`, calls
+`ReconstructRunState(session, invocationID)` — which **re-scans session event
+history**, not a persisted blob — and dispatches `Workflow.Resume`.
+
+Resume has two modes: **re-entry** (`RerunOnResume: &true`, the default for
+dynamic nodes) re-activates the node; **handoff** (nil/false) completes the
+asker with the response as output and schedules successors — and Pass 2 calls
+`findSuccessors` with **`event = nil`** (resume.go:211), so **no concrete route
+can fire**. An approval gate that routes on the human's answer must use
+re-entry.
+
+## Observability
+
+`RunState` is created in `newScheduler` and held on the unexported scheduler;
+`Run`/`RunNode` never expose it. `ReconstructRunState` is the only exported
+accessor and serves paused runs between turns. **A live UI must consume the
+event stream** — `NodeInfo.Path`, `Output`/`OutputFor`, `RequestedInput` — and
+**node start is not an event**: infer "running" from a node's first emitted
+event.
+
+## What is missing in pi-go
+
+Only the factory. `sop.Compile` already produces `[]workflow.Edge` and
+`Compiled.Workflow()` already calls `workflow.New`. The sole `NodeFactory` is
+`DescribeFactory`, whose nodes refuse to run.

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/execution-path.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/execution-path.md
@@ -1,0 +1,56 @@
+# Research: Execution Path — Is the Compiled SOP Workflow Executed?
+
+## Finding (critical)
+
+**The compiled ADK workflow graph is NOT executed by `/run` or `/plan`.** Both commands
+still run the imperative code path. The graph is dead code from the TUI's perspective —
+it is only compiled and validated by a CLI check tool and unit tests. There is no
+executable `NodeFactory` in the repo; only the non-executing `DescribeFactory`.
+
+This contradicts the assumption (Q5) that "the compiled workflow execution is already
+wired in and only the TUI visualization is missing." The visualization must therefore be
+a **derived rendering of the SOP's declared structure**, with the active stage driven by
+stage events emitted from the imperative coordinator/plan-agent path — not by a live
+workflow-engine execution.
+
+## Evidence
+
+### `/run` — `handleRunCommand` / `startRunAgent` (internal/tui/run.go)
+- `handleRunCommand` (run.go:394) parses args, reads PROMPT.md, runs preflight, parses
+  gates/checklist, dispatches to `startRunAgent` (run.go:454) or `handleRunParallel`
+  (run.go:451). Never touches `sop.Compile`/`Workflow`.
+- `startRunAgent` (run.go:511) spawns the worker directly via the Orchestrator:
+  - run.go:517 — `m.cfg.Orchestrator.SpawnWithInput(m.ctx, subagent.AgentInput{Type: "task", ...})`
+  - run.go:582,600 — parallel spawns the same way.
+  - run.go:1048 — retry path.
+- The run state machine is an imperative TUI event loop (`handleRunAgentEvent` run.go:717,
+  `handleRunAgentDone` run.go:836, `handleRunGateResult` run.go:1289, `handleRunMergeResult`
+  run.go:1479). The only `sop` usage in run.go is `sop.ParseVerdict` (run.go:959) and
+  `sop.BuildManifest`/`sop.WriteManifest` (run_preflight.go:61-62) — helpers, not graph execution.
+
+### `/plan` — `handlePlanCommand` / `startPlanSession` (internal/tui/plan.go)
+- `startPlanSession` (plan.go:392) loads the PDD SOP **as instruction text**, not a graph:
+  - plan.go:398 — `sop.LoadPDD(workDir)` returns a string (the PDD prompt).
+  - plan.go:408-417 — concatenates into an `instruction` string.
+  - plan.go:428 — `m.cfg.Agent.RebuildWithInstruction(instruction)`.
+  - plan.go:483 — `m.startAgentLoop(roughIdea)` — the imperative agent loop.
+- No `sop.Compile`/`Workflow` anywhere in plan.go.
+
+### Callers of `sop.Compile` / `Compiled.Workflow` / the workflow package
+- `sop.Compile` callers: `hack/sopcheck/describe.go:17` (CLI check tool) and
+  `internal/sop/schema_test.go` (unit tests).
+- `Compiled.Workflow()` callers: `internal/sop/schema_test.go:36` only. **No production caller.**
+- `google.golang.org/adk/v2/workflow` import: only inside `internal/sop` (compile.go:7,
+  describe.go:11). No TUI or other production package imports it.
+- The only `NodeFactory` is `DescribeFactory` (internal/sop/describe.go:22), which is
+  explicitly non-executing: `describeNode.Run` (describe.go:73-77) returns
+  `"node %q is a description only; compile with a real NodeFactory to execute"`.
+  Its doc comment (describe.go:19-21) says "Phase 3 supplies the factory that runs real
+  agents" — that factory does not exist.
+
+## Implication for design
+- The sidebar graph is a **visualization of the SOP's declared structure** (stages, edges,
+  routes, loop-backs), compiled with `DescribeFactory` (works without a provider).
+- The **active stage** is driven by `stage_start`/`stage_end` events emitted by the
+  imperative coordinator (run) and plan agent (plan) on the existing event channel.
+- No workflow-engine execution is required for this feature.

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/prompt-sources.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/prompt-sources.md
@@ -1,0 +1,109 @@
+# Research: Prompt/Instruction Sources for Stage Events
+
+## 1. coordinatorContract — internal/tui/run.go:229-296
+
+A `const` string injected into every `/run` prompt. It defines the Coordinator → Worker →
+Verifier execution contract: delegate slices to workers, verify each, tick plan.md checkboxes,
+spawn the Verifier, and end with a `VERDICT: PASS/FAIL` line.
+
+**Injection points** (all use `fmt.Fprintf(&b, coordinatorContract, specName)` — `%[1]s` is the spec name):
+- `buildRunPrompt` — run.go:301-325, injection at 304. Used by single-agent `/run` (startRunAgent, run.go:514).
+- `buildParallelPrompt` — run.go:678-697, injection at 681. Used by parallel `/run` (handleRunParallel, run.go:575-576).
+- `buildResumePrompt` — run.go:1089-1108, injection at 1099. Used by retry cycles (retryRun, run.go:1046).
+
+**Machine-readable signals today:** only the `VERDICT:` line, parsed by `sop.ParseVerdict`
+(run.go:959). There is **no structured stage/phase event** emitted from the coordinator prompt.
+Progress is tracked by the TUI re-reading plan.md checkboxes (`refreshRunChecklist`,
+run.go:1692-1703) and by the `runState.phase` field (run.go:54), set by the TUI event loop.
+
+**Implication:** to emit stage events from the run coordinator, the `coordinatorContract`
+must be extended with an instruction telling the coordinator to emit a machine-readable
+stage marker (e.g. a line like `STAGE: <id>` or a `{"type":"stage_start",...}` JSON event)
+as it enters/leaves each stage. The TUI's `handleRunAgentEvent` must parse it.
+
+## 2. DefaultPDDSOP — internal/sop/pdd_default.go:6-190
+
+A `const` string, the embedded default PDD SOP instruction. Phases (each produces an artifact):
+- Phase 1: Skeleton Creation (Already Done) — 20-22
+- Phase 2: Requirements Clarification — 24-29 (Q&A appended to requirements.md)
+- Phase 3: Objective Research — 31-44 (delegate to parallel explore subagents; write research/*.md)
+- Phase 4: Design Discussion — 46-58 (write design.md)
+- Phase 5: Structure Outline — 60-66 (write outline.md)
+- Phase 6: Implementation Plan — 68-94 (write plan.md with `- [ ] Slice N:` checkboxes)
+- Phase 7: PROMPT.md Generation — 96-104 (write PROMPT.md)
+
+The SOP instructs the LLM to "Announce the phase transition clearly (e.g., 'Moving to Phase 3:
+Research')" (pdd_default.go:18) — a text-only instruction, not a machine event.
+
+**Loading:** `sop.LoadPDD(workDir)` (sop.go:11-32): project `.pi-go/sops/pdd.md` → global
+`~/.pi-go/sops/pdd.md` → embedded `DefaultPDDSOP`.
+
+**Injection:** `startPlanSession` (plan.go:392-484): `sop.LoadPDD` (398), assembles instruction
+(408-417) = `sopText + "\n\n" + validate.PlanContract().Describe() + "\n## Current Task\n" + ...`,
+injects via `m.cfg.Agent.RebuildWithInstruction(instruction)` (428), creates fresh session (438),
+persists `PlanContext` with `Phase: "plan"` (457-462), sends rough idea as first user message,
+starts `m.startAgentLoop(roughIdea)` (483).
+
+## 3. Plan agent's multi-turn flow — artifact writing and phase signaling
+
+`/plan` runs through the **standard agent loop** (`startAgentLoop`, agent_loop.go:719-726 →
+`runAgentLoop` at 867 → `streamTurn` at 969). It is a normal interactive multi-turn conversation:
+the LLM writes artifacts with `write`/`edit` tools; the user reviews/approves between phases.
+
+**Does the LLM write artifact files?** Yes. The SOP instructs it to write to `specDir/` using
+write/edit tools (plan.go:416-417). `finishPlanWorktree` (plan.go:229-291) commits the worktree,
+validates artifacts, and merges on turn completion. It is invoked from `handleAgentDone`
+(agent_loop.go:1729-1733) when `m.mode == "plan"`.
+
+**How would it signal phase transitions?** There is **no existing event emission** from the plan
+agent for phase transitions. The only phase-related signals:
+- The SOP's prose instruction to "Announce the phase transition clearly" (pdd_default.go:18).
+- **Sidebar inference from artifact file existence:** `detectPlanPhases` (sidebar.go:98-105)
+  stats each phase artifact and marks a phase `Done` when the file exists. Driven from
+  tui.go:1734 (`in.PlanPhases = detectPlanPhases(specDir)`). The TUI polls disk, not the LLM.
+- `PlanContext.Phase` (store.go:33) is set once to `"plan"` at session creation (plan.go:461),
+  never updated per-phase.
+- Lifecycle events `turn_complete` and `user_input_required` via `runLifecycleHooks`
+  (agent_loop.go:1754-1758) fire on turn completion, not on phase transitions.
+
+**Implication:** to emit stage events from the plan agent, the `DefaultPDDSOP` instruction must
+be extended to tell the LLM to emit a machine-readable stage marker as it moves between PDD
+phases (e.g. a line like `STAGE: research` when it starts Phase 3). The TUI's plan agent-loop
+handler must parse it. Because `/plan` uses the `agentMsg` channel (not `subagent.Event`), the
+stage marker must be parsed from the plan agent's streamed text/tool events.
+
+## 4. session.AgentContext / run-tree recording (commit be8daa7)
+
+`internal/session/store.go:79-91`:
+```go
+type AgentContext struct {
+    AgentID   string `json:"agentID,omitempty"`
+    AgentType string `json:"agentType,omitempty"` // task | worker | quick-task | code-reviewer | explore
+    ParentID  string `json:"parentSessionID,omitempty"`
+    RunID     string `json:"runID,omitempty"` // groups every session of one /run
+    SpecName  string `json:"specName,omitempty"`
+    Slice     int    `json:"slice,omitempty"`
+    Cycle     int    `json:"cycle,omitempty"` // /run retry index
+    Worktree  string `json:"worktree,omitempty"`
+    Branch    string `json:"branch,omitempty"`
+    Status    string `json:"status,omitempty"` // terminal status, written when the run ends
+}
+```
+
+Nested optional block on `Meta` (store.go:73-75, `Agent *AgentContext json:"agentContext,omitempty"`).
+
+**Populated via env vars** (agentenv.go:14-24): `PI_AGENT_ID`, `PI_AGENT_TYPE`, `PI_RUN_ID`,
+`PI_SPEC_NAME`, `PI_RUN_SLICE`, `PI_RUN_CYCLE`, `PI_PARENT_SESSION`, `PI_AGENT_BRANCH`,
+`PI_WORKTREE_ROOT`. `AgentContextFromEnv()` (31-48) builds the struct; `isEmpty()` (53-59)
+returns nil when nothing identifying is set.
+
+The child writes it onto its own session at creation (`Agent.CreateSession`, agent.go:530-539).
+The orchestrator fills in agent id/type/worktree; the caller supplies run-level fields. `/run`
+mints one run id per invocation via `newRunID` (run.go:2086-2088) and passes it to every spawned
+agent through `runAttribution` (run.go:2096-2105), including retries and both parallel halves.
+
+**Relevance to stage tracking:** `AgentContext` records **where** an agent sits in a run tree
+(static attribution metadata) — it does **not** record stage/phase transitions. It is relevant
+only in that it provides the identity/attribution context (run id, spec, slice, cycle) a stage
+event would need to be attributed to, and it is the existing mechanism (env vars + session
+metadata) through which such context already flows to spawned agents.

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/sidebar-rendering.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/sidebar-rendering.md
@@ -1,0 +1,113 @@
+# Research: Sidebar Rendering & Test Patterns
+
+## SidebarRenderInput — internal/tui/sidebar.go:29-62 (plan/run-relevant fields)
+
+- `RunChecklist []ChecklistStep` (48) — steps from plan.md during /run
+- `RunPhase string` (49) — current /run phase (empty if not running)
+- `RunSpec string` (50) — spec name during /run
+- `RunCycle int` (51) — current retry cycle
+- `RunMaxCycle int` (52) — max retries
+- `PlanPhases []PlanPhase` (53) — PDD phase checklist in plan mode; nil/empty = hidden
+
+`PlanPhase` (76-79): `{Name string; Done bool}`. `ChecklistStep` (run.go:24-27):
+`{Title string; Done bool}`.
+
+`phaseArtifacts` (82-93): ordered 7 PDD phases → artifacts: Idea→rough-idea.md,
+Requirements→requirements.md, Research→research (dir), Design→design.md, Outline→outline.md,
+Plan→plan.md, Prompt→PROMPT.md.
+
+`detectPlanPhases(specDir)` (98-105): stats each artifact; `Done = (os.Stat err == nil)`.
+Degrades gracefully to all-incomplete on missing/unreadable dir.
+
+## Rendering
+
+`RenderSidebar(in)` (145-168): `w := max(in.Width, 10)`, `innerW := w - 3` (146-147), builds
+`sidebarStyles` from palette, concatenates section line-slices in order (152-165): mood, model,
+artifact, git, **mode**, agent, skill, memory, MCP, loading. Returns `sidebarFrame(...)`.
+
+`sidebarModeLines` (242-259) — the dispatcher:
+- If `len(in.RunChecklist) > 0 && in.RunPhase != ""` → `sidebarRunLines(...)` + `""` (243-245).
+- Else renders `Mode` heading + `[mode]`, appends `sidebarActivityLines`, and if
+  `len(in.PlanPhases) > 0` appends `sidebarPlanLines(...)` (255-257).
+
+`sidebarRunLines` (263-287): `Run: <spec>` heading (truncated to `innerW+2`), `cycle <RunCycle>/<RunMaxCycle> ∙ <RunPhase>` in peach, then each step: done → green `"  [x] "`, else overlay `"  [ ] "` (title truncated to `max(innerW-5, 10)`). If `in.Running`, appends `sidebarActivityLines`.
+
+`sidebarPlanLines` (293-312): nil if no PlanPhases. `Plan` heading, then per phase: done →
+green `[x]`, first not-done → peach `▶` (current), rest → overlay `[ ]`. Title truncated to
+`max(innerW-5, 10)`.
+
+`sidebarFrame` (490-548): pads/truncates content to `targetH = max(0, in.Height-matrixH-statusH-ruleH)` (509), fills with dim `"  ∙∙∙"`, appends matrix/status/rule, boxes with `Width(w).MaxWidth(w)` and `Height(in.Height).MaxHeight(in.Height)` (539-545).
+
+## Where inputs are assembled — tui.go
+
+`sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInput` (tui.go:1694-1737).
+Base struct at 1695-1724.
+
+Run fields (1725-1731), gated on `m.run != nil && m.run.phase != ""`:
+- `in.RunChecklist = m.run.checklist`
+- `in.RunPhase = m.run.phase`
+- `in.RunSpec = m.run.specName`
+- `in.RunCycle = m.run.retries + 1` (one-based)
+- `in.RunMaxCycle = m.run.maxRetries`
+
+Plan fields (1732-1735), gated on `m.mode == "plan" && m.planWorktreePath != "" && m.planTaskName != ""`:
+- `specDir := filepath.Join(m.planWorktreePath, "specs", m.planTaskName)`
+- `in.PlanPhases = detectPlanPhases(specDir)`
+
+Call site (tui.go:1566): `sidebar := RenderSidebar(m.sidebarRenderInput(sidebarWidth, panelRows))`
+inside the `if showSidebar` branch of `View()`, then `joinPanelSidebar(...)` (1567).
+
+`runState` source fields (run.go:39-62): `specName`, `phase` (54: "running","gating","verifying",
+"retrying","merging","done","failed"), `retries`, `maxRetries`, `checklist []ChecklistStep` (61).
+
+## Test patterns
+
+### Test helpers
+- `plain(lines []string) string` — sidebar_sections_test.go:20-22: `ansi.Strip(strings.Join(lines, "\n"))`.
+- `testSidebarStyles() sidebarStyles` — sidebar_sections_test.go:26-28: `newSidebarStyles(darkPalette)`.
+- `sidebarMockTokenTracker` — sidebar_test.go:356-376.
+- `newTestModel(t) *model` — teatest_test.go:19-36: minimal model (cfg ModelName/ProviderName, ctx/cancel, inputModel, chatModel, face, width 80, height 24).
+- `cplxModel(t) *model` — complexity_commands_test.go:22-42: like newTestModel but with SessionID, WorkDir: t.TempDir(), palette: darkPalette, width 100, height 30. Used for `sidebarRenderInput` tests.
+- `historyModel(t, entries...) *model` — history_key_test.go:9-22: model with history, statusModel, chatModel, width 100, height 40. Used by render-integrity tests.
+
+### sidebar_test.go (whole-sidebar RenderSidebar tests)
+- `TestRenderSidebar_RunChecklist` (266): builds `SidebarRenderInput{Width:30, Height:30, RunChecklist:[...], RunPhase:"running", RunSpec:"my-spec", RunCycle:2, RunMaxCycle:10, Running:true, ActiveTool:"edit"}` and asserts substrings `"Run: my-spec"`, `"cycle 2/10"`, `"[x] Setup project"`, `"[ ] Implement feature"`, `"edit"`, absence of `"[chat]"`.
+- `TestRenderSidebar_RunChecklistTruncatesLongTitles` (304): asserts `"…"`.
+- `TestRenderSidebar_RunChecklistThinkingNoTool` (322): asserts `"thinking"`.
+- `TestRenderSidebar_EmptyChecklistShowsNormalMode` (341): empty checklist falls through to `Mode`.
+- `TestRenderSidebar_PlanChecklist` (622): `Mode:"plan"`, `PlanPhases:[7 phases, Idea done]`; strips ANSI, asserts `"Plan"`, `"[x] Idea"`, `"▶ Requirements"`, `"[ ] Research"`, absence of `"[chat]"`.
+- `TestRenderSidebar_NoPlanSection` (648): no `"▶ "` / `"[x] Idea"` when no PlanPhases.
+
+### sidebar_sections_test.go (direct section-renderer tests)
+- `TestSidebarModeLines` (169): table of `SidebarRenderInput` → expected substring via `plain(sidebarModeLines(tt.in, 27, testSidebarStyles()))`.
+- `TestSidebarModeLinesRunChecklist` (194): asserts `"Run: my-spec"`, `"cycle 2/5 ∙ implement"`, `"[x] write tests"`, `"[ ] make them pass"`, absence of `"[chat]"`.
+- `TestSidebarPlanLines` (424): `plain(sidebarPlanLines(in, 27, testSidebarStyles()))` asserts `"Plan"`, `"[x] Idea"`, `"▶ Requirements"`, `"[ ] Research"`. `TestSidebarPlanLines_Hidden` (439): 0 lines for empty input.
+- `TestSidebarHiddenSections` (100): each section renderer returns 0 lines for empty input.
+- `TestDetectPlanPhases` (356), `_AllDone` (386), `_None` (409): write artifacts into `t.TempDir()` and assert the 7 phases' names and Done flags.
+
+### sidebarRenderInput assembly test
+- `TestCplxSidebarRenderInput` — complexity_commands_test.go:1666-1707: uses `cplxModel(t)`;
+  asserts size passthrough, empty run fields when no run, and with
+  `m.run = &runState{phase:"running", specName:"spec-1", retries:2, maxRetries:10, checklist:[...]}`
+  asserts `RunPhase`, `RunSpec`, `RunCycle==3` (one-based), `RunMaxCycle==10`, `len(RunChecklist)==1`.
+
+### Render-integrity tests (render_integrity_test.go)
+- `TestFrameHeightFitsTerminal` (83), `TestSidebarIsFixedSizeAndRightAligned` (120),
+  `TestChatOutputCannotTakeTheSidebarsColumns` (157), `TestFrameIntegrityOnRealContent` (199).
+  Build a `historyModel`, set `m.width`/`m.height`, call `m.applyResize()`, append
+  `realisticChat()` messages, assert every row is exactly terminal width, the rail holds its
+  column (`railCol := m.mainWidth() - railWidth`), and the sidebar occupies exactly
+  `SidebarWidth` columns (`width - sidebarStart == SidebarWidth`, 140-143).
+
+## SidebarWidth and inner-width math
+
+- `SidebarWidth = 23` — sidebar.go:26. Every consumer reads it (mainWidth, render-integrity column check).
+- Inner width: `w := max(in.Width, 10)`, `innerW := w - 3` (padding + border) — sidebar.go:146-147.
+- Checklist titles truncate to `max(innerW-5, 10)` to leave room for the `"  [x] "` prefix (274, 300).
+- Run heading truncates to `innerW+2` (265).
+
+**Noteworthy:** `sidebarRunLines` has no direct unit test — covered indirectly through
+`sidebarModeLines` (`TestSidebarModeLinesRunChecklist`) and whole-sidebar `RenderSidebar`
+tests. The run-checklist branch requires **both** `len(RunChecklist) > 0` **and**
+`RunPhase != ""`; an empty checklist falls through to the normal `Mode` display
+(pinned by `TestRenderSidebar_EmptyChecklistShowsNormalMode`).

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/sop-graph-model.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/sop-graph-model.md
@@ -84,7 +84,14 @@ In `sop`'s `wire` (compile.go:103-165):
 
 ### plan.sop.yaml
 Stages: `clarify`, `research`, `design`, `outline`, `plan`, `prompt`, `manifest`.
-Review checkpoints on `clarify`, `design`, `outline`, `plan`.
+Review checkpoints on `clarify`, `design`, `outline`, `plan` — **`clarify`, `design`
+and `outline` are `kind: human`** ("Approve to continue to research?", "Approve the
+design?", "Approve the outline before expanding it into the plan?"); only
+`plan.review` is `kind: agent` (`spec-reviewer`, `verdict_schema: Verdict`).
+
+`research` is a fan-out stage (`over: research_angles`, `agent: explore`,
+`max_concurrency: 4`, `isolation: sub_branch`, `join: research_summary`) — the only
+plan stage that is not a single `plan`-agent turn.
 
 Edges (verified via `Compiled.Describe()`):
 ```

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/sop-graph-model.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/sop-graph-model.md
@@ -1,0 +1,124 @@
+# Research: SOP Compiled Graph Data Model
+
+## Compiled struct — internal/sop/compile.go:32-39
+
+```go
+type Compiled struct {
+    Definition *Definition
+    Edges      []workflow.Edge
+    Nodes      map[string]workflow.Node   // indexed by stage id, and "<id>.review" for a stage's review checkpoint
+    Order      []string
+}
+```
+
+- `Definition` — the parsed SOP definition.
+- `Edges` — the compiled `[]workflow.Edge` list, built by `wire` (compile.go:160).
+- `Nodes` — map keyed by stage ID and by `"<id>.review"` for review checkpoints.
+- `Order` — stage IDs in build order, including `"<id>.review"` entries.
+
+`Compile(def *Definition, factory NodeFactory) (*Compiled, error)` (compile.go:44) lints
+first, then builds nodes via `buildStage` (63) and edges via `wire` (103).
+`Compiled.Workflow()` (219) assembles edges into a `*workflow.Workflow`.
+
+## Stage struct — internal/sop/schema.go:67-108 (graph-relevant fields)
+
+- `ID string` (68), `Description string` (69)
+- `Kind string` (74) — "agent" or "function"; empty resolves via `EffectiveKind()` (199):
+  agent if `Agent` set or `FanOut != nil`, else function.
+- `Agent string` (75)
+- `FanOut *FanOut` (84), `Join string` (85)
+- `Review *Review` (87)
+- `Routes map[string]string` (91) — output value → target stage ID
+- `LoopBack string` (92), `MaxCycle int` (93)
+- `OnFail string` (96) — "abort", "retry", or a stage ID
+- `Timeout Duration` (98), `Retry *Retry` (99)
+- `Gate string` (104), `GatesFrom string` (105), `OutputSchema string` (106)
+- `Next string` (107)
+
+`Definition` (schema.go:23-31): `SOP`, `Version`, `Description`, `Workspace`, `Defaults`,
+`Preflight []Stage`, `Stages []Stage`. `AllStages()` (192) = Preflight + Stages.
+
+## workflow.Edge — google.golang.org/adk/v2/workflow (v2.2.0)
+
+```go
+type Edge struct {
+    From  Node
+    To    Node
+    Route Route
+}
+```
+
+- `Node` interface exposes `Name()`, `Description()`, `Config()`, `Run`, etc.
+  `BaseNode.Name()` returns the node's name.
+- `Route` interface: `Matches(event *session.Event) bool`. `StringRoute` matches on a
+  string value; `Default` matches when no concrete route matches.
+- `Start` sentinel node is the entry point.
+
+Edge building (`workflow/edgebuilder.go`): `NewEdgeBuilder()`, `Add(from,to)` (unconditional,
+Route nil), `AddRoute(from,to,route)`, `AddRoutes(from, map[string]Node)` (one edge per entry
+with `StringRoute`), `AddFanOut`, `AddFanIn`, `Build()`.
+
+In `sop`'s `wire` (compile.go:103-165):
+- Entry: `b.Add(workflow.Start, c.Nodes[stages[0].ID])` (110).
+- Review path: `b.Add(from, r)` then `from = r` (116-117) — stage → review → successor.
+- Routes: `b.AddRoutes(from, routes)` (130).
+- LoopBack: `b.AddRoute(from, to, workflow.StringRoute(RecheckSignal))` where
+  `RecheckSignal = "RECHECK"` (140, const at compile.go:12).
+- Next: `b.Add(from, to)` (146).
+- OnFail (non-abort/retry): `b.AddRoute(from, to, workflow.StringRoute("FAIL"))` (156).
+
+## Compiling plan.sop.yaml / run.sop.yaml
+
+- **Loading:** `LoadDefinition(workDir, name string) (*Definition, error)` (load.go:25-36).
+  Resolution (`resolveDefinition`, load.go:52-71): project `.pi-go/sops/<name>.sop.yaml` →
+  global `~/.pi-go/sops/<name>.sop.yaml` → embedded default (`//go:embed`). Parses with
+  `ParseDefinition` (KnownFields(true)) and lints with `LintDefinition`.
+- **Factory:** `Compile(def, factory NodeFactory)`. `NodeFactory` interface (compile.go:22-29):
+  `AgentNode`, `FunctionNode`, `ReviewNode`.
+- **DescribeFactory** (describe.go:22-38) builds nodes that carry identity/config but do no
+  work; `Run` returns "description only" error. It compiles **without a provider, a worktree,
+  or a running agent** — ideal for the TUI to render the graph structure.
+- `Compiled.Describe()` (describe.go:81-116) renders stages and edges as text.
+
+## Exact stage IDs and edges
+
+### plan.sop.yaml
+Stages: `clarify`, `research`, `design`, `outline`, `plan`, `prompt`, `manifest`.
+Review checkpoints on `clarify`, `design`, `outline`, `plan`.
+
+Edges (verified via `Compiled.Describe()`):
+```
+START -> clarify
+clarify -> clarify.review
+clarify.review -> research
+research -> design
+design -> design.review
+design.review -> outline
+outline -> outline.review
+outline.review -> plan
+plan -> plan.review
+plan.review -> plan [FAIL]
+plan.review -> prompt [PASS]
+prompt -> manifest
+```
+
+### run.sop.yaml
+Stages: preflight `validate_spec`; then `slices`, `gates`, `verify`, `repair`, `merge`, `summary`.
+No review checkpoints.
+
+Edges (verified):
+```
+START -> validate_spec
+validate_spec -> slices
+slices -> gates
+slices -> repair [FAIL]
+gates -> verify
+gates -> repair [FAIL]
+verify -> merge [PASS]
+verify -> repair [FAIL]
+repair -> verify [RECHECK]
+merge -> summary
+```
+
+Note: `validate_spec` has `on_fail: abort` (run.sop.yaml:30), which produces **no** edge
+(compile.go:151 skips "abort").

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/subagent-events.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/research/subagent-events.md
@@ -1,0 +1,84 @@
+# Research: Subagent Event Channel & Event Types
+
+## Event struct — internal/subagent/types.go:100-109
+
+```go
+type Event struct {
+    Type       string `json:"type"`                 // "text_delta", "tool_call", "tool_result", "message_end", "error"
+    Content    string `json:"content,omitempty"`    // text for text_delta; tool name for tool_call; JSON for tool_result
+    Error      string `json:"error,omitempty"`       // error message for error events
+    SessionID  string `json:"session_id,omitempty"` // subprocess session ID (from message_start)
+    StopReason string `json:"stopReason,omitempty"` // ACP stopReason on message_end
+    ToolArgs   any    `json:"tool_input,omitempty"` // tool args for tool_call
+    Status     string `json:"status,omitempty"`     // final status for run_done events
+}
+```
+
+## Full set of Type values emitted
+
+| Type | Emitted at | Fields populated |
+|------|-----------|------------------|
+| `text_delta` | spawner.go:334,341; spawner_acp.go:212; spawner_codex.go:140 | `Content` |
+| `tool_call` | spawner.go:343; spawner_acp.go:214; spawner_codex.go:142 | `Content`, `ToolArgs` |
+| `tool_result` | spawner.go:345 | `Content` |
+| `message_start` | spawner.go:347; spawner_acp.go:160,191; spawner_codex.go:135,155 | `SessionID` |
+| `message_end` | spawner.go:349; spawner_acp.go:177; spawner_codex.go:179 | `StopReason` |
+| `error` | spawner.go:296; spawner_acp.go:172,218; spawner_codex.go:146,174 | `Error` |
+| `run_done` | orchestrator.go:633 (synthesized after process exit) | `Status` |
+
+**Unknown types pass through verbatim:** the spawner's `emitChildLine` default case
+(spawner.go:350-351) forwards any unknown `ev.Type` unchanged. ACP/codex adapters likewise
+pass through unknown types (spawner_acp.go:220, spawner_codex.go:148). The orchestrator's
+`forwardAgentEvents` republishes everything untouched (orchestrator.go:612-617). So a child
+emitting `{"type":"stage_start","content":"..."}` flows through unchanged.
+
+## Event flow: spawned subagent → TUI
+
+- `/run` spawns via `m.cfg.Orchestrator.SpawnWithInput` (run.go:517,582,600,1048), which
+  returns `(events <-chan subagent.Event, agentID string, err error)`.
+- `Spawn` (orchestrator.go:418-513) creates `events := make(chan Event, 64)` (line 505) and
+  launches `go o.forwardAgentEvents(events, proc, state, logACP)` (line 510).
+- `forwardAgentEvents` (orchestrator.go:608-641) republishes every `proc.Events()` item onto
+  `out`, writes the terminal `run_done` event (line 633), and `defer close(out)` (line 609).
+- TUI single-agent: `startRunAgent` stores the channel in `m.run.events` (run.go:549),
+  returns `waitForRunAgent(events, agentID)` (run.go:566).
+- `waitForRunAgent` (run.go:700-714) is a `tea.Cmd` blocking on `<-events`. On close →
+  `runAgentDoneMsg`; on `run_done` → `runAgentDoneMsg{status}`; else wraps in
+  `runAgentEventMsg` (run.go:160-163).
+- `handleRunAgentEvent` (run.go:717-752) switches on `ev.Type` → `applyRunTextDelta` /
+  `applyRunToolCall` / `applyRunToolResult` / `message_start` / `message_end` /
+  `applyRunError`, then re-arms via `m.waitForRunEvents()` (run.go:751).
+- Parallel mode: `handleRunParallel` (run.go:571-674) stores per-agent channels in
+  `m.run.parallel` (run.go:648-651), uses `waitForParallelRunEvents` (run.go:1773-1806) fan-in.
+
+## Adding a new event type (stage_start / stage_end)
+
+- **Producer side:** the spawner's default case already forwards unknown types verbatim, so
+  a child emitting `{"type":"stage_start","content":"<stage-id>"}` flows through unchanged.
+- **TUI consumer side:** `handleRunAgentEvent` (run.go:727-748) has **no `default` case** —
+  an unknown `ev.Type` falls through silently (only the matrix-rain feed at run.go:721-725
+  reacts). A new `case "stage_start"` / `case "stage_end"` must be added to this switch.
+  The `runAgentEventMsg` wrapper carries the full `subagent.Event`, so all fields are available.
+
+## Plan agent streaming — DIFFERENT mechanism
+
+`/plan` does **not** use the subagent channel. `startPlanSession` (plan.go:483) returns
+`m.startAgentLoop(roughIdea)` — the in-process agent loop (agent_loop.go:719-726):
+
+```go
+func (m *model) startAgentLoop(prompt string) tea.Cmd {
+    ch := make(chan agentMsg, 64)
+    m.agentCh = ch
+    ...
+    go m.runAgentLoop(agentCtx, prompt, ch, m.agentRun())
+    return waitForAgent(m.agentCh)
+}
+```
+
+This uses a `chan agentMsg` (a TUI-internal message type, distinct from `subagent.Event`)
+and drives the local `agent.Agent` directly. It does **not** spawn a subagent process and
+does **not** use `SpawnWithInput`.
+
+**Implication:** `/run` and `/plan` use two separate streaming paths. Stage events for
+`/run` ride the `subagent.Event` channel; stage events for `/plan` must ride the
+`agentMsg` channel (or be derived from the plan agent's tool calls / artifact writes).

--- a/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/rough-idea.md
+++ b/specs/features/TOO/024-tui-visual-workflow-during-plan-run-and-workflow/rough-idea.md
@@ -1,0 +1,3 @@
+# Rough Idea
+
+tui visual workflow during /plan /run and workflow SOP


### PR DESCRIPTION
The declarative SOPs compiled, linted, and then sat there. The only `NodeFactory` was `DescribeFactory`, whose nodes refuse to run, so `/plan` and `/run` kept driving the imperative path and the compiled graph was documentation. This adds the executor, and fixes a latent defect the graph was hiding.

## The executor

`internal/sop/exec` supplies the factory. Nodes are dynamic because the body needs `emit`: it publishes a lifecycle event announcing the stage started, then exactly one routing event. Three engine facts shape it, each read from `adk v2.2.0` source rather than assumed:

- **Routing matches `session.Event.Routes`, never a node's return value.** A body that returns `"PASS"` sets `Event.Output` and matches no edge at all — the silent failure this design was most exposed to.
- **A returned error does not take the `on_fail` edge.** It fails the whole workflow, so failure the SOP models as a route is reported as a *value*.
- **Nothing counts loop activations**, so `max_cycles` is enforced here, keyed by `(invocation, node)` — one factory serves concurrent invocations, and `NodeState.Attempt` is retry-only and resets on success.

`exec.Agent` wraps a compiled SOP as an ADK agent by building the workflow itself rather than via `workflowagent.New`, which passes no options and would silently drop `defaults.max_concurrency`.

## The compiler fix

`findSuccessors` documents and implements *"Edges with no Route always fire."* But `wire()` added the `on_fail` edge outside the switch that adds `next`, so a stage declaring both carried an unconditional forward edge **and** a FAIL edge — a failing `slices` scheduled `gates` *and* `repair`, proceeding to verification of work that had just failed.

A stage that can fail over now gets its forward edge as `workflow.Default`, which fires only when no concrete route matched. Invisible until now precisely because nothing executed the graph.

## Visualization

The sidebar draws the compiled graph — stage list on top, vertical text diagram underneath — with status from real execution. `RunState` is unreachable (unexported scheduler) and node *start* is not an event, so `stageTracker` folds the event stream: our lifecycle events mark running, `RequestedInput` marks waiting, and completion is inferred from the successor starting, which the scheduler guarantees.

## Tests

- Both embedded SOPs execute end to end through a real `runner.Runner`: forward path, FAIL routing to `repair` **without** also taking the forward edge, gate failure repairing and merging, a non-converging loop stopped by the cycle budget, and the plan SOP's `plan.review` FAIL round trip.
- A test runs a SOP and asserts the *rendered sidebar frames* mid-run and at completion.
- Guard tests pin the embedded stage ids, the plan review kinds (three are `kind: human`), and the no-unconditional-forward-edge invariant.

## Decisions recorded in `design.md`

- `repair` gets `max_cycles: 10`, matching today's `maxRetries`, so the loop bound is a port rather than a behaviour change.
- One worktree per run, owned by the workspace rather than one per agent — which collapses `mergeTargets()`'s three shapes to one and dissolves the repair-loop problem, at the cost of making the declared disjoint-file-set precondition load-bearing.

## Not included

The stage bodies are still injected — a real `StageRunner` that spawns subagents, runs gates and merges worktrees, plus the TUI wiring behind `PI_SOP_ENGINE=1`, is the next step. `/plan` follows `/run`: it needs HITL built from nothing, and three of its four checkpoints are human.

Gates: `go build ./...`, `go vet`, `golangci-lint` (0 issues), and all tests pass.
