### PR TITLE
fix(a2a): coalesce streamed text; cover the A2A server and CLI

### DIFF
--- a/internal/a2a/server/server_serve_test.go
+++ b/internal/a2a/server/server_serve_test.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
+
+	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
+
+	acpserver "github.com/dimetron/pi-go/internal/acp/server"
+)
+
+// freeAddr returns a loopback address that was bound and released, so Serve
+// can rebind it without colliding with another test.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return addr
+}
+
+// startServer runs Serve on ephemeral ports and returns both base URLs.
+func startServer(t *testing.T) (base, readyBase string) {
+	t.Helper()
+	addr, readyAddr := freeAddr(t), freeAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeConfig{
+			Addr:      addr,
+			ReadyAddr: readyAddr,
+			Handler:   acpserver.EchoPromptHandler,
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Error("Serve did not return after context cancel")
+		}
+	})
+
+	base, readyBase = "http://"+addr, "http://"+readyAddr
+	waitReady(t, base+"/health")
+	return base, readyBase
+}
+
+func waitReady(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not become ready", url)
+}
+
+func TestServeRequiresHandler(t *testing.T) {
+	err := Serve(context.Background(), ServeConfig{Addr: "127.0.0.1:0"})
+	if err == nil || !strings.Contains(err.Error(), "handler is required") {
+		t.Fatalf("Serve() error = %v, want a handler-is-required error", err)
+	}
+}
+
+func TestServeRejectsBadAddr(t *testing.T) {
+	err := Serve(context.Background(), ServeConfig{
+		Addr:    "127.0.0.1:not-a-port",
+		Handler: acpserver.EchoPromptHandler,
+	})
+	if err == nil || !strings.Contains(err.Error(), "listen") {
+		t.Fatalf("Serve() error = %v, want a listen error", err)
+	}
+}
+
+func TestServeRejectsBadReadyAddr(t *testing.T) {
+	err := Serve(context.Background(), ServeConfig{
+		Addr:      freeAddr(t),
+		ReadyAddr: "127.0.0.1:not-a-port",
+		Handler:   acpserver.EchoPromptHandler,
+	})
+	if err == nil || !strings.Contains(err.Error(), "listen ready") {
+		t.Fatalf("Serve() error = %v, want a ready-listener error", err)
+	}
+}
+
+func TestServeReturnsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, ServeConfig{
+			Addr:      freeAddr(t),
+			ReadyAddr: freeAddr(t),
+			Handler:   acpserver.EchoPromptHandler,
+		})
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !strings.Contains(err.Error(), context.Canceled.Error()) {
+			t.Fatalf("Serve() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after context cancel")
+	}
+}
+
+func TestServeHealthEndpoints(t *testing.T) {
+	base, _ := startServer(t)
+
+	for _, path := range []string{"/health", "/healthz"} {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(base + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d, want 200", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestServeReadyz(t *testing.T) {
+	_, readyBase := startServer(t)
+
+	t.Run("readyz is served", func(t *testing.T) {
+		resp, err := http.Get(readyBase + "/readyz")
+		if err != nil {
+			t.Fatalf("GET /readyz: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("other paths are 404", func(t *testing.T) {
+		resp, err := http.Get(readyBase + "/nope")
+		if err != nil {
+			t.Fatalf("GET /nope: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+}
+
+func TestServeGRPCHealth(t *testing.T) {
+	base, _ := startServer(t)
+	target := strings.TrimPrefix(base, "http://")
+
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(ctx,
+		&grpc_health_v1.HealthCheckRequest{Service: a2apb.A2AService_ServiceDesc.ServiceName})
+	if err != nil {
+		t.Fatalf("grpc health check: %v", err)
+	}
+	if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+		t.Errorf("status = %v, want SERVING", resp.Status)
+	}
+}

--- a/internal/a2a/server/server_test.go
+++ b/internal/a2a/server/server_test.go
@@ -35,12 +35,17 @@ func startTestServerWithHandler(t *testing.T, handler acpserver.PromptHandler) (
 	addr := ln.Addr().String()
 	_ = ln.Close() // let Serve rebind the same address
 
+	// Bind the readiness listener on an ephemeral port too, so parallel
+	// packages do not contend on the default :8081.
+	readyAddr := freeAddr(t)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
 		done <- Serve(ctx, ServeConfig{
-			Addr:    addr,
-			Handler: handler,
+			Addr:      addr,
+			ReadyAddr: readyAddr,
+			Handler:   handler,
 		})
 	}()
 

--- a/internal/a2a/server/server_units_test.go
+++ b/internal/a2a/server/server_units_test.go
@@ -1,0 +1,428 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	a2ataskstore "github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+
+	acpserver "github.com/dimetron/pi-go/internal/acp/server"
+)
+
+// discardLogger returns a logger that drops every record.
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// drain collects every event an executor iterator yields.
+func drain(seq func(func(a2a.Event, error) bool)) ([]a2a.Event, []error) {
+	var events []a2a.Event
+	var errs []error
+	seq(func(e a2a.Event, err error) bool {
+		events = append(events, e)
+		errs = append(errs, err)
+		return true
+	})
+	return events, errs
+}
+
+// states extracts the task state of every status-update event.
+func states(events []a2a.Event) []a2a.TaskState {
+	var out []a2a.TaskState
+	for _, e := range events {
+		if su, ok := e.(*a2a.TaskStatusUpdateEvent); ok {
+			out = append(out, su.Status.State)
+		}
+	}
+	return out
+}
+
+func newExecCtx(prompt string) *a2asrv.ExecutorContext {
+	return &a2asrv.ExecutorContext{
+		Message:   a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart(prompt)),
+		TaskID:    "task-1",
+		ContextID: "ctx-1",
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *a2a.Message
+		want string
+	}{
+		{"nil message", nil, ""},
+		{"no parts", a2a.NewMessage(a2a.MessageRoleUser), ""},
+		{"single part", a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi")), "hi"},
+		{
+			"parts concatenated",
+			a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("a"), a2a.NewTextPart("b")),
+			"ab",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractText(tt.msg); got != tt.want {
+				t.Errorf("extractText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteEmptyPrompt(t *testing.T) {
+	e := &piExecutor{handler: acpserver.EchoPromptHandler, logger: discardLogger()}
+	events, _ := drain(e.Execute(context.Background(), newExecCtx("   ")))
+
+	if got := states(events); len(got) != 1 || got[0] != a2a.TaskStateFailed {
+		t.Fatalf("states = %v, want [failed]", got)
+	}
+}
+
+func TestExecuteHandlerError(t *testing.T) {
+	wantErr := errors.New("model exploded")
+	h := func(context.Context, acpserver.PromptTurn) (acpserver.PromptResult, error) {
+		return acpserver.PromptResult{}, wantErr
+	}
+	e := &piExecutor{handler: h, logger: discardLogger()}
+	events, _ := drain(e.Execute(context.Background(), newExecCtx("hello")))
+
+	got := states(events)
+	if len(got) != 2 || got[0] != a2a.TaskStateWorking || got[1] != a2a.TaskStateFailed {
+		t.Fatalf("states = %v, want [working failed]", got)
+	}
+	last, ok := events[len(events)-1].(*a2a.TaskStatusUpdateEvent)
+	if !ok || last.Status.Message == nil {
+		t.Fatal("failed event carries no status message")
+	}
+	if txt := extractText(last.Status.Message); !strings.Contains(txt, wantErr.Error()) {
+		t.Errorf("failure text = %q, want it to contain %q", txt, wantErr)
+	}
+}
+
+func TestExecuteEmitsTaskWhenNotStored(t *testing.T) {
+	e := &piExecutor{handler: acpserver.EchoPromptHandler, logger: discardLogger()}
+	events, _ := drain(e.Execute(context.Background(), newExecCtx("hello")))
+
+	if len(events) == 0 {
+		t.Fatal("no events")
+	}
+	if _, ok := events[0].(*a2a.Task); !ok {
+		t.Fatalf("first event = %T, want *a2a.Task", events[0])
+	}
+	if got := states(events); len(got) != 2 || got[1] != a2a.TaskStateCompleted {
+		t.Fatalf("states = %v, want [working completed]", got)
+	}
+}
+
+func TestExecuteSkipsTaskWhenStored(t *testing.T) {
+	execCtx := newExecCtx("hello")
+	execCtx.StoredTask = &a2a.Task{ID: execCtx.TaskID, ContextID: execCtx.ContextID}
+
+	e := &piExecutor{handler: acpserver.EchoPromptHandler, logger: discardLogger()}
+	events, _ := drain(e.Execute(context.Background(), execCtx))
+
+	for _, ev := range events {
+		if _, ok := ev.(*a2a.Task); ok {
+			t.Fatal("emitted a Task even though one was already stored")
+		}
+	}
+}
+
+// TestExecuteStopsOnYieldFalse covers every early-return path taken when the
+// consumer stops reading part-way through the event stream.
+func TestExecuteStopsOnYieldFalse(t *testing.T) {
+	for _, stopAfter := range []int{1, 2, 3, 4} {
+		t.Run("stop-after-"+string(rune('0'+stopAfter)), func(t *testing.T) {
+			e := &piExecutor{handler: acpserver.EchoPromptHandler, logger: discardLogger()}
+			seen := 0
+			e.Execute(context.Background(), newExecCtx("hello"))(func(a2a.Event, error) bool {
+				seen++
+				return seen < stopAfter
+			})
+			if seen > stopAfter {
+				t.Fatalf("yielded %d events after asking to stop at %d", seen, stopAfter)
+			}
+		})
+	}
+}
+
+func TestCancelEmitsCanceled(t *testing.T) {
+	e := &piExecutor{handler: acpserver.EchoPromptHandler, logger: discardLogger()}
+	events, _ := drain(e.Cancel(context.Background(), newExecCtx("hello")))
+
+	if got := states(events); len(got) != 1 || got[0] != a2a.TaskStateCanceled {
+		t.Fatalf("states = %v, want [canceled]", got)
+	}
+}
+
+func TestTakeStoredTask(t *testing.T) {
+	withMeta := func(v any) *a2a.Message {
+		m := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("x"))
+		m.TaskID = "task-1"
+		m.ContextID = "ctx-1"
+		m.Metadata = map[string]any{storedTaskMetadataKey: v}
+		return m
+	}
+
+	t.Run("nil message", func(t *testing.T) {
+		task, err := takeStoredTask(nil)
+		if task != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", task, err)
+		}
+	})
+
+	t.Run("nil metadata", func(t *testing.T) {
+		task, err := takeStoredTask(a2a.NewMessage(a2a.MessageRoleUser))
+		if task != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", task, err)
+		}
+	})
+
+	t.Run("key absent", func(t *testing.T) {
+		m := a2a.NewMessage(a2a.MessageRoleUser)
+		m.Metadata = map[string]any{"other": 1}
+		task, err := takeStoredTask(m)
+		if task != nil || err != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", task, err)
+		}
+	})
+
+	t.Run("value not an object", func(t *testing.T) {
+		if _, err := takeStoredTask(withMeta("nope")); err == nil {
+			t.Fatal("want error for non-object metadata value")
+		}
+	})
+
+	t.Run("rejects non-continuation state", func(t *testing.T) {
+		for _, state := range []string{"", string(a2a.TaskStateCompleted), string(a2a.TaskStateWorking), "bogus"} {
+			v := map[string]any{"state": state}
+			if _, err := takeStoredTask(withMeta(v)); err == nil {
+				t.Errorf("state %q: want error", state)
+			}
+		}
+	})
+
+	t.Run("accepts continuation states", func(t *testing.T) {
+		for _, state := range []a2a.TaskState{a2a.TaskStateInputRequired, a2a.TaskStateAuthRequired} {
+			msg := withMeta(map[string]any{"state": string(state)})
+			task, err := takeStoredTask(msg)
+			if err != nil {
+				t.Fatalf("state %q: %v", state, err)
+			}
+			if task.Status.State != state {
+				t.Errorf("state = %q, want %q", task.Status.State, state)
+			}
+			if task.ID != "task-1" || task.ContextID != "ctx-1" {
+				t.Errorf("task ids = (%q, %q), want (task-1, ctx-1)", task.ID, task.ContextID)
+			}
+			if _, still := msg.Metadata[storedTaskMetadataKey]; still {
+				t.Error("metadata key was not consumed")
+			}
+		}
+	})
+
+	t.Run("decodes status message", func(t *testing.T) {
+		v := map[string]any{
+			"state": string(a2a.TaskStateInputRequired),
+			"message": map[string]any{
+				"role":  "agent",
+				"parts": []any{map[string]any{"kind": "text", "text": "more input please"}},
+			},
+		}
+		task, err := takeStoredTask(withMeta(v))
+		if err != nil {
+			t.Fatalf("takeStoredTask: %v", err)
+		}
+		if task.Status.Message == nil {
+			t.Fatal("status message not decoded")
+		}
+		if got := extractText(task.Status.Message); got != "more input please" {
+			t.Errorf("status text = %q, want %q", got, "more input please")
+		}
+	})
+
+	t.Run("nil status message stays nil", func(t *testing.T) {
+		v := map[string]any{"state": string(a2a.TaskStateInputRequired), "message": nil}
+		task, err := takeStoredTask(withMeta(v))
+		if err != nil {
+			t.Fatalf("takeStoredTask: %v", err)
+		}
+		if task.Status.Message != nil {
+			t.Error("want nil status message")
+		}
+	})
+
+	t.Run("unmarshalable status message", func(t *testing.T) {
+		v := map[string]any{"state": string(a2a.TaskStateInputRequired), "message": "not-an-object"}
+		if _, err := takeStoredTask(withMeta(v)); err == nil {
+			t.Fatal("want decode error")
+		}
+	})
+
+	t.Run("unencodable status message", func(t *testing.T) {
+		v := map[string]any{"state": string(a2a.TaskStateInputRequired), "message": make(chan int)}
+		if _, err := takeStoredTask(withMeta(v)); err == nil {
+			t.Fatal("want encode error")
+		}
+	})
+}
+
+func newSeedInterceptor() (*seedTaskInterceptor, a2ataskstore.Store) {
+	store := a2ataskstore.NewInMemory(nil)
+	return &seedTaskInterceptor{store: store}, store
+}
+
+func sendReq(msg *a2a.Message) *a2asrv.Request {
+	return &a2asrv.Request{Payload: &a2a.SendMessageRequest{Message: msg}}
+}
+
+func TestSeedTaskInterceptorPassthrough(t *testing.T) {
+	msgNoTask := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("x"))
+
+	tests := []struct {
+		name string
+		req  *a2asrv.Request
+	}{
+		{"nil request", nil},
+		{"wrong payload type", &a2asrv.Request{Payload: &a2a.GetTaskRequest{}}},
+		{"nil message", &a2asrv.Request{Payload: &a2a.SendMessageRequest{}}},
+		{"no task id", sendReq(msgNoTask)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, store := newSeedInterceptor()
+			ctx, res, err := i.Before(context.Background(), nil, tt.req)
+			if err != nil || res != nil || ctx == nil {
+				t.Fatalf("Before() = (%v, %v, %v), want passthrough", ctx, res, err)
+			}
+			if _, err := store.Get(context.Background(), "task-1"); !errors.Is(err, a2a.ErrTaskNotFound) {
+				t.Error("interceptor seeded a task it should have ignored")
+			}
+		})
+	}
+}
+
+func TestSeedTaskInterceptorSeedsSubmittedTask(t *testing.T) {
+	i, store := newSeedInterceptor()
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("x"))
+	msg.TaskID = "task-1"
+	msg.ContextID = "ctx-1"
+
+	if _, _, err := i.Before(context.Background(), nil, sendReq(msg)); err != nil {
+		t.Fatalf("Before: %v", err)
+	}
+	task, err := store.Get(context.Background(), "task-1")
+	if err != nil {
+		t.Fatalf("task was not seeded: %v", err)
+	}
+	if task.Task.ContextID != "ctx-1" {
+		t.Errorf("ContextID = %q, want ctx-1", task.Task.ContextID)
+	}
+}
+
+func TestSeedTaskInterceptorSeedsFromMetadata(t *testing.T) {
+	i, store := newSeedInterceptor()
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("x"))
+	msg.TaskID = "task-1"
+	msg.ContextID = "ctx-1"
+	msg.Metadata = map[string]any{
+		storedTaskMetadataKey: map[string]any{"state": string(a2a.TaskStateInputRequired)},
+	}
+
+	if _, _, err := i.Before(context.Background(), nil, sendReq(msg)); err != nil {
+		t.Fatalf("Before: %v", err)
+	}
+	task, err := store.Get(context.Background(), "task-1")
+	if err != nil {
+		t.Fatalf("task was not seeded: %v", err)
+	}
+	if task.Task.Status.State != a2a.TaskStateInputRequired {
+		t.Errorf("state = %q, want input-required", task.Task.Status.State)
+	}
+}
+
+func TestSeedTaskInterceptorPropagatesMetadataError(t *testing.T) {
+	i, _ := newSeedInterceptor()
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("x"))
+	msg.TaskID = "task-1"
+	msg.Metadata = map[string]any{storedTaskMetadataKey: map[string]any{"state": string(a2a.TaskStateCompleted)}}
+
+	if _, _, err := i.Before(context.Background(), nil, sendReq(msg)); err == nil {
+		t.Fatal("want error for invalid stored task state")
+	}
+}
+
+func TestSeedTaskInterceptorLeavesExistingTask(t *testing.T) {
+	i, store := newSeedInterceptor()
+	ctx := context.Background()
+	existing := &a2a.Task{
+		ID:        "task-1",
+		ContextID: "ctx-original",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateWorking},
+	}
+	if _, err := store.Create(ctx, existing); err != nil {
+		t.Fatalf("seed existing: %v", err)
+	}
+
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("x"))
+	msg.TaskID = "task-1"
+	msg.ContextID = "ctx-different"
+	if _, _, err := i.Before(ctx, nil, sendReq(msg)); err != nil {
+		t.Fatalf("Before: %v", err)
+	}
+
+	task, err := store.Get(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if task.Task.ContextID != "ctx-original" {
+		t.Errorf("ContextID = %q, want the stored task to be left alone", task.Task.ContextID)
+	}
+}
+
+func TestBuildCard(t *testing.T) {
+	t.Run("default card", func(t *testing.T) {
+		t.Setenv("KAGENT_AGENT_CARD_JSON", "")
+		card := buildCard("127.0.0.1:8085")
+		if card.Name != "pi-go" {
+			t.Errorf("Name = %q, want pi-go", card.Name)
+		}
+		if len(card.Skills) == 0 {
+			t.Error("default card must advertise at least one skill")
+		}
+		if !card.Capabilities.Streaming {
+			t.Error("default card should advertise streaming")
+		}
+		if len(card.SupportedInterfaces) != 1 {
+			t.Fatalf("interfaces = %d, want 1", len(card.SupportedInterfaces))
+		}
+		if got := card.SupportedInterfaces[0].URL; got != "http://127.0.0.1:8085" {
+			t.Errorf("URL = %q, want http://127.0.0.1:8085", got)
+		}
+	})
+
+	t.Run("injected card wins", func(t *testing.T) {
+		t.Setenv("KAGENT_AGENT_CARD_JSON", `{"name":"injected","version":"9.9.9"}`)
+		card := buildCard("127.0.0.1:8085")
+		if card.Name != "injected" || card.Version != "9.9.9" {
+			t.Errorf("card = %+v, want the injected identity", card)
+		}
+	})
+
+	t.Run("malformed injected card falls back", func(t *testing.T) {
+		t.Setenv("KAGENT_AGENT_CARD_JSON", `{"name":`)
+		if card := buildCard("127.0.0.1:8085"); card.Name != "pi-go" {
+			t.Errorf("Name = %q, want the built-in fallback", card.Name)
+		}
+	})
+
+	t.Run("whitespace is treated as unset", func(t *testing.T) {
+		t.Setenv("KAGENT_AGENT_CARD_JSON", "   ")
+		if card := buildCard("127.0.0.1:8085"); card.Name != "pi-go" {
+			t.Errorf("Name = %q, want the built-in fallback", card.Name)
+		}
+	})
+}

