### PR TITLE
docs(skills): add vhs-e2e-gif, the TUI/e2e GIF recording skill

### DIFF
--- a/.pi-go/skills/vhs-e2e-gif/SKILL.md
+++ b/.pi-go/skills/vhs-e2e-gif/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: vhs-e2e-gif
+description: Record a test run, a TUI session, or any terminal command as a GIF with VHS and attach it to a GitHub PR as a release-hosted asset, never a repo commit. Use when asked to record an e2e run, demo a fix on a PR, attach a GIF or screen recording to a pull request, show a test passing visually, or produce a terminal recording of pi-go. Encodes the sandbox trap that makes VHS segfault on the first attempt.
+---
+
+# Recording an e2e run as a GIF on a PR
+
+Turn a test run into a short GIF and hang it off the PR, so a reviewer sees the
+suite go green without checking out the branch.
+
+## The one trap
+
+**VHS segfaults inside the agent sandbox.** It binds a loopback port for `ttyd`,
+the sandbox refuses, and `randomPort()` dereferences the nil listener:
+
+```
+panic: runtime error: invalid memory address or nil pointer dereference
+main.randomPort()
+	github.com/charmbracelet/vhs/tty.go:22
+```
+
+That is the sandbox, not a broken tape. **Run every `vhs` invocation with the
+sandbox disabled.** Same for `gh` (network) — the upload step needs it too.
+
+Dependencies: `vhs`, `ttyd`, `ffmpeg` (`brew install vhs ttyd ffmpeg`). VHS pulls
+in the other two, but check before blaming a tape.
+
+## Workflow
+
+**1. Record.**
+
+```bash
+OUT=/tmp/e2e-tool-calls.gif DIR=$PWD \
+  scripts/record-gif.sh "go test -tags e2e ./internal/agent/ -run TestE2E -v 2>&1 | grep -E '^(--- |ok|FAIL)'"
+```
+
+The script writes the tape, runs VHS, and extracts the **final frame** next to
+the GIF as `<name>.last.png`.
+
+**2. Read the last frame before posting.** A GIF is opaque to you — the PNG is
+not. Open it and confirm the run actually passed. Posting a recording of a
+failing suite as evidence of a passing one is the failure mode this step exists
+to prevent.
+
+**3. Attach.**
+
+```bash
+CAPTIONS='e2e: tool calls after the fix' \
+  scripts/attach-gif-to-pr.sh 246 /tmp/e2e-tool-calls.gif
+```
+
+Uploads as a release asset — never a repo commit — and posts, or edits, a single
+recording comment on the PR, so a re-record updates that comment in place instead
+of adding another.
+
+## Choosing what to record
+
+Record the **narrowest command that proves the claim**, filtered to result lines.
+A full `go test ./...` scroll is unreadable at 14pt and the interesting line
+scrolls off. These read well:
+
+```bash
+go test -tags e2e ./internal/agent/ -run TestE2E -v 2>&1 | grep -E '^(--- |ok|FAIL)'
+go test -tags e2e ./... 2>&1 | grep -vE '(no test files)$'
+make lint
+```
+
+Sizing: 1280x720 at font size 14 fits ~30 result lines and lands around 150 KB.
+Go wider only if lines wrap.
+
+## Recording an interactive TUI
+
+A TUI is two input steps, not one: launch the program, then type *into* it. That
+is what `READY_RE` and `INPUT` are for.
+
+```bash
+OUT=/tmp/pi-tui-tools.gif DIR=$PWD \
+  READY_RE='tkn:' INPUT='show me your tools' \
+  WAIT_RE='took [0-9]+[.][0-9]+s' WAIT_TIMEOUT=240s \
+  HEIGHT=800 FRAMERATE=20 PLAYBACK_SPEED=2 SHRINK=1 \
+  scripts/record-gif.sh "./pi"
+```
+
+Four things that go wrong, in the order they bite:
+
+1. **The tape's shell starts in the tape file's directory, not yours.** `./pi`
+   becomes `No such file or directory` and you get a 60 KB GIF of a bash error.
+   `DIR` is the fix — the script always emits the `cd`.
+2. **Typing before the TUI has painted drops the keystrokes.** `READY_RE` holds
+   until the program's own output proves it is up. For pi-go, `tkn:` (the
+   statusline token counter) is a good marker; the banner is not, it renders
+   before the deferred init finishes.
+3. **A loose completion regex fires mid-render.** `WAIT_RE='took '` matched while
+   the answer was still streaming and cut the recording off at "thinking…".
+   Require the digits — `took [0-9]+[.][0-9]+s` — so only the finished summary
+   line can match.
+4. **TUI captures are several MB.** A full-screen repaint at 50fps is the
+   worst case for GIF deltas. `SHRINK=1` recompresses (12fps, 1000px, 96 colors)
+   and cut 2.9 MB to 1.3 MB with no loss of legibility.
+
+The alternate screen itself is a non-issue — VHS captures it correctly.
+
+Exiting is optional: the recording stops when `WAIT_RE` matches, and VHS kills
+the shell. `/exit` or `/quit` quits pi-go's TUI if you want the exit in frame.
+
+## Where the GIF gets hosted
+
+**Never commit a recording to the repo.** A recording is review scaffolding with
+a lifetime of days; a committed binary is in history forever and in every clone.
+`MODE=release` (the default) attaches the GIFs to a release tag instead — GitHub
+renders a release-asset URL as a real inline `<img data-animated-image>`, no camo
+proxy, and git history stays clean.
+
+```bash
+CAPTIONS='The TUI, after the fix|e2e: 19 tests green' \
+  scripts/attach-gif-to-pr.sh 246 /tmp/pi-tui-tools.gif /tmp/e2e-tool-calls.gif
+```
+
+`MODE=branch` still exists for a repo with releases disabled. Do not reach for it
+here.
+
+### Immutable releases change the rules
+
+pi-go has immutable releases enabled, which constrains the release path in two
+ways the script works around:
+
+1. **Assets attach at creation time only.** `gh release create <tag> a.gif b.gif`
+   works; a later `gh release upload` on a published release does not:
+   ```
+   HTTP 422: Cannot upload assets to an immutable release.
+   ```
+   So pass *every* GIF for a PR in one invocation. Adding one later means a new
+   release.
+2. **A deleted tag stays burned.** Re-creating a tag that once held an immutable
+   release fails with `tag_name was used by an immutable release`, even after
+   `gh release delete` and deleting the git tag. The script probes for a free
+   `media-pr<N>`, `media-pr<N>-2`, … rather than assuming.
+
+Neither the release-asset URL nor a raw URL renders for signed-out readers on a
+**private** repo; the script checks visibility and refuses rather than posting a
+broken image.
+
+## Tape gotchas
+
+- The command and `INPUT` are typed into double-quoted tape strings, so neither
+  **may contain a double quote**. Use single quotes; the script rejects the rest
+  with a clear error rather than emitting a broken tape.
+- `Wait+Screen@<timeout> /regex/` ends the take when the result line appears. A
+  regex that never matches burns the whole timeout and then fails the recording,
+  so match both outcomes (`ok|FAIL`), never just the happy one.
+- `Hide` / `Show` around the `cd` keeps the setup out of the frame.
+- VHS resets the shell's cwd afterwards; run it from a scratch directory and pass
+  `DIR` rather than relying on where you were.
+
+## Scripts
+
+| Script | Does |
+|---|---|
+| `scripts/record-gif.sh <command...>` | Tape → GIF → last-frame PNG. Knobs: `OUT`, `DIR`, `READY_RE`, `INPUT`, `WAIT_RE`, `WAIT_TIMEOUT`, `SHRINK`, `SHRINK_WIDTH`, `WIDTH`, `HEIGHT`, `FONT_SIZE`, `THEME`, `PADDING`, `FRAMERATE`, `PLAYBACK_SPEED` |
+| `scripts/attach-gif-to-pr.sh <pr> <file.gif> [more.gif ...]` | Publish as release assets, post/edit one PR comment. Knobs: `CAPTIONS` (`\|`-separated), `TAG`, `MODE` (`release`/`branch`), `MEDIA_DIR` |
+
+Both are pi-go-agnostic — they take any command and any PR.

