### PR TITLE
fix(sop): make /pr-autofix push loop back to watch, narrate stage starts

### DIFF
--- a/internal/sop/pr-autofix.sop.yaml
+++ b/internal/sop/pr-autofix.sop.yaml
@@ -133,9 +133,15 @@ stages:
   - id: push
     description: Push to the PR branch, which starts a fresh check run
     kind: function
-    run: git push
+    run: |
+      set -euo pipefail
+      git push
+      # A successful push starts a new CI run, so the run loops back to watch
+      # the checks settle. routes PASS takes the edge; loop_back would need
+      # RecheckSignal, which a shell stage cannot emit.
+    routes:
+      PASS: watch
     on_fail: abort
-    loop_back: watch
     max_cycles: 5
 
   - id: summary

--- a/internal/sop/prautofix_sop_test.go
+++ b/internal/sop/prautofix_sop_test.go
@@ -17,3 +17,27 @@ func TestPRAutofixSOPLints(t *testing.T) {
 		t.Fatalf("compile: %v", err)
 	}
 }
+
+// TestPRAutofixPushRoutesToWatch pins that a successful push loops back to
+// watch — the run re-polls CI after pushing, rather than ending. The push
+// stage uses routes PASS→watch (not loop_back, which needs RecheckSignal — a
+// route a shell stage cannot emit) and max_cycles bounds the loop.
+func TestPRAutofixPushRoutesToWatch(t *testing.T) {
+	def, err := LoadEmbeddedDefinition("pr-autofix")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	push, ok := def.Stage("push")
+	if !ok {
+		t.Fatal("push stage not found")
+	}
+	if push.LoopBack != "" {
+		t.Errorf("push.loop_back = %q, want empty — loop_back needs RecheckSignal, which a shell stage cannot emit", push.LoopBack)
+	}
+	if got := push.Routes["PASS"]; got != "watch" {
+		t.Errorf("push.routes[PASS] = %q, want %q", got, "watch")
+	}
+	if push.MaxCycle != 5 {
+		t.Errorf("push.max_cycles = %d, want 5", push.MaxCycle)
+	}
+}

--- a/internal/tui/prautofix.go
+++ b/internal/tui/prautofix.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -254,6 +255,9 @@ func (m *model) handlePRAutofixMsg(in prAutofixChan) (tea.Model, tea.Cmd) {
 	switch {
 	case in.msg.event != nil:
 		st.tracker.observe(in.msg.event)
+		if stage, cycle, ok := prAutofixStageStart(in.msg.event); ok {
+			m.appendAssistant(prAutofixStartLine(stage, cycle))
+		}
 	case in.msg.output != "":
 		m.appendAssistant(prAutofixStageLine(in.msg.stage, in.msg.output))
 	}
@@ -284,6 +288,57 @@ func prAutofixStageLine(stage, output string) string {
 		lines = append(lines[:maxLines], fmt.Sprintf("… %d more lines", omitted))
 	}
 	return "[" + stage + "] " + strings.Join(lines, "\n")
+}
+
+// prAutofixStageStart reports whether ev is a lifecycle event (a stage starting)
+// and, if so, the stage id and its cycle number. Cycle is 1 on first activation
+// and increments each time the graph routes back to the stage.
+func prAutofixStageStart(ev *session.Event) (stage string, cycle int, ok bool) {
+	stage, ok = sopexec.StageStarted(ev)
+	if !ok {
+		return "", 0, false
+	}
+	// The lifecycle event encodes the cycle as "stage#N" in Branch. StageStarted
+	// strips it; re-read the raw branch to recover the number.
+	if ev.Branch != "" {
+		for i := range ev.Branch {
+			if ev.Branch[i] == '#' {
+				if n, err := strconv.Atoi(ev.Branch[i+1:]); err == nil {
+					return stage, n, true
+				}
+				break
+			}
+		}
+	}
+	return stage, 1, true
+}
+
+// prAutofixStageNarration maps a stage id to the one-line description shown in
+// the transcript when the stage starts. This is the narration that makes a run
+// observable stage-by-stage rather than a stream of raw script output.
+var prAutofixStageNarration = map[string]string{
+	"resolve":  "Resolving PR and checking out the branch",
+	"watch":    "Polling CI checks until they settle",
+	"triage":   "Triaging check results — green or failing?",
+	"diagnose": "Pulling failing job logs for evidence",
+	"fix":      "Fixing the failing checks in the working tree",
+	"gates":    "Running local gates (build, vet, test, lint)",
+	"commit":   "Committing the fix (signed, signed off)",
+	"push":     "Pushing to the PR branch — a fresh CI run starts",
+	"summary":  "Writing the summary",
+}
+
+// prAutofixStartLine renders the narration for a stage starting. A cycle > 1
+// means the graph has looped back, so the line says which cycle it is.
+func prAutofixStartLine(stage string, cycle int) string {
+	desc := prAutofixStageNarration[stage]
+	if desc == "" {
+		desc = stage
+	}
+	if cycle > 1 {
+		return fmt.Sprintf("▶ %s — %s (cycle %d)", stage, desc, cycle)
+	}
+	return fmt.Sprintf("▶ %s — %s", stage, desc)
 }
 
 // showPRAutofixUsage explains the command.

