### PR TITLE
feat(session): rsync-safe session storage and lossless remote merge

### DIFF
--- a/hack/session-merge/main.go
+++ b/hack/session-merge/main.go
@@ -1,0 +1,49 @@
+// Command session-merge folds a staged remote pi-go sessions tree into the
+// local one without losing local data. It is the merge half of
+// scripts/sync-sessions.sh: rsync stages the remote tree, this command merges
+// it into ~/.pi-go/sessions.
+//
+// Usage:
+//
+//	session-merge --local <sessions-dir> --remote <staged-dir> [--dry-run]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/dimetron/pi-go/internal/session"
+)
+
+func main() {
+	local := flag.String("local", "", "local sessions dir (e.g. ~/.pi-go/sessions)")
+	remote := flag.String("remote", "", "staged remote sessions dir")
+	dryRun := flag.Bool("dry-run", false, "report what would change without writing")
+	flag.Parse()
+
+	if *local == "" || *remote == "" {
+		fmt.Fprintln(os.Stderr, "session-merge: --local and --remote are required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	report, err := session.MergeRemoteSessions(*local, *remote, session.MergeOptions{DryRun: *dryRun})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "session-merge: %v\n", err)
+		os.Exit(1)
+	}
+
+	verb := "merged"
+	if *dryRun {
+		verb = "would merge"
+	}
+	fmt.Printf("session-merge: %s %d new sessions, %d existing sessions, %d errors\n",
+		verb, report.Added, report.Merged, len(report.Errors))
+	for _, e := range report.Errors {
+		fmt.Fprintf(os.Stderr, "  error: %s\n", e)
+	}
+	if len(report.Errors) > 0 {
+		os.Exit(1)
+	}
+}

--- a/internal/session/branch.go
+++ b/internal/session/branch.go
@@ -201,11 +201,13 @@ func loadBranches(sessionDir string) (*branchState, error) {
 	return &bs, nil
 }
 
-// saveBranches writes branches.json to disk.
+// saveBranches writes branches.json to disk atomically (temp + rename) so a
+// concurrent reader — or rsync copying the sessions tree — never sees a torn
+// file.
 func saveBranches(sessionDir string, bs *branchState) error {
 	data, err := json.MarshalIndent(bs, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling branches: %w", err)
 	}
-	return os.WriteFile(filepath.Join(sessionDir, "branches.json"), data, 0o644)
+	return writeFileAtomic(filepath.Join(sessionDir, "branches.json"), data, 0o644)
 }

--- a/internal/session/merge.go
+++ b/internal/session/merge.go
@@ -10,9 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
-	"time"
 )
 
 // MergeOptions controls MergeRemoteSessions.
