### PR TITLE
fix(cli): resume virtual models via recorded provider

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -302,11 +302,13 @@ func resolveRuntimeModel(cfg config.Config, modelName, providerName string) (pro
 
 func resolveRuntimeModelForRole(cfg config.Config, modelName, providerName, activeRole string) (provider.Info, string, error) {
 	baseURL := flagURL
+	resumedProvider := ""
 	if baseURL == "" && flagSession != "" && flagModel == "" && activeRole == "default" {
 		if dir, err := sessionsDir(); err == nil {
-			if resumedProvider, resumedURL, ok := pisession.SessionBackend(dir, flagSession); ok {
-				if resumedProvider != "" {
-					providerName = resumedProvider
+			if rp, resumedURL, ok := pisession.SessionBackend(dir, flagSession); ok {
+				if rp != "" {
+					providerName = rp
+					resumedProvider = rp
 				}
 				baseURL = resumedURL
 			}
@@ -318,7 +320,17 @@ func resolveRuntimeModelForRole(cfg config.Config, modelName, providerName, acti
 	}
 	info, err := provider.ResolveWithBaseURL(modelName, baseURL)
 	if err != nil {
-		return provider.Info{}, "", fmt.Errorf("resolving model: %w", err)
+		// A resumed session's model may be a virtual name that only its
+		// recorded provider understands — e.g. an agentgateway virtual model
+		// like "ollama-deepseek", whose dash spelling carries no provider
+		// prefix and so cannot be resolved from the name alone. The provider
+		// recorded in the session metadata is the authority for which backend
+		// served it, so fall back to it rather than failing the resume.
+		if resumedProvider != "" {
+			info = provider.Info{Provider: resumedProvider, Model: modelName}
+		} else {
+			return provider.Info{}, "", fmt.Errorf("resolving model: %w", err)
+		}
 	}
 	if providerName != "" {
 		info.Provider = providerName

--- a/internal/cli/resume_model_test.go
+++ b/internal/cli/resume_model_test.go
@@ -59,6 +59,31 @@ func TestResolveRuntimeModel_RestoresSessionBackend(t *testing.T) {
 	}
 }
 
+// A resumed session whose model is a virtual name that only its recorded
+// provider understands — e.g. an agentgateway virtual model like
+// "ollama-deepseek", whose dash spelling carries no provider prefix — must
+// resolve through the recorded provider rather than failing on the name alone.
+func TestResolveRuntimeModel_ResumesVirtualModelViaRecordedProvider(t *testing.T) {
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	writeSessionBackendMeta(t, home, "sess-agw", "ollama-deepseek", "agentgateway", "")
+	origSession, origModel, origURL := flagSession, flagModel, flagURL
+	t.Cleanup(func() { flagSession, flagModel, flagURL = origSession, origModel, origURL })
+	flagSession, flagModel, flagURL = "sess-agw", "", ""
+
+	cfg := config.Config{Roles: map[string]config.RoleConfig{"default": {Model: "gpt-5.6-luna", Provider: "openai"}}}
+	info, _, err := resolveRuntimeModelForRole(cfg, "ollama-deepseek", "openai", "default")
+	if err != nil {
+		t.Fatalf("resolveRuntimeModelForRole: %v", err)
+	}
+	if info.Provider != "agentgateway" {
+		t.Fatalf("provider = %q, want agentgateway from recorded session metadata", info.Provider)
+	}
+	if info.Model != "ollama-deepseek" {
+		t.Fatalf("model = %q, want ollama-deepseek", info.Model)
+	}
+}
+
 func TestResolveRuntimeModel_ExplicitURLWinsResume(t *testing.T) {
 	home := t.TempDir()
 	testenv.SetHome(t, home)


### PR DESCRIPTION
A resumed session whose model is a virtual name that only its recorded
provider understands — e.g. an agentgateway virtual model like
"ollama-deepseek", whose dash spelling carries no provider prefix —
failed to resolve because the model name alone cannot determine the
provider. The provider recorded in the session metadata is the
authority for which backend served it, so fall back to it when name
resolution fails rather than aborting the resume.

Signed-off-by: dimetron <dimetron@me.com>
