### PR TITLE
feat(agent): teach the system prompt to report CI status as a box table

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -200,7 +200,42 @@ When a response benefits from a visual diagram, use these three styles as approp
 - **Mermaid ` + "`" + `flowchart` + "`" + `** (` + "`" + `TD` + "`" + ` or ` + "`" + `LR` + "`" + `) — for showing a process, pipeline, or decision flow with arrows. Use ` + "`" + `TD` + "`" + ` (top-down) for sequential steps, ` + "`" + `LR` + "`" + ` (left-right) for pipelines with feedback loops.
 - **ASCII tree** — for showing file/directory structure, nested config, or anything naturally tree-shaped. Use box-drawing characters (` + "`" + `├──` + "`" + `, ` + "`" + `└──` + "`" + `, ` + "`" + `│` + "`" + `) with optional emoji annotations.
 
-Prefer the simplest style that communicates the idea. Do not mix styles within a single diagram. Use markdown tables to compare or summarize when a diagram is not needed.
+Prefer the simplest style that communicates the idea. Do not mix styles within a single diagram. Use markdown tables to compare or summarize when a diagram is not needed — except for CI and check status, which has its own format below.
+
+# CI status tables
+
+When reporting the state of CI stages — check runs, test gates, coverage gates,
+or any set of named checks — draw a box-drawing table. Do not use a markdown
+table for this: the TUI renders the response as text, so a markdown table
+arrives as raw pipes and dashes, while a box-drawing table renders as the grid
+you drew.
+
+Rules:
+- Pad every cell so the column rules line up. The table is only readable if the
+  vertical bars align down the whole grid; count display width, remembering an
+  emoji occupies two columns.
+- One row per check, with a separator row between rows.
+- Write the status as emoji plus word — ✅ pass, ❌ fail, ⏳ running — so the
+  state still reads where emoji do not render.
+- Include a Before column only when you changed something and know both states.
+  For a single snapshot, drop it and show the current status alone.
+- Never invent a status. A check you have not actually observed is unknown:
+  say so or leave the row out. Report what the CI output said, not what you
+  expect it to say once it finishes.
+
+Example shape:
+
+    ┌─────────────────┬─────────┬────────────┐
+    │      Check      │ Before  │    Now     │
+    ├─────────────────┼─────────┼────────────┤
+    │ codecov/patch   │ ❌ fail │ ✅ pass    │
+    ├─────────────────┼─────────┼────────────┤
+    │ codecov/project │ ❌ fail │ ✅ pass    │
+    ├─────────────────┼─────────┼────────────┤
+    │ Test (Windows)  │ ❌ fail │ ⏳ running │
+    ├─────────────────┼─────────┼────────────┤
+    │ Test            │ pass    │ ⏳ running │
+    └─────────────────┴─────────┴────────────┘
 
 # Internal tools
 

--- a/internal/agent/prompt_ci_table_test.go
+++ b/internal/agent/prompt_ci_table_test.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ciTableExample returns the box-drawing table lines from the CI status tables
+// section of SystemInstruction, with the example's leading indent stripped.
+func ciTableExample(t *testing.T) []string {
+	t.Helper()
+	const heading = "# CI status tables"
+	i := strings.Index(SystemInstruction, heading)
+	if i < 0 {
+		t.Fatalf("SystemInstruction has no %q section", heading)
+	}
+	section := SystemInstruction[i:]
+	if j := strings.Index(section[len(heading):], "\n# "); j >= 0 {
+		section = section[:len(heading)+j]
+	}
+	var rows []string
+	for _, line := range strings.Split(section, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && strings.ContainsAny(trimmed, "┌├└│") {
+			rows = append(rows, trimmed)
+		}
+	}
+	if len(rows) == 0 {
+		t.Fatal("CI status tables section contains no box-drawing example")
+	}
+	return rows
+}
+
+// TestSystemInstruction_CITableSectionPresent pins the instruction that CI
+// status is reported as a box-drawing table rather than a markdown one, since
+// the TUI renders responses as text and a markdown table arrives as raw pipes.
+func TestSystemInstruction_CITableSectionPresent(t *testing.T) {
+	for _, want := range []string{
+		"# CI status tables",
+		"✅ pass",
+		"❌ fail",
+		"⏳ running",
+	} {
+		if !strings.Contains(SystemInstruction, want) {
+			t.Errorf("SystemInstruction missing %q", want)
+		}
+	}
+	if !strings.Contains(SystemInstruction, "except for CI and check status") {
+		t.Error("the Diagrams section must point at the CI status table format")
+	}
+}
+
+// TestSystemInstruction_CITableExampleAligns checks the worked example is
+// actually a well-formed grid. The example is what the model copies, so a
+// misaligned one teaches misalignment — and emoji are two columns wide, which
+// is exactly the mistake this catches.
+func TestSystemInstruction_CITableExampleAligns(t *testing.T) {
+	rows := ciTableExample(t)
+
+	width := ansi.StringWidth(rows[0])
+	for i, row := range rows {
+		if got := ansi.StringWidth(row); got != width {
+			t.Errorf("row %d width = %d, want %d (all rows must be equal width)\n%s", i, got, width, row)
+		}
+	}
+
+	// Every row must place its column rules at the same display columns.
+	want := ruleColumns(rows[0])
+	for i, row := range rows {
+		if got := ruleColumns(row); !equalInts(got, want) {
+			t.Errorf("row %d rules at columns %v, want %v\n%s", i, got, want, row)
+		}
+	}
+}
+
+// ruleColumns returns the display columns at which a table row places a
+// vertical rule of any kind.
+func ruleColumns(row string) []int {
+	var cols []int
+	col := 0
+	for _, r := range row {
+		if strings.ContainsRune("│┌┬┐├┼┤└┴┘", r) {
+			cols = append(cols, col)
+		}
+		col += ansi.StringWidth(string(r))
+	}
+	return cols
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
The prompt told the agent to reach for a markdown table whenever a diagram was
not needed. That is the wrong default for CI status: the TUI renders a response
as text, so a markdown table arrives as raw pipes and dashes rather than a grid.

Add a "CI status tables" section covering check runs, test gates and coverage
gates: draw the grid with box-drawing characters, pad cells so the column rules
line up (counting emoji as two columns, which is the alignment mistake worth
naming), write each status as emoji plus word so it still reads where emoji do
not render, and include a Before column only when both states are actually
known. The section closes on the rule that matters most — never report a status
you have not observed — which matches the anti-hallucination rules already in
the prompt.

The worked example is what the model copies, so a test pins that it is a
well-formed grid: every row the same display width, every column rule at the
same display column. A row that is one cell short, or that forgets an emoji is
two columns wide, fails both checks.

Signed-off-by: dimetron <dimetron@me.com>
