### PR TITLE
feat(hooks): refuse oversized GIFs and blobs before they enter history

### DIFF
--- a/.githooks/check-large-files
+++ b/.githooks/check-large-files
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# check-large-files: refuse to let oversized blobs — GIFs and screen
+# recordings above all — enter the repository.
+#
+# Two rules, two reasons:
+#
+#   1. GitHub's own limits. A blob over 50 MiB draws a warning and one over
+#      100 MiB is rejected outright at push time, with no way to un-push it
+#      afterwards: the object stays in history and the only fix is a rewrite.
+#      This gate fails long before that, at 10 MiB, because the repo has no
+#      legitimate file anywhere near it (the largest non-media file tracked is
+#      ~70 KiB).
+#
+#   2. CLAUDE.md's recording rule: a GIF of a test run or a TUI session is
+#      attached to a PR as a *release asset*, never committed. See the
+#      `vhs-e2e-gif` skill's attach-gif-to-pr.sh. Recordings are
+#      write-once and quickly stale, and every revision of one is kept forever
+#      by every clone. 1 MiB is generous for anything that genuinely belongs
+#      in-tree, such as a small doc illustration.
+#
+# Usage:
+#   check-large-files staged                 # pre-commit: blobs in the index
+#   check-large-files commits <rev-list-args…>   # pre-push: blobs a push adds
+#
+# Escape hatch — NOT --no-verify, which CLAUDE.md forbids because it also
+# skips the signing hooks:
+#
+#   PI_ALLOW_LARGE_FILES=1 git commit -sS -m "…"
+#
+# Thresholds are overridable for testing:
+#   PI_MEDIA_MAX_BYTES, PI_FILE_MAX_BYTES
+set -euo pipefail
+
+media_max=${PI_MEDIA_MAX_BYTES:-1048576}    #  1 MiB — GIFs, videos, casts
+file_max=${PI_FILE_MAX_BYTES:-10485760}     # 10 MiB — anything else
+
+# Animated and video formats plus terminal recordings. Still images are not
+# listed: they fall under the general file limit.
+media_re='\.(gif|gifv|apng|mp4|m4v|mov|webm|mkv|avi|ogv|cast)$'
+
+# Grandfathered paths, one extended-regex per line. Everything here is already
+# in history, so blocking it would only stop legitimate edits — the object is
+# in every clone either way.
+#
+#   docs/screen/pi-go.gif — 5.4 MiB, committed before this hook existed. It is
+#   referenced by nothing in the tree; it should move to a release asset and
+#   the entry below should go with it.
+allow_re='^docs/screen/pi-go\.gif$'
+
+if [ "${PI_ALLOW_LARGE_FILES:-}" = "1" ]; then
+  echo "check-large-files: skipped (PI_ALLOW_LARGE_FILES=1)" >&2
+  exit 0
+fi
+
+human() {
+  awk -v b="$1" 'BEGIN {
+    split("B KiB MiB GiB", u, " ")
+    i = 1
+    while (b >= 1024 && i < 4) { b /= 1024; i++ }
+    printf (i == 1 ? "%d %s\n" : "%.1f %s\n"), b, u[i]
+  }'
+}
+
+# Emits "size<TAB>path" for every blob to inspect.
+#
+# Both modes end in the same `cat-file --batch-check` pipeline: a stream of
+# "<sha> <path>" lines in, sizes out. It stays a pipeline (no temp file, no
+# process substitution) so that `set -o pipefail` still sees a git failure — a
+# gate that passes because its own enumeration broke is worse than no gate.
+list_blobs() {
+  local mode=$1
+  shift
+  {
+    case "$mode" in
+      staged)
+        # Raw format: ":<srcmode> <dstmode> <srcsha> <dstsha> <status>\t<path>".
+        # --no-renames keeps every record to a single path field; a rename
+        # would otherwise add a second one and shift the path column.
+        git diff --cached --raw --abbrev=40 --no-renames --diff-filter=ACM \
+          | sed 's/^://' \
+          | awk -F'\t' 'NF > 1 { split($1, f, " "); print f[4], $2 }'
+        ;;
+      commits)
+        # Objects reachable from the pushed commits but not from what the
+        # remote already has — i.e. exactly what this push would upload.
+        [ "$#" -gt 0 ] || return 0
+        git rev-list --objects "$@"
+        ;;
+    esac
+  } \
+    | git cat-file --batch-check='%(objecttype) %(objectsize) %(rest)' \
+    | awk '$1 == "blob" && NF > 2 {
+        size = $2
+        $1 = ""; $2 = ""
+        sub(/^  /, "")
+        printf "%s\t%s\n", size, $0
+      }'
+}
+
+case "${1:-}" in
+  staged | commits) ;;
+  *)
+    echo "check-large-files: usage: check-large-files staged|commits [rev-list-args…]" >&2
+    exit 2
+    ;;
+esac
+
+# Collected up front rather than piped straight into the loop: a `git` failure
+# inside a process substitution cannot fail the enclosing script, and a gate
+# that passes when its own enumeration broke is worse than no gate. Under
+# `set -e` plus `pipefail` a failed command substitution aborts the hook.
+blobs=$(list_blobs "$@" | sort -u)
+
+violations=()
+while IFS=$'\t' read -r size path; do
+  [ -n "$path" ] || continue
+  if printf '%s' "$path" | grep -qE "$allow_re"; then
+    continue
+  fi
+  if printf '%s' "$path" | grep -qiE "$media_re"; then
+    if [ "$size" -gt "$media_max" ]; then
+      violations+=("$(human "$size")|$path|recording/animation over $(human "$media_max")")
+    fi
+  elif [ "$size" -gt "$file_max" ]; then
+    violations+=("$(human "$size")|$path|file over $(human "$file_max")")
+  fi
+done <<< "$blobs"
+
+[ "${#violations[@]}" -eq 0 ] && exit 0
+
+{
+  echo
+  echo "check-large-files: refusing to add oversized files to git history:"
+  for v in "${violations[@]}"; do
+    IFS='|' read -r vsize vpath vwhy <<< "$v"
+    printf '  %-12s %s\n' "$vsize" "$vpath"
+    printf '  %-12s (%s)\n' "" "$vwhy"
+  done
+  echo
+  echo "GIFs and screen recordings belong on a GitHub release, not in the repo."
+  echo "Attach one to a PR instead — it stays out of every clone's history:"
+  echo
+  echo "  CAPTIONS='e2e: …' \\"
+  echo "    .claude/skills/vhs-e2e-gif/scripts/attach-gif-to-pr.sh <PR> <file.gif>"
+  echo
+  echo "Then unstage it:  git restore --staged <file>  (and delete or gitignore it)"
+  echo
+  echo "If a file genuinely must live in the tree, shrink it, or — as a last"
+  echo "resort — re-run with PI_ALLOW_LARGE_FILES=1. Do NOT use --no-verify:"
+  echo "it also skips the signing hooks and lands an unsigned commit."
+  echo
+} >&2
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Refuse oversized blobs — GIFs and screen recordings above all — before they
+# enter history, where they are permanent. Runs first: there is no point
+# formatting and linting a commit that cannot be allowed to exist.
+"$(dirname "$0")/check-large-files" staged
+
 # Format code with gofmt and goimports.
 # Exclude worktree directories (.worktrees/, .pi-go/) — they are separate
 # checkouts on their own branches and must not be reformatted by this hook.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# pre-push: hard-fail when any commit about to be pushed is unsigned or lacks
