### PR TITLE
feat(tui): color subagent card events by role, not one flat grey

### DIFF
--- a/internal/tui/agent_event_colors_test.go
+++ b/internal/tui/agent_event_colors_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// fgOf returns the foreground SGR sequence a rendered line opens with, so tests
+// can assert two kinds render in different colors without hard-coding hex.
+func fgOf(line string) string {
+	if i := strings.Index(line, "m"); i > 0 && strings.HasPrefix(line, "\x1b[") {
+		return line[:i+1]
+	}
+	return ""
+}
+
+func renderOne(t *testing.T, ev agentEv, st agentEventStyles) string {
+	t.Helper()
+	lines := agentEventLines(ev, st, 200)
+	if len(lines) != 1 {
+		t.Fatalf("kind %q rendered %d lines, want 1: %q", ev.kind, len(lines), lines)
+	}
+	return lines[0]
+}
+
+// TestAgentEventLines_KindsAreVisuallyDistinct pins the point of the
+// stylesheet: the four roles a card mixes must not collapse into one color.
+// Before this, speech, results and lifecycle events all rendered in Dim.
+func TestAgentEventLines_KindsAreVisuallyDistinct(t *testing.T) {
+	st := newAgentEventStyles("claude", Palette{})
+
+	text := renderOne(t, agentEv{kind: "text", content: "hi"}, st)
+	tool := renderOne(t, agentEv{kind: "tool_call", content: "git status"}, st)
+	result := renderOne(t, agentEv{kind: "tool_result", content: "ok"}, st)
+	thinking := renderOne(t, agentEv{kind: "thinking_delta", content: "hmm"}, st)
+	failure := renderOne(t, agentEv{kind: "error", content: "spawn failed"}, st)
+	lifecycle := renderOne(t, agentEv{kind: "run_done", content: ""}, st)
+
+	roles := map[string]string{
+		"text": text, "tool_call": tool, "tool_result": result,
+		"thinking_delta": thinking, "error": failure, "run_done": lifecycle,
+	}
+	seen := make(map[string]string, len(roles))
+	for name, line := range roles {
+		fg := fgOf(line)
+		if fg == "" {
+			t.Errorf("%s rendered with no color: %q", name, line)
+			continue
+		}
+		if prev, dup := seen[fg]; dup {
+			t.Errorf("%s and %s render in the same color %q — they must be distinguishable", name, prev, fg)
+		}
+		seen[fg] = name
+	}
+}
+
+// TestAgentEventLines_SpeechOutranksLifecycle guards the ranking rather than
+// the exact hues: what the agent said must not render in the faint color
+// reserved for bookkeeping.
+func TestAgentEventLines_SpeechOutranksLifecycle(t *testing.T) {
+	st := newAgentEventStyles("", Palette{})
+	text := fgOf(renderOne(t, agentEv{kind: "text", content: "the answer"}, st))
+	lifecycle := fgOf(renderOne(t, agentEv{kind: "run_done", content: ""}, st))
+	if text == lifecycle {
+		t.Errorf("agent speech and lifecycle noise share color %q", text)
+	}
+}
+
+// TestAgentEventLines_ErrorEventIsMarked covers the event that motivated the
+// change: a failed subagent arrives as kind "error" and used to fall through to
+// the grey default branch, reading like ordinary bookkeeping.
+func TestAgentEventLines_ErrorEventIsMarked(t *testing.T) {
+	st := newAgentEventStyles("", Palette{})
+	line := renderOne(t, agentEv{kind: "error", content: "acp: connection refused"}, st)
+	plain := ansi.Strip(line)
+	if !strings.HasPrefix(plain, "✗ ") {
+		t.Errorf("error line = %q, want the ✗ marker", plain)
+	}
+	if !strings.Contains(plain, "connection refused") {
+		t.Errorf("error line lost its message: %q", plain)
+	}
+	lifecycle := fgOf(renderOne(t, agentEv{kind: "run_done", content: ""}, st))
+	if fgOf(line) == lifecycle {
+		t.Errorf("error renders in the lifecycle color %q", lifecycle)
+	}
+}
+
+// TestAgentEventLines_FailedToolResult checks a tool result that reports a
+// failure is marked as one, and that a clean result is not.
+func TestAgentEventLines_FailedToolResult(t *testing.T) {
+	st := newAgentEventStyles("", Palette{})
+
+	cases := []struct {
+		name    string
+		content string
+		failed  bool
+	}{
+		{"json error field", `{"error":"file not found"}`, true},
+		{"non-zero exit code", `{"exit_code":1,"output":"boom"}`, true},
+		{"zero exit code", `{"exit_code":0,"output":"fine"}`, false},
+		{"empty error field", `{"error":"","output":"fine"}`, false},
+		{"plain text result", "3 files changed", false},
+		{"not json", "{definitely not json", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isFailedToolResult(tc.content); got != tc.failed {
+				t.Fatalf("isFailedToolResult(%q) = %v, want %v", tc.content, got, tc.failed)
+			}
+			plain := ansi.Strip(renderOne(t, agentEv{kind: "tool_result", content: tc.content}, st))
+			marker := "✓"
+			if tc.failed {
+				marker = "✗"
+			}
+			if !strings.Contains(plain, marker) {
+				t.Errorf("tool_result line = %q, want marker %q", plain, marker)
+			}
+		})
+	}
+}
+
+// TestAgentEventLines_ToolHueStillVariesByAgent keeps the one role that is
+// deliberately per-agent: with several subagents running in parallel, the tool
+// color is what tells their calls apart.
+func TestAgentEventLines_ToolHueStillVariesByAgent(t *testing.T) {
+	ev := agentEv{kind: "tool_call", content: "git status"}
+	claude := fgOf(renderOne(t, ev, newAgentEventStyles("claude", Palette{})))
+	gemini := fgOf(renderOne(t, ev, newAgentEventStyles("gemini", Palette{})))
+	if claude == gemini {
+		t.Errorf("claude and gemini tool calls share color %q", claude)
+	}
+}
+
+// TestAgentEventLines_SpeechColorIsAgentIndependent is the counterpart: every
+// role except the tool hue is semantic, so it must not drift per agent.
+func TestAgentEventLines_SpeechColorIsAgentIndependent(t *testing.T) {
+	ev := agentEv{kind: "text", content: "hi"}
+	claude := fgOf(renderOne(t, ev, newAgentEventStyles("claude", Palette{})))
+	gemini := fgOf(renderOne(t, ev, newAgentEventStyles("gemini", Palette{})))
+	if claude != gemini {
+		t.Errorf("speech color varies by agent: %q vs %q", claude, gemini)
+	}
+}

