### PR TITLE
fix/a2a stream heartbeat

### DIFF
--- a/internal/a2a/server/heartbeat_test.go
+++ b/internal/a2a/server/heartbeat_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+
+	acpserver "github.com/dimetron/pi-go/internal/acp/server"
+)
+
+// silentHandler models the shape that broke the kagent chat: a turn that
+// produces no session updates at all while it works, the way the subagent tool
+// does between its start and end frames. It blocks until release is closed.
+func silentHandler(release <-chan struct{}) acpserver.PromptHandler {
+	return func(ctx context.Context, _ acpserver.PromptTurn) (acpserver.PromptResult, error) {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return acpserver.PromptResult{}, ctx.Err()
+		}
+		return acpserver.PromptResult{FinalText: "done"}, nil
+	}
+}
+
+// TestExecuteHeartbeatsDuringSilentTurn is the regression test for the stall:
+// a turn that says nothing for longer than the client's idle timeout must
+// still put frames on the wire.
+func TestExecuteHeartbeatsDuringSilentTurn(t *testing.T) {
+	release := make(chan struct{})
+	e := &piExecutor{
+		handler:   silentHandler(release),
+		logger:    discardLogger(),
+		heartbeat: 10 * time.Millisecond,
+	}
+
+	var working atomic.Int32
+	done := make(chan []a2a.Event, 1)
+	go func() {
+		var events []a2a.Event
+		e.Execute(context.Background(), newExecCtx("hi"))(func(ev a2a.Event, _ error) bool {
+			events = append(events, ev)
+			if su, ok := ev.(*a2a.TaskStatusUpdateEvent); ok && su.Status.State == a2a.TaskStateWorking {
+				// The first Working is the turn opening, not a heartbeat.
+				if working.Add(1) >= 4 {
+					close(release)
+				}
+			}
+			return true
+		})
+		done <- events
+	}()
+
+	select {
+	case events := <-done:
+		got := states(events)
+		if n := working.Load(); n < 4 {
+			t.Fatalf("saw %d working updates, want the heartbeat to keep emitting them", n)
+		}
+		if len(got) == 0 || got[len(got)-1] != a2a.TaskStateCompleted {
+			t.Errorf("states = %v, want the turn to still complete", got)
+		}
+		// Heartbeats must not put anything in the transcript.
+		for _, ev := range events {
+			su, ok := ev.(*a2a.TaskStatusUpdateEvent)
+			if ok && su.Status.State == a2a.TaskStateWorking && su.Status.Message != nil {
+				t.Errorf("heartbeat carried a message %+v, want none", su.Status.Message)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return; heartbeat never released the handler")
+	}
+}
+
+// TestExecuteHeartbeatQuietWhenStreaming checks the Reset: a turn that streams
+// steadily is already proving itself alive, so it should not also accumulate
+// heartbeat frames.
+func TestExecuteHeartbeatQuietWhenStreaming(t *testing.T) {
+	e := &piExecutor{
+		handler: streamingHandler,
+		logger:  discardLogger(),
+		// Far longer than the streaming handler takes, so any Working
+		// update beyond the opening one means the ticker was not reset.
+		heartbeat: time.Hour,
+	}
+
+	events, _ := drain(e.Execute(context.Background(), newExecCtx("hi")))
+
+	var working int
+	for _, s := range states(events) {
+		if s == a2a.TaskStateWorking {
+			working++
+		}
+	}
+	if working != 1 {
+		t.Errorf("got %d working updates, want only the one that opens the turn", working)
+	}
+}
+
+// TestHeartbeatEvery covers the zero-value fallback, since every existing test
+// and Serve itself construct a piExecutor without setting heartbeat.
+func TestHeartbeatEvery(t *testing.T) {
+	if got := (&piExecutor{}).heartbeatEvery(); got != heartbeatInterval {
+		t.Errorf("heartbeatEvery() = %v, want the %v default", got, heartbeatInterval)
+	}
+	if got := (&piExecutor{heartbeat: time.Second}).heartbeatEvery(); got != time.Second {
+		t.Errorf("heartbeatEvery() = %v, want the 1s override", got)
+	}
+}

--- a/internal/a2a/server/server.go
+++ b/internal/a2a/server/server.go
@@ -33,6 +33,16 @@ import (
 	acpserver "github.com/dimetron/pi-go/internal/acp/server"
 )
 
+// heartbeatInterval is how long the executor lets a turn's stream stay silent
+// before emitting a Working status update to hold it open.
+//
+// The binding constraint is the ~30s after which the kagent path cancels a
+// SendStreamingMessage that has carried nothing. 10s leaves room for two
+// missed heartbeats before that cancel, which matters because the interval is
+// measured from the last event this process yielded, not from what the client
+// received — a slow hop shifts the deadline the wrong way.
+const heartbeatInterval = 10 * time.Second
+
 // ServeConfig configures a server.Serve run.
 type ServeConfig struct {
 	// Addr is the HTTP/gRPC listen address. Default ":8085".
@@ -175,6 +185,17 @@ type piExecutor struct {
 	handler acpserver.PromptHandler
 	cwd     string
 	logger  *slog.Logger
+	// heartbeat overrides heartbeatInterval. Zero means the default; only
+	// tests set it, so they need not wait out a real interval.
+	heartbeat time.Duration
+}
+
+// heartbeatEvery returns the interval between Working status updates.
+func (e *piExecutor) heartbeatEvery() time.Duration {
+	if e.heartbeat > 0 {
+		return e.heartbeat
+	}
+	return heartbeatInterval
 }
 
 func (e *piExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
@@ -246,8 +267,27 @@ func (e *piExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContex
 			}
 		}()
 
+		// Keep the stream from going quiet while a tool runs. A subagent is
+		// a single tool call that can legitimately run for minutes
+		// (subagent.DefaultAbsoluteTimeout is 20) and produces no A2A events
+		// between its start and end frames, but the kagent path cancels a
+		// SendStreamingMessage that carries nothing for ~30s and Substrate
+		// then checkpoints the actor as idle — freezing the turn mid-tool.
+		// A Working status update every heartbeatInterval resets the idle
+		// timers along that path; unlike an artifact it carries no content,
+		// so it neither reaches the transcript nor disturbs the artifact
+		// sequence the UI reassembles.
+		every := e.heartbeatEvery()
+		heartbeat := time.NewTicker(every)
+		defer heartbeat.Stop()
+
 		for {
 			select {
+			case <-heartbeat.C:
+				if !yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateWorking, nil), nil) {
+					cancel()
+					return
+				}
 			case ev, ok := <-updater.events:
 				if !ok {
 					res := <-resultCh
@@ -275,6 +315,10 @@ func (e *piExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContex
 					cancel()
 					return
 				}
+				// A real event is itself proof the stream is alive, so the
+				// next heartbeat is due a full interval from here rather
+				// than from whenever the ticker last fired.
+				heartbeat.Reset(every)
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
- **feat(a2a): route kagent controller URLs through gRPC-Web**
- **fix(a2a): heartbeat a silent turn so a subagent cannot stall the chat**
