### PR TITLE
feat(tui): show configured A2A agents in the sidebar

### DIFF
--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -151,6 +151,7 @@ func runInteractive(
 		ModelSwitcher: func(switchCtx context.Context, modelName string) (adkmodel.LLM, string, string, error) {
 			return buildSwitchedLLM(switchCtx, cfg, tokenTracker, modelName)
 		},
+		A2A: cfg.A2A,
 	})
 
 	initCancel() // signal deferred init to stop

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -64,9 +64,15 @@ type SidebarRenderInput struct {
 	Orchestrator   *subagent.Orchestrator   // may be nil — for agents section
 	Skills         []extension.Skill        // skills section; nil = hidden
 	MCPTools       []extension.MCPToolEntry // MCP tools section; nil = hidden
+	A2AAgents      []A2AAgentEntry          // A2A agents section; nil = hidden
 	MemoryStatus   *palace.PalaceStatus     // memory palace status; nil = hidden
 	Artifacts      []ArtifactEntry          // artifacts section; nil/empty = hidden
 	Palette        Palette                  // resolved theme palette; zero = dark default
+}
+
+// A2AAgentEntry is one row in the A2A Agents sidebar section.
+type A2AAgentEntry struct {
+	Name string
 }
 
 // ArtifactEntry is one row in the Artifacts sidebar section.
@@ -268,6 +274,7 @@ func sidebarTailLines(in SidebarRenderInput, innerW int, st sidebarStyles) []str
 		sidebarSkillLines(in, st),
 		sidebarMemoryLines(in, st),
 		sidebarMCPLines(in, innerW, st),
+		sidebarA2ALines(in, innerW, st),
 		sidebarLoadingLines(in, st),
 	} {
 		out = append(out, section...)
@@ -644,6 +651,21 @@ func sidebarMCPLines(in SidebarRenderInput, innerW int, st sidebarStyles) []stri
 		countLabel := fmt.Sprintf(" [%d]", toolCounts[srv])
 		srvLabel := truncateLabel(srv, max(innerW-4-len(countLabel), 1))
 		lines = append(lines, st.dim.Render("  ⬡ "+srvLabel+countLabel))
+	}
+	return append(lines, "")
+}
+
+// sidebarA2ALines lists configured remote A2A agents, one row per agent.
+func sidebarA2ALines(in SidebarRenderInput, innerW int, st sidebarStyles) []string {
+	if len(in.A2AAgents) == 0 {
+		return nil
+	}
+	// Blue heading, distinct from MCP's mauve.
+	lines := []string{st.blue.Bold(true).
+		Render(fmt.Sprintf("  A2A Agents [%d]", len(in.A2AAgents)))}
+	for _, a := range in.A2AAgents {
+		name := truncateLabel(a.Name, max(innerW-5, 1))
+		lines = append(lines, st.dim.Render("  ⬡ "+name))
 	}
 	return append(lines, "")
 }

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -434,6 +434,55 @@ func TestRenderSidebar_MCPTools(t *testing.T) {
 	}
 }
 
+func TestRenderSidebar_A2AAgents(t *testing.T) {
+	result := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 40,
+		A2AAgents: []A2AAgentEntry{
+			{Name: "k8s-agent"},
+			{Name: "istio-agent"},
+			{Name: "helm-agent"},
+		},
+	})
+	if !strings.Contains(result, "A2A Agents") {
+		t.Error("expected 'A2A Agents' heading in sidebar")
+	}
+	if !strings.Contains(result, "[3]") {
+		t.Error("expected '[3]' agent count in A2A Agents heading")
+	}
+	for _, name := range []string{"k8s-agent", "istio-agent", "helm-agent"} {
+		if !strings.Contains(result, name) {
+			t.Errorf("expected agent %q in sidebar", name)
+		}
+	}
+}
+
+func TestRenderSidebar_A2AAgents_EmptyHidden(t *testing.T) {
+	result := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 20,
+	})
+	if strings.Contains(result, "A2A Agents") {
+		t.Error("expected no 'A2A Agents' section when A2AAgents is nil")
+	}
+}
+
+func TestRenderSidebar_A2AAppearsAfterMCPTools(t *testing.T) {
+	result := RenderSidebar(SidebarRenderInput{
+		Width:  30,
+		Height: 40,
+		MCPTools: []extension.MCPToolEntry{
+			{Server: "filesystem", Tool: "read_file"},
+		},
+		A2AAgents: []A2AAgentEntry{
+			{Name: "k8s-agent"},
+		},
+	})
+	if strings.Index(result, "A2A Agents [1]") < strings.Index(result, "MCP Tools [1]") {
+		t.Error("expected A2A Agents section below MCP Tools section")
+	}
+}
+
 func TestRenderSidebar_Skills(t *testing.T) {
 	result := RenderSidebar(SidebarRenderInput{
 		Width:  30,

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -17,6 +17,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/dimetron/pi-go/internal/auth"
+	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/sop"
@@ -1701,6 +1702,19 @@ func clipMessagesToViewport(messagesView string, availableHeight, scroll int) (v
 	return visible, startLine, endLine
 }
 
+// a2aSidebarEntries flattens the configured A2A agents into sidebar rows, in
+// config order. A nil/empty config yields nil, hiding the section.
+func a2aSidebarEntries(cfg *config.A2AConfig) []A2AAgentEntry {
+	if cfg == nil {
+		return nil
+	}
+	entries := make([]A2AAgentEntry, 0, len(cfg.Agents))
+	for _, a := range cfg.Agents {
+		entries = append(entries, A2AAgentEntry{Name: a.Name})
+	}
+	return entries
+}
+
 // sidebarRenderInput gathers everything the sidebar draws for this frame.
 func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInput {
 	in := SidebarRenderInput{
@@ -1729,6 +1743,7 @@ func (m *model) sidebarRenderInput(sidebarWidth, panelRows int) SidebarRenderInp
 		StatusLine:   "",
 		Orchestrator: m.cfg.Orchestrator,
 		MCPTools:     extension.BuildMCPToolEntries(m.cfg.MCPToolsets),
+		A2AAgents:    a2aSidebarEntries(m.cfg.A2A),
 		MemoryStatus: m.memoryStatus,
 		Artifacts:    m.artifactList(),
 		Palette:      m.palette,

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -69,6 +69,8 @@ type Config struct {
 	MCPToolsets []adktool.Toolset
 	// MCPServers holds the configured MCP server definitions.
 	MCPServers []extension.MCPServerConfig
+	// A2A holds the configured A2A agent endpoints, shown in the sidebar.
+	A2A *config.A2AConfig
 
 	// ModelSwitcher creates a new LLM instance for the given model name,
 	// updates the token tracker's context window size, and returns the


### PR DESCRIPTION
Add an A2A Agents section to the right sidebar, mirroring the MCP Tools
section: a heading with the agent count and one row per configured agent
(k8s-agent, istio-agent, helm-agent). The section is hidden when no A2A
agents are configured.

- SidebarRenderInput gains A2AAgents []A2AAgentEntry
- sidebarA2ALines renders the section below MCP Tools
- tui.Config carries the A2A config from cli/interactive.go
- tests cover populated, empty-hidden, and section ordering

Signed-off-by: dimetron <dimetron@me.com>
