### PR TITLE
perf(agent): stop the read_image callback re-reading every screenshot each step

### DIFF
--- a/internal/acp/server/ollama_endpoint_test.go
+++ b/internal/acp/server/ollama_endpoint_test.go
@@ -24,7 +24,7 @@ func TestBuildSessionLLM_OllamaRoutesByTag(t *testing.T) {
 		},
 	}
 
-	llm, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
+	llm, _, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
 	if err != nil {
 		t.Fatalf("buildSessionLLM: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestBuildSessionLLM_OllamaHealthCheckFailureIsReported(t *testing.T) {
 		},
 	}
 
-	_, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
+	_, _, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
 	if err == nil {
 		t.Fatal("expected an error when the daemon is unreachable")
 	}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -162,12 +162,12 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		return nil, err
 	}
 
-	llm, err := buildSessionLLM(ctx, rt, cfg)
+	llm, providerName, err := buildSessionLLM(ctx, rt, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := buildSessionResources(rt, cfg, turn, cwd, span)
+	res, err := buildSessionResources(rt, cfg, turn, cwd, providerName, span)
 	if err != nil {
 		return nil, err
 	}
@@ -227,26 +227,28 @@ func loadSessionConfig(rt RuntimeConfig, cwd string) (config.Config, error) {
 }
 
 // buildSessionLLM resolves the default role to a provider and returns a
-// token-guarded LLM for it.
-func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (adkmodel.LLM, error) {
+// token-guarded LLM for it, along with the name of the provider it resolved to
+// — callbacks built alongside the agent need it to know what the wire format
+// can carry.
+func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (adkmodel.LLM, string, error) {
 	modelName, providerName, advisorModel, advisorMaxUses, advisorCaching, err := cfg.ResolveRole("default")
 	if err != nil {
-		return nil, fmt.Errorf("resolving model role: %w", err)
+		return nil, "", fmt.Errorf("resolving model role: %w", err)
 	}
 
 	info, baseURL, err := resolveSessionProvider(cfg, rt.BaseURL, modelName, providerName)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	apiKey := config.APIKeys()[info.Provider]
 	if err := checkProviderCredentials(info, apiKey, baseURL); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	baseURL, err = resolveOllamaBaseURL(info, apiKey, baseURL)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, &provider.LLMOptions{
@@ -257,12 +259,12 @@ func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (
 		AdvisorCaching:  advisorCaching,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("creating LLM provider: %w", err)
+		return nil, "", fmt.Errorf("creating LLM provider: %w", err)
 	}
 
 	tokenTracker := guardrail.New(cfg.MaxDailyTokens)
 	tokenTracker.SetContextWindowSize(sessionContextWindow(ctx, info, baseURL))
-	return guardrail.WrapModel(llm, tokenTracker), nil
+	return guardrail.WrapModel(llm, tokenTracker), info.Provider, nil
 }
 
 // checkProviderCredentials rejects a provider that needs an API key and has
@@ -358,7 +360,7 @@ type sessionResources struct {
 // buildSessionResources opens the sandbox and starts the subagent orchestrator
 // and LSP manager, assembling the tool set and callbacks around them. On
 // failure it releases whatever it had already opened.
-func buildSessionResources(rt RuntimeConfig, cfg config.Config, turn PromptTurn, cwd string, span trace.Span) (*sessionResources, error) {
+func buildSessionResources(rt RuntimeConfig, cfg config.Config, turn PromptTurn, cwd, providerName string, span trace.Span) (*sessionResources, error) {
 	sandboxRoot := cwd
 	if rt.SandboxRootFunc != nil {
 		sandboxRoot = rt.SandboxRootFunc(turn)
@@ -426,7 +428,7 @@ func buildSessionResources(rt RuntimeConfig, cfg config.Config, turn PromptTurn,
 
 	// Inject image bytes (screenshots) as visible InlineData parts for the model.
 	beforeModelCBs := []llmagent.BeforeModelCallback{
-		extension.BuildReadImageCallback(sandbox),
+		extension.BuildReadImageCallback(sandbox, providerName),
 	}
 
 	return &sessionResources{

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -679,7 +679,7 @@ func runNonInteractive(
 	beforeCBs = append(beforeCBs, tracingBefore...)
 	afterCBs = append(afterCBs, tracingAfter...)
 	llmBefore, llmAfter := extension.BuildLLMTracingCallbacks(info.Provider)
-	llmBefore = append(llmBefore, extension.BuildReadImageCallback(runtime.sandbox))
+	llmBefore = append(llmBefore, extension.BuildReadImageCallback(runtime.sandbox, info.Provider))
 
 	lspMgr := lsp.NewManager(nil)
 	defer lspMgr.Shutdown()

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -586,7 +586,7 @@ func buildDeferredCallbacks(
 	llmBefore, llmAfter := extension.BuildLLMTracingCallbacks(providerName)
 
 	// Inject image bytes (screenshots) as visible InlineData parts for the model.
-	llmBefore = append(llmBefore, extension.BuildReadImageCallback(sandbox))
+	llmBefore = append(llmBefore, extension.BuildReadImageCallback(sandbox, providerName))
 
 	if memRecorder != nil {
 		afterCBs = append(afterCBs, memRecorder.afterTool)

--- a/internal/extension/complexity_cog_extension_test.go
+++ b/internal/extension/complexity_cog_extension_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/genai"
 
+	"github.com/dimetron/pi-go/internal/notice"
 	"github.com/dimetron/pi-go/internal/tools"
 )
 
@@ -81,7 +82,7 @@ func TestReadImageCallback_SkipsEverythingButReadImageResults(t *testing.T) {
 	sb := cogSandbox(t)
 
 	t.Run("nil request", func(t *testing.T) {
-		resp, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, nil)
+		resp, err := BuildReadImageCallback(sb, "gemini")(&mockReadonlyContext{}, nil)
 		if resp != nil || err != nil {
 			t.Fatalf("callback(nil req) = %v, %v; want nil, nil", resp, err)
 		}
@@ -93,7 +94,7 @@ func TestReadImageCallback_SkipsEverythingButReadImageResults(t *testing.T) {
 			Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": "shot.png"})},
 		}
 		req := &model.LLMRequest{Contents: []*genai.Content{content}}
-		if _, err := BuildReadImageCallback(nil)(&mockReadonlyContext{}, req); err != nil {
+		if _, err := BuildReadImageCallback(nil, "gemini")(&mockReadonlyContext{}, req); err != nil {
 			t.Fatalf("callback: %v", err)
 		}
 		if len(content.Parts) != 1 {
@@ -118,7 +119,7 @@ func TestReadImageCallback_SkipsEverythingButReadImageResults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			content := &genai.Content{Role: "user", Parts: []*genai.Part{tc.part}}
 			req := &model.LLMRequest{Contents: []*genai.Content{nil, content}}
-			if _, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, req); err != nil {
+			if _, err := BuildReadImageCallback(sb, "gemini")(&mockReadonlyContext{}, req); err != nil {
 				t.Fatalf("callback: %v", err)
 			}
 			if got := len(content.Parts); got != 1 {
@@ -131,10 +132,10 @@ func TestReadImageCallback_SkipsEverythingButReadImageResults(t *testing.T) {
 	}
 }
 
-// TestReadImageCallback_UnreadablePathIsWarnedNotFatal pins that a read
+// TestReadImageCallback_UnreadablePathIsSkippedNotFatal pins that a read
 // failure only skips that one part: the callback still returns nil, nil and
 // still injects the image for a sibling part that does resolve.
-func TestReadImageCallback_UnreadablePathIsWarnedNotFatal(t *testing.T) {
+func TestReadImageCallback_UnreadablePathIsSkippedNotFatal(t *testing.T) {
 	sb := cogSandbox(t)
 	good := cogWriteImage(t, sb, "good.png")
 
@@ -147,7 +148,7 @@ func TestReadImageCallback_UnreadablePathIsWarnedNotFatal(t *testing.T) {
 	}
 	req := &model.LLMRequest{Contents: []*genai.Content{content}}
 
-	resp, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, req)
+	resp, err := BuildReadImageCallback(sb, "gemini")(&mockReadonlyContext{}, req)
 	if resp != nil || err != nil {
 		t.Fatalf("callback = %v, %v; want nil, nil", resp, err)
 	}
@@ -162,21 +163,27 @@ func TestReadImageCallback_UnreadablePathIsWarnedNotFatal(t *testing.T) {
 	}
 }
 
-// TestReadImageCallback_AppendsPerContentInOrder pins that images are appended
-// to the Content that carried the response — not pooled onto the first one —
-// and that two responses on one Content append in the order they appear.
-func TestReadImageCallback_AppendsPerContentInOrder(t *testing.T) {
+// TestReadImageCallback_InjectsNewestContentOnly pins the scoping rule: only
+// the last Content carrying read_image results is injected into, and within it
+// the images append in the order the responses appear. An older Content that
+// also carried a read_image result is left alone — re-injecting it on every
+// agentic step is what this scoping exists to stop.
+func TestReadImageCallback_InjectsNewestContentOnly(t *testing.T) {
 	sb := cogSandbox(t)
+	stale := cogWriteImage(t, sb, "stale.png")
 	first := cogWriteImage(t, sb, "first.png")
 	second := cogWriteImage(t, sb, "second.png")
-	other := cogWriteImage(t, sb, "other.png")
 
 	// Make the payloads distinguishable by size.
 	if err := os.WriteFile(second, append(cogPNGBytes(t), make([]byte, 64)...), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	contentA := &genai.Content{
+	older := &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": stale})},
+	}
+	newest := &genai.Content{
 		Role: "user",
 		Parts: []*genai.Part{
 			cogRespPart(readImageToolName, map[string]any{"path": first}),
@@ -184,18 +191,21 @@ func TestReadImageCallback_AppendsPerContentInOrder(t *testing.T) {
 			cogRespPart(readImageToolName, map[string]any{"path": second}),
 		},
 	}
-	contentB := &genai.Content{
-		Role:  "user",
-		Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": other})},
-	}
-	req := &model.LLMRequest{Contents: []*genai.Content{contentA, contentB}}
+	req := &model.LLMRequest{Contents: []*genai.Content{older, newest}}
 
-	if _, err := BuildReadImageCallback(sb)(&mockReadonlyContext{}, req); err != nil {
+	if _, err := BuildReadImageCallback(sb, "gemini")(&mockReadonlyContext{}, req); err != nil {
 		t.Fatalf("callback: %v", err)
 	}
 
-	if got := len(contentA.Parts); got != 5 {
-		t.Fatalf("contentA parts = %d, want 5", got)
+	if got := len(older.Parts); got != 1 {
+		t.Fatalf("older parts = %d, want 1 (a superseded read_image must not be re-injected)", got)
+	}
+	if n := cogInlineCount(older); n != 0 {
+		t.Fatalf("older inline parts = %d, want 0", n)
+	}
+
+	if got := len(newest.Parts); got != 5 {
+		t.Fatalf("newest parts = %d, want 5", got)
 	}
 	firstBytes, err := os.ReadFile(first)
 	if err != nil {
@@ -205,17 +215,104 @@ func TestReadImageCallback_AppendsPerContentInOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(contentA.Parts[3].InlineData.Data, firstBytes) {
-		t.Error("contentA.Parts[3] is not the first image: injection order changed")
+	if !bytes.Equal(newest.Parts[3].InlineData.Data, firstBytes) {
+		t.Error("newest.Parts[3] is not the first image: injection order changed")
 	}
-	if !bytes.Equal(contentA.Parts[4].InlineData.Data, secondBytes) {
-		t.Error("contentA.Parts[4] is not the second image: injection order changed")
+	if !bytes.Equal(newest.Parts[4].InlineData.Data, secondBytes) {
+		t.Error("newest.Parts[4] is not the second image: injection order changed")
 	}
-	if got := len(contentB.Parts); got != 2 {
-		t.Fatalf("contentB parts = %d, want 2 (its own image, not contentA's)", got)
+}
+
+// TestReadImageCallback_TrailingContentWithoutImages pins that the scan walks
+// back past the trailing turns a request processor may append — the newest
+// read_image result is still found and injected.
+func TestReadImageCallback_TrailingContentWithoutImages(t *testing.T) {
+	sb := cogSandbox(t)
+	shot := cogWriteImage(t, sb, "shot.png")
+
+	withImage := &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": shot})},
 	}
-	if cogInlineCount(contentB) != 1 {
-		t.Error("contentB did not receive its own inline image")
+	trailing := &genai.Content{Role: "user", Parts: []*genai.Part{{Text: "continue"}}}
+	req := &model.LLMRequest{Contents: []*genai.Content{withImage, trailing}}
+
+	if _, err := BuildReadImageCallback(sb, "gemini")(&mockReadonlyContext{}, req); err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	if n := cogInlineCount(withImage); n != 1 {
+		t.Fatalf("inline parts = %d, want 1", n)
+	}
+	if got := len(trailing.Parts); got != 1 {
+		t.Errorf("trailing parts = %d, want 1 (nothing injected there)", got)
+	}
+}
+
+// TestReadImageCallback_NonForwardingProviderIsNoOp pins that a provider whose
+// adapter drops InlineData gets a callback that does no work at all. Reading
+// the bytes there costs the disk I/O and buys nothing, because the parts are
+// discarded before the request goes out.
+func TestReadImageCallback_NonForwardingProviderIsNoOp(t *testing.T) {
+	sb := cogSandbox(t)
+	shot := cogWriteImage(t, sb, "shot.png")
+
+	for _, providerName := range []string{"ollama", "openai", "anthropic", ""} {
+		t.Run(providerName, func(t *testing.T) {
+			content := &genai.Content{
+				Role:  "user",
+				Parts: []*genai.Part{cogRespPart(readImageToolName, map[string]any{"path": shot})},
+			}
+			req := &model.LLMRequest{Contents: []*genai.Content{content}}
+			resp, err := BuildReadImageCallback(sb, providerName)(&mockReadonlyContext{}, req)
+			if resp != nil || err != nil {
+				t.Fatalf("callback = %v, %v; want nil, nil", resp, err)
+			}
+			if got := len(content.Parts); got != 1 {
+				t.Fatalf("parts = %d, want 1 (provider cannot carry InlineData)", got)
+			}
+		})
+	}
+}
+
+// TestReadImageCallback_WarnsOncePerPath pins the notice behavior. The
+// callback runs once per agentic step over a history that is rebuilt each
+// time, so an unreadable path would otherwise be reported again on every step
+// of the turn. A file that is merely gone is never reported: screenshots live
+// in scratch directories the agent cleans up itself.
+func TestReadImageCallback_WarnsOncePerPath(t *testing.T) {
+	sb := cogSandbox(t)
+
+	var got []string
+	prev := notice.SetSink(func(msg string) { got = append(got, msg) })
+	t.Cleanup(func() { notice.SetSink(prev) })
+
+	// A directory is readable as a path but not as a file, so ReadFile fails
+	// with something other than fs.ErrNotExist.
+	dir := filepath.Join(sb.Dir(), "adir")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(sb.Dir(), "gone.png")
+
+	cb := BuildReadImageCallback(sb, "gemini")
+	for range 3 {
+		req := &model.LLMRequest{Contents: []*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				cogRespPart(readImageToolName, map[string]any{"path": missing}),
+				cogRespPart(readImageToolName, map[string]any{"path": dir}),
+			},
+		}}}
+		if _, err := cb(&mockReadonlyContext{}, req); err != nil {
+			t.Fatalf("callback: %v", err)
+		}
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("notices = %d %q, want 1 (one per unreadable path, none for a deleted file)", len(got), got)
+	}
+	if !strings.Contains(got[0], "adir") {
+		t.Errorf("notice = %q, want the unreadable directory, not the deleted file", got[0])
 	}
 }
 

--- a/internal/extension/inline_images.go
+++ b/internal/extension/inline_images.go
@@ -1,0 +1,22 @@
+package extension
+
+// providerForwardsInlineImages reports whether the model adapter behind a
+// provider puts genai InlineData parts on the wire.
+//
+// Only the Gemini path does: provider.NewGemini returns ADK's native gemini
+// model, which hands genai.Content to the SDK unchanged. Every other provider
+// goes through an adapter that rebuilds the request from genai parts and reads
+// only text and function calls — see genaiSplitParts in
+// internal/provider/openai_completions.go, and the equivalent conversions in
+// anthropic.go and mistral.go. An InlineData part handed to those is dropped
+// without a word.
+//
+// It lives here rather than beside the adapters because piagent imports this
+// package and is walled off from internal/provider by TestPiagentStaysIsolated.
+//
+// This is not a statement about the model: a vision-capable model reached
+// through the OpenAI-compatible adapter still cannot be sent an image this
+// way. When an adapter learns to forward images, add its provider here.
+func providerForwardsInlineImages(providerName string) bool {
+	return providerName == "gemini"
+}

--- a/internal/extension/inline_images_test.go
+++ b/internal/extension/inline_images_test.go
@@ -1,0 +1,21 @@
+package extension
+
+import "testing"
+
+// TestProviderForwardsInlineImages pins which providers can carry an image
+// part. Only the ADK-native Gemini path hands genai.Content to the SDK
+// unchanged; every other adapter rebuilds the request from text and function
+// calls alone, so an InlineData part handed to it is dropped silently.
+func TestProviderForwardsInlineImages(t *testing.T) {
+	if !providerForwardsInlineImages("gemini") {
+		t.Error("gemini must forward inline images: NewGemini returns ADK's native model")
+	}
+	for _, p := range []string{
+		"ollama", "openai", "azure", "anthropic", "mistral",
+		"openrouter", "xai", "opencode", "", "unknown",
+	} {
+		if providerForwardsInlineImages(p) {
+			t.Errorf("providerForwardsInlineImages(%q) = true; no adapter for it converts InlineData", p)
+		}
+	}
+}

--- a/internal/extension/read_image.go
+++ b/internal/extension/read_image.go
@@ -1,6 +1,10 @@
 package extension
 
 import (
+	"errors"
+	"io/fs"
+	"sync"
+
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	"google.golang.org/adk/v2/model"
@@ -14,59 +18,119 @@ import (
 // callback turns into visible image parts.
 const readImageToolName = "read_image"
 
-// BuildReadImageCallback returns a BeforeModelCallback that finds FunctionResponse
-// parts from the read_image tool in the current turn and injects the underlying
-// image bytes as an InlineData part on the same user Content. This is what makes
-// a screenshot actually visible to a vision-capable model (Gemini, etc.).
+// BuildReadImageCallback returns a BeforeModelCallback that finds the newest
+// read_image FunctionResponse in the request and injects the underlying image
+// bytes as an InlineData part on the Content that carried it. This is what
+// makes a screenshot actually visible to a vision-capable model.
 //
-// The read_image tool returns only the path + metadata (never the bytes), so the
-// bytes never transit the text channel. The callback re-reads the file (sandboxed)
-// and appends a genai.Part{InlineData} alongside the text result. Providers that
-// forward InlineData (Gemini via ADK-native model) see the image; others simply
-// ignore it and fall back to the textual path.
-func BuildReadImageCallback(sb *tools.Sandbox) llmagent.BeforeModelCallback {
+// The read_image tool returns only the path + metadata (never the bytes), so
+// the bytes never transit the text channel. The callback re-reads the file
+// (sandboxed) and appends a genai.Part{InlineData} alongside the text result.
+//
+// Two things bound the work, because a BeforeModelCallback runs once per model
+// request — that is once per agentic step, not once per user turn, and ADK
+// rebuilds req.Contents from the session events each step, so nothing injected
+// here survives into the next one:
+//
+//   - Providers whose adapter drops InlineData get a no-op callback. Reading
+//     the file would be pure waste there; see providerForwardsInlineImages.
+//   - Only the most recent Content carrying read_image results is injected
+//     into, not every such Content in the history. Walking the whole history
+//     re-read and re-uploaded every screenshot the session had ever taken on
+//     every step. The trade is that only the latest image stays visible; an
+//     older one is still in context as its textual path + metadata.
+func BuildReadImageCallback(sb *tools.Sandbox, providerName string) llmagent.BeforeModelCallback {
+	if !providerForwardsInlineImages(providerName) {
+		return func(agent.Context, *model.LLMRequest) (*model.LLMResponse, error) {
+			return nil, nil
+		}
+	}
+	inj := &readImageInjector{sb: sb, warned: make(map[string]bool)}
 	return func(_ agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
-		injectReadImageParts(sb, req)
+		inj.inject(req)
 		return nil, nil
 	}
 }
 
-// injectReadImageParts appends the image bytes behind each read_image result
-// to the Content that carried the result. A nil request or sandbox is a no-op.
-func injectReadImageParts(sb *tools.Sandbox, req *model.LLMRequest) {
-	if req == nil || sb == nil {
+// readImageInjector holds the per-callback state: the sandbox to read through,
+// and the set of paths already warned about, so a file that stays unreadable
+// produces one notice rather than one per agentic step.
+type readImageInjector struct {
+	sb *tools.Sandbox
+
+	mu     sync.Mutex
+	warned map[string]bool
+}
+
+// inject appends the image bytes behind the newest read_image results to the
+// Content that carried them. A nil request or sandbox is a no-op.
+func (in *readImageInjector) inject(req *model.LLMRequest) {
+	if req == nil || in.sb == nil {
 		return
 	}
-	for _, content := range req.Contents {
+	content := latestReadImageContent(req.Contents)
+	if content == nil {
+		return
+	}
+	// The image parts go after the FunctionResponse on the same Content so the
+	// model sees path+metadata and the image together in one turn.
+	content.Parts = append(content.Parts, in.readImageParts(content.Parts)...)
+}
+
+// latestReadImageContent returns the last Content in contents that carries at
+// least one read_image FunctionResponse, or nil when none does.
+func latestReadImageContent(contents []*genai.Content) *genai.Content {
+	for i := len(contents) - 1; i >= 0; i-- {
+		content := contents[i]
 		if content == nil {
 			continue
 		}
-		// A read_image FunctionResponse is a user-turn part. We append the
-		// image parts to the same Content after the FunctionResponse so the
-		// model sees path+metadata and the image together in one turn.
-		content.Parts = append(content.Parts, readImageParts(sb, content.Parts)...)
+		for _, part := range content.Parts {
+			if _, ok := readImagePath(part); ok {
+				return content
+			}
+		}
 	}
+	return nil
 }
 
 // readImageParts reads the file behind every read_image FunctionResponse in
 // parts and returns the inline image parts to append, in the order the
-// responses appear. A file that cannot be read is warned about and skipped —
-// the textual path result still stands on its own.
-func readImageParts(sb *tools.Sandbox, parts []*genai.Part) []*genai.Part {
+// responses appear. A file that cannot be read is skipped — the textual path
+// result still stands on its own.
+func (in *readImageInjector) readImageParts(parts []*genai.Part) []*genai.Part {
 	var out []*genai.Part
 	for _, part := range parts {
 		path, ok := readImagePath(part)
 		if !ok {
 			continue
 		}
-		data, err := sb.ReadFile(path)
+		data, err := in.sb.ReadFile(path)
 		if err != nil {
-			notice.Notifyf("warning: read_image callback could not read %q: %v", path, err)
+			in.warn(path, err)
 			continue
 		}
 		out = append(out, genai.NewPartFromBytes(data, detectImageMIMEType(data, path)))
 	}
 	return out
+}
+
+// warn reports a path the callback could not read, at most once per path.
+//
+// A file that is simply gone is not reported at all: screenshots land in
+// scratch directories the agent cleans up itself, so a deleted image is the
+// normal end of its life, not a problem the user can act on.
+func (in *readImageInjector) warn(path string, err error) {
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	if in.warned[path] {
+		return
+	}
+	in.warned[path] = true
+	notice.Notifyf("warning: read_image callback could not read %q: %v", path, err)
 }
 
 // readImagePath returns the path a read_image FunctionResponse reported, and

--- a/internal/extension/read_image_test.go
+++ b/internal/extension/read_image_test.go
@@ -48,7 +48,7 @@ func TestBuildReadImageCallback(t *testing.T) {
 	writePNG(t, path)
 
 	t.Run("injects inline data part", func(t *testing.T) {
-		cb := BuildReadImageCallback(sb)
+		cb := BuildReadImageCallback(sb, "gemini")
 		// Build a request whose user-turn Content contains a read_image
 		// FunctionResponse referencing the screenshot path.
 		req := &model.LLMRequest{
@@ -93,7 +93,7 @@ func TestBuildReadImageCallback(t *testing.T) {
 	})
 
 	t.Run("ignores non-read_image tools", func(t *testing.T) {
-		cb := BuildReadImageCallback(sb)
+		cb := BuildReadImageCallback(sb, "gemini")
 		req := &model.LLMRequest{
 			Contents: []*genai.Content{
 				{
@@ -119,7 +119,7 @@ func TestBuildReadImageCallback(t *testing.T) {
 	})
 
 	t.Run("missing path is skipped", func(t *testing.T) {
-		cb := BuildReadImageCallback(sb)
+		cb := BuildReadImageCallback(sb, "gemini")
 		req := &model.LLMRequest{
 			Contents: []*genai.Content{
 				{
@@ -145,7 +145,7 @@ func TestBuildReadImageCallback(t *testing.T) {
 	})
 
 	t.Run("nil sandbox is a no-op", func(t *testing.T) {
-		cb := BuildReadImageCallback(nil)
+		cb := BuildReadImageCallback(nil, "gemini")
 		req := &model.LLMRequest{
 			Contents: []*genai.Content{
 				{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
@@ -184,7 +184,7 @@ func TestBuildReadImageCallback(t *testing.T) {
 		}
 		t.Cleanup(func() { sb.Close() })
 
-		cb := BuildReadImageCallback(sb)
+		cb := BuildReadImageCallback(sb, "gemini")
 		req := &model.LLMRequest{
 			Contents: []*genai.Content{
 				{

--- a/piagent/agent.go
+++ b/piagent/agent.go
@@ -452,7 +452,7 @@ func buildCallbacks(d callbackDeps) (callbackSet, afterCallbackSet) {
 	afterTool = append(afterTool, tracingAfter...)
 
 	beforeModel, afterModel := extension.BuildLLMTracingCallbacks(d.provider)
-	beforeModel = append(beforeModel, extension.BuildReadImageCallback(d.sandbox))
+	beforeModel = append(beforeModel, extension.BuildReadImageCallback(d.sandbox, d.provider))
 
 	// Dedup runs after the compactor so both calls are compared in their
 	// final, post-compaction form.


### PR DESCRIPTION
BuildReadImageCallback is a BeforeModelCallback, so it runs once per model
request — once per agentic step, not once per user turn. It walked all of
req.Contents, and ADK rebuilds those from the session events each step, so a
turn with N screenshots in history and M tool calls did N*M file reads and
emitted N*M warnings for the images the agent had since cleaned up. On any
provider but Gemini every byte of that was discarded before the request went
out.

Three bounds:

- Providers whose adapter drops InlineData get a no-op callback. Only the
  Gemini path hands genai.Content to the SDK unchanged; the OpenAI-compatible,
  Anthropic and Mistral adapters rebuild the request from text and function
  calls alone and drop an image part silently.
- Only the newest Content carrying read_image results is injected into. The
  trade is that a superseded screenshot is no longer re-attached; it remains
  in context as its textual path and metadata.
- A path that is simply gone is no longer reported at all — a scratch
  screenshot the agent deleted is the normal end of its life — and any other
  read failure is reported once per path rather than once per step.

The predicate lives in internal/extension rather than beside the adapters
because piagent imports this package and TestPiagentStaysIsolated walls it off
from internal/provider.

Signed-off-by: dimetron <dimetron@me.com>
