### PR TITLE
fix(tui): close notice blocks so a mid-turn warning stops swallowing the reply

### DIFF
--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -1384,7 +1384,14 @@ func (m *model) handleAgentText(msg agentTextMsg) (tea.Model, tea.Cmd) {
 	// a fresh block and the accumulator restarts with it. Carrying the buffer
 	// across a tool call made every later block re-render every earlier one,
 	// glued together without a separator ("...say hi." + "agy ran cleanly").
-	if n := len(m.chatModel.Messages); n > 0 && m.chatModel.Messages[n-1].role == "assistant" {
+	//
+	// A closed block — an error, a warning, a meta note — closes the message the
+	// same way a tool card does. It shares the "assistant" role, so without the
+	// guard a warning raised mid-turn (a retry, a truncation, a loop recovery)
+	// absorbs the rest of the reply: the notice text is overwritten and the
+	// answer is drawn in the warning's orange, unwrapped and unrendered.
+	if n := len(m.chatModel.Messages); n > 0 && m.chatModel.Messages[n-1].role == "assistant" &&
+		!m.chatModel.Messages[n-1].closed() {
 		m.chatModel.Streaming += msg.text
 		m.chatModel.Messages[n-1].content = m.chatModel.Streaming
 	} else {

--- a/internal/tui/agent_notice_block_test.go
+++ b/internal/tui/agent_notice_block_test.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// A warning raised mid-turn used to be indistinguishable from an open reply
+// block: both carry role "assistant", so the next text delta overwrote the
+// notice and inherited its styling. The notice must survive and the resumed
+// reply must land in a block of its own.
+func TestHandleAgentText_WarningClosesTheBlock(t *testing.T) {
+	m := &model{}
+	m.chatModel = ChatModel{Messages: make([]message, 0)}
+
+	m.handleAgentText(agentTextMsg{text: "first block."})
+	m.handleAgentWarning(agentWarningMsg{text: "Loop detected — resuming (attempt 1 of 2)."})
+	m.handleAgentText(agentTextMsg{text: "resumed reply."})
+
+	msgs := m.chatModel.Messages
+	if len(msgs) != 3 {
+		t.Fatalf("want 3 blocks (reply, warning, reply), got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].content != "first block." || msgs[0].closed() {
+		t.Errorf("first block altered: %+v", msgs[0])
+	}
+	if !msgs[1].isWarning {
+		t.Errorf("block 1 should be the warning, got %+v", msgs[1])
+	}
+	if msgs[1].content != "Loop detected — resuming (attempt 1 of 2)." {
+		t.Errorf("warning text was overwritten: %q", msgs[1].content)
+	}
+	if msgs[2].isWarning {
+		t.Error("resumed reply inherited the warning style")
+	}
+	if msgs[2].content != "resumed reply." {
+		t.Errorf("resumed reply replayed the earlier block: %q", msgs[2].content)
+	}
+}
+
+// Errors and meta notes share the warning's role and the same exposure.
+func TestHandleAgentText_ErrorAndMetaCloseTheBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		append func(*ChatModel)
+	}{
+		{"error", func(c *ChatModel) { c.AppendError("Error: boom") }},
+		{"meta", func(c *ChatModel) { c.AppendMeta("Σ 100 tokens") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &model{}
+			m.chatModel = ChatModel{Messages: make([]message, 0)}
+			m.handleAgentText(agentTextMsg{text: "reply."})
+			tc.append(&m.chatModel)
+			m.handleAgentText(agentTextMsg{text: "more."})
+
+			msgs := m.chatModel.Messages
+			if len(msgs) != 3 {
+				t.Fatalf("want 3 blocks, got %d: %+v", len(msgs), msgs)
+			}
+			if msgs[2].closed() || msgs[2].content != "more." {
+				t.Errorf("text after a closed block: %+v", msgs[2])
+			}
+		})
+	}
+}
+
+// The accumulator holds the block that just closed. Left in place, the next
+// delta appends to it and replays the closed block inside the new one.
+func TestAppendNotice_ResetsStreamingAccumulator(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		append func(*ChatModel)
+	}{
+		{"warning", func(c *ChatModel) { c.AppendWarning("careful") }},
+		{"error", func(c *ChatModel) { c.AppendError("boom") }},
+		{"meta", func(c *ChatModel) { c.AppendMeta("Σ 1") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cm := ChatModel{Messages: make([]message, 0), Streaming: "leftover"}
+			tc.append(&cm)
+			if cm.Streaming != "" {
+				t.Errorf("Streaming = %q, want empty", cm.Streaming)
+			}
+		})
+	}
+}
+
+// An unwrapped notice runs past the right edge, where the terminal clips the
+// line and takes its SGR reset with it, leaving the styling open for every line
+// drawn afterwards. Wrapping keeps each line — and its reset — inside the pane.
+func TestNoticeBody_WrapsAndClosesEveryLine(t *testing.T) {
+	cm := ChatModel{Width: 40}
+	long := strings.Repeat("warning text that keeps going ", 6)
+
+	for _, tc := range []struct {
+		name string
+		out  string
+	}{
+		{"warning", cm.assistantWarningBody(long, darkPalette)},
+		{"error", cm.assistantErrorBody(long, darkPalette)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := strings.Split(tc.out, "\n")
+			if len(lines) < 2 {
+				t.Fatalf("notice was not wrapped: %q", tc.out)
+			}
+			for i, ln := range lines {
+				if w := ansi.StringWidth(ln); w > cm.Width {
+					t.Errorf("line %d is %d cols wide, pane is %d: %q", i, w, cm.Width, ln)
+				}
+				// lipgloss closes with the implicit form, \x1b[m; accept both.
+				if strings.Contains(ln, "\x1b[") &&
+					!strings.HasSuffix(ln, "\x1b[m") && !strings.HasSuffix(ln, "\x1b[0m") {
+					t.Errorf("line %d leaves its styling open: %q", i, ln)
+				}
+			}
+		})
+	}
+}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -294,6 +294,16 @@ func (c *ChatModel) Clear() {
 	c.Scroll = 0
 }
 