--- a/.pi-go/skills/vhs-e2e-gif/scripts/attach-gif-to-pr.sh
+++ b/.pi-go/skills/vhs-e2e-gif/scripts/attach-gif-to-pr.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Publish one or more GIFs where a PR comment can render them, then post that
+# comment. Nothing binary is committed to the repository.
+#
+# Usage:
+#   attach-gif-to-pr.sh <pr-number> <file.gif> [file.gif ...]
+#
+# Environment:
+#   CAPTIONS   '|'-separated captions, one per file, in order
+#   TAG        release tag to create   (default: media-pr<PR>)
+#   MODE       release | branch        (default: release)
+#   MEDIA_DIR  in-repo path for MODE=branch  (default: docs/media)
+#
+# MODE=branch commits the GIFs to the PR branch. It exists only for repos where
+# releases are unavailable — prefer release, which leaves git history alone.
+set -euo pipefail
+
+PR=${1:?usage: attach-gif-to-pr.sh <pr-number> <file.gif> [file.gif ...]}
+shift
+[ $# -gt 0 ] || { echo "attach-gif-to-pr.sh: no GIF given" >&2; exit 2; }
+for f in "$@"; do
+  [ -f "$f" ] || { echo "attach-gif-to-pr.sh: no such file: $f" >&2; exit 1; }
+done
+FILES=("$@")
+
+MODE=${MODE:-release}
+TAG=${TAG:-media-pr$PR}
+MEDIA_DIR=${MEDIA_DIR:-docs/media}
+CAPTIONS=${CAPTIONS:-}
+
+command -v gh >/dev/null 2>&1 || { echo "attach-gif-to-pr.sh: gh not found" >&2; exit 1; }
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+if [ "$(gh repo view --json visibility -q .visibility)" != "PUBLIC" ]; then
+  echo "attach-gif-to-pr.sh: $REPO is not public — the URL will not render for" >&2
+  echo "                     readers who are not signed in." >&2
+  exit 1
+fi
+
+caption_for() { # 1-based index -> caption, falling back to the bare filename
+  local i=$1 n=1 c
+  local IFS='|'
+  for c in $CAPTIONS; do
+    [ "$n" = "$i" ] && { printf '%s' "$c"; return; }
+    n=$((n + 1))
+  done
+  printf '%s' "$(basename "${FILES[$((i - 1))]}")"
+}
+
+declare -a URLS=()
+
+publish_release() {
+  # An immutable release is sealed on publish: assets attach at CREATE time
+  # only, and `gh release upload` afterwards answers
+  #   HTTP 422: Cannot upload assets to an immutable release.
+  # A deleted immutable tag also stays burned ("tag_name was used by an
+  # immutable release"), so a re-record needs a fresh tag rather than a reuse.
+  local tag=$TAG n=2
+  while gh release view "$tag" >/dev/null 2>&1; do
+    tag="$TAG-$n"
+    n=$((n + 1))
+  done
+  if ! gh release create "$tag" "$@" \
+      --title "Media: PR #$PR recordings" \
+      --notes "Screen recordings referenced from PR #$PR. Not a software release." \
+      --latest=false >/dev/null; then
+    # Most likely the tag is burned by a previously deleted immutable release.
+    tag="$tag-$(date +%s)"
+    echo "retrying with tag $tag"
+    gh release create "$tag" "$@" \
+      --title "Media: PR #$PR recordings" \
+      --notes "Screen recordings referenced from PR #$PR. Not a software release." \
+      --latest=false >/dev/null
+  fi
+  local f
+  for f in "$@"; do
+    URLS+=("https://github.com/$REPO/releases/download/$tag/$(basename "$f")")
+  done
+  echo "release: https://github.com/$REPO/releases/tag/$tag"
+}
+
+publish_branch() {
+  local root branch f dest
+  root=$(git rev-parse --show-toplevel)
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  [ "$branch" != "HEAD" ] || { echo "attach-gif-to-pr.sh: detached HEAD" >&2; return 1; }
+  mkdir -p "$root/$MEDIA_DIR"
+  for f in "$@"; do
+    dest="$root/$MEDIA_DIR/$(basename "$f")"
+    cp "$f" "$dest"
+    git -C "$root" add "$MEDIA_DIR/$(basename "$f")"
+    URLS+=("https://raw.githubusercontent.com/$REPO/$branch/$MEDIA_DIR/$(basename "$f")")
+  done
+  if git -C "$root" diff --cached --quiet; then
+    echo "recordings unchanged; nothing to commit"
+  else
+    # -s -S per this repo's signing rule; signing needs the 1Password agent,
+    # which is unreachable from inside the agent sandbox.
+    git -C "$root" commit -s -S -q -m "docs(media): recordings for #$PR"
+  fi
+  git -C "$root" push -q origin "$branch"
+}
+
+case "$MODE" in
+  release) publish_release "$@" ;;
+  branch)  publish_branch "$@" ;;
+  *) echo "attach-gif-to-pr.sh: unknown MODE=$MODE (release|branch)" >&2; exit 2 ;;
+esac
+
+BODY="<!-- vhs-e2e-gif -->"
+i=1
+for url in "${URLS[@]}"; do
+  cap=$(caption_for "$i")
+  BODY="$BODY
+### $cap
+
+![$cap]($url)
+"
+  i=$((i + 1))
+done
+if [ "$MODE" = "release" ]; then
+  BODY="$BODY
+<sub>Recorded with VHS, hosted as release assets — nothing binary is committed to the repo.</sub>"
+else
+  BODY="$BODY
+<sub>Recorded with VHS.</sub>"
+fi
+
+# --edit-last keeps one recording comment per PR instead of a pile of them.
+if ! gh pr comment "$PR" --body "$BODY" --edit-last 2>/dev/null; then
+  gh pr comment "$PR" --body "$BODY"
+fi
+
+printf 'asset:   %s\n' "${URLS[@]}"