--- a/internal/tui/prautofix_test.go
+++ b/internal/tui/prautofix_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/adk/v2/session"
+
 	"github.com/dimetron/pi-go/internal/sop"
+	sopexec "github.com/dimetron/pi-go/internal/sop/exec"
 )
 
 // TestPRTargetAccepted pins which forms name a pull request. gh accepts a URL,
@@ -140,5 +143,58 @@ func TestPRAutofixSOPDrawsInSidebar(t *testing.T) {
 		if !slices.Contains(compiled.Order, id) {
 			t.Errorf("compiled order %v is missing stage %q", compiled.Order, id)
 		}
+	}
+}
+
+// TestPRAutofixStageStartExtractsCycle verifies the lifecycle event parser
+// recovers both the stage id and the cycle number, so the narration can say
+// "cycle 2" when the graph loops back.
+func TestPRAutofixStageStartExtractsCycle(t *testing.T) {
+	tests := []struct {
+		name      string
+		branch    string
+		author    string
+		wantStage string
+		wantCycle int
+		wantOK    bool
+	}{
+		{"first activation", "push", sopexec.LifecycleAuthor, "push", 1, true},
+		{"second cycle", "watch#2", sopexec.LifecycleAuthor, "watch", 2, true},
+		{"third cycle", "watch#3", sopexec.LifecycleAuthor, "watch", 3, true},
+		{"not a lifecycle event", "push", "model", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := &session.Event{Author: tt.author, Branch: tt.branch}
+			stage, cycle, ok := prAutofixStageStart(ev)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if stage != tt.wantStage {
+				t.Errorf("stage = %q, want %q", stage, tt.wantStage)
+			}
+			if cycle != tt.wantCycle {
+				t.Errorf("cycle = %d, want %d", cycle, tt.wantCycle)
+			}
+		})
+	}
+}
+
+// TestPRAutofixStartLineNarratesStage verifies the start line names the stage,
+// carries its description, and includes the cycle number on loops > 1.
+func TestPRAutofixStartLineNarratesStage(t *testing.T) {
+	if got := prAutofixStartLine("push", 1); !strings.Contains(got, "push") {
+		t.Errorf("first cycle: %q should name the stage", got)
+	}
+	if got := prAutofixStartLine("push", 1); !strings.Contains(got, "Pushing to the PR branch") {
+		t.Errorf("first cycle: %q should carry the stage's description", got)
+	}
+	if got := prAutofixStartLine("watch", 2); !strings.Contains(got, "cycle 2") {
+		t.Errorf("second cycle: %q should say which cycle it is", got)
+	}
+	// An unknown stage falls back to its id rather than empty text.
+	if got := prAutofixStartLine("unknown", 1); !strings.Contains(got, "unknown") {
+		t.Errorf("unknown stage: %q should fall back to its id", got)
 	}
 }


### PR DESCRIPTION
## What

Two bugs in `/pr-autofix`:

1. **The push loop never fired** — `push` used `loop_back: watch`, but `loop_back` edges require `RecheckSignal` (RECHECK) as the route. A shell stage running `git push` emits `VerdictPass` (PASS) on exit 0 — RECHECK is never produced, so the loop edge never matched. The workflow exited after one push without re-polling CI, never checking if the PR went green.

2. **No TUI narration during stage transitions** — the transcript only showed raw stage output, never announced which stage was running or which cycle.

## Fix

1. Changed `push` from `loop_back: watch` to `routes: { PASS: watch }`. A successful push (exit 0 → PASS) now routes back to `watch` to re-poll CI. `max_cycles: 5` stays on `push` to bound the loop.

2. Added stage-start narration: when a lifecycle event arrives, the TUI shows `▶ push — Pushing to the PR branch (cycle 2)` in the transcript. The cycle number is recovered from the event's branch field (`stage#N`).

## Files

- `internal/sop/pr-autofix.sop.yaml` — push stage: `loop_back` → `routes: PASS: watch`
- `internal/tui/prautofix.go` — stage-start narration (prAutofixStageStart, prAutofixStartLine, prAutofixStageNarration)
- `internal/sop/prautofix_sop_test.go` — test: push routes PASS to watch
- `internal/tui/prautofix_test.go` — tests: lifecycle event parsing, narration rendering

## Verification

- `go build` / `go vet` — clean
- `go test ./internal/tui/ -run PRAutofix` — all pass
- `go test ./internal/sop/... -run PRAutofix` — all pass
- `golangci-lint` (pre-commit hook) — 0 issues