### PR TITLE
feat(sop): add /pr-autofix, a SOP-driven PR watch-and-fix mode

### DIFF
--- a/internal/sop/exec/shell.go
+++ b/internal/sop/exec/shell.go
@@ -1,0 +1,186 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	"github.com/dimetron/pi-go/internal/sop/validate"
+)
+
+// RetryExitCode is the exit status a stage script uses to say "not yet" rather
+// than "failed".
+//
+// The distinction cannot be expressed by success and failure alone, and it is
+// the difference between a poll and a defeat: a `watch` stage that finds CI
+// still running has not failed, it simply has no answer yet, and what it wants
+// is the engine's backoff — not the SOP's failure edge. The value is sysexits'
+// EX_TEMPFAIL, which already means exactly this.
+const RetryExitCode = 75
+
+// errStageNotReady is returned for RetryExitCode. The engine applies the
+// stage's RetryConfig to a returned error, so reporting "not ready" as an error
+// is what makes retry/backoff do the waiting.
+var errStageNotReady = errors.New("stage not ready")
+
+// ShellRunner executes the stages a SOP declares as data.
+//
+// It is the piece that lets a SOP be written in YAML alone. A function stage
+// runs its `run:` script and reports the route its exit status implies; an
+// agent stage is handed to Agent, which the caller supplies because dispatching
+// one needs the orchestrator and this package must not depend on it.
+//
+// Exit status is the contract:
+//
+//	0                 PASS — take the stage's PASS route, or its forward path
+//	RetryExitCode     not ready — return an error so the engine backs off and
+//	                  runs the stage again, which is how polling is expressed
+//	anything else     FAIL — take the stage's FAIL route
+type ShellRunner struct {
+	// Dir is the working directory for stage scripts. Empty means the
+	// process's own.
+	Dir string
+
+	// RunDir holds a run's artifacts. It is exported to scripts as
+	// PI_RUN_DIR, and `produces:` paths resolve inside it.
+	RunDir string
+
+	// Env is extra environment for stage scripts, as "K=V" strings, on top of
+	// the process environment.
+	Env []string
+
+	// Shell interprets a stage's script. Empty means "bash".
+	Shell string
+
+	// Agent runs an agent stage. When nil, an agent stage fails rather than
+	// silently passing — a stage that quietly does nothing is the failure mode
+	// the declarative SOP exists to prevent.
+	Agent StageRunner
+
+	// Observe receives each stage's combined output as it completes, for the
+	// transcript. Optional.
+	Observe func(stage, output string)
+}
+
+// RunStage implements StageRunner.
+func (r ShellRunner) RunStage(ctx context.Context, req StageRequest) (StageOutcome, error) {
+	if req.Stage.AgentName() != "" {
+		if r.Agent == nil {
+			return StageOutcome{}, fmt.Errorf("stage %q dispatches to agent %q but no agent runner is configured",
+				req.Stage.ID, req.Stage.AgentName())
+		}
+		return r.Agent.RunStage(ctx, req)
+	}
+
+	// A function stage with no script is a marker — a join or a routing point.
+	// It passes rather than failing, so a SOP can name a step it does not yet
+	// automate.
+	if strings.TrimSpace(req.Stage.Run) == "" && strings.TrimSpace(req.Stage.Gate) == "" {
+		return StageOutcome{}, nil
+	}
+
+	if route, err := r.runScript(ctx, req, req.Stage.Run); err != nil || route != "" {
+		return StageOutcome{Route: route}, err
+	}
+
+	// The gate runs after the body, and a failing gate fails the stage: that
+	// ordering is what makes "verified" mean verified.
+	if route, err := r.runScript(ctx, req, req.Stage.Gate); err != nil || route != "" {
+		return StageOutcome{Route: route}, err
+	}
+
+	if findings := r.validateProduces(req.Stage); !findings.OK() {
+		r.observe(req.Stage.ID, findings.Format())
+		return StageOutcome{Route: sop.VerdictFail, Output: findings.Format()}, nil
+	}
+	return StageOutcome{Route: sop.VerdictPass}, nil
+}
+
+// runScript runs one script and maps its exit status onto a route. It returns
+// an empty route when the script succeeded, so the caller can continue to the
+// next step of the stage.
+func (r ShellRunner) runScript(ctx context.Context, req StageRequest, script string) (string, error) {
+	if strings.TrimSpace(script) == "" {
+		return "", nil
+	}
+
+	shell := r.Shell
+	if shell == "" {
+		shell = "bash"
+	}
+
+	cmd := exec.CommandContext(ctx, shell, "-c", script)
+	cmd.Dir = r.Dir
+	cmd.Env = append(os.Environ(), r.stageEnv(req)...)
+
+	out, err := cmd.CombinedOutput()
+	r.observe(req.Stage.ID, string(out))
+	if err == nil {
+		return "", nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.ExitCode() == RetryExitCode {
+			return "", fmt.Errorf("%w: %s", errStageNotReady, req.Stage.ID)
+		}
+		return sop.VerdictFail, nil
+	}
+	// The script could not be started at all — a missing shell, a bad working
+	// directory. That is not a stage verdict, it is a broken run.
+	return "", fmt.Errorf("running stage %q: %w", req.Stage.ID, err)
+}
+
+// stageEnv exports the run's context to a stage script, so the SOP addresses it
+// by name instead of having values interpolated into its text.
+func (r ShellRunner) stageEnv(req StageRequest) []string {
+	env := []string{
+		"PI_STAGE=" + req.Stage.ID,
+		"PI_CYCLE=" + strconv.Itoa(req.Cycle),
+	}
+	if r.RunDir != "" {
+		env = append(env, "PI_RUN_DIR="+r.RunDir)
+	}
+	return append(env, r.Env...)
+}
+
+// validateProduces applies each declared artifact's rules. The rules are the
+// same registry the plan artifacts use, so a SOP author has one vocabulary
+// rather than two.
+func (r ShellRunner) validateProduces(stage sop.Stage) validate.Findings {
+	var out validate.Findings
+	for _, p := range stage.Produces {
+		path := p.Path
+		if !filepath.IsAbs(path) && r.RunDir != "" {
+			path = filepath.Join(r.RunDir, path)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			out = append(out, validate.Finding{
+				Artifact: p.Path, Rule: "produces", Severity: validate.SeverityError,
+				Message: fmt.Sprintf("stage %q declares %s but it was not written: %v", stage.ID, p.Path, err),
+			})
+			continue
+		}
+		target := validate.Target{Artifact: p.Path, Content: string(content), RepoRoot: r.Dir}
+		for _, spec := range p.Validate {
+			out = append(out, validate.Apply(spec, target)...)
+		}
+	}
+	return out
+}
+
+func (r ShellRunner) observe(stage, output string) {
+	if r.Observe != nil && strings.TrimSpace(output) != "" {
+		r.Observe(stage, output)
+	}
+}
+
+// StageNotReady reports whether err is a stage asking to be run again.
+func StageNotReady(err error) bool { return errors.Is(err, errStageNotReady) }

