### PR TITLE
fix(provider): magistral 400s on prompt_mode; Mistral finish reasons swallowed

### DIFF
--- a/internal/provider/mistral.go
+++ b/internal/provider/mistral.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"google.golang.org/adk/v2/model"
-	"google.golang.org/genai"
 )
 
 const mistralDefaultBaseURL = "https://api.mistral.ai/v1"
@@ -177,12 +176,6 @@ func mistralReasoningEffort(level string) string {
 	default:
 		return ""
 	}
-}
-
-// mistralFinishReasonToGenai maps Mistral finish_reason to genai.FinishReason.
-// Mistral uses the same finish reasons as OpenAI.
-func mistralFinishReasonToGenai(reason string) genai.FinishReason {
-	return oaiFinishReasonToGenai(reason)
 }
 
 // Mistral reasoning models do not use delta.reasoning the way OpenRouter does.

--- a/internal/provider/mistral.go
+++ b/internal/provider/mistral.go
@@ -37,7 +37,7 @@ type mistralModel struct {
 // If baseURL is empty, the default Mistral API endpoint is used.
 // thinkingLevel controls reasoning: "none", "low", "medium", "high", "max".
 // It reaches the wire as `reasoning_effort` on the models that accept it and
-// as `prompt_mode` on the magistral family; empty leaves the model's default.
+// is omitted everywhere else; empty leaves the model's default in force.
 func NewMistral(_ context.Context, modelName, apiKey, baseURL, thinkingLevel string, llmOpts *LLMOptions) (model.LLM, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("mistral API key is required (set MISTRAL_API_KEY)")
@@ -98,8 +98,8 @@ func (m *mistralModel) GenerateContent(ctx context.Context, req *model.LLMReques
 			}
 		}
 
-		// openai-go has no fields for prompt_cache_key, reasoning_effort or
-		// prompt_mode, so they go on the wire as extra JSON fields. One call
+		// openai-go has no fields for prompt_cache_key or reasoning_effort, so
+		// they go on the wire as extra JSON fields. One call
 		// with one map: SetExtraFields replaces the whole map rather than
 		// merging into it (param.metadata.SetExtraFields).
 		params.SetExtraFields(mistralExtraFields(modelName, m.thinkingLevel, m.promptCacheKey))
@@ -124,41 +124,51 @@ var mistralHooks = oaiExtractHooks{
 }
 
 // mistralExtraFields builds the Mistral-specific request body fields for one
-// call: the prompt cache key always, plus whichever reasoning control this
-// model understands.
+// call: the prompt cache key always, plus reasoning_effort on the models that
+// accept it.
 func mistralExtraFields(modelName, thinkingLevel, promptCacheKey string) map[string]any {
 	extra := map[string]any{"prompt_cache_key": promptCacheKey}
-	switch {
-	case mistralUsesReasoningEffort(modelName):
+	if mistralUsesReasoningEffort(modelName) {
 		if effort := mistralReasoningEffort(thinkingLevel); effort != "" {
 			extra["reasoning_effort"] = effort
-		}
-	case mistralUsesPromptMode(modelName):
-		// prompt_mode has no "off" value — the field is simply omitted when
-		// thinking is not wanted, which leaves the model's default in force.
-		if level := strings.ToLower(strings.TrimSpace(thinkingLevel)); level != "" && level != "none" {
-			extra["prompt_mode"] = "reasoning"
 		}
 	}
 	return extra
 }
 
-// mistralUsesReasoningEffort reports whether a model id takes reasoning_effort
-// rather than prompt_mode. Mistral documents the parameter for the small and
-// medium reasoning models only.
-func mistralUsesReasoningEffort(modelName string) bool {
-	switch strings.ToLower(strings.TrimSpace(modelName)) {
-	case "mistral-small-2603", "mistral-small-latest", "mistral-medium-3.5":
-		return true
-	default:
-		return false
-	}
+// mistralReasoningEffortModels is the set of non-magistral model ids that
+// accept reasoning_effort, verified by probing the live API rather than read
+// off the docs.
+//
+// It is an exact-match set, deliberately. Prefix-matching "mistral-medium-"
+// looks tidier and is wrong: mistral-medium-2505 and mistral-medium-2508 both
+// answer 400 "reasoning_effort is not enabled for this model", so a prefix rule
+// would break those models outright. The two failure directions are not
+// symmetric — a missing entry costs the user thinking control on that model,
+// while a wrong entry makes every request to it fail — so an id is listed only
+// once it has been seen to work.
+var mistralReasoningEffortModels = map[string]bool{
+	"mistral-small-2603":    true,
+	"mistral-small-latest":  true,
+	"mistral-medium":        true,
+	"mistral-medium-2604":   true,
+	"mistral-medium-3":      true,
+	"mistral-medium-3-5":    true,
+	"mistral-medium-3.5":    true,
+	"mistral-medium-latest": true,
 }
 
-// mistralUsesPromptMode reports whether a model is a reasoning model that
-// controls thinking through prompt_mode:"reasoning" — the magistral family.
-func mistralUsesPromptMode(modelName string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(modelName)), "magistral")
+// mistralUsesReasoningEffort reports whether a model id accepts
+// reasoning_effort. The whole magistral family does; everything else must be
+// in mistralReasoningEffortModels.
+//
+// Note magistral takes reasoning_effort, NOT prompt_mode. prompt_mode belongs
+// to Mistral's conversations API; on chat completions it answers 400
+// "Reasoning prompt mode is not enabled for this model" for every model tried,
+// magistral included.
+func mistralUsesReasoningEffort(modelName string) bool {
+	name := strings.ToLower(strings.TrimSpace(modelName))
+	return strings.HasPrefix(name, "magistral") || mistralReasoningEffortModels[name]
 }
 
 // mistralReasoningEffort maps pi's thinking level onto Mistral's

--- a/internal/provider/mistral_e2e_test.go
+++ b/internal/provider/mistral_e2e_test.go
@@ -395,7 +395,7 @@ func TestE2EMistralPromptCacheKeyStable(t *testing.T) {
 
 // TestE2EMistralReasoningEffortAccepted pins the wire vocabulary: Mistral
 // documents exactly "high" and "none" for reasoning_effort, so both must be
-// accepted by the live API. A 422 here means the mapping drifted.
+// accepted by the live API. A 400 here means the mapping drifted.
 func TestE2EMistralReasoningEffortAccepted(t *testing.T) {
 	key := testGetMistralAPIKey(t)
 
@@ -413,6 +413,55 @@ func TestE2EMistralReasoningEffortAccepted(t *testing.T) {
 			for _, err := range llm.GenerateContent(context.Background(), req, false) {
 				if err != nil {
 					t.Fatalf("thinking level %q rejected by Mistral: %v", level, err)
+				}
+			}
+		})
+	}
+}
+
+// TestE2EMistralThinkingLevelAcrossModels is the test that would have caught
+// prompt_mode: it drives one representative of every class through a live
+// request with pi's default thinking level.
+//
+// The classes matter because the failure directions differ. A reasoning model
+// wrongly treated as plain silently loses thinking control; a plain model
+// wrongly sent reasoning_effort answers 400 and the turn dies. Both are
+// invisible to a unit test, which only sees the body pi built, never Mistral's
+// verdict on it.
+func TestE2EMistralThinkingLevelAcrossModels(t *testing.T) {
+	key := testGetMistralAPIKey(t)
+
+	models := []struct {
+		name       string
+		wantEffort bool // does this model accept reasoning_effort?
+	}{
+		{name: "mistral-small-latest", wantEffort: true},
+		{name: "mistral-medium-latest", wantEffort: true},
+		{name: "magistral-medium-latest", wantEffort: true},
+		{name: "mistral-medium-2508"},
+		{name: "mistral-large-latest"},
+		{name: "codestral-2508"},
+	}
+
+	for _, m := range models {
+		t.Run(m.name, func(t *testing.T) {
+			if got := mistralUsesReasoningEffort(m.name); got != m.wantEffort {
+				t.Errorf("mistralUsesReasoningEffort(%q) = %v, want %v", m.name, got, m.wantEffort)
+			}
+			// "high" is pi's default level, so this is the request an ordinary
+			// session sends.
+			llm, err := NewMistral(context.Background(), m.name, key, "", "high", nil)
+			if err != nil {
+				t.Fatalf("NewMistral() error: %v", err)
+			}
+			req := &model.LLMRequest{
+				Contents: []*genai.Content{
+					{Role: "user", Parts: []*genai.Part{{Text: "Say OK."}}},
+				},
+			}
+			for _, err := range llm.GenerateContent(context.Background(), req, false) {
+				if err != nil {
+					t.Fatalf("%s rejected pi's default thinking level: %v", m.name, err)
 				}
 			}
 		})

--- a/internal/provider/mistral_e2e_test.go
+++ b/internal/provider/mistral_e2e_test.go
@@ -418,3 +418,79 @@ func TestE2EMistralReasoningEffortAccepted(t *testing.T) {
 		})
 	}
 }
