### PR TITLE
fix(tui): stop the cycle detector aborting parallel background polls

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -31,6 +31,22 @@ const (
 	// make the repetition meaningless.
 	maxRepeatToolCalls = 10
 
+	// maxRunningPollRepeats is the identical-call threshold that replaces
+	// maxRepeatToolCalls while a bash poll's command is still running.
+	//
+	// A poll that returns byte-identical output is not evidence of a loop when
+	// the command behind it is alive: ffmpeg's palettegen pass, a linker, a
+	// test binary mid-run — all go quiet for tens of seconds while working, and
+	// at roughly three seconds per model round-trip ten identical polls is
+	// under half a minute of silence. Ten was a threshold set for tools whose
+	// target is static, and re-reading an unchanged file ten times really is a
+	// loop; waiting on a live process is not, so it gets its own budget.
+	//
+	// Deliberately large rather than unbounded: a model polling a hung handle
+	// forever should still be stopped eventually, and the poll's own wait_ms
+	// paces the spin in the meantime.
+	maxRunningPollRepeats = 500
+
 	// maxRepeatErrorCalls aliases maxRepeatToolCalls for callers that frame
 	// the threshold as an error-streak rather than a call-streak. The
 	// underlying detector is identical — identical fingerprint = stuck.
@@ -127,11 +143,16 @@ func extractAgentType(args map[string]any) string {
 
 // stuckDetector tracks recent tool calls and detects repetition loops.
 type stuckDetector struct {
-	recent     []string // ring of fingerprints (len <= recentWindowSize)
-	lastPrint  string   // fingerprint of last tool call
-	lastName   string   // tool name behind lastPrint
-	lastResult string   // fingerprint of the streak's previous result ("" = none yet)
-	streak     int      // consecutive identical tool calls with identical results
+	recent     []recentCall // ring of call+result pairs (len <= recentWindowSize)
+	recentSeq  int          // monotonic id handed to each entry in recent
+	lastPrint  string       // fingerprint of last tool call
+	lastName   string       // tool name behind lastPrint
+	lastResult string       // fingerprint of the streak's previous result ("" = none yet)
+	streak     int          // consecutive identical tool calls with identical results
+	// livePoll is set while the streak's tool is a bash poll whose last
+	// response reported the command still running. It swaps the identical-call
+	// threshold for maxRunningPollRepeats — see repeatLimit.
+	livePoll bool
 	// Two error detectors run in parallel. The args-aware streak keys on the
 	// call fingerprint, so only the same tool call failing repeatedly counts;
 	// the name-only streak keys on the tool name and compounds only across
@@ -151,11 +172,32 @@ type stuckDetector struct {
 
 // callRecord is what the detector remembers about an observed tool call so a
 // later response can be correlated back to it: the call's fingerprint (for the
-// args-aware error streak) and the message it appeared in (for the name-only
-// cross-batch streak).
+// args-aware error streak), the message it appeared in (for the name-only
+// cross-batch streak), and its slot in the repetition window (so the response
+// can be filed against the call it answers rather than against whichever call
+// happened to be observed last).
 type callRecord struct {
 	fp  string
 	msg int
+	seq int
+}
+
+// recentCall is one entry in the repetition window: a call, and what came back
+// from it. Both halves matter. Comparing calls alone cannot tell a model
+// spinning on a dead pattern from one driving several long-running jobs — the
+// fan-out of a parallel poll is a repeating sequence of fingerprints by
+// construction, and the only thing separating it from a genuine loop is that
+// its results keep changing. That is the rule observeResult already applies to
+// the identical-call streak; detectCycle applies it here.
+type recentCall struct {
+	call   string // call fingerprint
+	result string // result fingerprint; "" until the response arrives
+	seq    int    // matches the callRecord that produced it
+}
+
+// repeats reports whether c re-ran prev and got nothing new back.
+func (c recentCall) repeats(prev recentCall) bool {
+	return c.call == prev.call && c.result == prev.result
 }
 
 // volatileToolArgs address a slice of a target rather than the target itself.
@@ -209,7 +251,7 @@ func (s *stuckDetector) beginEvent() {
 // calls still reads as one message.
 func (s *stuckDetector) observe(id, name string, args map[string]any) (stuck bool, detail string) {
 	fp := toolFingerprint(name, args)
-	rec := callRecord{fp: fp, msg: s.msgSeq}
+	rec := callRecord{fp: fp, msg: s.msgSeq, seq: s.recentSeq}
 	if id != "" {
 		if s.callInfo == nil {
 			s.callInfo = make(map[string]callRecord)
@@ -229,24 +271,35 @@ func (s *stuckDetector) observe(id, name string, args map[string]any) (stuck boo
 		s.lastPrint = fp
 		s.lastName = name
 		s.lastResult = ""
+		s.livePoll = false
 	}
 
-	// Sliding window.
-	s.recent = append(s.recent, fp)
+	// Sliding window. The result half is filled in later, by observeResult.
+	s.recent = append(s.recent, recentCall{call: fp, seq: s.recentSeq})
+	s.recentSeq++
 	if len(s.recent) > recentWindowSize {
 		s.recent = s.recent[1:]
 	}
 
-	if s.streak >= maxRepeatToolCalls {
+	if limit := s.repeatLimit(); s.streak >= limit {
 		return true, fmt.Sprintf("identical tool call %q repeated %d times", name, s.streak)
 	}
 
-	// Detect short repeating cycles (AB AB AB) in the window.
-	if cycle := s.detectCycle(); cycle != "" {
-		return true, fmt.Sprintf("repeating tool cycle detected: %s", cycle)
-	}
-
+	// Cycle detection runs from observeResult instead: a cycle is only a cycle
+	// once the results are in, and at this point the call just observed has no
+	// result yet.
 	return false, ""
+}
+
+// repeatLimit is how many identical consecutive calls the current streak is
+// allowed before it counts as stuck. Waiting on a live command gets a much
+// larger budget than repeating a call against something static — see
+// maxRunningPollRepeats.
+func (s *stuckDetector) repeatLimit() int {
+	if s.livePoll {
+		return maxRunningPollRepeats
+	}
+	return maxRepeatToolCalls
 }
 
 // observeResult records a tool call's response. Polling tools repeat identical
@@ -257,13 +310,41 @@ func (s *stuckDetector) observe(id, name string, args map[string]any) (stuck boo
 // re-polling a finished command or re-reading an unchanged file is genuine
 // repetition. A stuck loop whose responses vary trivially (timestamps) escapes
 // this detector, but observeError and observeOutput still cover that shape.
-func (s *stuckDetector) observeResult(name string, response map[string]any) {
-	if name != s.lastName {
-		return
+//
+// It also closes the repetition window entry for the call it answers and runs
+// cycle detection, which is why it reports a verdict: a cycle is a claim about
+// calls *and* their results, so it cannot be decided when the call is observed.
+func (s *stuckDetector) observeResult(id, name string, response map[string]any) (stuck bool, detail string) {
+	fp := resultFingerprint(name, response)
+	rec, known := s.callFor(id, name)
+	if known {
+		s.fillResult(rec.seq, fp)
 	}
-	// bash_wait includes elapsed/idle fields that change on every poll even
-	// when the command produced no new output. Those fields are progress for the
-	// UI, not progress from the command, so exclude them from loop detection.
+
+	// The streak only tracks one call at a time, so a result belonging to some
+	// other call — another handle in the same parallel batch, or another tool
+	// entirely — must not be compared against it.
+	if name == s.lastName && (!known || rec.fp == s.lastPrint) {
+		if s.lastResult != "" && fp != s.lastResult {
+			s.streak = 0
+		}
+		s.lastResult = fp
+		s.livePoll = isLiveBashPoll(name, response)
+	}
+
+	if cycle := s.detectCycle(); cycle != "" {
+		return true, fmt.Sprintf("repeating tool cycle detected: %s", cycle)
+	}
+	return false, ""
+}
+
+// resultFingerprint hashes a tool response for comparison against the previous
+// response to the same call.
+//
+// bash_wait includes elapsed/idle fields that change on every poll even when
+// the command produced no new output. Those fields are progress for the UI, not
+// progress from the command, so exclude them from loop detection.
+func resultFingerprint(name string, response map[string]any) string {
 	stable := response
 	if isBashPoll(name) {
 		stable = make(map[string]any, len(response))
@@ -275,11 +356,42 @@ func (s *stuckDetector) observeResult(name string, response map[string]any) {
 	}
 	b, _ := json.Marshal(stable)
 	sum := sha256.Sum256(b)
-	fp := hex.EncodeToString(sum[:])[:16]
-	if s.lastResult != "" && fp != s.lastResult {
-		s.streak = 0
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// isLiveBashPoll reports whether response is a poll of a command that has not
+// finished yet.
+func isLiveBashPoll(name string, response map[string]any) bool {
+	if !isBashPoll(name) {
+		return false
 	}
-	s.lastResult = fp
+	running, _ := response["running"].(bool)
+	return running
+}
+
+// callFor resolves the call a response belongs to, by ID where the provider
+// supplies one and by tool name otherwise — the same fallback observeError
+// uses for ID-less calls.
+func (s *stuckDetector) callFor(id, name string) (callRecord, bool) {
+	if id != "" {
+		if rec, ok := s.callInfo[id]; ok {
+			return rec, true
+		}
+	}
+	rec, ok := s.lastCallByName[name]
+	return rec, ok
+}
+
+// fillResult attaches a result fingerprint to its call in the repetition
+// window. The entry is gone if the window has already slid past it, which is
+// not an error: a window that old cannot be part of a cycle being detected now.
+func (s *stuckDetector) fillResult(seq int, fp string) {
+	for i := range s.recent {
+		if s.recent[i].seq == seq {
+			s.recent[i].result = fp
+			return
+		}
+	}
 }
 
 // observeError records the outcome of a tool call and reports whether the loop
@@ -444,8 +556,18 @@ func isPeriodic(buf string, period, repeats int) bool {
 // A "cycle" requires that consecutive elements differ — a uniform window
 // like [a,a,a,a,a,a] is a streak, not a cycle, and the identical-call
 // detector above already handles that case at maxRepeatToolCalls.
+//
+// It also requires every repetition to have produced the same result as the
+// one before it. Distinct calls arranged in a repeating order are not on their
+// own evidence of anything: a model driving four background jobs polls them in
+// the same order every message, and a rotation of that fan-out is a perfect
+// length-3 cycle across message boundaries while every poll returns fresh
+// output. Without the result half, that shape aborts a working run in three
+// model messages — see session 260829-1537-6a139-71d65, which died eight
+// seconds after one of its four jobs finished and the fan-out fell to three.
 func (s *stuckDetector) detectCycle() string {
-	n := len(s.recent)
+	window := s.completedWindow()
+	n := len(window)
 	if n < 6 {
 		return ""
 	}
@@ -455,13 +577,13 @@ func (s *stuckDetector) detectCycle() string {
 		if n < need {
 			continue
 		}
-		tail := s.recent[n-need:]
+		tail := window[n-need:]
 		cycle := tail[:cycleLen]
 		// Require adjacent elements in the candidate cycle to differ —
 		// otherwise it's a uniform streak, not an alternating cycle.
 		cycleValid := true
 		for i := 1; i < cycleLen; i++ {
-			if cycle[i] == cycle[i-1] {
+			if cycle[i].call == cycle[i-1].call {
 				cycleValid = false
 				break
 			}
@@ -471,7 +593,7 @@ func (s *stuckDetector) detectCycle() string {
 		}
 		match := true
 		for i := cycleLen; i < need; i++ {
-			if tail[i] != cycle[i%cycleLen] {
+			if !tail[i].repeats(cycle[i%cycleLen]) {
 				match = false
 				break
 			}
@@ -481,6 +603,19 @@ func (s *stuckDetector) detectCycle() string {
 		}
 	}
 	return ""
+}
+
+// completedWindow is the leading run of the window whose responses have all
+// arrived. A call still in flight has no result to compare, and calls issued in
+// one batch are all observed before any of them answers, so the pending entries
+// are skipped rather than treated as matching anything.
+func (s *stuckDetector) completedWindow() []recentCall {
+	for i := range s.recent {
+		if s.recent[i].result == "" {
+			return s.recent[:i]
+		}
+	}
+	return s.recent
 }
 
 // agentMsg wraps messages coming from the agent goroutine via a channel.
@@ -1129,8 +1264,12 @@ func (m *model) emitPartResponse(
 
 	// A changed result on a repeated call is progress, not a loop
 	// (a poll returning fresh output) — let it reset the
-	// identical-call streak before the next call is observed.
-	detector.observeResult(fr.Name, fr.Response)
+	// identical-call streak before the next call is observed. This is
+	// also where cycle detection runs, since a cycle is only decidable
+	// once the calls in the window have their results.
+	if err := stuckErr(detector.observeResult(fr.ID, fr.Name, fr.Response)); err != nil {
+		return err
+	}
 
 	// Track per-tool error streaks: ADK wraps tool errors as
 	// map[string]any{"error": ...}. Anything else (including a

--- a/internal/tui/agent_loop_stuck_test.go
+++ b/internal/tui/agent_loop_stuck_test.go
@@ -121,7 +121,7 @@ func TestStuckDetector_ObserveResult_PollingNotStuck(t *testing.T) {
 		if stuck {
 			t.Fatalf("poll %d flagged stuck: %s", i, detail)
 		}
-		s.observeResult("bash_wait", map[string]any{
+		s.observeResult("c", "bash_wait", map[string]any{
 			"handle":  "bg_16",
 			"elapsed": i,
 			"stdout":  fmt.Sprintf("line %d\n", i), // command progress: every response differs
@@ -130,21 +130,50 @@ func TestStuckDetector_ObserveResult_PollingNotStuck(t *testing.T) {
 	}
 }
 
+// TestStuckDetector_ObserveResult_ChangingTimingDoesNotReset pins that
+// elapsed/idle are not progress: a poll whose only changing fields are the
+// clock still accumulates a streak. The budget is maxRunningPollRepeats rather
+// than maxRepeatToolCalls because the command is still running — see
+// TestStuckDetector_ObserveResult_FinishedPollTripsAtNormalThreshold for the
+// other half.
 func TestStuckDetector_ObserveResult_ChangingTimingDoesNotReset(t *testing.T) {
 	s := &stuckDetector{}
 	args := map[string]any{"handle": "bg_16"}
-	for i := 0; i < maxRepeatToolCalls; i++ {
+	for i := 0; i < maxRunningPollRepeats; i++ {
 		stuck, _ := s.observe("c", "bash_wait", args)
-		if i == maxRepeatToolCalls-1 && !stuck {
-			t.Fatalf("timing-only polls should trip after %d repeats", maxRepeatToolCalls)
+		if i < maxRepeatToolCalls && stuck {
+			t.Fatalf("poll %d of a running command tripped at the static-tool threshold", i)
 		}
-		s.observeResult("bash_wait", map[string]any{
+		if i == maxRunningPollRepeats-1 && !stuck {
+			t.Fatalf("timing-only polls should trip after %d repeats", maxRunningPollRepeats)
+		}
+		s.observeResult("c", "bash_wait", map[string]any{
 			"handle":  "bg_16",
 			"elapsed": i,
 			"idle":    i + 1,
 			"running": true,
 			"stdout":  "",
 			"stderr":  "",
+		})
+	}
+}
+
+// TestStuckDetector_ObserveResult_FinishedPollTripsAtNormalThreshold pins the
+// boundary of the running-command budget: once the command has exited there is
+// nothing left to wait for, so re-polling it is an ordinary repeated call.
+func TestStuckDetector_ObserveResult_FinishedPollTripsAtNormalThreshold(t *testing.T) {
+	s := &stuckDetector{}
+	args := map[string]any{"handle": "bg_16"}
+	for i := 0; i < maxRepeatToolCalls; i++ {
+		stuck, _ := s.observe("c", "bash_wait", args)
+		if i == maxRepeatToolCalls-1 && !stuck {
+			t.Fatalf("polling a finished command should trip after %d repeats", maxRepeatToolCalls)
+		}
+		s.observeResult("c", "bash_wait", map[string]any{
+			"handle":  "bg_16",
+			"elapsed": i,
+			"running": false,
+			"stdout":  "done",
 		})
 	}
 }
@@ -157,7 +186,7 @@ func TestStuckDetector_ObserveResult_IdenticalResultsStillStuck(t *testing.T) {
 	for i := 0; i < maxRepeatToolCalls; i++ {
 		stuck, _ := s.observe("c", "bash_wait", args)
 		tripped = tripped || stuck
-		s.observeResult("bash_wait", resp)
+		s.observeResult("c", "bash_wait", resp)
 	}
 	if !tripped {
 		t.Errorf("identical calls with identical results should still trip after %d repeats", maxRepeatToolCalls)
@@ -168,8 +197,8 @@ func TestStuckDetector_ObserveResult_OtherToolDoesNotReset(t *testing.T) {
 	s := &stuckDetector{}
 	s.observe("c", "read", map[string]any{"path": "/foo"})
 	s.observe("c", "read", map[string]any{"path": "/foo"})
-	s.observeResult("write", map[string]any{"changed": 1})
-	s.observeResult("write", map[string]any{"changed": 2})
+	s.observeResult("", "write", map[string]any{"changed": 1})
+	s.observeResult("", "write", map[string]any{"changed": 2})
 	if s.streak != 2 {
 		t.Errorf("streak = %d, want 2: another tool's results must not reset it", s.streak)
 	}
@@ -178,7 +207,7 @@ func TestStuckDetector_ObserveResult_OtherToolDoesNotReset(t *testing.T) {
 func TestStuckDetector_ObserveResult_FirstResultOnlySetsBaseline(t *testing.T) {
 	s := &stuckDetector{}
 	s.observe("c", "read", map[string]any{"path": "/foo"})
-	s.observeResult("read", map[string]any{"content": "x"})
+	s.observeResult("c", "read", map[string]any{"content": "x"})
 	if s.streak != 1 {
 		t.Errorf("streak = %d, want 1: the first result has nothing to compare against", s.streak)
 	}
@@ -344,7 +373,7 @@ func TestDetectCycle_ShortWindow(t *testing.T) {
 		t.Errorf("detectCycle on empty = %q, want empty", cycle)
 	}
 
-	s.recent = make([]string, 5)
+	s.recent = staleWindow("a", "b", "c", "d", "e")
 	if cycle := s.detectCycle(); cycle != "" {
 		t.Errorf("detectCycle on len=5 = %q, want empty", cycle)
 	}
@@ -352,7 +381,7 @@ func TestDetectCycle_ShortWindow(t *testing.T) {
 
 func TestDetectCycle_NoRepeat(t *testing.T) {
 	s := &stuckDetector{}
-	s.recent = []string{"a", "b", "c", "d", "e", "f"}
+	s.recent = staleWindow("a", "b", "c", "d", "e", "f")
 	if cycle := s.detectCycle(); cycle != "" {
 		t.Errorf("detectCycle on non-repeating = %q, want empty", cycle)
 	}
@@ -361,7 +390,7 @@ func TestDetectCycle_NoRepeat(t *testing.T) {
 func TestDetectCycle_TwoRepeat(t *testing.T) {
 	s := &stuckDetector{}
 	// ABABAB pattern - 3 repetitions of length-2 cycle
-	s.recent = []string{"a", "b", "a", "b", "a", "b"}
+	s.recent = staleWindow("a", "b", "a", "b", "a", "b")
 	cycle := s.detectCycle()
 	if cycle == "" {
 		t.Error("expected cycle detected for ABABAB pattern")
@@ -371,7 +400,7 @@ func TestDetectCycle_TwoRepeat(t *testing.T) {
 func TestDetectCycle_ThreeRepeat(t *testing.T) {
 	s := &stuckDetector{}
 	// ABCABCABC pattern - 3 repetitions of length-3 cycle (need 9 elements)
-	s.recent = []string{"a", "b", "c", "a", "b", "c", "a", "b", "c"}
+	s.recent = staleWindow("a", "b", "c", "a", "b", "c", "a", "b", "c")
 	cycle := s.detectCycle()
 	if cycle == "" {
 		t.Error("expected cycle detected for ABCABCABC pattern")
@@ -381,7 +410,7 @@ func TestDetectCycle_ThreeRepeat(t *testing.T) {
 func TestDetectCycle_NoPatternAtBoundary(t *testing.T) {
 	s := &stuckDetector{}
 	// AAB pattern - not a valid cycle
-	s.recent = []string{"a", "a", "b", "a", "a", "b"}
+	s.recent = staleWindow("a", "a", "b", "a", "a", "b")
 	cycle := s.detectCycle()
 	if cycle != "" {
 		t.Logf("cycle detected (may be valid): %s", cycle)
@@ -404,4 +433,173 @@ func TestSubmitPrompt_NilCancel(t *testing.T) {
 		// We can't fully test without the full model, but we test the cancel path
 	}()
 	_ = prompt // use the variable
+}
+
+// staleWindow builds a repetition window in which every call returned exactly
+// what it returned last time — repetition with no progress, which is the shape
+// detectCycle is meant to catch.
+func staleWindow(calls ...string) []recentCall {
+	w := make([]recentCall, len(calls))
+	for i, c := range calls {
+		w[i] = recentCall{call: c, result: "result-of-" + c, seq: i}
+	}
+	return w
+}
+
+// TestDetectCycle_ChangingResultsIsNotACycle is the counterpart to
+// TestDetectCycle_ThreeRepeat: the same ABCABCABC call pattern, but every call
+// returned something new. A repeating order of calls is not a loop when the
+// calls keep producing fresh output.
+func TestDetectCycle_ChangingResultsIsNotACycle(t *testing.T) {
+	s := &stuckDetector{}
+	calls := []string{"a", "b", "c", "a", "b", "c", "a", "b", "c"}
+	s.recent = make([]recentCall, len(calls))
+	for i, c := range calls {
+		s.recent[i] = recentCall{call: c, result: fmt.Sprintf("r%d", i), seq: i}
+	}
+	if cycle := s.detectCycle(); cycle != "" {
+		t.Errorf("detectCycle on progressing results = %q, want empty", cycle)
+	}
+}
+
+// TestDetectCycle_SkipsPendingResults pins that calls still in flight are not
+// treated as matching anything. A batch of parallel calls is all observed
+// before any of them answers, so without this the window would be mostly
+// unresolved entries.
+func TestDetectCycle_SkipsPendingResults(t *testing.T) {
+	s := &stuckDetector{}
+	s.recent = staleWindow("a", "b", "a", "b", "a", "b")
+	s.recent[3].result = "" // in flight
+	if cycle := s.detectCycle(); cycle != "" {
+		t.Errorf("detectCycle across a pending call = %q, want empty", cycle)
+	}
+}
+
+// TestStuckDetector_ParallelPollFanOutIsNotALoop replays session
+// 260829-1537-6a139-71d65: four backgrounded ffmpeg jobs polled together, one
+// bash_output call per handle per model message, every response carrying a
+// fresh frame count. When one job finished and the fan-out fell from four to
+// three, the pre-fix cycle detector matched a rotation of the remaining three
+// handles — (bg_9, bg_12, bg_10), straddling message boundaries — and aborted
+// a working run eight seconds later.
+//
+// The loop runs every fan-out width, not just three: cycle lengths 2 and 3 were
+// the only widths that could ever trip, which is exactly why the bug looked
+// arbitrary from the outside.
+func TestStuckDetector_ParallelPollFanOutIsNotALoop(t *testing.T) {
+	for fanOut := 1; fanOut <= 5; fanOut++ {
+		t.Run(fmt.Sprintf("fanout%d", fanOut), func(t *testing.T) {
+			handles := make([]string, fanOut)
+			for i := range handles {
+				handles[i] = fmt.Sprintf("bg_%d", i)
+			}
+			s := &stuckDetector{}
+			poll := 0
+			for round := 0; round < 8; round++ {
+				s.beginEvent()
+				ids := make([]string, fanOut)
+				for i, h := range handles {
+					ids[i] = fmt.Sprintf("call-%d-%d", round, i)
+					stuck, detail := s.observe(ids[i], "bash_output", map[string]any{
+						"handle": h, "wait_ms": 1000,
+					})
+					if stuck {
+						t.Fatalf("round %d, %s: false loop detection on call: %s", round, h, detail)
+					}
+				}
+				// Responses arrive as their own message, after every call in
+				// the batch has been observed.
+				for i, h := range handles {
+					poll++
+					stuck, detail := s.observeResult(ids[i], "bash_output", map[string]any{
+						"handle":  h,
+						"running": true,
+						"elapsed": fmt.Sprintf("%ds", poll),
+						"stderr":  fmt.Sprintf("frame= %d", poll), // ffmpeg progress
+					})
+					if stuck {
+						t.Fatalf("round %d, %s: false loop detection on result: %s", round, h, detail)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestStuckDetector_AlternatingCallsWithStaleResultsStillStuck is the guard on
+// the other side: an A-B-A-B flail where neither call produces anything new
+// must still be caught, through the same observe/observeResult path a real run
+// takes.
+func TestStuckDetector_AlternatingCallsWithStaleResultsStillStuck(t *testing.T) {
+	s := &stuckDetector{}
+	responses := map[string]map[string]any{
+		"/a": {"error": "no such file"},
+		"/b": {"error": "no such file"},
+	}
+	for round := 0; round < 4; round++ {
+		s.beginEvent()
+		for _, path := range []string{"/a", "/b"} {
+			id := fmt.Sprintf("call-%d-%s", round, path)
+			if stuck, _ := s.observe(id, "read", map[string]any{"path": path}); stuck {
+				return // caught on the call side
+			}
+			if stuck, detail := s.observeResult(id, "read", responses[path]); stuck {
+				if !strings.Contains(detail, "cycle") {
+					t.Fatalf("detail = %q, want a cycle", detail)
+				}
+				return
+			}
+		}
+	}
+	t.Error("stale A-B-A-B alternation was never flagged")
+}
+
+// TestStuckDetector_ReplaysSession260829 replays the recorded call sequence of
+// session 260829-1537-6a139-71d65 exactly: twenty messages polling four
+// handles, then two polling three after bg_11 exited, then one polling two.
+//
+// The fan-out transition is the point. Twenty identical rounds at width four
+// passed, because detectCycle only ever looked for cycles of length 2 and 3;
+// the run died three messages after the width fell to three, on a cycle
+// (bg_9, bg_12, bg_10) that is a rotation of the batch rather than the batch
+// itself. Nothing about the model's behavior changed at that boundary.
+func TestStuckDetector_ReplaysSession260829(t *testing.T) {
+	var messages [][]string
+	for i := 0; i < 20; i++ {
+		messages = append(messages, []string{"bg_12", "bg_10", "bg_11", "bg_9"})
+	}
+	messages = append(messages,
+		[]string{"bg_12", "bg_10", "bg_9"},
+		[]string{"bg_12", "bg_10", "bg_9"},
+		[]string{"bg_12", "bg_10"},
+	)
+
+	s := &stuckDetector{}
+	frame := 0
+	for n, batch := range messages {
+		s.beginEvent()
+		ids := make([]string, len(batch))
+		for i, h := range batch {
+			ids[i] = fmt.Sprintf("call-%d-%d", n, i)
+			if stuck, detail := s.observe(ids[i], "bash_output", map[string]any{
+				"handle": h, "wait_ms": 1000,
+			}); stuck {
+				t.Fatalf("message %d, %s: %s", n+3, h, detail)
+			}
+		}
+		for i, h := range batch {
+			frame++
+			if stuck, detail := s.observeResult(ids[i], "bash_output", map[string]any{
+				"handle":  h,
+				"running": true,
+				"elapsed": fmt.Sprintf("%ds", frame*3),
+				"stderr":  fmt.Sprintf("frame= %d fps=12 q=-1.0 size= %dkB", frame, frame*47),
+			}); stuck {
+				t.Fatalf("message %d, %s: %s", n+3, h, detail)
+			}
+		}
+	}
+	if s.streak > maxRepeatToolCalls {
+		t.Errorf("identical-call streak reached %d; no call in this session repeated its own args", s.streak)
+	}
 }


### PR DESCRIPTION
## The bug

Session `260829-1537-6a139-71d65` was killed mid-run with:

```
agent loop aborted: repeating tool cycle detected: length-3 cycle repeated 3 times
```

The model was re-encoding four GIFs with `ffmpeg`, polling each backgrounded
handle once per message. Every poll returned a fresh frame count. Nothing
repeated — no call in the entire session repeated its own arguments, and the
identical-call streak never counted past 1.

`detectCycle` compared call fingerprints alone. A parallel fan-out is a
repeating sequence of fingerprints *by construction*, so the window matched a
rotation of the batch, straddling message boundaries:

```
window (12):    bg_12 bg_10 bg_11 bg_9 | bg_12 bg_10 bg_9 | bg_12 bg_10 bg_9 | bg_12 bg_10
matched cycle:                  [bg_9    bg_12 bg_10]
```

That is three model messages, about eight seconds. Twenty earlier messages at
fan-out four passed untouched, because only cycle lengths 2 and 3 are ever
checked — the run died at the moment one job finished and the fan-out fell to
three. The outcome depended entirely on how many jobs happened to still be
running:

| parallel handles polled | before this change |
|---|---|
| 1 | safe (the streak detector is result-aware) |
| 2 | aborts after 3 messages |
| 3 | aborts after 3 messages |
| 4+ | safe (cycle length not checked) |

## The fix

Give the cycle detector the rule `observeResult` already applies to the
identical-call streak: **a repeat that produced something new is progress.**

- The repetition window holds call+result pairs (`recentCall`) instead of bare
  call fingerprints, and a cycle must repeat in both halves.
- Cycle detection moves from `observe` to `observeResult`. A cycle is not
  decidable while the calls in the window are still in flight, and a parallel
  batch is entirely observed before any of it answers; `completedWindow` skips
  pending entries rather than letting them match anything.
- Results are filed against the call they answer, by response ID
  (`callFor`/`fillResult`), with the same name-based fallback `observeError`
  uses for ID-less calls. This also fixes a latent bug: under fan-out the
  streak was comparing one handle's response against a different handle's.

## Split identical-call threshold

`maxRepeatToolCalls = 10` was set for tools whose target is static, where
re-reading an unchanged file ten times really is a loop. Waiting on a live
process is not: at roughly three seconds per model round-trip, ten identical
polls is under half a minute, and a linker or an ffmpeg palettegen pass goes
quiet for longer than that while working.

```go
maxRepeatToolCalls    = 10   // static target
maxRunningPollRepeats = 500  // bash poll whose response says running: true
```

A poll of a command that has already exited drops back to 10 — there is nothing
left to wait for. Large rather than unbounded, so a model polling a hung handle
is still stopped eventually.

## Verification

- Replays the recorded call sequence of the session, including the 4 → 3 → 2
  fan-out transition. Before this change it aborted at message 25 on the
  `bg_10` call, matching the live log exactly.
- Covers fan-out widths 1 through 5, so the outcome no longer depends on how
  many jobs are in flight.
- The stale A-B-A-B flail the detector exists for is still caught, now
  exercised through the live `observe`/`observeResult` path rather than by
  poking `s.recent` directly.
- `make lint` 0 issues, `go vet` clean, `make test` green apart from
  `TestNewPromptHandler_NoAPIKey`, which fails identically on `main` (the test
  wants "no API key" but the environment has one, so it reaches the API and
  gets a 404 for a retired model). Unrelated to this branch.

## Known gap, not addressed here

The session took a hard abort instead of the two recovery attempts
`runAgentLoop` grants a `*stuckError`. No `telling the model and resuming` line
in the log, no recovery prompt in `events.jsonl`. `errors.As` looks correct on
`main` and `TestRunAgentLoop_RecoversFromRepeatedOutput` passes, which points at
the binary that ran being older than `781a7a0` rather than at a live bug — but
it is unconfirmed, and worth its own look.
