### PR TITLE
docs(agentgateway): add standalone agentgateway example for pi-go

### DIFF
--- a/hack/agentgateway/.env.example
+++ b/hack/agentgateway/.env.example
@@ -1,0 +1,53 @@
+# Copy to .env and fill in only the providers you use. Every key is optional:
+# config.yaml reads each one as ${NAME:-}, so an unset key leaves that single
+# provider returning 401 while the rest of the gateway still starts.
+#
+#   cp .env.example .env
+#
+# pi-go keeps its own keys in <repo>/.pi-go/.env. To reuse them instead of
+# maintaining a second copy:
+#
+#   docker compose --env-file ../../.pi-go/.env up -d
+
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+MISTRAL_API_KEY=
+OPENROUTER_API_KEY=
+XAI_API_KEY=
+OPENCODE_API_KEY=
+
+# MCP: remote Tavily MCP server (mcp.tavily.com), key passed in the URL.
+TAVILY_API_KEY=
+
+# Ollama Cloud (https://ollama.com/settings/keys) — three accounts, one key
+# each. The ollama-deepseek virtual models spread DeepSeek traffic across all
+# three; ollama1/*, ollama2/*, ollama3/* address one directly.
+# Local Ollama needs no key.
+OLLAMA_API_KEY_1=
+OLLAMA_API_KEY_2=
+OLLAMA_API_KEY_3=
+
+# Local Ollama. From inside a container localhost is the container, so the
+# compose file overrides this to host.docker.internal.
+# OLLAMA_BASE_URL=http://localhost:11434/v1
+
+# Azure is commented out in config.yaml because the gateway refuses to start
+# without a resource name. Uncomment the provider and the azure/* model there,
+# then set these.
+# AZURE_OPENAI_API_KEY=
+# AZURE_OPENAI_RESOURCE_NAME=
+# AZURE_OPENAI_API_VERSION=2024-10-21
+
+# --- Database and storage -------------------------------------------------
+# Request log, usage and cost history. docker-compose.yaml overrides this to
+# reach the Postgres sibling service; set it here only for ./run.sh, which
+# talks to localhost. Any non-postgres URL is a SQLite file path, so
+# AGENTGATEWAY_DATABASE_URL=./agentgateway.db needs no second container.
+# AGENTGATEWAY_DATABASE_URL=postgresql://agentgateway:agentgateway@localhost:5432/agentgateway
+POSTGRES_PASSWORD=agentgateway
+
+# file = the UI saves config edits into config.yaml (mount must be writable).
+# hybrid = config.yaml is a baseline, UI edits go to the database.
+# readOnly = the UI cannot change config.
+AGENTGATEWAY_STORAGE_MODE=file