+
+// TestE2EMistralStreamingWithTools covers the path an interactive session
+// actually drives: streaming *and* tools together. The existing tool test is
+// non-streaming, so a tool call that survives a plain request but is lost or
+// mangled while being reassembled from stream deltas would not have been
+// caught. A tool call missing its id cannot be matched to its result, which
+// ends the turn early with no error — so each field is asserted, not just the
+// call's presence.
+func TestE2EMistralStreamingWithTools(t *testing.T) {
+	key := testGetMistralAPIKey(t)
+
+	llm, err := NewMistral(context.Background(), "mistral-small-latest", key, "", "", nil)
+	if err != nil {
+		t.Fatalf("NewMistral() error: %v", err)
+	}
+
+	tools := []*genai.Tool{{
+		FunctionDeclarations: []*genai.FunctionDeclaration{{
+			Name:        "read",
+			Description: "Read a file from the project",
+			ParametersJsonSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"file_path": map[string]any{"type": "string"},
+				},
+				"required": []any{"file_path"},
+			},
+		}},
+	}}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "Read the file README.md using the read tool."}}},
+		},
+		Config: &genai.GenerateContentConfig{Tools: tools},
+	}
+
+	var calls []*genai.FunctionCall
+	var final *model.LLMResponse
+	for resp, err := range llm.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		final = resp
+		if resp.Partial || resp.Content == nil {
+			continue
+		}
+		for _, p := range resp.Content.Parts {
+			if p.FunctionCall != nil {
+				calls = append(calls, p.FunctionCall)
+			}
+		}
+	}
+
+	if final == nil || !final.TurnComplete {
+		t.Fatal("expected a final TurnComplete response")
+	}
+	if len(calls) == 0 {
+		// Tool calling is the model's choice; the assertions below are what
+		// this test exists for, so an unused tool is logged, not failed.
+		t.Logf("model chose not to call a tool; finish reason %v", final.FinishReason)
+		return
+	}
+	for i, c := range calls {
+		if c.ID == "" {
+			t.Errorf("call %d: empty ID — the result could not be matched back to the call", i)
+		}
+		if c.Name != "read" {
+			t.Errorf("call %d: name = %q, want %q", i, c.Name, "read")
+		}
+		if len(c.Args) == 0 {
+			t.Errorf("call %d: arguments did not survive stream reassembly", i)
+		}
+		t.Logf("call %d: id=%q name=%q args=%v", i, c.ID, c.Name, c.Args)
+	}
+}

