### PR TITLE
feat(acp): add Google Antigravity as the "agy" ACP subagent

### DIFF
--- a/internal/acp/client/agy/agy.go
+++ b/internal/acp/client/agy/agy.go
@@ -170,10 +170,15 @@ func defaultArgs() []string {
 
 // defaultBinaryPaths returns the search order for the ACP server binary: the
 // pi-go install directory first, then Antigravity's own directory, then the
-// usual bin directories and PATH.
+// usual bin directories, and a bare-name PATH lookup only as a last resort.
+//
+// The order matters. A bare name resolves through exec.LookPath, so putting it
+// first would let any agy_acp_server earlier on PATH win over the copy the
+// installer placed in ~/.pi-go/acp/agy — the resolved binary would depend on
+// the caller's PATH rather than on what was installed.
 func defaultBinaryPaths() []string {
 	name := binaryName()
-	paths := []string{name}
+	var paths []string
 	if home, err := os.UserHomeDir(); err == nil {
 		paths = append(paths,
 			filepath.Join(home, ".pi-go", "acp", "agy", name),
@@ -181,7 +186,7 @@ func defaultBinaryPaths() []string {
 			filepath.Join(home, ".local", "bin", name),
 		)
 	}
-	return append(paths, filepath.Join("/usr/local/bin", name))
+	return append(paths, filepath.Join("/usr/local/bin", name), name)
 }
 
 // findBinary returns the first existing entry in paths, resolving bare names

--- a/internal/acp/client/agy/agy.go
+++ b/internal/acp/client/agy/agy.go
@@ -128,18 +128,18 @@ func (r Runner) resolveCommand(req RunRequest) (string, []string, error) {
 	}
 
 	if binary == "" {
-		if envCmd := os.Getenv(envACPAgyCmd); envCmd != "" {
-			// PI_ACP_AGY_CMD overrides the default binary. Parse
-			// "binary arg1 arg2 ..." from the env var; a bare binary
-			// falls back to the platform's default arguments.
-			parts := strings.Fields(envCmd)
-			if len(parts) > 0 {
-				binary = parts[0]
-				if len(parts) > 1 {
-					return binary, parts[1:], nil
-				}
-			}
-		} else {
+		// PI_ACP_AGY_CMD overrides the default binary. Parse
+		// "binary arg1 arg2 ..." from the env var; a bare binary falls back to
+		// the platform's default arguments. An override that is empty or only
+		// whitespace is treated as unset rather than as an empty command,
+		// which would otherwise reach exec as a spawn of "".
+		parts := strings.Fields(os.Getenv(envACPAgyCmd))
+		switch {
+		case len(parts) > 1:
+			return parts[0], parts[1:], nil
+		case len(parts) == 1:
+			binary = parts[0]
+		default:
 			found, err := findBinary(DefaultBinaryPaths)
 			if err != nil {
 				return "", nil, fmt.Errorf("finding %s: %w", BinaryName, err)
@@ -150,43 +150,63 @@ func (r Runner) resolveCommand(req RunRequest) (string, []string, error) {
 	return binary, append(cmdArgs, DefaultArgs...), nil
 }
 
-// binaryName returns the ACP server executable name for the running platform,
-// matching the "cmd" field of the registry entry.
-func binaryName() string {
-	if runtime.GOOS == "windows" {
+// binaryName returns the ACP server executable name for the running platform.
+func binaryName() string { return binaryNameFor(runtime.GOOS) }
+
+// binaryNameFor returns the executable name the registry entry declares for
+// goos. It takes the platform rather than reading runtime.GOOS so every
+// platform's answer is testable from whichever host the tests run on.
+func binaryNameFor(goos string) string {
+	if goos == "windows" {
 		return "agy_acp_server.exe"
 	}
 	return "agy_acp_server.par"
 }
 
-// defaultArgs returns the platform-specific argument list from the registry
+// defaultArgs returns the argument list for the running platform.
+func defaultArgs() []string { return defaultArgsFor(runtime.GOOS) }
+
+// defaultArgsFor returns the platform-specific argument list from the registry
 // entry. Only the Linux builds declare arguments.
-func defaultArgs() []string {
-	if runtime.GOOS == "linux" {
+func defaultArgsFor(goos string) []string {
+	if goos == "linux" {
 		return []string{"--uid="}
 	}
 	return nil
 }
 
-// defaultBinaryPaths returns the search order for the ACP server binary: the
-// pi-go install directory first, then Antigravity's own directory, then the
-// usual bin directories, and a bare-name PATH lookup only as a last resort.
+// defaultBinaryPaths returns the search order for the running platform.
+func defaultBinaryPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+	return defaultBinaryPathsFor(runtime.GOOS, home)
+}
+
+// defaultBinaryPathsFor returns the search order for the ACP server binary:
+// the pi-go install directory first, then Antigravity's own directory, then
+// the usual bin directories, and a bare-name PATH lookup only as a last
+// resort. An empty home drops the entries derived from it.
 //
 // The order matters. A bare name resolves through exec.LookPath, so putting it
 // first would let any agy_acp_server earlier on PATH win over the copy the
 // installer placed in ~/.pi-go/acp/agy — the resolved binary would depend on
 // the caller's PATH rather than on what was installed.
-func defaultBinaryPaths() []string {
-	name := binaryName()
+func defaultBinaryPathsFor(goos, home string) []string {
+	name := binaryNameFor(goos)
 	var paths []string
-	if home, err := os.UserHomeDir(); err == nil {
+	if home != "" {
 		paths = append(paths,
 			filepath.Join(home, ".pi-go", "acp", "agy", name),
 			filepath.Join(home, ".antigravity", "acp", name),
 			filepath.Join(home, ".local", "bin", name),
 		)
 	}
-	return append(paths, filepath.Join("/usr/local/bin", name), name)
+	if goos != "windows" {
+		paths = append(paths, filepath.Join("/usr/local/bin", name))
+	}
+	return append(paths, name)
 }
 
 // findBinary returns the first existing entry in paths, resolving bare names

--- a/internal/acp/client/agy/agy.go
+++ b/internal/acp/client/agy/agy.go
@@ -1,0 +1,207 @@
+// Package agy provides an ACP client for Google Antigravity via its
+// standalone ACP server binary (`agy_acp_server`). The ACP session lifecycle —
+// connection wiring, stderr streaming, event translation and result capture —
+// is provided by the shared client package; this package only resolves the
+// Antigravity ACP server binary and builds its argument list.
+//
+// The command shape mirrors the `antigravity-acp` entry in the Agent Client
+// Protocol registry (https://github.com/agentclientprotocol/registry):
+// the platform archive ships a single executable (`agy_acp_server.par`, or
+// `agy_acp_server.exe` on Windows) that speaks ACP over stdio, taking
+// `--uid=` on Linux and no arguments elsewhere.
+//
+// Unlike claude/gemini/cursor/copilot, the binary is not the vendor's
+// interactive CLI: the `agy` CLI has no ACP mode. Install the ACP server with
+// scripts/install-agy-acp.sh, which extracts it to ~/.pi-go/acp/agy.
+package agy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	shared "github.com/dimetron/pi-go/internal/acp"
+	client "github.com/dimetron/pi-go/internal/acp/client"
+)
+
+// BinaryName is the name of the Antigravity ACP server executable for the
+// running platform.
+var BinaryName = binaryName()
+
+// rpcTimeout caps Initialize and NewSession against a hung subprocess. See
+// claudecode for the rationale; 60s is enough for a normal startup but short
+// enough to surface a missing login or missing binary quickly.
+const rpcTimeout = 60 * time.Second
+
+// DefaultBinaryPaths lists the locations searched for the Antigravity ACP
+// server, in order. The first entry is the directory install-agy-acp.sh extracts
+// the registry archive into.
+var DefaultBinaryPaths = defaultBinaryPaths()
+
+// DefaultArgs are the platform-specific arguments the registry entry declares
+// for the ACP server. Linux builds require an explicit (empty) --uid.
+var DefaultArgs = defaultArgs()
+
+// Runner launches the Antigravity ACP server and manages the client-side
+// connection.
+//
+// The server does not inherit the agy CLI's login: it refuses session/new
+// until an auth method is selected in ~/.gemini/antigravity-acp/settings.json
+// ("auth": {"type": "oauth-personal" | "gemini-api-key" | "oauth-business" |
+// "agent-platform"}), and oauth-personal additionally needs a one-time browser
+// login. That first login is interactive, so it must be done by hand before a
+// subagent turn will run.
+type Runner struct {
+	// ClientInfo identifies this client to the agent.
+	ClientInfo acp.Implementation
+
+	// Binary is the path to the agy ACP server binary.
+	// If empty, uses the first found in DefaultBinaryPaths.
+	Binary string
+
+	// Logger for connection debugging.
+	Logger *slog.Logger
+
+	// ExtraEnv is additional environment variables to pass to the subprocess.
+	ExtraEnv []string
+}
+
+// RunRequest describes an Antigravity prompt turn.
+type RunRequest struct {
+	Prompt    string   // Prompt to send to Antigravity
+	SessionID string   // Optional session ID to resume
+	CWD       string   // Working directory
+	Env       []string // Additional environment variables
+	Command   []string // Optional command override for testing (defaults to the ACP server)
+}
+
+// envACPAgyCmd is the environment variable that overrides the Antigravity ACP
+// command. Format: "binary arg1 arg2 ..." or just "binary" (args default to
+// the platform's DefaultArgs).
+const envACPAgyCmd = "PI_ACP_AGY_CMD"
+
+// Start launches the Antigravity ACP server and begins the ACP flow,
+// delegating the session lifecycle to the shared client runner.
+func (r Runner) Start(ctx context.Context, req RunRequest) (*client.RunningSession, error) {
+	if strings.TrimSpace(req.Prompt) == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	binary, cmdArgs, err := r.resolveCommand(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, binary, cmdArgs...)
+	runner := client.Runner{ClientInfo: r.ClientInfo, Logger: r.Logger, ExtraEnv: r.ExtraEnv}
+	return runner.StartCommand(ctx, cmd, shared.RunRequest{
+		Prompt:     req.Prompt,
+		SessionID:  req.SessionID,
+		CWD:        req.CWD,
+		Env:        req.Env,
+		RPCTimeout: rpcTimeout,
+	})
+}
+
+// resolveCommand determines the binary and argument list for the Antigravity
+// ACP subprocess, honoring (in order) an explicit Binary, a test Command
+// override, the PI_ACP_AGY_CMD env override, and finally DefaultBinaryPaths.
+func (r Runner) resolveCommand(req RunRequest) (string, []string, error) {
+	binary := r.Binary
+	var cmdArgs []string
+
+	// When req.Command is supplied (test override) honor it verbatim — no
+	// default flag injection — so helper processes can be exercised without
+	// the real ACP server argument shape. This mirrors the other adapters.
+	if binary == "" && len(req.Command) > 0 {
+		binary = req.Command[0]
+		cmdArgs = append([]string(nil), req.Command[1:]...)
+		return binary, cmdArgs, nil
+	}
+
+	if binary == "" {
+		if envCmd := os.Getenv(envACPAgyCmd); envCmd != "" {
+			// PI_ACP_AGY_CMD overrides the default binary. Parse
+			// "binary arg1 arg2 ..." from the env var; a bare binary
+			// falls back to the platform's default arguments.
+			parts := strings.Fields(envCmd)
+			if len(parts) > 0 {
+				binary = parts[0]
+				if len(parts) > 1 {
+					return binary, parts[1:], nil
+				}
+			}
+		} else {
+			found, err := findBinary(DefaultBinaryPaths)
+			if err != nil {
+				return "", nil, fmt.Errorf("finding %s: %w", BinaryName, err)
+			}
+			binary = found
+		}
+	}
+	return binary, append(cmdArgs, DefaultArgs...), nil
+}
+
+// binaryName returns the ACP server executable name for the running platform,
+// matching the "cmd" field of the registry entry.
+func binaryName() string {
+	if runtime.GOOS == "windows" {
+		return "agy_acp_server.exe"
+	}
+	return "agy_acp_server.par"
+}
+
+// defaultArgs returns the platform-specific argument list from the registry
+// entry. Only the Linux builds declare arguments.
+func defaultArgs() []string {
+	if runtime.GOOS == "linux" {
+		return []string{"--uid="}
+	}
+	return nil
+}
+
+// defaultBinaryPaths returns the search order for the ACP server binary: the
+// pi-go install directory first, then Antigravity's own directory, then the
+// usual bin directories and PATH.
+func defaultBinaryPaths() []string {
+	name := binaryName()
+	paths := []string{name}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths,
+			filepath.Join(home, ".pi-go", "acp", "agy", name),
+			filepath.Join(home, ".antigravity", "acp", name),
+			filepath.Join(home, ".local", "bin", name),
+		)
+	}
+	return append(paths, filepath.Join("/usr/local/bin", name))
+}
+
+// findBinary returns the first existing entry in paths, resolving bare names
+// via PATH and absolute/relative paths via stat.
+func findBinary(paths []string) (string, error) {
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		// Check if it's a full path that exists
+		if filepath.IsAbs(path) || strings.HasPrefix(path, ".") {
+			if _, err := os.Stat(path); err == nil {
+				return path, nil
+			}
+			continue
+		}
+		// Try using LookPath for commands in PATH
+		if fullPath, err := exec.LookPath(path); err == nil {
+			return fullPath, nil
+		}
+	}
+	return "", fmt.Errorf("%s not found in PATH or default locations", BinaryName)
+}

--- a/internal/acp/client/agy/agy_test.go
+++ b/internal/acp/client/agy/agy_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -92,22 +93,105 @@ func TestResolveCommandDefaultArgs(t *testing.T) {
 }
 
 // TestPlatformDefaults verifies the binary name and argument list match the
-// antigravity-acp registry entry for the running platform.
+// antigravity-acp registry entry, for every platform the entry covers rather
+// than only the one running the test. The registry declares agy_acp_server.exe
+// on Windows and .par elsewhere, and --uid= on Linux alone.
 func TestPlatformDefaults(t *testing.T) {
-	wantName := "agy_acp_server.par"
-	if runtime.GOOS == "windows" {
-		wantName = "agy_acp_server.exe"
-	}
-	if got := binaryName(); got != wantName {
-		t.Errorf("binaryName() = %q, want %q", got, wantName)
+	tests := []struct {
+		goos     string
+		wantName string
+		wantArgs []string
+	}{
+		{goos: "darwin", wantName: "agy_acp_server.par"},
+		{goos: "linux", wantName: "agy_acp_server.par", wantArgs: []string{"--uid="}},
+		{goos: "windows", wantName: "agy_acp_server.exe"},
 	}
 
-	var wantArgs []string
-	if runtime.GOOS == "linux" {
-		wantArgs = []string{"--uid="}
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			if got := binaryNameFor(tt.goos); got != tt.wantName {
+				t.Errorf("binaryNameFor(%q) = %q, want %q", tt.goos, got, tt.wantName)
+			}
+			if got := defaultArgsFor(tt.goos); fmt.Sprint(got) != fmt.Sprint(tt.wantArgs) {
+				t.Errorf("defaultArgsFor(%q) = %v, want %v", tt.goos, got, tt.wantArgs)
+			}
+		})
 	}
-	if fmt.Sprint(defaultArgs()) != fmt.Sprint(wantArgs) {
-		t.Errorf("defaultArgs() = %v, want %v", defaultArgs(), wantArgs)
+
+	// The running platform's values are what the package actually uses.
+	if got := binaryName(); got != binaryNameFor(runtime.GOOS) {
+		t.Errorf("binaryName() = %q, want %q", got, binaryNameFor(runtime.GOOS))
+	}
+	if got := defaultArgs(); fmt.Sprint(got) != fmt.Sprint(defaultArgsFor(runtime.GOOS)) {
+		t.Errorf("defaultArgs() = %v, want %v", got, defaultArgsFor(runtime.GOOS))
+	}
+}
+
+// TestDefaultBinaryPathsForPlatforms pins the search order on every platform:
+// the install directory first, the bare name (the only entry that reaches
+// exec.LookPath) last, and no Unix system path on Windows.
+func TestDefaultBinaryPathsForPlatforms(t *testing.T) {
+	const home = "/home/someone"
+
+	for _, goos := range []string{"darwin", "linux", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			paths := defaultBinaryPathsFor(goos, home)
+			name := binaryNameFor(goos)
+
+			if want := filepath.Join(home, ".pi-go", "acp", "agy", name); paths[0] != want {
+				t.Errorf("first entry = %q, want the install dir %q", paths[0], want)
+			}
+			if last := paths[len(paths)-1]; last != name {
+				t.Errorf("last entry = %q, want the bare name %q", last, name)
+			}
+			for i, p := range paths[:len(paths)-1] {
+				if filepath.Dir(p) == "." {
+					t.Errorf("entry %d = %q; only the last entry may be a bare name", i, p)
+				}
+			}
+
+			hasUnixBin := slices.Contains(paths, filepath.Join("/usr/local/bin", name))
+			if goos == "windows" && hasUnixBin {
+				t.Errorf("windows search list %v should not carry a Unix system path", paths)
+			}
+			if goos != "windows" && !hasUnixBin {
+				t.Errorf("%s search list %v should carry /usr/local/bin", goos, paths)
+			}
+		})
+	}
+}
+
+// TestDefaultBinaryPathsForNoHome verifies an unresolvable home directory
+// drops only the entries derived from it, leaving a usable search list.
+func TestDefaultBinaryPathsForNoHome(t *testing.T) {
+	paths := defaultBinaryPathsFor("linux", "")
+	want := []string{filepath.Join("/usr/local/bin", "agy_acp_server.par"), "agy_acp_server.par"}
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("defaultBinaryPathsFor(linux, \"\") = %v, want %v", paths, want)
+	}
+}
+
+// TestStartReportsUnresolvedBinary verifies Start surfaces the resolution
+// error rather than spawning something unexpected.
+func TestStartReportsUnresolvedBinary(t *testing.T) {
+	orig := DefaultBinaryPaths
+	t.Cleanup(func() { DefaultBinaryPaths = orig })
+	DefaultBinaryPaths = []string{filepath.Join(t.TempDir(), "no-such-agy")}
+
+	if _, err := (Runner{}).Start(context.Background(), RunRequest{Prompt: "hi"}); err == nil {
+		t.Fatal("expected an error when the binary cannot be resolved")
+	}
+}
+
+// TestFindBinarySkipsEmptyEntries verifies an empty entry is skipped rather
+// than resolved, so a misconfigured list cannot spawn the wrong thing.
+func TestFindBinarySkipsEmptyEntries(t *testing.T) {
+	path, err := findBinary([]string{"", "ls"})
+	if err != nil {
+		t.Fatalf("findBinary: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected the non-empty entry to resolve")
 	}
 }
 
@@ -153,6 +237,29 @@ func TestResolveCommandEnvOverride(t *testing.T) {
 			t.Fatalf("binary=%q args=%v, want /bin/echo %v", binary, args, DefaultArgs)
 		}
 	})
+}
+
+// TestResolveCommandBlankEnvOverride verifies a whitespace-only
+// PI_ACP_AGY_CMD is treated as unset. Splitting it yields no fields, and
+// without this it would leave the binary empty and reach exec as a spawn
+// of "" — an error far from its cause.
+func TestResolveCommandBlankEnvOverride(t *testing.T) {
+	t.Setenv(envACPAgyCmd, "   ")
+
+	orig := DefaultBinaryPaths
+	t.Cleanup(func() { DefaultBinaryPaths = orig })
+	DefaultBinaryPaths = []string{"ls"}
+
+	binary, _, err := (Runner{}).resolveCommand(RunRequest{Prompt: "hi"})
+	if err != nil {
+		t.Fatalf("resolveCommand error: %v", err)
+	}
+	if binary == "" {
+		t.Fatal("binary is empty; a blank override must fall back to the default search")
+	}
+	if !strings.HasSuffix(binary, "ls") {
+		t.Errorf("binary = %q, want the entry resolved from DefaultBinaryPaths", binary)
+	}
 }
 
 // TestResolveCommandMissingBinary verifies a helpful error when no binary is
@@ -204,9 +311,13 @@ func TestBinaryPathsPreferInstallDirOverPATH(t *testing.T) {
 	if got := DefaultBinaryPaths[len(DefaultBinaryPaths)-1]; got != BinaryName {
 		t.Errorf("last search entry = %q, want the bare name %q so PATH is the last resort", got, BinaryName)
 	}
+	// Directory-qualified rather than absolute: on Windows an absolute path
+	// needs a drive letter, and the entries built from the home directory are
+	// the ones that matter here. What must not appear before the last entry is
+	// a second bare name, since that would reach exec.LookPath too.
 	for i, path := range DefaultBinaryPaths[:len(DefaultBinaryPaths)-1] {
-		if !filepath.IsAbs(path) {
-			t.Errorf("entry %d = %q; every entry before the bare name must be an absolute path", i, path)
+		if filepath.Dir(path) == "." {
+			t.Errorf("entry %d = %q; every entry before the bare name must name a directory", i, path)
 		}
 	}
 	if strings.Contains(DefaultBinaryPaths[0], filepath.Join(".pi-go", "acp", "agy")) {

--- a/internal/acp/client/agy/agy_test.go
+++ b/internal/acp/client/agy/agy_test.go
@@ -246,19 +246,24 @@ func TestResolveCommandEnvOverride(t *testing.T) {
 func TestResolveCommandBlankEnvOverride(t *testing.T) {
 	t.Setenv(envACPAgyCmd, "   ")
 
+	// An absolute path is resolved by stat rather than by exec.LookPath, so
+	// the expected value is exact on every platform — a PATH lookup would
+	// come back as "ls.exe" on Windows.
+	installed := filepath.Join(t.TempDir(), binaryName())
+	if err := os.WriteFile(installed, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+
 	orig := DefaultBinaryPaths
 	t.Cleanup(func() { DefaultBinaryPaths = orig })
-	DefaultBinaryPaths = []string{"ls"}
+	DefaultBinaryPaths = []string{installed}
 
 	binary, _, err := (Runner{}).resolveCommand(RunRequest{Prompt: "hi"})
 	if err != nil {
 		t.Fatalf("resolveCommand error: %v", err)
 	}
-	if binary == "" {
-		t.Fatal("binary is empty; a blank override must fall back to the default search")
-	}
-	if !strings.HasSuffix(binary, "ls") {
-		t.Errorf("binary = %q, want the entry resolved from DefaultBinaryPaths", binary)
+	if binary != installed {
+		t.Errorf("binary = %q, want %q resolved from DefaultBinaryPaths", binary, installed)
 	}
 }
 

--- a/internal/acp/client/agy/agy_test.go
+++ b/internal/acp/client/agy/agy_test.go
@@ -3,6 +3,7 @@ package agy
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -191,5 +192,29 @@ func TestBinaryPaths(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("DefaultBinaryPaths %v should include ~/.pi-go/acp/agy", DefaultBinaryPaths)
+	}
+}
+
+// TestBinaryPathsPreferInstallDirOverPATH pins the search order: the bare name
+// resolves through exec.LookPath, so it must come last. If it came first, a
+// binary earlier on the caller's PATH would shadow the one the installer put
+// in ~/.pi-go/acp/agy, making the resolved server depend on the environment
+// rather than on what was installed.
+func TestBinaryPathsPreferInstallDirOverPATH(t *testing.T) {
+	if got := DefaultBinaryPaths[len(DefaultBinaryPaths)-1]; got != BinaryName {
+		t.Errorf("last search entry = %q, want the bare name %q so PATH is the last resort", got, BinaryName)
+	}
+	for i, path := range DefaultBinaryPaths[:len(DefaultBinaryPaths)-1] {
+		if !filepath.IsAbs(path) {
+			t.Errorf("entry %d = %q; every entry before the bare name must be an absolute path", i, path)
+		}
+	}
+	if strings.Contains(DefaultBinaryPaths[0], filepath.Join(".pi-go", "acp", "agy")) {
+		return
+	}
+	// Only a home directory that cannot be resolved should drop the install
+	// dir from the front, and then the list is the fixed system paths.
+	if home, err := os.UserHomeDir(); err == nil {
+		t.Errorf("first search entry = %q, want the install dir under %s", DefaultBinaryPaths[0], home)
 	}
 }

--- a/internal/acp/client/agy/agy_test.go
+++ b/internal/acp/client/agy/agy_test.go
@@ -1,0 +1,195 @@
+package agy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestRunnerStartRejectsEmptyPrompt verifies that an empty prompt is rejected.
+func TestRunnerStartRejectsEmptyPrompt(t *testing.T) {
+	runner := Runner{}
+	_, err := runner.Start(context.Background(), RunRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty prompt")
+	}
+}
+
+// TestRunnerFindsBinary verifies binary lookup works correctly.
+func TestRunnerFindsBinary(t *testing.T) {
+	// Test that findBinary returns error when binary not found.
+	_, err := findBinary([]string{"nonexistent-binary-xyz"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary")
+	}
+
+	// Test that it finds an existing binary in PATH.
+	path, err := findBinary([]string{"ls"})
+	if err != nil {
+		t.Fatalf("findBinary(ls) failed: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path for ls")
+	}
+}
+
+// TestRunRequestValidation verifies prompt validation through Start.
+func TestRunRequestValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     RunRequest
+		wantErr bool
+	}{
+		{
+			name:    "empty prompt",
+			req:     RunRequest{Prompt: ""},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only prompt",
+			req:     RunRequest{Prompt: "   "},
+			wantErr: true,
+		},
+		{
+			name: "valid prompt with binary",
+			req: RunRequest{
+				Prompt:  "Hello",
+				Command: []string{"/bin/true"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := Runner{}
+			_, err := runner.Start(context.Background(), tt.req)
+			if tt.wantErr && err == nil {
+				t.Errorf("Start() error = nil, wantErr true")
+			}
+		})
+	}
+}
+
+// TestResolveCommandDefaultArgs verifies the platform's registry arguments are
+// applied when only the binary is set.
+func TestResolveCommandDefaultArgs(t *testing.T) {
+	r := Runner{Binary: "agy_acp_server.par"}
+	binary, args, err := r.resolveCommand(RunRequest{Prompt: "hi"})
+	if err != nil {
+		t.Fatalf("resolveCommand error: %v", err)
+	}
+	if binary != "agy_acp_server.par" {
+		t.Fatalf("binary = %q, want agy_acp_server.par", binary)
+	}
+	if fmt.Sprint(args) != fmt.Sprint(DefaultArgs) {
+		t.Fatalf("args = %v, want %v", args, DefaultArgs)
+	}
+}
+
+// TestPlatformDefaults verifies the binary name and argument list match the
+// antigravity-acp registry entry for the running platform.
+func TestPlatformDefaults(t *testing.T) {
+	wantName := "agy_acp_server.par"
+	if runtime.GOOS == "windows" {
+		wantName = "agy_acp_server.exe"
+	}
+	if got := binaryName(); got != wantName {
+		t.Errorf("binaryName() = %q, want %q", got, wantName)
+	}
+
+	var wantArgs []string
+	if runtime.GOOS == "linux" {
+		wantArgs = []string{"--uid="}
+	}
+	if fmt.Sprint(defaultArgs()) != fmt.Sprint(wantArgs) {
+		t.Errorf("defaultArgs() = %v, want %v", defaultArgs(), wantArgs)
+	}
+}
+
+// TestResolveCommandHonorsCommandOverride verifies a test Command override is
+// passed verbatim without default argument injection.
+func TestResolveCommandHonorsCommandOverride(t *testing.T) {
+	r := Runner{}
+	binary, args, err := r.resolveCommand(RunRequest{
+		Prompt:  "hi",
+		Command: []string{"/bin/echo", "x"},
+	})
+	if err != nil {
+		t.Fatalf("resolveCommand error: %v", err)
+	}
+	if binary != "/bin/echo" || fmt.Sprint(args) != fmt.Sprint([]string{"x"}) {
+		t.Fatalf("binary=%q args=%v, want /bin/echo [x]", binary, args)
+	}
+}
+
+// TestResolveCommandEnvOverride verifies PI_ACP_AGY_CMD overrides binary and
+// args.
+func TestResolveCommandEnvOverride(t *testing.T) {
+	t.Run("binary and args", func(t *testing.T) {
+		t.Setenv(envACPAgyCmd, "/bin/echo --foo")
+		r := Runner{}
+		binary, args, err := r.resolveCommand(RunRequest{Prompt: "hi"})
+		if err != nil {
+			t.Fatalf("resolveCommand error: %v", err)
+		}
+		if binary != "/bin/echo" || fmt.Sprint(args) != fmt.Sprint([]string{"--foo"}) {
+			t.Fatalf("binary=%q args=%v, want /bin/echo [--foo]", binary, args)
+		}
+	})
+
+	t.Run("bare binary falls back to default args", func(t *testing.T) {
+		t.Setenv(envACPAgyCmd, "/bin/echo")
+		r := Runner{}
+		binary, args, err := r.resolveCommand(RunRequest{Prompt: "hi"})
+		if err != nil {
+			t.Fatalf("resolveCommand error: %v", err)
+		}
+		if binary != "/bin/echo" || fmt.Sprint(args) != fmt.Sprint(DefaultArgs) {
+			t.Fatalf("binary=%q args=%v, want /bin/echo %v", binary, args, DefaultArgs)
+		}
+	})
+}
+
+// TestResolveCommandMissingBinary verifies a helpful error when no binary is
+// found in the default paths.
+func TestResolveCommandMissingBinary(t *testing.T) {
+	// Point the default lookup at a nonexistent absolute path only.
+	orig := DefaultBinaryPaths
+	t.Cleanup(func() { DefaultBinaryPaths = orig })
+	DefaultBinaryPaths = []string{filepath.Join(t.TempDir(), "no-such-agy")}
+
+	r := Runner{}
+	_, _, err := r.resolveCommand(RunRequest{Prompt: "hi"})
+	if err == nil {
+		t.Fatal("expected error when binary is missing")
+	}
+	if !strings.Contains(err.Error(), BinaryName) {
+		t.Errorf("error %q should name the missing binary %q", err, BinaryName)
+	}
+}
+
+// TestBinaryPaths verifies default binary paths are reasonable and include the
+// directory install-agy-acp.sh extracts the registry archive into.
+func TestBinaryPaths(t *testing.T) {
+	if len(DefaultBinaryPaths) == 0 {
+		t.Fatal("DefaultBinaryPaths should not be empty")
+	}
+	for _, path := range DefaultBinaryPaths {
+		if path == "" {
+			t.Error("DefaultBinaryPaths contains empty string")
+		}
+	}
+	var found bool
+	for _, path := range DefaultBinaryPaths {
+		if strings.Contains(path, filepath.Join(".pi-go", "acp", "agy")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("DefaultBinaryPaths %v should include ~/.pi-go/acp/agy", DefaultBinaryPaths)
+	}
+}

--- a/internal/acp/client/agy/e2e_test.go
+++ b/internal/acp/client/agy/e2e_test.go
@@ -1,0 +1,78 @@
+//go:build e2e
+
+package agy
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	shared "github.com/dimetron/pi-go/internal/acp"
+)
+
+// envE2E gates the credentialed run. The ACP server refuses session/new until
+// an auth method is chosen in ~/.gemini/antigravity-acp/settings.json, and
+// oauth-personal then blocks on an interactive browser login — which would
+// hang an unattended `make test-e2e` for the full deadline rather than fail.
+const envE2E = "PI_ACP_AGY_E2E"
+
+// requireAgyServer skips the test unless the Antigravity ACP server is
+// installed (scripts/install-agy-acp.sh) and the caller has opted in. These
+// tests spawn the real server and make model calls, so they run only under
+// `make test-e2e` with PI_ACP_AGY_E2E set.
+func requireAgyServer(t *testing.T) {
+	t.Helper()
+	if _, err := findBinary(DefaultBinaryPaths); err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+	if os.Getenv(envE2E) == "" {
+		t.Skipf("skipping: set %s=1 once Antigravity is authenticated", envE2E)
+	}
+}
+
+// TestE2EAgyTurn drives a full turn against the real ACP server: spawn,
+// initialize, session/new, prompt, streamed events, result.
+func TestE2EAgyTurn(t *testing.T) {
+	requireAgyServer(t)
+
+	r := Runner{}
+	sess, err := r.Start(t.Context(), RunRequest{
+		Prompt: "Reply with exactly: PIGO_OK. Do not run any commands or edit any files.",
+		CWD:    t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var text strings.Builder
+	deadline := time.After(3 * time.Minute)
+drain:
+	for {
+		select {
+		case ev, ok := <-sess.Events():
+			if !ok {
+				break drain
+			}
+			t.Logf("event: type=%s content=%q err=%q", ev.Type, ev.Content, ev.Error)
+			if ev.Type == shared.EventTypeMessage {
+				text.WriteString(ev.Content)
+			}
+		case <-deadline:
+			_ = sess.Cancel()
+			t.Fatal("timed out waiting for the turn to complete")
+		}
+	}
+
+	result := sess.Wait()
+	if strings.Contains(result.Error, "Authentication required") {
+		t.Skipf("skipping: Antigravity ACP server is not authenticated: %s", result.Error)
+	}
+	if result.Status != shared.StatusSuccess {
+		t.Fatalf("status = %q, want %q (error: %q, stderr: %q)",
+			result.Status, shared.StatusSuccess, result.Error, result.Stderr)
+	}
+	if strings.TrimSpace(text.String()) == "" && strings.TrimSpace(result.Result) == "" {
+		t.Error("no agent message streamed back")
+	}
+}

--- a/internal/subagent/agents_test.go
+++ b/internal/subagent/agents_test.go
@@ -256,9 +256,9 @@ func TestLoadBundledAgents(t *testing.T) {
 		t.Fatalf("LoadBundledAgents failed: %v", err)
 	}
 
-	// Expected 17 agents: explore, plan, designer, task, quick-task, worker, code-reviewer, spec-reviewer, memory-compressor, discovery, claude, gemini, cursor, copilot, architect, codex, codex-review
-	if len(agents) != 17 {
-		t.Errorf("expected 17 bundled agents, got %d: %v", len(agents), agentNames(agents))
+	// Expected 18 agents: explore, plan, designer, task, quick-task, worker, code-reviewer, spec-reviewer, memory-compressor, discovery, claude, gemini, cursor, copilot, agy, architect, codex, codex-review
+	if len(agents) != 18 {
+		t.Errorf("expected 18 bundled agents, got %d: %v", len(agents), agentNames(agents))
 	}
 
 	// Verify all agents have required fields
@@ -305,9 +305,9 @@ func TestDiscoverAgents_Bundled(t *testing.T) {
 		t.Fatalf("DiscoverAgents failed: %v", err)
 	}
 
-	// Should have 17 bundled agents
-	if len(result.Bundled) != 17 {
-		t.Errorf("expected 17 bundled agents, got %d", len(result.Bundled))
+	// Should have 18 bundled agents
+	if len(result.Bundled) != 18 {
+		t.Errorf("expected 18 bundled agents, got %d", len(result.Bundled))
 	}
 
 	// All should have bundled source
@@ -325,13 +325,13 @@ func TestDiscoverAgents_Both(t *testing.T) {
 	}
 
 	// Should have bundled agents
-	if len(result.Bundled) != 17 {
-		t.Errorf("expected 17 bundled agents, got %d", len(result.Bundled))
+	if len(result.Bundled) != 18 {
+		t.Errorf("expected 18 bundled agents, got %d", len(result.Bundled))
 	}
 
 	// All should be in merged All slice
-	if len(result.All) < 17 {
-		t.Errorf("expected at least 17 agents in All, got %d", len(result.All))
+	if len(result.All) < 18 {
+		t.Errorf("expected at least 18 agents in All, got %d", len(result.All))
 	}
 }
 

--- a/internal/subagent/bundled/agy.md
+++ b/internal/subagent/bundled/agy.md
@@ -1,0 +1,86 @@
+---
+name: agy
+description: Google Antigravity ACP agent — spawn Antigravity via its `agy_acp_server` ACP binary
+role: default
+worktree: false
+tools: read, grep, find, tree, ls, bash, edit, write
+---
+
+You are Google Antigravity, running as a subagent of pi-go via the ACP (Agent Client Protocol) subprocess adapter.
+
+## Your Identity
+
+You are Antigravity, Google's AI coding agent, running in a pi-go subagent context. You have access to the full suite of
+pi-go tools and can perform development tasks.
+
+## Capabilities
+
+You have access to the following tools for filesystem operations, code exploration, and web research:
+
+- **read**: Read file contents with line number support
+- **grep**: Search file contents using regex patterns
+- **find**: Find files matching glob patterns
+- **tree**: Show directory tree structure
+- **ls**: List directory contents
+- **bash**: Execute shell commands
+- **edit**: Edit files using precise line replacements
+- **write**: Write complete file contents
+
+## Installation
+
+Unlike the other ACP agents, the `agy` CLI itself has no ACP mode — Antigravity ships a separate ACP server binary,
+published as a platform archive in the [Agent Client Protocol registry](https://github.com/agentclientprotocol/registry)
+under `antigravity-acp`. Install it once with:
+
+```bash
+scripts/install-agy-acp.sh            # macOS / Linux
+```
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\install-agy-acp.ps1   # Windows
+```
+
+That downloads and extracts the archive for the current platform into `~/.pi-go/acp/agy/`, which is the first entry in
+the adapter's search path. `PI_ACP_AGY_CMD` overrides the resolved command (`"binary arg1 arg2 …"`) if the server lives
+elsewhere.
+
+## Authentication
+
+The ACP server does **not** inherit the `agy` CLI's login. Select an auth method in
+`~/.gemini/antigravity-acp/settings.json` before the first turn:
+
+```json
+{ "auth": { "type": "oauth-personal" } }
+```
+
+Accepted types are `oauth-personal`, `gemini-api-key` (needs `GEMINI_API_KEY`), `oauth-business` (Gemini Enterprise) and
+`agent-platform`. Without one, `session/new` fails with `Authentication required`.
+
+`oauth-personal` additionally needs a one-time browser login: the server prints a `accounts.google.com` URL and waits on
+a loopback redirect. That URL goes to **stdout**, i.e. into the ACP stream, so pi-go logs it as an unparseable message
+rather than showing it — run the server once by hand to complete the login:
+
+```bash
+~/.pi-go/acp/agy/agy_acp_server.par
+```
+
+The parent pi-go process forwards the current environment, so an exported `GEMINI_API_KEY` reaches the server.
+
+## Session Behavior
+
+- Each prompt turn is a single ACP interaction spoken over stdin/stdout as newline-delimited JSON-RPC 2.0
+- Results are streamed back incrementally to the parent pi-go process
+- The parent process manages session lifecycle and timeout
+
+## Working Directory
+
+You operate in the working directory passed by the parent pi-go process. All file operations are relative to this
+directory unless absolute paths are provided.
+
+## Best Practices
+
+1. **Be methodical**: Read files before modifying them
+2. **Check before running**: Verify commands won't have destructive effects
+3. **Use appropriate tools**: Choose the right tool for the task
+4. **Report progress**: Stream significant steps back to the parent
+5. **Handle errors gracefully**: Return clear error messages when operations fail

--- a/internal/subagent/coverage_test.go
+++ b/internal/subagent/coverage_test.go
@@ -362,13 +362,13 @@ func TestToSpawnInput_KnownBundled(t *testing.T) {
 	}
 }
 
-// TestStartACPSession_KnownAgents verifies the claude/gemini/cursor branches
+// TestStartACPSession_KnownAgents verifies the claude/gemini/cursor/copilot/agy branches
 // are hit — but since we can't actually launch the CLI binaries in a sandbox,
 // we tolerate failure from session.Start and only assert the branch routes to
 // a specific runner (i.e. the error comes from the runner, not from "unknown
 // ACP agent").
 func TestStartACPSession_KnownAgents_RoutesToRunner(t *testing.T) {
-	for _, name := range []string{"claude", "gemini", "cursor", "copilot"} {
+	for _, name := range []string{"claude", "gemini", "cursor", "copilot", "agy"} {
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 			defer cancel()

--- a/internal/subagent/orchestrator.go
+++ b/internal/subagent/orchestrator.go
@@ -80,6 +80,7 @@ var acpAgentNames = map[string]struct{}{
 	"gemini":  {},
 	"cursor":  {},
 	"copilot": {},
+	"agy":     {},
 }
 
 // isACPAgent reports whether the named agent is an ACP subprocess adapter.

--- a/internal/subagent/spawner_acp.go
+++ b/internal/subagent/spawner_acp.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	sharedacp "github.com/dimetron/pi-go/internal/acp"
+	"github.com/dimetron/pi-go/internal/acp/client/agy"
 	"github.com/dimetron/pi-go/internal/acp/client/claudecode"
 	"github.com/dimetron/pi-go/internal/acp/client/copilot"
 	"github.com/dimetron/pi-go/internal/acp/client/cursor"
@@ -14,7 +15,7 @@ import (
 )
 
 // acpSession is the shared interface implemented by every per-runner
-// RunningSession (claudecode, gemini, cursor). It lets dispatchACP treat
+// RunningSession (claudecode, gemini, cursor, agy). It lets dispatchACP treat
 // them uniformly when pumping events back to the orchestrator.
 type acpSession interface {
 	Events() <-chan sharedacp.Event
@@ -25,7 +26,7 @@ type acpSession interface {
 
 // startACPSessionFn is the constructor used by dispatchACP to start a
 // runner. It is overridable in tests so the dispatcher can be exercised
-// without invoking real claude/gemini/cursor binaries.
+// without invoking real claude/gemini/cursor/agy binaries.
 var startACPSessionFn = startACPSession
 
 // acpCompletionSentinel is the exact string the preamble asks ACP subagents
@@ -61,7 +62,7 @@ func acpPromptPreamble(agentName, task string) string {
 		agentName, task, acpCompletionSentinel, acpCompletionSentinel)
 }
 
-// dispatchACP starts an ACP-based subagent (claude, gemini, cursor) and
+// dispatchACP starts an ACP-based subagent (claude, gemini, cursor, agy) and
 // returns a *Process whose event channel is fed by the runner's session,
 // translated into the orchestrator's Event format.
 //
@@ -135,6 +136,13 @@ func startACPSession(ctx context.Context, agentName, prompt string, opts SpawnOp
 	case "copilot":
 		r := copilot.Runner{ExtraEnv: opts.Env}
 		return r.Start(ctx, copilot.RunRequest{
+			Prompt: prompt,
+			CWD:    opts.WorkDir,
+			Env:    opts.Env,
+		})
+	case "agy":
+		r := agy.Runner{ExtraEnv: opts.Env}
+		return r.Start(ctx, agy.RunRequest{
 			Prompt: prompt,
 			CWD:    opts.WorkDir,
 			Env:    opts.Env,

--- a/internal/subagent/types_test.go
+++ b/internal/subagent/types_test.go
@@ -11,8 +11,8 @@ func TestBundledAgents_AllDefined(t *testing.T) {
 		t.Fatalf("LoadBundledAgents failed: %v", err)
 	}
 
-	// Should have exactly 17 bundled agents
-	expected := []string{"explore", "plan", "designer", "task", "quick-task", "worker", "code-reviewer", "spec-reviewer", "memory-compressor", "discovery", "claude", "gemini", "cursor", "copilot", "architect", "codex", "codex-review"}
+	// Should have exactly 18 bundled agents
+	expected := []string{"explore", "plan", "designer", "task", "quick-task", "worker", "code-reviewer", "spec-reviewer", "memory-compressor", "discovery", "claude", "gemini", "cursor", "copilot", "agy", "architect", "codex", "codex-review"}
 	if len(agents) != len(expected) {
 		t.Errorf("expected %d bundled agents, got %d: %v", len(expected), len(agents), agentNames(agents))
 	}

--- a/scripts/install-agy-acp.ps1
+++ b/scripts/install-agy-acp.ps1
@@ -1,0 +1,99 @@
+# Installer for the Google Antigravity ACP server used by pi-go's "agy" subagent.
+#
+# The agy CLI has no ACP mode: Antigravity ships a standalone ACP server binary
+# distributed as a platform archive by the Agent Client Protocol registry. This
+# script resolves the entry for the current platform, downloads the archive and
+# extracts it into %USERPROFILE%\.pi-go\acp\agy, which is the first location the
+# adapter (internal/acp/client/agy) searches.
+#
+# The download is large (~300 MB compressed, ~900 MB extracted).
+#
+# Works on Windows PowerShell 5.1 (Windows 10/11 built-in) and PowerShell 7+.
+#
+# Usage:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File install-agy-acp.ps1 [-InstallDir <path>]
+
+param(
+    [string]$InstallDir = (Join-Path $env:USERPROFILE ".pi-go\acp\agy"),
+    [string]$AgentJsonUrl = $env:AGY_ACP_AGENT_JSON
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $AgentJsonUrl) {
+    $AgentJsonUrl = "https://raw.githubusercontent.com/agentclientprotocol/registry/main/antigravity-acp/agent.json"
+}
+
+# Windows PowerShell 5.1 images can default to TLS 1.0/1.1, which the download
+# hosts reject. Only force TLS 1.2 when the process is pinned to something
+# older; SystemDefault already negotiates 1.2 or 1.3. See install.ps1.
+if ([Net.ServicePointManager]::SecurityProtocol -ne [Net.SecurityProtocolType]::SystemDefault) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
+
+# --- Resolve the registry entry for this platform ----------------------------
+# Registry platform identifiers come from the registry's FORMAT.md.
+$arch = $env:PROCESSOR_ARCHITECTURE
+if (-not $arch) { $arch = "AMD64" }
+switch ($arch.ToUpper()) {
+    "AMD64" { $platform = "windows-x86_64" }
+    "ARM64" { $platform = "windows-aarch64" }
+    default { throw "Unsupported architecture $arch" }
+}
+
+Write-Host "Resolving antigravity-acp for $platform..."
+$entry = Invoke-RestMethod -Uri $AgentJsonUrl -UseBasicParsing
+$target = $entry.distribution.binary.$platform
+if (-not $target) { throw "No binary distribution for $platform" }
+
+$archiveUrl = $target.archive
+$sha256 = $target.sha256
+
+# --- Download ----------------------------------------------------------------
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("agy-acp-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    $archive = Join-Path $tmp ([System.IO.Path]::GetFileName($archiveUrl.Split("?")[0]))
+
+    Write-Host "Downloading $archiveUrl"
+    # Invoke-WebRequest's progress bar makes a 300 MB download crawl on 5.1.
+    $oldProgress = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
+    try {
+        Invoke-WebRequest -Uri $archiveUrl -OutFile $archive -UseBasicParsing
+    } finally {
+        $ProgressPreference = $oldProgress
+    }
+
+    if ($sha256) {
+        Write-Host "Verifying sha256..."
+        $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash
+        if ($actual.ToLower() -ne $sha256.ToLower()) {
+            throw "sha256 mismatch: got $actual, want $sha256"
+        }
+    }
+
+    # --- Extract -------------------------------------------------------------
+    Write-Host "Extracting into $InstallDir"
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    if ($archive -notmatch "\.zip$") {
+        throw "Unsupported archive format $archive"
+    }
+    # Expand-Archive -Force needs PowerShell 5.0+; it is present on every
+    # supported Windows build.
+    Expand-Archive -Path $archive -DestinationPath $InstallDir -Force
+} finally {
+    Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$server = Join-Path $InstallDir "agy_acp_server.exe"
+if (-not (Test-Path $server)) {
+    throw "No agy_acp_server.exe found under $InstallDir"
+}
+
+Write-Host "Installed $server"
+Write-Host "pi-go finds it automatically; override with PI_ACP_AGY_CMD if you move it."
+Write-Host ""
+Write-Host "Next: the server does not inherit the agy CLI login. Select an auth method in"
+Write-Host "  %USERPROFILE%\.gemini\antigravity-acp\settings.json, e.g. {""auth"": {""type"": ""oauth-personal""}},"
+Write-Host "then run $server once by hand to complete the one-time browser sign-in."

--- a/scripts/install-agy-acp.sh
+++ b/scripts/install-agy-acp.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Install the Google Antigravity ACP server used by pi-go's "agy" subagent.
+#
+# The agy CLI has no ACP mode: Antigravity ships a standalone ACP server binary
+# distributed as a platform archive by the Agent Client Protocol registry. This
+# script resolves the entry for the current platform, downloads the archive and
+# extracts it into ~/.pi-go/acp/agy, which is the first location the adapter
+# (internal/acp/client/agy) searches.
+#
+# The download is large (~300 MB compressed, ~900 MB extracted).
+#
+# Usage: scripts/install-agy-acp.sh [install-dir]
+
+set -euo pipefail
+
+AGENT_JSON_URL="${AGY_ACP_AGENT_JSON:-https://raw.githubusercontent.com/agentclientprotocol/registry/main/antigravity-acp/agent.json}"
+INSTALL_DIR="${1:-$HOME/.pi-go/acp/agy}"
+
+for cmd in curl python3 unzip; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "error: $cmd is required" >&2; exit 1; }
+done
+
+# Map uname output onto the registry's platform identifiers (FORMAT.md).
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux)  os=linux ;;
+  *)      echo "error: unsupported OS $(uname -s); install the Windows build manually" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  arm64|aarch64) arch=aarch64 ;;
+  x86_64|amd64)  arch=x86_64 ;;
+  *)             echo "error: unsupported architecture $(uname -m)" >&2; exit 1 ;;
+esac
+platform="$os-$arch"
+
+echo "==> resolving antigravity-acp for $platform"
+entry="$(curl -fsSL "$AGENT_JSON_URL")"
+read -r archive_url sha256 <<EOF
+$(printf '%s' "$entry" | python3 -c '
+import json, sys
+platform = sys.argv[1]
+target = json.load(sys.stdin)["distribution"]["binary"].get(platform)
+if target is None:
+    sys.exit(f"no binary distribution for {platform}")
+print(target["archive"], target.get("sha256", ""))
+' "$platform")
+EOF
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+archive="$tmp/${archive_url##*/}"
+
+echo "==> downloading $archive_url"
+curl -fL --progress-bar -o "$archive" "$archive_url"
+
+if [ -n "$sha256" ]; then
+  echo "==> verifying sha256"
+  actual="$(python3 -c '
+import hashlib, sys
+h = hashlib.sha256()
+with open(sys.argv[1], "rb") as f:
+    for chunk in iter(lambda: f.read(1 << 20), b""):
+        h.update(chunk)
+print(h.hexdigest())
+' "$archive")"
+  if [ "$(printf '%s' "$actual" | tr 'A-Z' 'a-z')" != "$(printf '%s' "$sha256" | tr 'A-Z' 'a-z')" ]; then
+    echo "error: sha256 mismatch: got $actual, want $sha256" >&2
+    exit 1
+  fi
+fi
+
+echo "==> extracting into $INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+case "$archive" in
+  *.zip)             unzip -oq "$archive" -d "$INSTALL_DIR" ;;
+  *.tar.gz|*.tgz)    tar -xzf "$archive" -C "$INSTALL_DIR" ;;
+  *.tar.bz2|*.tbz2)  tar -xjf "$archive" -C "$INSTALL_DIR" ;;
+  *)                 echo "error: unsupported archive format $archive" >&2; exit 1 ;;
+esac
+
+# The .par server loads its sibling helper binaries from the same directory, so
+# everything the archive contains stays together and must stay executable.
+find "$INSTALL_DIR" -maxdepth 1 -type f -name 'agy_acp_server*' -exec chmod +x {} +
+
+server="$INSTALL_DIR/agy_acp_server.par"
+[ -f "$server" ] || server="$INSTALL_DIR/agy_acp_server.exe"
+if [ ! -f "$server" ]; then
+  echo "error: no agy_acp_server binary found under $INSTALL_DIR" >&2
+  exit 1
+fi
+
+echo "==> installed $server"
+echo "    pi-go finds it automatically; override with PI_ACP_AGY_CMD if you move it."
+echo
+echo "Next: the server does not inherit the agy CLI login. Select an auth method in"
+echo "  ~/.gemini/antigravity-acp/settings.json, e.g. {\"auth\": {\"type\": \"oauth-personal\"}},"
+echo "then run $server once by hand to complete the one-time browser sign-in."


### PR DESCRIPTION
Adds a fifth ACP subprocess adapter alongside claude/gemini/cursor/copilot,
built from the antigravity-acp entry in the Agent Client Protocol registry
(agentclientprotocol/registry).

Unlike the others, the vendor CLI is not the ACP endpoint: `agy` has no ACP
mode, so the adapter runs the standalone `agy_acp_server` binary the registry
distributes as a platform archive. internal/acp/client/agy resolves it from
~/.pi-go/acp/agy first, honours PI_ACP_AGY_CMD, and applies the registry's
platform arguments (--uid= on Linux only).

scripts/install-agy-acp.sh and scripts/install-agy-acp.ps1 install the server:
they read the registry entry, resolve the current platform, verify the sha256
when the entry carries one, and extract into ~/.pi-go/acp/agy.

Verified against the real darwin-arm64 server: pi-go spawns it, completes
initialize (protocolVersion 1, agentInfo antigravity-acp) and reaches
session/new. The turn then stops at authentication — the server does not
inherit the agy CLI login and needs an auth type in
~/.gemini/antigravity-acp/settings.json plus a one-time browser sign-in. The
build-tagged e2e test is gated behind PI_ACP_AGY_E2E so an unattended
`make test-e2e` skips rather than blocking on that login.

Verification: go build ./..., go vet ./..., go test ./internal/subagent/...
./internal/acp/..., make lint (0 issues), and an installer run against a stub
registry entry.

Signed-off-by: dimetron <dimetron@me.com>