--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -1,0 +1,390 @@
+# agentgateway for pi-go
+
+One [agentgateway](https://agentgateway.dev/docs/standalone/latest) in front of
+every provider pi-go can talk to, and in front of the coding agents that speak a
+native provider API — Claude Code, Codex, and Antigravity.
+
+Why bother, when each of these can call its vendor directly: one place that
+holds the keys, one request log across every agent and model, and one file to
+edit when a model is retired or a provider needs failover.
+
+## Layout
+
+| File | What it is |
+|---|---|
+| `config.yaml` | **The config.** All pi-go providers under `<provider>/` prefixes, plus unprefixed routes for the coding agents. |
+| `base-costs.json` | Cost data overlay. |
+| `.env.example` | Every key the config reads. Copy to `.env`. |
+| `docker-compose.yaml` | Runs `config.yaml` plus Postgres for the request log. |
+| `run.sh` | Runs `config.yaml` from a local binary. |
+| `migrate-sessions.py` | Replays pre-gateway pi-go session history into the request log. |
+| `ollama-cloud.yaml`, `ollama-cloud-k8s.yaml`, `docker-compose.ollama-cloud.yaml` | The upstream 3-instance Ollama Cloud example, kept as-is. `config.yaml` now absorbs it — same three keys, plus the `ollama-deepseek` virtual models. |
+
+Requires **agentgateway ≥ 1.5.0** (`modelCatalog` and the provider presets do
+not exist in earlier releases).
+
+## Start it
+
+```bash
+cp .env.example .env && $EDITOR .env
+docker compose up -d
+```
+
+To reuse the keys pi-go already has instead of maintaining a second copy:
+
+```bash
+docker compose --env-file ../../.pi-go/.env up -d
+```
+
+Or from a local binary — `run.sh` finds it on `PATH`, at
+`tmp/agentgateway/target/release/agentgateway`, or wherever `AGENTGATEWAY_BIN`
+points:
+
+```bash
+set -a; . ../../.pi-go/.env; set +a
+./run.sh
+```
+
+Either way: LLM endpoint on `http://localhost:4000`, UI on
+`http://localhost:4000/ui`.
+
+`AGENTGATEWAY_API_KEY` is the key *clients* send to the gateway, distinct from
+every provider key above, which the gateway holds and spends upstream. The
+config sets it under `llm.policies.apiKey` with `mode: strict`, so a request
+without it is rejected; see [Client authentication](#client-authentication).
+
+```bash
+curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $AGENTGATEWAY_API_KEY" | jq -r '.data[].id'
+```
+
+## Two naming schemes, on purpose
+
+**Prefixed** — one per pi-go provider. The prefix is stripped before
+forwarding, so the upstream sees its own model id. This is what pi-go's
+`agentgateway` provider talks to.
+
+| Send | Goes to | Key |
+|---|---|---|
+| `anthropic/<model>` | Anthropic | `ANTHROPIC_API_KEY` |
+| `openai/<model>` | OpenAI | `OPENAI_API_KEY` |
+| `gemini/<model>` | Gemini | `GEMINI_API_KEY` |
+| `mistral/<model>` | Mistral | `MISTRAL_API_KEY` |
+| `openrouter/<model>` | OpenRouter | `OPENROUTER_API_KEY` |
+| `xai/<model>` | xAI | `XAI_API_KEY` |
+| `ollama/<model>` | local Ollama | — |
+| `ollama1/<model>`, `ollama2/`, `ollama3/` | Ollama Cloud, one account each | `OLLAMA_API_KEY_1/2/3` |
+| `ollama-cloud/<model>` | Ollama Cloud account 1 | `OLLAMA_API_KEY_1` |
+| `opencode/<model>` | OpenCode Zen | `OPENCODE_API_KEY` |
+| `azure/<model>` | Azure OpenAI | commented out — see below |
+
+`openrouter/` strips only its own leading segment, so
+`openrouter/anthropic/claude-opus-5` reaches OpenRouter as
+`anthropic/claude-opus-5`.
+
+**Unprefixed** — `claude-*`, `gpt-*`, `o3*`, `gemini-*`, `grok-*`. A coding
+agent sends its vendor's own model id and has nowhere to put a prefix, so these
+pass the id through untouched.
+
+**Virtual** — named entry points, so a client never has to name an instance or
+a specific model. Repoint them here rather than reconfiguring every caller.
+
+| Name | Routing |
+|---|---|
+| `ollama-deepseek-balanced` | DeepSeek weighted evenly across all three Ollama Cloud accounts |
+| `ollama-deepseek` | DeepSeek on account 1, failing over to 2 then 3 |
+| `ollama-gemma4`, `ollama-glm-flash`, `ollama-minimax` | Failover variants of those models across the three accounts, same pattern |
+| `pi-default` | Claude Opus, failing over to GPT then Gemini |
+| `pi-fast` | Ollama Cloud DeepSeek (account 1), failing over to `gpt-5.6-luna` |
+
+### DeepSeek across three Ollama Cloud accounts
+
+Three accounts, one key each, following the upstream `llm-ollama-cloud`
+example. Address one directly when you care which account pays:
+
+```bash
+curl -s http://localhost:4000/v1/chat/completions -H 'content-type: application/json' \
+  -H "Authorization: Bearer $AGENTGATEWAY_API_KEY" \
+  -d '{"model":"ollama2/deepseek-v4-flash:0731-cloud",
+       "messages":[{"role":"user","content":"say ok"}]}'
+```
+
+Or let the gateway choose — `ollama-deepseek-balanced` spreads load and rate
+limits across all three, `ollama-deepseek` prefers account 1 and falls
+through only when one is degraded:
+
+```bash
+curl -s http://localhost:4000/v1/chat/completions -H 'content-type: application/json' \
+  -H "Authorization: Bearer $AGENTGATEWAY_API_KEY" \
+  -d '{"model":"ollama-deepseek","messages":[{"role":"user","content":"say ok"}]}'
+```
+
+Set `OLLAMA_API_KEY_1`, `_2` and `_3` from
+<https://ollama.com/settings/keys>. Unset keys are not fatal — that account
+just 401s, and the failover variant routes around it.
+
+### Azure is opt-in
+
+Azure cannot ship enabled: the gateway refuses to start unless
+`azureResourceName` is set, and there is no honest placeholder. It is the one
+provider not in `config.yaml`. To add it, set `AZURE_OPENAI_RESOURCE_NAME` and
+append:
+
+```yaml
+# under llm.providers
+- name: azure
+  provider: azure
+  params:
+    apiKey: ${AZURE_OPENAI_API_KEY:-}
+    azureResourceName: ${AZURE_OPENAI_RESOURCE_NAME:-}
+    azureApiVersion: ${AZURE_OPENAI_API_VERSION:-2024-10-21}
+
+# under llm.models
+- name: azure/*
+  provider:
+    reference: azure
+  transformation:
+    model: llmRequest.model.stripPrefix("azure/")
+```
+
+## config.yaml is machine-managed
+
+The compose mount for `config.yaml` is deliberately **not** `:ro`, and
+`storage.mode` defaults to `file`. Together that means the UI can save changes —
+and that the gateway **rewrites the file and strips every comment** when it
+does. That is why the config carries only a header and this README carries the
+explanation.
+
+| `AGENTGATEWAY_STORAGE_MODE` | UI saves go to | `config.yaml` |
+|---|---|---|
+| `file` (default) | `config.yaml` | rewritten, comments stripped |
+| `hybrid` | the database, as an overlay on this file | left alone |
+| `readOnly` | nowhere — UI edits refused | left alone; restore `:ro` too |
+
+Pick `hybrid` if you want to keep an annotated, hand-authored config under
+version control and still edit through the UI.
+
+The container runs as uid 65532. On macOS (Docker Desktop, OrbStack) the bind
+mount maps ownership and writes just work. On Linux the file must be writable by
+that uid — `chmod 666 config.yaml` — or every UI save fails.
+
+**Anything you create in the UI lands in this file**, including API keys under
+`llm.policies.apiKey`. Those are real credentials in plaintext. Treat
+`config.yaml` as a secret once you have used the UI: do not commit it, or switch
+to `hybrid` so credentials live in the database instead.
+
+## Database
+
+`config.database.url` backs the request log, usage history, and the UI's request
+views. Compose runs Postgres for it:
+
+```bash
+docker compose up -d          # starts agentgateway + postgres
+docker compose exec postgres psql -U agentgateway -d agentgateway -c '\dt'
+```
+
+Tables: `request_logs` (one row per request — model, provider, status, tokens,
+duration), `request_log_payloads`, `budget_usage`.
+
+```sql
+select gen_ai_provider_name, gen_ai_request_model, http_status,
+       input_tokens, output_tokens
+from request_logs order by completed_at desc limit 20;
+```
+
+The gateway reaches Postgres as the `postgres` service; compose overrides
+`AGENTGATEWAY_DATABASE_URL` for that. The config default points at `localhost`,
+which is what `./run.sh` needs. **Any URL that is not `postgres://` or
+`postgresql://` is treated as a SQLite file**, so
+`AGENTGATEWAY_DATABASE_URL=./agentgateway.db ./run.sh` needs no container at
+all.
+
+Postgres is not published to the host by default; uncomment the `ports` block in
+`docker-compose.yaml` to reach it with `psql` directly. The `postgres-data`
+volume persists across `docker compose down`, so request history survives
+restarts — use `down -v` to discard it.
+
+### Cost tracking
+
+`request_logs.cost` is populated once the catalog knows the model:
+
+```
+ gen_ai_request_model | http_status | input_tokens | output_tokens |  cost
+ claude-haiku-4-5     |         200 |            8 |             8 | 4.8e-05
+```
+
+If cost is NULL, the model is not in the catalog — refresh it (below).
+
+## Wiring the clients
+
+### Client authentication
+
+The gateway authenticates clients itself — set in `config.yaml` under
+`llm.policies.apiKey` as `mode: strict` with the key list. A request that
+sends `Authorization: Bearer $AGENTGATEWAY_API_KEY` is accepted; anything else
+gets 401 before it reaches a provider. The provider keys stay server-side:
+the gateway swaps in the right upstream key per route.
+
+Two things follow:
+
+- **Clients never hold a real provider key.** The variable every client points
+  at — pi-go's `AGENTGATEWAY_API_KEY`, Claude Code's `ANTHROPIC_AUTH_TOKEN`,
+  Codex's `env_key` — can be any non-empty value only because the config was
+  built with the gateway key in it. That value *is* the shared client secret.
+- **The key lives in `config.yaml` in plaintext** and, with `storage.mode=file`,
+  any key created in the UI lands there too — see
+  [config.yaml is machine-managed](#configyaml-is-machine-managed).
+
+Export it once and every client below reuses it:
+
+```bash
+export AGENTGATEWAY_API_KEY=agw_sk_...   # the value from llm.policies.apiKey
+```
+
+### pi-go
+
+```bash
+export AGENTGATEWAY_BASE_URL=http://localhost:4000
+export AGENTGATEWAY_API_KEY=agw_sk_...   # must match llm.policies.apiKey
+pi --model 'agentgateway/anthropic/claude-opus-5'
+```
+
+### Claude Code — Anthropic Messages, `/v1/messages`
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:4000
+export ANTHROPIC_AUTH_TOKEN=agw_sk_...    # must be non-empty AND match the gateway's client key
+claude
+```
+
+Claude Code's model ids (`claude-opus-5`, …) match the `claude-*` route, and its
+token counting hits `/v1/messages/count_tokens`, which the gateway also serves.
+To send it somewhere other than Anthropic, set `ANTHROPIC_MODEL` to any route
+the gateway exposes — `ANTHROPIC_MODEL=openrouter/moonshotai/kimi-k2` reaches
+OpenRouter over the Anthropic wire format, because the gateway translates
+between formats.
+
+### Codex — OpenAI Responses, `/v1/responses`
+
+In `~/.codex/config.toml`:
+
+```toml
+model_provider = "agentgateway"
+model = "gpt-5.6"
+
+[model_providers.agentgateway]
+name = "agentgateway"
+base_url = "http://localhost:4000/v1"
+env_key = "AGENTGATEWAY_API_KEY"
+wire_api = "responses"
+```
+
+`wire_api = "responses"` is the only value Codex supports, and `/v1/responses`
+is one of the gateway's routes. `env_key` must name a variable set to the
+gateway's client key (`AGENTGATEWAY_API_KEY` above) — mode is `strict`, so the
+gateway rejects empty or wrong values.
+
+### Antigravity — no supported hook, two surfaces ready
+
+**Antigravity does not officially expose a custom base URL or BYOK setting for
+its agent model.** Settings like `antigravity.openai-compatible.endpoint` circulate
+in [community threads](https://discuss.ai.google.dev/t/how-to-properly-configure-custom-openai-compatible-models-in-antigravity-ide/168654)
+but are not documented by Google, and reports of them working are mixed and
+build-dependent. Nothing here can change that.
+
+What this config does is make the gateway ready for whichever surface a given
+build exposes:
+
+- **Gemini native** — `:generateContent`, `:streamGenerateContent`,
+  `:countTokens`, served against the `gemini-*` route.
+- **OpenAI-compatible** — `/v1/models` and `/v1/chat/completions` at
+  `http://localhost:4000/v1`, which is the shape an "Ollama" or
+  "OpenAI-compatible provider" field expects.
+
+If your build offers an OpenAI-compatible or Ollama endpoint field, point it at
+`http://localhost:4000/v1` with the gateway's client key (`AGENTGATEWAY_API_KEY`
+above). If it does not, the honest
+answer today is a community patch such as
+[antigravity-add-model](https://github.com/vahapogut/antigravity-add-model),
+which injects a proxy into the Electron app — out of scope for this directory.
+
+## Cost catalogs: base-costs.json and pi-aliases.json
+
+Two `config.modelCatalog` sources, merged in order — later wins.
+
+| File | Mount | Contents |
+|---|---|---|
+| `base-costs.json` | **read-write** | The full models.dev catalog, ~930 models across 19 providers. Machine-managed. |
+| `pi-aliases.json` | read-only | 62 hand-maintained entries: pi-go's dotted aliases (`claude-sonnet-4.5`), older OpenAI ids (`o1-mini`, `gpt-5.1-codex`), and Ollama/OpenRouter prices the base catalog lacks. |
+
+**`base-costs.json` is mounted writable on purpose.** The UI's refresh action —
+`POST /api/costs/refresh-base` — fetches models.dev, **overwrites this file**,
+and hot-reloads it without a restart. A read-only mount makes it fail.
+
+```bash
+curl -X POST http://localhost:4000/api/costs/refresh-base \
+  -H "Authorization: Bearer $AGENTGATEWAY_API_KEY"
+# {"providers":19,"models":930}
+```
+
+Because a refresh overwrites the whole file, **never hand-edit
+`base-costs.json`** — your edits are lost on the next refresh. That is exactly
+why the pi-go aliases live in a separate, read-only `pi-aliases.json` layered
+after it. Startup should report the merged total (base + aliases, overlapping
+ids counted once):
+
+```
+info llm::catalog  model catalog loaded  providers=20 models=977
+```
+
+### A configured catalog replaces the built-in one on v1.5.0
+
+The binary embeds a models.dev catalog, and newer builds merge it *under* your
+configured sources. **v1.5.0 does not** — configuring `modelCatalog` replaces it
+outright. So a small hand-written overlay silently removes cost data for every
+model it omits, which is why `base-costs.json` must hold the complete catalog
+and must be populated by refresh rather than by hand.
+
+Rates are USD per million tokens, as strings. Model ids match **exactly** — no
+wildcards, so `"*"` matches nothing. The file takes only a `providers` key; a
+`metadata` block is rejected on this version.
+
+## Gotchas worth knowing
+
+These each cost a debugging cycle when this config was built.
+
+- **The whole config file is shell-expanded, comments included.** A bare
+  `$NAME` for an unset variable aborts startup with
+  `error looking key 'NAME' up`. Every key uses `${NAME:-}` so an unset provider
+  degrades to a 401 on that one route instead of taking the gateway down — and
+  no comment may contain a bare dollar-name.
+- **`base-costs.json` takes only `providers`.** A `metadata` block is rejected
+  (`unknown field 'metadata'`), and the failure is a warning at startup, not an
+  error, so cost data silently goes missing.
+- **The UI is on `:4000/ui`**, served by the gateway itself. The admin listener
+  on `:15000` binds to localhost inside the container and is not the UI.
+- **`localhost` inside a container is the container.** The compose file points
+  `OLLAMA_BASE_URL` at `host.docker.internal` and adds the `host-gateway` entry
+  that Linux needs.
+
+## Verify a change
+
+`--validate-only` parses the config without binding ports:
+
+```bash
+docker run --rm -v "$PWD:/etc/agentgateway:ro" -w /etc/agentgateway \
+  ghcr.io/agentgateway/agentgateway:v1.5.0 --validate-only -f config.yaml
+```
+
+Then check a route end to end — a 200 here means the prefix was stripped and the
+upstream accepted the model:
+
+```bash
+curl -s http://localhost:4000/v1/messages -H 'content-type: application/json' \
+  -H "Authorization: Bearer $AGENTGATEWAY_API_KEY" \
+  -d '{"model":"anthropic/claude-haiku-4-5","max_tokens":16,
+       "messages":[{"role":"user","content":"say ok"}]}' | jq -r '.model'
+```
+
+An upstream error (`invalid_request_error`, `no credits remaining`) still proves
+the routing worked: the request reached the vendor. A gateway error looks
+different — it names the model or the route.

--- a/hack/agentgateway/base-costs.json
+++ b/hack/agentgateway/base-costs.json
@@ -1,0 +1,7529 @@
+{
+  "providers": {
+    "anthropic": {
+      "models": {
+        "claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-haiku-4-5": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "claude-haiku-4-5-20251001": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "claude-opus-4-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-5-20251101": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-6": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-sonnet-4-5": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4-5-20250929": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4-6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        }
+      }
+    },
+    "aws.bedrock": {
+      "models": {
+        "amazon.nova-2-lite-v1:0": {
+          "rates": {
+            "input": "0.33",
+            "output": "2.75"
+          }
+        },
+        "amazon.nova-lite-v1:0": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.24",
+            "cacheRead": "0.015"
+          }
+        },
+        "amazon.nova-micro-v1:0": {
+          "rates": {
+            "input": "0.035",
+            "output": "0.14",
+            "cacheRead": "0.00875"
+          }
+        },
+        "amazon.nova-pro-v1:0": {
+          "rates": {
+            "input": "0.8",
+            "output": "3.2",
+            "cacheRead": "0.2"
+          }
+        },
+        "anthropic.claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "anthropic.claude-opus-4-5-20251101-v1:0": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic.claude-opus-4-6-v1": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic.claude-opus-4-7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic.claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic.claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "anthropic.claude-sonnet-4-6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "anthropic.claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "au.anthropic.claude-opus-4-6-v1": {
+          "rates": {
+            "input": "16.5",
+            "output": "82.5",
+            "cacheRead": "1.65",
+            "cacheWrite": "20.625"
+          }
+        },
+        "au.anthropic.claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "au.anthropic.claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "au.anthropic.claude-sonnet-4-6": {
+          "rates": {
+            "input": "3.3",
+            "output": "16.5",
+            "cacheRead": "0.33",
+            "cacheWrite": "4.125"
+          }
+        },
+        "au.anthropic.claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "deepseek.r1-v1:0": {
+          "rates": {
+            "input": "1.35",
+            "output": "5.4"
+          }
+        },
+        "deepseek.v3-v1:0": {
+          "rates": {
+            "input": "0.58",
+            "output": "1.68"
+          }
+        },
+        "deepseek.v3.2": {
+          "rates": {
+            "input": "0.62",
+            "output": "1.85"
+          }
+        },
+        "eu.anthropic.claude-fable-5": {
+          "rates": {
+            "input": "11",
+            "output": "55",
+            "cacheRead": "1.1",
+            "cacheWrite": "13.75"
+          }
+        },
+        "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "rates": {
+            "input": "1.1",
+            "output": "5.5",
+            "cacheRead": "0.11",
+            "cacheWrite": "1.375"
+          }
+        },
+        "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+          "rates": {
+            "input": "5.5",
+            "output": "27.5",
+            "cacheRead": "0.55",
+            "cacheWrite": "6.875"
+          }
+        },
+        "eu.anthropic.claude-opus-4-6-v1": {
+          "rates": {
+            "input": "5.5",
+            "output": "27.5",
+            "cacheRead": "0.55",
+            "cacheWrite": "6.875"
+          }
+        },
+        "eu.anthropic.claude-opus-4-7": {
+          "rates": {
+            "input": "5.5",
+            "output": "27.5",
+            "cacheRead": "0.55",
+            "cacheWrite": "6.875"
+          }
+        },
+        "eu.anthropic.claude-opus-4-8": {
+          "rates": {
+            "input": "5.5",
+            "output": "27.5",
+            "cacheRead": "0.55",
+            "cacheWrite": "6.875"
+          }
+        },
+        "eu.anthropic.claude-opus-5": {
+          "rates": {
+            "input": "5.5",
+            "output": "27.5",
+            "cacheRead": "0.55",
+            "cacheWrite": "6.875"
+          }
+        },
+        "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "rates": {
+            "input": "3.3",
+            "output": "16.5",
+            "cacheRead": "0.33",
+            "cacheWrite": "4.125"
+          }
+        },
+        "eu.anthropic.claude-sonnet-4-6": {
+          "rates": {
+            "input": "3.3",
+            "output": "16.5",
+            "cacheRead": "0.33",
+            "cacheWrite": "4.125"
+          }
+        },
+        "eu.anthropic.claude-sonnet-5": {
+          "rates": {
+            "input": "2.2",
+            "output": "11",
+            "cacheRead": "0.22",
+            "cacheWrite": "2.75"
+          }
+        },
+        "global.anthropic.claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "global.anthropic.claude-opus-4-6-v1": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "global.anthropic.claude-opus-4-7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "global.anthropic.claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "global.anthropic.claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "global.anthropic.claude-sonnet-4-6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "global.anthropic.claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "global.openai.gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "global.openai.gpt-5.6-sol": {
+          "rates": {
+            "input": "4",
+            "output": "20",
+            "cacheRead": "0.4",
+            "cacheWrite": "5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "8",
+                "output": "30",
+                "cacheRead": "0.8",
+                "cacheWrite": "10"
+              }
+            }
+          ]
+        },
+        "global.openai.gpt-5.6-terra": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "google.gemma-3-12b-it": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.1"
+          }
+        },
+        "google.gemma-3-27b-it": {
+          "rates": {
+            "input": "0.12",
+            "output": "0.2"
+          }
+        },
+        "google.gemma-3-4b-it": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.08"
+          }
+        },
+        "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "jp.anthropic.claude-opus-4-7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "jp.anthropic.claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "jp.anthropic.claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "jp.anthropic.claude-sonnet-4-6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "jp.anthropic.claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "meta.llama3-1-70b-instruct-v1:0": {
+          "rates": {
+            "input": "0.72",
+            "output": "0.72"
+          }
+        },
+        "meta.llama3-1-8b-instruct-v1:0": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.22"
+          }
+        },
+        "meta.llama3-3-70b-instruct-v1:0": {
+          "rates": {
+            "input": "0.72",
+            "output": "0.72"
+          }
+        },
+        "meta.llama4-maverick-17b-instruct-v1:0": {
+          "rates": {
+            "input": "0.24",
+            "output": "0.97"
+          }
+        },
+        "meta.llama4-scout-17b-instruct-v1:0": {
+          "rates": {
+            "input": "0.17",
+            "output": "0.66"
+          }
+        },
+        "minimax.minimax-m2": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2"
+          }
+        },
+        "minimax.minimax-m2.1": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2"
+          }
+        },
+        "minimax.minimax-m2.5": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2"
+          }
+        },
+        "mistral.devstral-2-123b": {
+          "rates": {
+            "input": "0.4",
+            "output": "2"
+          }
+        },
+        "mistral.magistral-small-2509": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5"
+          }
+        },
+        "mistral.ministral-3-14b-instruct": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.2"
+          }
+        },
+        "mistral.ministral-3-3b-instruct": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.1"
+          }
+        },
+        "mistral.ministral-3-8b-instruct": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.15"
+          }
+        },
+        "mistral.mistral-large-3-675b-instruct": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5"
+          }
+        },
+        "mistral.pixtral-large-2502-v1:0": {
+          "rates": {
+            "input": "2",
+            "output": "6"
+          }
+        },
+        "mistral.voxtral-mini-3b-2507": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.04"
+          }
+        },
+        "mistral.voxtral-small-24b-2507": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.35"
+          }
+        },
+        "moonshot.kimi-k2-thinking": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.5"
+          }
+        },
+        "moonshotai.kimi-k2.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "3"
+          }
+        },
+        "nvidia.nemotron-nano-12b-v2": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.6"
+          }
+        },
+        "nvidia.nemotron-nano-3-30b": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.24"
+          }
+        },
+        "nvidia.nemotron-nano-9b-v2": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.23"
+          }
+        },
+        "nvidia.nemotron-super-3-120b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.65"
+          }
+        },
+        "openai.gpt-5.4": {
+          "rates": {
+            "input": "2.75",
+            "output": "16.5",
+            "cacheRead": "0.275"
+          }
+        },
+        "openai.gpt-5.5": {
+          "rates": {
+            "input": "5.5",
+            "output": "33",
+            "cacheRead": "0.55"
+          }
+        },
+        "openai.gpt-5.6-luna": {
+          "rates": {
+            "input": "0.22",
+            "output": "1.32",
+            "cacheRead": "0.022",
+            "cacheWrite": "0.275"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.44",
+                "output": "1.98",
+                "cacheRead": "0.044",
+                "cacheWrite": "0.55"
+              }
+            }
+          ]
+        },
+        "openai.gpt-5.6-sol": {
+          "rates": {
+            "input": "4.4",
+            "output": "22",
+            "cacheRead": "0.44",
+            "cacheWrite": "5.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "8.8",
+                "output": "33",
+                "cacheRead": "0.88",
+                "cacheWrite": "11"
+              }
+            }
+          ]
+        },
+        "openai.gpt-5.6-terra": {
+          "rates": {
+            "input": "2.2",
+            "output": "13.2",
+            "cacheRead": "0.22",
+            "cacheWrite": "2.75"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4.4",
+                "output": "19.8",
+                "cacheRead": "0.44",
+                "cacheWrite": "5.5"
+              }
+            }
+          ]
+        },
+        "openai.gpt-oss-120b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "openai.gpt-oss-120b-1:0": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "openai.gpt-oss-20b": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.3"
+          }
+        },
+        "openai.gpt-oss-20b-1:0": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.3"
+          }
+        },
+        "openai.gpt-oss-safeguard-120b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "openai.gpt-oss-safeguard-20b": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.2"
+          }
+        },
+        "qwen.qwen3-235b-a22b-2507-v1:0": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.88"
+          }
+        },
+        "qwen.qwen3-32b-v1:0": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "qwen.qwen3-coder-30b-a3b-v1:0": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "qwen.qwen3-coder-480b-a35b-v1:0": {
+          "rates": {
+            "input": "0.22",
+            "output": "1.8"
+          }
+        },
+        "qwen.qwen3-coder-next": {
+          "rates": {
+            "input": "0.22",
+            "output": "1.8"
+          }
+        },
+        "qwen.qwen3-next-80b-a3b": {
+          "rates": {
+            "input": "0.14",
+            "output": "1.4"
+          }
+        },
+        "qwen.qwen3-vl-235b-a22b": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.5"
+          }
+        },
+        "us.anthropic.claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "us.anthropic.claude-opus-4-6-v1": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "us.anthropic.claude-opus-4-7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "us.anthropic.claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "us.anthropic.claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "us.anthropic.claude-sonnet-4-6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "us.anthropic.claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "us.deepseek.r1-v1:0": {
+          "rates": {
+            "input": "1.35",
+            "output": "5.4"
+          }
+        },
+        "us.meta.llama4-maverick-17b-instruct-v1:0": {
+          "rates": {
+            "input": "0.24",
+            "output": "0.97"
+          }
+        },
+        "us.meta.llama4-scout-17b-instruct-v1:0": {
+          "rates": {
+            "input": "0.17",
+            "output": "0.66"
+          }
+        },
+        "writer.palmyra-x4-v1:0": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "writer.palmyra-x5-v1:0": {
+          "rates": {
+            "input": "0.6",
+            "output": "6"
+          }
+        },
+        "xai.grok-4.3": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          }
+        },
+        "xai.grok-4.6": {
+          "rates": {
+            "input": "2.2",
+            "output": "6.6",
+            "cacheRead": "0.55"
+          }
+        },
+        "zai.glm-4.7": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.2"
+          }
+        },
+        "zai.glm-4.7-flash": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.4"
+          }
+        },
+        "zai.glm-5": {
+          "rates": {
+            "input": "1",
+            "output": "3.2"
+          }
+        }
+      }
+    },
+    "azure": {
+      "models": {
+        "claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-haiku-4-5": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "claude-mythos-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-opus-4-1": {
+          "rates": {
+            "input": "15",
+            "output": "75",
+            "cacheRead": "1.5",
+            "cacheWrite": "18.75"
+          }
+        },
+        "claude-opus-4-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-6": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "claude-opus-4-7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-sonnet-4-5": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4-6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "codestral-2501": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.9"
+          }
+        },
+        "cohere-command-a": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "cohere-embed-v-4-0": {
+          "rates": {
+            "input": "0.12",
+            "output": "0"
+          }
+        },
+        "cohere-embed-v3-english": {
+          "rates": {
+            "input": "0.1",
+            "output": "0"
+          }
+        },
+        "cohere-embed-v3-multilingual": {
+          "rates": {
+            "input": "0.1",
+            "output": "0"
+          }
+        },
+        "deepseek-v3.2": {
+          "rates": {
+            "input": "0.58",
+            "output": "1.68"
+          }
+        },
+        "deepseek-v3.2-speciale": {
+          "rates": {
+            "input": "0.58",
+            "output": "1.68"
+          }
+        },
+        "deepseek-v4-flash": {
+          "rates": {
+            "input": "0.19",
+            "output": "0.51"
+          }
+        },
+        "deepseek-v4-pro": {
+          "rates": {
+            "input": "1.74",
+            "output": "3.48"
+          }
+        },
+        "gpt-5": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.13"
+          }
+        },
+        "gpt-5-codex": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.13"
+          }
+        },
+        "gpt-5-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.03"
+          }
+        },
+        "gpt-5-nano": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.4",
+            "cacheRead": "0.01"
+          }
+        },
+        "gpt-5-pro": {
+          "rates": {
+            "input": "15",
+            "output": "120"
+          }
+        },
+        "gpt-5.1": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5.1-codex": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5.1-codex-max": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5.1-codex-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.025"
+          }
+        },
+        "gpt-5.2": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5.2-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.3-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.4": {
+          "rates": {
+            "input": "2.5",
+            "output": "15",
+            "cacheRead": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "5",
+                "output": "22.5",
+                "cacheRead": "0.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.4-mini": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "cacheRead": "0.075"
+          }
+        },
+        "gpt-5.4-nano": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.25",
+            "cacheRead": "0.02"
+          }
+        },
+        "gpt-5.4-pro": {
+          "rates": {
+            "input": "30",
+            "output": "180"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "60",
+                "output": "270"
+              }
+            }
+          ]
+        },
+        "gpt-5.5": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "10",
+                "output": "45",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-sol": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "10",
+                "output": "45",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-terra": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "gpt-chat-latest": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          }
+        },
+        "gpt-image-1": {
+          "rates": {
+            "input": "5",
+            "output": "40",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-image-1.5": {
+          "rates": {
+            "input": "5",
+            "output": "32",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-image-2": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "1.25"
+          }
+        },
+        "grok-4-1-fast-non-reasoning": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.5",
+            "cacheRead": "0.05"
+          }
+        },
+        "grok-4-1-fast-reasoning": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.5",
+            "cacheRead": "0.05"
+          }
+        },
+        "grok-4-20-non-reasoning": {
+          "rates": {
+            "input": "2",
+            "output": "6"
+          }
+        },
+        "grok-4-20-reasoning": {
+          "rates": {
+            "input": "2",
+            "output": "6"
+          }
+        },
+        "kimi-k2.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "3"
+          }
+        },
+        "kimi-k2.6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4"
+          }
+        },
+        "kimi-k2.7-code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.19"
+          }
+        },
+        "llama-3.3-70b-instruct": {
+          "rates": {
+            "input": "0.71",
+            "output": "0.71"
+          }
+        },
+        "llama-4-maverick-17b-128e-instruct-fp8": {
+          "rates": {
+            "input": "0.25",
+            "output": "1"
+          }
+        },
+        "llama-4-scout-17b-16e-instruct": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.78"
+          }
+        },
+        "ministral-3b": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.04"
+          }
+        },
+        "mistral-medium-2505": {
+          "rates": {
+            "input": "0.4",
+            "output": "2"
+          }
+        },
+        "mistral-small-2503": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "model-router": {
+          "rates": {
+            "input": "0.14",
+            "output": "0"
+          }
+        },
+        "o3": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "phi-4": {
+          "rates": {
+            "input": "0.125",
+            "output": "0.5"
+          }
+        },
+        "phi-4-mini": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.3"
+          }
+        },
+        "phi-4-mini-reasoning": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.3"
+          }
+        },
+        "phi-4-multimodal": {
+          "rates": {
+            "input": "0.08",
+            "output": "0.32",
+            "inputAudio": "4"
+          }
+        },
+        "phi-4-reasoning": {
+          "rates": {
+            "input": "0.125",
+            "output": "0.5"
+          }
+        },
+        "phi-4-reasoning-plus": {
+          "rates": {
+            "input": "0.125",
+            "output": "0.5"
+          }
+        },
+        "text-embedding-3-large": {
+          "rates": {
+            "input": "0.13",
+            "output": "0"
+          }
+        },
+        "text-embedding-3-small": {
+          "rates": {
+            "input": "0.02",
+            "output": "0"
+          }
+        },
+        "text-embedding-ada-002": {
+          "rates": {
+            "input": "0.1",
+            "output": "0"
+          }
+        }
+      }
+    },
+    "baseten": {
+      "models": {
+        "deepseek-ai/DeepSeek-V4-Flash-0731": {
+          "rates": {
+            "input": "0.13",
+            "output": "0.26",
+            "cacheRead": "0.028"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro": {
+          "rates": {
+            "input": "1.74",
+            "output": "3.48",
+            "cacheRead": "0.145"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro-0813": {
+          "rates": {
+            "input": "1.32",
+            "output": "3.96"
+          }
+        },
+        "moonshotai/Kimi-K2.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "3",
+            "cacheRead": "0.12"
+          }
+        },
+        "moonshotai/Kimi-K2.6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "moonshotai/Kimi-K2.7-Code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "moonshotai/Kimi-K3": {
+          "rates": {
+            "input": "3",
+            "output": "15"
+          }
+        },
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.4",
+            "cacheRead": "0.12"
+          }
+        },
+        "nvidia/Nemotron-120B-A12B": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.75",
+            "cacheRead": "0.06"
+          }
+        },
+        "openai/gpt-oss-120b": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.5"
+          }
+        },
+        "thinkingmachines/inkling": {
+          "rates": {
+            "input": "1",
+            "output": "4.05"
+          }
+        },
+        "thinkingmachines/inkling-small": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.2",
+            "cacheRead": "0.1"
+          }
+        },
+        "zai-org/GLM-4.7": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.2",
+            "cacheRead": "0.12"
+          }
+        },
+        "zai-org/GLM-5": {
+          "rates": {
+            "input": "0.95",
+            "output": "3.15",
+            "cacheRead": "0.2"
+          }
+        },
+        "zai-org/GLM-5.1": {
+          "rates": {
+            "input": "1.3",
+            "output": "4.3",
+            "cacheRead": "0.26"
+          }
+        },
+        "zai-org/GLM-5.2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.3"
+          }
+        },
+        "zai-org/GLM-5.2-Fast": {
+          "rates": {
+            "input": "2.1",
+            "output": "6.6",
+            "cacheRead": "0.21"
+          }
+        },
+        "zai-org/GLM-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.14"
+          }
+        },
+        "zai-org/GLM-5.3-Flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.5"
+          }
+        }
+      }
+    },
+    "cerebras": {
+      "models": {
+        "gemma-4-31b": {
+          "rates": {
+            "input": "0.99",
+            "output": "1.49"
+          }
+        },
+        "gpt-oss-120b": {
+          "rates": {
+            "input": "0.35",
+            "output": "0.75"
+          }
+        }
+      }
+    },
+    "cohere": {
+      "models": {
+        "command-a-03-2025": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "command-a-plus-05-2026": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "command-a-reasoning-08-2025": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "command-a-translate-08-2025": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "command-a-vision-07-2025": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "command-r-08-2024": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "command-r-plus-08-2024": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "command-r7b-12-2024": {
+          "rates": {
+            "input": "0.0375",
+            "output": "0.15"
+          }
+        },
+        "command-r7b-arabic-02-2025": {
+          "rates": {
+            "input": "0.0375",
+            "output": "0.15"
+          }
+        },
+        "north-mini-code-1-0": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        }
+      }
+    },
+    "copilot": {
+      "models": {
+        "claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-haiku-4.5": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "claude-opus-4.5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4.6": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4.7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4.8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-sonnet-4": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4.5": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4.6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "gemini-3.1-pro-preview": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "gemini-3.5-flash": {
+          "rates": {
+            "input": "1.5",
+            "output": "9",
+            "cacheRead": "0.15",
+            "inputAudio": "1.5"
+          }
+        },
+        "gemini-3.6-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075"
+          }
+        },
+        "gemini-3.7-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075"
+          }
+        },
+        "gpt-4.1": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "gpt-5-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.025"
+          }
+        },
+        "gpt-5.2": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.2-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.3-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.4": {
+          "rates": {
+            "input": "2.5",
+            "output": "15",
+            "cacheRead": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "5",
+                "output": "22.5",
+                "cacheRead": "0.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.4-mini": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "cacheRead": "0.075"
+          }
+        },
+        "gpt-5.4-nano": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.25",
+            "cacheRead": "0.02"
+          }
+        },
+        "gpt-5.5": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "10",
+                "output": "45",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-sol": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "15",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-terra": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "grok-4.5": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "grok-4.6": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "kimi-k2.7-code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.19"
+          }
+        },
+        "kimi-k3": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3"
+          }
+        },
+        "mai-code-1-flash-picker": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "cacheRead": "0.075"
+          }
+        },
+        "mai-code-1.1-flash": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02"
+          }
+        }
+      }
+    },
+    "deepinfra": {
+      "models": {
+        "ByteDance/Seed-2.0-code": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.1"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1",
+                "output": "6",
+                "cacheRead": "0.2"
+              }
+            }
+          ]
+        },
+        "ByteDance/Seed-2.0-mini": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4",
+            "cacheRead": "0.02"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "0.2",
+                "output": "0.8",
+                "cacheRead": "0.2"
+              }
+            }
+          ]
+        },
+        "ByteDance/Seed-2.0-pro": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.1"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1",
+                "output": "6",
+                "cacheRead": "0.2"
+              }
+            }
+          ]
+        },
+        "MiniMaxAI/MiniMax-M2.7": {
+          "rates": {
+            "input": "0.25",
+            "output": "1",
+            "cacheRead": "0.05"
+          }
+        },
+        "MiniMaxAI/MiniMax-M3": {
+          "rates": {
+            "input": "0.28",
+            "output": "1.1",
+            "cacheRead": "0.056"
+          }
+        },
+        "Qwen/Qwen3-235B-A22B-Instruct-2507": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.55"
+          }
+        },
+        "Qwen/Qwen3-30B-A3B": {
+          "rates": {
+            "input": "0.12",
+            "output": "0.5"
+          }
+        },
+        "Qwen/Qwen3-32B": {
+          "rates": {
+            "input": "0.08",
+            "output": "0.28"
+          }
+        },
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
+          "rates": {
+            "input": "0.3",
+            "output": "1",
+            "cacheRead": "0.1"
+          }
+        },
+        "Qwen/Qwen3-Max": {
+          "rates": {
+            "input": "1.2",
+            "output": "6",
+            "cacheRead": "0.24"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "2.4",
+                "output": "12",
+                "cacheRead": "0.48"
+              }
+            },
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "3",
+                "output": "15",
+                "cacheRead": "0.6"
+              }
+            }
+          ]
+        },
+        "Qwen/Qwen3-Next-80B-A3B-Instruct": {
+          "rates": {
+            "input": "0.09",
+            "output": "1.1"
+          }
+        },
+        "Qwen/Qwen3-VL-235B-A22B-Instruct": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.88",
+            "cacheRead": "0.11"
+          }
+        },
+        "Qwen/Qwen3.5-122B-A10B": {
+          "rates": {
+            "input": "0.29",
+            "output": "2.4"
+          }
+        },
+        "Qwen/Qwen3.5-27B": {
+          "rates": {
+            "input": "0.26",
+            "output": "2.6"
+          }
+        },
+        "Qwen/Qwen3.5-35B-A3B": {
+          "rates": {
+            "input": "0.14",
+            "output": "1",
+            "cacheRead": "0.05"
+          }
+        },
+        "Qwen/Qwen3.5-397B-A17B": {
+          "rates": {
+            "input": "0.45",
+            "output": "3",
+            "cacheRead": "0.22"
+          }
+        },
+        "Qwen/Qwen3.5-9B": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.15"
+          }
+        },
+        "Qwen/Qwen3.6-27B": {
+          "rates": {
+            "input": "0.32",
+            "output": "3.2"
+          }
+        },
+        "Qwen/Qwen3.6-35B-A3B": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.95"
+          }
+        },
+        "Qwen/Qwen3.7-Max": {
+          "rates": {
+            "input": "2.5",
+            "output": "7.5",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "5",
+                "output": "15",
+                "cacheRead": "1"
+              }
+            },
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "6.25",
+                "output": "18.5",
+                "cacheRead": "1.25"
+              }
+            }
+          ]
+        },
+        "Qwen/Qwen3.8-2.4T-A95B": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.2"
+          }
+        },
+        "Qwen/Qwen3.8-27B": {
+          "rates": {
+            "input": "0.4",
+            "output": "3",
+            "cacheRead": "0.04"
+          }
+        },
+        "Qwen/Qwen3.8-Max": {
+          "rates": {
+            "input": "1.65",
+            "output": "4.951",
+            "cacheRead": "0.206"
+          }
+        },
+        "XiaomiMiMo/MiMo-V2.5": {
+          "rates": {
+            "input": "0.4",
+            "output": "2",
+            "cacheRead": "0.08"
+          }
+        },
+        "XiaomiMiMo/MiMo-V2.5-Pro": {
+          "rates": {
+            "input": "1",
+            "output": "3",
+            "cacheRead": "0.2"
+          }
+        },
+        "deepseek-ai/DeepSeek-R1-0528": {
+          "rates": {
+            "input": "0.5",
+            "output": "2.15",
+            "cacheRead": "0.35"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3": {
+          "rates": {
+            "input": "0.32",
+            "output": "0.89"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3-0324": {
+          "rates": {
+            "input": "0.24",
+            "output": "0.9",
+            "cacheRead": "0.135"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3.1": {
+          "rates": {
+            "input": "0.25",
+            "output": "0.95",
+            "cacheRead": "0.13"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3.2": {
+          "rates": {
+            "input": "0.26",
+            "output": "0.38",
+            "cacheRead": "0.13"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.18",
+            "cacheRead": "0.018"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash-0731": {
+          "rates": {
+            "input": "0.08",
+            "output": "0.18",
+            "cacheRead": "0.016"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro": {
+          "rates": {
+            "input": "1.3",
+            "output": "2.6",
+            "cacheRead": "0.1"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro-0813": {
+          "rates": {
+            "input": "1.3",
+            "output": "2.6",
+            "cacheRead": "0.1"
+          }
+        },
+        "google/gemma-4-26B-A4B-it": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.34"
+          }
+        },
+        "google/gemma-4-31B-it": {
+          "rates": {
+            "input": "0.13",
+            "output": "0.38"
+          }
+        },
+        "google/gemma-4-E4B-it": {
+          "rates": {
+            "input": "0.02",
+            "output": "0.1"
+          }
+        },
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.32"
+          }
+        },
+        "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.8"
+          }
+        },
+        "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "moonshotai/Kimi-K2.5": {
+          "rates": {
+            "input": "0.45",
+            "output": "2.25",
+            "cacheRead": "0.07"
+          }
+        },
+        "moonshotai/Kimi-K2.6": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.5",
+            "cacheRead": "0.15"
+          }
+        },
+        "moonshotai/Kimi-K2.7-Code": {
+          "rates": {
+            "input": "0.68",
+            "output": "3.4",
+            "cacheRead": "0.136"
+          }
+        },
+        "moonshotai/Kimi-K3": {
+          "rates": {
+            "input": "2.85",
+            "output": "14.25",
+            "cacheRead": "0.285"
+          }
+        },
+        "nvidia/Nemotron-3-Nano-30B-A3B": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.2",
+            "cacheRead": "0.025"
+          }
+        },
+        "openai/gpt-oss-120b": {
+          "rates": {
+            "input": "0.037",
+            "output": "0.17"
+          }
+        },
+        "openai/gpt-oss-20b": {
+          "rates": {
+            "input": "0.03",
+            "output": "0.14"
+          }
+        },
+        "stepfun-ai/Step-3.7-Flash": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.15",
+            "cacheRead": "0.04"
+          }
+        },
+        "tencent/Hy3": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.58",
+            "cacheRead": "0.035"
+          }
+        },
+        "thinkingmachines/Inkling": {
+          "rates": {
+            "input": "0.95",
+            "output": "4.05",
+            "cacheRead": "0.16"
+          }
+        },
+        "thinkingmachines/Inkling-Small": {
+          "rates": {
+            "input": "0.45",
+            "output": "1.2",
+            "cacheRead": "0.1"
+          }
+        },
+        "zai-org/GLM-4.6": {
+          "rates": {
+            "input": "0.5",
+            "output": "2",
+            "cacheRead": "0.1"
+          }
+        },
+        "zai-org/GLM-4.7": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.75",
+            "cacheRead": "0.08"
+          }
+        },
+        "zai-org/GLM-4.7-Flash": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.4",
+            "cacheRead": "0.01"
+          }
+        },
+        "zai-org/GLM-5": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.08",
+            "cacheRead": "0.12"
+          }
+        },
+        "zai-org/GLM-5.1": {
+          "rates": {
+            "input": "1.05",
+            "output": "3.5",
+            "cacheRead": "0.205"
+          }
+        },
+        "zai-org/GLM-5.2": {
+          "rates": {
+            "input": "0.75",
+            "output": "2.4",
+            "cacheRead": "0.14"
+          }
+        },
+        "zai-org/GLM-5.3": {
+          "rates": {
+            "input": "1.2",
+            "output": "4",
+            "cacheRead": "0.12"
+          }
+        },
+        "zai-org/GLM-5.3-Flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.5",
+            "cacheRead": "0.03"
+          }
+        }
+      }
+    },
+    "deepseek": {
+      "models": {
+        "deepseek-v4-flash": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.0028",
+            "reasoning": "0.28"
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.0028",
+            "reasoning": "0.28"
+          }
+        },
+        "deepseek-v4-pro": {
+          "rates": {
+            "input": "0.435",
+            "output": "0.87",
+            "cacheRead": "0.003625",
+            "reasoning": "0.87"
+          }
+        }
+      }
+    },
+    "fireworks": {
+      "models": {
+        "accounts/fireworks/models/deepseek-v4-flash-0731": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.028"
+          }
+        },
+        "accounts/fireworks/models/deepseek-v4-pro-0813": {
+          "rates": {
+            "input": "1.32",
+            "output": "3.96",
+            "cacheRead": "0.044"
+          }
+        },
+        "accounts/fireworks/models/glm-5p2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.14"
+          }
+        },
+        "accounts/fireworks/models/glm-5p3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "accounts/fireworks/models/glm-5p3-flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.5",
+            "cacheRead": "0.029"
+          }
+        },
+        "accounts/fireworks/models/gpt-oss-120b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.015"
+          }
+        },
+        "accounts/fireworks/models/inkling": {
+          "rates": {
+            "input": "1",
+            "output": "4.05",
+            "cacheRead": "0.17"
+          }
+        },
+        "accounts/fireworks/models/kimi-k2p6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "accounts/fireworks/models/kimi-k2p7-code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.19"
+          }
+        },
+        "accounts/fireworks/models/kimi-k3": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3"
+          }
+        },
+        "accounts/fireworks/models/minimax-m3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "accounts/fireworks/models/muse-glimmer-30b": {
+          "rates": {
+            "input": "0.35",
+            "output": "1.5",
+            "cacheRead": "0.04"
+          }
+        },
+        "accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.4",
+            "cacheRead": "0.119"
+          }
+        },
+        "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.2",
+            "cacheRead": "0.01"
+          }
+        },
+        "accounts/fireworks/models/qwen3p7-plus": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.6",
+            "cacheRead": "0.08"
+          }
+        },
+        "accounts/fireworks/models/qwen3p8-max": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.25"
+          }
+        },
+        "accounts/fireworks/routers/glm-5p2-fast": {
+          "rates": {
+            "input": "2.1",
+            "output": "6.6",
+            "cacheRead": "0.21"
+          }
+        },
+        "accounts/fireworks/routers/kimi-k3-fast": {
+          "rates": {
+            "input": "4.5",
+            "output": "22.5",
+            "cacheRead": "0.45"
+          }
+        }
+      }
+    },
+    "gcp.gemini": {
+      "models": {
+        "deep-research-max-preview-04-2026": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "deep-research-preview-04-2026": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "gemini-2.5-computer-use-preview-10-2025": {
+          "rates": {
+            "input": "1.25",
+            "output": "10"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "15"
+              }
+            }
+          ]
+        },
+        "gemini-2.5-flash": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03",
+            "inputAudio": "1"
+          }
+        },
+        "gemini-2.5-flash-image": {
+          "rates": {
+            "input": "0.3",
+            "output": "30",
+            "cacheRead": "0.075"
+          }
+        },
+        "gemini-2.5-flash-lite": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4",
+            "cacheRead": "0.01",
+            "inputAudio": "0.3"
+          }
+        },
+        "gemini-2.5-flash-preview-tts": {
+          "rates": {
+            "input": "0.5",
+            "output": "10"
+          }
+        },
+        "gemini-2.5-pro": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "15",
+                "cacheRead": "0.25"
+              }
+            }
+          ]
+        },
+        "gemini-2.5-pro-preview-tts": {
+          "rates": {
+            "input": "1",
+            "output": "20"
+          }
+        },
+        "gemini-3-flash-preview": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.05",
+            "inputAudio": "1"
+          }
+        },
+        "gemini-3-pro-image": {
+          "rates": {
+            "input": "2",
+            "output": "120"
+          }
+        },
+        "gemini-3-pro-image-preview": {
+          "rates": {
+            "input": "2",
+            "output": "120"
+          }
+        },
+        "gemini-3.1-flash-image": {
+          "rates": {
+            "input": "0.5",
+            "output": "60"
+          }
+        },
+        "gemini-3.1-flash-image-preview": {
+          "rates": {
+            "input": "0.5",
+            "output": "60"
+          }
+        },
+        "gemini-3.1-flash-lite": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.5",
+            "cacheRead": "0.025",
+            "inputAudio": "0.5"
+          }
+        },
+        "gemini-3.1-flash-lite-image": {
+          "rates": {
+            "input": "0.25",
+            "output": "30"
+          }
+        },
+        "gemini-3.1-flash-live-preview": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "inputAudio": "3",
+            "outputAudio": "12"
+          }
+        },
+        "gemini-3.1-flash-tts-preview": {
+          "rates": {
+            "input": "1",
+            "output": "20"
+          }
+        },
+        "gemini-3.1-pro-preview": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "gemini-3.1-pro-preview-customtools": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "gemini-3.5-flash": {
+          "rates": {
+            "input": "1.5",
+            "output": "9",
+            "cacheRead": "0.15",
+            "inputAudio": "1.5"
+          }
+        },
+        "gemini-3.5-flash-lite": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03"
+          }
+        },
+        "gemini-3.5-live-translate-preview": {
+          "rates": {
+            "input": "3.5",
+            "output": "21",
+            "inputAudio": "3.5",
+            "outputAudio": "21"
+          }
+        },
+        "gemini-3.6-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-3.7-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-embedding-001": {
+          "rates": {
+            "input": "0.15",
+            "output": "0"
+          }
+        },
+        "gemini-embedding-2": {
+          "rates": {
+            "input": "0.2",
+            "output": "0",
+            "inputAudio": "6.5"
+          }
+        },
+        "gemini-flash-latest": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-flash-lite-latest": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03"
+          }
+        },
+        "gemini-omni-flash-preview": {
+          "rates": {
+            "input": "1.5",
+            "output": "17.5"
+          }
+        },
+        "lyria-3-clip-preview": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "lyria-3-pro-preview": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        }
+      }
+    },
+    "gcp.vertex_ai": {
+      "models": {
+        "claude-fable-5@default": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-haiku-4-5@20251001": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "claude-opus-4-5@20251101": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-opus-4-6@default": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "claude-opus-4-7@default": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "claude-opus-4-8@default": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "claude-opus-5@default": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "claude-sonnet-4-5@20250929": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4-6@default": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "6",
+                "output": "22.5",
+                "cacheRead": "0.6",
+                "cacheWrite": "7.5"
+              }
+            }
+          ]
+        },
+        "claude-sonnet-5@default": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "gemini-2.5-flash": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03",
+            "inputAudio": "1"
+          }
+        },
+        "gemini-2.5-flash-image": {
+          "rates": {
+            "input": "0.3",
+            "output": "30"
+          }
+        },
+        "gemini-2.5-flash-lite": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4",
+            "cacheRead": "0.01",
+            "inputAudio": "0.3"
+          }
+        },
+        "gemini-2.5-flash-tts": {
+          "rates": {
+            "input": "0.5",
+            "output": "10"
+          }
+        },
+        "gemini-2.5-pro": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "15",
+                "cacheRead": "0.25"
+              }
+            }
+          ]
+        },
+        "gemini-2.5-pro-tts": {
+          "rates": {
+            "input": "1",
+            "output": "20"
+          }
+        },
+        "gemini-3-flash-preview": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.05",
+            "inputAudio": "1"
+          }
+        },
+        "gemini-3-pro-image": {
+          "rates": {
+            "input": "2",
+            "output": "120",
+            "cacheRead": "0.2"
+          }
+        },
+        "gemini-3.1-flash-image": {
+          "rates": {
+            "input": "0.5",
+            "output": "60",
+            "cacheRead": "0.05"
+          }
+        },
+        "gemini-3.1-flash-lite": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.5",
+            "cacheRead": "0.025",
+            "inputAudio": "0.5"
+          }
+        },
+        "gemini-3.1-pro-preview": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "gemini-3.1-pro-preview-customtools": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "gemini-3.5-flash": {
+          "rates": {
+            "input": "1.5",
+            "output": "9",
+            "cacheRead": "0.15",
+            "inputAudio": "1.5"
+          }
+        },
+        "gemini-3.5-flash-lite": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03"
+          }
+        },
+        "gemini-3.6-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-3.7-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-embedding-001": {
+          "rates": {
+            "input": "0.15",
+            "output": "0"
+          }
+        },
+        "gemini-flash-latest": {
+          "rates": {
+            "input": "1.5",
+            "output": "9",
+            "cacheRead": "0.15",
+            "inputAudio": "1.5"
+          }
+        },
+        "gemini-flash-lite-latest": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.5",
+            "cacheRead": "0.025",
+            "inputAudio": "0.5"
+          }
+        },
+        "meta/llama-4-maverick-17b-128e-instruct-maas": {
+          "rates": {
+            "input": "0.35",
+            "output": "1.15"
+          }
+        },
+        "openai/gpt-oss-120b-maas": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.36"
+          }
+        }
+      }
+    },
+    "groq": {
+      "models": {
+        "allam-2-7b": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "llama-3.1-8b-instant": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.08"
+          }
+        },
+        "llama-3.3-70b-versatile": {
+          "rates": {
+            "input": "0.59",
+            "output": "0.79"
+          }
+        },
+        "meta-llama/llama-prompt-guard-2-22m": {
+          "rates": {
+            "input": "0.03",
+            "output": "0.03"
+          }
+        },
+        "meta-llama/llama-prompt-guard-2-86m": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.04"
+          }
+        },
+        "openai/gpt-oss-120b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.075"
+          }
+        },
+        "openai/gpt-oss-20b": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.3",
+            "cacheRead": "0.0375"
+          }
+        },
+        "openai/gpt-oss-safeguard-20b": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.3"
+          }
+        },
+        "qwen/qwen3.6-27b": {
+          "rates": {
+            "input": "0.6",
+            "output": "3",
+            "cacheRead": "0.3"
+          }
+        },
+        "qwen/qwen3.8-27b": {
+          "rates": {
+            "input": "0.8",
+            "output": "4"
+          }
+        }
+      }
+    },
+    "huggingface": {
+      "models": {
+        "MiniMaxAI/MiniMax-M2": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2"
+          }
+        },
+        "MiniMaxAI/MiniMax-M2.1": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2"
+          }
+        },
+        "MiniMaxAI/MiniMax-M2.5": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.03"
+          }
+        },
+        "MiniMaxAI/MiniMax-M2.7": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "MiniMaxAI/MiniMax-M3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2"
+          }
+        },
+        "Qwen/Qwen2.5-Coder-32B-Instruct": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.2"
+          }
+        },
+        "Qwen/Qwen3-235B-A22B": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.8"
+          }
+        },
+        "Qwen/Qwen3-235B-A22B-Instruct-2507": {
+          "rates": {
+            "input": "0.855",
+            "output": "2.565"
+          }
+        },
+        "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+          "rates": {
+            "input": "0.3",
+            "output": "3"
+          }
+        },
+        "Qwen/Qwen3-30B-A3B": {
+          "rates": {
+            "input": "0.12",
+            "output": "0.5"
+          }
+        },
+        "Qwen/Qwen3-32B": {
+          "rates": {
+            "input": "0.29",
+            "output": "0.59"
+          }
+        },
+        "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.26"
+          }
+        },
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+          "rates": {
+            "input": "2",
+            "output": "2"
+          }
+        },
+        "Qwen/Qwen3-Coder-Next": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.5"
+          }
+        },
+        "Qwen/Qwen3-Embedding-4B": {
+          "rates": {
+            "input": "0.01",
+            "output": "0"
+          }
+        },
+        "Qwen/Qwen3-Embedding-8B": {
+          "rates": {
+            "input": "0.01",
+            "output": "0"
+          }
+        },
+        "Qwen/Qwen3-Next-80B-A3B-Instruct": {
+          "rates": {
+            "input": "0.25",
+            "output": "1"
+          }
+        },
+        "Qwen/Qwen3-Next-80B-A3B-Thinking": {
+          "rates": {
+            "input": "0.3",
+            "output": "2"
+          }
+        },
+        "Qwen/Qwen3-VL-235B-A22B-Instruct": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.5"
+          }
+        },
+        "Qwen/Qwen3-VL-235B-A22B-Thinking": {
+          "rates": {
+            "input": "0.98",
+            "output": "3.95"
+          }
+        },
+        "Qwen/Qwen3.5-122B-A10B": {
+          "rates": {
+            "input": "0.4",
+            "output": "3.2"
+          }
+        },
+        "Qwen/Qwen3.5-27B": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.4"
+          }
+        },
+        "Qwen/Qwen3.5-35B-A3B": {
+          "rates": {
+            "input": "0.25",
+            "output": "2"
+          }
+        },
+        "Qwen/Qwen3.5-397B-A17B": {
+          "rates": {
+            "input": "0.6",
+            "output": "3.6"
+          }
+        },
+        "Qwen/Qwen3.5-9B": {
+          "rates": {
+            "input": "0.17",
+            "output": "0.25"
+          }
+        },
+        "Qwen/Qwen3.6-27B": {
+          "rates": {
+            "input": "0.47",
+            "output": "3.19"
+          }
+        },
+        "Qwen/Qwen3.6-35B-A3B": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.95"
+          }
+        },
+        "Qwen/Qwen3.8-2.4T-A95B": {
+          "rates": {
+            "input": "2.5",
+            "output": "6.25"
+          }
+        },
+        "Qwen/Qwen3.8-27B": {
+          "rates": {
+            "input": "0.4",
+            "output": "3"
+          }
+        },
+        "XiaomiMiMo/MiMo-V2-Flash": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "XiaomiMiMo/MiMo-V2.5": {
+          "rates": {
+            "input": "0.4",
+            "output": "2"
+          }
+        },
+        "XiaomiMiMo/MiMo-V2.5-Pro": {
+          "rates": {
+            "input": "1",
+            "output": "3"
+          }
+        },
+        "deepseek-ai/DeepSeek-R1": {
+          "rates": {
+            "input": "0.7",
+            "output": "2.5"
+          }
+        },
+        "deepseek-ai/DeepSeek-R1-0528": {
+          "rates": {
+            "input": "3",
+            "output": "5"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.3"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3-0324": {
+          "rates": {
+            "input": "0.27",
+            "output": "1.12"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3.1": {
+          "rates": {
+            "input": "0.27",
+            "output": "1"
+          }
+        },
+        "deepseek-ai/DeepSeek-V3.2": {
+          "rates": {
+            "input": "0.28",
+            "output": "0.4"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash-0731": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro": {
+          "rates": {
+            "input": "0.435",
+            "output": "0.87",
+            "cacheRead": "0.003625"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro-0813": {
+          "rates": {
+            "input": "1.32",
+            "output": "3.96"
+          }
+        },
+        "google/gemma-4-26B-A4B-it": {
+          "rates": {
+            "input": "0.13",
+            "output": "0.4"
+          }
+        },
+        "google/gemma-4-31B-it": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.4"
+          }
+        },
+        "meta-llama/Llama-3.1-8B-Instruct": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.06"
+          }
+        },
+        "meta-llama/Llama-3.3-70B-Instruct": {
+          "rates": {
+            "input": "0.59",
+            "output": "0.79"
+          }
+        },
+        "moonshotai/Kimi-K2-Instruct": {
+          "rates": {
+            "input": "1",
+            "output": "3"
+          }
+        },
+        "moonshotai/Kimi-K2-Instruct-0905": {
+          "rates": {
+            "input": "1",
+            "output": "3"
+          }
+        },
+        "moonshotai/Kimi-K2-Thinking": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.5",
+            "cacheRead": "0.15"
+          }
+        },
+        "moonshotai/Kimi-K2.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "3",
+            "cacheRead": "0.1"
+          }
+        },
+        "moonshotai/Kimi-K2.6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "moonshotai/Kimi-K2.7-Code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4"
+          }
+        },
+        "moonshotai/Kimi-K3": {
+          "rates": {
+            "input": "3",
+            "output": "15"
+          }
+        },
+        "openai/gpt-oss-120b": {
+          "rates": {
+            "input": "0.25",
+            "output": "0.69"
+          }
+        },
+        "openai/gpt-oss-20b": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.5"
+          }
+        },
+        "stepfun-ai/Step-3.5-Flash": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "stepfun-ai/Step-3.7-Flash": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.15"
+          }
+        },
+        "tencent/Hy3": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.58"
+          }
+        },
+        "thinkingmachines/Inkling": {
+          "rates": {
+            "input": "1",
+            "output": "4.05"
+          }
+        },
+        "thinkingmachines/Inkling-Small": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.2"
+          }
+        },
+        "zai-org/GLM-4.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.2"
+          }
+        },
+        "zai-org/GLM-4.5-Air": {
+          "rates": {
+            "input": "0.13",
+            "output": "0.85"
+          }
+        },
+        "zai-org/GLM-4.5V": {
+          "rates": {
+            "input": "0.6",
+            "output": "1.8"
+          }
+        },
+        "zai-org/GLM-4.6": {
+          "rates": {
+            "input": "0.55",
+            "output": "2.2"
+          }
+        },
+        "zai-org/GLM-4.6V-Flash": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.9"
+          }
+        },
+        "zai-org/GLM-4.7": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.2",
+            "cacheRead": "0.11"
+          }
+        },
+        "zai-org/GLM-4.7-Flash": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "zai-org/GLM-5": {
+          "rates": {
+            "input": "1",
+            "output": "3.2",
+            "cacheRead": "0.2"
+          }
+        },
+        "zai-org/GLM-5.1": {
+          "rates": {
+            "input": "1",
+            "output": "3.2",
+            "cacheRead": "0.2"
+          }
+        },
+        "zai-org/GLM-5.2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4"
+          }
+        },
+        "zai-org/GLM-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4"
+          }
+        },
+        "zai-org/GLM-5.3-Flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.5"
+          }
+        }
+      }
+    },
+    "mistral": {
+      "models": {
+        "codestral-latest": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.9"
+          }
+        },
+        "magistral-medium-latest": {
+          "rates": {
+            "input": "2",
+            "output": "5"
+          }
+        },
+        "magistral-small": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5"
+          }
+        },
+        "ministral-3b-latest": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.04"
+          }
+        },
+        "ministral-8b-latest": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.1"
+          }
+        },
+        "mistral-embed": {
+          "rates": {
+            "input": "0.1",
+            "output": "0"
+          }
+        },
+        "mistral-large-2411": {
+          "rates": {
+            "input": "2",
+            "output": "6"
+          }
+        },
+        "mistral-large-2512": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5"
+          }
+        },
+        "mistral-large-latest": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5"
+          }
+        },
+        "mistral-medium-2505": {
+          "rates": {
+            "input": "0.4",
+            "output": "2"
+          }
+        },
+        "mistral-medium-2508": {
+          "rates": {
+            "input": "0.4",
+            "output": "2"
+          }
+        },
+        "mistral-medium-2604": {
+          "rates": {
+            "input": "1.5",
+            "output": "7.5"
+          }
+        },
+        "mistral-medium-latest": {
+          "rates": {
+            "input": "1.5",
+            "output": "7.5"
+          }
+        },
+        "mistral-nemo": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.15"
+          }
+        },
+        "mistral-small-2506": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "mistral-small-2603": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "mistral-small-latest": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "open-mistral-7b": {
+          "rates": {
+            "input": "0.25",
+            "output": "0.25"
+          }
+        },
+        "open-mixtral-8x22b": {
+          "rates": {
+            "input": "2",
+            "output": "6"
+          }
+        },
+        "open-mixtral-8x7b": {
+          "rates": {
+            "input": "0.7",
+            "output": "0.7"
+          }
+        },
+        "pixtral-12b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.15"
+          }
+        },
+        "pixtral-large-latest": {
+          "rates": {
+            "input": "2",
+            "output": "6"
+          }
+        },
+        "voxtral-small-latest": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "zai-glm-5-2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.14"
+          }
+        }
+      }
+    },
+    "openai": {
+      "models": {
+        "gpt-4.1": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "gpt-4.1-mini": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.6",
+            "cacheRead": "0.1"
+          }
+        },
+        "gpt-4o": {
+          "rates": {
+            "input": "2.5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-4o-2024-08-06": {
+          "rates": {
+            "input": "2.5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-4o-2024-11-20": {
+          "rates": {
+            "input": "2.5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-4o-mini": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.075"
+          }
+        },
+        "gpt-5": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.025"
+          }
+        },
+        "gpt-5-nano": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.4",
+            "cacheRead": "0.005"
+          }
+        },
+        "gpt-5-pro": {
+          "rates": {
+            "input": "15",
+            "output": "120"
+          }
+        },
+        "gpt-5.1": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5.2": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.2-chat-latest": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.2-pro": {
+          "rates": {
+            "input": "21",
+            "output": "168"
+          }
+        },
+        "gpt-5.3-chat-latest": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.3-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.3-codex-spark": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "gpt-5.4": {
+          "rates": {
+            "input": "2.5",
+            "output": "15",
+            "cacheRead": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "5",
+                "output": "22.5",
+                "cacheRead": "0.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.4-mini": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "cacheRead": "0.075"
+          }
+        },
+        "gpt-5.4-nano": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.25",
+            "cacheRead": "0.02"
+          }
+        },
+        "gpt-5.4-pro": {
+          "rates": {
+            "input": "30",
+            "output": "180"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "60",
+                "output": "270"
+              }
+            }
+          ]
+        },
+        "gpt-5.5": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "10",
+                "output": "45",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "gpt-5.5-pro": {
+          "rates": {
+            "input": "30",
+            "output": "180"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "60",
+                "output": "270"
+              }
+            }
+          ]
+        },
+        "gpt-5.6": {
+          "rates": {
+            "input": "4",
+            "output": "20",
+            "cacheRead": "0.4",
+            "cacheWrite": "5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "8",
+                "output": "30",
+                "cacheRead": "0.8",
+                "cacheWrite": "10"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-sol": {
+          "rates": {
+            "input": "4",
+            "output": "20",
+            "cacheRead": "0.4",
+            "cacheWrite": "5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "8",
+                "output": "30",
+                "cacheRead": "0.8",
+                "cacheWrite": "10"
+              }
+            }
+          ]
+        },
+        "gpt-5.6-terra": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "gpt-image-2": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-realtime-2.1": {
+          "rates": {
+            "input": "4",
+            "output": "24",
+            "cacheRead": "0.4",
+            "inputAudio": "32",
+            "outputAudio": "64"
+          }
+        },
+        "o3": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "o3-pro": {
+          "rates": {
+            "input": "20",
+            "output": "80"
+          }
+        },
+        "text-embedding-3-large": {
+          "rates": {
+            "input": "0.13",
+            "output": "0"
+          }
+        },
+        "text-embedding-3-small": {
+          "rates": {
+            "input": "0.02",
+            "output": "0"
+          }
+        },
+        "text-embedding-ada-002": {
+          "rates": {
+            "input": "0.1",
+            "output": "0"
+          }
+        }
+      }
+    },
+    "openrouter": {
+      "models": {
+        "aion-labs/aion-2.0": {
+          "rates": {
+            "input": "0.8",
+            "output": "1.6",
+            "cacheRead": "0.2"
+          }
+        },
+        "aion-labs/aion-3.0": {
+          "rates": {
+            "input": "3",
+            "output": "6",
+            "cacheRead": "0.75"
+          }
+        },
+        "aion-labs/aion-3.0-mini": {
+          "rates": {
+            "input": "0.7",
+            "output": "1.4",
+            "cacheRead": "0.18"
+          }
+        },
+        "aion-labs/aion-rp-llama-3.1-8b": {
+          "rates": {
+            "input": "0.8",
+            "output": "1.6"
+          }
+        },
+        "amazon/nova-2-lite-v1": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5"
+          }
+        },
+        "amazon/nova-lite-v1": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.24"
+          }
+        },
+        "amazon/nova-micro-v1": {
+          "rates": {
+            "input": "0.035",
+            "output": "0.14"
+          }
+        },
+        "amazon/nova-premier-v1": {
+          "rates": {
+            "input": "2.5",
+            "output": "12.5",
+            "cacheRead": "0.625"
+          }
+        },
+        "amazon/nova-pro-v1": {
+          "rates": {
+            "input": "0.8",
+            "output": "3.2"
+          }
+        },
+        "anthracite-org/magnum-v4-72b": {
+          "rates": {
+            "input": "2.5",
+            "output": "5"
+          }
+        },
+        "anthropic/claude-3-haiku": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.25",
+            "cacheRead": "0.03",
+            "cacheWrite": "0.3"
+          }
+        },
+        "anthropic/claude-fable-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic/claude-haiku-4.5": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "anthropic/claude-opus-4": {
+          "rates": {
+            "input": "15",
+            "output": "75",
+            "cacheRead": "1.5",
+            "cacheWrite": "18.75"
+          }
+        },
+        "anthropic/claude-opus-4.1": {
+          "rates": {
+            "input": "15",
+            "output": "75",
+            "cacheRead": "1.5",
+            "cacheWrite": "18.75"
+          }
+        },
+        "anthropic/claude-opus-4.5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic/claude-opus-4.6": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "anthropic/claude-opus-4.7": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "10",
+                "output": "37.5",
+                "cacheRead": "1",
+                "cacheWrite": "12.5"
+              }
+            }
+          ]
+        },
+        "anthropic/claude-opus-4.7-fast": {
+          "rates": {
+            "input": "30",
+            "output": "150",
+            "cacheRead": "3",
+            "cacheWrite": "37.5"
+          }
+        },
+        "anthropic/claude-opus-4.8": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic/claude-opus-4.8-fast": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic/claude-opus-5": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "anthropic/claude-opus-5-fast": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic/claude-sonnet-4": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "6",
+                "output": "22.5",
+                "cacheRead": "0.6",
+                "cacheWrite": "7.5"
+              }
+            }
+          ]
+        },
+        "anthropic/claude-sonnet-4.5": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "6",
+                "output": "22.5",
+                "cacheRead": "0.6",
+                "cacheWrite": "7.5"
+              }
+            }
+          ]
+        },
+        "anthropic/claude-sonnet-4.6": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "6",
+                "output": "22.5",
+                "cacheRead": "0.6",
+                "cacheWrite": "7.5"
+              }
+            }
+          ]
+        },
+        "anthropic/claude-sonnet-5": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "arcee-ai/trinity-large-thinking": {
+          "rates": {
+            "input": "0.25",
+            "output": "0.8",
+            "cacheRead": "0.06"
+          }
+        },
+        "baidu/ernie-4.5-vl-424b-a47b": {
+          "rates": {
+            "input": "0.42",
+            "output": "1.25"
+          }
+        },
+        "bytedance-seed/seed-1.6": {
+          "rates": {
+            "input": "0.25",
+            "output": "2"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "0.5",
+                "output": "4"
+              }
+            }
+          ]
+        },
+        "bytedance-seed/seed-1.6-flash": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.3"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "0.1",
+                "output": "0.8"
+              }
+            }
+          ]
+        },
+        "bytedance-seed/seed-2-1-turbo": {
+          "rates": {
+            "input": "0.5",
+            "output": "2.5"
+          }
+        },
+        "bytedance-seed/seed-2.0-code": {
+          "rates": {
+            "input": "0.5",
+            "output": "3"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1",
+                "output": "6"
+              }
+            }
+          ]
+        },
+        "bytedance-seed/seed-2.0-lite": {
+          "rates": {
+            "input": "0.25",
+            "output": "2"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "0.5",
+                "output": "4"
+              }
+            }
+          ]
+        },
+        "bytedance-seed/seed-2.0-mini": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "0.2",
+                "output": "0.8"
+              }
+            }
+          ]
+        },
+        "bytedance/ui-tars-1.5-7b": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.1"
+          }
+        },
+        "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.9"
+          }
+        },
+        "cohere/command-a": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "cohere/command-r-08-2024": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "cohere/command-r-plus-08-2024": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "cohere/command-r7b-12-2024": {
+          "rates": {
+            "input": "0.0375",
+            "output": "0.15"
+          }
+        },
+        "cohere/north-mini-code:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "deepseek/deepseek-chat": {
+          "rates": {
+            "input": "0.2574",
+            "output": "1.0287"
+          }
+        },
+        "deepseek/deepseek-chat-v3-0324": {
+          "rates": {
+            "input": "0.25",
+            "output": "1"
+          }
+        },
+        "deepseek/deepseek-chat-v3.1": {
+          "rates": {
+            "input": "0.55",
+            "output": "1.65",
+            "cacheRead": "0.55"
+          }
+        },
+        "deepseek/deepseek-r1": {
+          "rates": {
+            "input": "0.7",
+            "output": "2.5"
+          }
+        },
+        "deepseek/deepseek-r1-0528": {
+          "rates": {
+            "input": "0.5",
+            "output": "2.15",
+            "cacheRead": "0.35"
+          }
+        },
+        "deepseek/deepseek-r1-distill-llama-70b": {
+          "rates": {
+            "input": "0.8",
+            "output": "0.8"
+          }
+        },
+        "deepseek/deepseek-v3.1-terminus": {
+          "rates": {
+            "input": "0.27",
+            "output": "1",
+            "cacheRead": "0.135"
+          }
+        },
+        "deepseek/deepseek-v3.2": {
+          "rates": {
+            "input": "0.269",
+            "output": "0.4",
+            "cacheRead": "0.1345"
+          }
+        },
+        "deepseek/deepseek-v3.2-exp": {
+          "rates": {
+            "input": "0.27",
+            "output": "0.41"
+          }
+        },
+        "deepseek/deepseek-v4-flash": {
+          "rates": {
+            "input": "0.08092",
+            "output": "0.16184",
+            "cacheRead": "0.016184"
+          }
+        },
+        "deepseek/deepseek-v4-flash-0731": {
+          "rates": {
+            "input": "0.065",
+            "output": "0.18",
+            "cacheRead": "0.016"
+          }
+        },
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek/deepseek-v4-pro": {
+          "rates": {
+            "input": "1.6",
+            "output": "3.2",
+            "cacheRead": "0.135"
+          }
+        },
+        "deepseek/deepseek-v4-pro-0813": {
+          "rates": {
+            "input": "0.66",
+            "output": "1.98",
+            "cacheRead": "0.022"
+          }
+        },
+        "dots-studio/dots-3-note-preview:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "google/gemini-2.5-flash": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03",
+            "cacheWrite": "0.083333",
+            "reasoning": "2.5"
+          }
+        },
+        "google/gemini-2.5-flash-image": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03",
+            "cacheWrite": "0.083333"
+          }
+        },
+        "google/gemini-2.5-flash-lite": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4",
+            "cacheRead": "0.01",
+            "cacheWrite": "0.083333",
+            "reasoning": "0.4"
+          }
+        },
+        "google/gemini-2.5-pro": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125",
+            "cacheWrite": "0.375",
+            "reasoning": "10"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "15",
+                "cacheRead": "0.25"
+              }
+            }
+          ]
+        },
+        "google/gemini-2.5-pro-preview": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125",
+            "cacheWrite": "0.375",
+            "reasoning": "10"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "15",
+                "cacheRead": "0.25"
+              }
+            }
+          ]
+        },
+        "google/gemini-2.5-pro-preview-05-06": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125",
+            "cacheWrite": "0.375",
+            "reasoning": "10"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "15",
+                "cacheRead": "0.25"
+              }
+            }
+          ]
+        },
+        "google/gemini-3-flash-preview": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.05",
+            "cacheWrite": "0.083333",
+            "reasoning": "3"
+          }
+        },
+        "google/gemini-3-pro-image": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "0.375",
+            "reasoning": "12"
+          }
+        },
+        "google/gemini-3-pro-image-preview": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "0.375",
+            "reasoning": "12"
+          }
+        },
+        "google/gemini-3.1-flash-image": {
+          "rates": {
+            "input": "0.5",
+            "output": "3"
+          }
+        },
+        "google/gemini-3.1-flash-image-preview": {
+          "rates": {
+            "input": "0.5",
+            "output": "3"
+          }
+        },
+        "google/gemini-3.1-flash-lite": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.5",
+            "cacheRead": "0.025",
+            "cacheWrite": "0.083333",
+            "reasoning": "1.5"
+          }
+        },
+        "google/gemini-3.1-flash-lite-image": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.5"
+          }
+        },
+        "google/gemini-3.1-flash-lite-preview": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.5",
+            "cacheRead": "0.025",
+            "cacheWrite": "0.083333",
+            "reasoning": "1.5"
+          }
+        },
+        "google/gemini-3.1-pro-preview": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "0.375",
+            "reasoning": "12"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "google/gemini-3.1-pro-preview-customtools": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "0.375",
+            "reasoning": "12"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "google/gemini-3.5-flash": {
+          "rates": {
+            "input": "1.5",
+            "output": "9",
+            "cacheRead": "0.15",
+            "cacheWrite": "0.083333",
+            "reasoning": "9"
+          }
+        },
+        "google/gemini-3.5-flash-lite": {
+          "rates": {
+            "input": "0.3",
+            "output": "2.5",
+            "cacheRead": "0.03",
+            "cacheWrite": "0.083333",
+            "reasoning": "2.5"
+          }
+        },
+        "google/gemini-3.6-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "cacheWrite": "0.041667",
+            "reasoning": "3.75"
+          }
+        },
+        "google/gemini-3.7-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "cacheWrite": "0.041667",
+            "reasoning": "3.75"
+          }
+        },
+        "google/gemma-2-27b-it": {
+          "rates": {
+            "input": "0.65",
+            "output": "0.65"
+          }
+        },
+        "google/gemma-3-12b-it": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.15"
+          }
+        },
+        "google/gemma-3-27b-it": {
+          "rates": {
+            "input": "0.08",
+            "output": "0.45",
+            "cacheRead": "0.04"
+          }
+        },
+        "google/gemma-3-4b-it": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.1"
+          }
+        },
+        "google/gemma-4-26b-a4b-it": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.34"
+          }
+        },
+        "google/gemma-4-26b-a4b-it:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "google/gemma-4-31b-it": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.34",
+            "cacheRead": "0.05"
+          }
+        },
+        "google/gemma-4-31b-it:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "google/lyria-3-clip-preview": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "google/lyria-3-pro-preview": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "gryphe/mythomax-l2-13b": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.06"
+          }
+        },
+        "ibm-granite/granite-4.0-h-micro": {
+          "rates": {
+            "input": "0.017",
+            "output": "0.112"
+          }
+        },
+        "ibm-granite/granite-4.1-8b": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.1",
+            "cacheRead": "0.05"
+          }
+        },
+        "ibm-granite/granite-4.2-8b": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.15",
+            "cacheRead": "0.05"
+          }
+        },
+        "inception/mercury-2": {
+          "rates": {
+            "input": "0.25",
+            "output": "0.75",
+            "cacheRead": "0.025"
+          }
+        },
+        "inclusionai/ling-3.0-flash": {
+          "rates": {
+            "input": "0.021",
+            "output": "0.063",
+            "cacheRead": "0.0042"
+          }
+        },
+        "inclusionai/ling-3.0-flash-fin:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "kwaipilot/kat-coder-pro-v2": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "kwaipilot/kat-coder-pro-v2.5": {
+          "rates": {
+            "input": "0.74",
+            "output": "2.96",
+            "cacheRead": "0.15"
+          }
+        },
+        "liquid/lfm-2.5-2.6b:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "mancer/weaver": {
+          "rates": {
+            "input": "0.4",
+            "output": "0.75"
+          }
+        },
+        "meituan/longcat-2.0": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.006"
+          }
+        },
+        "meta-llama/llama-3.1-70b-instruct": {
+          "rates": {
+            "input": "0.4",
+            "output": "0.4"
+          }
+        },
+        "meta-llama/llama-3.1-8b-instruct": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.08",
+            "cacheRead": "0.025"
+          }
+        },
+        "meta-llama/llama-3.2-1b-instruct": {
+          "rates": {
+            "input": "0.027",
+            "output": "0.201"
+          }
+        },
+        "meta-llama/llama-3.2-3b-instruct": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.33"
+          }
+        },
+        "meta-llama/llama-3.3-70b-instruct": {
+          "rates": {
+            "input": "0.71",
+            "output": "0.71",
+            "cacheRead": "0.71"
+          }
+        },
+        "meta-llama/llama-4-maverick": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.696"
+          }
+        },
+        "meta-llama/llama-4-scout": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "meta-llama/llama-guard-4-12b": {
+          "rates": {
+            "input": "0.18",
+            "output": "0.18"
+          }
+        },
+        "meta/muse-glimmer-30b": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.04"
+          }
+        },
+        "meta/muse-spark-1.1": {
+          "rates": {
+            "input": "1.25",
+            "output": "4.25",
+            "cacheRead": "0.15"
+          }
+        },
+        "meta/muse-spark-1.2": {
+          "rates": {
+            "input": "1.25",
+            "output": "4.25",
+            "cacheRead": "0.15"
+          }
+        },
+        "meta/muse-spark-1.2-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "microsoft/phi-4": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.14"
+          }
+        },
+        "microsoft/wizardlm-2-8x22b": {
+          "rates": {
+            "input": "0.62",
+            "output": "0.62"
+          }
+        },
+        "minimax/minimax-01": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.1"
+          }
+        },
+        "minimax/minimax-m1": {
+          "rates": {
+            "input": "0.55",
+            "output": "2.2"
+          }
+        },
+        "minimax/minimax-m2": {
+          "rates": {
+            "input": "0.255",
+            "output": "1.02"
+          }
+        },
+        "minimax/minimax-m2-her": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.03"
+          }
+        },
+        "minimax/minimax-m2.1": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.03"
+          }
+        },
+        "minimax/minimax-m2.5": {
+          "rates": {
+            "input": "0.27",
+            "output": "1.08",
+            "cacheRead": "0.027"
+          }
+        },
+        "minimax/minimax-m2.7": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "minimax/minimax-m2.7:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "minimax/minimax-m3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "minimax/minimax-m3:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "mistralai/codestral-2508": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.9",
+            "cacheRead": "0.03"
+          }
+        },
+        "mistralai/devstral-2512": {
+          "rates": {
+            "input": "0.4",
+            "output": "2",
+            "cacheRead": "0.04"
+          }
+        },
+        "mistralai/ministral-14b-2512": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.2",
+            "cacheRead": "0.02"
+          }
+        },
+        "mistralai/ministral-3b-2512": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.1",
+            "cacheRead": "0.01"
+          }
+        },
+        "mistralai/ministral-8b-2512": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.15",
+            "cacheRead": "0.015"
+          }
+        },
+        "mistralai/mistral-large": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.2"
+          }
+        },
+        "mistralai/mistral-large-2407": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.2"
+          }
+        },
+        "mistralai/mistral-large-2512": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5",
+            "cacheRead": "0.05"
+          }
+        },
+        "mistralai/mistral-medium-3": {
+          "rates": {
+            "input": "0.4",
+            "output": "2",
+            "cacheRead": "0.04"
+          }
+        },
+        "mistralai/mistral-medium-3-5": {
+          "rates": {
+            "input": "1.5",
+            "output": "7.5"
+          }
+        },
+        "mistralai/mistral-medium-3.1": {
+          "rates": {
+            "input": "0.4",
+            "output": "2",
+            "cacheRead": "0.04"
+          }
+        },
+        "mistralai/mistral-nemo": {
+          "rates": {
+            "input": "0.019",
+            "output": "0.03"
+          }
+        },
+        "mistralai/mistral-saba": {
+          "rates": {
+            "input": "0.2",
+            "output": "0.6",
+            "cacheRead": "0.02"
+          }
+        },
+        "mistralai/mistral-small-24b-instruct-2501": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.08"
+          }
+        },
+        "mistralai/mistral-small-2603": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.015"
+          }
+        },
+        "mistralai/mistral-small-3.1-24b-instruct": {
+          "rates": {
+            "input": "0.351",
+            "output": "0.555"
+          }
+        },
+        "mistralai/mistral-small-3.2-24b-instruct": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.2"
+          }
+        },
+        "mistralai/mixtral-8x22b-instruct": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.2"
+          }
+        },
+        "mistralai/voxtral-small-24b-2507": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3",
+            "cacheRead": "0.01"
+          }
+        },
+        "moonshotai/kimi-k2": {
+          "rates": {
+            "input": "0.57",
+            "output": "2.3"
+          }
+        },
+        "moonshotai/kimi-k2-0905": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.5"
+          }
+        },
+        "moonshotai/kimi-k2-thinking": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.5",
+            "cacheRead": "0.15"
+          }
+        },
+        "moonshotai/kimi-k2.5": {
+          "rates": {
+            "input": "0.45",
+            "output": "2.25",
+            "cacheRead": "0.07"
+          }
+        },
+        "moonshotai/kimi-k2.6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "moonshotai/kimi-k2.7-code": {
+          "rates": {
+            "input": "0.66",
+            "output": "3.4",
+            "cacheRead": "0.18"
+          }
+        },
+        "moonshotai/kimi-k3": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3"
+          }
+        },
+        "morph/morph-v3-fast": {
+          "rates": {
+            "input": "0.8",
+            "output": "1.2"
+          }
+        },
+        "morph/morph-v3-large": {
+          "rates": {
+            "input": "0.9",
+            "output": "1.9"
+          }
+        },
+        "nex-agi/nex-n2-mini": {
+          "rates": {
+            "input": "0.025",
+            "output": "0.1",
+            "cacheRead": "0.0025"
+          }
+        },
+        "nex-agi/nex-n2-pro": {
+          "rates": {
+            "input": "0.25",
+            "output": "1",
+            "cacheRead": "0.025"
+          }
+        },
+        "nousresearch/hermes-3-llama-3.1-405b": {
+          "rates": {
+            "input": "1",
+            "output": "1"
+          }
+        },
+        "nousresearch/hermes-3-llama-3.1-70b": {
+          "rates": {
+            "input": "0.7",
+            "output": "0.7"
+          }
+        },
+        "nousresearch/hermes-4-405b": {
+          "rates": {
+            "input": "1",
+            "output": "3"
+          }
+        },
+        "nousresearch/hermes-4-70b": {
+          "rates": {
+            "input": "0.13",
+            "output": "0.4"
+          }
+        },
+        "nvidia/nemotron-3-nano-30b-a3b": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.2",
+            "cacheRead": "0.025"
+          }
+        },
+        "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "nvidia/nemotron-3-super-120b-a12b": {
+          "rates": {
+            "input": "0.085",
+            "output": "0.4"
+          }
+        },
+        "nvidia/nemotron-3-super-120b-a12b:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "nvidia/nemotron-3-ultra-550b-a55b": {
+          "rates": {
+            "input": "0.5",
+            "output": "2.2",
+            "cacheRead": "0.1"
+          }
+        },
+        "nvidia/nemotron-3-ultra-550b-a55b:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "nvidia/nemotron-3.5-content-safety:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "nvidia/nemotron-3.5-lightning": {
+          "rates": {
+            "input": "0.08",
+            "output": "0.2",
+            "cacheRead": "0.04"
+          }
+        },
+        "nvidia/nemotron-3.5-lightning:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "openai/gpt-3.5-turbo": {
+          "rates": {
+            "input": "0.5",
+            "output": "1.5"
+          }
+        },
+        "openai/gpt-3.5-turbo-0613": {
+          "rates": {
+            "input": "1",
+            "output": "2"
+          }
+        },
+        "openai/gpt-3.5-turbo-16k": {
+          "rates": {
+            "input": "3",
+            "output": "4"
+          }
+        },
+        "openai/gpt-3.5-turbo-instruct": {
+          "rates": {
+            "input": "1.5",
+            "output": "2"
+          }
+        },
+        "openai/gpt-4": {
+          "rates": {
+            "input": "30",
+            "output": "60"
+          }
+        },
+        "openai/gpt-4-turbo": {
+          "rates": {
+            "input": "10",
+            "output": "30"
+          }
+        },
+        "openai/gpt-4-turbo-preview": {
+          "rates": {
+            "input": "10",
+            "output": "30"
+          }
+        },
+        "openai/gpt-4.1": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "openai/gpt-4.1-mini": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.6",
+            "cacheRead": "0.1"
+          }
+        },
+        "openai/gpt-4.1-nano": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4",
+            "cacheRead": "0.025"
+          }
+        },
+        "openai/gpt-4o": {
+          "rates": {
+            "input": "2.5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "openai/gpt-4o-2024-05-13": {
+          "rates": {
+            "input": "5",
+            "output": "15"
+          }
+        },
+        "openai/gpt-4o-2024-08-06": {
+          "rates": {
+            "input": "2.5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "openai/gpt-4o-2024-11-20": {
+          "rates": {
+            "input": "2.5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "openai/gpt-4o-mini": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.075"
+          }
+        },
+        "openai/gpt-4o-mini-2024-07-18": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.075"
+          }
+        },
+        "openai/gpt-5": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "openai/gpt-5-image": {
+          "rates": {
+            "input": "10",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "openai/gpt-5-image-mini": {
+          "rates": {
+            "input": "2.5",
+            "output": "2",
+            "cacheRead": "0.25"
+          }
+        },
+        "openai/gpt-5-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.025"
+          }
+        },
+        "openai/gpt-5-nano": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.4",
+            "cacheRead": "0.005"
+          }
+        },
+        "openai/gpt-5-pro": {
+          "rates": {
+            "input": "15",
+            "output": "120"
+          }
+        },
+        "openai/gpt-5.1": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "openai/gpt-5.1-codex": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.13"
+          }
+        },
+        "openai/gpt-5.1-codex-max": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "openai/gpt-5.1-codex-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.03"
+          }
+        },
+        "openai/gpt-5.2": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "openai/gpt-5.2-chat": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "openai/gpt-5.2-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "openai/gpt-5.2-pro": {
+          "rates": {
+            "input": "21",
+            "output": "168"
+          }
+        },
+        "openai/gpt-5.3-codex": {
+          "rates": {
+            "input": "1.75",
+            "output": "14",
+            "cacheRead": "0.175"
+          }
+        },
+        "openai/gpt-5.4": {
+          "rates": {
+            "input": "2.5",
+            "output": "15",
+            "cacheRead": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "5",
+                "output": "22.5",
+                "cacheRead": "0.5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.4-image-2": {
+          "rates": {
+            "input": "8",
+            "output": "15",
+            "cacheRead": "2"
+          }
+        },
+        "openai/gpt-5.4-mini": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "cacheRead": "0.075"
+          }
+        },
+        "openai/gpt-5.4-nano": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.25",
+            "cacheRead": "0.02"
+          }
+        },
+        "openai/gpt-5.4-pro": {
+          "rates": {
+            "input": "30",
+            "output": "180"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "60",
+                "output": "270"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.5": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "10",
+                "output": "45",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.5-pro": {
+          "rates": {
+            "input": "30",
+            "output": "180"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "60",
+                "output": "270"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.6-luna-pro": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.6-sol": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "15",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.6-sol-pro": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "15",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.6-terra": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-5.6-terra-pro": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "openai/gpt-audio": {
+          "rates": {
+            "input": "2.5",
+            "output": "10"
+          }
+        },
+        "openai/gpt-audio-mini": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.4"
+          }
+        },
+        "openai/gpt-chat-latest": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          }
+        },
+        "openai/gpt-oss-120b": {
+          "rates": {
+            "input": "0.037",
+            "output": "0.17"
+          }
+        },
+        "openai/gpt-oss-20b": {
+          "rates": {
+            "input": "0.03",
+            "output": "0.13",
+            "cacheRead": "0.03"
+          }
+        },
+        "openai/gpt-oss-safeguard-20b": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.3",
+            "cacheRead": "0.0375"
+          }
+        },
+        "openai/o1": {
+          "rates": {
+            "input": "15",
+            "output": "60",
+            "cacheRead": "7.5"
+          }
+        },
+        "openai/o1-pro": {
+          "rates": {
+            "input": "150",
+            "output": "600"
+          }
+        },
+        "openai/o3": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "openai/o3-mini": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.55"
+          }
+        },
+        "openai/o3-mini-high": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.55"
+          }
+        },
+        "openai/o3-pro": {
+          "rates": {
+            "input": "20",
+            "output": "80"
+          }
+        },
+        "openai/o4-mini": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.275"
+          }
+        },
+        "openai/o4-mini-high": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.275"
+          }
+        },
+        "openrouter/free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "perceptron/perceptron-mk1": {
+          "rates": {
+            "input": "0.15",
+            "output": "1.5"
+          }
+        },
+        "perplexity/sonar": {
+          "rates": {
+            "input": "1",
+            "output": "1"
+          }
+        },
+        "perplexity/sonar-deep-research": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "reasoning": "3"
+          }
+        },
+        "perplexity/sonar-pro": {
+          "rates": {
+            "input": "3",
+            "output": "15"
+          }
+        },
+        "perplexity/sonar-pro-search": {
+          "rates": {
+            "input": "3",
+            "output": "15"
+          }
+        },
+        "perplexity/sonar-reasoning-pro": {
+          "rates": {
+            "input": "2",
+            "output": "8"
+          }
+        },
+        "poolside/laguna-s-2.1": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.18",
+            "cacheRead": "0.009"
+          }
+        },
+        "poolside/laguna-s-2.1:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "poolside/laguna-xs-2.1": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.12",
+            "cacheRead": "0.03"
+          }
+        },
+        "poolside/laguna-xs-2.1:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "qwen/qwen-2.5-72b-instruct": {
+          "rates": {
+            "input": "0.36",
+            "output": "0.4"
+          }
+        },
+        "qwen/qwen-2.5-7b-instruct": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2"
+          }
+        },
+        "qwen/qwen-2.5-coder-32b-instruct": {
+          "rates": {
+            "input": "0.66",
+            "output": "1"
+          }
+        },
+        "qwen/qwen-plus": {
+          "rates": {
+            "input": "0.26",
+            "output": "0.78",
+            "cacheRead": "0.052",
+            "cacheWrite": "0.325"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.78",
+                "output": "2.34",
+                "cacheRead": "0.156",
+                "cacheWrite": "0.975"
+              }
+            }
+          ]
+        },
+        "qwen/qwen-plus-2025-07-28": {
+          "rates": {
+            "input": "0.26",
+            "output": "0.78"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.78",
+                "output": "2.34"
+              }
+            }
+          ]
+        },
+        "qwen/qwen2.5-vl-72b-instruct": {
+          "rates": {
+            "input": "0.25",
+            "output": "0.75"
+          }
+        },
+        "qwen/qwen3-14b": {
+          "rates": {
+            "input": "0.12",
+            "output": "0.24"
+          }
+        },
+        "qwen/qwen3-235b-a22b": {
+          "rates": {
+            "input": "0.455",
+            "output": "1.82"
+          }
+        },
+        "qwen/qwen3-235b-a22b-2507": {
+          "rates": {
+            "input": "0.0875",
+            "output": "0.35",
+            "cacheRead": "0.0175"
+          }
+        },
+        "qwen/qwen3-235b-a22b-thinking-2507": {
+          "rates": {
+            "input": "0.23",
+            "output": "2.3"
+          }
+        },
+        "qwen/qwen3-30b-a3b": {
+          "rates": {
+            "input": "0.12",
+            "output": "0.5"
+          }
+        },
+        "qwen/qwen3-30b-a3b-instruct-2507": {
+          "rates": {
+            "input": "0.04815",
+            "output": "0.19305"
+          }
+        },
+        "qwen/qwen3-30b-a3b-thinking-2507": {
+          "rates": {
+            "input": "0.2",
+            "output": "2.4"
+          }
+        },
+        "qwen/qwen3-32b": {
+          "rates": {
+            "input": "0.08",
+            "output": "0.28"
+          }
+        },
+        "qwen/qwen3-8b": {
+          "rates": {
+            "input": "0.117",
+            "output": "0.455"
+          }
+        },
+        "qwen/qwen3-coder": {
+          "rates": {
+            "input": "0.3",
+            "output": "1",
+            "cacheRead": "0.1"
+          }
+        },
+        "qwen/qwen3-coder-30b-a3b-instruct": {
+          "rates": {
+            "input": "0.07",
+            "output": "0.28"
+          }
+        },
+        "qwen/qwen3-coder-flash": {
+          "rates": {
+            "input": "0.195",
+            "output": "0.975",
+            "cacheRead": "0.039",
+            "cacheWrite": "0.24375"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "0.325",
+                "output": "1.625",
+                "cacheRead": "0.065",
+                "cacheWrite": "0.40625"
+              }
+            },
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "0.52",
+                "output": "2.6",
+                "cacheRead": "0.104",
+                "cacheWrite": "0.65"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3-coder-next": {
+          "rates": {
+            "input": "0.12",
+            "output": "0.8",
+            "cacheRead": "0.07"
+          }
+        },
+        "qwen/qwen3-coder-plus": {
+          "rates": {
+            "input": "0.65",
+            "output": "3.25",
+            "cacheRead": "0.13",
+            "cacheWrite": "0.8125"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "1.17",
+                "output": "5.85",
+                "cacheRead": "0.234",
+                "cacheWrite": "1.4625"
+              }
+            },
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1.95",
+                "output": "9.75",
+                "cacheRead": "0.39",
+                "cacheWrite": "2.4375"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3-max": {
+          "rates": {
+            "input": "0.78",
+            "output": "3.9",
+            "cacheRead": "0.156",
+            "cacheWrite": "0.975"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "1.56",
+                "output": "7.8",
+                "cacheRead": "0.312",
+                "cacheWrite": "1.95"
+              }
+            },
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1.95",
+                "output": "9.75",
+                "cacheRead": "0.39",
+                "cacheWrite": "2.4375"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3-max-thinking": {
+          "rates": {
+            "input": "0.78",
+            "output": "3.9"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "1.56",
+                "output": "7.8"
+              }
+            },
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1.95",
+                "output": "9.75"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3-next-80b-a3b-instruct": {
+          "rates": {
+            "input": "0.1",
+            "output": "1.1",
+            "cacheRead": "0.07"
+          }
+        },
+        "qwen/qwen3-next-80b-a3b-thinking": {
+          "rates": {
+            "input": "0.15",
+            "output": "1.2"
+          }
+        },
+        "qwen/qwen3-vl-235b-a22b-instruct": {
+          "rates": {
+            "input": "0.21",
+            "output": "1.9",
+            "cacheRead": "0.1"
+          }
+        },
+        "qwen/qwen3-vl-235b-a22b-thinking": {
+          "rates": {
+            "input": "0.4",
+            "output": "4"
+          }
+        },
+        "qwen/qwen3-vl-30b-a3b-instruct": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "qwen/qwen3-vl-30b-a3b-thinking": {
+          "rates": {
+            "input": "0.2",
+            "output": "2.4"
+          }
+        },
+        "qwen/qwen3-vl-32b-instruct": {
+          "rates": {
+            "input": "0.104",
+            "output": "0.416"
+          }
+        },
+        "qwen/qwen3-vl-8b-instruct": {
+          "rates": {
+            "input": "0.117",
+            "output": "0.455"
+          }
+        },
+        "qwen/qwen3-vl-8b-thinking": {
+          "rates": {
+            "input": "0.18",
+            "output": "2.1"
+          }
+        },
+        "qwen/qwen3.5-122b-a10b": {
+          "rates": {
+            "input": "0.29",
+            "output": "2.4"
+          }
+        },
+        "qwen/qwen3.5-27b": {
+          "rates": {
+            "input": "0.195",
+            "output": "1.56"
+          }
+        },
+        "qwen/qwen3.5-35b-a3b": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.25",
+            "cacheRead": "0.25"
+          }
+        },
+        "qwen/qwen3.5-397b-a17b": {
+          "rates": {
+            "input": "0.39",
+            "output": "2.34"
+          }
+        },
+        "qwen/qwen3.5-9b": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.15"
+          }
+        },
+        "qwen/qwen3.5-flash-02-23": {
+          "rates": {
+            "input": "0.065",
+            "output": "0.26"
+          }
+        },
+        "qwen/qwen3.5-plus-02-15": {
+          "rates": {
+            "input": "0.26",
+            "output": "1.56"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.325",
+                "output": "1.95"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.5-plus-20260420": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.8",
+            "cacheWrite": "0.375"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.375",
+                "output": "2.25",
+                "cacheWrite": "0.46875"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.6-27b": {
+          "rates": {
+            "input": "0.6",
+            "output": "3.6",
+            "cacheRead": "0.12"
+          }
+        },
+        "qwen/qwen3.6-35b-a3b": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.9",
+            "cacheRead": "0.05"
+          }
+        },
+        "qwen/qwen3.6-flash": {
+          "rates": {
+            "input": "0.1875",
+            "output": "1.125",
+            "cacheWrite": "0.234375"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.75",
+                "output": "3",
+                "cacheWrite": "0.9375"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.6-max-preview": {
+          "rates": {
+            "input": "1.027",
+            "output": "6.162",
+            "cacheWrite": "1.28375"
+          },
+          "tiers": [
+            {
+              "contextOver": 128000,
+              "rates": {
+                "input": "1.58",
+                "output": "9.48",
+                "cacheWrite": "1.975"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.6-plus": {
+          "rates": {
+            "input": "0.325",
+            "output": "1.95",
+            "cacheWrite": "0.40625"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "1.3",
+                "output": "3.9",
+                "cacheWrite": "1.625"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.7-flash": {
+          "rates": {
+            "input": "0.03",
+            "output": "0.13",
+            "cacheRead": "0.006",
+            "cacheWrite": "0.038"
+          },
+          "tiers": [
+            {
+              "contextOver": 32000,
+              "rates": {
+                "input": "0.1",
+                "output": "0.4",
+                "cacheRead": "0.02",
+                "cacheWrite": "0.125"
+              }
+            },
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.2",
+                "output": "0.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.25"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.7-max": {
+          "rates": {
+            "input": "1.475",
+            "output": "4.425",
+            "cacheRead": "0.295",
+            "cacheWrite": "1.84375"
+          }
+        },
+        "qwen/qwen3.7-plus": {
+          "rates": {
+            "input": "0.32",
+            "output": "1.28",
+            "cacheRead": "0.064",
+            "cacheWrite": "0.4"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "0.96",
+                "output": "3.84",
+                "cacheRead": "0.192",
+                "cacheWrite": "1.2"
+              }
+            }
+          ]
+        },
+        "qwen/qwen3.8-2.4t-a95b": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.25"
+          }
+        },
+        "qwen/qwen3.8-27b": {
+          "rates": {
+            "input": "0.425",
+            "output": "2.55",
+            "cacheRead": "0.085",
+            "cacheWrite": "0.53125"
+          }
+        },
+        "qwen/qwen3.8-flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.47",
+            "cacheRead": "0.016",
+            "cacheWrite": "0.2"
+          }
+        },
+        "qwen/qwen3.8-max": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.25",
+            "cacheWrite": "2.5"
+          }
+        },
+        "rekaai/reka-edge": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.1"
+          }
+        },
+        "rekaai/reka-flash-3": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2"
+          }
+        },
+        "relace/relace-apply-3": {
+          "rates": {
+            "input": "0.85",
+            "output": "1.25"
+          }
+        },
+        "relace/relace-search": {
+          "rates": {
+            "input": "1",
+            "output": "3"
+          }
+        },
+        "sakana/fugu-ultra": {
+          "rates": {
+            "input": "5",
+            "output": "30",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "10",
+                "output": "45",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "sakana/sakana-namazu": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.15"
+          }
+        },
+        "sao10k/l3-lunaris-8b": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.05"
+          }
+        },
+        "sao10k/l3.1-euryale-70b": {
+          "rates": {
+            "input": "0.85",
+            "output": "0.85"
+          }
+        },
+        "sao10k/l3.3-euryale-70b": {
+          "rates": {
+            "input": "0.65",
+            "output": "0.75"
+          }
+        },
+        "stepfun/step-3.5-flash": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.3"
+          }
+        },
+        "stepfun/step-3.7-flash": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.15",
+            "cacheRead": "0.04"
+          }
+        },
+        "tencent/hunyuan-a13b-instruct": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.57"
+          }
+        },
+        "tencent/hy-mt2-1.8b": {
+          "rates": {
+            "input": "0.044",
+            "output": "0.177"
+          }
+        },
+        "tencent/hy-mt2-30b-a3b": {
+          "rates": {
+            "input": "0.074",
+            "output": "0.295"
+          }
+        },
+        "tencent/hy-mt2-7b": {
+          "rates": {
+            "input": "0.074",
+            "output": "0.295"
+          }
+        },
+        "tencent/hy3": {
+          "rates": {
+            "input": "0.132",
+            "output": "0.528",
+            "cacheRead": "0.033"
+          }
+        },
+        "tencent/hy3-preview": {
+          "rates": {
+            "input": "0.18",
+            "output": "0.6",
+            "cacheRead": "0.06"
+          }
+        },
+        "tencent/hy4-preview": {
+          "rates": {
+            "input": "0.834",
+            "output": "2.501",
+            "cacheRead": "0.042"
+          }
+        },
+        "thedrummer/cydonia-24b-v4.1": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.5",
+            "cacheRead": "0.15"
+          }
+        },
+        "thedrummer/skyfall-36b-v2": {
+          "rates": {
+            "input": "0.55",
+            "output": "0.8",
+            "cacheRead": "0.25"
+          }
+        },
+        "thedrummer/unslopnemo-12b": {
+          "rates": {
+            "input": "0.4",
+            "output": "0.4"
+          }
+        },
+        "thinkingmachines/inkling": {
+          "rates": {
+            "input": "1",
+            "output": "4.05",
+            "cacheRead": "0.17"
+          }
+        },
+        "thinkingmachines/inkling-small": {
+          "rates": {
+            "input": "0.45",
+            "output": "1.2",
+            "cacheRead": "0.1"
+          }
+        },
+        "thinkingmachines/inkling-small:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "thinkingmachines/inkling:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "undi95/remm-slerp-l2-13b": {
+          "rates": {
+            "input": "0.45",
+            "output": "0.65"
+          }
+        },
+        "upstage/solar-pro-3": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6",
+            "cacheRead": "0.015"
+          }
+        },
+        "upstage/solar-pro4": {
+          "rates": {
+            "input": "0.03",
+            "output": "0.12",
+            "cacheRead": "0.006"
+          }
+        },
+        "writer/palmyra-x5": {
+          "rates": {
+            "input": "0.6",
+            "output": "6"
+          }
+        },
+        "x-ai/grok-4.20": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "x-ai/grok-4.20-multi-agent": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "x-ai/grok-4.3": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "x-ai/grok-4.5": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.3"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "0.6"
+              }
+            }
+          ]
+        },
+        "x-ai/grok-4.6": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "x-ai/grok-build-0.1": {
+          "rates": {
+            "input": "1",
+            "output": "2",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2",
+                "output": "4",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "xiaomi/mimo-v2.5": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.0028"
+          }
+        },
+        "xiaomi/mimo-v2.5-pro": {
+          "rates": {
+            "input": "0.435",
+            "output": "0.87",
+            "cacheRead": "0.0036"
+          }
+        },
+        "z-ai/glm-4.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "2.2",
+            "cacheRead": "0.11"
+          }
+        },
+        "z-ai/glm-4.5-air": {
+          "rates": {
+            "input": "0.13",
+            "output": "0.85",
+            "cacheRead": "0.025"
+          }
+        },
+        "z-ai/glm-4.5v": {
+          "rates": {
+            "input": "0.6",
+            "output": "1.8",
+            "cacheRead": "0.11"
+          }
+        },
+        "z-ai/glm-4.6": {
+          "rates": {
+            "input": "0.43",
+            "output": "1.75",
+            "cacheRead": "0.08"
+          }
+        },
+        "z-ai/glm-4.6v": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.9",
+            "cacheRead": "0.055"
+          }
+        },
+        "z-ai/glm-4.7": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.75",
+            "cacheRead": "0.08"
+          }
+        },
+        "z-ai/glm-4.7-flash": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.4",
+            "cacheRead": "0.01"
+          }
+        },
+        "z-ai/glm-5": {
+          "rates": {
+            "input": "0.6",
+            "output": "1.92",
+            "cacheRead": "0.12"
+          }
+        },
+        "z-ai/glm-5-turbo": {
+          "rates": {
+            "input": "1.2",
+            "output": "4",
+            "cacheRead": "0.24"
+          }
+        },
+        "z-ai/glm-5.1": {
+          "rates": {
+            "input": "0.966",
+            "output": "3.036",
+            "cacheRead": "0.1794"
+          }
+        },
+        "z-ai/glm-5.2": {
+          "rates": {
+            "input": "1.19",
+            "output": "3.74",
+            "cacheRead": "0.221"
+          }
+        },
+        "z-ai/glm-5.2:free": {
+          "rates": {
+            "input": "0",
+            "output": "0"
+          }
+        },
+        "z-ai/glm-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "z-ai/glm-5.3-flash": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
+        "z-ai/glm-5v-turbo": {
+          "rates": {
+            "input": "1.2",
+            "output": "4",
+            "cacheRead": "0.24"
+          }
+        },
+        "~anthropic/claude-fable-latest": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "~anthropic/claude-haiku-latest": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "~anthropic/claude-opus-latest": {
+          "rates": {
+            "input": "5",
+            "output": "25",
+            "cacheRead": "0.5",
+            "cacheWrite": "6.25"
+          }
+        },
+        "~anthropic/claude-sonnet-latest": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          }
+        },
+        "~deepseek/deepseek-v4-flash-latest": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.16",
+            "cacheRead": "0.013"
+          }
+        },
+        "~google/gemini-flash-latest": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "cacheWrite": "0.041667",
+            "reasoning": "3.75"
+          }
+        },
+        "~google/gemini-pro-latest": {
+          "rates": {
+            "input": "2",
+            "output": "12",
+            "cacheRead": "0.2",
+            "cacheWrite": "0.375",
+            "reasoning": "12"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "18",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "~moonshotai/kimi-latest": {
+          "rates": {
+            "input": "2.55",
+            "output": "12.75",
+            "cacheRead": "0.256"
+          }
+        },
+        "~openai/gpt-latest": {
+          "rates": {
+            "input": "2",
+            "output": "10",
+            "cacheRead": "0.2",
+            "cacheWrite": "2.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "4",
+                "output": "15",
+                "cacheRead": "0.4",
+                "cacheWrite": "5"
+              }
+            }
+          ]
+        },
+        "~openai/gpt-mini-latest": {
+          "rates": {
+            "input": "0.75",
+            "output": "4.5",
+            "cacheRead": "0.075"
+          }
+        },
+        "~x-ai/grok-latest": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "~z-ai/glm-latest": {
+          "rates": {
+            "input": "1.17",
+            "output": "3.96",
+            "cacheRead": "0.234"
+          }
+        }
+      }
+    },
+    "togetherai": {
+      "models": {
+        "LiquidAI/LFM2-24B-A2B": {
+          "rates": {
+            "input": "0.03",
+            "output": "0.12"
+          }
+        },
+        "MiniMaxAI/MiniMax-M2.7": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "MiniMaxAI/MiniMax-M3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "Qwen/Qwen2.5-7B-Instruct-Turbo": {
+          "rates": {
+            "input": "0.3",
+            "output": "0.3"
+          }
+        },
+        "Qwen/Qwen3.5-9B": {
+          "rates": {
+            "input": "0.17",
+            "output": "0.25"
+          }
+        },
+        "Qwen/Qwen3.6-Plus": {
+          "rates": {
+            "input": "0.5",
+            "output": "3"
+          }
+        },
+        "Qwen/Qwen3.7-Max": {
+          "rates": {
+            "input": "1.25",
+            "output": "3.75",
+            "cacheRead": "0.125"
+          }
+        },
+        "deepcogito/cogito-v2-1-671b": {
+          "rates": {
+            "input": "1.25",
+            "output": "1.25"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Flash-0731": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.03"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro": {
+          "rates": {
+            "input": "1.74",
+            "output": "3.48",
+            "cacheRead": "0.2"
+          }
+        },
+        "deepseek-ai/DeepSeek-V4-Pro-0813": {
+          "rates": {
+            "input": "1.32",
+            "output": "3.96",
+            "cacheRead": "0.13"
+          }
+        },
+        "google/gemma-3n-E4B-it": {
+          "rates": {
+            "input": "0.06",
+            "output": "0.12"
+          }
+        },
+        "google/gemma-4-31B-it": {
+          "rates": {
+            "input": "0.39",
+            "output": "0.97"
+          }
+        },
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+          "rates": {
+            "input": "1.04",
+            "output": "1.04"
+          }
+        },
+        "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.14"
+          }
+        },
+        "moonshotai/Kimi-K2.6": {
+          "rates": {
+            "input": "1.2",
+            "output": "4.5",
+            "cacheRead": "0.2"
+          }
+        },
+        "moonshotai/Kimi-K2.7-Code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.19"
+          }
+        },
+        "moonshotai/Kimi-K3": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3"
+          }
+        },
+        "nvidia/nemotron-3-ultra-550b-a55b": {
+          "rates": {
+            "input": "0.6",
+            "output": "3.6",
+            "cacheRead": "0.2"
+          }
+        },
+        "openai/gpt-oss-120b": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.6"
+          }
+        },
+        "openai/gpt-oss-20b": {
+          "rates": {
+            "input": "0.05",
+            "output": "0.2"
+          }
+        },
+        "pearl-ai/gemma-4-31b-it": {
+          "rates": {
+            "input": "0.28",
+            "output": "0.86"
+          }
+        },
+        "thinkingmachines/Inkling": {
+          "rates": {
+            "input": "1",
+            "output": "4.05",
+            "cacheRead": "0.17"
+          }
+        },
+        "zai-org/GLM-5.2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "zai-org/GLM-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "zai-org/GLM-5.3-Flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.5",
+            "cacheRead": "0.03"
+          }
+        }
+      }
+    },
+    "xai": {
+      "models": {
+        "grok-4.20-0309-non-reasoning": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "grok-4.20-0309-reasoning": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "grok-4.20-multi-agent-0309": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "grok-4.3": {
+          "rates": {
+            "input": "1.25",
+            "output": "2.5",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2.5",
+                "output": "5",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "grok-4.5": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.3"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "0.6"
+              }
+            }
+          ]
+        },
+        "grok-4.6": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "grok-build-0.1": {
+          "rates": {
+            "input": "1",
+            "output": "2",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "2",
+                "output": "4",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/hack/agentgateway/config.yaml
+++ b/hack/agentgateway/config.yaml
@@ -1,0 +1,246 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+config:
+  logging:
+    fields:
+      add:
+        llm.prompt: llm.prompt
+        llm.completion: llm.completion
+  database:
+    url: ${AGENTGATEWAY_DATABASE_URL:-postgresql://agentgateway:agentgateway@localhost:5432/agentgateway}
+  storage:
+    mode: ${AGENTGATEWAY_STORAGE_MODE:-file}
+  modelCatalog:
+  - file: ${AGENTGATEWAY_BASE_COSTS:-./base-costs.json}
+  - file: ${AGENTGATEWAY_PI_ALIASES:-./pi-aliases.json}
+  - inline:
+      providers: {}
+gateways:
+  default:
+    port: 4000
+mcp:
+  gateways: default
+  prefixMode: always
+  targets:
+  - name: openai-docs
+    mcp:
+      host: https://developers.openai.com/mcp
+  - name: tavily
+    mcp:
+      host: mcp.tavily.com
+      port: 443
+      path: /mcp/?tavilyApiKey=${TAVILY_API_KEY:-}
+    policies:
+      backendTLS:
+        hostname: mcp.tavily.com
+
+ui:
+  gateways: default
+llm:
+  providers:
+  - name: anthropic
+    provider: anthropic
+    params:
+      apiKey: ${ANTHROPIC_API_KEY:-}
+  - name: openai
+    provider: openai
+    params:
+      apiKey: ${OPENAI_API_KEY:-}
+  - name: gemini
+    provider: gemini
+    params:
+      apiKey: ${GEMINI_API_KEY:-}
+  - name: mistral
+    provider: mistral
+    params:
+      apiKey: ${MISTRAL_API_KEY:-}
+  - name: openrouter
+    provider: openrouter
+    params:
+      apiKey: ${OPENROUTER_API_KEY:-}
+  - name: xai
+    provider: xai
+    params:
+      apiKey: ${XAI_API_KEY:-}
+  - name: ollama
+    provider: ollama
+    params:
+      baseUrl: ${OLLAMA_BASE_URL:-http://localhost:11434/v1}
+  - name: ollama-cloud-1
+    provider: ollama
+    params:
+      baseUrl: https://ollama.com/v1
+      apiKey: ${OLLAMA_API_KEY_1:-}
+  - name: ollama-cloud-2
+    provider: ollama
+    params:
+      baseUrl: https://ollama.com/v1
+      apiKey: ${OLLAMA_API_KEY_2:-}
+  - name: ollama-cloud-3
+    provider: ollama
+    params:
+      baseUrl: https://ollama.com/v1
+      apiKey: ${OLLAMA_API_KEY_3:-}
+  - name: opencode
+    provider:
+      custom:
+        providerOverride: opencode
+        formats:
+        - type: completions
+        - type: messages
+    params:
+      baseUrl: ${OPENCODE_BASE_URL:-https://opencode.ai/zen/go/v1}
+      apiKey: ${OPENCODE_API_KEY:-}
+  models:
+  - name: anthropic/*
+    provider:
+      reference: anthropic
+    transformation:
+      model: llmRequest.model.stripPrefix("anthropic/")
+  - name: openai/*
+    provider:
+      reference: openai
+    transformation:
+      model: llmRequest.model.stripPrefix("openai/")
+  - name: gemini/*
+    provider:
+      reference: gemini
+    transformation:
+      model: llmRequest.model.stripPrefix("gemini/")
+  - name: mistral/*
+    provider:
+      reference: mistral
+    transformation:
+      model: llmRequest.model.stripPrefix("mistral/")
+  - name: openrouter/*
+    provider:
+      reference: openrouter
+    transformation:
+      model: llmRequest.model.stripPrefix("openrouter/")
+  - name: xai/*
+    provider:
+      reference: xai
+    transformation:
+      model: llmRequest.model.stripPrefix("xai/")
+  - name: ollama/*
+    provider:
+      reference: ollama
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama/")
+  - name: ollama1/*
+    provider:
+      reference: ollama-cloud-1
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama1/")
+  - name: ollama2/*
+    provider:
+      reference: ollama-cloud-2
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama2/")
+  - name: ollama3/*
+    provider:
+      reference: ollama-cloud-3
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama3/")
+  - name: ollama-cloud/*
+    provider:
+      reference: ollama-cloud-1
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama-cloud/")
+  - name: opencode/*
+    provider:
+      reference: opencode
+    transformation:
+      model: llmRequest.model.stripPrefix("opencode/")
+  - name: claude-*
+    provider:
+      reference: anthropic
+  - name: gpt-*
+    provider:
+      reference: openai
+  - name: o3*
+    provider:
+      reference: openai
+  - name: gemini-*
+    provider:
+      reference: gemini
+  - name: grok-*
+    provider:
+      reference: xai
+  virtualModels:
+  - name: ollama-deepseek-balanced
+    routing:
+      weighted:
+        targets:
+        - model: ollama1/deepseek-v4-flash:0731-cloud
+          weight: 1
+        - model: ollama2/deepseek-v4-flash:0731-cloud
+          weight: 1
+        - model: ollama3/deepseek-v4-flash:0731-cloud
+          weight: 1
+  - name: ollama-gemma4
+    routing:
+      failover:
+        targets:
+        - model: ollama1/gemma4:cloud
+          priority: 0
+        - model: ollama2/gemma4:cloud
+          priority: 1
+        - model: ollama3/gemma4:cloud
+          priority: 2
+  - name: ollama-glm-flash
+    routing:
+      failover:
+        targets:
+        - model: ollama1/glm-5.3-flash:cloud
+          priority: 0
+        - model: ollama2/glm-5.3-flash:cloud
+          priority: 1
+        - model: ollama3/glm-5.3-flash:cloud
+          priority: 2
+  - name: ollama-minimax
+    routing:
+      failover:
+        targets:
+        - model: ollama1/minimax-m3:cloud
+          priority: 0
+        - model: ollama2/minimax-m3:cloud
+          priority: 1
+        - model: ollama3/minimax-m3:cloud
+          priority: 2
+  - name: ollama-deepseek
+    routing:
+      failover:
+        targets:
+        - model: ollama1/deepseek-v4-flash:0731-cloud
+          priority: 0
+        - model: ollama2/deepseek-v4-flash:0731-cloud
+          priority: 1
+        - model: ollama3/deepseek-v4-flash:0731-cloud
+          priority: 2
+  - name: pi-default
+    routing:
+      failover:
+        targets:
+        - model: anthropic/claude-opus-5
+          priority: 0
+        - model: openai/gpt-5.6
+          priority: 1
+        - model: gemini/gemini-3-pro
+          priority: 2
+  - name: pi-fast
+    routing:
+      failover:
+        targets:
+        - model: ollama1/deepseek-v4-flash:0731-cloud
+          priority: 0
+        - model: openai/gpt-5.6-luna
+          priority: 1
+  policies:
+    apiKey:
+      mode: strict
+      keys:
+      - key: ${AGENTGATEWAY_API_KEY:-agw_sk_CHANGE_ME}
+        metadata:
+          name: pi-go
+          agentgateway.dev/id: 32a5356e-e005-45a1-ade5-d4862546b64c
+          agentgateway.dev/createdAt: 1788259453

--- a/hack/agentgateway/docker-compose.ollama-cloud.yaml
+++ b/hack/agentgateway/docker-compose.ollama-cloud.yaml
@@ -1,0 +1,46 @@
+# The upstream llm-ollama-cloud example: 3 Ollama Cloud instances, each with its
+# own key, plus the Postgres that agentgateway writes request logs to.
+# Superseded for day-to-day use by config.yaml (which exposes ollama-cloud/*),
+# kept because ollama-cloud.yaml and ollama-cloud-k8s.yaml still reference it.
+#
+#   docker compose -f docker-compose.ollama-cloud.yaml up -d
+#
+# UI admin - http://localhost:15000/ui
+# LLM port - http://localhost:4000/ - use as base URL
+services:
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:v1.5.0
+    container_name: agentgateway-ollama-cloud
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    environment:
+      OLLAMA_API_KEY_1: ${OLLAMA_API_KEY_1:-}
+      OLLAMA_API_KEY_2: ${OLLAMA_API_KEY_2:-}
+      OLLAMA_API_KEY_3: ${OLLAMA_API_KEY_3:-}
+      AGENTGATEWAY_DATABASE_URL: postgresql://agentgateway:agentgateway@postgres:5432/agentgateway
+    volumes:
+      - ./ollama-cloud.yaml:/etc/agentgateway/config.yaml:ro
+    command:
+      - -f
+      - /etc/agentgateway/config.yaml
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: agentgateway
+      POSTGRES_USER: agentgateway
+      POSTGRES_PASSWORD: agentgateway
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agentgateway -d agentgateway"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  postgres-data:

--- a/hack/agentgateway/docker-compose.yaml
+++ b/hack/agentgateway/docker-compose.yaml
@@ -1,0 +1,97 @@
+# agentgateway in front of every pi-go provider and the three coding agents,
+# with Postgres behind it for the request log.
+#
+#   cp .env.example .env && $EDITOR .env
+#   docker compose up -d
+#
+# To reuse pi-go's own keys instead of a second copy of them:
+#   docker compose --env-file ../../.pi-go/.env up -d
+#
+# LLM endpoint: http://localhost:4000     UI: http://localhost:4000/ui
+
+services:
+  agentgateway:
+    # Pinned rather than :latest so a config that validates today keeps working.
+    # config.yaml needs >= v1.5.0 (modelCatalog, provider presets).
+    image: ghcr.io/agentgateway/agentgateway:v1.5.0
+    container_name: agentgateway
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    environment:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      MISTRAL_API_KEY: ${MISTRAL_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
+      OPENCODE_API_KEY: ${OPENCODE_API_KEY:-}
+      # MCP: Tavily's remote server takes its key in the URL query.
+      TAVILY_API_KEY: ${TAVILY_API_KEY:-}
+      OLLAMA_API_KEY_1: ${OLLAMA_API_KEY_1:-}
+      OLLAMA_API_KEY_2: ${OLLAMA_API_KEY_2:-}
+      OLLAMA_API_KEY_3: ${OLLAMA_API_KEY_3:-}
+      # localhost inside a container is the container, so reach the host's
+      # Ollama explicitly. Linux needs the extra_hosts entry below.
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434/v1}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_RESOURCE_NAME: ${AZURE_OPENAI_RESOURCE_NAME:-}
+      AZURE_OPENAI_API_VERSION: ${AZURE_OPENAI_API_VERSION:-2024-10-21}
+      # The config default points at localhost, which is right for run.sh but
+      # wrong in a container: here Postgres is a sibling service.
+      AGENTGATEWAY_DATABASE_URL: postgresql://agentgateway:agentgateway@postgres:5432/agentgateway
+      AGENTGATEWAY_STORAGE_MODE: ${AGENTGATEWAY_STORAGE_MODE:-file}
+      # Required, and deliberately has no default. config.yaml uses the bare
+      # ${AGENTGATEWAY_API_KEY} for llm.policies.apiKey, so an empty value would
+      # register an empty key that strict mode then accepts. `:?` makes compose
+      # refuse to start with a readable message instead of crash-looping the
+      # container on "error looking key 'AGENTGATEWAY_API_KEY' up".
+      AGENTGATEWAY_API_KEY: ${AGENTGATEWAY_API_KEY:?set AGENTGATEWAY_API_KEY in your env file (see .env.example)}
+      # Catalog paths, resolved against working_dir inside the container.
+      AGENTGATEWAY_BASE_COSTS: ${AGENTGATEWAY_BASE_COSTS:-./base-costs.json}
+      AGENTGATEWAY_PI_ALIASES: ${AGENTGATEWAY_PI_ALIASES:-./pi-aliases.json}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      # Deliberately NOT :ro — with storage.mode=file the UI saves config
+      # changes by rewriting this file, and a read-only mount makes every save
+      # fail. The container runs as uid 65532, so on Linux the file must be
+      # group/other writable (chmod 666 config.yaml) for a save to land;
+      # Docker Desktop and OrbStack on macOS map the owner and need nothing.
+      # Set AGENTGATEWAY_STORAGE_MODE=readOnly and restore :ro to lock it down.
+      - ./config.yaml:/etc/agentgateway/config.yaml
+      # Also NOT :ro. POST /api/costs/refresh-base (the UI's "refresh costs"
+      # action) rewrites this file from models.dev, then hot-reloads it.
+      # A read-only mount makes that fail with a permission error.
+      - ./base-costs.json:/etc/agentgateway/base-costs.json
+      # Hand-maintained aliases, layered after base-costs.json so a refresh
+      # cannot wipe them. Read-only: nothing in the gateway writes this.
+      - ./pi-aliases.json:/etc/agentgateway/pi-aliases.json:ro
+    working_dir: /etc/agentgateway
+    command: ["-f", "/etc/agentgateway/config.yaml"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17
+    container_name: agentgateway-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: agentgateway
+      POSTGRES_USER: agentgateway
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-agentgateway}
+    # Not published by default: the gateway reaches it over the compose network.
+    # Uncomment to inspect it with psql from the host.
+    # ports:
+    #   - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agentgateway -d agentgateway"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  postgres-data:

--- a/hack/agentgateway/migrate-sessions.py
+++ b/hack/agentgateway/migrate-sessions.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Import pi-go session history into agentgateway's request_logs table.
+
+pi-go writes one directory per session under ~/.pi-go/sessions/. Sessions that
+ran before pi-go pointed at the gateway never reached agentgateway, so its
+analytics start the day the gateway did. This replays those sessions into the
+request log so the dashboard covers the whole history.
+
+Each assistant turn in events.jsonl carries a usageMetadata block:
+
+    {"usageMetadata": {"promptTokenCount": 17252, "candidatesTokenCount": 39},
+     "timestamp": "...", "id": "4002169e-...", "content": {...}}
+
+which maps onto one request_logs row. Cost is *reconstructed* from today's
+catalog rates, not recovered — rates change, so treat it as an estimate. Every
+imported row carries attributes_json.agw.backfill = "pi-go-sessions" so it can
+be told apart from live traffic, and deleted again:
+
+    DELETE FROM request_logs WHERE attributes_json->>'agw.backfill' = 'pi-go-sessions';
+
+Usage:
+    ./migrate-sessions.py                      # dry run: report, write nothing
+    ./migrate-sessions.py --since 2026-08-01   # limit by session start date
+    ./migrate-sessions.py --out load.sql       # emit SQL
+    ./migrate-sessions.py --out load.sql --apply   # emit and load via docker compose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SESSIONS = Path(os.environ.get("PI_GO_SESSIONS", Path.home() / ".pi-go" / "sessions"))
+CATALOGS = [HERE / "base-costs.json", HERE / "pi-aliases.json"]
+MARKER = "pi-go-sessions"
+
+# agentgateway's cost catalog keys Google and AWS under their cloud names, while
+# pi-go calls them "gemini" and "bedrock". Look costs up under the catalog's
+# spelling or every Gemini row silently prices at zero.
+CATALOG_PROVIDER = {
+    "gemini": "gcp.gemini",
+    "vertex": "gcp.vertex_ai",
+    "bedrock": "aws.bedrock",
+}
+
+# Sessions whose provider is already the gateway are in request_logs already;
+# importing them would double-count.
+SKIP_PROVIDERS = {"agentgateway"}
+
+# A turn that takes longer than this is a stalled session, not a slow model.
+MAX_DURATION_MS = 10 * 60 * 1000
+
+
+# --- model / provider normalisation ---------------------------------------
+
+# pi-go has spelled the same Ollama Cloud model several ways over time. The
+# catalog matches ids exactly, so collapse them or the cost lookup misses and
+# the dashboard splits one model into several rows.
+MODEL_ALIASES = {
+    "deepseek-v4-flash:0731:cloud": "deepseek-v4-flash:0731-cloud",
+    "deepseek-v4-pro:0813:cloud": "deepseek-v4-pro:0813-cloud",
+}
+
+_PREFIX_PROVIDER = (
+    ("claude", "anthropic"),
+    ("gpt-oss", "ollama"),  # before the gpt- rule: gpt-oss is an Ollama model
+    ("gpt", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("o4", "openai"),
+    ("gemini", "gemini"),
+    ("gemma", "ollama"),
+    ("mistral", "mistral"),
+    ("magistral", "mistral"),
+    ("ministral", "mistral"),
+    ("codestral", "mistral"),
+    ("grok", "xai"),
+    ("glm", "ollama"),
+    ("deepseek", "ollama"),
+    ("minimax", "ollama"),
+    ("qwen", "ollama"),
+    ("kimi", "ollama"),
+    ("nemotron", "ollama"),
+    ("zai-", "mistral"),
+)
+
+
+def normalise_model(model: str) -> str:
+    model = (model or "").strip()
+    return MODEL_ALIASES.get(model, model)
+
+
+def infer_provider(model: str, declared: str | None) -> str:
+    """Trust meta.json when it names a provider; otherwise read it off the model.
+
+    4,285 of ~4,980 sessions predate the provider field, so inference is the
+    common path, not the fallback.
+    """
+    if declared and declared not in ("", "?"):
+        return declared
+    m = (model or "").lower()
+    if not m:
+        return "unknown"
+    # An OpenRouter id is the only one with a vendor prefix: "vendor/model".
+    if "/" in m:
+        return "openrouter"
+    if m.endswith(":cloud") or m.endswith("-cloud") or ":cloud" in m or "-cloud" in m:
+        return "ollama"
+    for prefix, provider in _PREFIX_PROVIDER:
+        if m.startswith(prefix):
+            return provider
+    return "unknown"
+
+
+# --- cost ------------------------------------------------------------------
+
+
+def load_catalog() -> dict[tuple[str, str], dict]:
+    """Merge the catalog files the gateway itself reads, later file winning."""
+    rates: dict[tuple[str, str], dict] = {}
+    for path in CATALOGS:
+        if not path.exists():
+            continue
+        doc = json.loads(path.read_text())
+        for provider, pdata in doc.get("providers", {}).items():
+            for model, mdata in pdata.get("models", {}).items():
+                r = mdata.get("rates") or {}
+                if r:
+                    rates[(provider, model)] = r
+    return rates
+
+
+def cost_for(rates, provider: str, model: str, tin: int, tout: int):
+    """Return (cost, matched) — matched is False when the model has no rates."""
+    provider = CATALOG_PROVIDER.get(provider, provider)
+    r = rates.get((provider, model))
+    if r is None and model.endswith("-cloud"):
+        r = rates.get((provider, model[: -len("-cloud")]))
+    if r is None and model.endswith(":cloud"):
+        r = rates.get((provider, model[: -len(":cloud")]))
+    if r is None:
+        return 0.0, False
+    c = tin * float(r.get("input", 0)) / 1e6 + tout * float(r.get("output", 0)) / 1e6
+    return c, True
+
+
+# --- extraction ------------------------------------------------------------
+
+
+def parse_ts(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def iter_turns(session_dir: Path):
+    """Yield (event_id, completed_at, prev_ts, input_tokens, output_tokens).
+
+    Only events carrying token usage become rows; user messages and tool events
+    are not billable and have no place in a request log.
+    """
+    events = session_dir / "events.jsonl"
+    if not events.exists():
+        return
+    prev_ts = None
+    with events.open(errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = parse_ts(e.get("timestamp"))
+            usage = e.get("usageMetadata")
+            if isinstance(usage, dict):
+                tin = usage.get("promptTokenCount") or 0
+                tout = usage.get("candidatesTokenCount") or 0
+                if (tin or tout) and ts is not None:
+                    yield (e.get("id"), ts, prev_ts, int(tin), int(tout))
+            if ts is not None:
+                prev_ts = ts
+
+
+def sql_str(value) -> str:
+    if value is None:
+        return "NULL"
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--since", help="only sessions created on/after this date (YYYY-MM-DD)")
+    ap.add_argument("--out", help="write SQL here (default: dry run, no output)")
+    ap.add_argument("--apply", action="store_true", help="load --out via docker compose exec postgres")
+    ap.add_argument("--env-file", default="../../.pi-go/.env", help="compose --env-file used by --apply")
+    ap.add_argument("--batch", type=int, default=500, help="rows per INSERT statement")
+    args = ap.parse_args()
+
+    if args.apply and not args.out:
+        ap.error("--apply requires --out")
+
+    since = None
+    if args.since:
+        since = datetime.strptime(args.since, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    if not SESSIONS.is_dir():
+        print(f"no session directory at {SESSIONS}", file=sys.stderr)
+        return 1
+
+    rates = load_catalog()
+    print(f"catalog: {len(rates)} priced models from {', '.join(p.name for p in CATALOGS if p.exists())}")
+
+    rows = []
+    stats = Counter()
+    per_model = Counter()
+    tokens_in = Counter()
+    tokens_out = Counter()
+    cost_by_model = Counter()
+    unpriced = Counter()
+    seen_ids: set[str] = set()
+
+    for entry in sorted(SESSIONS.iterdir()):
+        if not entry.is_dir():
+            continue
+        meta_path = entry / "meta.json"
+        if not meta_path.exists():
+            stats["sessions_no_meta"] += 1
+            continue
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            stats["sessions_unreadable"] += 1
+            continue
+
+        created = parse_ts(meta.get("createdAt"))
+        if since and created and created < since:
+            stats["sessions_before_since"] += 1
+            continue
+
+        declared = meta.get("provider")
+        if declared in SKIP_PROVIDERS:
+            stats["sessions_already_via_gateway"] += 1
+            continue
+
+        model = normalise_model(meta.get("model") or "")
+        provider = infer_provider(model, declared)
+        if provider == "unknown":
+            stats["sessions_unknown_provider"] += 1
+        stats["sessions_scanned"] += 1
+
+        session_rows = 0
+        for event_id, ts, prev_ts, tin, tout in iter_turns(entry):
+            # The event id is the dedupe key; a re-run must not double-insert.
+            rid = f"pigo-{event_id}" if event_id else f"pigo-{entry.name}-{session_rows}"
+            if rid in seen_ids:
+                stats["turns_duplicate_id"] += 1
+                continue
+            seen_ids.add(rid)
+
+            duration_ms = 0
+            if prev_ts is not None:
+                duration_ms = int((ts - prev_ts).total_seconds() * 1000)
+                duration_ms = max(0, min(duration_ms, MAX_DURATION_MS))
+            started = ts - timedelta(milliseconds=duration_ms)
+
+            cost, matched = cost_for(rates, provider, model, tin, tout)
+            if not matched:
+                unpriced[f"{provider}/{model}"] += 1
+
+            attrs = {
+                "agw.backfill": MARKER,
+                "pi.session_id": meta.get("id") or entry.name,
+                "pi.title": meta.get("title"),
+                "pi.work_dir": meta.get("workDir"),
+                "gen_ai.provider.name": provider,
+                "gen_ai.request.model": model,
+                "gen_ai.usage.input_tokens": tin,
+                "gen_ai.usage.output_tokens": tout,
+                "agw.ai.usage.cost.total": cost,
+                "agw.cost_basis": "reconstructed-from-current-catalog" if matched else "no-rates",
+            }
+            rows.append(
+                "("
+                + ", ".join(
+                    [
+                        sql_str(rid),
+                        sql_str(started.isoformat()),
+                        sql_str(ts.isoformat()),
+                        str(duration_ms),
+                        "200",
+                        sql_str("chat"),
+                        sql_str(provider),
+                        sql_str(model),
+                        sql_str(model),
+                        str(tin),
+                        str(tout),
+                        str(tin + tout),
+                        repr(cost),
+                        sql_str("pi-go"),
+                        "false",
+                        sql_str(json.dumps(attrs)) + "::jsonb",
+                    ]
+                )
+                + ")"
+            )
+            session_rows += 1
+            stats["turns"] += 1
+            per_model[f"{provider}/{model}"] += 1
+            tokens_in[f"{provider}/{model}"] += tin
+            tokens_out[f"{provider}/{model}"] += tout
+            cost_by_model[f"{provider}/{model}"] += cost
+
+        if session_rows:
+            stats["sessions_with_turns"] += 1
+
+    # --- report ---
+    print()
+    for key in (
+        "sessions_scanned",
+        "sessions_with_turns",
+        "sessions_already_via_gateway",
+        "sessions_before_since",
+        "sessions_unknown_provider",
+        "sessions_no_meta",
+        "sessions_unreadable",
+        "turns",
+        "turns_duplicate_id",
+    ):
+        if stats[key]:
+            print(f"  {key:32} {stats[key]:,}")
+
+    print(f"\n  {'model':40} {'rows':>7} {'in':>15} {'out':>10} {'cost':>10}")
+    for name, n in per_model.most_common(20):
+        print(f"  {name:40} {n:>7,} {tokens_in[name]:>15,} {tokens_out[name]:>10,} {cost_by_model[name]:>10.4f}")
+
+    print(f"\n  TOTAL rows={stats['turns']:,} in={sum(tokens_in.values()):,} "
+          f"out={sum(tokens_out.values()):,} cost=${sum(cost_by_model.values()):.4f}")
+    if unpriced:
+        print(f"\n  unpriced (cost recorded as 0) — add rates to pi-aliases.json to fix:")
+        for name, n in unpriced.most_common(10):
+            print(f"    {name:44} {n:,} turns")
+
+    if not args.out:
+        print("\ndry run — nothing written. Re-run with --out FILE [--apply] to load.")
+        return 0
+
+    cols = (
+        "id, started_at, completed_at, duration_ms, http_status, gen_ai_operation_name, "
+        "gen_ai_provider_name, gen_ai_request_model, gen_ai_response_model, "
+        "input_tokens, output_tokens, total_tokens, cost, user_agent_name, has_payload, attributes_json"
+    )
+    out = Path(args.out)
+    with out.open("w") as fh:
+        fh.write("BEGIN;\n")
+        for i in range(0, len(rows), args.batch):
+            chunk = rows[i : i + args.batch]
+            fh.write(f"INSERT INTO request_logs ({cols}) VALUES\n")
+            fh.write(",\n".join(chunk))
+            fh.write("\nON CONFLICT (id) DO NOTHING;\n")
+        fh.write("COMMIT;\n")
+    print(f"\nwrote {len(rows):,} rows to {out} ({out.stat().st_size/1e6:.1f} MB)")
+
+    if not args.apply:
+        print("re-run with --apply to load it, or pipe it into psql yourself.")
+        return 0
+
+    cmd = [
+        "docker", "compose", "--env-file", args.env_file,
+        "exec", "-T", "postgres",
+        "psql", "-U", "agentgateway", "-d", "agentgateway", "-v", "ON_ERROR_STOP=1", "-q",
+    ]
+    print(f"loading via: {' '.join(cmd)}")
+    with out.open("rb") as fh:
+        proc = subprocess.run(cmd, stdin=fh, cwd=HERE)
+    if proc.returncode != 0:
+        print("load failed", file=sys.stderr)
+        return proc.returncode
+    print("loaded.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hack/agentgateway/ollama-cloud-k8s.yaml
+++ b/hack/agentgateway/ollama-cloud-k8s.yaml
@@ -1,0 +1,176 @@
+---
+# 3 Ollama Cloud API keys — one per instance.
+# Replace the placeholders with real keys from https://ollama.com/settings/keys
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ollama-cloud-key-1
+  namespace: default
+stringData:
+  Authorization: ollama_key_1_placeholder
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ollama-cloud-key-2
+  namespace: default
+stringData:
+  Authorization: ollama_key_2_placeholder
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ollama-cloud-key-3
+  namespace: default
+stringData:
+  Authorization: ollama_key_3_placeholder
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ollama-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: llm
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: ollama-cloud-1
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ollama-gw
+    sectionName: llm
+  match:
+    model: ollama1/*
+  provider: Ollama
+  baseURL: https://ollama.com/v1
+  policies:
+    auth:
+      secretRef:
+        name: ollama-cloud-key-1
+        key: Authorization
+    transformations:
+    - field: model
+      expression: 'llmRequest.model.stripPrefix("ollama1/")'
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: ollama-cloud-2
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ollama-gw
+    sectionName: llm
+  match:
+    model: ollama2/*
+  provider: Ollama
+  baseURL: https://ollama.com/v1
+  policies:
+    auth:
+      secretRef:
+        name: ollama-cloud-key-2
+        key: Authorization
+    transformations:
+    - field: model
+      expression: 'llmRequest.model.stripPrefix("ollama2/")'
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: ollama-cloud-3
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ollama-gw
+    sectionName: llm
+  match:
+    model: ollama3/*
+  provider: Ollama
+  baseURL: https://ollama.com/v1
+  policies:
+    auth:
+      secretRef:
+        name: ollama-cloud-key-3
+        key: Authorization
+    transformations:
+    - field: model
+      expression: 'llmRequest.model.stripPrefix("ollama3/")'
+---
+# Virtual Model: Load-balances requests evenly across all 3 Ollama Cloud instances
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: ollama-balanced
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ollama-gw
+    sectionName: llm
+  virtualModel:
+    weighted:
+      targets:
+      - modelRef:
+          name: ollama-cloud-1
+        model: ollama1/deepseek-v4-flash:0731-cloud
+        weight: 1
+      - modelRef:
+          name: ollama-cloud-2
+        model: ollama2/deepseek-v4-flash:0731-cloud
+        weight: 1
+      - modelRef:
+          name: ollama-cloud-3
+        model: ollama3/deepseek-v4-flash:0731-cloud
+        weight: 1
+---
+# Virtual Model: Priority failover routing across Ollama Cloud instances
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: ollama-resilient
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ollama-gw
+    sectionName: llm
+  virtualModel:
+    failover:
+      targets:
+      - modelRef:
+          name: ollama-cloud-1
+        model: ollama1/deepseek-v4-flash:0731-cloud
+        priority: 0
+      - modelRef:
+          name: ollama-cloud-2
+        model: ollama2/deepseek-v4-flash:0731-cloud
+        priority: 1
+      - modelRef:
+          name: ollama-cloud-3
+        model: ollama3/deepseek-v4-flash:0731-cloud
+        priority: 2
+
+

--- a/hack/agentgateway/ollama-cloud.yaml
+++ b/hack/agentgateway/ollama-cloud.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+config:
+  database:
+    url: ${AGENTGATEWAY_DATABASE_URL:-postgresql://agentgateway:agentgateway@localhost:5432/agentgateway}
+gateways:
+  default:
+    port: 4000
+ui:
+  gateways: default
+llm:
+  providers:
+  - name: ollama-1
+    provider: ollama
+    params:
+      baseUrl: https://ollama.com/v1
+      apiKey: ${OLLAMA_API_KEY_1:-}
+  - name: ollama-2
+    provider: ollama
+    params:
+      baseUrl: https://ollama.com/v1
+      apiKey: ${OLLAMA_API_KEY_2:-}
+  - name: ollama-3
+    provider: ollama
+    params:
+      baseUrl: https://ollama.com/v1
+      apiKey: ${OLLAMA_API_KEY_3:-}
+  models:
+  - name: ollama1/*
+    provider:
+      reference: ollama-1
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama1/")
+  - name: ollama2/*
+    provider:
+      reference: ollama-2
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama2/")
+  - name: ollama3/*
+    provider:
+      reference: ollama-3
+    transformation:
+      model: llmRequest.model.stripPrefix("ollama3/")
+  virtualModels:
+  - name: ollama
+    routing:
+      failover:
+        targets:
+        - model: ollama1/deepseek-v4-flash:0731-cloud
+          priority: 0
+        - model: ollama2/deepseek-v4-flash:0731-cloud
+          priority: 1
+        - model: ollama3/deepseek-v4-flash:0731-cloud
+          priority: 2
+  policies:
+    apiKey:
+      mode: strict
+      keys:
+      - key: ${AGENTGATEWAY_API_KEY:-agw_sk_CHANGE_ME}
+        metadata:
+          name: pi-go
+          agentgateway.dev/id: bf981e0f-2d7c-4945-9b22-bb13ff04dbba
+          agentgateway.dev/createdAt: 1788257821

--- a/hack/agentgateway/pi-aliases.json
+++ b/hack/agentgateway/pi-aliases.json
@@ -1,0 +1,461 @@
+{
+  "providers": {
+    "anthropic": {
+      "models": {
+        "claude-3-haiku": {
+          "rates": {
+            "input": "0.25",
+            "output": "1.25",
+            "cacheRead": "0.025",
+            "cacheWrite": "0.3125"
+          }
+        },
+        "claude-3-opus": {
+          "rates": {
+            "input": "15",
+            "output": "75",
+            "cacheRead": "1.5",
+            "cacheWrite": "18.75"
+          }
+        },
+        "claude-3.5-haiku": {
+          "rates": {
+            "input": "0.8",
+            "output": "4",
+            "cacheRead": "0.08",
+            "cacheWrite": "1"
+          }
+        },
+        "claude-3.5-sonnet": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-3.7-sonnet": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-4.5-haiku": {
+          "rates": {
+            "input": "1",
+            "output": "5",
+            "cacheRead": "0.1",
+            "cacheWrite": "1.25"
+          }
+        },
+        "claude-mythos-5": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-opus-4": {
+          "rates": {
+            "input": "15",
+            "output": "75",
+            "cacheRead": "1.5",
+            "cacheWrite": "18.75"
+          }
+        },
+        "claude-opus-4-1": {
+          "rates": {
+            "input": "15",
+            "output": "75",
+            "cacheRead": "1.5",
+            "cacheWrite": "18.75"
+          }
+        },
+        "claude-sonnet-4.5": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3",
+            "cacheWrite": "3.75"
+          }
+        },
+        "claude-sonnet-4.5-200k": {
+          "rates": {
+            "input": "6",
+            "output": "22.5",
+            "cacheRead": "0.6",
+            "cacheWrite": "7.5"
+          }
+        }
+      }
+    },
+    "openai": {
+      "models": {
+        "chatgpt-4o-latest": {
+          "rates": {
+            "input": "5",
+            "output": "15"
+          }
+        },
+        "gpt-4.1-nano": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.4",
+            "cacheRead": "0.025"
+          }
+        },
+        "gpt-4.5": {
+          "rates": {
+            "input": "75",
+            "output": "150",
+            "cacheRead": "37.5"
+          }
+        },
+        "gpt-5.1-codex": {
+          "rates": {
+            "input": "1.25",
+            "output": "10",
+            "cacheRead": "0.125"
+          }
+        },
+        "gpt-5.1-codex-mini": {
+          "rates": {
+            "input": "0.25",
+            "output": "2",
+            "cacheRead": "0.025"
+          }
+        },
+        "gpt-5.4-272k": {
+          "rates": {
+            "input": "5",
+            "output": "22.5",
+            "cacheRead": "0.5"
+          }
+        },
+        "gpt-5.4-pro-272k": {
+          "rates": {
+            "input": "60",
+            "output": "270"
+          }
+        },
+        "gpt-5.5-272k": {
+          "rates": {
+            "input": "10",
+            "output": "45",
+            "cacheRead": "1"
+          }
+        },
+        "gpt-image-1": {
+          "rates": {
+            "input": "10",
+            "output": "40",
+            "cacheRead": "1.25"
+          }
+        },
+        "gpt-image-1-mini": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.2"
+          }
+        },
+        "gpt-image-2-image": {
+          "rates": {
+            "input": "8",
+            "output": "30",
+            "cacheRead": "2"
+          }
+        },
+        "gpt-image-2-text": {
+          "rates": {
+            "input": "5",
+            "output": "10",
+            "cacheRead": "1.25"
+          }
+        },
+        "o1-mini": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.55"
+          }
+        },
+        "o1-preview": {
+          "rates": {
+            "input": "15",
+            "output": "60",
+            "cacheRead": "7.5"
+          }
+        },
+        "o1-pro": {
+          "rates": {
+            "input": "150",
+            "output": "600"
+          }
+        },
+        "o3-deep-research": {
+          "rates": {
+            "input": "10",
+            "output": "40",
+            "cacheRead": "2.5"
+          }
+        },
+        "o3-mini": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.55"
+          }
+        },
+        "o4-mini": {
+          "rates": {
+            "input": "1.1",
+            "output": "4.4",
+            "cacheRead": "0.275"
+          }
+        },
+        "o4-mini-deep-research": {
+          "rates": {
+            "input": "2",
+            "output": "8",
+            "cacheRead": "0.5"
+          }
+        },
+        "text-davinci-003": {
+          "rates": {
+            "input": "20",
+            "output": "20"
+          }
+        }
+      }
+    },
+    "ollama": {
+      "models": {
+        "deepseek-v4-flash:0731": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek-v4-flash:0731-cloud": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek-v4-pro:0813": {
+          "rates": {
+            "input": "0.66",
+            "output": "1.98",
+            "cacheRead": "0.022"
+          }
+        },
+        "deepseek-v4-pro:0813-cloud": {
+          "rates": {
+            "input": "0.66",
+            "output": "1.98",
+            "cacheRead": "0.022"
+          }
+        },
+        "gemma4:31b": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.34",
+            "cacheRead": "0.05"
+          }
+        },
+        "gemma4:cloud": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.34",
+            "cacheRead": "0.05"
+          }
+        },
+        "glm-5.1": {
+          "rates": {
+            "input": "0.966",
+            "output": "3.036",
+            "cacheRead": "0.1794"
+          }
+        },
+        "glm-5.1:cloud": {
+          "rates": {
+            "input": "0.966",
+            "output": "3.036",
+            "cacheRead": "0.1794"
+          }
+        },
+        "glm-5.2": {
+          "rates": {
+            "input": "1.19",
+            "output": "3.74",
+            "cacheRead": "0.221"
+          }
+        },
+        "glm-5.2:cloud": {
+          "rates": {
+            "input": "1.19",
+            "output": "3.74",
+            "cacheRead": "0.221"
+          }
+        },
+        "glm-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.3-flash": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
+        "glm-5.3-flash:cloud": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
+        "glm-5.3:cloud": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "minimax-m3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "minimax-m3:cloud": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        }
+      }
+    },
+    "openrouter": {
+      "models": {
+        "deepseek/deepseek-v3.2": {
+          "rates": {
+            "input": "0.269",
+            "output": "0.4",
+            "cacheRead": "0.1345"
+          }
+        },
+        "deepseek/deepseek-v4-flash": {
+          "rates": {
+            "input": "0.08092",
+            "output": "0.16184",
+            "cacheRead": "0.016184"
+          }
+        },
+        "deepseek/deepseek-v4-flash-0731": {
+          "rates": {
+            "input": "0.065",
+            "output": "0.18",
+            "cacheRead": "0.016"
+          }
+        },
+        "deepseek/deepseek-v4-pro": {
+          "rates": {
+            "input": "1.6",
+            "output": "3.2",
+            "cacheRead": "0.135"
+          }
+        },
+        "deepseek/deepseek-v4-pro-0813": {
+          "rates": {
+            "input": "0.66",
+            "output": "1.98",
+            "cacheRead": "0.022"
+          }
+        },
+        "google/gemma-4-31b-it": {
+          "rates": {
+            "input": "0.09",
+            "output": "0.34",
+            "cacheRead": "0.05"
+          }
+        },
+        "minimax/minimax-m2.7": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "minimax/minimax-m3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "z-ai/glm-4.6": {
+          "rates": {
+            "input": "0.43",
+            "output": "1.75",
+            "cacheRead": "0.08"
+          }
+        },
+        "z-ai/glm-4.7": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.75",
+            "cacheRead": "0.08"
+          }
+        },
+        "z-ai/glm-5": {
+          "rates": {
+            "input": "0.6",
+            "output": "1.92",
+            "cacheRead": "0.12"
+          }
+        },
+        "z-ai/glm-5.1": {
+          "rates": {
+            "input": "0.966",
+            "output": "3.036",
+            "cacheRead": "0.1794"
+          }
+        },
+        "z-ai/glm-5.2": {
+          "rates": {
+            "input": "1.19",
+            "output": "3.74",
+            "cacheRead": "0.221"
+          }
+        },
+        "z-ai/glm-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "z-ai/glm-5.3-flash": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        }
+      }
+    }
+  }
+}

--- a/hack/agentgateway/run.sh
+++ b/hack/agentgateway/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run agentgateway from a local binary against config.yaml.
+#
+#   ./run.sh                       # uses ./config.yaml
+#   ./run.sh ollama-cloud.yaml     # or any other config in this directory
+#
+# Keys come from the environment. To reuse pi-go's:
+#   set -a; . ../../.pi-go/.env; set +a; ./run.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="${SCRIPT_DIR}/${1:-config.yaml}"
+[[ $# -gt 0 ]] && shift
+
+# Prefer an explicit override, then a cargo build in the agentgateway checkout,
+# then whatever is on PATH.
+BINARY="${AGENTGATEWAY_BIN:-}"
+if [[ -z "${BINARY}" ]]; then
+  REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+  for candidate in "${REPO_ROOT}/tmp/agentgateway/target/release/agentgateway" "$(command -v agentgateway || true)"; do
+    if [[ -n "${candidate}" && -x "${candidate}" ]]; then BINARY="${candidate}"; break; fi
+  done
+fi
+
+if [[ -z "${BINARY}" ]]; then
+  echo "agentgateway binary not found." >&2
+  echo "Install it, set AGENTGATEWAY_BIN, or build it:" >&2
+  echo "  cargo build --release -p agentgateway-app   # in tmp/agentgateway" >&2
+  echo "Or skip the binary entirely: docker compose up -d" >&2
+  exit 1
+fi
+
+# config.yaml resolves ./base-costs.json relative to the working directory.
+cd "${SCRIPT_DIR}"
+echo "agentgateway $("${BINARY}" -V 2>/dev/null || echo '?') -f ${CONFIG}" >&2
+exec "${BINARY}" -f "${CONFIG}" "$@"


### PR DESCRIPTION
One agentgateway in front of every provider pi-go can talk to, plus the
coding agents that speak a native provider API (Claude Code, Codex,
Antigravity). Includes config.yaml, docker-compose, run.sh, cost overlay,
and a migrate-sessions.py that replays pre-gateway pi-go session history
into the request log.

Signed-off-by: dimetron <dimetron@me.com>
