### PR TITLE
fix(hooks): stop pre-push re-checking already-published commits

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -38,8 +38,12 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     range="$(git rev-list "$local_sha" --not --remotes="$remote")"
     size_scan+=("$local_sha" --not --remotes="$remote")
   else
-    range="$(git rev-list "$remote_sha..$local_sha")"
-    size_scan+=("$remote_sha..$local_sha")
+    # Exclude commits already reachable from a remote branch. After a
+    # rebase onto an updated main, remote_sha..local_sha also spans the
+    # upstream commits the rebase pulled in — commits that are already
+    # published and are not this push's to vouch for.
+    range="$(git rev-list "$remote_sha..$local_sha" --not --remotes="$remote")"
+    size_scan+=("$remote_sha..$local_sha" --not --remotes="$remote")
   fi
 
   for sha in $range; do


### PR DESCRIPTION
Blocks #273, and every future branch rebased onto a main that has absorbed a PR.

## The bug

`.githooks/pre-push` computes the range of commits to vouch for two ways:

```bash
if [ "$remote_sha" = "$zero" ]; then
  range="$(git rev-list "$local_sha" --not --remotes="$remote")"   # new ref
else
  range="$(git rev-list "$remote_sha..$local_sha")"                # existing ref
fi
```

The new-ref branch correctly excludes commits already on a remote. The existing-ref branch does not. After a rebase onto an updated `main`, `remote_sha..local_sha` also spans the upstream commits the rebase pulled in — commits that are already published and are not this push's to vouch for.

GitHub's merge-button commits never carry a `Signed-off-by` trailer. So once a PR merges, any branch rebased onto the new `main` fails to push, naming a commit the author did not write and cannot amend without rewriting published history.

Concretely, `5de899a` (merge of #274) blocks #273:

```
pre-push: commits missing a matching Signed-off-by trailer:
  5de899a7d05862775f40f0ac03cefba2969a127c
```

Both commits on that branch are signed and signed-off. The hook is objecting to `main`.

## The fix

Exclude commits reachable from a remote branch, matching what the new-ref branch already does. The `size_scan` range gets the same treatment, for the same reason.

## Verification

Ran both hook versions against the exact stdin git supplies for the blocked push:

| | Range checked | Result |
|---|---|---|
| Before | 5 commits (3 already on `main`) | fails on `5de899a` |
| After | 2 commits (the author's own) | passes |

No behaviour change for a normal non-rebased push, where the upstream commits are not in the range to begin with.

## What this does not weaken

The hook still hard-fails any unsigned or un-signed-off commit that this push would actually introduce. It stops asserting things about commits that are already on the remote — where the check is both redundant and unactionable, since the objects have already left the machine.