### PR TITLE
fix(provider): resolve agentgateway virtual model context windows + enrich model list

### DIFF
--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -216,7 +216,7 @@ func printProviderModels(providerName string, models []provider.ModelInfo) {
 
 	fmt.Printf("%s (%d models):\n", providerName, len(models))
 	for _, m := range models {
-		if providerName == "mistral" && m.ContextWindow > 0 {
+		if (providerName == "mistral" || providerName == "agentgateway") && m.ContextWindow > 0 {
 			fmt.Printf("  %-45s  %-10s  %s\n", m.ID, humanTokens(m.ContextWindow), strings.Join(m.Capabilities, ","))
 		} else if m.OwnedBy != "" {
 			fmt.Printf("  %-45s  %s\n", m.ID, m.OwnedBy)

--- a/internal/provider/agentgateway_test.go
+++ b/internal/provider/agentgateway_test.go
@@ -66,6 +66,19 @@ func TestContextWindowSizeForAgentGateway(t *testing.T) {
 	}
 }
 
+// TestContextWindowSizeForAgentGatewayVirtualModels pins that the gateway's
+// virtual model names resolve to the deepseek window they route to. A session
+// that names the virtual model (e.g. `ollama-deepseek`) must not fall back to a
+// 0 window, which disables auto-compaction and lets the session grow unchecked
+// until the model hits its output cap.
+func TestContextWindowSizeForAgentGatewayVirtualModels(t *testing.T) {
+	for _, name := range []string{"ollama-deepseek", "ollama-deepseek-balanced", "pi-fast"} {
+		if got := ContextWindowSizeFor("agentgateway", name); got != 1_000_000 {
+			t.Errorf("ContextWindowSizeFor(agentgateway, %q) = %d, want 1000000", name, got)
+		}
+	}
+}
+
 // TestListAgentGatewayModels covers the listing path against a stub gateway:
 // the OpenAI {"data":[...]} envelope, and the bearer header a gateway that
 // requires the optional AGENTGATEWAY_API_KEY would check.

--- a/internal/provider/agentgateway_test.go
+++ b/internal/provider/agentgateway_test.go
@@ -118,6 +118,41 @@ func TestListAgentGatewayModels(t *testing.T) {
 	}
 }
 
+// TestListAgentGatewayModelsEnrichesContextWindow pins that the listing path
+// fills in the context window from the embedded table, since the gateway's
+// /v1/models only carries id/owned_by. This is what makes `pi model list
+// agentgateway -o json` show a real context_window for the virtual models.
+func TestListAgentGatewayModelsEnrichesContextWindow(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "ollama-deepseek", "owned_by": "openai"},
+				{"id": "ollama-gemma4", "owned_by": "openai"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	models, err := listAgentGatewayModels(context.Background(), ListModelsOptions{
+		APIKey:  "agw-key",
+		BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("listAgentGatewayModels: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("got %d models, want 2", len(models))
+	}
+	// ollama-deepseek routes to deepseek-v4-flash:0731-cloud (1M).
+	if got := models[0].ContextWindow; got != 1_000_000 {
+		t.Errorf("ollama-deepseek ContextWindow = %d, want 1000000", got)
+	}
+	// ollama-gemma4 routes to gemma4:cloud, which is not in the table → 0.
+	if got := models[1].ContextWindow; got != 0 {
+		t.Errorf("ollama-gemma4 ContextWindow = %d, want 0 (uncataloged)", got)
+	}
+}
+
 // TestListModelsRoutesAgentGateway pins that the exported entry point reaches
 // the agentgateway branch, not the default "unsupported provider" error.
 func TestListModelsRoutesAgentGateway(t *testing.T) {

--- a/internal/provider/list_models.go
+++ b/internal/provider/list_models.go
@@ -191,8 +191,20 @@ func listOpenRouterModels(ctx context.Context, opts ListModelsOptions) ([]ModelI
 // listAgentGatewayModels fetches models from GET /v1/models on the local
 // agentgateway. The gateway is OpenAI-compatible, so the shared bearer
 // envelope applies; the default endpoint is localhost:4000.
+//
+// The gateway's /v1/models only carries id/owned_by — no context window — so
+// each model is enriched from the embedded context-window table. That is what
+// makes `pi model list agentgateway -o json` show a real context_window for
+// the virtual models (e.g. ollama-deepseek → 1M) instead of omitting the field.
 func listAgentGatewayModels(ctx context.Context, opts ListModelsOptions) ([]ModelInfo, error) {
-	return listBearerModels(ctx, opts, "agentgateway", "agentgateway")
+	models, err := listBearerModels(ctx, opts, "agentgateway", "agentgateway")
+	if err != nil {
+		return nil, err
+	}
+	for i := range models {
+		models[i].ContextWindow = ContextWindowSizeFor("agentgateway", models[i].ID)
+	}
+	return models, nil
 }
 
 // listBearerModels fetches models from GET <base>/v1/models with bearer auth

--- a/internal/provider/modeldata/context-windows.json
+++ b/internal/provider/modeldata/context-windows.json
@@ -133,6 +133,9 @@
     "deepseek-v4-flash": 1000000
   },
   "agentgateway": {
-    "deepseek-v4-flash:0731-cloud": 1000000
+    "deepseek-v4-flash:0731-cloud": 1000000,
+    "ollama-deepseek": 1000000,
+    "ollama-deepseek-balanced": 1000000,
+    "pi-fast": 1000000
   }
 }


### PR DESCRIPTION
## What

Two related fixes for the agentgateway provider, both stemming from the same root cause: pi-go's embedded context-window table only knew the underlying model name `deepseek-v4-flash:0731-cloud`, not the gateway's **virtual** model names.

### 1. Resolve virtual model context windows (compaction fix)

A session that names a virtual model (e.g. `ollama-deepseek`) resolved to a **0** context window, which disables auto-compaction and lets the session grow unchecked until the model hits its output cap (`MAX_TOKENS`). This is exactly what happened in session `260902-1345-5c9fe-53670` — the turn was truncated mid-edit.

Adds the deepseek-routing virtual names to the agentgateway window table:
- `ollama-deepseek` → 1M
- `ollama-deepseek-balanced` → 1M
- `pi-fast` → 1M

### 2. Enrich `pi model list agentgateway` with context window

The gateway's `/v1/models` only returns `id`/`owned_by` — no context window. The listing path now enriches each model from the embedded table, so the deepseek virtual models report their real 1M window in both the human table and `-o json`.

## Why it matters

Without the window, auto-compaction stays off and a long session grows until the provider rejects it or the model truncates. With it, compaction budgets against the real 1M window.

## Verification

- `go test ./internal/provider/` — pass (incl. new `TestContextWindowSizeForAgentGatewayVirtualModels` and `TestListAgentGatewayModelsEnrichesContextWindow`)
- `go build ./...` — pass
- `go vet ./internal/cli/` — pass
- golangci-lint — 0 issues
- Live run against the running gateway confirms both table and JSON output

Note: the `internal/cli` test suite hangs under the sandbox (known `httptest.NewServer` issue), so the cli change was verified with `go vet` + a live binary run.