### PR TITLE
fix(ci): repin docker setup-qemu/buildx to SHAs that exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@53851d14592ddc461f34820568d9eb1614a2d1a6 # v3.7.1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce097002bb # v3.15.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.5.0


### PR DESCRIPTION
## Problem

The `Release` workflow's **Docker image** job on tag `v0.0.89` ([run 33509515343](https://github.com/dimetron/pi-go/actions/runs/33509515343/job/99862739976)) failed before executing a single step:

```
Unable to resolve action `docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce097002bb`,
unable to find version `f95db51fddba0c2d1ec667646a06c2ce097002bb`.
Unable to resolve action `docker/setup-qemu-action@53851d14592ddc461f34820568d9eb1614a2d1a6`,
unable to find version `53851d14592ddc461f34820568d9eb1614a2d1a6`.
```

Both pins were fictional:

- The qemu SHA is a mangled v3.3.0 — real `53851d14592bedcffcf25ea515637cff71ef929a`, pinned as `53851d14592ddc461f34820568d9eb1614a2d1a6` (same 11-char prefix, different tail), labelled `v3.7.1`.
- The buildx comment claimed `v3.15.0`, a tag that has never been cut; the highest `v3` release is `v3.12.0`.

Because action resolution happens during workflow setup, the job never started, and `kagent manifest` was skipped. `Lint`, `Test` and `GoReleaser` all passed.

## Fix

Repin both to the current head of the `v3` line, preserving the major version the comments intended:

| Action | Was | Now |
|---|---|---|
| `docker/setup-qemu-action` | `53851d1` (claimed v3.7.1, nonexistent) | `c7c5346` — v3.7.0 |
| `docker/setup-buildx-action` | `f95db51` (claimed v3.15.0, nonexistent) | `8d2750c` — v3.12.0 |

## Verification

Every pinned SHA across `.github/workflows/` was resolved against the GitHub API; all 14 now return a commit:

```
OK actions-rust-lang/setup-rust-toolchain@166cdcf   OK docker/build-push-action@4a13e50
OK actions/attest-build-provenance@4d10147          OK docker/login-action@74a5d14
OK actions/attest-sbom@c604332                      OK docker/setup-buildx-action@8d2750c
OK actions/checkout@3d3c42e                         OK docker/setup-qemu-action@c7c5346
OK actions/setup-go@b7ad1da                         OK golangci/golangci-lint-action@ba0d7d2
OK anchore/sbom-action/download-syft@e22c389        OK goreleaser/goreleaser-action@f06c13b
OK astral-sh/setup-uv@20cfd1b
OK codecov/codecov-action@fb8b358
```

Lint and formatting ran clean via the pre-commit hook.

## Follow-up

`v0.0.89` was cut from the broken workflow file, so the release image was never pushed. After this merges, the tag needs to be re-pointed at the fixed commit (or a new patch tag cut) to get a green `Docker image` + `kagent manifest` run.