### PR TITLE
fix(acp): stop the ACP SDK logging to the terminal and corrupting the TUI

### DIFF
--- a/internal/acp/client/logger_test.go
+++ b/internal/acp/client/logger_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+// TestRunnerLoggerNeverNil pins the guarantee that makes the TUI safe: a Runner
+// with no Logger must still hand the SDK a real logger. The SDK falls back to
+// slog.Default() when its logger is unset, and slog.Default() writes to stderr
+// — the terminal the TUI draws on.
+func TestRunnerLoggerNeverNil(t *testing.T) {
+	if got := (Runner{}).logger(); got == nil {
+		t.Fatal("Runner{}.logger() = nil; the SDK would fall back to slog.Default() and write to stderr")
+	}
+}
+
+// TestRunnerLoggerDiscardsByDefault checks the default logger actually swallows
+// records rather than merely being non-nil.
+func TestRunnerLoggerDiscardsByDefault(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	(Runner{}).logger().Info("connection closed", "cause", "peer connection closed")
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if buf.Len() != 0 {
+		t.Errorf("default logger wrote %q to stderr; it must discard", buf.String())
+	}
+}
+
+// TestRunnerLoggerHonoursExplicit keeps the override working, so a caller that
+// wants SDK diagnostics in the session log still gets them.
+func TestRunnerLoggerHonoursExplicit(t *testing.T) {
+	var buf bytes.Buffer
+	want := slog.New(slog.NewTextHandler(&buf, nil))
+	if got := (Runner{Logger: want}).logger(); got != want {
+		t.Error("an explicit Logger must be used as-is")
+	}
+	(Runner{Logger: want}).logger().Info("hello")
+	if buf.Len() == 0 {
+		t.Error("explicit logger received no records")
+	}
+}

--- a/internal/acp/client/runner.go
+++ b/internal/acp/client/runner.go
@@ -54,9 +54,22 @@ func (r Runner) startCommand(ctx context.Context, cmd *exec.Cmd, req shared.RunR
 	session := newRunningSession(cmd, stdin, stderr)
 	client := &callbackClient{session: session}
 	conn := acp.NewClientSideConnection(client, stdin, stdout)
-	if r.Logger != nil {
-		conn.SetLogger(r.Logger)
-	}
+	// Always install a logger. With none set the SDK falls back to
+	// slog.Default(), which writes to stderr — the same terminal the TUI is
+	// drawing on. Its end-of-run line
+	//
+	//	INFO connection closed cause="peer connection closed"
+	//
+	// lands mid-frame and carries its own newline, which scrolls the terminal
+	// by a row. The TUI renders inline rather than on the alternate screen, so
+	// it repaints by moving the cursor up a counted number of rows: after that
+	// scroll every frame lands one row off, stranding the previous frame's
+	// status bar in the input line for the rest of the session.
+	//
+	// No caller sets Logger today, so defaulting here rather than at each call
+	// site is what makes the guarantee hold for every agent — and for the next
+	// one added.
+	conn.SetLogger(r.logger())
 	session.conn = conn
 
 	go session.run(req, r.clientInfo())
@@ -78,6 +91,15 @@ func (r Runner) Start(ctx context.Context, req shared.RunRequest) (*RunningSessi
 
 	cmd := exec.CommandContext(ctx, req.Command[0], req.Command[1:]...)
 	return r.startCommand(ctx, cmd, req)
+}
+
+// logger returns the logger for SDK connection diagnostics. A nil Logger means
+// "discard", never "fall back to slog.Default()" — see startCommand.
+func (r Runner) logger() *slog.Logger {
+	if r.Logger != nil {
+		return r.Logger
+	}
+	return slog.New(slog.DiscardHandler)
 }
 
 func (r Runner) clientInfo() acp.Implementation {


### PR DESCRIPTION
Running "@agy say Hi!" corrupted the TUI every time: the status bar appeared
twice, the second copy drawn into the input line and half-overwritten, with
fragments spilling below the panel. It reproduced in every recording made
today and in the blog GIF.

The cause is one log line. coder/acp-go-sdk logs internal connection
diagnostics through slog.Default() whenever no logger is installed
(connection.go loggerOrDefault), and slog.Default() writes to stderr — the
same terminal the TUI is drawing on. When a subagent's connection closes at
the end of a run the SDK emits

	INFO connection closed cause="peer connection closed"

straight to the screen, mid-frame, carrying its own newline. That scrolls the
terminal by a row. The TUI renders inline rather than on the alternate screen,
so it repaints by moving the cursor up a counted number of rows: after that
single scroll every frame lands one row off, for the rest of the session.

Runner.startCommand only called SetLogger when Logger was non-nil, and no
caller ever sets it — so every ACP agent (agy, claudecode, gemini, cursor,
copilot) leaked. Default it in Runner.logger() instead of at the call sites,
so the guarantee holds for the agents that exist and the next one added. An
explicit Logger still wins, for callers that want the diagnostics in the
session log.

Verified by driving the real TUI under a pty on two models. Before: 2
"connection closed" writes, terminal scrolled 6 times, two status bars on
screen. After, with agy completing normally in both runs: zero such writes and
one status bar.

	                 before      after
	stray writes         2          0
	status bars          2          1

Not covered here: internal/acp/server takes the same default, but writes to
stderr as an ACP agent on stdio, where stderr is the diagnostic channel and no
TUI is drawing.

Signed-off-by: dimetron <dimetron@me.com>