--- a/internal/provider/mistral_reasoning_test.go
+++ b/internal/provider/mistral_reasoning_test.go
@@ -243,6 +243,48 @@ func TestMistralMessageThinking(t *testing.T) {
 	if got := mistralMessageThinking(`not json`); got != "" {
 		t.Errorf("mistralMessageThinking(malformed) = %q, want %q", got, "")
 	}
+	if got := mistralMessageThinking(`{"choices":[]}`); got != "" {
+		t.Errorf("mistralMessageThinking(no choices) = %q, want %q", got, "")
+	}
+}
+
+// TestMistralSystemInstruction pins that a system instruction is prepended as a
+// system message rather than dropped, and that it rides alongside the Mistral
+// extra fields.
+func TestMistralSystemInstruction(t *testing.T) {
+	c := newMistralCapture(t, mistralPlainCompletion)
+	m, err := NewMistral(context.Background(), "mistral-large-latest", "test-key", c.srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewMistral() error: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+		Config:   &genai.GenerateContentConfig{SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "You are Misty."}}}},
+	}
+	for _, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+	}
+
+	if len(c.bodies) != 1 {
+		t.Fatalf("expected 1 captured request, got %d", len(c.bodies))
+	}
+	messages, _ := c.bodies[0]["messages"].([]any)
+	if len(messages) < 2 {
+		t.Fatalf("expected the system message plus the user message, got %d", len(messages))
+	}
+	first, _ := messages[0].(map[string]any)
+	if role, _ := first["role"].(string); role != "system" {
+		t.Errorf("first message role = %q, want %q", role, "system")
+	}
+	if content, _ := first["content"].(string); !strings.Contains(content, "You are Misty.") {
+		t.Errorf("system message = %q, want it to carry the instruction", content)
+	}
+	if _, ok := c.bodies[0]["prompt_cache_key"].(string); !ok {
+		t.Error("prompt_cache_key missing when a system instruction is present")
+	}
 }
 
 func TestMistralAnswerText(t *testing.T) {

--- a/internal/provider/mistral_reasoning_test.go
+++ b/internal/provider/mistral_reasoning_test.go
@@ -63,21 +63,33 @@ func mistralSend(t *testing.T, m model.LLM) {
 
 func TestMistralRequestReasoningFields(t *testing.T) {
 	tests := []struct {
-		name           string
-		modelName      string
-		thinkingLevel  string
-		wantEffort     string // "" means the field must be absent
-		wantPromptMode string
+		name          string
+		modelName     string
+		thinkingLevel string
+		wantEffort    string // "" means the field must be absent
 	}{
 		{name: "small latest high", modelName: "mistral-small-latest", thinkingLevel: "high", wantEffort: "high"},
 		{name: "medium 3.5 medium", modelName: "mistral-medium-3.5", thinkingLevel: "medium", wantEffort: "high"},
+		{name: "medium 3-5 hyphenated", modelName: "mistral-medium-3-5", thinkingLevel: "high", wantEffort: "high"},
+		{name: "medium latest alias", modelName: "mistral-medium-latest", thinkingLevel: "high", wantEffort: "high"},
+		{name: "medium 3", modelName: "mistral-medium-3", thinkingLevel: "high", wantEffort: "high"},
+		{name: "medium bare", modelName: "mistral-medium", thinkingLevel: "high", wantEffort: "high"},
+		{name: "medium 2604", modelName: "mistral-medium-2604", thinkingLevel: "high", wantEffort: "high"},
 		{name: "small 2603 max", modelName: "mistral-small-2603", thinkingLevel: "max", wantEffort: "high"},
 		{name: "small latest none", modelName: "mistral-small-latest", thinkingLevel: "none", wantEffort: "none"},
 		{name: "small latest unset", modelName: "mistral-small-latest", thinkingLevel: ""},
-		{name: "magistral high", modelName: "magistral-medium-latest", thinkingLevel: "high", wantPromptMode: "reasoning"},
-		{name: "magistral none", modelName: "magistral-medium-latest", thinkingLevel: "none"},
+		// magistral takes reasoning_effort like the rest; prompt_mode is a
+		// conversations-API field and is rejected here.
+		{name: "magistral high", modelName: "magistral-medium-latest", thinkingLevel: "high", wantEffort: "high"},
+		{name: "magistral small high", modelName: "magistral-small-latest", thinkingLevel: "high", wantEffort: "high"},
+		{name: "magistral none", modelName: "magistral-medium-latest", thinkingLevel: "none", wantEffort: "none"},
 		{name: "magistral unset", modelName: "magistral-medium-latest", thinkingLevel: ""},
-		{name: "non-reasoning model ignores the level", modelName: "mistral-large-latest", thinkingLevel: "high"},
+		// These answer 400 when reasoning_effort is present, so the field must
+		// stay off the wire for them.
+		{name: "medium 2505 rejects the field", modelName: "mistral-medium-2505", thinkingLevel: "high"},
+		{name: "medium 2508 rejects the field", modelName: "mistral-medium-2508", thinkingLevel: "high"},
+		{name: "large ignores the level", modelName: "mistral-large-latest", thinkingLevel: "high"},
+		{name: "codestral ignores the level", modelName: "codestral-2508", thinkingLevel: "high"},
 	}
 
 	for _, tt := range tests {
@@ -98,9 +110,19 @@ func TestMistralRequestReasoningFields(t *testing.T) {
 			if effort != tt.wantEffort {
 				t.Errorf("reasoning_effort = %q, want %q", effort, tt.wantEffort)
 			}
-			promptMode, _ := body["prompt_mode"].(string)
-			if promptMode != tt.wantPromptMode {
-				t.Errorf("prompt_mode = %q, want %q", promptMode, tt.wantPromptMode)
+			if _, present := body["prompt_mode"]; present {
+				t.Error("prompt_mode must never be sent: chat completions answers 400 for it on every model")
+			}
+			// Exclusivity, not just presence: SetExtraFields replaces the map
+			// rather than merging, and this pins that contract against an SDK
+			// upgrade that changed it to merge.
+			if _, ok := body["prompt_cache_key"].(string); !ok {
+				t.Error("prompt_cache_key missing from the request body")
+			}
+			if tt.wantEffort == "" {
+				if _, present := body["reasoning_effort"]; present {
+					t.Error("reasoning_effort present when no level should be sent")
+				}
 			}
 		})
 	}
@@ -166,8 +188,16 @@ func TestMistralReasoningEffort(t *testing.T) {
 }
 
 func TestMistralUsesReasoningEffort(t *testing.T) {
-	yes := []string{"mistral-small-2603", "mistral-small-latest", "mistral-medium-3.5", "MISTRAL-SMALL-LATEST"}
-	no := []string{"mistral-large-latest", "magistral-medium-latest", "codestral-2508", ""}
+	yes := []string{
+		"mistral-small-2603", "mistral-small-latest", "mistral-medium", "mistral-medium-2604",
+		"mistral-medium-3", "mistral-medium-3-5", "mistral-medium-3.5", "mistral-medium-latest",
+		"magistral-medium-latest", "magistral-small-latest", "MISTRAL-SMALL-LATEST",
+	}
+	no := []string{
+		"mistral-large-latest", "codestral-2508", "",
+		// Verified 400s: these must not be matched by a tempting prefix rule.
+		"mistral-medium-2505", "mistral-medium-2508",
+	}
 	for _, name := range yes {
 		if !mistralUsesReasoningEffort(name) {
 			t.Errorf("mistralUsesReasoningEffort(%q) = false, want true", name)
@@ -176,21 +206,6 @@ func TestMistralUsesReasoningEffort(t *testing.T) {
 	for _, name := range no {
 		if mistralUsesReasoningEffort(name) {
 			t.Errorf("mistralUsesReasoningEffort(%q) = true, want false", name)
-		}
-	}
-}
-
-func TestMistralUsesPromptMode(t *testing.T) {
-	yes := []string{"magistral-medium-latest", "magistral-small-2509", "Magistral-Medium"}
-	no := []string{"mistral-large-latest", "mistral-small-latest", ""}
-	for _, name := range yes {
-		if !mistralUsesPromptMode(name) {
-			t.Errorf("mistralUsesPromptMode(%q) = false, want true", name)
-		}
-	}
-	for _, name := range no {
-		if mistralUsesPromptMode(name) {
-			t.Errorf("mistralUsesPromptMode(%q) = true, want false", name)
 		}
 	}
 }

--- a/internal/provider/mistral_test.go
+++ b/internal/provider/mistral_test.go
@@ -308,6 +308,11 @@ func TestMistralWithToolCalls(t *testing.T) {
 	}
 }
 
+// TestMistralFinishReasonMapping covers Mistral's finish_reason enum
+// (stop|length|model_length|error|tool_calls) against the mapper the request
+// path actually uses. The previous version of this test called a
+// mistralFinishReasonToGenai wrapper that nothing on the request path invoked,
+// so it passed while model_length and error were being mapped to Stop.
 func TestMistralFinishReasonMapping(t *testing.T) {
 	tests := []struct {
 		reason string
@@ -315,14 +320,18 @@ func TestMistralFinishReasonMapping(t *testing.T) {
 	}{
 		{"stop", genai.FinishReasonStop},
 		{"length", genai.FinishReasonMaxTokens},
+		{"model_length", genai.FinishReasonMaxTokens},
+		{"error", genai.FinishReasonOther},
 		{"content_filter", genai.FinishReasonSafety},
 		{"tool_calls", genai.FinishReasonStop},
+		{"", genai.FinishReasonStop},
+		{"something_new", genai.FinishReasonStop},
 	}
 	for _, tt := range tests {
 		t.Run(tt.reason, func(t *testing.T) {
-			got := mistralFinishReasonToGenai(tt.reason)
+			got := oaiFinishReasonToGenai(tt.reason)
 			if got != tt.want {
-				t.Errorf("mistralFinishReasonToGenai(%q) = %v, want %v", tt.reason, got, tt.want)
+				t.Errorf("oaiFinishReasonToGenai(%q) = %v, want %v", tt.reason, got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -158,13 +158,30 @@ func (m *openaiModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 }
 
 // oaiFinishReasonToGenai maps finish reasons to genai.FinishReason.
+// oaiFinishReasonToGenai maps a Chat Completions finish_reason onto
+// genai.FinishReason. It serves every provider on this path, so it carries the
+// union of their vocabularies: OpenAI's stop/length/content_filter/tool_calls
+// plus Mistral's model_length and error (its full enum is
+// stop|length|model_length|error|tool_calls — mistralai/client-python,
+// ChatCompletionChoiceFinishReason).
+//
+// model_length and error must not fall through to Stop. The TUI warns about a
+// truncated reply by watching for FinishReasonMaxTokens
+// (tui/agent_loop.go:1014), so a Mistral turn cut off at the context limit
+// would otherwise be presented as a complete one — a turn that just looks
+// short. error means generation failed partway; reporting that as a clean stop
+// claims a success the provider never gave.
 func oaiFinishReasonToGenai(reason string) genai.FinishReason {
 	switch reason {
-	case "length":
+	case "length", "model_length":
 		return genai.FinishReasonMaxTokens
 	case "content_filter":
 		return genai.FinishReasonSafety
+	case "error":
+		return genai.FinishReasonOther
 	default:
+		// stop and tool_calls both end the turn cleanly; an unrecognized
+		// value from an open enum is treated the same way.
 		return genai.FinishReasonStop
 	}
 }


### PR DESCRIPTION
## Summary

Two live-API bugs in the Mistral provider, plus the review findings from `specs/issues/review-mistral.md` that survived verification. Every claim here was checked against `api.mistral.ai` with a real key — the docs are wrong or silent on most of it.

## 1. Magistral was broken outright (`d0a81d1`)

**Every magistral request was failing.** pi's default thinking level is `high`, so `mistralExtraFields` put `prompt_mode:"reasoning"` on the wire for the magistral family. Chat completions answers:

```
400 {"message":"Reasoning prompt mode is not enabled for this model","code":"3051"}
```

`prompt_mode` belongs to Mistral's **conversations** API, not chat completions. It is rejected on *every* model tried, magistral included. The reference implementation the original plan was drawn from uses the conversations API, which is how the field got here.

magistral takes `reasoning_effort` like everything else, so the `prompt_mode` branch is deleted rather than repaired.

## 2. The `reasoning_effort` allowlist was short (`d0a81d1`)

`mistral-medium-latest` — the alias most users type — plus `mistral-medium`, `mistral-medium-3`, `mistral-medium-3-5` and `mistral-medium-2604` all accept `reasoning_effort`, and none were listed. `--think high` was silently dropped on all of them.

The set is now the one the live API confirms, and it stays **exact-match on purpose**:

| Model | `reasoning_effort` |
|---|---|
| `mistral-small-latest`, `mistral-small-2603` | ✅ |
| `mistral-medium`, `-latest`, `-3`, `-3-5`, `-3.5`, `-2604` | ✅ |
| `magistral-medium-latest`, `magistral-small-latest` | ✅ |
| `mistral-medium-2505`, `mistral-medium-2508` | ❌ 400 |
| `mistral-large-latest`, `codestral-2508` | ❌ 400 |

Prefix-matching `mistral-medium-` is the obvious tidy-up and is **wrong**: `2505` and `2508` answer 400. The two failure directions are not symmetric — a missing entry costs thinking control on that model, a wrong entry kills every request to it — so an id is listed only once it has been seen to work.

## 3. Mistral's `model_length` and `error` finish reasons were swallowed (`15520c6`)

Mistral's enum is `stop | length | model_length | error | tool_calls` (`mistralai/client-python`, `ChatCompletionChoiceFinishReason`). `oaiFinishReasonToGenai` handled `length` and `content_filter` and defaulted the rest to `Stop`.

That is user-visible. The TUI warns about truncation by watching for `FinishReasonMaxTokens` (`internal/tui/agent_loop.go:1014`), so a Mistral turn cut off at the **context limit** was presented as a finished turn — one that just looks short, with no explanation. `error` means generation failed partway, and reporting it as `Stop` claims a success the provider never gave.

`mistralFinishReasonToGenai` looked like it owned this mapping, but **nothing on the request path called it** — the runners call `oaiFinishReasonToGenai` directly. Its test passed while the live path was wrong. The wrapper is gone; the test now exercises the mapper that actually runs, across the full enum.

## Testing

`TestE2EMistralThinkingLevelAcrossModels` drives one model per class through a live request at pi's default level. **It fails against the previous code** with the 400 above:

```
--- FAIL: TestE2EMistralThinkingLevelAcrossModels/magistral-medium-latest
    magistral-medium-latest rejected pi's default thinking level: 400 Bad Request
```

A unit test cannot catch either bug — it only sees the body pi built, never Mistral's verdict on it. That gap is why `prompt_mode` shipped with a green suite.

Also added: an e2e test for **streaming with tools** (the existing tool test is non-streaming, so nothing covered a tool call reassembled from stream deltas), and unit coverage for `mistralMessageThinking`'s empty-choices path and the system-instruction branch.

## On `specs/issues/review-mistral.md`

| # | Verdict |
|---|---|
| 1 — effort collapses to `"high"` | **Correct, working as intended.** Mistral documents only `high`/`none`. Left as is. |
| 2 — allowlist drift | **Correct, and understated** — it missed `mistral-medium-3-5` too. But its **proposed fix is wrong**: prefix-matching breaks `2505`/`2508`. Fixed differently, see above. |
| 3 — cache key never rotated | **Plausible, not fixed.** Directionally right that compaction breaks the prefix; the billing impact is asserted, not measured. Deferred. |
| 4 — dead `mistralFinishReasonToGenai` | **Correct.** Fixed — and it turned out to hide a real bug, not just a spare name. |
| 5 — `[]byte`/`string` round-trip | **Correct but not fixed.** Real double allocation; not on any measured hot path, and left out to keep this PR to behavior. |
| 6 — `SetExtraFields` "may be stale" | **Half right.** The replace-not-merge claim was already verified against openai-go v3.52.0 (`packages/param/param.go:157`); the fair part is that no test pinned it. `TestMistralRequestReasoningFields` now asserts exclusivity. |

## Gates

- `go build ./...` ✅ · `go vet ./...` ✅
- `go test ./internal/provider ./internal/tui` ✅
- `golangci-lint run ./cmd/... ./internal/... ./hack/...` ✅ (0 issues)
- `go test -tags e2e -run TestE2EMistral ./internal/provider` ✅ — **run live against api.mistral.ai**, not just compiled
- All commits signed + `Signed-off-by` ✅

## Note

`15520c6` and `0cd8626` were pushed to `feat/mistral-provider-signed` **after** #241 merged at `5faffcb`, so they never reached main. They are cherry-picked here.