+// closed reports whether a message is a finished block that must never absorb
+// more streamed text. Errors, warnings, meta notes and pre-rendered output all
+// carry role "assistant" so they sit in the reply column, but each is complete
+// the moment it is appended. Streaming into one overwrites the notice with the
+// reply and drags the notice's styling over every line that follows — a
+// mid-turn warning used to swallow the rest of the answer and paint it orange.
+func (m *message) closed() bool {
+	return m.isError || m.isWarning || m.isMeta || m.preRendered
+}
+
 // AppendError adds an error message styled with red text. Errors that end a
 // run must be impossible to miss: the plain assistant bubble reads like part of
 // the model's answer, which is how provider failures used to slip past.
@@ -303,7 +313,7 @@ func (c *ChatModel) AppendError(text string) {
 		content: text,
 		isError: true,
 	})
-	c.Scroll = 0
+	c.closeStreamingBlock()
 }
 
 // AppendWarning adds a warning message styled with yellow text.
@@ -313,6 +323,15 @@ func (c *ChatModel) AppendWarning(text string) {
 		content:   text,
 		isWarning: true,
 	})
+	c.closeStreamingBlock()
+}
+
+// closeStreamingBlock ends the open reply block. The accumulator has to be
+// dropped along with it: it holds the text of the block that just closed, and
+// the next delta appends to whatever is left in it, so a stale buffer replays
+// the previous block inside the new one.
+func (c *ChatModel) closeStreamingBlock() {
+	c.Streaming = ""
 	c.Scroll = 0
 }
 
@@ -325,7 +344,7 @@ func (c *ChatModel) AppendMeta(text string) {
 		content: text,
 		isMeta:  true,
 	})
-	c.Scroll = 0
+	c.closeStreamingBlock()
 }
 
 // ResetScroll resets the scroll offset to bottom.
