### PR TITLE
feat/a2a streaming

### DIFF
--- a/docs/kagent-harness.md
+++ b/docs/kagent-harness.md
@@ -11,6 +11,7 @@ Docs in this section:
 | File | Purpose |
 |---|---|
 | `specs/kagent/Dockerfile` | Builds the pi-go-kagent adapter image |
+| `specs/kagent/image-digests.sh` | Prints the digest-pinned amd64/arm64 image refs for a release |
 | `specs/kagent/DEPLOY.md` | Full end-to-end deploy steps on local Kind |
 | `specs/kagent/harness.yaml` | `Harness` + `AgentTemplate` manifests |
 
@@ -57,7 +58,13 @@ docker buildx build --platform linux/amd64,linux/arm64 --push \
 ```
 
 The release workflow (`release.yml`) already builds and pushes the image to
-`ghcr.io/<owner>/<repo>-kagent:<tag>` on every `v*` tag push.
+`ghcr.io/<owner>/<repo>-kagent:<tag>` on every `v*` tag push. To identify the
+immutable digests for a release — the manifest-list digest plus the
+per-architecture `linux/amd64` and `linux/arm64` digests — run:
+
+```bash
+./specs/kagent/image-digests.sh <tag>   # e.g. v0.0.87
+```
 
 ## Deploy on kagent
 
@@ -65,7 +72,8 @@ See [`specs/kagent/DEPLOY.md`](../specs/kagent/DEPLOY.md) for the full walkthrou
 The short version:
 
 1. Build/push the image and copy its immutable digest
-   (`docker buildx imagetools inspect ...`).
+   (`docker buildx imagetools inspect ...`), or run
+   `specs/kagent/image-digests.sh <tag>` for a release.
 2. Substitute the digest into `specs/kagent/harness.yaml`.
 3. `kubectl apply -f specs/kagent/harness.yaml`.
 4. Verify the Harness and AgentTemplate conditions are all `True`.

--- a/internal/a2a/server/server.go
+++ b/internal/a2a/server/server.go
@@ -191,8 +191,8 @@ func (e *piExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContex
 		// event ("message not allowed after task was stored"). When no task
 		// was stored, the manager requires the first event to be a Task.
 		// Emit the same sequence kagent's ADK executor and a2a-go's own
-		// exec executor emit: Task (if needed) → Working → artifact with the
-		// reply → Completed.
+		// exec executor emit: Task (if needed) → Working → streamed
+		// artifacts → Completed.
 		if execCtx.StoredTask == nil {
 			if !yield(a2a.NewSubmittedTask(execCtx, execCtx.Message), nil) {
 				return
@@ -201,24 +201,74 @@ func (e *piExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContex
 		if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
 			return
 		}
-		result, err := e.handler(ctx, acpserver.PromptTurn{
-			SessionID: execCtx.ContextID,
-			CWD:       e.cwd,
-			Prompt:    prompt,
-			Updater:   nil,
-		})
-		if err != nil {
-			e.logger.Log(ctx, slog.LevelError, "a2a-server: prompt failed",
-				"task", execCtx.TaskID, "err", err)
-			yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed,
-				a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(err.Error()))), nil)
-			return
+
+		// Run the prompt turn in a goroutine and stream its ACP session
+		// updates back as A2A artifact events. The adapter.Stream classifies
+		// ADK events (thought vs text vs tool calls) and calls the updater,
+		// which pushes A2A events onto a channel this iterator drains and
+		// yields — so thinking and tool calls reach the UI as they happen,
+		// not in one artifact at the end of the turn.
+		runCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		updater := newA2AUpdater(runCtx, execCtx)
+
+		type turnResult struct {
+			result acpserver.PromptResult
+			err    error
 		}
-		if !yield(a2a.NewArtifactEvent(execCtx, a2a.NewTextPart(result.FinalText)), nil) {
-			return
-		}
-		if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil) {
-			return
+		resultCh := make(chan turnResult, 1)
+		go func() {
+			var res turnResult
+			defer func() {
+				if r := recover(); r != nil {
+					e.logger.Log(ctx, slog.LevelError, "a2a-server: prompt panic",
+						"task", execCtx.TaskID, "panic", r)
+					res = turnResult{err: fmt.Errorf("handler panicked: %v", r)}
+				}
+				close(updater.events)
+				resultCh <- res
+			}()
+			res.result, res.err = e.handler(runCtx, acpserver.PromptTurn{
+				SessionID: execCtx.ContextID,
+				CWD:       e.cwd,
+				Prompt:    prompt,
+				Updater:   updater,
+			})
+		}()
+
+		for {
+			select {
+			case ev, ok := <-updater.events:
+				if !ok {
+					res := <-resultCh
+					if res.err != nil {
+						e.logger.Log(ctx, slog.LevelError, "a2a-server: prompt failed",
+							"task", execCtx.TaskID, "err", res.err)
+						yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed,
+							a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(res.err.Error()))), nil)
+						return
+					}
+					// The reply was already streamed as chunks; a final
+					// artifact would duplicate it. Emit one only when the
+					// turn produced text without streaming it.
+					if !updater.streamedText() && strings.TrimSpace(res.result.FinalText) != "" {
+						if !yield(a2a.NewArtifactEvent(execCtx, a2a.NewTextPart(res.result.FinalText)), nil) {
+							return
+						}
+					}
+					if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCompleted, nil), nil) {
+						return
+					}
+					return
+				}
+				if !yield(ev, nil) {
+					cancel()
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }

--- a/internal/a2a/server/server_test.go
+++ b/internal/a2a/server/server_test.go
@@ -10,13 +10,23 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	a2aclient "github.com/a2aproject/a2a-go/v2/a2aclient"
+	acp "github.com/coder/acp-go-sdk"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 
 	acpserver "github.com/dimetron/pi-go/internal/acp/server"
+	acpadapter "github.com/dimetron/pi-go/internal/acp/server/adapter"
 )
 
 // startTestServer runs Serve on an ephemeral port with the echo handler and
 // returns the base URL and a stop function.
 func startTestServer(t *testing.T) (string, func()) {
+	return startTestServerWithHandler(t, acpserver.EchoPromptHandler)
+}
+
+// startTestServerWithHandler runs Serve on an ephemeral port with the given
+// prompt handler and returns the base URL and a stop function.
+func startTestServerWithHandler(t *testing.T, handler acpserver.PromptHandler) (string, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -30,7 +40,7 @@ func startTestServer(t *testing.T) (string, func()) {
 	go func() {
 		done <- Serve(ctx, ServeConfig{
 			Addr:    addr,
-			Handler: acpserver.EchoPromptHandler,
+			Handler: handler,
 		})
 	}()
 
@@ -135,5 +145,99 @@ func TestServeHealth(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("health status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// streamingHandler emits a thought chunk, a tool-call start, a tool-call end,
+// and a text chunk through the adapter stream — the same sequence the real pi
+// runtime produces for a turn with reasoning and a tool call.
+func streamingHandler(ctx context.Context, turn acpserver.PromptTurn) (acpserver.PromptResult, error) {
+	if turn.Updater == nil {
+		return acpserver.PromptResult{}, nil
+	}
+	stream := acpadapter.New(turn.Updater)
+	if err := stream.OnEvent(ctx, &adksession.Event{Content: &genai.Content{
+		Parts: []*genai.Part{{Text: "thinking hard", Thought: true}},
+	}}); err != nil {
+		return acpserver.PromptResult{}, err
+	}
+	callID, err := stream.OnToolStart(ctx, "bash", map[string]any{"command": "git status -s"})
+	if err != nil {
+		return acpserver.PromptResult{}, err
+	}
+	if err := stream.OnToolEnd(ctx, callID, map[string]any{"command": "git status -s"},
+		map[string]any{"output": " M server.go"}, nil); err != nil {
+		return acpserver.PromptResult{}, err
+	}
+	if err := stream.OnEvent(ctx, &adksession.Event{Content: &genai.Content{
+		Parts: []*genai.Part{{Text: "done"}},
+	}}); err != nil {
+		return acpserver.PromptResult{}, err
+	}
+	return acpserver.PromptResult{FinalText: "done", StopReason: acp.StopReasonEndTurn}, nil
+}
+
+// TestServeStreamingEvents verifies that thinking and tool calls are streamed
+// back to the A2A client as artifact events, not collapsed into one final
+// artifact. The kagent UI renders the data parts as tool-call cards.
+func TestServeStreamingEvents(t *testing.T) {
+	base, stop := startTestServerWithHandler(t, streamingHandler)
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cli, err := a2aclient.NewFromEndpoints(ctx, []*a2a.AgentInterface{
+		a2a.NewAgentInterface(base+"/", a2a.TransportProtocolJSONRPC),
+	})
+	if err != nil {
+		t.Fatalf("NewFromEndpoints: %v", err)
+	}
+	defer cli.Destroy()
+
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("stream me"))
+	var sawThought, sawToolCall, sawToolResult, sawText bool
+	for ev, err := range cli.SendStreamingMessage(ctx, &a2a.SendMessageRequest{Message: msg}) {
+		if err != nil {
+			t.Fatalf("SendStreamingMessage: %v", err)
+		}
+		art, ok := ev.(*a2a.TaskArtifactUpdateEvent)
+		if !ok {
+			continue
+		}
+		for _, part := range art.Artifact.Parts {
+			if part == nil {
+				continue
+			}
+			if text := part.Text(); text != "" {
+				if part.Meta()[adkMetaThoughtKey] == true {
+					sawThought = true
+				}
+				if text == "done" {
+					sawText = true
+				}
+				continue
+			}
+			if data, ok := part.Data().(map[string]any); ok {
+				switch part.Meta()[adkMetaTypeKey] {
+				case "function_call":
+					sawToolCall = data["name"] == "git status -s" && data["args"] != nil
+				case "function_response":
+					sawToolResult = data["name"] == "git status -s" && data["response"] != nil
+				}
+			}
+		}
+	}
+	if !sawThought {
+		t.Error("no thought artifact streamed")
+	}
+	if !sawToolCall {
+		t.Error("no function_call artifact streamed")
+	}
+	if !sawToolResult {
+		t.Error("no function_response artifact streamed")
+	}
+	if !sawText {
+		t.Error("no text artifact streamed")
 	}
 }

--- a/internal/a2a/server/stream.go
+++ b/internal/a2a/server/stream.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"context"
+	"sync"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	acp "github.com/coder/acp-go-sdk"
+)
+
+// ADK metadata keys, matching what kagent's ADK executor writes on A2A parts
+// (google.golang.org/adk/v2/server/adka2a/v2). The kagent UI classifies data
+// parts by shape ({name,args} vs {name,response}) rather than by these keys,
+// but keeping them lets ADK-based clients round-trip the parts.
+const (
+	adkMetaTypeKey    = "adk_type"
+	adkMetaThoughtKey = "adk_thought"
+)
+
+// a2aUpdater implements acpserver.SessionUpdater by translating ACP session
+// updates into A2A TaskArtifactUpdateEvents, mirroring how kagent's ADK
+// executor converts ADK session events to A2A artifacts:
+//
+//   - agent_message_chunk  → text artifact (append to one artifact per turn)
+//   - agent_thought_chunk  → text artifact marked adk_thought (append)
+//   - tool_call start      → data part {name, args, id}  adk_type=function_call
+//   - tool_call update     → data part {name, response}  adk_type=function_response
+//
+// Events are pushed to a channel that piExecutor.Execute drains and yields to
+// the A2A client, so streaming reaches the UI as it happens rather than in one
+// artifact at the end of the turn.
+type a2aUpdater struct {
+	ctx     context.Context
+	execCtx *a2asrv.ExecutorContext
+	events  chan a2a.Event
+
+	mu                sync.Mutex
+	textArtifactID    a2a.ArtifactID
+	thoughtArtifactID a2a.ArtifactID
+	toolNames         map[string]string // ACP call ID → tool name
+}
+
+func newA2AUpdater(ctx context.Context, execCtx *a2asrv.ExecutorContext) *a2aUpdater {
+	return &a2aUpdater{
+		ctx:       ctx,
+		execCtx:   execCtx,
+		events:    make(chan a2a.Event, 64),
+		toolNames: map[string]string{},
+	}
+}
+
+// Update implements acpserver.SessionUpdater.
+func (u *a2aUpdater) Update(ctx context.Context, update acp.SessionUpdate) error {
+	switch {
+	case update.AgentMessageChunk != nil:
+		return u.emitText(ctx, update.AgentMessageChunk.Content, false)
+	case update.AgentThoughtChunk != nil:
+		return u.emitText(ctx, update.AgentThoughtChunk.Content, true)
+	case update.ToolCall != nil:
+		return u.emitToolStart(ctx, update.ToolCall)
+	case update.ToolCallUpdate != nil:
+		return u.emitToolEnd(ctx, update.ToolCallUpdate)
+	}
+	return nil
+}
+
+// streamedText reports whether any assistant text artifact was emitted this
+// turn. The executor uses it to decide whether the final artifact would
+// duplicate text the client already received as chunks.
+func (u *a2aUpdater) streamedText() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.textArtifactID != ""
+}
+
+// emitText streams one text chunk as an artifact update. The first chunk of a
+// kind creates the artifact; later chunks append to it (Append=true), which is
+// how the kagent UI accumulates a reply token by token.
+func (u *a2aUpdater) emitText(ctx context.Context, content acp.ContentBlock, thought bool) error {
+	text := ""
+	if content.Text != nil {
+		text = content.Text.Text
+	}
+	if text == "" {
+		return nil
+	}
+
+	u.mu.Lock()
+	id := u.textArtifactID
+	if thought {
+		id = u.thoughtArtifactID
+	}
+	var ev *a2a.TaskArtifactUpdateEvent
+	if id == "" {
+		ev = a2a.NewArtifactEvent(u.execCtx, a2a.NewTextPart(text))
+		if thought {
+			ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
+		}
+		id = ev.Artifact.ID
+		if thought {
+			u.thoughtArtifactID = id
+		} else {
+			u.textArtifactID = id
+		}
+	} else {
+		ev = a2a.NewArtifactUpdateEvent(u.execCtx, id, a2a.NewTextPart(text))
+		if thought {
+			ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
+		}
+	}
+	u.mu.Unlock()
+
+	return u.emit(ctx, ev)
+}
+
+// emitToolStart streams a tool invocation as a function_call data part. The
+// ACP update carries the human-readable title (e.g. "bash git status -s"),
+// which is what the kagent UI shows as the card header; the raw args ride in
+// RawInput. The title is remembered so the matching result carries the same
+// name.
+func (u *a2aUpdater) emitToolStart(ctx context.Context, tc *acp.SessionUpdateToolCall) error {
+	name := tc.Title
+	if name == "" {
+		name = "tool"
+	}
+
+	u.mu.Lock()
+	u.toolNames[string(tc.ToolCallId)] = name
+	u.mu.Unlock()
+
+	part := a2a.NewDataPart(map[string]any{
+		"name": name,
+		"args": tc.RawInput,
+		"id":   string(tc.ToolCallId),
+	})
+	part.SetMeta(adkMetaTypeKey, "function_call")
+	return u.emit(ctx, a2a.NewArtifactEvent(u.execCtx, part))
+}
+
+// emitToolEnd streams a tool result as a function_response data part.
+func (u *a2aUpdater) emitToolEnd(ctx context.Context, tu *acp.SessionToolCallUpdate) error {
+	u.mu.Lock()
+	name := u.toolNames[string(tu.ToolCallId)]
+	delete(u.toolNames, string(tu.ToolCallId))
+	u.mu.Unlock()
+	if name == "" {
+		name = "tool"
+	}
+
+	part := a2a.NewDataPart(map[string]any{
+		"name":     name,
+		"response": tu.RawOutput,
+	})
+	part.SetMeta(adkMetaTypeKey, "function_response")
+	return u.emit(ctx, a2a.NewArtifactEvent(u.execCtx, part))
+}
+
+// emit pushes one event to the executor's drain channel, aborting when the
+// run context is canceled (the client stopped pulling).
+func (u *a2aUpdater) emit(ctx context.Context, ev a2a.Event) error {
+	select {
+	case u.events <- ev:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/specs/kagent/DEPLOY.md
+++ b/specs/kagent/DEPLOY.md
@@ -46,7 +46,16 @@ image: localhost:5001/dimetron/pi-go-kagent@sha256:<64-hex-digit-digest>
 
 A public release gets the same image with both architectures from the release
 workflow: `ghcr.io/<owner>/pi-go-kagent:<tag>` (see
-[release.yml](../../.github/workflows/release.yml)).
+[release.yml](../../.github/workflows/release.yml)). Identify the immutable
+digests for a release — the manifest-list digest plus the per-architecture
+`linux/amd64` and `linux/arm64` digests — with:
+
+```bash
+./image-digests.sh <tag>   # e.g. ./image-digests.sh v0.0.87
+```
+
+Pick the arch matching the worker nodes (the local Kind Substrate workers are
+arm64) and substitute the digest in `harness.yaml` or `manifests.yaml`.
 
 Check that the Kind cluster can resolve the registry before applying:
 

--- a/specs/kagent/image-digests.sh
+++ b/specs/kagent/image-digests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Identify the digest-pinned pi-go-kagent image references for a release.
+#
+# The release workflow (.github/workflows/release.yml) builds and pushes a
+# multi-arch image (linux/amd64 + linux/arm64) to GHCR on every v* tag:
+#
+#   ghcr.io/<owner>/pi-go-kagent:<tag>
+#
+# Substrate requires digest-pinned image references, so before deploying a
+# release you need the immutable digests. This script prints the manifest-list
+# digest plus the per-architecture digests, and a ready-to-paste YAML snippet
+# for specs/kagent/manifests.yaml.
+#
+# Usage:
+#   ./image-digests.sh <tag>            # e.g. v0.0.87
+#   ./image-digests.sh v0.0.87
+#
+# Requires: docker with buildx (docker buildx imagetools), jq.
+set -euo pipefail
+
+TAG="${1:?usage: image-digests.sh <tag> (e.g. v0.0.87)}"
+IMAGE="ghcr.io/dimetron/pi-go-kagent"
+REF="${IMAGE}:${TAG}"
+
+if ! docker buildx imagetools inspect "${REF}" >/dev/null 2>&1; then
+  echo "error: ${REF} is not published (or not pullable)." >&2
+  echo "The release workflow pushes it on every v* tag; check the tag name." >&2
+  exit 1
+fi
+
+echo "== ${REF} =="
+echo
+
+# Manifest-list digest (the multi-arch image as a whole).
+LIST_DIGEST="$(docker buildx imagetools inspect "${REF}" | awk '/^Digest:/ {print $2}')"
+echo "manifest list: ${IMAGE}@${LIST_DIGEST}"
+echo
+
+# Per-architecture digests from the manifest list.
+RAW="$(docker buildx imagetools inspect --raw "${REF}")"
+AMD64_DIGEST="$(printf '%s' "${RAW}" | jq -r '.manifests[] | select(.platform.os=="linux" and .platform.architecture=="amd64") | .digest' | head -1)"
+ARM64_DIGEST="$(printf '%s' "${RAW}" | jq -r '.manifests[] | select(.platform.os=="linux" and .platform.architecture=="arm64") | .digest' | head -1)"
+
+if [ -z "${AMD64_DIGEST}" ] || [ -z "${ARM64_DIGEST}" ]; then
+  echo "error: could not find linux/amd64 and linux/arm64 in the manifest list." >&2
+  exit 1
+fi
+
+echo "linux/amd64: ${IMAGE}@${AMD64_DIGEST}"
+echo "linux/arm64: ${IMAGE}@${ARM64_DIGEST}"
+echo
+
+cat <<EOF
+YAML for specs/kagent/manifests.yaml (pick the arch matching the worker nodes):
+
+  # amd64
+  image: ${IMAGE}@${AMD64_DIGEST}
+  # arm64
+  image: ${IMAGE}@${ARM64_DIGEST}
+  # multi-arch (kagent pulls the right arch automatically)
+  image: ${IMAGE}@${LIST_DIGEST}
+EOF

--- a/specs/kagent/manifests.yaml
+++ b/specs/kagent/manifests.yaml
@@ -1,3 +1,19 @@
+# Deployable kagent Harness + AgentTemplate for pi-go on Agent Substrate.
+#
+# The workload image must be digest-pinned. The release workflow
+# (.github/workflows/release.yml) pushes a multi-arch image
+# (linux/amd64 + linux/arm64) to GHCR on every v* tag:
+#
+#   ghcr.io/dimetron/pi-go-kagent:<tag>
+#
+# Identify the immutable digests for a release with:
+#
+#   ./image-digests.sh <tag>     # e.g. v0.0.87
+#
+# which prints the manifest-list digest plus the per-architecture digests.
+# Pick the arch matching the worker nodes (the local Kind Substrate workers
+# are arm64) and substitute it below. The digest below is from a local dev
+# build; replace it before deploying a release.
 apiVersion: kagent.dev/v1alpha3
 kind: Harness
 metadata:
@@ -8,6 +24,8 @@ spec:
   # compiler is not yet implemented (see specs/kagent/custom-harness.md).
   kagent: {}
   workload:
+    # arm64 (local Kind Substrate workers). For amd64 workers use the
+    # linux/amd64 digest from image-digests.sh.
     image: localhost:5001/dimetron/pi-go-kagent@sha256:c748aec952342bc1eec298174cedf1e5b8bc403b397215e2b54fe08e5fbf2b07
   substrate:
     workerPoolRef:


### PR DESCRIPTION
- **feat(kagent): add image-digests.sh to identify per-arch release images**
- **feat(a2a): stream thinking and tool calls to the A2A client**
