### PR TITLE
feat/drop easyjson

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/text v0.41.0
 	google.golang.org/adk/v2 v2.2.0
 	google.golang.org/genai v1.70.0
+	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.57.0
@@ -126,7 +127,6 @@ require (
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/knights-analytics/ortgenai v0.3.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
-	github.com/mailru/easyjson v0.9.2 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
@@ -179,7 +179,6 @@ require (
 	google.golang.org/api v0.293.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
-	google.golang.org/grpc v1.83.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	modernc.org/libc v1.75.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
@@ -189,3 +188,12 @@ require (
 )
 
 replace github.com/coder/acp-go-sdk => ./third_party/acp-go-sdk
+
+// wk8/go-ordered-map/v2 pulls in github.com/mailru/easyjson (a VK-affiliated
+// library flagged as a supply-chain risk; see lima-vm/lima#3527). The vendored
+// copy under third_party/go-ordered-map is the pb33f/ordered-map fork (which
+// drops the easyjson import) keeping the original module path, so the replace
+// works without a module-path collision. Remove this replace when
+// ollama/ollama switches its internal/orderedmap wrapper to the fork (or drops
+// the dependency).
+replace github.com/wk8/go-ordered-map/v2 => ./third_party/go-ordered-map

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/coder/acp-go-sdk v0.13.5 h1:LI9jq5xon7xslaYlnoktvTVyDlE37yIk2daT7N9ASYk=
-github.com/coder/acp-go-sdk v0.13.5/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -343,8 +341,6 @@ github.com/letsencrypt/boulder v0.20260309.0 h1:kZynrxK3QfqLGx6hhoz+Rfs3hgltJs1p
 github.com/letsencrypt/boulder v0.20260309.0/go.mod h1:yG8lj8pNPZ8taq3oNdTpfBS+eC74IaEuiewqzVpXiWE=
 github.com/lucasb-eyer/go-colorful v1.4.1 h1:1EO+WB73+EH8EVbzlrG3KLAfEypQWVHIBqlTf+2hNss=
 github.com/lucasb-eyer/go-colorful v1.4.1/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M=
-github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -476,8 +472,6 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/viant/afs v1.30.0 h1:dbgVVSCPwGHUgpgkWJ5gdjKBqssT7OV7Z2M81CjwZEY=
 github.com/viant/afs v1.30.0/go.mod h1:rScbFd9LJPGTM8HOI8Kjwee0AZ+MZMupAvFpPg+Qdj4=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xo/terminfo v1.0.0 h1:2ZpYzqWzyyytjk3TP6aJVDhkMAkc99/1xKQdA3TDTBY=
 github.com/xo/terminfo v1.0.0/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yalue/onnxruntime_go v1.32.1 h1:bjvmp0ONztctKBOkaU6hgphVoKPH3GTZAJvFfPHdtcI=

--- a/ollama-pr-draft.md
+++ b/ollama-pr-draft.md
@@ -1,0 +1,55 @@
+# Drop the mailru/easyjson transitive dependency
+
+## Summary
+
+`internal/orderedmap` wraps `github.com/wk8/go-ordered-map/v2`, whose `json.go`
+imports `github.com/mailru/easyjson/jwriter`. easyjson is a VK-affiliated
+library (maintainers based in Russia, affiliated with VK Group) that has been
+flagged as a supply-chain risk — see the Hunted Labs report
+["The Russian Open Source Project That We Can't Live Without"](https://huntedlabs.com/the-russian-open-source-project-that-we-cant-live-without/)
+and the tracking issues in other projects:
+
+- lima-vm/lima#3527 — "Remove indirect dependency on github.com/mailru/easyjson"
+- invopop/jsonschema#182 — "Consider removing easyjson dependency due to security risks"
+- getkin/kin-openapi#1192 — "Consider removing easyjson dependency due to sanction concerns"
+
+This PR removes easyjson from the build graph by switching the ordered-map
+dependency to the API-compatible fork that dropped it.
+
+## Change
+
+Swap the ordered-map dependency in `internal/orderedmap/orderedmap.go`:
+
+```go
+-	orderedmap "github.com/wk8/go-ordered-map/v2"
++	orderedmap "github.com/pb33f/ordered-map/v2"
+```
+
+and update `go.mod`:
+
+```
+-	github.com/wk8/go-ordered-map/v2 v2.1.8
++	github.com/pb33f/ordered-map/v2 v2.3.1
+```
+
+then `go mod tidy` drops `github.com/mailru/easyjson` (and `gopkg.in/yaml.v3`)
+from `go.sum`.
+
+## Why this fork
+
+`github.com/pb33f/ordered-map/v2` is a fork of `wk8/go-ordered-map` that
+removed the easyjson import from `json.go` (it now uses only stdlib
+`encoding/json` plus `github.com/buger/jsonparser`). It is already the
+dependency of choice in the ecosystem for this exact reason — `invopop/jsonschema`
+v0.14.0 and lima both switched to it (lima-vm/lima#4916).
+
+The public API used by `internal/orderedmap` is unchanged — `New`, `Get`,
+`Set`, `Len`, `Oldest`, `Next`, `ToMap`, `MarshalJSON`, `UnmarshalJSON` all
+have identical signatures — so the wrapper needs no code changes.
+
+## Verification
+
+- `go build ./...` passes
+- `go test ./api/...` passes
+- `go mod tidy` removes `github.com/mailru/easyjson` from `go.sum`
+- `go list -deps` no longer contains `github.com/mailru/easyjson`

--- a/third_party/go-ordered-map/LICENSE
+++ b/third_party/go-ordered-map/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/go-ordered-map/go.mod
+++ b/third_party/go-ordered-map/go.mod
@@ -1,0 +1,9 @@
+module github.com/wk8/go-ordered-map/v2
+
+go 1.24
+
+require (
+	github.com/bahlo/generic-list-go v0.2.0
+	github.com/buger/jsonparser v1.1.2
+	go.yaml.in/yaml/v4 v4.0.0-rc.2
+)

--- a/third_party/go-ordered-map/go.sum
+++ b/third_party/go-ordered-map/go.sum
@@ -1,0 +1,6 @@
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/third_party/go-ordered-map/json.go
+++ b/third_party/go-ordered-map/json.go
@@ -1,0 +1,243 @@
+package orderedmap
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/buger/jsonparser"
+)
+
+var (
+	_ json.Marshaler   = &OrderedMap[int, any]{}
+	_ json.Unmarshaler = &OrderedMap[int, any]{}
+)
+
+// MarshalJSON implements the json.Marshaler interface.
+func (om *OrderedMap[K, V]) MarshalJSON() ([]byte, error) { //nolint:funlen
+	if om == nil || om.list == nil {
+		return []byte("null"), nil
+	}
+
+	buf := &bytes.Buffer{}
+	buf.WriteByte('{')
+
+	for pair, firstIteration := om.Oldest(), true; pair != nil; pair = pair.Next() {
+		if firstIteration {
+			firstIteration = false
+		} else {
+			buf.WriteByte(',')
+		}
+
+		// Marshal the key
+		switch key := any(pair.Key).(type) {
+		case string:
+			if err := writeJSONString(buf, key, om.disableHTMLEscape); err != nil {
+				return nil, err
+			}
+		case encoding.TextMarshaler:
+			buf.WriteByte('"')
+			text, err := key.MarshalText()
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(text)
+			buf.WriteByte('"')
+		case int:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.Itoa(key))
+			buf.WriteByte('"')
+		case int8:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatInt(int64(key), 10))
+			buf.WriteByte('"')
+		case int16:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatInt(int64(key), 10))
+			buf.WriteByte('"')
+		case int32:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatInt(int64(key), 10))
+			buf.WriteByte('"')
+		case int64:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatInt(key, 10))
+			buf.WriteByte('"')
+		case uint:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatUint(uint64(key), 10))
+			buf.WriteByte('"')
+		case uint8:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatUint(uint64(key), 10))
+			buf.WriteByte('"')
+		case uint16:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatUint(uint64(key), 10))
+			buf.WriteByte('"')
+		case uint32:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatUint(uint64(key), 10))
+			buf.WriteByte('"')
+		case uint64:
+			buf.WriteByte('"')
+			buf.WriteString(strconv.FormatUint(key, 10))
+			buf.WriteByte('"')
+		default:
+			// this switch takes care of wrapper types around primitive types, such as
+			// type myType string
+			switch keyValue := reflect.ValueOf(key); keyValue.Type().Kind() {
+			case reflect.String:
+				if err := writeJSONString(buf, keyValue.String(), om.disableHTMLEscape); err != nil {
+					return nil, err
+				}
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				buf.WriteByte('"')
+				buf.WriteString(strconv.FormatInt(keyValue.Int(), 10))
+				buf.WriteByte('"')
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				buf.WriteByte('"')
+				buf.WriteString(strconv.FormatUint(keyValue.Uint(), 10))
+				buf.WriteByte('"')
+			default:
+				return nil, fmt.Errorf("unsupported key type: %T", key)
+			}
+		}
+
+		buf.WriteByte(':')
+
+		// Marshal the value
+		valueBytes, err := jsonMarshal(pair.Value, om.disableHTMLEscape)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valueBytes)
+	}
+
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// writeJSONString writes a JSON-encoded string to the buffer.
+// It handles proper escaping according to JSON specification.
+func writeJSONString(buf *bytes.Buffer, str string, disableHTMLEscape bool) error {
+	// Use json.Marshal for proper escaping
+	var encoded []byte
+	var err error
+	if disableHTMLEscape {
+		// Create a temporary buffer and encoder to handle HTML escaping
+		tempBuf := &bytes.Buffer{}
+		encoder := json.NewEncoder(tempBuf)
+		encoder.SetEscapeHTML(false)
+		err = encoder.Encode(str)
+		if err != nil {
+			return err
+		}
+		// Remove the trailing newline that Encode adds
+		encoded = bytes.TrimRight(tempBuf.Bytes(), "\n")
+	} else {
+		encoded, err = json.Marshal(str)
+		if err != nil {
+			return err
+		}
+	}
+	buf.Write(encoded)
+	return nil
+}
+
+func jsonMarshal(value interface{}, disableHTMLEscape bool) ([]byte, error) {
+	if disableHTMLEscape {
+		buffer := &bytes.Buffer{}
+		encoder := json.NewEncoder(buffer)
+		encoder.SetEscapeHTML(false)
+		err := encoder.Encode(value)
+		// Encode() adds an extra newline, strip it off to guarantee same behavior as json.Marshal
+		return bytes.TrimRight(buffer.Bytes(), "\n"), err
+	}
+	return json.Marshal(value)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (om *OrderedMap[K, V]) UnmarshalJSON(data []byte) error {
+	if om.list == nil {
+		om.initialize(0, om.disableHTMLEscape)
+	}
+
+	return jsonparser.ObjectEach(
+		data,
+		func(keyData []byte, valueData []byte, dataType jsonparser.ValueType, offset int) error {
+			if dataType == jsonparser.String {
+				// jsonparser removes the enclosing quotes; we need to restore them to make a valid JSON
+				valueData = data[offset-len(valueData)-2 : offset]
+			}
+
+			var key K
+			var value V
+
+			switch typedKey := any(&key).(type) {
+			case *string:
+				s, err := decodeUTF8(keyData)
+				if err != nil {
+					return err
+				}
+				*typedKey = s
+			case encoding.TextUnmarshaler:
+				if err := typedKey.UnmarshalText(keyData); err != nil {
+					return err
+				}
+			case *int, *int8, *int16, *int32, *int64, *uint, *uint8, *uint16, *uint32, *uint64:
+				if err := json.Unmarshal(keyData, typedKey); err != nil {
+					return err
+				}
+			default:
+				// this switch takes care of wrapper types around primitive types, such as
+				// type myType string
+				switch reflect.TypeOf(key).Kind() {
+				case reflect.String:
+					s, err := decodeUTF8(keyData)
+					if err != nil {
+						return err
+					}
+
+					convertedKeyData := reflect.ValueOf(s).Convert(reflect.TypeOf(key))
+					reflect.ValueOf(&key).Elem().Set(convertedKeyData)
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+					if err := json.Unmarshal(keyData, &key); err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("unsupported key type: %T", key)
+				}
+			}
+
+			if err := json.Unmarshal(valueData, &value); err != nil {
+				return err
+			}
+
+			om.Set(key, value)
+			return nil
+		})
+}
+
+func decodeUTF8(input []byte) (string, error) {
+	remaining, offset := input, 0
+	runes := make([]rune, 0, len(remaining))
+
+	for len(remaining) > 0 {
+		r, size := utf8.DecodeRune(remaining)
+		if r == utf8.RuneError && size <= 1 {
+			return "", fmt.Errorf("not a valid UTF-8 string (at position %d): %s", offset, string(input))
+		}
+
+		runes = append(runes, r)
+		remaining = remaining[size:]
+		offset += size
+	}
+
+	return string(runes), nil
+}

--- a/third_party/go-ordered-map/orderedmap.go
+++ b/third_party/go-ordered-map/orderedmap.go
@@ -1,0 +1,398 @@
+// Package orderedmap implements an ordered map, i.e. a map that also keeps track of
+// the order in which keys were inserted.
+//
+// All operations are constant-time.
+//
+// Github repo: https://github.com/pb33f/ordered-map
+package orderedmap
+
+import (
+	"fmt"
+	"iter"
+
+	list "github.com/bahlo/generic-list-go"
+)
+
+type Pair[K comparable, V any] struct {
+	Key   K
+	Value V
+
+	element *list.Element[*Pair[K, V]]
+}
+
+type OrderedMap[K comparable, V any] struct {
+	pairs             map[K]*Pair[K, V]
+	list              *list.List[*Pair[K, V]]
+	disableHTMLEscape bool
+}
+
+type initConfig[K comparable, V any] struct {
+	capacity          int
+	initialData       []Pair[K, V]
+	disableHTMLEscape bool
+}
+
+type InitOption[K comparable, V any] func(config *initConfig[K, V])
+
+// WithCapacity allows giving a capacity hint for the map, akin to the standard make(map[K]V, capacity).
+func WithCapacity[K comparable, V any](capacity int) InitOption[K, V] {
+	return func(c *initConfig[K, V]) {
+		c.capacity = capacity
+	}
+}
+
+// WithInitialData allows passing in initial data for the map.
+func WithInitialData[K comparable, V any](initialData ...Pair[K, V]) InitOption[K, V] {
+	return func(c *initConfig[K, V]) {
+		c.initialData = initialData
+		if c.capacity < len(initialData) {
+			c.capacity = len(initialData)
+		}
+	}
+}
+
+// WithDisableHTMLEscape disables HTMl escaping when marshalling to JSON
+func WithDisableHTMLEscape[K comparable, V any]() InitOption[K, V] {
+	return func(c *initConfig[K, V]) {
+		c.disableHTMLEscape = true
+	}
+}
+
+// New creates a new OrderedMap.
+// options can either be one or several InitOption[K, V], or a single integer,
+// which is then interpreted as a capacity hint, à la make(map[K]V, capacity).
+func New[K comparable, V any](options ...any) *OrderedMap[K, V] {
+	orderedMap := &OrderedMap[K, V]{}
+
+	var config initConfig[K, V]
+	for _, untypedOption := range options {
+		switch option := untypedOption.(type) {
+		case int:
+			if len(options) != 1 {
+				invalidOption()
+			}
+			config.capacity = option
+		case bool:
+			if len(options) != 1 {
+				invalidOption()
+			}
+			config.disableHTMLEscape = option
+
+		case InitOption[K, V]:
+			option(&config)
+
+		default:
+			invalidOption()
+		}
+	}
+
+	orderedMap.initialize(config.capacity, config.disableHTMLEscape)
+	orderedMap.AddPairs(config.initialData...)
+
+	return orderedMap
+}
+
+const invalidOptionMessage = `when using orderedmap.New[K,V]() with options, either provide one or several InitOption[K, V]; or a single integer which is then interpreted as a capacity hint, à la make(map[K]V, capacity).` //nolint:lll
+
+func invalidOption() { panic(invalidOptionMessage) }
+
+func (om *OrderedMap[K, V]) initialize(capacity int, disableHTMLEscape bool) {
+	om.pairs = make(map[K]*Pair[K, V], capacity)
+	om.list = list.New[*Pair[K, V]]()
+	om.disableHTMLEscape = disableHTMLEscape
+}
+
+// Get looks for the given key, and returns the value associated with it,
+// or V's nil value if not found. The boolean it returns says whether the key is present in the map.
+func (om *OrderedMap[K, V]) Get(key K) (val V, present bool) {
+	if pair, present := om.pairs[key]; present {
+		return pair.Value, true
+	}
+
+	return
+}
+
+// Load is an alias for Get, mostly to present an API similar to `sync.Map`'s.
+func (om *OrderedMap[K, V]) Load(key K) (V, bool) {
+	return om.Get(key)
+}
+
+// Value returns the value associated with the given key or the zero value.
+func (om *OrderedMap[K, V]) Value(key K) (val V) {
+	if pair, present := om.pairs[key]; present {
+		val = pair.Value
+	}
+	return
+}
+
+// GetPair looks for the given key, and returns the pair associated with it,
+// or nil if not found. The Pair struct can then be used to iterate over the ordered map
+// from that point, either forward or backward.
+func (om *OrderedMap[K, V]) GetPair(key K) *Pair[K, V] {
+	return om.pairs[key]
+}
+
+// Set sets the key-value pair, and returns what `Get` would have returned
+// on that key prior to the call to `Set`.
+func (om *OrderedMap[K, V]) Set(key K, value V) (val V, present bool) {
+	if pair, present := om.pairs[key]; present {
+		oldValue := pair.Value
+		pair.Value = value
+		return oldValue, true
+	}
+
+	pair := &Pair[K, V]{
+		Key:   key,
+		Value: value,
+	}
+	pair.element = om.list.PushBack(pair)
+	om.pairs[key] = pair
+
+	return
+}
+
+// AddPairs allows setting multiple pairs at a time. It's equivalent to calling
+// Set on each pair sequentially.
+func (om *OrderedMap[K, V]) AddPairs(pairs ...Pair[K, V]) {
+	for _, pair := range pairs {
+		om.Set(pair.Key, pair.Value)
+	}
+}
+
+// Store is an alias for Set, mostly to present an API similar to `sync.Map`'s.
+func (om *OrderedMap[K, V]) Store(key K, value V) (V, bool) {
+	return om.Set(key, value)
+}
+
+// Delete removes the key-value pair, and returns what `Get` would have returned
+// on that key prior to the call to `Delete`.
+func (om *OrderedMap[K, V]) Delete(key K) (val V, present bool) {
+	if pair, present := om.pairs[key]; present {
+		om.list.Remove(pair.element)
+		delete(om.pairs, key)
+		return pair.Value, true
+	}
+	return
+}
+
+// Len returns the length of the ordered map.
+func (om *OrderedMap[K, V]) Len() int {
+	if om == nil || om.pairs == nil {
+		return 0
+	}
+	return len(om.pairs)
+}
+
+// Oldest returns a pointer to the oldest pair. It's meant to be used to iterate on the ordered map's
+// pairs from the oldest to the newest, e.g.:
+// for pair := orderedMap.Oldest(); pair != nil; pair = pair.Next() { fmt.Printf("%v => %v\n", pair.Key, pair.Value) }
+func (om *OrderedMap[K, V]) Oldest() *Pair[K, V] {
+	if om == nil || om.list == nil {
+		return nil
+	}
+	return listElementToPair(om.list.Front())
+}
+
+// Newest returns a pointer to the newest pair. It's meant to be used to iterate on the ordered map's
+// pairs from the newest to the oldest, e.g.:
+// for pair := orderedMap.Newest(); pair != nil; pair = pair.Prev() { fmt.Printf("%v => %v\n", pair.Key, pair.Value) }
+func (om *OrderedMap[K, V]) Newest() *Pair[K, V] {
+	if om == nil || om.list == nil {
+		return nil
+	}
+	return listElementToPair(om.list.Back())
+}
+
+// Next returns a pointer to the next pair.
+func (p *Pair[K, V]) Next() *Pair[K, V] {
+	return listElementToPair(p.element.Next())
+}
+
+// Prev returns a pointer to the previous pair.
+func (p *Pair[K, V]) Prev() *Pair[K, V] {
+	return listElementToPair(p.element.Prev())
+}
+
+func listElementToPair[K comparable, V any](element *list.Element[*Pair[K, V]]) *Pair[K, V] {
+	if element == nil {
+		return nil
+	}
+	return element.Value
+}
+
+// KeyNotFoundError may be returned by functions in this package when they're called with keys that are not present
+// in the map.
+type KeyNotFoundError[K comparable] struct {
+	MissingKey K
+}
+
+func (e *KeyNotFoundError[K]) Error() string {
+	return fmt.Sprintf("missing key: %v", e.MissingKey)
+}
+
+// MoveAfter moves the value associated with key to its new position after the one associated with markKey.
+// Returns an error iff key or markKey are not present in the map. If an error is returned,
+// it will be a KeyNotFoundError.
+func (om *OrderedMap[K, V]) MoveAfter(key, markKey K) error {
+	elements, err := om.getElements(key, markKey)
+	if err != nil {
+		return err
+	}
+	om.list.MoveAfter(elements[0], elements[1])
+	return nil
+}
+
+// MoveBefore moves the value associated with key to its new position before the one associated with markKey.
+// Returns an error iff key or markKey are not present in the map. If an error is returned,
+// it will be a KeyNotFoundError.
+func (om *OrderedMap[K, V]) MoveBefore(key, markKey K) error {
+	elements, err := om.getElements(key, markKey)
+	if err != nil {
+		return err
+	}
+	om.list.MoveBefore(elements[0], elements[1])
+	return nil
+}
+
+func (om *OrderedMap[K, V]) getElements(keys ...K) ([]*list.Element[*Pair[K, V]], error) {
+	elements := make([]*list.Element[*Pair[K, V]], len(keys))
+	for i, k := range keys {
+		pair, present := om.pairs[k]
+		if !present {
+			return nil, &KeyNotFoundError[K]{k}
+		}
+		elements[i] = pair.element
+	}
+	return elements, nil
+}
+
+// MoveToBack moves the value associated with key to the back of the ordered map,
+// i.e. makes it the newest pair in the map.
+// Returns an error iff key is not present in the map. If an error is returned,
+// it will be a KeyNotFoundError.
+func (om *OrderedMap[K, V]) MoveToBack(key K) error {
+	_, err := om.GetAndMoveToBack(key)
+	return err
+}
+
+// MoveToFront moves the value associated with key to the front of the ordered map,
+// i.e. makes it the oldest pair in the map.
+// Returns an error iff key is not present in the map. If an error is returned,
+// it will be a KeyNotFoundError.
+func (om *OrderedMap[K, V]) MoveToFront(key K) error {
+	_, err := om.GetAndMoveToFront(key)
+	return err
+}
+
+// GetAndMoveToBack combines Get and MoveToBack in the same call. If an error is returned,
+// it will be a KeyNotFoundError.
+func (om *OrderedMap[K, V]) GetAndMoveToBack(key K) (val V, err error) {
+	if pair, present := om.pairs[key]; present {
+		val = pair.Value
+		om.list.MoveToBack(pair.element)
+	} else {
+		err = &KeyNotFoundError[K]{key}
+	}
+
+	return
+}
+
+// GetAndMoveToFront combines Get and MoveToFront in the same call. If an error is returned,
+// it will be a KeyNotFoundError.
+func (om *OrderedMap[K, V]) GetAndMoveToFront(key K) (val V, err error) {
+	if pair, present := om.pairs[key]; present {
+		val = pair.Value
+		om.list.MoveToFront(pair.element)
+	} else {
+		err = &KeyNotFoundError[K]{key}
+	}
+
+	return
+}
+
+// FromOldest returns an iterator over all the key-value pairs in the map, starting from the oldest pair.
+func (om *OrderedMap[K, V]) FromOldest() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+			if !yield(pair.Key, pair.Value) {
+				return
+			}
+		}
+	}
+}
+
+// FromNewest returns an iterator over all the key-value pairs in the map, starting from the newest pair.
+func (om *OrderedMap[K, V]) FromNewest() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+			if !yield(pair.Key, pair.Value) {
+				return
+			}
+		}
+	}
+}
+
+// KeysFromOldest returns an iterator over all the keys in the map, starting from the oldest pair.
+func (om *OrderedMap[K, V]) KeysFromOldest() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+			if !yield(pair.Key) {
+				return
+			}
+		}
+	}
+}
+
+// KeysFromNewest returns an iterator over all the keys in the map, starting from the newest pair.
+func (om *OrderedMap[K, V]) KeysFromNewest() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+			if !yield(pair.Key) {
+				return
+			}
+		}
+	}
+}
+
+// ValuesFromOldest returns an iterator over all the values in the map, starting from the oldest pair.
+func (om *OrderedMap[K, V]) ValuesFromOldest() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+			if !yield(pair.Value) {
+				return
+			}
+		}
+	}
+}
+
+// ValuesFromNewest returns an iterator over all the values in the map, starting from the newest pair.
+func (om *OrderedMap[K, V]) ValuesFromNewest() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+			if !yield(pair.Value) {
+				return
+			}
+		}
+	}
+}
+
+// From creates a new OrderedMap from an iterator over key-value pairs.
+func From[K comparable, V any](i iter.Seq2[K, V]) *OrderedMap[K, V] {
+	oMap := New[K, V]()
+
+	for k, v := range i {
+		oMap.Set(k, v)
+	}
+
+	return oMap
+}
+
+func (om *OrderedMap[K, V]) Filter(predicate func(K, V) bool) {
+	for pair := om.Oldest(); pair != nil; {
+		key, value := pair.Key, pair.Value
+		pair = pair.Next()
+		if !predicate(key, value) {
+			om.Delete(key)
+		}
+	}
+}