--- a/.pi-go/skills/vhs-e2e-gif/scripts/record-gif.sh
+++ b/.pi-go/skills/vhs-e2e-gif/scripts/record-gif.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Record a command's terminal output as a GIF with VHS, and extract the final
+# frame as a PNG so the result can actually be read back.
+#
+# Usage:
+#   record-gif.sh <command...>
+#
+# Environment:
+#   OUT           output GIF path            (default: e2e.gif)
+#   DIR           directory to run in        (default: $PWD)
+#   WAIT_RE       regex that ends the take   (default: (^|[[:space:]])(ok|FAIL|PASS)[[:space:]])
+#   READY_RE      regex that must appear before INPUT is typed (optional; for a
+#                 TUI, a statusline marker saying it has finished painting)
+#   INPUT         text typed INTO the launched program once READY_RE matches,
+#                 followed by Enter — how you drive a TUI rather than a one-shot
+#                 command
+#   WAIT_TIMEOUT  give up after              (default: 900s)
+#   SHRINK        1 = recompress the GIF (TUI captures run several MB)
+#   SHRINK_WIDTH  width to scale down to when SHRINK=1  (default: 1000)
+#   WIDTH HEIGHT FONT_SIZE THEME PADDING FRAMERATE PLAYBACK_SPEED   cosmetics
+#
+# The command must not contain a double quote: it is typed into the tape inside
+# a double-quoted string so the viewer sees the real command. Use single quotes.
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "usage: record-gif.sh <command...>" >&2
+  exit 2
+fi
+
+CMD="$*"
+case "$CMD$INPUT" in
+  *'"'*)
+    echo "record-gif.sh: the command contains a double quote, which breaks the tape string." >&2
+    echo "               rewrite it with single quotes." >&2
+    exit 2
+    ;;
+esac
+
+OUT=${OUT:-e2e.gif}
+DIR=${DIR:-$PWD}
+WAIT_RE=${WAIT_RE:-(^|[[:space:]])(ok|FAIL|PASS)[[:space:]]}
+WAIT_TIMEOUT=${WAIT_TIMEOUT:-900s}
+READY_RE=${READY_RE:-}
+INPUT=${INPUT:-}
+WIDTH=${WIDTH:-1280}
+HEIGHT=${HEIGHT:-720}
+FONT_SIZE=${FONT_SIZE:-14}
+THEME=${THEME:-Catppuccin Macchiato}
+PADDING=${PADDING:-24}
+FRAMERATE=${FRAMERATE:-24}
+PLAYBACK_SPEED=${PLAYBACK_SPEED:-1}
+SHRINK=${SHRINK:-0}
+SHRINK_WIDTH=${SHRINK_WIDTH:-1000}
+
+for bin in vhs ttyd ffmpeg; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "record-gif.sh: $bin not found (brew install $bin)" >&2; exit 1; }
+done
+
+OUT_DIR=$(cd "$(dirname "$OUT")" && pwd)
+OUT_BASE=$(basename "$OUT")
+OUT="$OUT_DIR/$OUT_BASE"
+TAPE=$(mktemp -t vhs-tape.XXXXXX).tape
+trap 'rm -f "$TAPE"' EXIT
+
+# The tape's shell starts in the tape file's directory, not yours, so the cd is
+# not optional — without it a relative command (./pi) is "No such file".
+{
+  cat <<EOF
+Output "$OUT"
+
+Set Shell "bash"
+Set FontSize $FONT_SIZE
+Set Width $WIDTH
+Set Height $HEIGHT
+Set Padding $PADDING
+Set Theme "$THEME"
+Set TypingSpeed 20ms
+Set Framerate $FRAMERATE
+Set PlaybackSpeed $PLAYBACK_SPEED
+
+Hide
+Type "cd $DIR && clear" Enter
+Show
+
+Sleep 1s
+Type "$CMD"
+Sleep 500ms
+Enter
+EOF
+  # A TUI needs to finish painting before it will accept a keystroke, so hold
+  # until its own output says it is up, then type the prompt into it.
+  if [ -n "$READY_RE" ]; then
+    printf 'Wait+Screen@%s /%s/\nSleep 2s\n' "$WAIT_TIMEOUT" "$READY_RE"
+  fi
+  if [ -n "$INPUT" ]; then
+    printf 'Type "%s"\nSleep 1s\nEnter\n' "$INPUT"
+  fi
+  cat <<EOF
+Wait+Screen@$WAIT_TIMEOUT /$WAIT_RE/
+Sleep 4s
+EOF
+} > "$TAPE"
+
+if [ -n "$INPUT" ]; then
+  echo "recording: $CMD  <- \"$INPUT\""
+else
+  echo "recording: $CMD"
+fi
+vhs "$TAPE"
+
+# The last frame is the only part a reader can check without playing the GIF,
+# so always leave one behind.
+FRAME="${OUT%.gif}.last.png"
+ffmpeg -y -loglevel error -sseof -2 -i "$OUT" -frames:v 1 "$FRAME"
+
+BYTES=$(wc -c < "$OUT" | tr -d ' ')
+if [ "$SHRINK" = "1" ]; then
+  TMP_GIF="${OUT%.gif}.shrunk.gif"
+  ffmpeg -y -loglevel error -i "$OUT" \
+    -vf "fps=12,scale=$SHRINK_WIDTH:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=96[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3" \
+    "$TMP_GIF"
+  mv "$TMP_GIF" "$OUT"
+  ffmpeg -y -loglevel error -sseof -1 -i "$OUT" -frames:v 1 "$FRAME"
+  echo "shrunk:     $(numfmt --to=iec "$BYTES" 2>/dev/null || echo "$BYTES B") -> $(du -h "$OUT" | cut -f1)"
+elif [ "$BYTES" -gt 1500000 ]; then
+  echo "note:       $(du -h "$OUT" | cut -f1) is large for a PR comment — re-run with SHRINK=1"
+fi
+
+echo "gif:        $OUT ($(du -h "$OUT" | cut -f1))"
+echo "last frame: $FRAME"