@@ -35,17 +33,22 @@ type MergeReport struct {
 // place. Sessions that exist only on the remote side are copied in. Sessions
 // present on both sides are merged:
 //
-//   - events.jsonl: union by event ID. If one side is a prefix of the other
-//     (the common "one machine continued the session" case) the longer file
-//     wins; otherwise events are deduplicated by ID and ordered by timestamp.
+//   - events.jsonl: the local file is never rewritten — remote-only events are
+//     appended. If one side is a strict continuation of the other (the common
+//     "one machine continued the session" case) the missing tail is appended;
+//     otherwise the remote events whose IDs are absent locally are appended.
+//     Appending (rather than replace) means a pi still writing to the session
+//     cannot lose its events to the merge: both processes only ever add lines,
+//     at worst interleaved.
 //   - meta.json: the copy with the newer updatedAt wins.
 //   - trajectory.atif.json / acp.jsonl: the winning side's copy wins.
-//   - branches/: per-branch events are merged with the same union rule;
-//     branches.json metadata follows the events winner.
+//   - branches/: per-branch events are merged with the same append rule;
+//     branches.json branch entries are merged by name, preserving local-only
+//     branches.
 //
 // Local-only sessions are never touched, and nothing is ever deleted. All
-// writes are atomic (temp + rename), so an interrupted merge leaves each file
-// either old or new, never torn.
+// writes are atomic (temp + rename) or pure appends, so an interrupted merge
+// leaves each file either old or new, never torn.
 func MergeRemoteSessions(localDir, remoteDir string, opts MergeOptions) (MergeReport, error) {
 	var report MergeReport
 	entries, err := os.ReadDir(remoteDir)
@@ -66,7 +69,12 @@ func MergeRemoteSessions(localDir, remoteDir string, opts MergeOptions) (MergeRe
 			continue
 		}
 		localSession := filepath.Join(localDir, id)
-		if _, err := os.Stat(filepath.Join(localSession, "meta.json")); os.IsNotExist(err) {
+		exists, err := localSessionExists(localSession)
+		if err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", id, err))
+			continue
+		}
+		if !exists {
 			if err := r.copyDir(localSession, remoteSession); err != nil {
 				report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", id, err))
 				continue
@@ -95,6 +103,22 @@ func isSessionDir(dir string) bool {
 	return false
 }
 
+// localSessionExists reports whether the local side already has this session.
+// Either marker (meta.json or events.jsonl) counts: a session with only an
+// events file (torn or legacy) must still be merged, never overwritten.
+func localSessionExists(dir string) (bool, error) {
+	for _, f := range []string{"meta.json", "events.jsonl"} {
+		_, err := os.Stat(filepath.Join(dir, f))
+		if err == nil {
+			return true, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
 // mergeRunner carries merge state (currently just dry-run) through the
 // per-session merge helpers.
 type mergeRunner struct {
@@ -111,14 +135,17 @@ func (r *mergeRunner) mergeSession(localDir, remoteDir string) error {
 		return err
 	}
 	if wEvents == "remote" {
-		// Remote is a strict continuation of local: its derived files are the
-		// authoritative ones. For "local" or "merged" winners the local
-		// derived files stay put.
+		// Remote events are a strict, longer continuation of local: its
+		// derived files are the authoritative ones. For "local" or "merged"
+		// winners the local derived files stay put.
 		if err := r.copyDerivedFiles(localDir, remoteDir); err != nil {
 			return err
 		}
 	}
-	return r.mergeBranchesDir(localDir, remoteDir, wEvents)
+	if err := r.mergeBranchesDir(localDir, remoteDir); err != nil {
+		return err
+	}
+	return r.mergeBranchesJSON(localDir, remoteDir)
 }
 
 // derivedFiles are per-session artifacts derived from events; they follow the
@@ -145,10 +172,18 @@ func (r *mergeRunner) copyDerivedFiles(localDir, remoteDir string) error {
 }
 
 // mergeEventsFiles merges the events.jsonl of two session dirs into the local
-// one and reports which side won: "local", "remote", or "merged".
+// one and reports which side the local history now reflects: "local" (nothing
+// changed), "remote" (remote was a strict, longer continuation and its tail
+// was appended), or "merged" (remote-only events were appended).
+//
+// The local file is never replaced wholesale: only lines absent from it are
+// appended. Appends cannot lose concurrent pi writes the way a read-modify-
+// write rewrite would — both writers only ever add lines.
 func (r *mergeRunner) mergeEventsFiles(localDir, remoteDir string) (string, error) {
-	lData, lErr := os.ReadFile(filepath.Join(localDir, "events.jsonl"))
-	rData, rErr := os.ReadFile(filepath.Join(remoteDir, "events.jsonl"))
+	localPath := filepath.Join(localDir, "events.jsonl")
+	remotePath := filepath.Join(remoteDir, "events.jsonl")
+	lData, lErr := os.ReadFile(localPath)
+	rData, rErr := os.ReadFile(remotePath)
 	lMissing := lErr != nil && os.IsNotExist(lErr)
 	rMissing := rErr != nil && os.IsNotExist(rErr)
 	switch {
@@ -159,29 +194,93 @@ func (r *mergeRunner) mergeEventsFiles(localDir, remoteDir string) (string, erro
 	case lMissing && rMissing:
 		return "local", nil
 	case lMissing:
-		if err := r.writeFileAtomic(filepath.Join(localDir, "events.jsonl"), rData, 0o644); err != nil {
+		if err := r.appendToFile(localPath, rData); err != nil {
 			return "", err
 		}
 		return "remote", nil
 	case rMissing:
 		return "local", nil
 	}
-	merged, winner := mergeEventsData(lData, rData)
-	if winner != "local" {
-		if err := r.writeFileAtomic(filepath.Join(localDir, "events.jsonl"), merged, 0o644); err != nil {
+	l, err := parseRawEvents(lData)
+	if err != nil {
+		return "", fmt.Errorf("parsing local events: %w", err)
+	}
+	remote, err := parseRawEvents(rData)
+	if err != nil {
+		return "", fmt.Errorf("parsing remote events: %w", err)
+	}
+	if len(remote) == 0 {
+		return "local", nil
+	}
+	// Strict continuation: the shorter sequence is a prefix of the longer one.
+	// Append the longer tail. Equal-length identical histories are NOT a
+	// continuation (nothing to append) and must not trigger a write.
+	if len(l) < len(remote) && isPrefix(l, remote) {
+		tail := marshalEvents(remote[len(l):])
+		if err := r.appendToFile(localPath, tail); err != nil {
 			return "", err
 		}
+		return "remote", nil
 	}
-	return winner, nil
+	if len(remote) < len(l) && isPrefix(remote, l) {
+		return "local", nil
+	}
+	// Divergent histories: append remote events whose IDs are absent locally.
+	lIDs := make(map[string]bool, len(l))
+	for _, e := range l {
+		if e.id != "" {
+			lIDs[e.id] = true
+		}
+	}
+	var missing []rawEvent
+	for _, e := range remote {
+		if e.id != "" && lIDs[e.id] {
+			continue
+		}
+		missing = append(missing, e)
+	}
+	if len(missing) == 0 {
+		return "local", nil
+	}
+	if err := r.appendToFile(localPath, marshalEvents(missing)); err != nil {
+		return "", err
+	}
+	return "merged", nil
 }
 
-// rawEvent is one JSONL line plus the fields the merge keys on. Keeping the
-// raw line means a merged file preserves every field of the original events,
-// including ones this binary does not know about.
+// marshalEvents renders raw events back to JSONL in their given order.
+func marshalEvents(events []rawEvent) []byte {
+	var sb strings.Builder
+	for _, e := range events {
+		sb.Write(e.line)
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+// appendToFile appends data to path with O_APPEND so the write is atomic and
+// interleaves safely with other appenders (a pi still running on this session).
+func (r *mergeRunner) appendToFile(path string, data []byte) error {
+	if r.dryRun || len(data) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening %s for append: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("appending to %s: %w", path, err)
+	}
+	return f.Sync()
+}
+
+// rawEvent is one JSONL line plus its event ID, the field the merge keys on.
+// Keeping the raw line means an appended event preserves every field of the
+// original, including ones this binary does not know about.
 type rawEvent struct {
-	line      []byte
-	id        string
-	timestamp time.Time
+	line []byte
+	id   string
 }
 
 // parseRawEvents splits a JSONL events file into rawEvent entries.
@@ -192,13 +291,12 @@ func parseRawEvents(data []byte) ([]rawEvent, error) {
 			continue
 		}
 		var meta struct {
-			ID        string    `json:"id"`
-			Timestamp time.Time `json:"timestamp"`
+			ID string `json:"id"`
 		}
 		if err := json.Unmarshal([]byte(line), &meta); err != nil {
 			return nil, err
 		}
-		out = append(out, rawEvent{line: []byte(line), id: meta.ID, timestamp: meta.Timestamp})
+		out = append(out, rawEvent{line: []byte(line), id: meta.ID})
 	}
 	return out, nil
 }
@@ -214,57 +312,6 @@ func isPrefix(a, b []rawEvent) bool {
 		}
 	}
 	return true
-}
-
-// unionEvents deduplicates by event ID and orders by timestamp. Events with an
-// empty ID are kept as-is (they cannot be deduplicated).
-func unionEvents(a, b []rawEvent) []rawEvent {
-	seen := make(map[string]bool)
-	out := make([]rawEvent, 0, len(a)+len(b))
-	for _, e := range append(append([]rawEvent{}, a...), b...) {
-		if e.id != "" {
-			if seen[e.id] {
-				continue
-			}
-			seen[e.id] = true
-		}
-		out = append(out, e)
-	}
-	sort.SliceStable(out, func(i, j int) bool { return out[i].timestamp.Before(out[j].timestamp) })
-	return out
-}
-
-// mergeEventsData merges two events.jsonl payloads. It returns the merged
-// bytes and the winner: "local" (keep local), "remote" (remote is a strict
-// continuation), or "merged" (both sides contributed unique events).
-func mergeEventsData(local, remote []byte) ([]byte, string) {
-	l, err := parseRawEvents(local)
-	if err != nil {
-		return local, "local"
-	}
-	r, err := parseRawEvents(remote)
-	if err != nil {
-		return local, "local"
-	}
-	if len(l) == 0 {
-		return remote, "remote"
-	}
-	if len(r) == 0 {
-		return local, "local"
-	}
-	if isPrefix(l, r) {
-		return remote, "remote"
-	}
-	if isPrefix(r, l) {
-		return local, "local"
-	}
-	merged := unionEvents(l, r)
-	var sb strings.Builder
-	for _, e := range merged {
-		sb.Write(e.line)
-		sb.WriteByte('\n')
-	}
-	return []byte(sb.String()), "merged"
 }
 
 // mergeMeta keeps the meta.json with the newer updatedAt. The winning file is
@@ -304,9 +351,9 @@ func (r *mergeRunner) copyMeta(localDir, remoteDir string) (string, error) {
 }
 
 // mergeBranchesDir merges the branches/ subdirectory. Per-branch events are
-// merged with the same union rule; branches.json metadata follows the events
-// winner.
-func (r *mergeRunner) mergeBranchesDir(localDir, remoteDir, winner string) error {
+// merged with the same append rule as the root events file; branches that
+// exist only on one side are copied in without touching the other side.
+func (r *mergeRunner) mergeBranchesDir(localDir, remoteDir string) error {
 	localBranches := filepath.Join(localDir, "branches")
 	remoteBranches := filepath.Join(remoteDir, "branches")
 	_, lErr := os.ReadDir(localBranches)
@@ -342,17 +389,77 @@ func (r *mergeRunner) mergeBranchesDir(localDir, remoteDir, winner string) error
 			return err
 		}
 	}
-	if winner == "remote" {
-		data, err := os.ReadFile(filepath.Join(remoteDir, "branches.json"))
+	return nil
+}
+
+// mergeBranchesJSON merges branches.json by branch name, preserving local-only
+// branches and the per-branch heads that each side progressed. The active
+// branch is the local one unless the remote side is a strict continuation of
+// it, in which case the remote active branch is kept.
+func (r *mergeRunner) mergeBranchesJSON(localDir, remoteDir string) error {
+	lPath := filepath.Join(localDir, "branches.json")
+	rPath := filepath.Join(remoteDir, "branches.json")
+	_, lStatErr := os.Stat(lPath)
+	_, rStatErr := os.Stat(rPath)
+	switch {
+	case lStatErr != nil && !os.IsNotExist(lStatErr):
+		return lStatErr
+	case rStatErr != nil && !os.IsNotExist(rStatErr):
+		return rStatErr
+	}
+	lHas := lStatErr == nil
+	rHas := rStatErr == nil
+	switch {
+	case !lHas && !rHas:
+		return nil
+	case !lHas:
+		data, err := os.ReadFile(rPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
 			return err
 		}
-		return r.writeFileAtomic(filepath.Join(localDir, "branches.json"), data, 0o644)
+		return r.writeFileAtomic(lPath, data, 0o644)
+	case !rHas:
+		return nil
 	}
-	return nil
+
+	// Both sides have branch state: union branch entries by name, keeping the
+	// larger per-branch head and the local active branch unless remote is a
+	// strict continuation.
+	lBS, err := loadBranches(localDir)
+	if err != nil {
+		return err
+	}
+	rBS, err := loadBranches(remoteDir)
+	if err != nil {
+		return err
+	}
+	merged := branchState{
+		Active:   lBS.Active,
+		Branches: make(map[string]BranchInfo, len(lBS.Branches)+len(rBS.Branches)),
+	}
+	for name, bi := range lBS.Branches {
+		merged.Branches[name] = bi
+	}
+	for name, rbi := range rBS.Branches {
+		if lbi, ok := merged.Branches[name]; !ok {
+			merged.Branches[name] = rbi
+		} else if rbi.Head > lbi.Head {
+			merged.Branches[name] = rbi
+		}
+	}
+	// Keep the local active branch unless it does not exist locally and the
+	// remote side introduced it (remote-only branch): never point active at a
+	// branch that is absent from the merged map.
+	if _, ok := rBS.Branches[lBS.Active]; !ok {
+		if _, ok := merged.Branches[rBS.Active]; ok {
+			merged.Active = rBS.Active
+		}
+	}
+	data, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling merged branches: %w", err)
+	}
+	return r.writeFileAtomic(lPath, data, 0o644)
 }
 
 // copyDir copies a directory tree from src to dst, atomically per file.

--- a/internal/session/merge.go
+++ b/internal/session/merge.go
@@ -1,0 +1,390 @@
+// Package session — merge.go implements safe merging of a remote sessions
+// tree into the local one. It is the merge half of an rsync-based session
+// sync: rsync stages the remote tree, this code folds it into the local tree
+// without ever deleting or truncating local data.
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// MergeOptions controls MergeRemoteSessions.
+type MergeOptions struct {
+	// DryRun reports what would change without writing anything.
+	DryRun bool
+}
+
+// MergeReport summarizes one MergeRemoteSessions run.
+type MergeReport struct {
+	// Added counts sessions that existed only on the remote side.
+	Added int
+	// Merged counts sessions present on both sides that were folded together.
+	Merged int
+	// Errors lists per-session failures; the run continues past them.
+	Errors []string
+}
+
+// MergeRemoteSessions folds every session under remoteDir into localDir in
+// place. Sessions that exist only on the remote side are copied in. Sessions
+// present on both sides are merged:
+//
+//   - events.jsonl: union by event ID. If one side is a prefix of the other
+//     (the common "one machine continued the session" case) the longer file
+//     wins; otherwise events are deduplicated by ID and ordered by timestamp.
+//   - meta.json: the copy with the newer updatedAt wins.
+//   - trajectory.atif.json / acp.jsonl: the winning side's copy wins.
+//   - branches/: per-branch events are merged with the same union rule;
+//     branches.json metadata follows the events winner.
+//
+// Local-only sessions are never touched, and nothing is ever deleted. All
+// writes are atomic (temp + rename), so an interrupted merge leaves each file
+// either old or new, never torn.
+func MergeRemoteSessions(localDir, remoteDir string, opts MergeOptions) (MergeReport, error) {
+	var report MergeReport
+	entries, err := os.ReadDir(remoteDir)
+	if err != nil {
+		return report, fmt.Errorf("reading remote sessions dir: %w", err)
+	}
+	r := &mergeRunner{dryRun: opts.DryRun}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+		remoteSession := filepath.Join(remoteDir, id)
+		// Only real session dirs are synced. The sessions root also holds
+		// non-session dirs (archive/, backup/, .idea/) that must not be
+		// treated as sessions.
+		if !isSessionDir(remoteSession) {
+			continue
+		}
+		localSession := filepath.Join(localDir, id)
+		if _, err := os.Stat(filepath.Join(localSession, "meta.json")); os.IsNotExist(err) {
+			if err := r.copyDir(localSession, remoteSession); err != nil {
+				report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", id, err))
+				continue
+			}
+			report.Added++
+			continue
+		}
+		if err := r.mergeSession(localSession, remoteSession); err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", id, err))
+			continue
+		}
+		report.Merged++
+	}
+	return report, nil
+}
+
+// isSessionDir reports whether dir looks like a session directory: it carries
+// a meta.json or an events.jsonl at its top level. Non-session dirs in the
+// sessions root (archive/, backup/, .idea/) are skipped by the merge.
+func isSessionDir(dir string) bool {
+	for _, f := range []string{"meta.json", "events.jsonl"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeRunner carries merge state (currently just dry-run) through the
+// per-session merge helpers.
+type mergeRunner struct {
+	dryRun bool
+}
+
+// mergeSession folds one remote session directory into the local one.
+func (r *mergeRunner) mergeSession(localDir, remoteDir string) error {
+	wEvents, err := r.mergeEventsFiles(localDir, remoteDir)
+	if err != nil {
+		return err
+	}
+	if _, err := r.mergeMeta(localDir, remoteDir); err != nil {
+		return err
+	}
+	if wEvents == "remote" {
+		// Remote is a strict continuation of local: its derived files are the
+		// authoritative ones. For "local" or "merged" winners the local
+		// derived files stay put.
+		if err := r.copyDerivedFiles(localDir, remoteDir); err != nil {
+			return err
+		}
+	}
+	return r.mergeBranchesDir(localDir, remoteDir, wEvents)
+}
+
+// derivedFiles are per-session artifacts derived from events; they follow the
+// events winner rather than being merged themselves.
+var derivedFiles = []string{"trajectory.atif.json", "acp.jsonl"}
+
+// copyDerivedFiles copies the winner side's derived files over the local ones.
+func (r *mergeRunner) copyDerivedFiles(localDir, remoteDir string) error {
+	for _, f := range derivedFiles {
+		src := filepath.Join(remoteDir, f)
+		dst := filepath.Join(localDir, f)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := r.writeFileAtomic(dst, data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mergeEventsFiles merges the events.jsonl of two session dirs into the local
+// one and reports which side won: "local", "remote", or "merged".
+func (r *mergeRunner) mergeEventsFiles(localDir, remoteDir string) (string, error) {
+	lData, lErr := os.ReadFile(filepath.Join(localDir, "events.jsonl"))
+	rData, rErr := os.ReadFile(filepath.Join(remoteDir, "events.jsonl"))
+	lMissing := lErr != nil && os.IsNotExist(lErr)
+	rMissing := rErr != nil && os.IsNotExist(rErr)
+	switch {
+	case lErr != nil && !lMissing:
+		return "", lErr
+	case rErr != nil && !rMissing:
+		return "", rErr
+	case lMissing && rMissing:
+		return "local", nil
+	case lMissing:
+		if err := r.writeFileAtomic(filepath.Join(localDir, "events.jsonl"), rData, 0o644); err != nil {
+			return "", err
+		}
+		return "remote", nil
+	case rMissing:
+		return "local", nil
+	}
+	merged, winner := mergeEventsData(lData, rData)
+	if winner != "local" {
+		if err := r.writeFileAtomic(filepath.Join(localDir, "events.jsonl"), merged, 0o644); err != nil {
+			return "", err
+		}
+	}
+	return winner, nil
+}
+
+// rawEvent is one JSONL line plus the fields the merge keys on. Keeping the
+// raw line means a merged file preserves every field of the original events,
+// including ones this binary does not know about.
+type rawEvent struct {
+	line      []byte
+	id        string
+	timestamp time.Time
+}
+
+// parseRawEvents splits a JSONL events file into rawEvent entries.
+func parseRawEvents(data []byte) ([]rawEvent, error) {
+	var out []rawEvent
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var meta struct {
+			ID        string    `json:"id"`
+			Timestamp time.Time `json:"timestamp"`
+		}
+		if err := json.Unmarshal([]byte(line), &meta); err != nil {
+			return nil, err
+		}
+		out = append(out, rawEvent{line: []byte(line), id: meta.ID, timestamp: meta.Timestamp})
+	}
+	return out, nil
+}
+
+// isPrefix reports whether a's event ID sequence is a prefix of b's.
+func isPrefix(a, b []rawEvent) bool {
+	if len(a) > len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].id != b[i].id {
+			return false
+		}
+	}
+	return true
+}
+
+// unionEvents deduplicates by event ID and orders by timestamp. Events with an
+// empty ID are kept as-is (they cannot be deduplicated).
+func unionEvents(a, b []rawEvent) []rawEvent {
+	seen := make(map[string]bool)
+	out := make([]rawEvent, 0, len(a)+len(b))
+	for _, e := range append(append([]rawEvent{}, a...), b...) {
+		if e.id != "" {
+			if seen[e.id] {
+				continue
+			}
+			seen[e.id] = true
+		}
+		out = append(out, e)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].timestamp.Before(out[j].timestamp) })
+	return out
+}
+
+// mergeEventsData merges two events.jsonl payloads. It returns the merged
+// bytes and the winner: "local" (keep local), "remote" (remote is a strict
+// continuation), or "merged" (both sides contributed unique events).
+func mergeEventsData(local, remote []byte) ([]byte, string) {
+	l, err := parseRawEvents(local)
+	if err != nil {
+		return local, "local"
+	}
+	r, err := parseRawEvents(remote)
+	if err != nil {
+		return local, "local"
+	}
+	if len(l) == 0 {
+		return remote, "remote"
+	}
+	if len(r) == 0 {
+		return local, "local"
+	}
+	if isPrefix(l, r) {
+		return remote, "remote"
+	}
+	if isPrefix(r, l) {
+		return local, "local"
+	}
+	merged := unionEvents(l, r)
+	var sb strings.Builder
+	for _, e := range merged {
+		sb.Write(e.line)
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String()), "merged"
+}
+
+// mergeMeta keeps the meta.json with the newer updatedAt. The winning file is
+// copied byte-for-byte so fields this binary does not know about survive.
+func (r *mergeRunner) mergeMeta(localDir, remoteDir string) (string, error) {
+	lMeta, lErr := readMeta(localDir)
+	rMeta, rErr := readMeta(remoteDir)
+	lMissing := lErr != nil && os.IsNotExist(lErr)
+	rMissing := rErr != nil && os.IsNotExist(rErr)
+	switch {
+	case lErr != nil && !lMissing:
+		return "", lErr
+	case rErr != nil && !rMissing:
+		return "", rErr
+	case lMissing && rMissing:
+		return "local", nil
+	case lMissing:
+		return r.copyMeta(localDir, remoteDir)
+	case rMissing:
+		return "local", nil
+	}
+	if rMeta.UpdatedAt.After(lMeta.UpdatedAt) {
+		return r.copyMeta(localDir, remoteDir)
+	}
+	return "local", nil
+}
+
+func (r *mergeRunner) copyMeta(localDir, remoteDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(remoteDir, "meta.json"))
+	if err != nil {
+		return "", err
+	}
+	if err := r.writeFileAtomic(filepath.Join(localDir, "meta.json"), data, 0o644); err != nil {
+		return "", err
+	}
+	return "remote", nil
+}
+
+// mergeBranchesDir merges the branches/ subdirectory. Per-branch events are
+// merged with the same union rule; branches.json metadata follows the events
+// winner.
+func (r *mergeRunner) mergeBranchesDir(localDir, remoteDir, winner string) error {
+	localBranches := filepath.Join(localDir, "branches")
+	remoteBranches := filepath.Join(remoteDir, "branches")
+	_, lErr := os.ReadDir(localBranches)
+	rEntries, rErr := os.ReadDir(remoteBranches)
+	lMissing := lErr != nil && os.IsNotExist(lErr)
+	rMissing := rErr != nil && os.IsNotExist(rErr)
+	switch {
+	case lErr != nil && !lMissing:
+		return lErr
+	case rErr != nil && !rMissing:
+		return rErr
+	case lMissing && rMissing:
+		return nil
+	case lMissing:
+		return r.copyDir(localBranches, remoteBranches)
+	case rMissing:
+		return nil
+	}
+	for _, re := range rEntries {
+		if !re.IsDir() {
+			continue
+		}
+		name := re.Name()
+		lBranch := filepath.Join(localBranches, name)
+		rBranch := filepath.Join(remoteBranches, name)
+		if _, err := os.Stat(filepath.Join(lBranch, "events.jsonl")); os.IsNotExist(err) {
+			if err := r.copyDir(lBranch, rBranch); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := r.mergeEventsFiles(lBranch, rBranch); err != nil {
+			return err
+		}
+	}
+	if winner == "remote" {
+		data, err := os.ReadFile(filepath.Join(remoteDir, "branches.json"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		return r.writeFileAtomic(filepath.Join(localDir, "branches.json"), data, 0o644)
+	}
+	return nil
+}
+
+// copyDir copies a directory tree from src to dst, atomically per file.
+func (r *mergeRunner) copyDir(dst, src string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			if r.dryRun {
+				return nil
+			}
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return r.writeFileAtomic(target, data, 0o644)
+	})
+}
+
+// writeFileAtomic writes data to path via a temp file and rename, unless the
+// runner is in dry-run mode, in which case it does nothing.
+func (r *mergeRunner) writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if r.dryRun {
+		return nil
+	}
+	return writeFileAtomic(path, data, perm)
+}

--- a/internal/session/merge_test.go
+++ b/internal/session/merge_test.go
@@ -7,69 +7,6 @@ import (
 	"testing"
 )
 
-func TestMergeEventsData_EmptyLocal(t *testing.T) {
-	remote := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
-	merged, winner := mergeEventsData(nil, []byte(remote))
-	if winner != "remote" || string(merged) != remote {
-		t.Fatalf("empty local should take remote: winner=%s merged=%q", winner, merged)
-	}
-}
-
-func TestMergeEventsData_EmptyRemote(t *testing.T) {
-	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
-	merged, winner := mergeEventsData([]byte(local), nil)
-	if winner != "local" || string(merged) != local {
-		t.Fatalf("empty remote should keep local: winner=%s merged=%q", winner, merged)
-	}
-}
-
-func TestMergeEventsData_LocalPrefixOfRemote(t *testing.T) {
-	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
-	remote := local + "{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n"
-	merged, winner := mergeEventsData([]byte(local), []byte(remote))
-	if winner != "remote" || string(merged) != remote {
-		t.Fatalf("remote continuation should win: winner=%s merged=%q", winner, merged)
-	}
-}
-
-func TestMergeEventsData_RemotePrefixOfLocal(t *testing.T) {
-	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n"
-	remote := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
-	merged, winner := mergeEventsData([]byte(local), []byte(remote))
-	if winner != "local" || string(merged) != local {
-		t.Fatalf("local continuation should win: winner=%s merged=%q", winner, merged)
-	}
-}
-
-func TestMergeEventsData_Divergent(t *testing.T) {
-	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:02Z\"}\n"
-	remote := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"c\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n"
-	merged, winner := mergeEventsData([]byte(local), []byte(remote))
-	if winner != "merged" {
-		t.Fatalf("divergent should merge: winner=%s", winner)
-	}
-	// Union by ID, ordered by timestamp: a, c, b.
-	want := []string{"\"id\":\"a\"", "\"id\":\"c\"", "\"id\":\"b\""}
-	got := strings.Split(strings.TrimSpace(string(merged)), "\n")
-	if len(got) != len(want) {
-		t.Fatalf("expected %d events, got %d: %q", len(want), len(got), merged)
-	}
-	for i, w := range want {
-		if !strings.Contains(got[i], w) {
-			t.Fatalf("event %d should contain %s, got %q", i, w, got[i])
-		}
-	}
-}
-
-func TestMergeEventsData_UnparseableKeepsLocal(t *testing.T) {
-	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
-	remote := "not json\n"
-	merged, winner := mergeEventsData([]byte(local), []byte(remote))
-	if winner != "local" || string(merged) != local {
-		t.Fatalf("unparseable remote should keep local: winner=%s", winner)
-	}
-}
-
 // writeSessionDir creates a session dir with the given events and meta.
 func writeSessionDir(t *testing.T, root, id, events, updatedAt string) string {
 	t.Helper()
@@ -87,6 +24,142 @@ func writeSessionDir(t *testing.T, root, id, events, updatedAt string) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+// readSessionEvents returns the events.jsonl bytes of a session dir.
+func readSessionEvents(t *testing.T, root, id string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, id, "events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestMergeEventsFiles_EmptyLocal(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "", "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+
+	winner, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if winner != "remote" {
+		t.Fatalf("empty local should take remote, got %s", winner)
+	}
+	if got := readSessionEvents(t, local, "s"); !strings.Contains(got, "\"id\":\"a\"") {
+		t.Fatalf("remote events not copied: %q", got)
+	}
+}
+
+func TestMergeEventsFiles_EmptyRemote(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", "", "2026-01-01T00:00:00Z")
+
+	winner, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if winner != "local" {
+		t.Fatalf("empty remote should keep local, got %s", winner)
+	}
+}
+
+func TestMergeEventsFiles_RemoteContinuation(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", "{\"id\":\"a\"}\n{\"id\":\"b\"}\n", "2026-01-01T00:00:00Z")
+
+	winner, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if winner != "remote" {
+		t.Fatalf("remote continuation should win, got %s", winner)
+	}
+	if got := readSessionEvents(t, local, "s"); got != "{\"id\":\"a\"}\n{\"id\":\"b\"}\n" {
+		t.Fatalf("remote tail not appended: %q", got)
+	}
+}
+
+func TestMergeEventsFiles_LocalContinuation(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "{\"id\":\"a\"}\n{\"id\":\"b\"}\n", "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+
+	winner, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if winner != "local" {
+		t.Fatalf("local continuation should stay, got %s", winner)
+	}
+	if got := readSessionEvents(t, local, "s"); got != "{\"id\":\"a\"}\n{\"id\":\"b\"}\n" {
+		t.Fatalf("local events must not be truncated: %q", got)
+	}
+}
+
+func TestMergeEventsFiles_EqualHistoriesNoWrite(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	events := "{\"id\":\"a\"}\n{\"id\":\"b\"}\n"
+	writeSessionDir(t, local, "s", events, "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", events, "2026-01-01T00:00:00Z")
+
+	winner, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Equal histories are NOT a continuation: nothing to append.
+	if winner != "local" {
+		t.Fatalf("equal histories must not be treated as continuation, got %s", winner)
+	}
+	if got := readSessionEvents(t, local, "s"); got != events {
+		t.Fatalf("local events changed: %q", got)
+	}
+}
+
+func TestMergeEventsFiles_DivergentAppendsRemoteOnly(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "{\"id\":\"a\"}\n{\"id\":\"b\"}\n", "2026-01-01T00:00:00Z")
+	// Remote diverges: shares a, adds c. The remote-only event c is appended.
+	writeSessionDir(t, remote, "s", "{\"id\":\"a\"}\n{\"id\":\"c\"}\n", "2026-01-01T00:00:00Z")
+
+	winner, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if winner != "merged" {
+		t.Fatalf("divergent should merge, got %s", winner)
+	}
+	got := readSessionEvents(t, local, "s")
+	if !strings.Contains(got, "\"id\":\"c\"") {
+		t.Fatalf("remote-only event not appended: %q", got)
+	}
+	if !strings.Contains(got, "\"id\":\"b\"") {
+		t.Fatalf("local-only event lost: %q", got)
+	}
+	if strings.Count(got, "\"id\":\"a\"") != 1 {
+		t.Fatalf("shared event duplicated: %q", got)
+	}
+}
+
+func TestMergeEventsFiles_UnparseableRemoteErrors(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", "not json\n", "2026-01-01T00:00:00Z")
+
+	if _, err := (&mergeRunner{}).mergeEventsFiles(filepath.Join(local, "s"), filepath.Join(remote, "s")); err == nil {
+		t.Fatal("unparseable remote events must be reported, not silently skipped")
+	}
 }
 
 func TestMergeRemoteSessions_AddsNew(t *testing.T) {
@@ -118,9 +191,35 @@ func TestMergeRemoteSessions_KeepsLocalOnly(t *testing.T) {
 	if report.Added != 0 || report.Merged != 0 {
 		t.Fatalf("local-only session must be untouched: added=%d merged=%d", report.Added, report.Merged)
 	}
-	data, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl"))
-	if err != nil || string(data) != "{\"id\":\"a\"}\n" {
-		t.Fatalf("local-only session was modified: %q %v", data, err)
+	if got := readSessionEvents(t, local, "260101-0000-aaaaa-11111"); got != "{\"id\":\"a\"}\n" {
+		t.Fatalf("local-only session modified: %q", got)
+	}
+}
+
+func TestMergeRemoteSessions_EventsOnlyLocalSessionIsMerged(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	// Local has events.jsonl but no meta.json (torn or legacy): it must be
+	// merged, not treated as absent and overwritten.
+	sid := "260101-0000-aaaaa-11111"
+	localDir := filepath.Join(local, sid)
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "events.jsonl"), []byte("{\"id\":\"a\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSessionDir(t, remote, sid, "{\"id\":\"a\"}\n{\"id\":\"b\"}\n", "2026-01-01T00:00:00Z")
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Merged != 1 || report.Added != 0 {
+		t.Fatalf("events-only local session should be merged: %+v", report)
+	}
+	if got := readSessionEvents(t, local, sid); !strings.Contains(got, "\"id\":\"b\"") {
+		t.Fatalf("local events lost in events-only merge: %q", got)
 	}
 }
 
@@ -141,12 +240,9 @@ func TestMergeRemoteSessions_MergesContinuation(t *testing.T) {
 	if report.Merged != 1 {
 		t.Fatalf("expected 1 merged, got %d", report.Merged)
 	}
-	data, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "\"id\":\"b\"") {
-		t.Fatalf("remote continuation events missing after merge: %q", data)
+	got := readSessionEvents(t, local, "260101-0000-aaaaa-11111")
+	if !strings.Contains(got, "\"id\":\"b\"") {
+		t.Fatalf("remote continuation events missing after merge: %q", got)
 	}
 	// meta should be the newer remote one
 	meta, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "meta.json"))
@@ -177,9 +273,8 @@ func TestMergeRemoteSessions_DryRunWritesNothing(t *testing.T) {
 		t.Fatalf("dry-run should still report: added=%d merged=%d", report.Added, report.Merged)
 	}
 	// Nothing written: local session unchanged, new session absent.
-	data, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl"))
-	if err != nil || string(data) != "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n" {
-		t.Fatalf("dry-run modified local events: %q %v", data, err)
+	if got := readSessionEvents(t, local, "260101-0000-aaaaa-11111"); got != "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n" {
+		t.Fatalf("dry-run modified local events: %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(local, "260101-0000-bbbbb-22222")); !os.IsNotExist(err) {
 		t.Fatalf("dry-run created a new session dir")
@@ -248,23 +343,77 @@ func TestMergeRemoteSessions_SkipsNonSessionDirs(t *testing.T) {
 	}
 }
 
-func TestMergeRemoteSessions_TimeOrdering(t *testing.T) {
-	// Ensure the divergent merge orders by timestamp, not by input order.
-	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:05Z\"}\n"
-	remote := "{\"id\":\"c\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n{\"id\":\"d\",\"timestamp\":\"2026-01-01T00:00:02Z\"}\n"
-	merged, winner := mergeEventsData([]byte(local), []byte(remote))
-	if winner != "merged" {
-		t.Fatalf("expected merged, got %s", winner)
+func TestMergeBranchesJSON_UnionPreservesLocalOnly(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "s", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+	// Local has branches: main (head 1) and local-only "l" (head 3).
+	lb := branchState{Active: "l", Branches: map[string]BranchInfo{
+		"main": {Name: "main", Head: 1},
+		"l":    {Name: "l", Head: 3, Parent: ptr("main"), ForkPoint: 1},
+	}}
+	if err := saveBranches(filepath.Join(local, "s"), &lb); err != nil {
+		t.Fatal(err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(merged)), "\n")
-	if len(lines) != 4 {
-		t.Fatalf("expected 4 events, got %d", len(lines))
+	// Remote has main (head 2 — further along) and remote-only "r".
+	rb := branchState{Active: "r", Branches: map[string]BranchInfo{
+		"main": {Name: "main", Head: 2},
+		"r":    {Name: "r", Head: 1, Parent: ptr("main"), ForkPoint: 2},
+	}}
+	if err := saveBranches(filepath.Join(remote, "s"), &rb); err != nil {
+		t.Fatal(err)
 	}
-	// a(0) c(1) d(2) b(5)
-	want := []string{"\"id\":\"a\"", "\"id\":\"c\"", "\"id\":\"d\"", "\"id\":\"b\""}
-	for i, w := range want {
-		if !strings.Contains(lines[i], w) {
-			t.Fatalf("line %d should contain %s, got %q", i, w, lines[i])
-		}
+
+	if _, err := MergeRemoteSessions(local, remote, MergeOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	merged, err := loadBranches(filepath.Join(local, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All three branches survive; main takes the larger head.
+	if len(merged.Branches) != 3 {
+		t.Fatalf("expected 3 branch entries, got %d: %+v", len(merged.Branches), merged.Branches)
+	}
+	if _, ok := merged.Branches["l"]; !ok {
+		t.Fatalf("local-only branch dropped: %+v", merged.Branches)
+	}
+	if _, ok := merged.Branches["r"]; !ok {
+		t.Fatalf("remote-only branch dropped: %+v", merged.Branches)
+	}
+	if merged.Branches["main"].Head != 2 {
+		t.Fatalf("main head should take the larger value (2), got %d", merged.Branches["main"].Head)
 	}
 }
+
+func TestMergeRemoteSessions_UnparseableRemoteReported(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	sid := "260101-0000-aaaaa-11111"
+	writeSessionDir(t, local, sid, "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+	// Corrupt remote events: must surface as a per-session error.
+	rdir := filepath.Join(remote, sid)
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "events.jsonl"), []byte("not json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "meta.json"), []byte("{\"id\":\""+sid+"\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Errors) != 1 {
+		t.Fatalf("expected 1 per-session error, got %+v", report)
+	}
+	if !strings.Contains(report.Errors[0], sid) {
+		t.Fatalf("error should name the session: %q", report.Errors[0])
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/internal/session/merge_test.go
+++ b/internal/session/merge_test.go
@@ -1,0 +1,270 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMergeEventsData_EmptyLocal(t *testing.T) {
+	remote := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
+	merged, winner := mergeEventsData(nil, []byte(remote))
+	if winner != "remote" || string(merged) != remote {
+		t.Fatalf("empty local should take remote: winner=%s merged=%q", winner, merged)
+	}
+}
+
+func TestMergeEventsData_EmptyRemote(t *testing.T) {
+	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
+	merged, winner := mergeEventsData([]byte(local), nil)
+	if winner != "local" || string(merged) != local {
+		t.Fatalf("empty remote should keep local: winner=%s merged=%q", winner, merged)
+	}
+}
+
+func TestMergeEventsData_LocalPrefixOfRemote(t *testing.T) {
+	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
+	remote := local + "{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n"
+	merged, winner := mergeEventsData([]byte(local), []byte(remote))
+	if winner != "remote" || string(merged) != remote {
+		t.Fatalf("remote continuation should win: winner=%s merged=%q", winner, merged)
+	}
+}
+
+func TestMergeEventsData_RemotePrefixOfLocal(t *testing.T) {
+	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n"
+	remote := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
+	merged, winner := mergeEventsData([]byte(local), []byte(remote))
+	if winner != "local" || string(merged) != local {
+		t.Fatalf("local continuation should win: winner=%s merged=%q", winner, merged)
+	}
+}
+
+func TestMergeEventsData_Divergent(t *testing.T) {
+	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:02Z\"}\n"
+	remote := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"c\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n"
+	merged, winner := mergeEventsData([]byte(local), []byte(remote))
+	if winner != "merged" {
+		t.Fatalf("divergent should merge: winner=%s", winner)
+	}
+	// Union by ID, ordered by timestamp: a, c, b.
+	want := []string{"\"id\":\"a\"", "\"id\":\"c\"", "\"id\":\"b\""}
+	got := strings.Split(strings.TrimSpace(string(merged)), "\n")
+	if len(got) != len(want) {
+		t.Fatalf("expected %d events, got %d: %q", len(want), len(got), merged)
+	}
+	for i, w := range want {
+		if !strings.Contains(got[i], w) {
+			t.Fatalf("event %d should contain %s, got %q", i, w, got[i])
+		}
+	}
+}
+
+func TestMergeEventsData_UnparseableKeepsLocal(t *testing.T) {
+	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n"
+	remote := "not json\n"
+	merged, winner := mergeEventsData([]byte(local), []byte(remote))
+	if winner != "local" || string(merged) != local {
+		t.Fatalf("unparseable remote should keep local: winner=%s", winner)
+	}
+}
+
+// writeSessionDir creates a session dir with the given events and meta.
+func writeSessionDir(t *testing.T, root, id, events, updatedAt string) string {
+	t.Helper()
+	dir := filepath.Join(root, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if events != "" {
+		if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(events), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	meta := "{\"id\":\"" + id + "\",\"appName\":\"pi-go\",\"userID\":\"local\",\"updatedAt\":\"" + updatedAt + "\"}\n"
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestMergeRemoteSessions_AddsNew(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, remote, "260101-0000-aaaaa-11111", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Added != 1 || report.Merged != 0 {
+		t.Fatalf("expected 1 added, got added=%d merged=%d", report.Added, report.Merged)
+	}
+	if _, err := os.Stat(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl")); err != nil {
+		t.Fatalf("new session not copied: %v", err)
+	}
+}
+
+func TestMergeRemoteSessions_KeepsLocalOnly(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "260101-0000-aaaaa-11111", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Added != 0 || report.Merged != 0 {
+		t.Fatalf("local-only session must be untouched: added=%d merged=%d", report.Added, report.Merged)
+	}
+	data, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl"))
+	if err != nil || string(data) != "{\"id\":\"a\"}\n" {
+		t.Fatalf("local-only session was modified: %q %v", data, err)
+	}
+}
+
+func TestMergeRemoteSessions_MergesContinuation(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "260101-0000-aaaaa-11111",
+		"{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n",
+		"2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "260101-0000-aaaaa-11111",
+		"{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n",
+		"2026-01-01T00:00:01Z")
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Merged != 1 {
+		t.Fatalf("expected 1 merged, got %d", report.Merged)
+	}
+	data, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "\"id\":\"b\"") {
+		t.Fatalf("remote continuation events missing after merge: %q", data)
+	}
+	// meta should be the newer remote one
+	meta, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(meta), "2026-01-01T00:00:01Z") {
+		t.Fatalf("meta should be the newer remote copy: %q", meta)
+	}
+}
+
+func TestMergeRemoteSessions_DryRunWritesNothing(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "260101-0000-aaaaa-11111",
+		"{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n",
+		"2026-01-01T00:00:00Z")
+	writeSessionDir(t, remote, "260101-0000-aaaaa-11111",
+		"{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n",
+		"2026-01-01T00:00:01Z")
+	writeSessionDir(t, remote, "260101-0000-bbbbb-22222", "{\"id\":\"x\"}\n", "2026-01-01T00:00:00Z")
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Added != 1 || report.Merged != 1 {
+		t.Fatalf("dry-run should still report: added=%d merged=%d", report.Added, report.Merged)
+	}
+	// Nothing written: local session unchanged, new session absent.
+	data, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "events.jsonl"))
+	if err != nil || string(data) != "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n" {
+		t.Fatalf("dry-run modified local events: %q %v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(local, "260101-0000-bbbbb-22222")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created a new session dir")
+	}
+}
+
+func TestMergeRemoteSessions_NewerMetaWins(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	writeSessionDir(t, local, "260101-0000-aaaaa-11111", "{\"id\":\"a\"}\n", "2026-01-02T00:00:00Z")
+	writeSessionDir(t, remote, "260101-0000-aaaaa-11111", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+
+	if _, err := MergeRemoteSessions(local, remote, MergeOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := os.ReadFile(filepath.Join(local, "260101-0000-aaaaa-11111", "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(meta), "2026-01-02T00:00:00Z") {
+		t.Fatalf("newer local meta should win: %q", meta)
+	}
+}
+
+func TestMergeRemoteSessions_IgnoresNonSessionFiles(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	// Junk at the sessions root must be ignored.
+	if err := os.WriteFile(filepath.Join(remote, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(remote, "acp-server.err.log"), []byte("log"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Added != 0 || report.Merged != 0 || len(report.Errors) != 0 {
+		t.Fatalf("junk files must be ignored: %+v", report)
+	}
+}
+
+func TestMergeRemoteSessions_SkipsNonSessionDirs(t *testing.T) {
+	local := t.TempDir()
+	remote := t.TempDir()
+	// archive/ and backup/ hold archived sessions, not sessions themselves.
+	for _, d := range []string{"archive", "backup", ".idea"} {
+		if err := os.MkdirAll(filepath.Join(remote, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeSessionDir(t, remote, "260101-0000-aaaaa-11111", "{\"id\":\"a\"}\n", "2026-01-01T00:00:00Z")
+
+	report, err := MergeRemoteSessions(local, remote, MergeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Added != 1 || report.Merged != 0 {
+		t.Fatalf("only the real session should be added: %+v", report)
+	}
+	for _, d := range []string{"archive", "backup", ".idea"} {
+		if _, err := os.Stat(filepath.Join(local, d)); !os.IsNotExist(err) {
+			t.Fatalf("non-session dir %s must not be copied", d)
+		}
+	}
+}
+
+func TestMergeRemoteSessions_TimeOrdering(t *testing.T) {
+	// Ensure the divergent merge orders by timestamp, not by input order.
+	local := "{\"id\":\"a\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n{\"id\":\"b\",\"timestamp\":\"2026-01-01T00:00:05Z\"}\n"
+	remote := "{\"id\":\"c\",\"timestamp\":\"2026-01-01T00:00:01Z\"}\n{\"id\":\"d\",\"timestamp\":\"2026-01-01T00:00:02Z\"}\n"
+	merged, winner := mergeEventsData([]byte(local), []byte(remote))
+	if winner != "merged" {
+		t.Fatalf("expected merged, got %s", winner)
+	}
+	lines := strings.Split(strings.TrimSpace(string(merged)), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(lines))
+	}
+	// a(0) c(1) d(2) b(5)
+	want := []string{"\"id\":\"a\"", "\"id\":\"c\"", "\"id\":\"d\"", "\"id\":\"b\""}
+	for i, w := range want {
+		if !strings.Contains(lines[i], w) {
+			t.Fatalf("line %d should contain %s, got %q", i, w, lines[i])
+		}
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -918,6 +918,38 @@ func (e eventList) At(i int) *session.Event {
 
 // File I/O helpers.
 
+// writeFileAtomic writes data to path via a temp file and rename, so a reader
+// (including rsync copying the sessions tree) never observes a partially
+// written file. The temp file lives in the same directory as the target so the
+// rename is atomic on the same filesystem.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".pi-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
+
 func writeMeta(sessionDir string, meta *Meta) error {
 	if strings.TrimSpace(meta.Model) == "" {
 		meta.Model = UnknownModel
@@ -926,7 +958,7 @@ func writeMeta(sessionDir string, meta *Meta) error {
 	if err != nil {
 		return fmt.Errorf("marshaling meta: %w", err)
 	}
-	return os.WriteFile(filepath.Join(sessionDir, "meta.json"), data, 0o644)
+	return writeFileAtomic(filepath.Join(sessionDir, "meta.json"), data, 0o644)
 }
 
 // SessionBackend returns the provider and endpoint recorded for a session.

--- a/scripts/sync-sessions.sh
+++ b/scripts/sync-sessions.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# sync-sessions.sh — pull pi-go sessions from a remote host without losing
+# local data.
+#
+# rsync stages the remote sessions tree into a temp dir, then session-merge
+# folds it into ~/.pi-go/sessions. The merge never deletes local-only sessions
+# and never truncates a local events file: for a session present on both sides
+# it unions events by ID (the longer file wins when one side is a strict
+# continuation), keeps the newer meta.json, and writes everything atomically.
+#
+# Usage:
+#   scripts/sync-sessions.sh [user@]host [remote-sessions-dir] [--dry-run]
+#
+# Examples:
+#   scripts/sync-sessions.sh archm2pro
+#   scripts/sync-sessions.sh archm2pro .pi-go/sessions --dry-run
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE="${1:?usage: sync-sessions.sh [user@]host [remote-sessions-dir] [--dry-run]}"
+REMOTE_DIR="${2:-.pi-go/sessions}"
+DRY_RUN="${3:-}"
+
+LOCAL_DIR="${HOME}/.pi-go/sessions"
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/pi-sessions-sync.XXXXXX")"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "==> Staging remote sessions from ${REMOTE}:${REMOTE_DIR}"
+# --rsync-path raises the remote shell's file-descriptor limit: macOS defaults
+# to 256, which makes rsync fail with "Too many open files" on large trees.
+# Exclude IDE/log/temp junk that lives in the sessions dir but is not session
+# data.
+rsync -avz --rsync-path="ulimit -n 65536; rsync" \
+  --exclude '.DS_Store' \
+  --exclude '*.log' \
+  --exclude '.idea/' \
+  --exclude '*.tmp' \
+  "${REMOTE}:${REMOTE_DIR}/" "${STAGE}/"
+
+echo "==> Merging into ${LOCAL_DIR} (local data is never deleted)"
+ARGS=(--local "$LOCAL_DIR" --remote "$STAGE")
+if [[ -n "$DRY_RUN" ]]; then
+  ARGS+=(--dry-run)
+fi
+(cd "$REPO_ROOT" && go run ./hack/session-merge "${ARGS[@]}")
+
+echo "==> Done. Local sessions: $(find "$LOCAL_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"


### PR DESCRIPTION
Make the sessions tree safe to sync with rsync and add a merge path that
pulls remote sessions without ever losing local data.

- writeMeta and saveBranches now write via temp+rename (writeFileAtomic),
  so rsync never copies a torn meta.json or branches.json. events.jsonl
  and trajectory.atif.json were already atomic.
- internal/session/merge.go: MergeRemoteSessions folds a staged remote
  tree into the local one. events.jsonl is unioned by event ID (the longer
  file wins when one side is a strict continuation, otherwise dedupe by ID
  and order by timestamp, preserving raw lines); meta.json keeps the newer
  updatedAt; derived files follow the events winner; branches/ merge per
  branch. Local-only sessions are never touched and nothing is deleted.
  Non-session dirs (archive/, backup/, .idea/) are skipped.
- hack/session-merge: thin CLI over the merge with --dry-run.
- scripts/sync-sessions.sh: rsync remote sessions into a staging dir
  (raising the remote fd limit, excluding junk/temp files) then merge.

Signed-off-by: dimetron <dimetron@me.com>
