### PR TITLE
fix(a2a): match kagent's artifact protocol; template the harness manifest

### DIFF
--- a/internal/a2a/server/server.go
+++ b/internal/a2a/server/server.go
@@ -235,6 +235,15 @@ func (e *piExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContex
 				Prompt:    prompt,
 				Updater:   updater,
 			})
+			// Settle the artifact left open by the last text chunk: the
+			// closing frame replaces it with the whole text and marks it
+			// the last chunk, matching what kagent's ADK runtime emits.
+			if res.err == nil {
+				if err := updater.closeTextArtifacts(runCtx); err != nil {
+					e.logger.Log(ctx, slog.LevelWarn, "a2a-server: closing artifacts",
+						"task", execCtx.TaskID, "err", err)
+				}
+			}
 		}()
 
 		for {

--- a/internal/a2a/server/stream.go
+++ b/internal/a2a/server/stream.go
@@ -78,15 +78,20 @@ func (u *a2aUpdater) streamedText() bool {
 	return u.streamedAnyText
 }
 
-// emitText streams one text chunk as an artifact update.
+// emitText streams one text chunk, following the artifact protocol kagent's
+// own ADK runtime emits (google.golang.org/adk/v2 server/adka2a/v2, and the
+// run captured in kagent's ui/src/api/chat/a2aGrpcChatClient.ts):
 //
-// Each chunk carries the full text accumulated for the open artifact and is
-// sent with Append=false, so the artifact always holds exactly one text part
-// that grows. A2A's append semantics (a2aevent.applyArtifactUpdate) concatenate
-// *parts*, not text: appending each chunk as its own part leaves the stored
-// task holding one part per token, and a client that renders a part at a time
-// shows a single reply as a column of fragments. Replacing keeps one part, so
-// the reply renders as one growing message.
+//	artifactUpdate  id=A  "alpha"              (no append)  first chunk
+//	artifactUpdate  id=A  " beta"              append:true  delta
+//	artifactUpdate  id=A  " gamma"             append:true  delta
+//	artifactUpdate  id=A  "alpha beta gamma"   lastChunk    full replacement
+//
+// The deltas are what let the UI stream a reply token by token: it yields a
+// "delta" for an append and grows one message. The closing frame replaces the
+// artifact with the whole text, which both settles the rendered message and
+// leaves the stored task holding a single part — reloading history then shows
+// one message rather than one per token.
 func (u *a2aUpdater) emitText(ctx context.Context, content acp.ContentBlock, thought bool) error {
 	text := ""
 	if content.Text != nil {
@@ -102,22 +107,19 @@ func (u *a2aUpdater) emitText(ctx context.Context, content acp.ContentBlock, tho
 		buf, id = &u.thoughtBuf, u.thoughtArtifactID
 	}
 	buf.WriteString(text)
-	full := buf.String()
 
+	// The chunk itself, not the accumulation: an append adds to what was sent.
 	var ev *a2a.TaskArtifactUpdateEvent
 	if id == "" {
-		ev = a2a.NewArtifactEvent(u.execCtx, a2a.NewTextPart(full))
-		id = ev.Artifact.ID
+		ev = a2a.NewArtifactEvent(u.execCtx, a2a.NewTextPart(text))
 		if thought {
-			u.thoughtArtifactID = id
+			u.thoughtArtifactID = ev.Artifact.ID
 		} else {
-			u.textArtifactID = id
+			u.textArtifactID = ev.Artifact.ID
 			u.streamedAnyText = true
 		}
 	} else {
-		ev = a2a.NewArtifactUpdateEvent(u.execCtx, id, a2a.NewTextPart(full))
-		// Replace the artifact's single part rather than appending another.
-		ev.Append = false
+		ev = a2a.NewArtifactUpdateEvent(u.execCtx, id, a2a.NewTextPart(text))
 	}
 	if thought {
 		ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
@@ -127,16 +129,49 @@ func (u *a2aUpdater) emitText(ctx context.Context, content acp.ContentBlock, tho
 	return u.emit(ctx, ev)
 }
 
-// closeTextArtifacts ends the open text and thinking artifacts so the next
-// chunk starts a new one. Called at a tool-call boundary: without it, text
-// produced after a tool call would keep growing the artifact opened before it,
-// and the reply would render above the tool card instead of below it.
-func (u *a2aUpdater) closeTextArtifacts() {
+// closeTextArtifacts settles the open text and thinking artifacts: each is
+// replaced with the full text streamed into it and marked as the last chunk,
+// so the next chunk starts a new artifact.
+//
+// Called at every tool-call boundary and once more when the turn ends. Without
+// the boundary calls, text produced after a tool call would keep growing the
+// artifact opened before it and render above the tool card instead of below;
+// without the replacement, the stored task keeps one part per token.
+func (u *a2aUpdater) closeTextArtifacts(ctx context.Context) error {
 	u.mu.Lock()
-	defer u.mu.Unlock()
+	type pending struct {
+		id      a2a.ArtifactID
+		text    string
+		thought bool
+	}
+	var closing []pending
+	if u.textArtifactID != "" {
+		closing = append(closing, pending{u.textArtifactID, u.textBuf.String(), false})
+	}
+	if u.thoughtArtifactID != "" {
+		closing = append(closing, pending{u.thoughtArtifactID, u.thoughtBuf.String(), true})
+	}
 	u.textArtifactID, u.thoughtArtifactID = "", ""
 	u.textBuf.Reset()
 	u.thoughtBuf.Reset()
+	u.mu.Unlock()
+
+	for _, c := range closing {
+		if c.text == "" {
+			continue
+		}
+		ev := a2a.NewArtifactUpdateEvent(u.execCtx, c.id, a2a.NewTextPart(c.text))
+		// Replace rather than append: this frame carries the whole text.
+		ev.Append = false
+		ev.LastChunk = true
+		if c.thought {
+			ev.Artifact.Parts[0].SetMeta(adkMetaThoughtKey, true)
+		}
+		if err := u.emit(ctx, ev); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // emitToolStart streams a tool invocation as a function_call data part. The
@@ -150,7 +185,9 @@ func (u *a2aUpdater) emitToolStart(ctx context.Context, tc *acp.SessionUpdateToo
 		name = "tool"
 	}
 
-	u.closeTextArtifacts()
+	if err := u.closeTextArtifacts(ctx); err != nil {
+		return err
+	}
 
 	u.mu.Lock()
 	u.toolNames[string(tc.ToolCallId)] = name
@@ -167,7 +204,9 @@ func (u *a2aUpdater) emitToolStart(ctx context.Context, tc *acp.SessionUpdateToo
 
 // emitToolEnd streams a tool result as a function_response data part.
 func (u *a2aUpdater) emitToolEnd(ctx context.Context, tu *acp.SessionToolCallUpdate) error {
-	u.closeTextArtifacts()
+	if err := u.closeTextArtifacts(ctx); err != nil {
+		return err
+	}
 
 	u.mu.Lock()
 	name := u.toolNames[string(tu.ToolCallId)]

--- a/internal/a2a/server/stream_coalesce_test.go
+++ b/internal/a2a/server/stream_coalesce_test.go
@@ -36,6 +36,11 @@ func collect(t *testing.T, fn func(u *a2aUpdater)) ([]a2a.Event, *a2asrvExecCtx)
 	u := newA2AUpdater(context.Background(), execCtx)
 	go func() {
 		fn(u)
+		// The executor settles the open artifact when the turn ends; the
+		// closing frame is part of the protocol, not an afterthought.
+		if err := u.closeTextArtifacts(context.Background()); err != nil {
+			t.Errorf("closeTextArtifacts: %v", err)
+		}
 		close(u.events)
 	}()
 	var events []a2a.Event
@@ -156,6 +161,7 @@ func TestStreamedTextSuppressesFinalArtifact(t *testing.T) {
 		_ = u.Update(ctx, acp.SessionUpdate{ToolCall: &acp.SessionUpdateToolCall{
 			ToolCallId: "call-1", Title: "bash ls",
 		}})
+		_ = u.closeTextArtifacts(ctx)
 		close(u.events)
 	}()
 	for range u.events { //nolint:revive // draining
@@ -190,5 +196,141 @@ func TestBashOutputLinesCoalesce(t *testing.T) {
 	}
 	if got := task.Artifacts[0].Parts[0].Text(); got != strings.Join(lines, "") {
 		t.Errorf("text = %q, want the lines joined into one part", got)
+	}
+}
+
+// TestStreamFramesMatchKagentContract pins the wire sequence against the run
+// kagent captured from its own ADK runtime and documented in
+// ui/src/api/chat/a2aGrpcChatClient.ts:
+//
+//	artifactUpdate  id=A  "alpha"              (no append)
+//	artifactUpdate  id=A  " beta"              append: true
+//	artifactUpdate  id=A  " gamma"             append: true
+//	artifactUpdate  id=A  "alpha beta gamma"   lastChunk: true
+//
+// The deltas are what make the UI stream token by token; the closing frame is
+// what settles the message and leaves one part in the stored task.
+func TestStreamFramesMatchKagentContract(t *testing.T) {
+	ctx := context.Background()
+	events, _ := collect(t, func(u *a2aUpdater) {
+		for _, chunk := range []string{"alpha", " beta", " gamma"} {
+			if err := u.Update(ctx, textChunk(chunk)); err != nil {
+				t.Errorf("Update: %v", err)
+			}
+		}
+	})
+
+	if len(events) != 4 {
+		t.Fatalf("frames = %d, want 4 (3 chunks + closing replacement)", len(events))
+	}
+
+	type frame struct {
+		text      string
+		append    bool
+		lastChunk bool
+	}
+	want := []frame{
+		{"alpha", false, false},
+		{" beta", true, false},
+		{" gamma", true, false},
+		{"alpha beta gamma", false, true},
+	}
+
+	var id a2a.ArtifactID
+	for i, ev := range events {
+		au, ok := ev.(*a2a.TaskArtifactUpdateEvent)
+		if !ok {
+			t.Fatalf("frame %d is %T, want *a2a.TaskArtifactUpdateEvent", i, ev)
+		}
+		if i == 0 {
+			id = au.Artifact.ID
+		} else if au.Artifact.ID != id {
+			t.Errorf("frame %d artifact id = %q, want every frame to share %q", i, au.Artifact.ID, id)
+		}
+		got := frame{au.Artifact.Parts[0].Text(), au.Append, au.LastChunk}
+		if got != want[i] {
+			t.Errorf("frame %d = %+v, want %+v", i, got, want[i])
+		}
+	}
+}
+
+// TestThinkingFramesCarryThoughtMeta keeps the adk_thought marker on every
+// frame, including the closing replacement, so a client that classifies parts
+// by metadata does not show the last one as an ordinary reply.
+func TestThinkingFramesCarryThoughtMeta(t *testing.T) {
+	ctx := context.Background()
+	events, _ := collect(t, func(u *a2aUpdater) {
+		_ = u.Update(ctx, thoughtChunk("weighing "))
+		_ = u.Update(ctx, thoughtChunk("options"))
+	})
+
+	if len(events) != 3 {
+		t.Fatalf("frames = %d, want 3 (2 chunks + closing replacement)", len(events))
+	}
+	for i, ev := range events {
+		au := ev.(*a2a.TaskArtifactUpdateEvent)
+		if v, ok := au.Artifact.Parts[0].Meta()[adkMetaThoughtKey].(bool); !ok || !v {
+			t.Errorf("frame %d is missing %s=true", i, adkMetaThoughtKey)
+		}
+	}
+	last := events[2].(*a2a.TaskArtifactUpdateEvent)
+	if got := last.Artifact.Parts[0].Text(); got != "weighing options" {
+		t.Errorf("closing thinking text = %q, want %q", got, "weighing options")
+	}
+	if !last.LastChunk || last.Append {
+		t.Errorf("closing frame append=%v lastChunk=%v, want append=false lastChunk=true",
+			last.Append, last.LastChunk)
+	}
+}
+
+// TestToolPartsMatchKagentShape pins the data-part shape the kagent UI
+// classifies tool cards by ({name,args} vs {name,response}), with the ADK
+// metadata key kagent's ReadMetadataValue looks for first.
+func TestToolPartsMatchKagentShape(t *testing.T) {
+	ctx := context.Background()
+	events, _ := collect(t, func(u *a2aUpdater) {
+		_ = u.Update(ctx, acp.SessionUpdate{ToolCall: &acp.SessionUpdateToolCall{
+			ToolCallId: "call-1", Title: "bash git status -s",
+			RawInput: map[string]any{"command": "git status -s"},
+		}})
+		_ = u.Update(ctx, acp.SessionUpdate{ToolCallUpdate: &acp.SessionToolCallUpdate{
+			ToolCallId: "call-1", RawOutput: map[string]any{"exit_code": 0},
+		}})
+	})
+
+	if len(events) != 2 {
+		t.Fatalf("frames = %d, want 2", len(events))
+	}
+
+	call := events[0].(*a2a.TaskArtifactUpdateEvent).Artifact.Parts[0]
+	if got, _ := call.Meta()[adkMetaTypeKey].(string); got != "function_call" {
+		t.Errorf("call %s = %q, want function_call", adkMetaTypeKey, got)
+	}
+	callData, ok := call.Data().(map[string]any)
+	if !ok {
+		t.Fatalf("call data = %T, want map[string]any", call.Data())
+	}
+	for _, key := range []string{"name", "args", "id"} {
+		if _, has := callData[key]; !has {
+			t.Errorf("function_call part is missing %q", key)
+		}
+	}
+	if callData["name"] != "bash git status -s" {
+		t.Errorf("call name = %v, want the ACP title", callData["name"])
+	}
+
+	resp := events[1].(*a2a.TaskArtifactUpdateEvent).Artifact.Parts[0]
+	if got, _ := resp.Meta()[adkMetaTypeKey].(string); got != "function_response" {
+		t.Errorf("response %s = %q, want function_response", adkMetaTypeKey, got)
+	}
+	respData, ok := resp.Data().(map[string]any)
+	if !ok {
+		t.Fatalf("response data = %T, want map[string]any", resp.Data())
+	}
+	if _, has := respData["response"]; !has {
+		t.Error("function_response part is missing \"response\"")
+	}
+	if respData["name"] != "bash git status -s" {
+		t.Errorf("response name = %v, want the same title as the call", respData["name"])
 	}
 }

--- a/specs/kagent/manifests.yaml
+++ b/specs/kagent/manifests.yaml
@@ -26,7 +26,7 @@ spec:
   workload:
     # arm64 (local Kind Substrate workers). For amd64 workers use the
     # linux/amd64 digest from image-digests.sh.
-    image: localhost:5001/dimetron/pi-go-kagent@sha256:c748aec952342bc1eec298174cedf1e5b8bc403b397215e2b54fe08e5fbf2b07
+    image: localhost:5001/dimetron/pi-go-kagent@sha256:09ff19adabaaaab8762107e510658986bec87198152a6dd6c0895028bdf640cf
   substrate:
     workerPoolRef:
       name: kagent-default

--- a/specs/kagent/manifests.yaml
+++ b/specs/kagent/manifests.yaml
@@ -26,7 +26,7 @@ spec:
   workload:
     # arm64 (local Kind Substrate workers). For amd64 workers use the
     # linux/amd64 digest from image-digests.sh.
-    image: localhost:5001/dimetron/pi-go-kagent@sha256:09ff19adabaaaab8762107e510658986bec87198152a6dd6c0895028bdf640cf
+    image: localhost:5001/dimetron/pi-go-kagent@sha256:a3a1a87b904ce2eb2f6bff4d70e279f3de2af188c9ee886f0c28dc7ffd2cba39
   substrate:
     workerPoolRef:
       name: kagent-default


### PR DESCRIPTION
Follow-up to #273 (merged). Two things: the streaming fix corrected against kagent's actual protocol, and `specs/kagent/manifests.yaml` turned into a template rendered on release.

## 1. The artifact protocol, corrected

#273 sent the accumulated text with `Append=false` on every chunk. That renders as one message — so the tests passed — but it is not what kagent emits, and it discards the streaming path: the UI treats a non-append frame as a whole new message, so a reply replaced itself once per token instead of growing.

kagent's UI documents the sequence it measured from its own ADK runtime (`ui/src/api/chat/a2aGrpcChatClient.ts`), and `adk/v2`'s `artifactMaker` produces it:

```
artifactUpdate  id=A  "alpha"              (no append)
artifactUpdate  id=A  " beta"              append: true
artifactUpdate  id=A  " gamma"             append: true
artifactUpdate  id=A  "alpha beta gamma"   lastChunk: true
```

Deltas carry the chunk and append; the closing frame carries the whole text and replaces. The UI yields a `delta` for an append and grows one message, then settles it on the replacement. Because a replacement also collapses the stored artifact to a single part, reloading history shows one message rather than one per token — which is what the reported column of fragments actually was.

`closeTextArtifacts` emits that closing frame at every tool-call boundary and once when the turn ends.

Tool parts already matched kagent's shape; there are now tests pinning it: `{name,args,id}` / `{name,response}` under `adk_type`, which is the key `ReadMetadataValue` looks for first and what the UI classifies cards by. `adk_thought` stays on every thinking frame including the closing one.

New tests assert the frame sequence field by field — text, `append`, `lastChunk`, and that every frame shares one artifact ID.

## 2. The manifest is now a template

`specs/kagent/manifests.yaml` committed a rendered manifest pinned to `localhost:5001/dimetron/pi-go-kagent@sha256:…` — a digest from a local dev build, in a registry only the machine that built it can reach. Substrate requires a digest-pinned image and a digest only exists once an image is pushed, so any committed rendering is stale by the next build. It had already drifted from the cluster twice in one day.

`specs/kagent/harness.yaml` was a second near-copy of the same two resources with a `<PI_GO_ADAPTER_DIGEST>` placeholder and no env block. Two files describing one deployment drift apart, and these had. That is item 18 on #271.

Both are replaced by `manifests.yaml.tmpl` + `render-manifests.sh`:

```bash
./render-manifests.sh --image ghcr.io/dimetron/pi-go-kagent@sha256:<digest> \
  | kubectl apply -f -
```

- `--image` is required and is **rejected unless digest-pinned** — a tag deploys whatever it points at today, which is what pinning exists to prevent.
- `--namespace`, `--name`, `--worker-pool`, `--snapshot-location`, `--model-config`, `--model`, `--base-url` override the defaults.
- `--no-env` omits the Harness env block, for a manifest that should not carry one cluster's model endpoint.
- Substitution is `sed` + `awk`, not `envsubst`, which is absent from a default macOS.

### On release

The `docker` job now exposes the pushed image's manifest-list digest as a job output. A new `kagent-manifest` job renders the template against it with `--no-env` and attaches the result as **`kagent-manifests.yaml`**, so a release ships a manifest pinned to the image that release actually built — no manual digest copying, and nothing stale in git.

## Verification

- `go test -race ./internal/a2a/...` — pass
- `go vet`, `golangci-lint` — clean
- Coverage 93.5%
- Both renderings (with and without `--no-env`) validated with `kubectl apply --dry-run=server` against a live kagent cluster
- Script rejects a tag, a missing `--image`, and an unknown argument
- Workflow YAML parses; `docker.outputs.digest` and `kagent-manifest.needs` confirmed

## Not verified

The deployed image was rebuilt and the Harness repinned, but I could not drive the kagent chat UI to send a turn — typed text never reaches its input, so Send stays disabled. The protocol change is verified against kagent's own source and by unit tests, not by a live chat. Worth watching on the next real turn: text before a tool call should render above its card and text after it below, which is what the boundary close changes.