--- a/internal/sop/exec/shell_test.go
+++ b/internal/sop/exec/shell_test.go
@@ -58,12 +58,15 @@ func TestShellRunnerExitStatusRoutes(t *testing.T) {
 // stage verified.
 func TestShellRunnerRunsGateAfterBody(t *testing.T) {
 	dir := t.TempDir()
-	order := filepath.Join(dir, "order")
 
+	// The script names the file relative to the runner's working directory.
+	// Interpolating the absolute path would embed a Windows path into a bash
+	// script, where the backslashes read as escapes and the redirect lands
+	// somewhere else entirely.
 	stage := sop.Stage{
 		ID:   "s",
-		Run:  "echo body >> " + order,
-		Gate: "echo gate >> " + order + "; exit 1",
+		Run:  "echo body >> order",
+		Gate: "echo gate >> order; exit 1",
 	}
 	out, err := runStage(t, ShellRunner{Dir: dir}, stage)
 	if err != nil {
@@ -73,7 +76,7 @@ func TestShellRunnerRunsGateAfterBody(t *testing.T) {
 		t.Errorf("route = %q, want %q — a failing gate fails the stage", out.Route, sop.VerdictFail)
 	}
 
-	got, err := os.ReadFile(order)
+	got, err := os.ReadFile(filepath.Join(dir, "order"))
 	if err != nil {
 		t.Fatalf("read order: %v", err)
 	}
@@ -86,13 +89,15 @@ func TestShellRunnerRunsGateAfterBody(t *testing.T) {
 // running the gate anyway would report on a stage that never happened.
 func TestShellRunnerSkipsGateWhenBodyFails(t *testing.T) {
 	dir := t.TempDir()
-	marker := filepath.Join(dir, "gate-ran")
 
-	stage := sop.Stage{ID: "s", Run: "exit 1", Gate: "touch " + marker}
+	// Relative, so the gate would really write inside dir on every platform —
+	// an absolute Windows path in a bash script would make this pass whether
+	// or not the gate ran.
+	stage := sop.Stage{ID: "s", Run: "exit 1", Gate: "touch gate-ran"}
 	if _, err := runStage(t, ShellRunner{Dir: dir}, stage); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := os.Stat(marker); err == nil {
+	if _, err := os.Stat(filepath.Join(dir, "gate-ran")); err == nil {
 		t.Error("gate ran after a failed body")
 	}
 }
@@ -105,7 +110,7 @@ func TestShellRunnerExportsStageEnv(t *testing.T) {
 
 	stage := sop.Stage{
 		ID:  "watch",
-		Run: `printf '%s %s %s %s' "$PI_STAGE" "$PI_CYCLE" "$PI_RUN_DIR" "$PI_PR" > ` + filepath.Join(dir, "env"),
+		Run: `printf '%s %s %s %s' "$PI_STAGE" "$PI_CYCLE" "$PI_RUN_DIR" "$PI_PR" > env`,
 	}
 	r := ShellRunner{Dir: dir, RunDir: runDir, Env: []string{"PI_PR=https://example.test/pull/1"}}
 	if _, err := r.RunStage(context.Background(), StageRequest{Stage: stage, Cycle: 3}); err != nil {

--- a/internal/sop/exec/shell_test.go
+++ b/internal/sop/exec/shell_test.go
@@ -1,0 +1,235 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// runStage is the shorthand every case here needs: one stage, one runner, one
+// outcome.
+func runStage(t *testing.T, r ShellRunner, stage sop.Stage) (StageOutcome, error) {
+	t.Helper()
+	return r.RunStage(context.Background(), StageRequest{Stage: stage, Cycle: 1})
+}
+
+// TestShellRunnerExitStatusRoutes pins the contract the whole declarative SOP
+// rests on: a script's exit status, and nothing else, decides the route.
+func TestShellRunnerExitStatusRoutes(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		wantRoute string
+		wantRetry bool
+	}{
+		{name: "success passes", script: "true", wantRoute: sop.VerdictPass},
+		{name: "failure routes FAIL", script: "exit 1", wantRoute: sop.VerdictFail},
+		{name: "other failure routes FAIL", script: "exit 2", wantRoute: sop.VerdictFail},
+		{name: "temp fail asks to be retried", script: "exit 75", wantRetry: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runStage(t, ShellRunner{}, sop.Stage{ID: "s", Run: tt.script})
+
+			if tt.wantRetry {
+				if !StageNotReady(err) {
+					t.Fatalf("err = %v, want a not-ready error so the engine retries", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if out.Route != tt.wantRoute {
+				t.Errorf("route = %q, want %q", out.Route, tt.wantRoute)
+			}
+		})
+	}
+}
+
+// TestShellRunnerRunsGateAfterBody verifies the gate runs after the body and
+// can fail a stage whose body succeeded — the ordering that makes a "verified"
+// stage verified.
+func TestShellRunnerRunsGateAfterBody(t *testing.T) {
+	dir := t.TempDir()
+	order := filepath.Join(dir, "order")
+
+	stage := sop.Stage{
+		ID:   "s",
+		Run:  "echo body >> " + order,
+		Gate: "echo gate >> " + order + "; exit 1",
+	}
+	out, err := runStage(t, ShellRunner{Dir: dir}, stage)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Route != sop.VerdictFail {
+		t.Errorf("route = %q, want %q — a failing gate fails the stage", out.Route, sop.VerdictFail)
+	}
+
+	got, err := os.ReadFile(order)
+	if err != nil {
+		t.Fatalf("read order: %v", err)
+	}
+	if want := "body\ngate\n"; string(got) != want {
+		t.Errorf("execution order = %q, want %q", got, want)
+	}
+}
+
+// TestShellRunnerSkipsGateWhenBodyFails verifies a failed body short-circuits:
+// running the gate anyway would report on a stage that never happened.
+func TestShellRunnerSkipsGateWhenBodyFails(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "gate-ran")
+
+	stage := sop.Stage{ID: "s", Run: "exit 1", Gate: "touch " + marker}
+	if _, err := runStage(t, ShellRunner{Dir: dir}, stage); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("gate ran after a failed body")
+	}
+}
+
+// TestShellRunnerExportsStageEnv verifies a script addresses the run by
+// environment variable rather than by text interpolation.
+func TestShellRunnerExportsStageEnv(t *testing.T) {
+	dir := t.TempDir()
+	runDir := t.TempDir()
+
+	stage := sop.Stage{
+		ID:  "watch",
+		Run: `printf '%s %s %s %s' "$PI_STAGE" "$PI_CYCLE" "$PI_RUN_DIR" "$PI_PR" > ` + filepath.Join(dir, "env"),
+	}
+	r := ShellRunner{Dir: dir, RunDir: runDir, Env: []string{"PI_PR=https://example.test/pull/1"}}
+	if _, err := r.RunStage(context.Background(), StageRequest{Stage: stage, Cycle: 3}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "env"))
+	if err != nil {
+		t.Fatalf("read env: %v", err)
+	}
+	want := "watch 3 " + runDir + " https://example.test/pull/1"
+	if string(got) != want {
+		t.Errorf("stage env = %q, want %q", got, want)
+	}
+}
+
+// TestShellRunnerValidatesProduces verifies a stage that exits 0 without
+// writing what it declared still fails. A stage reporting success for an
+// artifact nobody checked is the failure the SOP's validators exist to catch.
+func TestShellRunnerValidatesProduces(t *testing.T) {
+	runDir := t.TempDir()
+	stage := sop.Stage{
+		ID:       "diagnose",
+		Run:      "true",
+		Produces: []sop.Produces{{Path: "failures.log", Validate: []string{"non_empty"}}},
+	}
+
+	out, err := runStage(t, ShellRunner{RunDir: runDir}, stage)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Route != sop.VerdictFail {
+		t.Errorf("route = %q, want %q for a missing declared artifact", out.Route, sop.VerdictFail)
+	}
+
+	// Writing it makes the same stage pass.
+	if err := os.WriteFile(filepath.Join(runDir, "failures.log"), []byte("boom\n"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	out, err = runStage(t, ShellRunner{RunDir: runDir}, stage)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Route != sop.VerdictPass {
+		t.Errorf("route = %q, want %q once the artifact exists", out.Route, sop.VerdictPass)
+	}
+}
+
+// TestShellRunnerDispatchesAgentStages verifies an agent stage goes to the
+// injected runner rather than the shell.
+func TestShellRunnerDispatchesAgentStages(t *testing.T) {
+	var got string
+	r := ShellRunner{Agent: RunnerFunc(func(_ context.Context, req StageRequest) (StageOutcome, error) {
+		got = req.Stage.AgentName()
+		return StageOutcome{Route: sop.VerdictPass}, nil
+	})}
+
+	if _, err := runStage(t, r, sop.Stage{ID: "fix", Agent: "worker"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "worker" {
+		t.Errorf("dispatched agent = %q, want worker", got)
+	}
+}
+
+// TestShellRunnerRefusesAgentStageWithoutRunner verifies an agent stage with no
+// runner configured fails loudly. Passing silently would let a SOP report a
+// stage complete that never ran.
+func TestShellRunnerRefusesAgentStageWithoutRunner(t *testing.T) {
+	_, err := runStage(t, ShellRunner{}, sop.Stage{ID: "fix", Agent: "worker"})
+	if err == nil {
+		t.Fatal("expected an error for an agent stage with no agent runner")
+	}
+	if !strings.Contains(err.Error(), "worker") {
+		t.Errorf("error %q should name the agent it could not dispatch", err)
+	}
+}
+
+// TestShellRunnerEmptyStagePasses verifies a stage with no script is a marker
+// rather than a failure, so a SOP can name a step it does not yet automate.
+func TestShellRunnerEmptyStagePasses(t *testing.T) {
+	out, err := runStage(t, ShellRunner{}, sop.Stage{ID: "marker"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Route != "" {
+		t.Errorf("route = %q, want the forward path", out.Route)
+	}
+}
+
+// TestShellRunnerReportsUnstartableScript verifies a shell that cannot run at
+// all is a broken run, not a stage verdict.
+func TestShellRunnerReportsUnstartableScript(t *testing.T) {
+	r := ShellRunner{Shell: filepath.Join(t.TempDir(), "no-such-shell")}
+	_, err := runStage(t, r, sop.Stage{ID: "s", Run: "true"})
+	if err == nil {
+		t.Fatal("expected an error when the shell cannot be started")
+	}
+	if StageNotReady(err) {
+		t.Error("an unstartable shell must not be reported as not-ready")
+	}
+}
+
+// TestShellRunnerObservesOutput verifies stage output reaches the transcript
+// hook, which is what the TUI renders.
+func TestShellRunnerObservesOutput(t *testing.T) {
+	var stage, out string
+	r := ShellRunner{Observe: func(s, o string) { stage, out = s, o }}
+
+	if _, err := runStage(t, r, sop.Stage{ID: "triage", Run: "echo hello"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stage != "triage" || !strings.Contains(out, "hello") {
+		t.Errorf("observed (%q, %q), want triage and output containing hello", stage, out)
+	}
+}
+
+// TestStageNotReadyIgnoresOtherErrors guards the helper against reporting any
+// error as a retry request.
+func TestStageNotReadyIgnoresOtherErrors(t *testing.T) {
+	if StageNotReady(errors.New("boom")) {
+		t.Error("an unrelated error must not read as not-ready")
+	}
+	if StageNotReady(nil) {
+		t.Error("nil must not read as not-ready")
+	}
+}

--- a/internal/sop/load.go
+++ b/internal/sop/load.go
@@ -16,7 +16,11 @@ var defaultPlanSOP []byte
 //go:embed run.sop.yaml
 var defaultRunSOP []byte
 
-// LoadDefinition returns the declarative SOP named `name` ("plan" or "run").
+//go:embed pr-autofix.sop.yaml
+var defaultPRAutofixSOP []byte
+
+// LoadDefinition returns the declarative SOP named `name` ("plan", "run" or
+// "pr-autofix").
 //
 // Resolution mirrors LoadPDD: project .pi-go/sops/<name>.sop.yaml → global
 // ~/.pi-go/sops/<name>.sop.yaml → embedded default. An override that fails to
@@ -90,6 +94,8 @@ func embeddedDefinition(name string) (data []byte, source string) {
 	switch name {
 	case "run":
 		return defaultRunSOP, "embedded run.sop.yaml"
+	case "pr-autofix":
+		return defaultPRAutofixSOP, "embedded pr-autofix.sop.yaml"
 	default:
 		return defaultPlanSOP, "embedded plan.sop.yaml"
 	}

--- a/internal/sop/pr-autofix.sop.yaml
+++ b/internal/sop/pr-autofix.sop.yaml
@@ -1,0 +1,156 @@
+sop: pr-autofix
+version: 2
+description: Watch a GitHub PR's checks and fix them until the PR is green
+
+# The PR's own branch is the workspace. A per-run worktree would put the fixes
+# somewhere the PR cannot see: the whole point is to push to the branch under
+# review, so the run edits the checkout it was started from and never merges.
+workspace:
+  worktree: none
+  merge_on: never
+  cleanup: always
+
+defaults:
+  timeout: 30m
+  max_concurrency: 1
+  on_rate_limit: throttle
+
+preflight:
+  - id: resolve
+    description: Resolve the PR and refuse a run that cannot push to it
+    kind: function
+    run: |
+      set -euo pipefail
+      gh pr view "$PI_PR" --json number,state,headRefName,mergeStateStatus > "$PI_RUN_DIR/pr.json"
+      test "$(jq -r .state < "$PI_RUN_DIR/pr.json")" = OPEN
+      test "$(git rev-parse --abbrev-ref HEAD)" = "$(jq -r .headRefName < "$PI_RUN_DIR/pr.json")"
+    on_fail: abort
+    next: watch
+
+stages:
+  # Polling belongs to the engine, not to a loop inside a shell command: a stage
+  # that blocks for the length of a CI run reports nothing while it waits, and
+  # the sidebar would sit on one glyph for ten minutes. One poll per activation
+  # keeps the run observable and lets retry/backoff do the waiting.
+  - id: watch
+    description: Poll the PR's checks until they settle
+    kind: function
+    # Exit 75 is the engine's "not ready": it re-runs the stage under the retry
+    # policy below rather than taking a failure edge, which is how one poll per
+    # activation adds up to a wait without blocking a stage for the length of a
+    # CI run.
+    run: |
+      set -euo pipefail
+      gh pr view "$PI_PR" --json statusCheckRollup > "$PI_RUN_DIR/checks.json"
+      pending=$(jq '[.statusCheckRollup[] | select((.status // "COMPLETED") != "COMPLETED")] | length' \
+        < "$PI_RUN_DIR/checks.json")
+      test "$pending" -eq 0 || exit 75
+    retry:
+      max_attempts: 60
+      initial_delay: 20s
+      max_delay: 60s
+      backoff: 1.5
+      jitter: 0.2
+    next: triage
+
+  - id: triage
+    description: Separate a green PR from the checks that actually failed
+    kind: function
+    run: |
+      set -euo pipefail
+      jq -r '[.statusCheckRollup[]
+              | select((.conclusion // .state) as $c
+                       | $c != "SUCCESS" and $c != "NEUTRAL" and $c != "SKIPPED")]' \
+        < "$PI_RUN_DIR/checks.json" > "$PI_RUN_DIR/failing.json"
+      test "$(jq 'length' < "$PI_RUN_DIR/failing.json")" -eq 0
+    routes:
+      PASS: summary
+      FAIL: diagnose
+
+  - id: diagnose
+    description: Pull the failing jobs' logs so the fix has evidence, not guesses
+    kind: function
+    run: |
+      set -euo pipefail
+      : > "$PI_RUN_DIR/failures.log"
+      jq -r '.[] | (.name // .context) + "\t" + (.detailsUrl // "")' < "$PI_RUN_DIR/failing.json" |
+      while IFS=$'\t' read -r name url; do
+        printf '=== %s ===\n' "$name" >> "$PI_RUN_DIR/failures.log"
+        run_id=$(printf '%s' "$url" | grep -oE 'runs/[0-9]+' | cut -d/ -f2 || true)
+        job_id=$(printf '%s' "$url" | grep -oE 'job/[0-9]+' | cut -d/ -f2 || true)
+        if [ -n "$run_id" ] && [ -n "$job_id" ]; then
+          gh run view "$run_id" --job "$job_id" --log-failed 2>&1 | tail -n 200 >> "$PI_RUN_DIR/failures.log"
+        else
+          printf 'no job log available; check %s\n' "$url" >> "$PI_RUN_DIR/failures.log"
+        fi
+      done
+      test -s "$PI_RUN_DIR/failures.log"
+    next: fix
+    produces:
+      - path: failures.log
+        validate:
+          - non_empty
+
+  - id: fix
+    description: Fix the failing checks in the working tree
+    agent: worker
+    inputs: [failures.log, failing.json]
+    timeout: 20m
+    next: gates
+
+  # The local gates are what stop a blind push. A fix that does not build here
+  # would burn a full CI cycle to learn the same thing ten minutes later.
+  - id: gates
+    description: Prove the fix locally before it costs a CI run
+    kind: function
+    run: |
+      set -euo pipefail
+      go build ./...
+      go vet ./...
+      go test ./...
+      make lint
+    timeout: 20m
+    routes:
+      PASS: commit
+      FAIL: fix
+
+  # Signing is interactive here: gpg.ssh.program is 1Password's op-ssh-sign,
+  # which prompts. A run left unattended parks on this stage rather than
+  # failing, and the sidebar shows it as waiting, because the commit is one
+  # approval away rather than broken.
+  - id: commit
+    description: Commit the fix, signed and signed off
+    kind: function
+    run: |
+      set -euo pipefail
+      git add -A
+      git diff --cached --quiet && exit 0
+      git commit -s -S -m "$PI_FIX_MESSAGE"
+    timeout: 10m
+    on_fail: abort
+    next: push
+
+  - id: push
+    description: Push to the PR branch, which starts a fresh check run
+    kind: function
+    run: git push
+    on_fail: abort
+    loop_back: watch
+    max_cycles: 5
+
+  - id: summary
+    description: Report what was fixed and how many cycles it took
+    kind: function
+    run: |
+      set -euo pipefail
+      {
+        printf '# pr-autofix %s\n\n' "$PI_PR"
+        printf 'Cycles: %s\n\n' "$PI_CYCLE"
+        printf '## Final check status\n\n'
+        jq -r '.statusCheckRollup[] | "- " + (.name // .context) + ": " + (.conclusion // .state)' \
+          < "$PI_RUN_DIR/checks.json"
+      } > "$PI_RUN_DIR/summary.md"
+    produces:
+      - path: summary.md
+        validate:
+          - non_empty

--- a/internal/sop/pr-autofix.sop.yaml
+++ b/internal/sop/pr-autofix.sop.yaml
@@ -133,9 +133,15 @@ stages:
   - id: push
     description: Push to the PR branch, which starts a fresh check run
     kind: function
-    run: git push
+    run: |
+      set -euo pipefail
+      git push
+      # A successful push starts a new CI run, so the run loops back to watch
+      # the checks settle. routes PASS takes the edge; loop_back would need
+      # RecheckSignal, which a shell stage cannot emit.
+    routes:
+      PASS: watch
     on_fail: abort
-    loop_back: watch
     max_cycles: 5
 
   - id: summary

--- a/internal/sop/prautofix_sop_test.go
+++ b/internal/sop/prautofix_sop_test.go
@@ -17,3 +17,27 @@ func TestPRAutofixSOPLints(t *testing.T) {
 		t.Fatalf("compile: %v", err)
 	}
 }
+
+// TestPRAutofixPushRoutesToWatch pins that a successful push loops back to
+// watch — the run re-polls CI after pushing, rather than ending. The push
+// stage uses routes PASS→watch (not loop_back, which needs RecheckSignal — a
+// route a shell stage cannot emit) and max_cycles bounds the loop.
+func TestPRAutofixPushRoutesToWatch(t *testing.T) {
+	def, err := LoadEmbeddedDefinition("pr-autofix")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	push, ok := def.Stage("push")
+	if !ok {
+		t.Fatal("push stage not found")
+	}
+	if push.LoopBack != "" {
+		t.Errorf("push.loop_back = %q, want empty — loop_back needs RecheckSignal, which a shell stage cannot emit", push.LoopBack)
+	}
+	if got := push.Routes["PASS"]; got != "watch" {
+		t.Errorf("push.routes[PASS] = %q, want %q", got, "watch")
+	}
+	if push.MaxCycle != 5 {
+		t.Errorf("push.max_cycles = %d, want 5", push.MaxCycle)
+	}
+}

--- a/internal/sop/prautofix_sop_test.go
+++ b/internal/sop/prautofix_sop_test.go
@@ -1,0 +1,19 @@
+package sop
+
+import "testing"
+
+func TestPRAutofixSOPLints(t *testing.T) {
+	def, err := LoadEmbeddedDefinition("pr-autofix")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if def.SOP != "pr-autofix" {
+		t.Fatalf("sop name = %q", def.SOP)
+	}
+	if f := LintDefinition(def); !f.OK() {
+		t.Fatalf("lint findings:\n%s", f.Format())
+	}
+	if _, err := Compile(def, DescribeFactory{}); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+}

--- a/internal/sop/schema.go
+++ b/internal/sop/schema.go
@@ -98,6 +98,12 @@ type Stage struct {
 	Timeout Duration `yaml:"timeout"`
 	Retry   *Retry   `yaml:"retry"`
 
+	// Run is the shell command that *is* a function stage's body. Gate runs
+	// after a body; Run is the body, which is what lets a SOP express a step
+	// like "poll the PR's checks" as data rather than as Go. Exit status is
+	// the stage's route: 0 is PASS, non-zero is FAIL.
+	Run string `yaml:"run"`
+
 	// Gate is a shell command the engine runs after the stage body. Running it
 	// here rather than asking the LLM to is what makes a "verified" slice
 	// verified.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -113,6 +113,11 @@ var slashCommandSpecs = []slashCommandSpec{
 		desc: "Execute a spec with task agent (verifies subagent exit status before merging)",
 		run:  (*model).handleRunCommand,
 	},
+	{
+		name: "/pr-autofix",
+		desc: "Watch a GitHub PR's checks and fix them until it is green",
+		run:  (*model).handlePRAutofixCommand,
+	},
 	{name: "/skills", desc: "List skills (create, load)", run: (*model).handleSkillsCommand},
 	{name: "/skill-list", desc: "List all loaded skills", hidden: true, run: slashCmdBare((*model).handleSkillListCommand)},
 	{name: "/skill-load", desc: "Reload skills from disk", hidden: true, run: slashCmdBare((*model).handleSkillLoadCommand)},

--- a/internal/tui/complexity_commands_test.go
+++ b/internal/tui/complexity_commands_test.go
@@ -85,6 +85,7 @@ func TestCplxSlashCommandSpecs_CoverExpectedSet(t *testing.T) {
 	want := []string{
 		"/help", "/clear", "/copy", "/model", "/session", "/context", "/branch",
 		"/compact", "/subagents", "/history", "/login", "/commit", "/plan", "/run",
+		"/pr-autofix",
 		"/skills", "/skill-list", "/skill-load", "/skill-create", "/theme", "/ping",
 		"/rtk", "/mcp", "/restart", "/exit", "/quit",
 	}
@@ -112,6 +113,9 @@ func TestCplxSlashCommands_DerivedOrder(t *testing.T) {
 	want := []string{
 		"/help", "/clear", "/copy", "/model", "/session", "/context", "/branch",
 		"/compact", "/subagents", "/history", "/login", "/commit", "/plan", "/run",
+		// After /plan, so "/p" still completes to /plan and "/pr" is
+		// unambiguous: autocomplete returns the first prefix match.
+		"/pr-autofix",
 		"/skills", "/theme", "/ping", "/rtk", "/mcp", "/restart", "/exit", "/quit",
 	}
 	if len(slashCommands) != len(want) {

--- a/internal/tui/prautofix.go
+++ b/internal/tui/prautofix.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -254,6 +255,9 @@ func (m *model) handlePRAutofixMsg(in prAutofixChan) (tea.Model, tea.Cmd) {
 	switch {
 	case in.msg.event != nil:
 		st.tracker.observe(in.msg.event)
+		if stage, cycle, ok := prAutofixStageStart(in.msg.event); ok {
+			m.appendAssistant(prAutofixStartLine(stage, cycle))
+		}
 	case in.msg.output != "":
 		m.appendAssistant(prAutofixStageLine(in.msg.stage, in.msg.output))
 	}
@@ -284,6 +288,57 @@ func prAutofixStageLine(stage, output string) string {
 		lines = append(lines[:maxLines], fmt.Sprintf("… %d more lines", omitted))
 	}
 	return "[" + stage + "] " + strings.Join(lines, "\n")
+}
+
+// prAutofixStageStart reports whether ev is a lifecycle event (a stage starting)
+// and, if so, the stage id and its cycle number. Cycle is 1 on first activation
+// and increments each time the graph routes back to the stage.
+func prAutofixStageStart(ev *session.Event) (stage string, cycle int, ok bool) {
+	stage, ok = sopexec.StageStarted(ev)
+	if !ok {
+		return "", 0, false
+	}
+	// The lifecycle event encodes the cycle as "stage#N" in Branch. StageStarted
+	// strips it; re-read the raw branch to recover the number.
+	if ev.Branch != "" {
+		for i := range ev.Branch {
+			if ev.Branch[i] == '#' {
+				if n, err := strconv.Atoi(ev.Branch[i+1:]); err == nil {
+					return stage, n, true
+				}
+				break
+			}
+		}
+	}
+	return stage, 1, true
+}
+
+// prAutofixStageNarration maps a stage id to the one-line description shown in
+// the transcript when the stage starts. This is the narration that makes a run
+// observable stage-by-stage rather than a stream of raw script output.
+var prAutofixStageNarration = map[string]string{
+	"resolve":  "Resolving PR and checking out the branch",
+	"watch":    "Polling CI checks until they settle",
+	"triage":   "Triaging check results — green or failing?",
+	"diagnose": "Pulling failing job logs for evidence",
+	"fix":      "Fixing the failing checks in the working tree",
+	"gates":    "Running local gates (build, vet, test, lint)",
+	"commit":   "Committing the fix (signed, signed off)",
+	"push":     "Pushing to the PR branch — a fresh CI run starts",
+	"summary":  "Writing the summary",
+}
+
+// prAutofixStartLine renders the narration for a stage starting. A cycle > 1
+// means the graph has looped back, so the line says which cycle it is.
+func prAutofixStartLine(stage string, cycle int) string {
+	desc := prAutofixStageNarration[stage]
+	if desc == "" {
+		desc = stage
+	}
+	if cycle > 1 {
+		return fmt.Sprintf("▶ %s — %s (cycle %d)", stage, desc, cycle)
+	}
+	return fmt.Sprintf("▶ %s — %s", stage, desc)
 }
 
 // showPRAutofixUsage explains the command.

--- a/internal/tui/prautofix.go
+++ b/internal/tui/prautofix.go
@@ -1,0 +1,309 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+
+	"github.com/dimetron/pi-go/internal/sop"
+	sopexec "github.com/dimetron/pi-go/internal/sop/exec"
+	"github.com/dimetron/pi-go/internal/subagent"
+)
+
+// prAutofixState tracks one /pr-autofix run.
+//
+// Unlike /plan and /run, nothing here mirrors the workflow: the SOP is the
+// workflow, the engine walks it, and this struct only holds what the TUI has
+// to draw. Stage status comes from stageTracker, which reads the engine's own
+// event stream rather than guessing from artifacts on disk.
+type prAutofixState struct {
+	pr      string // the PR as the user gave it, passed to gh
+	runDir  string // where stage artifacts land
+	tracker *stageTracker
+	started time.Time
+
+	done bool
+	err  error
+}
+
+// prAutofixMsg carries one step of a run back to the TUI.
+type prAutofixMsg struct {
+	event  *session.Event // engine event; drives stage status
+	stage  string         // stage that produced Output, for transcript lines
+	output string
+	done   bool
+	err    error
+}
+
+// prNumber matches the forms a PR is named by: a full URL, a #123, or a bare
+// number. gh accepts all three, so this only has to recognize them well enough
+// to reject something that is plainly not a PR.
+var prNumber = regexp.MustCompile(`^(https://github\.com/[^/]+/[^/]+/pull/\d+|#?\d+)$`)
+
+// handlePRAutofixCommand starts a /pr-autofix run.
+func (m *model) handlePRAutofixCommand(args []string) (tea.Model, tea.Cmd) {
+	if len(args) == 0 {
+		m.showPRAutofixUsage()
+		return m, nil
+	}
+	target := strings.TrimSpace(args[0])
+	if !prNumber.MatchString(target) {
+		m.appendAssistant(fmt.Sprintf("Not a pull request: %q. Pass a PR URL, #123, or 123.", target))
+		return m, nil
+	}
+	if m.prAutofix != nil && !m.prAutofix.done {
+		m.appendAssistant("A /pr-autofix run is already in flight. Wait for it to finish, or restart the session.")
+		return m, nil
+	}
+
+	runDir, err := os.MkdirTemp("", "pi-pr-autofix-")
+	if err != nil {
+		m.appendAssistant(fmt.Sprintf("Cannot create a run directory: %v", err))
+		return m, nil
+	}
+
+	m.prAutofix = &prAutofixState{
+		pr:      target,
+		runDir:  runDir,
+		tracker: newStageTracker(),
+		started: time.Now(),
+	}
+	m.appendAssistant(fmt.Sprintf("Watching %s. Fixing until green, up to 5 push cycles.", target))
+
+	ch := make(chan prAutofixMsg, 64)
+	go m.runPRAutofix(ch, target, runDir)
+	return m, waitForPRAutofix(ch)
+}
+
+// runPRAutofix walks the pr-autofix SOP to completion, reporting every engine
+// event and every stage's output on ch.
+//
+// It runs the SOP the user's overrides resolve to rather than the embedded copy
+// — a run is the one place an override is meant to take effect — while the
+// sidebar keeps drawing the embedded graph, so the diagram cannot drift from
+// what LoadEmbeddedDefinition compiles.
+func (m *model) runPRAutofix(ch chan<- prAutofixMsg, target, runDir string) {
+	defer close(ch)
+
+	def, err := sop.LoadDefinition(m.cfg.WorkDir, "pr-autofix")
+	if err != nil {
+		ch <- prAutofixMsg{done: true, err: err}
+		return
+	}
+
+	shell := sopexec.ShellRunner{
+		Dir:    m.cfg.WorkDir,
+		RunDir: runDir,
+		Env: []string{
+			"PI_PR=" + target,
+			"PI_FIX_MESSAGE=" + prAutofixCommitMessage,
+		},
+		Agent: m.prAutofixAgentRunner(runDir),
+		Observe: func(stage, out string) {
+			ch <- prAutofixMsg{stage: stage, output: out}
+		},
+	}
+
+	ag, _, err := sopexec.Agent(def, sopexec.NewFactory(shell))
+	if err != nil {
+		ch <- prAutofixMsg{done: true, err: err}
+		return
+	}
+	r, err := runner.New(runner.Config{
+		AppName:           "pi-pr-autofix",
+		Agent:             ag,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		ch <- prAutofixMsg{done: true, err: err}
+		return
+	}
+
+	var runErr error
+	for ev, err := range r.Run(context.Background(), "pi", "pr-autofix-"+filepath.Base(runDir),
+		genai.NewContentFromText(target, genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			runErr = err
+			break
+		}
+		ch <- prAutofixMsg{event: ev}
+	}
+	ch <- prAutofixMsg{done: true, err: runErr}
+}
+
+// prAutofixAgentRunner bridges an `agent:` stage to the subagent orchestrator.
+//
+// It blocks until the subagent finishes, because a SOP stage is finished when
+// its work is: returning early would let the graph advance to the local gates
+// while the fix was still being written.
+func (m *model) prAutofixAgentRunner(runDir string) sopexec.StageRunner {
+	orch := m.cfg.Orchestrator
+	workDir := m.cfg.WorkDir
+
+	return sopexec.RunnerFunc(func(ctx context.Context, req sopexec.StageRequest) (sopexec.StageOutcome, error) {
+		if orch == nil {
+			return sopexec.StageOutcome{}, fmt.Errorf("stage %q needs the subagent system, which is not available", req.Stage.ID)
+		}
+		cfg, err := orch.LookupAgent(req.Stage.AgentName())
+		if err != nil {
+			return sopexec.StageOutcome{}, fmt.Errorf("stage %q: %w", req.Stage.ID, err)
+		}
+
+		events, _, err := orch.Spawn(ctx, subagent.SpawnInput{
+			Agent:   cfg,
+			Prompt:  prAutofixStagePrompt(req.Stage, runDir),
+			WorkDir: workDir,
+		})
+		if err != nil {
+			return sopexec.StageOutcome{}, fmt.Errorf("stage %q: spawning %s: %w", req.Stage.ID, cfg.Name, err)
+		}
+
+		var failed bool
+		var text strings.Builder
+		for ev := range events {
+			switch ev.Type {
+			case "text_delta":
+				text.WriteString(ev.Content)
+			case "error":
+				failed = true
+				text.WriteString("\n" + ev.Error)
+			}
+		}
+		if failed {
+			return sopexec.StageOutcome{Route: sop.VerdictFail, Output: text.String()}, nil
+		}
+		return sopexec.StageOutcome{Route: sop.VerdictPass, Output: text.String()}, nil
+	})
+}
+
+// prAutofixStagePrompt builds an agent stage's task from the SOP: its own
+// description, plus the artifacts the stage declared as inputs.
+//
+// Reading the inputs here rather than naming them in the prompt is deliberate.
+// A stage that says "read failures.log" is a stage that depends on the agent
+// choosing to; pasting the evidence in removes the choice.
+func prAutofixStagePrompt(stage sop.Stage, runDir string) string {
+	var b strings.Builder
+	b.WriteString(stage.Description)
+	b.WriteString("\n\nThe failing checks are below, taken from the jobs' own logs.\n")
+	b.WriteString("Fix them in the working tree. Do not commit, push, or touch the PR — ")
+	b.WriteString("later stages do that once the local gates pass.\n")
+
+	for _, name := range stage.Inputs {
+		content, err := os.ReadFile(filepath.Join(runDir, name))
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&b, "\n--- %s ---\n%s\n", name, truncateForPrompt(string(content)))
+	}
+	return b.String()
+}
+
+// truncateForPrompt keeps a log's tail: a failing job says what went wrong at
+// the end, and the head is setup noise.
+func truncateForPrompt(s string) string {
+	const maxBytes = 24 * 1024
+	if len(s) <= maxBytes {
+		return s
+	}
+	return "… truncated …\n" + s[len(s)-maxBytes:]
+}
+
+// prAutofixCommitMessage is what a fix cycle commits under. It says which
+// machinery produced the commit without naming the session that drove it.
+const prAutofixCommitMessage = "fix: repair failing CI checks\n\n" +
+	"Applied by /pr-autofix from the failing jobs' logs, verified against the\n" +
+	"local gates (build, vet, test, lint) before pushing."
+
+// waitForPRAutofix reads one message from the run.
+func waitForPRAutofix(ch chan prAutofixMsg) tea.Cmd {
+	return func() tea.Msg {
+		msg, ok := <-ch
+		if !ok {
+			return prAutofixMsg{done: true}
+		}
+		return prAutofixChan{msg: msg, ch: ch}
+	}
+}
+
+// prAutofixChan pairs a message with the channel it came from, so Update can
+// queue the next read without holding the channel on the model.
+type prAutofixChan struct {
+	msg prAutofixMsg
+	ch  chan prAutofixMsg
+}
+
+// handlePRAutofixMsg folds one run message into the model.
+func (m *model) handlePRAutofixMsg(in prAutofixChan) (tea.Model, tea.Cmd) {
+	st := m.prAutofix
+	if st == nil {
+		return m, nil
+	}
+
+	switch {
+	case in.msg.event != nil:
+		st.tracker.observe(in.msg.event)
+	case in.msg.output != "":
+		m.appendAssistant(prAutofixStageLine(in.msg.stage, in.msg.output))
+	}
+
+	if in.msg.done {
+		st.done = true
+		st.err = in.msg.err
+		if in.msg.err != nil {
+			st.tracker.fail()
+			m.appendAssistant(fmt.Sprintf("pr-autofix stopped: %v", in.msg.err))
+		} else {
+			st.tracker.finish()
+			m.appendAssistant(fmt.Sprintf("pr-autofix finished in %s.", time.Since(st.started).Round(time.Second)))
+		}
+		return m, nil
+	}
+	return m, waitForPRAutofix(in.ch)
+}
+
+// prAutofixStageLine renders one stage's output for the transcript, trimmed:
+// a failing job log runs to hundreds of lines, and the whole of it belongs in
+// the artifact the fix agent reads, not in the chat.
+func prAutofixStageLine(stage, output string) string {
+	const maxLines = 12
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) > maxLines {
+		omitted := len(lines) - maxLines
+		lines = append(lines[:maxLines], fmt.Sprintf("… %d more lines", omitted))
+	}
+	return "[" + stage + "] " + strings.Join(lines, "\n")
+}
+
+// showPRAutofixUsage explains the command.
+func (m *model) showPRAutofixUsage() {
+	m.appendAssistant(strings.Join([]string{
+		"Usage: /pr-autofix <pr>",
+		"",
+		"Watches a GitHub PR's checks and fixes them until it is green:",
+		"poll → triage → pull the failing job logs → fix → local gates → commit → push, and back to poll.",
+		"",
+		"The PR's branch must be the one checked out here, and the run pushes to it.",
+		"Commits are signed, so each cycle waits on the signing prompt.",
+		"",
+		"  /pr-autofix 253",
+		"  /pr-autofix https://github.com/dimetron/pi-go/pull/253",
+	}, "\n"))
+}
+
+// appendAssistant adds one assistant line to the transcript. The TUI owns the
+// terminal, so this is the only way this mode says anything.
+func (m *model) appendAssistant(text string) {
+	m.chatModel.Messages = append(m.chatModel.Messages, message{role: "assistant", content: text})
+}

--- a/internal/tui/prautofix_test.go
+++ b/internal/tui/prautofix_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/adk/v2/session"
+
 	"github.com/dimetron/pi-go/internal/sop"
+	sopexec "github.com/dimetron/pi-go/internal/sop/exec"
 )
 
 // TestPRTargetAccepted pins which forms name a pull request. gh accepts a URL,
@@ -140,5 +143,58 @@ func TestPRAutofixSOPDrawsInSidebar(t *testing.T) {
 		if !slices.Contains(compiled.Order, id) {
 			t.Errorf("compiled order %v is missing stage %q", compiled.Order, id)
 		}
+	}
+}
+
+// TestPRAutofixStageStartExtractsCycle verifies the lifecycle event parser
+// recovers both the stage id and the cycle number, so the narration can say
+// "cycle 2" when the graph loops back.
+func TestPRAutofixStageStartExtractsCycle(t *testing.T) {
+	tests := []struct {
+		name      string
+		branch    string
+		author    string
+		wantStage string
+		wantCycle int
+		wantOK    bool
+	}{
+		{"first activation", "push", sopexec.LifecycleAuthor, "push", 1, true},
+		{"second cycle", "watch#2", sopexec.LifecycleAuthor, "watch", 2, true},
+		{"third cycle", "watch#3", sopexec.LifecycleAuthor, "watch", 3, true},
+		{"not a lifecycle event", "push", "model", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := &session.Event{Author: tt.author, Branch: tt.branch}
+			stage, cycle, ok := prAutofixStageStart(ev)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if stage != tt.wantStage {
+				t.Errorf("stage = %q, want %q", stage, tt.wantStage)
+			}
+			if cycle != tt.wantCycle {
+				t.Errorf("cycle = %d, want %d", cycle, tt.wantCycle)
+			}
+		})
+	}
+}
+
+// TestPRAutofixStartLineNarratesStage verifies the start line names the stage,
+// carries its description, and includes the cycle number on loops > 1.
+func TestPRAutofixStartLineNarratesStage(t *testing.T) {
+	if got := prAutofixStartLine("push", 1); !strings.Contains(got, "push") {
+		t.Errorf("first cycle: %q should name the stage", got)
+	}
+	if got := prAutofixStartLine("push", 1); !strings.Contains(got, "Pushing to the PR branch") {
+		t.Errorf("first cycle: %q should carry the stage's description", got)
+	}
+	if got := prAutofixStartLine("watch", 2); !strings.Contains(got, "cycle 2") {
+		t.Errorf("second cycle: %q should say which cycle it is", got)
+	}
+	// An unknown stage falls back to its id rather than empty text.
+	if got := prAutofixStartLine("unknown", 1); !strings.Contains(got, "unknown") {
+		t.Errorf("unknown stage: %q should fall back to its id", got)
 	}
 }

--- a/internal/tui/prautofix_test.go
+++ b/internal/tui/prautofix_test.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/sop"
+)
+
+// TestPRTargetAccepted pins which forms name a pull request. gh accepts a URL,
+// a #123 and a bare number; anything else is a typo worth rejecting before a
+// run starts rather than after gh fails.
+func TestPRTargetAccepted(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"https://github.com/dimetron/pi-go/pull/253", true},
+		{"#253", true},
+		{"253", true},
+		{"", false},
+		{"main", false},
+		{"https://github.com/dimetron/pi-go/issues/253", false},
+		{"https://example.com/dimetron/pi-go/pull/253", false},
+		{"253; rm -rf /", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := prNumber.MatchString(tt.in); got != tt.want {
+				t.Errorf("prNumber.MatchString(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPRAutofixStagePromptEmbedsInputs verifies the fix agent is handed the
+// evidence rather than told where to find it.
+func TestPRAutofixStagePromptEmbedsInputs(t *testing.T) {
+	runDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(runDir, "failures.log"), []byte("undefined: Foo"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	stage := sop.Stage{
+		ID:          "fix",
+		Description: "Fix the failing checks in the working tree",
+		Agent:       "worker",
+		Inputs:      []string{"failures.log", "missing.json"},
+	}
+	got := prAutofixStagePrompt(stage, runDir)
+
+	if !strings.Contains(got, stage.Description) {
+		t.Error("prompt should carry the stage's own description")
+	}
+	if !strings.Contains(got, "undefined: Foo") {
+		t.Error("prompt should embed the input's content, not just its name")
+	}
+	if !strings.Contains(got, "Do not commit, push") {
+		t.Error("prompt should tell the agent that later stages own the commit")
+	}
+	// A declared input that no stage wrote is skipped rather than fatal: the
+	// prompt is still useful with the evidence that does exist.
+	if strings.Contains(got, "--- missing.json ---") {
+		t.Error("a missing input should be skipped, not announced")
+	}
+}
+
+// TestTruncateForPromptKeepsTail verifies an oversized log keeps its end,
+// where a failing job says what actually went wrong.
+func TestTruncateForPromptKeepsTail(t *testing.T) {
+	body := strings.Repeat("noise\n", 20000) + "FINAL: the real error"
+	got := truncateForPrompt(body)
+
+	if len(got) > 25*1024 {
+		t.Errorf("truncated length = %d, want it bounded", len(got))
+	}
+	if !strings.Contains(got, "FINAL: the real error") {
+		t.Error("truncation dropped the tail, which is the part that matters")
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Error("truncation should say it happened")
+	}
+}
+
+// TestTruncateForPromptLeavesShortInputAlone verifies a log that fits is passed
+// through untouched.
+func TestTruncateForPromptLeavesShortInputAlone(t *testing.T) {
+	const short = "one line"
+	if got := truncateForPrompt(short); got != short {
+		t.Errorf("truncateForPrompt(%q) = %q, want it unchanged", short, got)
+	}
+}
+
+// TestPRAutofixStageLineTrims verifies a long stage output is trimmed for the
+// transcript. The whole log belongs in the artifact the fix agent reads; the
+// chat gets a readable excerpt.
+func TestPRAutofixStageLineTrims(t *testing.T) {
+	out := strings.Repeat("line\n", 40)
+	got := prAutofixStageLine("diagnose", out)
+
+	if !strings.HasPrefix(got, "[diagnose] ") {
+		t.Errorf("line = %q, want it to name its stage", got)
+	}
+	if n := strings.Count(got, "\n") + 1; n > 14 {
+		t.Errorf("rendered %d lines, want a trimmed excerpt", n)
+	}
+	if !strings.Contains(got, "more lines") {
+		t.Error("a trimmed excerpt should say how much it dropped")
+	}
+}
+
+// TestPRAutofixStageLineKeepsShortOutput verifies output that already fits is
+// shown whole.
+func TestPRAutofixStageLineKeepsShortOutput(t *testing.T) {
+	got := prAutofixStageLine("triage", "2 checks failing\n")
+	if got != "[triage] 2 checks failing" {
+		t.Errorf("line = %q, want the output kept whole", got)
+	}
+}
+
+// TestPRAutofixSOPDrawsInSidebar verifies the mode's graph is the compiled SOP
+// — the diagram and the executed workflow are the same definition, so they
+// cannot drift.
+func TestPRAutofixSOPDrawsInSidebar(t *testing.T) {
+	def, err := sop.LoadEmbeddedDefinition("pr-autofix")
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefinition: %v", err)
+	}
+	compiled, err := sop.Compile(def, sop.DescribeFactory{})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	want := []string{"resolve", "watch", "triage", "diagnose", "fix", "gates", "commit", "push", "summary"}
+	for _, id := range want {
+		if !slices.Contains(compiled.Order, id) {
+			t.Errorf("compiled order %v is missing stage %q", compiled.Order, id)
+		}
+	}
+}

--- a/internal/tui/prautofix_test.go
+++ b/internal/tui/prautofix_test.go
@@ -1,16 +1,22 @@
 package tui
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"google.golang.org/adk/v2/session"
 
+	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/sop"
 	sopexec "github.com/dimetron/pi-go/internal/sop/exec"
+	"github.com/dimetron/pi-go/internal/subagent"
 )
 
 // TestPRTargetAccepted pins which forms name a pull request. gh accepts a URL,
@@ -162,6 +168,10 @@ func TestPRAutofixStageStartExtractsCycle(t *testing.T) {
 		{"second cycle", "watch#2", sopexec.LifecycleAuthor, "watch", 2, true},
 		{"third cycle", "watch#3", sopexec.LifecycleAuthor, "watch", 3, true},
 		{"not a lifecycle event", "push", "model", "", 0, false},
+		// A branch whose suffix is not a number falls back to cycle 1 rather
+		// than dropping the stage start.
+		{"unparsable cycle", "watch#later", sopexec.LifecycleAuthor, "watch", 1, true},
+		{"no branch at all", "", sopexec.LifecycleAuthor, "", 1, true},
 	}
 
 	for _, tt := range tests {
@@ -196,5 +206,443 @@ func TestPRAutofixStartLineNarratesStage(t *testing.T) {
 	// An unknown stage falls back to its id rather than empty text.
 	if got := prAutofixStartLine("unknown", 1); !strings.Contains(got, "unknown") {
 		t.Errorf("unknown stage: %q should fall back to its id", got)
+	}
+}
+
+// --- Command, run loop and message folding ---
+
+// prAutofixModel builds the smallest model the mode needs: a transcript to
+// append to and a working directory to resolve the SOP from.
+func prAutofixModel(workDir string) *model {
+	return &model{
+		cfg:       Config{WorkDir: workDir},
+		chatModel: ChatModel{Messages: make([]message, 0)},
+	}
+}
+
+// lastAssistant returns the text of the last transcript line.
+func lastAssistant(t *testing.T, m *model) string {
+	t.Helper()
+	if len(m.chatModel.Messages) == 0 {
+		t.Fatal("no transcript lines were appended")
+	}
+	return m.chatModel.Messages[len(m.chatModel.Messages)-1].content
+}
+
+// writeSOPOverride installs a project SOP override under workDir, the path
+// LoadDefinition prefers over the embedded copy.
+func writeSOPOverride(t *testing.T, workDir, body string) {
+	t.Helper()
+	dir := filepath.Join(workDir, ".pi-go", "sops")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sops: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pr-autofix.sop.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+}
+
+// trivialSOP is a valid pr-autofix override whose stages are shell no-ops. It
+// exercises the engine end to end without reaching for gh or git.
+const trivialSOP = `sop: pr-autofix
+version: 2
+description: a no-op pr-autofix for tests
+workspace:
+  worktree: none
+  merge_on: never
+  cleanup: always
+stages:
+  - id: watch
+    description: pretend to poll
+    kind: function
+    run: echo watched
+    next: summary
+  - id: summary
+    description: pretend to summarize
+    kind: function
+    run: echo summarized
+`
+
+// TestPRAutofixCommandRejectsBadInput verifies the command explains itself
+// rather than starting a run it cannot finish.
+func TestPRAutofixCommandRejectsBadInput(t *testing.T) {
+	t.Run("no argument shows usage", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		if _, cmd := m.handlePRAutofixCommand(nil); cmd != nil {
+			t.Error("usage must not start a run")
+		}
+		if got := lastAssistant(t, m); !strings.Contains(got, "/pr-autofix <pr>") {
+			t.Errorf("message = %q, want the usage text", got)
+		}
+		if m.prAutofix != nil {
+			t.Error("usage must not create run state")
+		}
+	})
+
+	t.Run("a non-PR argument is refused", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		if _, cmd := m.handlePRAutofixCommand([]string{"main"}); cmd != nil {
+			t.Error("a bad target must not start a run")
+		}
+		if got := lastAssistant(t, m); !strings.Contains(got, "Not a pull request") {
+			t.Errorf("message = %q, want a rejection naming the input", got)
+		}
+	})
+
+	t.Run("a second run is refused while one is in flight", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		m.prAutofix = &prAutofixState{pr: "253"}
+
+		if _, cmd := m.handlePRAutofixCommand([]string{"254"}); cmd != nil {
+			t.Error("a concurrent run must not be started")
+		}
+		if got := lastAssistant(t, m); !strings.Contains(got, "already in flight") {
+			t.Errorf("message = %q, want a refusal", got)
+		}
+		if m.prAutofix.pr != "253" {
+			t.Errorf("in-flight run was replaced: pr = %q", m.prAutofix.pr)
+		}
+	})
+
+	t.Run("a finished run does not block a new one", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		writeSOPOverride(t, m.cfg.WorkDir, trivialSOP)
+		m.prAutofix = &prAutofixState{pr: "253", done: true}
+
+		_, cmd := m.handlePRAutofixCommand([]string{"254"})
+		if cmd == nil {
+			t.Fatal("a finished run must not block the next one")
+		}
+		if m.prAutofix.pr != "254" {
+			t.Errorf("pr = %q, want the new target", m.prAutofix.pr)
+		}
+		t.Cleanup(func() { os.RemoveAll(m.prAutofix.runDir) })
+		drainPRAutofix(t, m, cmd)
+	})
+}
+
+// TestPRAutofixCommandStartsRun verifies the accepted path: state is created,
+// the transcript says what is happening, and the returned command feeds the
+// run's messages back into the model until it finishes.
+func TestPRAutofixCommandStartsRun(t *testing.T) {
+	m := prAutofixModel(t.TempDir())
+	writeSOPOverride(t, m.cfg.WorkDir, trivialSOP)
+
+	_, cmd := m.handlePRAutofixCommand([]string{"https://github.com/dimetron/pi-go/pull/253"})
+	if cmd == nil {
+		t.Fatal("an accepted target must start a run")
+	}
+	if m.prAutofix == nil {
+		t.Fatal("no run state was created")
+	}
+	if m.prAutofix.runDir == "" {
+		t.Error("run state has no run directory for stage artifacts")
+	}
+	t.Cleanup(func() { os.RemoveAll(m.prAutofix.runDir) })
+	if m.prAutofix.tracker == nil {
+		t.Error("run state has no stage tracker, so the sidebar would show nothing")
+	}
+
+	drainPRAutofix(t, m, cmd)
+
+	if !m.prAutofix.done {
+		t.Error("run did not finish")
+	}
+	if m.prAutofix.err != nil {
+		t.Errorf("run error = %v, want a clean finish", m.prAutofix.err)
+	}
+	transcript := allAssistant(m)
+	if !strings.Contains(transcript, "Watching https://github.com/dimetron/pi-go/pull/253") {
+		t.Error("transcript should announce what is being watched")
+	}
+	if !strings.Contains(transcript, "pr-autofix finished in") {
+		t.Errorf("transcript should report the finish, got:\n%s", transcript)
+	}
+	if !strings.Contains(transcript, "watched") {
+		t.Error("transcript should carry the stages' own output")
+	}
+}
+
+// drainPRAutofix runs the command loop the TUI would run, folding every message
+// back into the model until the run reports done.
+func drainPRAutofix(t *testing.T, m *model, cmd tea.Cmd) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for cmd != nil {
+		if time.Now().After(deadline) {
+			t.Fatal("pr-autofix run did not finish in time")
+		}
+		msg := cmd()
+		next, ok := msg.(prAutofixChan)
+		if !ok {
+			// The channel closed; the terminal message is not a chan message.
+			return
+		}
+		_, cmd = m.handlePRAutofixMsg(next)
+	}
+}
+
+// allAssistant joins the transcript for substring assertions.
+func allAssistant(m *model) string {
+	var b strings.Builder
+	for _, msg := range m.chatModel.Messages {
+		b.WriteString(msg.content)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// TestPRAutofixRunReportsLoadFailure verifies an override that does not compile
+// stops the run and says so, rather than falling back to the embedded SOP.
+func TestPRAutofixRunReportsLoadFailure(t *testing.T) {
+	workDir := t.TempDir()
+	writeSOPOverride(t, workDir, "sop: pr-autofix\nversion: 2\nstages: []\n")
+
+	m := prAutofixModel(workDir)
+	ch := make(chan prAutofixMsg, 8)
+	go m.runPRAutofix(ch, "253", t.TempDir())
+
+	var last prAutofixMsg
+	for msg := range ch {
+		last = msg
+	}
+	if !last.done {
+		t.Fatal("run did not report done")
+	}
+	if last.err == nil {
+		t.Fatal("an override with no stages must fail the run, not schedule nothing")
+	}
+}
+
+// TestPRAutofixRunEmitsStagesAndFinishes verifies a walk of the SOP reports
+// each stage's output and ends with a clean done message.
+func TestPRAutofixRunEmitsStagesAndFinishes(t *testing.T) {
+	workDir := t.TempDir()
+	writeSOPOverride(t, workDir, trivialSOP)
+
+	m := prAutofixModel(workDir)
+	// The run is drained concurrently rather than after the fact: a buffered
+	// channel sized to today's event count would deadlock the moment the
+	// engine emitted one more.
+	ch := make(chan prAutofixMsg, 8)
+	go m.runPRAutofix(ch, "253", t.TempDir())
+
+	var outputs []string
+	var events int
+	var last prAutofixMsg
+	for msg := range ch {
+		if msg.output != "" {
+			outputs = append(outputs, msg.stage+":"+strings.TrimSpace(msg.output))
+		}
+		if msg.event != nil {
+			events++
+		}
+		last = msg
+	}
+
+	if !last.done || last.err != nil {
+		t.Fatalf("final message = %+v, want a clean done", last)
+	}
+	if events == 0 {
+		t.Error("no engine events reached the TUI, so the sidebar would never update")
+	}
+	if !slices.Contains(outputs, "watch:watched") {
+		t.Errorf("stage output = %v, want the watch stage's own output", outputs)
+	}
+}
+
+// TestWaitForPRAutofixReadsOneMessage verifies the command reads exactly one
+// message and pairs it with its channel, and that a closed channel ends the
+// loop rather than blocking it.
+func TestWaitForPRAutofixReadsOneMessage(t *testing.T) {
+	t.Run("delivers a message with its channel", func(t *testing.T) {
+		ch := make(chan prAutofixMsg, 1)
+		ch <- prAutofixMsg{stage: "watch", output: "polling"}
+
+		got, ok := waitForPRAutofix(ch)().(prAutofixChan)
+		if !ok {
+			t.Fatal("want a prAutofixChan so Update can queue the next read")
+		}
+		if got.msg.stage != "watch" || got.ch != ch {
+			t.Errorf("got %+v, want the message paired with its own channel", got.msg)
+		}
+	})
+
+	t.Run("a closed channel ends the run", func(t *testing.T) {
+		ch := make(chan prAutofixMsg)
+		close(ch)
+
+		got, ok := waitForPRAutofix(ch)().(prAutofixMsg)
+		if !ok || !got.done {
+			t.Errorf("got %#v, want a done message so the loop stops", got)
+		}
+	})
+}
+
+// TestHandlePRAutofixMsgFolds verifies each kind of run message lands in the
+// model: stage starts narrate, output goes to the transcript, and done settles
+// the state either way.
+func TestHandlePRAutofixMsgFolds(t *testing.T) {
+	newState := func(m *model) {
+		m.prAutofix = &prAutofixState{pr: "253", tracker: newStageTracker(), started: time.Now()}
+	}
+
+	t.Run("a message with no run state is dropped", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		if _, cmd := m.handlePRAutofixMsg(prAutofixChan{}); cmd != nil {
+			t.Error("a message arriving after the state is gone must not requeue")
+		}
+	})
+
+	t.Run("a stage start narrates", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		newState(m)
+		ch := make(chan prAutofixMsg, 1)
+		ev := &session.Event{Author: sopexec.LifecycleAuthor, Branch: "watch#2"}
+
+		_, cmd := m.handlePRAutofixMsg(prAutofixChan{msg: prAutofixMsg{event: ev}, ch: ch})
+		if cmd == nil {
+			t.Error("a non-final message must queue the next read")
+		}
+		if got := lastAssistant(t, m); !strings.Contains(got, "cycle 2") {
+			t.Errorf("narration = %q, want the cycle number", got)
+		}
+	})
+
+	t.Run("stage output reaches the transcript", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		newState(m)
+		ch := make(chan prAutofixMsg, 1)
+
+		m.handlePRAutofixMsg(prAutofixChan{msg: prAutofixMsg{stage: "triage", output: "2 failing"}, ch: ch})
+		if got := lastAssistant(t, m); got != "[triage] 2 failing" {
+			t.Errorf("transcript line = %q", got)
+		}
+	})
+
+	t.Run("done settles the run", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		newState(m)
+
+		_, cmd := m.handlePRAutofixMsg(prAutofixChan{msg: prAutofixMsg{done: true}})
+		if cmd != nil {
+			t.Error("a finished run must not queue another read")
+		}
+		if !m.prAutofix.done || m.prAutofix.err != nil {
+			t.Errorf("state = %+v, want a clean finish", m.prAutofix)
+		}
+		if got := lastAssistant(t, m); !strings.Contains(got, "finished in") {
+			t.Errorf("message = %q, want the finish line", got)
+		}
+	})
+
+	t.Run("a failed run reports its error", func(t *testing.T) {
+		m := prAutofixModel(t.TempDir())
+		newState(m)
+
+		_, cmd := m.handlePRAutofixMsg(prAutofixChan{msg: prAutofixMsg{done: true, err: errors.New("gh exploded")}})
+		if cmd != nil {
+			t.Error("a failed run must not queue another read")
+		}
+		if m.prAutofix.err == nil {
+			t.Error("the error was dropped from the state")
+		}
+		if got := lastAssistant(t, m); !strings.Contains(got, "gh exploded") {
+			t.Errorf("message = %q, want the error surfaced", got)
+		}
+	})
+}
+
+// TestPRAutofixAgentRunnerRefusesWithoutOrchestrator verifies an agent stage
+// fails loudly when the subagent system is missing. Passing silently would let
+// the SOP advance to the gates with no fix written.
+func TestPRAutofixAgentRunnerRefusesWithoutOrchestrator(t *testing.T) {
+	m := prAutofixModel(t.TempDir())
+	runner := m.prAutofixAgentRunner(t.TempDir())
+
+	_, err := runner.RunStage(context.Background(), sopexec.StageRequest{
+		Stage: sop.Stage{ID: "fix", Agent: "worker"},
+	})
+	if err == nil {
+		t.Fatal("an agent stage with no orchestrator must fail")
+	}
+	if !strings.Contains(err.Error(), "fix") {
+		t.Errorf("error %q should name the stage it could not run", err)
+	}
+}
+
+// TestPRAutofixAgentRunnerRejectsUnknownAgent verifies a stage naming an agent
+// the orchestrator does not have fails on lookup rather than at spawn.
+func TestPRAutofixAgentRunnerRejectsUnknownAgent(t *testing.T) {
+	m := prAutofixModel(t.TempDir())
+	m.cfg.Orchestrator = subagent.NewOrchestrator(&config.Config{}, "", nil)
+	runner := m.prAutofixAgentRunner(t.TempDir())
+
+	_, err := runner.RunStage(context.Background(), sopexec.StageRequest{
+		Stage: sop.Stage{ID: "fix", Agent: "no-such-agent"},
+	})
+	if err == nil {
+		t.Fatal("an unknown agent must fail the stage")
+	}
+	if !strings.Contains(err.Error(), "fix") {
+		t.Errorf("error %q should name the stage", err)
+	}
+}
+
+// TestPRAutofixAgentRunnerReportsSpawnFailure verifies a stage whose agent is
+// known but cannot be started fails the run rather than reporting a fix that
+// was never written.
+func TestPRAutofixAgentRunnerReportsSpawnFailure(t *testing.T) {
+	orch := subagent.NewOrchestrator(&config.Config{}, "", nil)
+	orch.RegisterAgents([]subagent.AgentConfig{{Name: "worker", Description: "test agent"}})
+	// A shut-down orchestrator refuses to spawn, which is the cheapest way to
+	// reach the failure branch without starting a real subagent.
+	orch.Shutdown()
+
+	m := prAutofixModel(t.TempDir())
+	m.cfg.Orchestrator = orch
+
+	_, err := m.prAutofixAgentRunner(t.TempDir()).RunStage(context.Background(), sopexec.StageRequest{
+		Stage: sop.Stage{ID: "fix", Agent: "worker"},
+	})
+	if err == nil {
+		t.Fatal("a spawn that fails must fail the stage")
+	}
+	if !strings.Contains(err.Error(), "fix") || !strings.Contains(err.Error(), "worker") {
+		t.Errorf("error %q should name the stage and the agent", err)
+	}
+}
+
+// TestPRAutofixMessageRoutesThroughUpdate verifies a run message reaches the
+// handler through the TUI's own dispatch, not just by direct call.
+func TestPRAutofixMessageRoutesThroughUpdate(t *testing.T) {
+	m := prAutofixModel(t.TempDir())
+	m.prAutofix = &prAutofixState{pr: "253", tracker: newStageTracker(), started: time.Now()}
+
+	_, _, handled := m.updateRunWorkflow(prAutofixChan{msg: prAutofixMsg{done: true}})
+	if !handled {
+		t.Fatal("updateRunWorkflow must claim prAutofixChan, or run messages never arrive")
+	}
+	if !m.prAutofix.done {
+		t.Error("the message was claimed but not folded into the state")
+	}
+}
+
+// TestPRAutofixDrawsItsGraphInTheSidebar verifies an in-flight run puts the
+// compiled pr-autofix graph on the sidebar, with the tracker's statuses.
+func TestPRAutofixDrawsItsGraphInTheSidebar(t *testing.T) {
+	m := prAutofixModel(t.TempDir())
+
+	if in := m.sidebarRenderInput(30, 20); in.Graph != nil {
+		t.Fatal("no run should mean no graph")
+	}
+
+	m.prAutofix = &prAutofixState{pr: "253", tracker: newStageTracker(), started: time.Now()}
+	in := m.sidebarRenderInput(30, 20)
+	if in.Graph == nil {
+		t.Fatal("an in-flight run should draw its graph")
+	}
+	if !slices.Contains(in.Graph.Order, "watch") {
+		t.Errorf("graph order = %v, want the pr-autofix stages", in.Graph.Order)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -136,6 +136,10 @@ type model struct {
 	// Run flow state (/run command).
 	run *runState
 
+	// prAutofix is the in-flight /pr-autofix run, or nil. Unlike run, it holds
+	// no copy of the workflow: the SOP is the workflow and the engine walks it.
+	prAutofix *prAutofixState
+
 	// Branch popup state (shown on status bar click).
 	branchPopup *branchPopupState
 
@@ -855,6 +859,9 @@ func (m *model) updateRunWorkflow(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return model, cmd, true
 	case runMergeResultMsg:
 		model, cmd := m.handleRunMergeResult(msg)
+		return model, cmd, true
+	case prAutofixChan:
+		model, cmd := m.handlePRAutofixMsg(msg)
 		return model, cmd, true
 	}
 	return nil, nil, false
@@ -1740,6 +1747,17 @@ func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInp
 				Order:  g.Order,
 				Edges:  g.GraphEdges(),
 				Status: planStageStatus(in.PlanPhases),
+			}
+		}
+	}
+	if in.Graph == nil && m.prAutofix != nil {
+		// The engine drives this mode, so its statuses come from the event
+		// stream rather than from a projection of some parallel state.
+		if g := m.sopGraph("pr-autofix"); g != nil {
+			in.Graph = &SOPGraph{
+				Order:  g.Order,
+				Edges:  g.GraphEdges(),
+				Status: m.prAutofix.tracker.statuses(),
 			}
 		}
 	}


### PR DESCRIPTION
Adds a third mode alongside /plan and /run: given a PR, it polls the checks,
pulls the failing jobs' logs, dispatches a fix, proves it against the local
gates, commits and pushes, then watches the fresh run — up to five cycles.

Unlike /plan and /run, the workflow is not a Go state machine. pr-autofix.sop.yaml
*is* the workflow and the engine walks it, which is what makes the sidebar
diagram and the executed graph the same definition rather than two things that
can drift. It also makes the mode's behavior editable without a rebuild, through
the override path LoadDefinition already resolves.

Two pieces of Go were missing for a SOP to be executable as data, and both are
general rather than PR-specific:

- Stage.Run, the shell command that *is* a function stage's body. Gate runs
  after a body; Run is the body, which is what lets "poll the PR's checks" be
  data instead of code.
- exec.ShellRunner, which executes those stages. Exit status is the contract:
  0 is PASS, non-zero is FAIL, and 75 (EX_TEMPFAIL) means "not ready" — returned
  as an error so the engine's retry policy does the waiting. That distinction is
  what lets one poll per activation add up to a wait without a stage blocking
  for the length of a CI run, so the sidebar keeps moving. Agent stages are
  handed to an injected runner, because dispatching one needs the orchestrator
  and internal/sop must not depend on it.

Stage status in the sidebar comes from stageTracker, which reads the engine's
own event stream. It was written for exactly this and had no caller until now;
/plan and /run still project status from artifacts and run state, as their
comments say, until the engine drives them too.

The commit stage signs, and signing here prompts through 1Password, so an
unattended cycle parks on it — the diagram draws that stage as waiting rather
than failed, because the commit is one approval away rather than broken.

Verification: go build ./..., go vet ./..., go test ./... (full suite),
make lint (0 issues), and the compiled graph rendered through the real sidebar
renderer to confirm the stages, the conditional edges and the loop back to watch
all draw.

Signed-off-by: dimetron <dimetron@me.com>
