### PR TITLE
feat(tui): render a2a agent calls as agent cards

### DIFF
--- a/internal/tui/agent_event_test.go
+++ b/internal/tui/agent_event_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/dimetron/pi-go/internal/extension"
 )
 
@@ -263,6 +265,36 @@ func TestSplitSubagentCards_Chain(t *testing.T) {
 	}
 	if cards[0].agentType != "explore" || cards[1].agentType != "task" {
 		t.Errorf("chain card types = %q/%q, want explore/task", cards[0].agentType, cards[1].agentType)
+	}
+}
+
+func TestSplitSubagentCards_A2A(t *testing.T) {
+	base := message{role: "tool", tool: "a2a"}
+	cards := splitSubagentCards(base, map[string]any{
+		"agent_name": "istio-agent",
+		"prompt":     "check the mesh",
+	})
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card, got %d", len(cards))
+	}
+	if cards[0].agentLabel != "istio-agent" {
+		t.Errorf("agentLabel = %q, want %q", cards[0].agentLabel, "istio-agent")
+	}
+	if cards[0].agentTitle != "check the mesh" {
+		t.Errorf("agentTitle = %q, want %q", cards[0].agentTitle, "check the mesh")
+	}
+}
+
+func TestSplitSubagentCards_A2AWithoutName(t *testing.T) {
+	base := message{role: "tool", tool: "a2a"}
+	cards := splitSubagentCards(base, map[string]any{
+		"prompt": "hello",
+	})
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card, got %d", len(cards))
+	}
+	if cards[0].agentLabel != "" {
+		t.Errorf("agentLabel = %q, want empty when agent_name is absent", cards[0].agentLabel)
 	}
 }
 
@@ -1610,5 +1642,53 @@ func TestAgentDoneMsg_ErrorDoesNotFireUserInputHook(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	if _, err := os.Stat(inputOut); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("user_input_required hook ran after an error, stat err = %v", err)
+	}
+}
+
+// TestA2ACallRendersAsAgentCard drives the full call path for the a2a tool:
+// handleAgentToolCall fans it into an agent card with the configured agent
+// name as the bracketed label, and the renderer draws it as agent[istio-agent]
+// with the result under the gutter — the same shape as a subagent card.
+func TestA2ACallRendersAsAgentCard(t *testing.T) {
+	m := &model{
+		width:     120,
+		chatModel: ChatModel{Messages: []message{{role: "user", content: "call istio"}}},
+		agentCh:   make(chan agentMsg, 8),
+	}
+	m.handleAgentToolCall(agentToolCallMsg{
+		id:   "fc-1",
+		name: "a2a",
+		args: map[string]any{"agent_name": "istio-agent", "prompt": "check the mesh"},
+	})
+	if len(m.chatModel.Messages) != 2 {
+		t.Fatalf("expected 2 messages (user + a2a card), got %d", len(m.chatModel.Messages))
+	}
+	card := m.chatModel.Messages[1]
+	if card.tool != "a2a" {
+		t.Errorf("card.tool = %q, want a2a", card.tool)
+	}
+	if card.agentLabel != "istio-agent" {
+		t.Errorf("card.agentLabel = %q, want istio-agent", card.agentLabel)
+	}
+	if card.agentTitle != "check the mesh" {
+		t.Errorf("card.agentTitle = %q, want check the mesh", card.agentTitle)
+	}
+
+	// Result binds to the card by call ID.
+	m.handleAgentToolResult(agentToolResultMsg{id: "fc-1", name: "a2a", content: `{"status":"completed","result":"Hello!"}`})
+	if m.chatModel.Messages[1].content == "" {
+		t.Fatal("a2a result did not bind to the card")
+	}
+
+	m.chatModel.UpdateRenderer(m.width)
+	output := ansi.Strip(m.chatModel.RenderMessages(m.running))
+	if !strings.Contains(output, "agent[istio-agent]") {
+		t.Errorf("rendered output missing agent[istio-agent]:\n%s", output)
+	}
+	if !strings.Contains(output, "check the mesh") {
+		t.Errorf("rendered output missing the prompt title:\n%s", output)
+	}
+	if !strings.Contains(output, "→") {
+		t.Errorf("rendered output missing the result gutter:\n%s", output)
 	}
 }

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -1453,12 +1453,13 @@ func (m *model) handleAgentToolCall(msg agentToolCallMsg) (tea.Model, tea.Cmd) {
 		// filters on tool=="bash"), so reusing the field here cannot cross wires.
 		agentID: handle, pollCount: 1,
 	}