### PR DESCRIPTION
Ships the **vhs-e2e-gif** skill: record a terminal command, a test run, or an interactive TUI session as a GIF with VHS, and hang it off a PR as a release-hosted asset — never a repo commit.

### Why it moves

The skill was living untracked in `.claude/skills/`, which `~/.gitignore` excludes via `**/.claude/`. Nobody else could see it. `.pi-go/skills/` is where the other 20 skills already live, and it is what pi-go's own agent loads.

### What's in it

| File | Does |
|---|---|
| `SKILL.md` | The write-up: recording an e2e run, recording an interactive TUI, hosting, tape gotchas |
| `scripts/record-gif.sh` | tape → GIF → last-frame PNG |
| `scripts/attach-gif-to-pr.sh` | release assets + one PR comment, edited in place on re-record |

Both scripts are copied unchanged and stay pi-go-agnostic — any command, any PR.

### The traps it encodes

- **VHS segfaults under the agent sandbox** — it binds a loopback port for `ttyd`, the sandbox refuses, and `randomPort()` dereferences the nil listener. Run `vhs` (and `gh`) with the sandbox disabled.
- **The tape's shell starts in the tape file's directory**, not yours, so `./pi` becomes `No such file or directory` and you get a 60 KB GIF of a bash error. `DIR` emits the `cd`.
- **Typing before the TUI has painted drops the keystrokes.** `READY_RE` holds until the program's own output proves it is up — `tkn:` works for pi-go, the banner does not.
- **A loose completion regex fires mid-render.** `WAIT_RE='took '` cut a take off at "thinking…"; require the digits.
- **Immutable releases accept assets at creation time only**, and a deleted tag stays burned — so the script probes for a free `media-pr<N>` rather than assuming.

### Verification

`bash -n` clean on both scripts; the pre-commit hook (gofmt + golangci-lint) passed with 0 issues. No Go code is touched — docs and shell only.
