### PR TITLE
fix(subagent): forward agentgateway credentials to subagents

### DIFF
--- a/internal/subagent/environ.go
+++ b/internal/subagent/environ.go
@@ -52,6 +52,8 @@ var DefaultEnvAllowlist = []string{
 	"GEMINI_API_KEY",
 	"GOOGLE_API_KEY", // legacy fallback
 	"GEMINI_BASE_URL",
+	"AGENTGATEWAY_API_KEY",
+	"AGENTGATEWAY_BASE_URL",
 	"OLLAMA_HOST", // Ollama server address override.
 	"CODEX_HOME",  // Codex CLI config/state dir — its auth lives here.
 

--- a/internal/subagent/environ_test.go
+++ b/internal/subagent/environ_test.go
@@ -111,6 +111,18 @@ func TestDefaultEnvAllowlist(t *testing.T) {
 		}
 	})
 
+	t.Run("contains agentgateway credentials for subagent processes", func(t *testing.T) {
+		// Subagents are themselves pi processes; when the parent is pointed at a
+		// local agentgateway they must inherit the gateway key and base URL or the
+		// child starts up unauthenticated and cannot reach the gateway.
+		required := []string{"AGENTGATEWAY_API_KEY", "AGENTGATEWAY_BASE_URL"}
+		for _, req := range required {
+			if !slices.Contains(DefaultEnvAllowlist, req) {
+				t.Errorf("DefaultEnvAllowlist missing agentgateway credential %q", req)
+			}
+		}
+	})
+
 	t.Run("contains CODEX_HOME for codex subagents", func(t *testing.T) {
 		// codex app-server reads its config and login state from CODEX_HOME;
 		// without it a codex subagent starts up unauthenticated.


### PR DESCRIPTION
Subagents are themselves pi processes. When the parent is pointed at a local
agentgateway, FilterEnv's DefaultEnvAllowlist dropped AGENTGATEWAY_API_KEY
from the child env, so the child started up unauthenticated and could not
reach the gateway. Add AGENTGATEWAY_API_KEY and AGENTGATEWAY_BASE_URL,
matching the existing GEMINI_API_KEY/GEMINI_BASE_URL pattern.

Signed-off-by: dimetron <dimetron@me.com>