@@ -853,9 +872,7 @@ func (c *ChatModel) assistantBody(msg *message, content string, p Palette, bulle
 		// classic light-theme casualty — it washes out to nothing on white.
 		// Orange carries the same "look here, but nothing broke" weight and
 		// stays legible on both backgrounds.
-		warnStyle := lipgloss.NewStyle().Foreground(p.Peach).Bold(true)
-		warnBullet := lipgloss.NewStyle().Foreground(p.Peach).Bold(true).Render("⚠ ")
-		return warnBullet + warnStyle.Render(content)
+		return c.assistantWarningBody(content, p)
 	case msg.isMeta:
 		// A dim "Σ" prefix marks the line as a per-turn tally rather than the
 		// model's own words — the reply uses "◉", so the two must never be
@@ -874,16 +891,31 @@ func (c *ChatModel) assistantBody(msg *message, content string, p Palette, bulle
 // do — an error truncated by the terminal is barely better than the silent
 // failure this replaces.
 func (c *ChatModel) assistantErrorBody(content string, p Palette) string {
-	errStyle := lipgloss.NewStyle().Foreground(p.Error).Bold(true)
+	return c.noticeBody(content, "✖ ", lipgloss.NewStyle().Foreground(p.Error).Bold(true))
+}
 
+// assistantWarningBody renders a warning reply, wrapped for the same reason
+// errors are. A retry notice or a loop-detection line easily outruns the pane,
+// and an over-wide line is cut at the right edge by the terminal — which takes
+// the trailing SGR reset with it and leaves the styling open, so everything
+// drawn afterwards inherits the warning's orange.
+func (c *ChatModel) assistantWarningBody(content string, p Palette) string {
+	return c.noticeBody(content, "⚠ ", lipgloss.NewStyle().Foreground(p.Peach).Bold(true))
+}
+
+// noticeBody renders a bullet-prefixed notice wrapped to the pane, styling and
+// closing each line on its own so no line can carry an unterminated color into
+// the next one. The hanging indent keeps continuation lines under the text
+// rather than under the bullet.
+func (c *ChatModel) noticeBody(content, bullet string, style lipgloss.Style) string {
 	var b strings.Builder
-	b.WriteString(errStyle.Render("✖ "))
-	contentWidth := renderWrapWidth(c.Width, 3) // "✖ " plus the hanging indent
+	b.WriteString(style.Render(bullet))
+	contentWidth := renderWrapWidth(c.Width, 3) // bullet plus the hanging indent
 	for j, line := range wordWrap(content, contentWidth) {
 		if j > 0 {
 			b.WriteString("\n   ")
 		}
-		b.WriteString(errStyle.Render(line))
+		b.WriteString(style.Render(line))
 	}
 	return b.String()
 }


### PR DESCRIPTION
## The bug

A warning raised mid-turn turned the rest of the reply orange, unwrapped, and unrendered — one unbroken wall of peach text under a single `⚠`.

## Why

`AppendWarning` builds a message with `role: "assistant"` so it sits in the reply column (`internal/tui/chat.go`). `handleAgentText` continued writing into any trailing `"assistant"` message (`internal/tui/agent_loop.go`), checking only the role:

```go
if n := len(m.chatModel.Messages); n > 0 && m.chatModel.Messages[n-1].role == "assistant" {
    m.chatModel.Streaming += msg.text
    m.chatModel.Messages[n-1].content = m.chatModel.Streaming
}
```

Two failures compounded:

1. `AppendWarning` never cleared `ChatModel.Streaming`, so the accumulator still held the **previous** block. The first delta after the warning wrote that stale buffer over the warning's own text — the notice was erased and the earlier block replayed inside it.
2. The message kept `isWarning`, so `assistantBody` sent the entire resumed answer through the warning branch: peach + bold, no `RenderMarkdown` (raw ``` fences on screen), no wrapping (lines running off the right edge).

Reproduced before the fix — `text` → `warning` → `text`:

```
msg[0] role="assistant" warn=false content="first block."
msg[1] role="assistant" warn=true  content="first block. resumed reply text"
```

The warning text is gone entirely and the reply inherited its styling.

Triggers are the three mid-turn notices: the retry notifier, the max-tokens truncation notice, and the stuck-loop recovery line. `AppendError` and `AppendMeta` share the role and had the same exposure.

## The fix

- **`message.closed()`** marks a finished block (error, warning, meta, pre-rendered). `handleAgentText` refuses to append into one, so the resumed reply opens a fresh block and renders as normal markdown.
- **`closeStreamingBlock`** resets the accumulator in `AppendError`/`AppendWarning`/`AppendMeta`, so a closed block can never be replayed into the next one.
- **The warning body now wraps** like the error body, through a shared `noticeBody`. An over-wide notice is clipped at the right edge by the terminal, which takes the trailing SGR reset with it and leaves the styling open for every line drawn afterwards; wrapping keeps each line — and its reset — inside the pane.

## Tests

`internal/tui/agent_notice_block_test.go`:

- a warning between two text deltas leaves three blocks, keeps its own text, and the resumed reply is unstyled
- same for errors and meta notes
- all three `Append*` calls reset the accumulator
- every notice line fits the pane width and closes its own styling

## Verification

`go build`, `go vet`, `golangci-lint` (0 issues), `go test ./internal/...` — all clean. The `internal/tui` package needs the sandbox disabled: `httptest.NewServer` panics in `newLocalListener` under it.

## Noted, not fixed

`wordWrap` drops the space that triggers a wrap when the break lands on the preceding word, gluing two words together (`going warning` + `text` → `warningtext`). It is pre-existing and affects every wrapped block (user, thinking, error), so it is out of scope here — worth its own change.