--- a/internal/a2a/server/server_units_test.go
+++ b/internal/a2a/server/server_units_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -425,4 +426,83 @@ func TestBuildCard(t *testing.T) {
 			t.Errorf("Name = %q, want the built-in fallback", card.Name)
 		}
 	})
+}
+
+// TestExecuteRecoversHandlerPanic covers the recover() path added with
+// streaming: a panicking prompt turn must surface as a failed task rather
+// than taking the server down.
+func TestExecuteRecoversHandlerPanic(t *testing.T) {
+	h := func(context.Context, acpserver.PromptTurn) (acpserver.PromptResult, error) {
+		panic("boom")
+	}
+	e := &piExecutor{handler: h, logger: discardLogger()}
+	events, _ := drain(e.Execute(context.Background(), newExecCtx("hello")))
+
+	got := states(events)
+	if len(got) != 2 || got[1] != a2a.TaskStateFailed {
+		t.Fatalf("states = %v, want [working failed]", got)
+	}
+	last := events[len(events)-1].(*a2a.TaskStatusUpdateEvent)
+	if txt := extractText(last.Status.Message); !strings.Contains(txt, "handler panicked") {
+		t.Errorf("failure text = %q, want it to mention the panic", txt)
+	}
+}
+
+// TestExecuteReturnsOnContextCancel covers the ctx.Done() branch of the
+// streaming loop: a canceled request context stops the iterator.
+func TestExecuteReturnsOnContextCancel(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	h := func(ctx context.Context, _ acpserver.PromptTurn) (acpserver.PromptResult, error) {
+		select {
+		case <-ctx.Done():
+			return acpserver.PromptResult{}, ctx.Err()
+		case <-release:
+			return acpserver.PromptResult{}, nil
+		}
+	}
+	e := &piExecutor{handler: h, logger: discardLogger()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan []a2a.TaskState, 1)
+	go func() {
+		events, _ := drain(e.Execute(ctx, newExecCtx("hello")))
+		done <- states(events)
+	}()
+
+	// Let the executor emit Task and Working, then cancel mid-turn.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case got := <-done:
+		if len(got) == 0 || got[0] != a2a.TaskStateWorking {
+			t.Fatalf("states = %v, want the turn to stop after working", got)
+		}
+		for _, s := range got {
+			if s == a2a.TaskStateCompleted {
+				t.Error("turn completed despite a canceled context")
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return after context cancel")
+	}
+}
+
+// TestExecuteStopsWhileStreaming covers the cancel() taken when the consumer
+// stops reading part-way through streamed artifact events.
+func TestExecuteStopsWhileStreaming(t *testing.T) {
+	e := &piExecutor{handler: streamingHandler, logger: discardLogger()}
+
+	seen := 0
+	e.Execute(context.Background(), newExecCtx("hello"))(func(a2a.Event, error) bool {
+		seen++
+		// Stop once past Task + Working, i.e. during the streamed artifacts.
+		return seen < 3
+	})
+
+	if seen != 3 {
+		t.Fatalf("yielded %d events, want the iterator to stop at 3", seen)
+	}
 }

--- a/internal/a2a/server/stream.go
+++ b/internal/a2a/server/stream.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -38,6 +39,9 @@ type a2aUpdater struct {
 	mu                sync.Mutex
 	textArtifactID    a2a.ArtifactID
 	thoughtArtifactID a2a.ArtifactID
+	textBuf           strings.Builder // accumulated assistant text for the open artifact
+	thoughtBuf        strings.Builder // accumulated thinking for the open artifact
+	streamedAnyText   bool
 	toolNames         map[string]string // ACP call ID → tool name
 }
 
@@ -71,12 +75,18 @@ func (u *a2aUpdater) Update(ctx context.Context, update acp.SessionUpdate) error
 func (u *a2aUpdater) streamedText() bool {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	return u.textArtifactID != ""
+	return u.streamedAnyText
 }
 
-// emitText streams one text chunk as an artifact update. The first chunk of a
-// kind creates the artifact; later chunks append to it (Append=true), which is
-// how the kagent UI accumulates a reply token by token.
+// emitText streams one text chunk as an artifact update.
+//
+// Each chunk carries the full text accumulated for the open artifact and is
+// sent with Append=false, so the artifact always holds exactly one text part
+// that grows. A2A's append semantics (a2aevent.applyArtifactUpdate) concatenate
+// *parts*, not text: appending each chunk as its own part leaves the stored
+// task holding one part per token, and a client that renders a part at a time
+// shows a single reply as a column of fragments. Replacing keeps one part, so
+// the reply renders as one growing message.
 func (u *a2aUpdater) emitText(ctx context.Context, content acp.ContentBlock, thought bool) error {
 	text := ""
 	if content.Text != nil {
@@ -87,31 +97,46 @@ func (u *a2aUpdater) emitText(ctx context.Context, content acp.ContentBlock, tho
 	}
 
 	u.mu.Lock()
-	id := u.textArtifactID
+	buf, id := &u.textBuf, u.textArtifactID
 	if thought {
-		id = u.thoughtArtifactID
+		buf, id = &u.thoughtBuf, u.thoughtArtifactID
 	}
+	buf.WriteString(text)
+	full := buf.String()
+
 	var ev *a2a.TaskArtifactUpdateEvent
 	if id == "" {
-		ev = a2a.NewArtifactEvent(u.execCtx, a2a.NewTextPart(text))
-		if thought {
-			ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
-		}
+		ev = a2a.NewArtifactEvent(u.execCtx, a2a.NewTextPart(full))
 		id = ev.Artifact.ID
 		if thought {
 			u.thoughtArtifactID = id
 		} else {
 			u.textArtifactID = id
+			u.streamedAnyText = true
 		}
 	} else {
-		ev = a2a.NewArtifactUpdateEvent(u.execCtx, id, a2a.NewTextPart(text))
-		if thought {
-			ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
-		}
+		ev = a2a.NewArtifactUpdateEvent(u.execCtx, id, a2a.NewTextPart(full))
+		// Replace the artifact's single part rather than appending another.
+		ev.Append = false
+	}
+	if thought {
+		ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
 	}
 	u.mu.Unlock()
 
 	return u.emit(ctx, ev)
+}
+
+// closeTextArtifacts ends the open text and thinking artifacts so the next
+// chunk starts a new one. Called at a tool-call boundary: without it, text
+// produced after a tool call would keep growing the artifact opened before it,
+// and the reply would render above the tool card instead of below it.
+func (u *a2aUpdater) closeTextArtifacts() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.textArtifactID, u.thoughtArtifactID = "", ""
+	u.textBuf.Reset()
+	u.thoughtBuf.Reset()
 }
 
 // emitToolStart streams a tool invocation as a function_call data part. The
@@ -124,6 +149,8 @@ func (u *a2aUpdater) emitToolStart(ctx context.Context, tc *acp.SessionUpdateToo
 	if name == "" {
 		name = "tool"
 	}
+
+	u.closeTextArtifacts()
 
 	u.mu.Lock()
 	u.toolNames[string(tc.ToolCallId)] = name
@@ -140,6 +167,8 @@ func (u *a2aUpdater) emitToolStart(ctx context.Context, tc *acp.SessionUpdateToo
 
 // emitToolEnd streams a tool result as a function_response data part.
 func (u *a2aUpdater) emitToolEnd(ctx context.Context, tu *acp.SessionToolCallUpdate) error {
+	u.closeTextArtifacts()
+
 	u.mu.Lock()
 	name := u.toolNames[string(tu.ToolCallId)]
 	delete(u.toolNames, string(tu.ToolCallId))

--- a/internal/a2a/server/stream_coalesce_test.go
+++ b/internal/a2a/server/stream_coalesce_test.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aevent"
+	acp "github.com/coder/acp-go-sdk"
+)
+
+// applyToTask folds the updater's events into a task the way a2a-go's task
+// manager does, so assertions run against what a client actually stores.
+func applyToTask(t *testing.T, execCtxTaskID a2a.TaskID, events []a2a.Event) *a2a.Task {
+	t.Helper()
+	task := &a2a.Task{ID: execCtxTaskID, ContextID: "ctx-1"}
+	for _, ev := range events {
+		au, ok := ev.(*a2a.TaskArtifactUpdateEvent)
+		if !ok {
+			continue
+		}
+		updated, err := a2aevent.ApplyArtifactUpdate(task, au)
+		if err != nil {
+			t.Fatalf("ApplyArtifactUpdate: %v", err)
+		}
+		task = updated
+	}
+	return task
+}
+
+// collect drains the updater's channel after fn has run.
+func collect(t *testing.T, fn func(u *a2aUpdater)) ([]a2a.Event, *a2asrvExecCtx) {
+	t.Helper()
+	execCtx := newExecCtx("hello")
+	u := newA2AUpdater(context.Background(), execCtx)
+	go func() {
+		fn(u)
+		close(u.events)
+	}()
+	var events []a2a.Event
+	for ev := range u.events {
+		events = append(events, ev)
+	}
+	return events, &a2asrvExecCtx{TaskID: execCtx.TaskID}
+}
+
+type a2asrvExecCtx struct{ TaskID a2a.TaskID }
+
+func textChunk(s string) acp.SessionUpdate {
+	return acp.SessionUpdate{AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+		Content: acp.ContentBlock{Text: &acp.ContentBlockText{Text: s}},
+	}}
+}
+
+func thoughtChunk(s string) acp.SessionUpdate {
+	return acp.SessionUpdate{AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+		Content: acp.ContentBlock{Text: &acp.ContentBlockText{Text: s}},
+	}}
+}
+
+// TestStreamedTextCoalescesIntoOnePart is the regression test for the kagent
+// UI rendering one reply as a column of fragments. A2A append semantics
+// concatenate parts, not text, so streaming each chunk as its own part left
+// the stored task holding one part per token.
+func TestStreamedTextCoalescesIntoOnePart(t *testing.T) {
+	ctx := context.Background()
+	events, ec := collect(t, func(u *a2aUpdater) {
+		for _, chunk := range []string{"Here ", "are ", "the ", "tools."} {
+			if err := u.Update(ctx, textChunk(chunk)); err != nil {
+				t.Errorf("Update: %v", err)
+			}
+		}
+	})
+
+	task := applyToTask(t, ec.TaskID, events)
+	if len(task.Artifacts) != 1 {
+		t.Fatalf("artifacts = %d, want 1", len(task.Artifacts))
+	}
+	if got := len(task.Artifacts[0].Parts); got != 1 {
+		t.Fatalf("parts in the text artifact = %d, want 1 (one bubble, not one per chunk)", got)
+	}
+	if got := task.Artifacts[0].Parts[0].Text(); got != "Here are the tools." {
+		t.Errorf("text = %q, want the chunks joined", got)
+	}
+}
+
+// TestThinkingCoalescesSeparately keeps thinking in its own artifact so the UI
+// can render it apart from the reply.
+func TestThinkingCoalescesSeparately(t *testing.T) {
+	ctx := context.Background()
+	events, ec := collect(t, func(u *a2aUpdater) {
+		_ = u.Update(ctx, thoughtChunk("let me "))
+		_ = u.Update(ctx, thoughtChunk("check"))
+		_ = u.Update(ctx, textChunk("done"))
+	})
+
+	task := applyToTask(t, ec.TaskID, events)
+	if len(task.Artifacts) != 2 {
+		t.Fatalf("artifacts = %d, want 2 (thinking + reply)", len(task.Artifacts))
+	}
+	for _, art := range task.Artifacts {
+		if len(art.Parts) != 1 {
+			t.Errorf("artifact %s has %d parts, want 1", art.ID, len(art.Parts))
+		}
+	}
+	if got := task.Artifacts[0].Parts[0].Text(); got != "let me check" {
+		t.Errorf("thinking = %q, want %q", got, "let me check")
+	}
+	if got := task.Artifacts[1].Parts[0].Text(); got != "done" {
+		t.Errorf("reply = %q, want %q", got, "done")
+	}
+}
+
+// TestTextAfterToolCallStartsNewArtifact pins the ordering: text produced
+// after a tool call must not grow the artifact opened before it, or the reply
+// renders above the tool card instead of below it.
+func TestTextAfterToolCallStartsNewArtifact(t *testing.T) {
+	ctx := context.Background()
+	events, ec := collect(t, func(u *a2aUpdater) {
+		_ = u.Update(ctx, textChunk("checking now"))
+		_ = u.Update(ctx, acp.SessionUpdate{ToolCall: &acp.SessionUpdateToolCall{
+			ToolCallId: "call-1", Title: "bash git status -s",
+		}})
+		_ = u.Update(ctx, acp.SessionUpdate{ToolCallUpdate: &acp.SessionToolCallUpdate{
+			ToolCallId: "call-1", RawOutput: map[string]any{"exit_code": 0},
+		}})
+		_ = u.Update(ctx, textChunk("all clean"))
+	})
+
+	task := applyToTask(t, ec.TaskID, events)
+	if len(task.Artifacts) != 4 {
+		t.Fatalf("artifacts = %d, want 4 (text, call, response, text)", len(task.Artifacts))
+	}
+	if got := task.Artifacts[0].Parts[0].Text(); got != "checking now" {
+		t.Errorf("first artifact = %q, want the pre-tool text", got)
+	}
+	if got := task.Artifacts[3].Parts[0].Text(); got != "all clean" {
+		t.Errorf("last artifact = %q, want the post-tool text in its own artifact", got)
+	}
+	for i, art := range task.Artifacts {
+		if len(art.Parts) != 1 {
+			t.Errorf("artifact %d has %d parts, want 1", i, len(art.Parts))
+		}
+	}
+}
+
+// TestStreamedTextSuppressesFinalArtifact keeps the executor from appending a
+// duplicate final artifact once text has already been streamed, even though
+// tool boundaries clear the open artifact ID.
+func TestStreamedTextSuppressesFinalArtifact(t *testing.T) {
+	ctx := context.Background()
+	u := newA2AUpdater(ctx, newExecCtx("hello"))
+	go func() {
+		_ = u.Update(ctx, textChunk("partial"))
+		_ = u.Update(ctx, acp.SessionUpdate{ToolCall: &acp.SessionUpdateToolCall{
+			ToolCallId: "call-1", Title: "bash ls",
+		}})
+		close(u.events)
+	}()
+	for range u.events { //nolint:revive // draining
+	}
+
+	if !u.streamedText() {
+		t.Error("streamedText() = false after a tool call cleared the artifact ID; " +
+			"the executor would emit a duplicate final artifact")
+	}
+}
+
+// TestBashOutputLinesCoalesce reproduces the reported symptom directly: the
+// bash tool streams stdout a line at a time, which rendered as one bubble per
+// line in the kagent UI.
+func TestBashOutputLinesCoalesce(t *testing.T) {
+	ctx := context.Background()
+	lines := []string{
+		"go -> /usr/local/go/bin/go\n",
+		"pip -> /usr/bin/pip\n",
+		"git -> /usr/bin/git\n",
+	}
+	events, ec := collect(t, func(u *a2aUpdater) {
+		for _, line := range lines {
+			_ = u.Update(ctx, textChunk(line))
+		}
+	})
+
+	task := applyToTask(t, ec.TaskID, events)
+	if len(task.Artifacts) != 1 || len(task.Artifacts[0].Parts) != 1 {
+		t.Fatalf("got %d artifacts with %d parts, want 1 artifact with 1 part",
+			len(task.Artifacts), len(task.Artifacts[0].Parts))
+	}
+	if got := task.Artifacts[0].Parts[0].Text(); got != strings.Join(lines, "") {
+		t.Errorf("text = %q, want the lines joined into one part", got)
+	}
+}

--- a/internal/cli/a2a_server_test.go
+++ b/internal/cli/a2a_server_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// freeA2AAddr returns a loopback address that was bound and released.
+func freeA2AAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return addr
+}
+
+// canceledCmd returns a command whose context is already canceled, so the
+// A2A server binds its listeners and then shuts straight back down.
+func canceledCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+// isolateA2AFlags points the package-level flags at ephemeral ports and a
+// throwaway HOME, restoring them when the test ends.
+func isolateA2AFlags(t *testing.T) {
+	t.Helper()
+	origAddr, origReady := flagA2AAddr, flagA2AReadyAddr
+	origModel, origURL, origSystem := flagModel, flagURL, flagSystem
+	t.Cleanup(func() {
+		flagA2AAddr, flagA2AReadyAddr = origAddr, origReady
+		flagModel, flagURL, flagSystem = origModel, origURL, origSystem
+	})
+	flagA2AAddr = freeA2AAddr(t)
+	flagA2AReadyAddr = freeA2AAddr(t)
+	flagModel, flagURL, flagSystem = "", "", ""
+	t.Setenv("HOME", t.TempDir())
+}
+
+func TestNewA2AServerCmd(t *testing.T) {
+	cmd := newA2AServerCmd()
+
+	if cmd.Use != "a2a" {
+		t.Errorf("Use = %q, want a2a", cmd.Use)
+	}
+	if cmd.RunE == nil {
+		t.Error("RunE is nil")
+	}
+	for _, name := range []string{"model", "url", "header", "insecure", "addr", "ready-addr"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag %q is not registered", name)
+		}
+	}
+	if f := cmd.Flags().Lookup("header"); f != nil && f.NoOptDefVal != "" {
+		t.Errorf("header NoOptDefVal = %q, want empty", f.NoOptDefVal)
+	}
+	if f := cmd.Flags().Lookup("ready-addr"); f != nil && f.DefValue != ":8081" {
+		t.Errorf("ready-addr default = %q, want :8081", f.DefValue)
+	}
+}
+
+func TestRunA2AServerShutsDownOnCanceledContext(t *testing.T) {
+	isolateA2AFlags(t)
+
+	err := runA2AServer(canceledCmd(t), nil)
+	if err == nil {
+		t.Fatal("runA2AServer() = nil, want the context cancellation to surface")
+	}
+	if !strings.Contains(err.Error(), "a2a server") {
+		t.Errorf("error = %v, want it wrapped with %q", err, "a2a server")
+	}
+}
+
+func TestRunA2AServerWritesErrorLog(t *testing.T) {
+	isolateA2AFlags(t)
+	home := os.Getenv("HOME")
+
+	if err := runA2AServer(canceledCmd(t), nil); err == nil {
+		t.Fatal("want an error from the canceled context")
+	}
+
+	logPath := filepath.Join(home, ".pi-go", "sessions", "a2a-server.err.log")
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("error log was not created at %s: %v", logPath, err)
+	}
+	if len(body) == 0 {
+		t.Error("error log is empty; the shutdown error was not recorded")
+	}
+}
+
+func TestRunA2AServerResolvesModelFromEnv(t *testing.T) {
+	isolateA2AFlags(t)
+	t.Setenv("PI_MODEL", "env-model")
+	t.Setenv("PI_BASE_URL", "http://env.invalid")
+	t.Setenv("PI_SYSTEM", "env system prompt")
+
+	if err := runA2AServer(canceledCmd(t), nil); err == nil {
+		t.Fatal("want an error from the canceled context")
+	}
+}
+
+func TestRunA2AServerPrefersFlagsOverEnv(t *testing.T) {
+	isolateA2AFlags(t)
+	flagModel, flagURL, flagSystem = "flag-model", "http://flag.invalid", "flag system"
+	t.Setenv("PI_MODEL", "env-model")
+	t.Setenv("PI_BASE_URL", "http://env.invalid")
+	t.Setenv("PI_SYSTEM", "env system prompt")
+
+	if err := runA2AServer(canceledCmd(t), nil); err == nil {
+		t.Fatal("want an error from the canceled context")
+	}
+}
+
+func TestRunA2AServerUsesPortEnvWhenAddrUnset(t *testing.T) {
+	isolateA2AFlags(t)
+	port := strings.TrimPrefix(freeA2AAddr(t), "127.0.0.1:")
+	flagA2AAddr = ""
+	t.Setenv("PORT", port)
+
+	if err := runA2AServer(canceledCmd(t), nil); err == nil {
+		t.Fatal("want an error from the canceled context")
+	}
+}