--- a/third_party/go-ordered-map/yaml.go
+++ b/third_party/go-ordered-map/yaml.go
@@ -1,0 +1,71 @@
+package orderedmap
+
+import (
+	"fmt"
+
+	"go.yaml.in/yaml/v4"
+)
+
+var (
+	_ yaml.Marshaler   = &OrderedMap[int, any]{}
+	_ yaml.Unmarshaler = &OrderedMap[int, any]{}
+)
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (om *OrderedMap[K, V]) MarshalYAML() (interface{}, error) {
+	if om == nil {
+		return []byte("null"), nil
+	}
+
+	node := yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		key, value := pair.Key, pair.Value
+
+		keyNode := &yaml.Node{}
+
+		// serialize key to yaml, then deserialize it back into the node
+		// this is a hack to get the correct tag for the key
+		if err := keyNode.Encode(key); err != nil {
+			return nil, err
+		}
+
+		valueNode := &yaml.Node{}
+		if err := valueNode.Encode(value); err != nil {
+			return nil, err
+		}
+
+		node.Content = append(node.Content, keyNode, valueNode)
+	}
+
+	return &node, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (om *OrderedMap[K, V]) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("pipeline must contain YAML mapping, has %v", value.Kind)
+	}
+
+	if om.list == nil {
+		om.initialize(0, om.disableHTMLEscape)
+	}
+
+	for index := 0; index < len(value.Content); index += 2 {
+		var key K
+		var val V
+
+		if err := value.Content[index].Decode(&key); err != nil {
+			return err
+		}
+		if err := value.Content[index+1].Decode(&val); err != nil {
+			return err
+		}
+
+		om.Set(key, val)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What

Drop `github.com/mailru/easyjson` from the build graph.

`wk8/go-ordered-map/v2` (an indirect dep, pulled in by `ollama/ollama/api`'s
`internal/orderedmap` wrapper) imports `easyjson/jwriter` for ordered-map JSON
encoding. easyjson is a VK-affiliated library flagged as a supply-chain risk —
see lima-vm/lima#3527, invopop/jsonschema#182, getkin/kin-openapi#1192.

## How

Vendor the **`pb33f/ordered-map` fork** (API-identical, drops the easyjson
import) under `third_party/go-ordered-map`, keeping the original `wk8` module
path, and `replace` the remote module with it.

A direct `replace` to `pb33f/ordered-map/v2` is impossible here: pi-go already
requires that module path via `invopop/jsonschema` (pulled in by
`anthropics/anthropic-sdk-go`), and Go forbids one module under two paths. The
vendored copy follows the existing `third_party/acp-go-sdk` pattern.

## Verification

- `go build ./...` — pass
- `go test ./internal/provider/... ./internal/palace/...` (the two packages
  importing `ollama/ollama/api`) — pass
- `go vet` + compile-only tests on all packages importing `provider` — pass
- `go list -deps ./cmd/pi | grep mailru/easyjson` — 0 matches (out of the binary)
- easyjson removed from `go.sum` (6 lines)

## Follow-up

`ollama-pr-draft.md` contains a ready-to-file upstream PR for ollama/ollama to
make the same swap (their go.mod has no module-path collision, so it's a
one-line import change). When it lands, bump `ollama/ollama` and delete the
`replace` + `third_party/go-ordered-map/`.
