### PR TITLE
pimodels: add NewFromInfo

### DIFF
--- a/pimodels/README.md
+++ b/pimodels/README.md
@@ -87,12 +87,17 @@ here that touches pi-go's configuration; `New` is self-contained.
 info, err := pimodels.Resolve("claude-sonnet-5")
 // info.Provider == "anthropic"
 
+m, err := pimodels.NewFromInfo(ctx, info) // build exactly that resolved pair
+
 pimodels.ContextWindow("gemini-3.7-flash")           // tokens, 0 if unknown
 pimodels.ContextWindowFor("azure", "my-deployment")  // provider-aware
 ```
 
 `Resolve` needs no credential and makes no request, so it is safe to run at
-startup to validate configuration.
+startup to validate configuration. If you want to build the inspected model
+later, pass the returned `Info` to `NewFromInfo`; `Info.Model` is the provider's
+stripped model/deployment name, so feeding it back to `New` reparses it as a new
+user-facing model name.
 
 ## Finding the provider from a model
 

--- a/pimodels/pimodels.go
+++ b/pimodels/pimodels.go
@@ -98,6 +98,11 @@ type Info struct {
 	BaseURL string
 	// Ollama reports whether the model is served by an Ollama daemon.
 	Ollama bool
+	// LocalOllama reports that an explicit ollama/ prefix selected the local
+	// daemon. It preserves that routing decision when the Info is passed to
+	// NewFromInfo, even if the stripped model name also looks like an Ollama
+	// cloud tag.
+	LocalOllama bool
 	// Custom reports whether an explicit OpenAI-compatible endpoint was used.
 	Custom bool
 }
@@ -201,19 +206,35 @@ func New(ctx context.Context, modelName string, opts ...Option) (Model, error) {
 		return nil, err
 	}
 
-	apiKey := o.apiKey
-	if apiKey == "" {
-		apiKey = provider.APIKeyFromEnv(info.Provider)
+	return newFromProviderInfo(ctx, info, o)
+}
+
+// NewFromInfo builds a client from the result of [Resolve], without reparsing
+// Info.Model as a fresh model name. Use it when startup code first inspects a
+// model with Resolve and later wants to construct exactly that resolved
+// provider/model pair.
+func NewFromInfo(ctx context.Context, info Info, opts ...Option) (Model, error) {
+	if info.Provider == "" {
+		return nil, fmt.Errorf("pimodels: provider must not be empty")
+	}
+	if info.Model == "" {
+		return nil, fmt.Errorf("pimodels: model name must not be empty")
 	}
 
-	llmOpts := o.llm
-	m, err := provider.NewLLM(ctx, info, apiKey, o.baseURL, o.thinkingLevel, &llmOpts)
-	if err != nil {
-		return nil, fmt.Errorf("pimodels: building %s model %q: %w", info.Provider, info.Model, err)
+	var o options
+	for _, opt := range opts {
+		opt(&o)
 	}
-	// Carry the resolved provider on the model itself, so a consumer never has
-	// to keep its own model-name prefix table to find out.
-	return providerModel{LLM: m, provider: info.Provider}, nil
+
+	providerInfo := provider.Info{
+		Provider:    info.Provider,
+		Model:       info.Model,
+		Ollama:      info.Ollama,
+		LocalOllama: info.LocalOllama,
+		Custom:      info.Custom,
+		BaseURL:     info.BaseURL,
+	}
+	return newFromProviderInfo(ctx, providerInfo, o)
 }
 
 // FromConfig builds the model a `pi` session would use for the given role,
@@ -255,11 +276,12 @@ func Resolve(modelName string, opts ...Option) (Info, error) {
 		return Info{}, err
 	}
 	return Info{
-		Provider: info.Provider,
-		Model:    info.Model,
-		BaseURL:  info.BaseURL,
-		Ollama:   info.Ollama,
-		Custom:   info.Custom,
+		Provider:    info.Provider,
+		Model:       info.Model,
+		BaseURL:     info.BaseURL,
+		Ollama:      info.Ollama,
+		LocalOllama: info.LocalOllama,
+		Custom:      info.Custom,
 	}, nil
 }
 
@@ -279,6 +301,27 @@ func ContextWindowFor(providerName, modelName string) int64 {
 // from, so an embedder can report a missing credential precisely.
 func APIKeyEnvVar(providerName string) string {
 	return provider.APIKeyEnvVar(providerName)
+}
+
+func newFromProviderInfo(ctx context.Context, info provider.Info, o options) (Model, error) {
+	apiKey := o.apiKey
+	if apiKey == "" {
+		apiKey = provider.APIKeyFromEnv(info.Provider)
+	}
+
+	baseURL := o.baseURL
+	if baseURL == "" {
+		baseURL = info.BaseURL
+	}
+
+	llmOpts := o.llm
+	m, err := provider.NewLLM(ctx, info, apiKey, baseURL, o.thinkingLevel, &llmOpts)
+	if err != nil {
+		return nil, fmt.Errorf("pimodels: building %s model %q: %w", info.Provider, info.Model, err)
+	}
+	// Carry the resolved provider on the model itself, so a consumer never has
+	// to keep its own model-name prefix table to find out.
+	return providerModel{LLM: m, provider: info.Provider}, nil
 }
 
 // resolveInfo picks the resolution path: an explicit base URL means the caller

--- a/pimodels/pimodels_test.go
+++ b/pimodels/pimodels_test.go
@@ -56,6 +56,67 @@ func TestResolveKnownModels(t *testing.T) {
 	}
 }
 
+func TestResolveMarksExplicitOllamaAsLocal(t *testing.T) {
+	info, err := Resolve("ollama/deepseek-v4-flash:0731-cloud")
+	if err != nil {
+		t.Fatalf("Resolve explicit Ollama model: %v", err)
+	}
+	if !info.LocalOllama {
+		t.Fatal("Resolve lost the explicit ollama/ local-routing decision")
+	}
+}
+
+func TestNewFromInfoBuildsResolvedPrefixedModels(t *testing.T) {
+	tests := []struct {
+		name string
+		info Info
+		opts []Option
+	}{
+		{
+			name: "ollama prefix",
+			info: Info{Provider: "ollama", Model: "gemma4:e4b", Ollama: true, LocalOllama: true},
+		},
+		{
+			name: "azure prefix",
+			info: Info{Provider: "azure", Model: "prod-deployment"},
+			opts: []Option{WithBaseURL("https://azure.example.openai.azure.com"), WithAPIKey("test-key")},
+		},
+		{
+			name: "opencode prefix",
+			info: Info{Provider: "opencode", Model: "kimi-k3"},
+			opts: []Option{WithAPIKey("test-key")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewFromInfo(context.Background(), tt.info, tt.opts...)
+			if err != nil {
+				t.Fatalf("NewFromInfo(%+v): %v", tt.info, err)
+			}
+			if got := m.Name(); got != tt.info.Model {
+				t.Fatalf("Name() = %q, want resolved model %q", got, tt.info.Model)
+			}
+			p, ok := any(m).(interface{ Provider() string })
+			if !ok {
+				t.Fatal("NewFromInfo result does not report its provider")
+			}
+			if got := p.Provider(); got != tt.info.Provider {
+				t.Fatalf("Provider() = %q, want %q", got, tt.info.Provider)
+			}
+		})
+	}
+}
+
+func TestNewFromInfoRejectsIncompleteInfo(t *testing.T) {
+	if _, err := NewFromInfo(context.Background(), Info{Model: "gemma4:e4b"}); err == nil {
+		t.Fatal("NewFromInfo accepted an Info without a provider")
+	}
+	if _, err := NewFromInfo(context.Background(), Info{Provider: "ollama"}); err == nil {
+		t.Fatal("NewFromInfo accepted an Info without a model")
+	}
+}
+
 func TestResolveUnknownModel(t *testing.T) {
 	if _, err := Resolve("not-a-model-at-all-123"); err == nil {
 		t.Fatal("expected an error for an unresolvable model name")


### PR DESCRIPTION
## Summary

- add `pimodels.NewFromInfo` so embedders can build the provider/model pair returned by `Resolve` without reparsing the stripped `Info.Model`
- preserve the explicit `ollama/` local-routing decision on public `Info`
- document the inspect-then-build path and add coverage for ollama, azure, and opencode resolved names

Fixes #182.

## Verification

- `go test ./pimodels`
- `go test ./internal/provider ./pimodels`
- `go test ./...` (fails only in `internal/sop/validate`: `make` is not on PATH in this environment, so `TestRuleGatesMakeTargetWarnsOnly` receives an error instead of its expected warning)