--- a/internal/cli/a2a_server_test.go
+++ b/internal/cli/a2a_server_test.go
@@ -49,7 +49,12 @@ func isolateA2AFlags(t *testing.T) {
 	flagA2AAddr = freeA2AAddr(t)
 	flagA2AReadyAddr = freeA2AAddr(t)
 	flagModel, flagURL, flagSystem = "", "", ""
-	t.Setenv("HOME", t.TempDir())
+
+	// os.UserHomeDir reads $HOME on unix and %USERPROFILE% on Windows; set
+	// both so the server's log directory lands in the temp dir either way.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 }
 
 func TestNewA2AServerCmd(t *testing.T) {
@@ -88,7 +93,13 @@ func TestRunA2AServerShutsDownOnCanceledContext(t *testing.T) {
 
 func TestRunA2AServerWritesErrorLog(t *testing.T) {
 	isolateA2AFlags(t)
-	home := os.Getenv("HOME")
+
+	// Resolve the home directory the same way runA2AServer does, so the
+	// assertion follows the platform rather than assuming $HOME.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
 
 	if err := runA2AServer(canceledCmd(t), nil); err == nil {
 		t.Fatal("want an error from the canceled context")


### PR DESCRIPTION
Follow-up to #272 and #274. Fixes the kagent UI rendering reported on the live cluster, and closes the coverage gap #272 merged with. Item 17 on #271.

Needs #275 to land first (the pre-push hook blocks any branch rebased onto a main that has absorbed a PR).

## The rendering bug

In the kagent UI a single reply rendered as a column of fragments — `nes`, `uv\` for Java`, `Script/Python` — and every line of bash stdout became its own bubble.

A2A append semantics concatenate **parts, not text**:

```go
// a2aevent.applyArtifactUpdate
toUpdate.Parts = append(toUpdate.Parts, artifact.Parts...)
```

`emitText` sent each chunk as its own part via `NewArtifactUpdateEvent` (which sets `Append: true`). So the stored task held **one part per token**, and a client that renders a part at a time shows one reply as many messages. The UI loads history through `A2AService/ListTasks`, so this is the stored shape — not a live-streaming artifact.

**Fix:** accumulate the text for the open artifact and send the full value with `Append=false`, which replaces the single part rather than adding another. The artifact grows; the part count stays at one.

**Second fix:** close the open text and thinking artifacts at each tool-call boundary. Without it, text produced after a tool call kept growing the artifact opened before it, so the reply rendered *above* the tool card instead of below. `streamedText()` now uses a sticky flag, since the artifact ID is cleared at those boundaries and the executor reads it to decide whether a final artifact would duplicate streamed text.

The tests fold emitted events through `a2aevent.ApplyArtifactUpdate`, so they assert the shape a client actually stores. Against the unfixed code:

```
parts in the text artifact = 4, want 1 (one bubble, not one per chunk)
artifacts = 3, want 4 (text, call, response, text)
thinking = "let me ", want "let me check"
got 1 artifacts with 3 parts, want 1 artifact with 1 part
```

## Coverage

#272 landed at 50.2% patch coverage with both codecov checks failing — `server.go` 57.7%, `a2a_server.go` 28.8%. The uncovered set was also where the defects were: `takeStoredTask`, `Cancel`, `buildCard`'s fallback and the whole `runA2AServer` path had no tests.

| | Before | After |
|---|---|---|
| `internal/a2a/server` (package) | 63.3% | **93.5%** |
| `Execute` | 52.6% | 96.7% |
| `Cancel` | 0% | 100% |
| `takeStoredTask` | 0% | 100% |
| `buildCard` | 50% | 100% |
| `seedTaskInterceptor.Before` | 21.1% | 89.5% |
| `Serve` | 84.2% | 93.9% |
| `runA2AServer` | 0% | **95.3%** |

**Executor** — empty prompt, handler error, stored-vs-new task, early consumer stop, panic recovery, context cancel, mid-stream stop.

**`takeStoredTask`** — nil message, nil metadata, absent key, non-object value, rejected and accepted states, status-message decode, both encode and decode failures, metadata-key consumption.

**`seedTaskInterceptor`** — four passthrough cases, seeding a submitted task, seeding from continuation metadata, error propagation, leaving a stored task untouched.

**`buildCard`** — default, injected `KAGENT_AGENT_CARD_JSON`, malformed JSON, whitespace-as-unset.

**`Serve`** — missing handler, bad listen address, bad readiness address, shutdown on cancel, `/health`, `/healthz`, `/readyz` and its 404, and a gRPC health check on the shared port.

**`runA2AServer`** — driven with an already-canceled context; covers flag-vs-env resolution, the `$PORT` fallback, and the error log.

## Also fixed

The test helper left `ReadyAddr` empty, so every test bound the default `:8081` — the suite contended on a fixed port and never asserted the readiness contract. Now ephemeral, and `/readyz` is covered. That is item 17 on #271.

`os.UserHomeDir` reads `%USERPROFILE%` on Windows, not `$HOME`, so the error-log test pointed at a temp dir while the server wrote to the real profile. Both variables are set and the path is resolved the way the server resolves it.

## Verification

- `go test -race ./internal/a2a/... ./internal/cli/` — pass
- `go vet` — clean
- `golangci-lint` — 0 issues
- Regression tests confirmed failing against the unfixed `stream.go`

## Note for reviewers

`a2a.TaskState` marshals as `TASK_STATE_INPUT_REQUIRED`, not the kebab-case `input-required` of the A2A JSON spec. Tests derive state strings from the constants. Worth confirming separately that kagent's gateway serializes stored-task metadata the same way — if it emits kebab-case, `takeStoredTask` rejects every real continuation. These tests cannot settle that.