-	if msg.name == "agent" || msg.name == "subagent" {
+	if msg.name == "agent" || msg.name == "subagent" || msg.name == "a2a" {
 		// A single subagent tool call in parallel/chain mode spawns N children.
 		// Render one card per child so the user sees agent[pi], agent[claude],
 		// ... instead of a collapsed agent[pi+claude+...] card. Each card
 		// carries its own type + title and will later be matched to its spawn
-		// event by agent-ID prefix.
+		// event by agent-ID prefix. A2A calls render the same card shape, with
+		// the configured agent name (agent_name) as the bracketed label.
 		subMsgs := splitSubagentCards(newMsg, msg.args)
 		m.chatModel.Messages = append(m.chatModel.Messages, subMsgs...)
 		return m, waitForAgent(m.agentCh)
@@ -1486,6 +1487,14 @@ func splitSubagentCards(base message, args map[string]any) []message {
 		prompt, _ = args["task"].(string)
 	}
 	single.agentTitle = truncatePrompt(prompt)
+	// A2A calls carry the configured agent name in agent_name; render it
+	// verbatim in the bracket so the card reads agent[istio-agent] rather than
+	// collapsing to agent[pi].
+	if base.tool == "a2a" {
+		if name, _ := args["agent_name"].(string); name != "" {
+			single.agentLabel = name
+		}
+	}
 	return []message{single}
 }
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -129,14 +129,20 @@ type message struct {
 	// matchToolResultCard treats it like an empty card when binding the result.
 	pendingRefresh bool
 	// Subagent event stream (for tool=="agent" or tool=="subagent").
-	agentID       string    // subagent ID for matching events
-	agentType     string    // subagent type (e.g. "task", "explore")
-	agentTitle    string    // short description from prompt
-	agentEvents   []agentEv // streamed events from the subagent
-	pipelineID    string    // pipeline ID for grouping
-	pipelineMode  string    // "single", "parallel", "chain"
-	pipelineStep  int       // 1-based step in pipeline
-	pipelineTotal int       // total steps in pipeline
+	agentID     string    // subagent ID for matching events
+	agentType   string    // subagent type (e.g. "task", "explore")
+	agentTitle  string    // short description from prompt
+	agentEvents []agentEv // streamed events from the subagent
+	// agentLabel is the verbatim string rendered inside "agent[...]" for a
+	// card whose label is not derived from agentType. A2A calls set it to the
+	// configured agent name (e.g. "istio-agent") so the card reads
+	// "agent[istio-agent]" instead of collapsing to "agent[pi]". Empty for
+	// subagent cards, which derive the label from agentType.
+	agentLabel    string
+	pipelineID    string // pipeline ID for grouping
+	pipelineMode  string // "single", "parallel", "chain"
+	pipelineStep  int    // 1-based step in pipeline
+	pipelineTotal int    // total steps in pipeline
 	// Render cache: stores pre-rendered output to avoid repeated glamour and
 	// chroma work. renderCacheKey fingerprints every input the render depends
 	// on, so a message that changes re-renders itself — no caller has to
@@ -194,6 +200,7 @@ func (m *message) renderKey(width int, compactTools, hasSeparator, streamingPlac
 	h = fnvStr(h, m.agentID)
 	h = fnvStr(h, m.agentType)
 	h = fnvStr(h, m.agentTitle)
+	h = fnvStr(h, m.agentLabel)
 	h = fnvStr(h, m.pipelineID)
 	h = fnvStr(h, m.pipelineMode)
 	for _, ev := range m.agentEvents {

--- a/internal/tui/complexity_render_test.go
+++ b/internal/tui/complexity_render_test.go
@@ -433,6 +433,37 @@ func TestAgentCallSummaryRender(t *testing.T) {
 	}
 }
 
+// TestA2ACallSummaryRender pins the "agent_name: prompt" join and both
+// truncations, mirroring the subagent summary.
+func TestA2ACallSummaryRender(t *testing.T) {
+	tests := []struct {
+		desc string
+		args map[string]any
+		want string
+	}{
+		{"both", map[string]any{"agent_name": "istio-agent", "prompt": "check the mesh"}, "istio-agent: check the mesh"},
+		{"name only", map[string]any{"agent_name": "istio-agent"}, "istio-agent"},
+		{"prompt only", map[string]any{"prompt": "just a prompt"}, "just a prompt"},
+		{"neither", map[string]any{}, ""},
+		{"first line only", map[string]any{"agent_name": "a", "prompt": "first line\nsecond line"}, "a: first line"},
+		{
+			"long prompt clipped to 60",
+			map[string]any{"agent_name": "a", "prompt": strings.Repeat("p", 100)},
+			"a: " + strings.Repeat("p", 57) + "...",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := a2aCallSummary(tc.args); got != tc.want {
+				t.Errorf("a2aCallSummary(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+			if got := toolCallSummary("a2a", tc.args); got != tc.want {
+				t.Errorf("toolCallSummary(a2a) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // formatToolResult and its extracted shapes
 // ---------------------------------------------------------------------------
@@ -480,6 +511,9 @@ func TestFormatToolResultRender(t *testing.T) {
 		{"bash exit zero", map[string]any{"exit_code": 0.0, "stdout": "hi", "stderr": ""}, "hi"},
 		{"bash exit nonzero", map[string]any{"exit_code": 1.0, "stdout": "", "stderr": "bad"}, "exit 1: bad"},
 		{"bash no output", map[string]any{"exit_code": 0.0}, "(No output)"},
+		{"a2a result", map[string]any{"status": "completed", "result": "Hello!"}, "Hello!"},
+		{"a2a error", map[string]any{"status": "failed", "error": "boom"}, "error: boom"},
+		{"a2a empty result falls through", map[string]any{"status": "completed", "result": ""}, `{"result":"","status":"completed"}`},
 		{"fallback json", map[string]any{"unknown": "value"}, `{"unknown":"value"}`},
 		{"fallback empty", map[string]any{}, "{}"},
 	}
@@ -570,6 +604,7 @@ func TestToolResultShapesReject(t *testing.T) {
 		"diagnostics": diagnosticsResultSummary,
 		"bashWindow":  bashWindowResultSummary,
 		"bashExit":    bashExitResultSummary,
+		"a2a":         a2aResultSummary,
 	}
 	if len(shapes) != len(toolResultShapes) {
 		t.Fatalf("test covers %d shapes but formatToolResult tries %d", len(shapes), len(toolResultShapes))
@@ -1168,6 +1203,8 @@ func TestAgentCardHeaderRender(t *testing.T) {
 		{"agy keeps its name", ToolDisplayModel{}, message{agentType: "agy", content: "x"}, "◉ agent[agy]\n"},
 		{"copilot keeps its name", ToolDisplayModel{}, message{agentType: "copilot", content: "x"}, "◉ agent[copilot]\n"},
 		{"codex keeps its name", ToolDisplayModel{}, message{agentType: "codex", content: "x"}, "◉ agent[codex]\n"},
+		{"a2a label is verbatim", ToolDisplayModel{}, message{tool: "a2a", agentLabel: "istio-agent", content: "x"}, "◉ agent[istio-agent]\n"},
+		{"a2a label wins over type", ToolDisplayModel{}, message{tool: "a2a", agentType: "task", agentLabel: "istio-agent", content: "x"}, "◉ agent[istio-agent]\n"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/tui/minimap.go
+++ b/internal/tui/minimap.go
@@ -160,7 +160,7 @@ func toolBlockKind(tool string) blockKind {
 		return blockEdit
 	case "bash", "shell":
 		return blockExecute
-	case "agent", "subagent":
+	case "agent", "subagent", "a2a":
 		return blockAgent
 	}
 	return blockTool

--- a/internal/tui/minimap_test.go
+++ b/internal/tui/minimap_test.go
@@ -24,6 +24,7 @@ func TestKindOf(t *testing.T) {
 		{"write tool", message{role: "tool", tool: "write"}, blockEdit},
 		{"bash tool", message{role: "tool", tool: "bash"}, blockExecute},
 		{"subagent", message{role: "tool", tool: "subagent"}, blockAgent},
+		{"a2a", message{role: "tool", tool: "a2a"}, blockAgent},
 		{"mcp tool", message{role: "tool", tool: "some_mcp_thing"}, blockTool},
 	}
 	for _, tt := range tests {

--- a/internal/tui/tool_display.go
+++ b/internal/tui/tool_display.go
@@ -139,7 +139,7 @@ func (t *ToolDisplayModel) RenderToolMessage(msg message) string {
 	if msg.tool == "skill" {
 		return t.renderSkillTool(msg, dim, p)
 	}
-	if msg.tool == "agent" || msg.tool == "subagent" {
+	if msg.tool == "agent" || msg.tool == "subagent" || msg.tool == "a2a" {
 		return t.renderAgentTool(msg, dim, p)
 	}
 	return t.renderRegularTool(msg, dim, p)
@@ -259,6 +259,12 @@ func (t *ToolDisplayModel) agentCardHeader(msg message, p Palette) string {
 	b.WriteString(agentBullet)
 	b.WriteString(typeStyle.Render("agent"))
 	label := agentBracketLabel(msg.agentType)
+	if msg.agentLabel != "" {
+		// A2A cards carry the configured agent name verbatim (e.g.
+		// "istio-agent"); it is not a subagent type, so it must not be
+		// collapsed through agentBracketLabel.
+		label = msg.agentLabel
+	}
 	if label != "" {
 		b.WriteString(typeStyle.Render("[" + label + "]"))
 	}
@@ -762,6 +768,8 @@ func toolCallSummary(name string, args map[string]any) string {
 		return treeCallSummary(args)
 	case "agent":
 		return agentCallSummary(args)
+	case "a2a":
+		return a2aCallSummary(args)
 	}
 	return ""
 }
@@ -796,6 +804,28 @@ func agentCallSummary(args map[string]any) string {
 		return fmt.Sprintf("%s: %s", typ, prompt)
 	case typ != "":
 		return typ
+	default:
+		return prompt
+	}
+}
+
+// a2aCallSummary summarizes an A2A call as "agent_name: prompt", dropping
+// whichever half is absent. It mirrors agentCallSummary so the a2a card's
+// header reads like a subagent card's.
+func a2aCallSummary(args map[string]any) string {
+	name, _ := args["agent_name"].(string)
+	prompt, _ := args["prompt"].(string)
+	if idx := strings.IndexByte(prompt, '\n'); idx > 0 {
+		prompt = prompt[:idx]
+	}
+	if len(prompt) > 60 {
+		prompt = prompt[:57] + "..."
+	}
+	switch {
+	case name != "" && prompt != "":
+		return fmt.Sprintf("%s: %s", name, prompt)
+	case name != "":
+		return name
 	default:
 		return prompt
 	}
@@ -848,6 +878,7 @@ var toolResultShapes = []toolResultShape{
 	diagnosticsResultSummary,
 	bashWindowResultSummary,
 	bashExitResultSummary,
+	a2aResultSummary,
 }
 
 // formatToolResult extracts a readable summary from a parsed tool result.
@@ -1048,6 +1079,21 @@ func bashExitResultSummary(data map[string]any) (string, bool) {
 	}
 	if int(code) != 0 {
 		return fmt.Sprintf("exit %d: %s", int(code), result), true
+	}
+	return result, true
+}
+
+// a2aResultSummary formats an A2A tool result as the remote agent's reply.
+// The A2AOutput shape carries the answer in "result" (with "status" and
+// "error" alongside); a failed call surfaces its error instead. This is what
+// lets the a2a card's gutter read "→ Hello! ..." rather than raw JSON.
+func a2aResultSummary(data map[string]any) (string, bool) {
+	if err, _ := data["error"].(string); err != "" {
+		return "error: " + err, true
+	}
+	result, ok := data["result"].(string)
+	if !ok || result == "" {
+		return "", false
 	}
 	return result, true
 }


### PR DESCRIPTION
When the model calls the a2a tool, draw it as an agent card
(agent[istio-agent] <prompt>) with the remote reply under the gutter,
matching the subagent card shape instead of a plain a2a(...) tool card.

- route tool=="a2a" through the agent-card path in handleAgentToolCall
- add message.agentLabel for the verbatim bracket label (agent_name)
- render a2a via renderAgentTool; summarize calls as "agent_name: prompt"
- extract the A2AOutput result/error in a2aResultSummary so the gutter
  shows the agent's reply, not raw JSON
- minimap classifies a2a as blockAgent (mauve rail)

Signed-off-by: dimetron <dimetron@me.com>