-# a Signed-off-by trailer.
+# pre-push: hard-fail when any commit about to be pushed is unsigned, lacks a
+# Signed-off-by trailer, or carries an oversized blob.
+#
+# The size check is repeated here rather than left to pre-commit because a
+# push is the last reversible moment: GitHub rejects a blob over 100 MiB and
+# nothing can un-push one under that, so a commit that reached the branch some
+# other way still has to be caught before the objects leave the machine.
 #
 # The post-commit hook only warns — it cannot stop an unsigned commit, and
 # AGENTS.md records commits (0714568, a8b243b, bcb6d26) that reached the
@@ -19,6 +24,7 @@ zero=0000000000000000000000000000000000000000
 
 unsigned=()
 missing_sob=()
+size_scan=()
 
 while read -r local_ref local_sha remote_ref remote_sha; do
   # Branch deletion or remote already has the ref with no new commits.
@@ -30,8 +36,10 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     # limited to what this push would add. Fall back to the full history
     # behind local_sha minus existing remotes to avoid re-checking history.
     range="$(git rev-list "$local_sha" --not --remotes="$remote")"
+    size_scan+=("$local_sha" --not --remotes="$remote")
   else
     range="$(git rev-list "$remote_sha..$local_sha")"
+    size_scan+=("$remote_sha..$local_sha")
   fi
 
   for sha in $range; do
@@ -49,6 +57,9 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 done
 
 fail=0
+if [ "${#size_scan[@]}" -gt 0 ]; then
+  "$(dirname "$0")/check-large-files" commits "${size_scan[@]}" || fail=1
+fi
 if [ "${#unsigned[@]}" -gt 0 ]; then
   echo "pre-push: UNSIGNED commits cannot be pushed:" >&2
   printf '  %s\n' "${unsigned[@]}" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,46 @@ branch never touched (currently 10 `SA1019` deprecation errors in
 `hack/test/mcp/`). When that happens, stop and report it — the fix is to clear
 the unrelated lint failure or to have the user decide, not to bypass the hook.
 