--- a/internal/tui/complexity_render_test.go
+++ b/internal/tui/complexity_render_test.go
@@ -1086,10 +1086,10 @@ func TestRenderableAgentEventsRender(t *testing.T) {
 // notes: whole events dropped reports a count, a single over-long event
 // reports that its head was cut.
 func TestAgentWindowLinesRender(t *testing.T) {
-	st := lipgloss.NewStyle()
+	st := newAgentEventStyles("", Palette{})
 
 	t.Run("empty stream has no lines and no note", func(t *testing.T) {
-		lines, note := agentWindowLines(nil, st, st, 60)
+		lines, note := agentWindowLines(nil, st, 60)
 		if len(lines) != 0 || note != "" {
 			t.Errorf("got %d lines, note %q", len(lines), note)
 		}
@@ -1097,7 +1097,7 @@ func TestAgentWindowLinesRender(t *testing.T) {
 
 	t.Run("under budget shows everything with no note", func(t *testing.T) {
 		evs := []agentEv{{kind: "text", content: "a"}, {kind: "text", content: "b"}}
-		lines, note := agentWindowLines(evs, st, st, 60)
+		lines, note := agentWindowLines(evs, st, 60)
 		if len(lines) != 2 || note != "" {
 			t.Errorf("got %d lines %v, note %q", len(lines), lines, note)
 		}
@@ -1111,7 +1111,7 @@ func TestAgentWindowLinesRender(t *testing.T) {
 		for i := range evs {
 			evs[i] = agentEv{kind: "text", content: fmt.Sprintf("e%d", i)}
 		}
-		lines, note := agentWindowLines(evs, st, st, 60)
+		lines, note := agentWindowLines(evs, st, 60)
 		if len(lines) != maxAgentOutputLines {
 			t.Errorf("got %d lines, want %d", len(lines), maxAgentOutputLines)
 		}
@@ -1125,7 +1125,7 @@ func TestAgentWindowLinesRender(t *testing.T) {
 
 	t.Run("one over-long event reports a clip", func(t *testing.T) {
 		evs := []agentEv{{kind: "text", content: strings.Repeat("word ", 200)}}
-		lines, note := agentWindowLines(evs, st, st, 40)
+		lines, note := agentWindowLines(evs, st, 40)
 		if len(lines) != maxAgentOutputLines {
 			t.Errorf("got %d lines, want %d", len(lines), maxAgentOutputLines)
 		}

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -305,11 +305,8 @@ func agentTitleFit(title string, n int) string {
 // agentEventWindow renders the card's live event stream, newest activity last,
 // preceded by a note whenever output was withheld.
 func agentEventWindow(msg message, dim lipgloss.Style, p Palette, cw int) string {
-	evStyle := lipgloss.NewStyle().Foreground(p.Dim)
-	evToolStyle := lipgloss.NewStyle().Foreground(agentToolColor(msg.agentType, p))
-
 	renderable := renderableAgentEvents(msg.agentEvents)
-	lines, note := agentWindowLines(renderable, evStyle, evToolStyle, cw)
+	lines, note := agentWindowLines(renderable, newAgentEventStyles(msg.agentType, p), cw)
 
 	var b strings.Builder
 	if note != "" {
@@ -356,10 +353,10 @@ func renderableAgentEvents(evs []agentEv) []agentEv {
 // The note is written whenever output was withheld. A single huge event is
 // clipped without any whole event being dropped, and hiding 60-odd lines with
 // no mark would read as if that were all the agent said.
-func agentWindowLines(renderable []agentEv, evStyle, evToolStyle lipgloss.Style, cw int) (lines []string, note string) {
+func agentWindowLines(renderable []agentEv, st agentEventStyles, cw int) (lines []string, note string) {
 	used := 0
 	for i := len(renderable) - 1; i >= 0 && len(lines) < maxAgentOutputLines; i-- {
-		lines = append(agentEventLines(renderable[i], evStyle, evToolStyle, cw), lines...)
+		lines = append(agentEventLines(renderable[i], st, cw), lines...)
 		used++
 	}
 	skipped := len(renderable) - used
@@ -455,42 +452,100 @@ func (t *ToolDisplayModel) renderLiveOutput(msg message, dim lipgloss.Style, p P
 // enough to see what the agent is doing right now.
 const maxAgentOutputLines = 3
 
+// agentEventStyles is the per-kind stylesheet for a subagent card's event
+// window. The card mixes four different sorts of line — what the agent said,
+// what it ran, what came back, and lifecycle bookkeeping — and rendering them
+// all in one muted grey left the agent's actual answer no more prominent than a
+// "run_done" marker, and a failed run indistinguishable from a healthy one.
+//
+// The ranking is deliberate: speech reads brightest, then tool activity, then
+// results, with lifecycle noise faintest and errors pulled out in red.
+type agentEventStyles struct {
+	text      lipgloss.Style // what the agent said — the reason the card exists
+	tool      lipgloss.Style // tool calls, in the per-agent hue
+	result    lipgloss.Style // tool results that came back clean
+	thinking  lipgloss.Style // reasoning — deliberately backgrounded
+	failure   lipgloss.Style // error events and failed tool results
+	lifecycle lipgloss.Style // run_done and other bookkeeping
+}
+
+// newAgentEventStyles builds the card stylesheet. Only the tool hue varies by
+// agent: it is what lets a user pick one agent's calls out of several running
+// in parallel, so it stays keyed to agentType while every other role is
+// semantic and shared.
+func newAgentEventStyles(agentType string, p Palette) agentEventStyles {
+	p = paletteOrDark(p)
+	return agentEventStyles{
+		text:      lipgloss.NewStyle().Foreground(p.Text),
+		tool:      lipgloss.NewStyle().Foreground(agentToolColor(agentType, p)),
+		result:    lipgloss.NewStyle().Foreground(p.Success),
+		thinking:  lipgloss.NewStyle().Foreground(p.Dim),
+		failure:   lipgloss.NewStyle().Foreground(p.Error),
+		lifecycle: lipgloss.NewStyle().Foreground(p.Faint),
+	}
+}
+
 // agentEventLines renders one subagent event into the lines it occupies in the
 // card, already styled and soft-wrapped to width.
-func agentEventLines(ev agentEv, evStyle, evToolStyle lipgloss.Style, width int) []string {
+func agentEventLines(ev agentEv, st agentEventStyles, width int) []string {
 	var line string
 	switch ev.kind {
 	case "tool_call":
 		// Collapse embedded newlines so tool-call headers occupy one visual
 		// row — otherwise markdown prose inside a tool title (e.g. Gemini's
 		// "**Identifying...**\n\n\n...") drops blank rows into the card gutter.
-		line = evToolStyle.Render("⚙ " + collapseToSingleLine(ev.content))
+		line = st.tool.Render("⚙ " + collapseToSingleLine(ev.content))
 	case "tool_result":
-		line = evStyle.Render("  ✓ " + truncateRunes(toolResultSummary(ev.content), 80))
-	case "stderr":
-		// Subprocess stderr — diagnostic chatter. Color it with the per-agent
-		// hue (orange/gray/blue) so users can tell at a glance which subagent
-		// is writing what when several run in parallel. The thin "▎" marker
-		// still distinguishes stderr from real tool calls, which use "⚙".
-		line = evToolStyle.Render("▎ " + truncateRunes(collapseToSingleLine(ev.content), 120))
+		summary := truncateRunes(toolResultSummary(ev.content), 80)
+		if isFailedToolResult(ev.content) {
+			line = st.failure.Render("  ✗ " + summary)
+		} else {
+			line = st.result.Render("  ✓ " + summary)
+		}
 	case "text", "text_delta":
 		// Subagent message text — what the agent actually said. Collapse
 		// internal blank-line runs so paragraph spacing from streamed chunks
 		// doesn't produce wide gaps in the card.
-		line = evStyle.Render("» " + collapseToSingleLine(ev.content))
+		line = st.text.Render("» " + collapseToSingleLine(ev.content))
 	case "thinking_delta":
 		// Subagent reasoning — show it with the same 💭 marker the main
 		// chat uses for thinking, so it reads as thought, not speech.
-		line = evStyle.Render("💭 " + collapseToSingleLine(ev.content))
+		line = st.thinking.Render("💭 " + collapseToSingleLine(ev.content))
+	case "error":
+		// A failed spawn or a subprocess that died. This arrives as a normal
+		// event (forwardSingleModeEvents substitutes Event.Error into the
+		// content), so without its own branch it rendered as a grey
+		// "error: ..." line indistinguishable from lifecycle bookkeeping.
+		line = st.failure.Render("✗ " + truncateRunes(collapseToSingleLine(ev.content), 120))
 	default:
 		content := collapseToSingleLine(ev.content)
 		if content == "" {
-			line = evStyle.Render(ev.kind)
+			line = st.lifecycle.Render(ev.kind)
 		} else {
-			line = evStyle.Render(ev.kind + ": " + content)
+			line = st.lifecycle.Render(ev.kind + ": " + content)
 		}
 	}
 	return softWrap(line, width)
+}
+
+// isFailedToolResult reports whether a subagent tool result describes a
+// failure. The event carries only a content string — the shape a tool chose for
+// its own result — so this reads the two markers those results actually use: a
+// JSON "error" field, and a non-zero "exit_code". Anything else counts as
+// success, which keeps an unrecognized result looking normal rather than
+// painting every unfamiliar tool red.
+func isFailedToolResult(content string) bool {
+	var data map[string]any
+	if json.Unmarshal([]byte(content), &data) != nil {
+		return false
+	}
+	if s, ok := data["error"].(string); ok && strings.TrimSpace(s) != "" {
+		return true
+	}
+	if code, ok := data["exit_code"].(float64); ok && code != 0 {
+		return true
+	}
+	return false
 }
 
 // truncateRunes clips s to at most n runes, marking the cut. Slicing by byte


### PR DESCRIPTION
A subagent card mixes four different sorts of line: what the agent said, what
it ran, what came back, and lifecycle bookkeeping. Four of the six event kinds
rendered in the same Dim grey, so the agent's actual answer carried no more
visual weight than a "run_done" marker.

Worse, a failed run was invisible. Subagent "error" events reach the card as
ordinary events — forwardSingleModeEvents substitutes Event.Error into the
content — and had no branch of their own, so a dead subprocess rendered as a
grey "error: ..." line indistinguishable from bookkeeping.

Replace the two ad-hoc styles with an agentEventStyles set and rank the roles:
speech in Text, tool calls in the per-agent hue, clean results in Success,
reasoning in Dim, errors and failed results in Error, lifecycle in Faint. Tool
results now also report failure, read from the two markers results actually
carry — a JSON "error" field and a non-zero "exit_code" — with anything
unrecognized still rendering as success so an unfamiliar tool is not painted
red.

Only the tool hue stays keyed to the agent: it is what tells several parallel
agents' calls apart. Every other role is semantic and shared, and a test pins
that split in both directions.

Also drops the dead "stderr" branch. renderableAgentEvents filters stderr
before agentEventLines can ever see it, so the branch and its comment described
behavior that could not happen.

Verified live against a real agy run: speech renders in Text, run_done in
Faint, card results in Success green.

Signed-off-by: dimetron <dimetron@me.com>
