### PR TITLE
fix(tui): show real subagent type in agent[...] header

### DIFF
--- a/internal/tui/complexity_render_test.go
+++ b/internal/tui/complexity_render_test.go
@@ -929,6 +929,11 @@ func TestRenderToolCardsRender(t *testing.T) {
 			want: "◉ agent[claude+pi+gemini]\n  │ → ok\n",
 		},
 		{
+			desc: "bundled adapters keep their names, pi subagents collapse",
+			msg:  message{role: "tool", tool: "subagent", agentType: "agy+task+copilot+codex", content: "ok"},
+			want: "◉ agent[agy+pi+copilot+codex]\n  │ → ok\n",
+		},
+		{
 			desc: "agent result collapses newlines into one gutter line",
 			msg:  message{role: "tool", tool: "agent", agentType: "gemini", content: "one\ntwo\n\nthree"},
 			want: "◉ agent[gemini]\n  │ → one two three\n",
@@ -1066,7 +1071,7 @@ func TestRenderableAgentEventsRender(t *testing.T) {
 		{kind: "custom"},
 	}
 	got := renderableAgentEvents(in)
-	want := []string{"text", "tool_call", "stderr", "custom"}
+	want := []string{"text", "tool_call", "custom"}
 	if len(got) != len(want) {
 		t.Fatalf("kept %d events (%v), want %d", len(got), got, len(want))
 	}
@@ -1160,6 +1165,9 @@ func TestAgentCardHeaderRender(t *testing.T) {
 		{"label only", ToolDisplayModel{}, message{agentType: "task", content: "x"}, "◉ agent[pi]\n"},
 		{"title only", ToolDisplayModel{}, message{agentTitle: "hi", content: "x"}, "◉ agent hi\n"},
 		{"both", ToolDisplayModel{}, message{agentType: "gemini", agentTitle: "hi", content: "x"}, "◉ agent[gemini] hi\n"},
+		{"agy keeps its name", ToolDisplayModel{}, message{agentType: "agy", content: "x"}, "◉ agent[agy]\n"},
+		{"copilot keeps its name", ToolDisplayModel{}, message{agentType: "copilot", content: "x"}, "◉ agent[copilot]\n"},
+		{"codex keeps its name", ToolDisplayModel{}, message{agentType: "codex", content: "x"}, "◉ agent[codex]\n"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/tui/run_gate_status_test.go
+++ b/internal/tui/run_gate_status_test.go
@@ -12,15 +12,18 @@ func TestRunGatesClassifiesPassFailHang(t *testing.T) {
 		name    string
 		command string
 		want    GateStatus
+		// timeout is per-case: pass/fail need headroom for `sh -c` spawn on a
+		// slow Windows runner, but hang must trip the deadline quickly.
+		timeout time.Duration
 	}{
-		{"pass", "true", GatePass},
-		{"fail", "exit 3", GateFail},
-		{"hang", "sleep 30", GateHang},
+		{"pass", "true", GatePass, 5 * time.Second},
+		{"fail", "exit 3", GateFail, 5 * time.Second},
+		{"hang", "sleep 30", GateHang, 150 * time.Millisecond},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			msg := runGatesTimeout(t.Context(), t.TempDir(),
-				[]Gate{{Name: tt.name, Command: tt.command}}, 150*time.Millisecond)
+				[]Gate{{Name: tt.name, Command: tt.command}}, tt.timeout)
 
 			if len(msg.results) != 1 {
 				t.Fatalf("got %d results, want 1", len(msg.results))

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -13,17 +13,27 @@ import (
 	"github.com/alecthomas/chroma/v2/formatters"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/reflow/wrap"
 
 	"charm.land/lipgloss/v2"
 )
 
-// acpBundledAgents lists agent names backed by ACP subprocess adapters; the
-// rest are regular pi-based subagents and render under the "pi" label.
+// acpBundledAgents lists bundled agent names that are NOT regular pi-based
+// subagents and so keep their own label in the "agent[...]" header instead of
+// collapsing to "pi". It mirrors the union of internal/subagent.acpAgentNames
+// (claude, gemini, cursor, copilot, agy) and codexAgentNames (codex,
+// codex-review): every name that has its own subprocess adapter renders under
+// its real name; built-in pi subagents (task, explore, worker, …) fall through
+// to "pi".
 var acpBundledAgents = map[string]struct{}{
-	"claude": {},
-	"gemini": {},
-	"cursor": {},
+	"claude":       {},
+	"gemini":       {},
+	"cursor":       {},
+	"copilot":      {},
+	"agy":          {},
+	"codex":        {},
+	"codex-review": {},
 }
 
 // agentToolColor returns the foreground color used for tool/command lines
@@ -52,7 +62,8 @@ func agentToolColor(agentType string, pal Palette) color.Color {
 }
 
 // agentBracketLabel returns the string rendered inside "agent[...]" for a
-// given subagent type. ACP-backed agents (claude, gemini) keep their name;
+// given subagent type. Bundled agents with their own subprocess adapter
+// (claude, gemini, cursor, copilot, agy, codex, codex-review) keep their name;
 // all other pi-based subagents collapse to "pi". Parallel/chain calls encode
 // multiple agents as "claude+gemini" — each component is mapped individually
 // and duplicates are deduped, so [claude+explore+task] becomes [claude+pi].
@@ -315,7 +326,13 @@ func renderableAgentEvents(evs []agentEv) []agentEv {
 	renderable := make([]agentEv, 0, len(evs))
 	for _, ev := range evs {
 		switch ev.kind {
-		case "message_start", "message_end", "done", "spawn":
+		case "message_start", "message_end", "done", "spawn", "stderr":
+			// stderr is dropped from the live card: subprocess diagnostics
+			// (Antigravity's raw WS frame dumps, "Stdin closed, cleaning
+			// up...", OAuth chatter) flood the TUI and corrupt the layout.
+			// The full stderr is still durably captured in RunResult.Stderr
+			// and surfaced on error via acpErrorText, so diagnostics on real
+			// failures are preserved — only the live cosmetic stream is gone.
 			continue
 		case "text", "text_delta":
 			if strings.TrimSpace(ev.content) == "" {
@@ -517,10 +534,17 @@ func (t ToolDisplayModel) argWidth() int {
 // collapseToSingleLine replaces newlines and tabs with spaces and collapses
 // runs of whitespace, so long multi-line content renders on a single wrapped
 // line under the agent tool's "│ " gutter rather than drifting to column 0.
+//
+// ANSI escape sequences are stripped first: subagent text (notably Antigravity)
+// can carry SGR color codes, cursor moves or OSC sequences that, if left in,
+// execute as terminal control codes when Bubble Tea paints the styled string
+// and shift the TUI layout. ansi.Strip removes CSI/OSC/other escapes before the
+// whitespace pass, so only plain text reaches the renderer.
 func collapseToSingleLine(s string) string {
 	if s == "" {
 		return ""
 	}
+	s = ansi.Strip(s)
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\t", " ")


### PR DESCRIPTION
## What

`acpBundledAgents` in `internal/tui/tool_display.go` only listed `claude`, `gemini` and `cursor`, so `copilot`, `agy`, `codex` and `codex-review` all collapsed to `agent[pi]` in the live card header instead of their real type.

## Fix

Extended `acpBundledAgents` to the full union of the two authoritative sets in `internal/subagent`:
- `acpAgentNames` (orchestrator.go): `claude, gemini, cursor, copilot, agy`
- `codexAgentNames` (spawner_codex.go): `codex, codex-review`

Now each bundled adapter renders under its real name; built-in pi subagents (`task`, `explore`, `worker`, …) still collapse to `pi`. Updated the doc comments on the map and on `agentBracketLabel`.

## Also included (from prior unstaged work)

- Drop `stderr` events from the live card: Antigravity's raw WS frame dumps and OAuth chatter flood the TUI and corrupt the layout. The full stderr stays captured in `RunResult.Stderr` and surfaces on error via `acpErrorText`, so diagnostics on real failures are preserved.
- Strip ANSI escapes in `collapseToSingleLine` via `ansi.Strip` so SGR/cursor/OSC sequences from subagent text (notably Antigravity) don't execute as terminal control codes and shift the TUI layout.

## Tests

- `TestAgentCardHeaderRender`: `agy`, `copilot`, `codex` keep their names
- `TestRenderToolCardsRender`: compound `agy+task+copilot+codex` → `agent[agy+pi+copilot+codex]`
- `TestRenderableAgentEventsRender`: updated for the stderr filter

## Verification

- `go build ./internal/tui/...` — clean
- `go test ./internal/tui/` (full suite) — `ok` in 17.0s
- `golangci-lint` (pre-commit hook) — 0 issues
- commit signed (`gpgsig` header present)