+## Never commit a GIF or a screen recording
+
+**Recordings go on a GitHub release, never into git history.** A GIF of a test
+run or a TUI session is large, write-once, and stale within a week — but every
+revision of one is downloaded by every clone forever, and a blob cannot be
+un-pushed without rewriting history for everyone. GitHub itself warns above
+50 MiB and rejects a push above 100 MiB.
+
+Attach one to a PR instead — the `vhs-e2e-gif` skill wraps this:
+
+```bash
+CAPTIONS='e2e: tool calls after the fix' \
+  .claude/skills/vhs-e2e-gif/scripts/attach-gif-to-pr.sh 246 /tmp/e2e.gif
+```
+
+`.githooks/check-large-files` enforces it from both `pre-commit` (staged blobs)
+and `pre-push` (blobs the push would upload), with two limits:
+
+| What | Limit | Why |
+|---|---|---|
+| `.gif .gifv .apng .mp4 .m4v .mov .webm .mkv .avi .ogv .cast` | 1 MiB | Recordings belong on a release |
+| Anything else | 10 MiB | Far below GitHub's 100 MiB hard reject; the largest non-media file in the tree is ~70 KiB |
+
+The check runs twice on purpose. `pre-commit` catches it early, when unstaging
+is the whole fix; `pre-push` is the last reversible moment for a commit that
+reached the branch some other way — a rebase, a cherry-pick, another tool.
+
+One path is grandfathered in the script's `allow_re`: `docs/screen/pi-go.gif`
+(5.4 MiB), committed before the hook existed and referenced by nothing in the
+tree. It should move to a release asset and take its allowlist entry with it.
+
+If a file genuinely has to live in the tree, shrink it, or as a last resort:
+
+```bash
+PI_ALLOW_LARGE_FILES=1 git commit -sS -m "..."
+```
+
+**Do not reach for `--no-verify`** — it skips the signing hooks too, and lands
+an unsigned commit (see above).
+
 ## Review with Codex: open the PR first, review on GitHub
 
 **The PR is the review track.** Open it first, then have Codex post its review

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,17 @@ install:
 
 # hooks: point core.hooksPath at the versioned .githooks/ directory.
 #
-# The hooks enforce AGENTS.md's signing rules: commit-msg adds a missing
+# The hooks enforce CLAUDE.md's signing rules: commit-msg adds a missing
 # Signed-off-by, post-commit warns on unsigned commits, and pre-push
 # HARD-FAILS any push containing unsigned or unsigned-off commits.
+#
+# pre-commit and pre-push also run check-large-files, which refuses oversized
+# blobs — GIFs and screen recordings above all, which belong on a release
+# rather than in every clone's history forever.
 # Run once per clone: `make hooks`.
 hooks:
 	git config core.hooksPath .githooks
-	@echo "hooks installed: commit-msg, post-commit, pre-push (.githooks/)"
+	@echo "hooks installed: pre-commit, commit-msg, post-commit, pre-push (.githooks/)"
 
 # Accelerated build: ONNX Runtime + CoreML (Apple GPU / Neural Engine).
 #


### PR DESCRIPTION
## Why

A GIF of a test run or a TUI session is large, write-once, and stale within a week — but every revision of one is downloaded by every clone, forever. There is no un-pushing a blob: GitHub warns above 50 MiB and rejects above 100 MiB, and anything under that stays in history until someone rewrites it for everybody.

`CLAUDE.md` already says recordings belong on a GitHub release. Nothing enforced it, and `docs/screen/pi-go.gif` — 5.4 MiB, referenced by nothing in the tree — is what that looks like in practice.

## What

`.githooks/check-large-files`, gating two limits:

| What | Limit | Rationale |
|---|---|---|
| `.gif .gifv .apng .mp4 .m4v .mov .webm .mkv .avi .ogv .cast` | 1 MiB | Recordings go on a release, per `CLAUDE.md` |
| Anything else | 10 MiB | Far below GitHub's 100 MiB hard reject; the largest non-media file tracked is ~70 KiB |

It runs from **`pre-commit`** over staged blobs, where unstaging is the whole fix, and again from **`pre-push`** over the blobs a push would upload — the last reversible moment for a commit that arrived by rebase or cherry-pick rather than by `git commit`.

The escape hatch is `PI_ALLOW_LARGE_FILES=1`, deliberately **not** `--no-verify`, which would also skip the signing hooks and land an unsigned commit.

## Implementation notes

Both modes end in one `cat-file --batch-check` pipeline so `set -o pipefail` still sees a git failure — a gate that passes because its own enumeration broke is worse than no gate. NUL-delimited paths are avoided for the same reason: they cannot survive a command substitution, and a process substitution swallows the exit status. (Both of these were real bugs caught during testing, not hypotheticals.)

## Grandfathered path — worth a second opinion

`docs/screen/pi-go.gif` is allowlisted in the script's `allow_re`. Blocking it would only stop legitimate edits to an object every clone already has. But it appears to be a leftover from the earlier release-asset migration and is referenced by no README or doc — **it should probably be deleted outright and its allowlist entry removed.** Not done here, to keep this PR to the gate itself.

## Verification

10 cases across throwaway repos, plus end-to-end `pre-push` runs against a real remote:

- clean commits pass; oversized GIF and oversized generic blob blocked in both `staged` and `commits` modes
- paths containing spaces handled correctly
- allowlisted path passes, and a negative control (allowlist emptied) correctly flags `pi-go.gif` — confirming the allowlist is what lets it through, and that it is the only exception
- bad usage exits 2; an unresolvable rev exits 128 rather than passing silently
- clean incremental push produces no size output at all

The push that created this branch ran the new `pre-push` check for real and passed.