### PR TITLE
fix(agentgateway): route Gemini via Google's OpenAI-compatible endpoint

### DIFF
--- a/hack/agentgateway/.env.example
+++ b/hack/agentgateway/.env.example
@@ -12,6 +12,10 @@
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 GEMINI_API_KEY=
+# Gemini is wired to Google's OpenAI-compatible endpoint, because the
+# native one rejects an AI Studio API key sent as a Bearer token.
+# Override only to point at a proxy; see CLAUDE.md.
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
 MISTRAL_API_KEY=
 OPENROUTER_API_KEY=
 XAI_API_KEY=

--- a/hack/agentgateway/CLAUDE.md
+++ b/hack/agentgateway/CLAUDE.md
@@ -151,10 +151,16 @@ Measured, same conversation both ways:
 | `gemini-2.5-flash` | no | 200 | 200 |
 
 This is a **client** obligation, not something the gateway can paper over — it
-forwards what it is given. A client that strips unknown fields from
-`tool_calls` cannot hold a multi-turn tool conversation with any Gemini 3 model.
-The 2.5 line is unaffected, which makes it the fallback while a client is being
-fixed.
+forwards what it is given, and it was verified to forward `extra_content` in
+both directions. A client that strips unknown fields from `tool_calls` cannot
+hold a multi-turn tool conversation with any Gemini 3 model; the 2.5 line is
+unaffected and is the fallback while a client is being fixed.
+
+pi-go itself carries the signature through
+`internal/provider/openai_thought_signature.go`, parking it on
+`genai.Part.ThoughtSignature` between the response and the next request. If a
+Gemini 3 tool loop starts 400ing again, look there before looking at this
+config.
 
 ## Diagnosing a 401: three probes, in order
 

--- a/hack/agentgateway/CLAUDE.md
+++ b/hack/agentgateway/CLAUDE.md
@@ -77,17 +77,84 @@ provider is wired to that:
 
 ```yaml
 - name: gemini
-  provider: openai
+  provider:
+    custom:
+      providerOverride: gcp.gemini
+      formats:
+      - type: completions
   params:
     baseUrl: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
     apiKey: ${GEMINI_API_KEY:-}
 ```
 
-Do not "fix" this back to `provider: gemini`. If a future agentgateway release
-sends `x-goog-api-key`, verify with the probes below before switching.
+**`providerOverride: gcp.gemini` is load-bearing, not decoration.** A plain
+`provider: openai` with the same `baseUrl` authenticates identically and returns
+200s — but it reports `gen_ai.provider.name=openai`, so the cost catalog looks
+the model up under `openai`, finds no `gemini-*` there, and every Gemini request
+logs with **no `agw.ai.usage.cost.total` at all**. Nothing errors; the cost
+column in the UI is simply blank. The override keeps the provider identity that
+`base-costs.json` keys on (`providers."gcp.gemini"`) while the request still
+goes out in OpenAI wire format with Bearer auth.
+
+Whenever you retarget a provider's `baseUrl`, check a log line for
+`agw.ai.usage.cost.total` — silent loss of cost attribution is the failure mode
+this config invites.
+
+Do not "fix" this back to `provider: gemini` — **including on the strength of
+the upstream docs**, which prescribe exactly that:
+
+```yaml
+# https://agentgateway.dev/docs/standalone/latest/llm/providers/gemini/
+llm:
+  models:
+  - name: "*"
+    provider: gemini
+    params:
+      apiKey: "$GEMINI_API_KEY"
+```
+
+That is the config this directory started from, and it 401s on v1.5.0 —
+the latest release as of 2026-09-03, so there is no version to upgrade into.
+The provider reference elsewhere notes `auth.gcp uses Application Default
+Credentials`, which fits what the wire shows: the preset is built around a GCP
+OAuth token, and hands an AI Studio API key to the same code path. If a later
+release sends `x-goog-api-key`, re-run the probes below before switching back.
 
 Vertex AI is a different story — it genuinely wants an OAuth2 token — and is not
 configured here.
+
+### Gemini 3.x tool calls need their thought_signature echoed back
+
+A one-shot Gemini 3 request works; the *second* turn of a tool-using
+conversation fails with a 400 that has nothing to do with the gateway:
+
+```
+Function call is missing a thought_signature in functionCall parts. This is
+required for tools to work correctly... position 2.
+https://ai.google.dev/gemini-api/docs/thought-signatures
+```
+
+Gemini 3 returns an opaque signature on each tool call, inside a non-standard
+field an OpenAI-shaped client will happily drop:
+
+```json
+"tool_calls": [{"id": "...", "type": "function", "function": {...},
+                "extra_content": {"google": {"thought_signature": "Ep4BCpsB..."}}}]
+```
+
+It must come back verbatim on the assistant message that replays that tool call.
+Measured, same conversation both ways:
+
+| Model | Signature returned | Replay without it | Replay with it |
+|---|---|---|---|
+| `gemini-3.8-flash` | yes | **400** | 200 |
+| `gemini-2.5-flash` | no | 200 | 200 |
+
+This is a **client** obligation, not something the gateway can paper over — it
+forwards what it is given. A client that strips unknown fields from
+`tool_calls` cannot hold a multi-turn tool conversation with any Gemini 3 model.
+The 2.5 line is unaffected, which makes it the fallback while a client is being
+fixed.
 
 ## Diagnosing a 401: three probes, in order
 
@@ -133,6 +200,7 @@ reading rather than skimming:
 | `Method doesn't allow unregistered callers` (403) | No credential reached the API at all — an empty `${VAR:-}` |
 | `API key ... used with other authentication credentials` (401) | Both `x-goog-api-key` and `Authorization` were sent |
 | `API key not valid` (400) | The key really is wrong |
+| `missing a thought_signature` (400) | Not auth at all — see the Gemini 3.x section above |
 
 Two more environment traps that read as auth failures but are not: the container
 is distroless, so `docker exec agentgateway env` fails with

--- a/hack/agentgateway/CLAUDE.md
+++ b/hack/agentgateway/CLAUDE.md
@@ -1,0 +1,187 @@
+# CLAUDE.md — hack/agentgateway
+
+Guidance for coding agents changing the agentgateway deployment in this
+directory. `README.md` is the reference for *what* is here (layout, naming
+schemes, catalogs, client wiring); this file is the rules for *how* to change
+it safely, and the failures worth recognizing on sight.
+
+The repo-root `CLAUDE.md` still applies — worktrees, signed commits, no
+`--no-verify`.
+
+## The pieces
+
+| File | Role |
+|---|---|
+| `config.yaml` | The gateway config. Machine-managed — see below. |
+| `.env` / `.env.example` | Provider keys and the gateway's own API key. `.env` is gitignored. |
+| `docker-compose.yaml` | The normal way to run it, plus Postgres for the request log. |
+| `run.sh` | Runs a local `agentgateway` binary against `config.yaml` instead. |
+| `base-costs.json` | Generated cost catalog, refreshed from models.dev by the UI. |
+| `pi-aliases.json` | Hand-maintained catalog, layered after `base-costs.json`. |
+
+Endpoint `http://localhost:4000`, UI `http://localhost:4000/ui`.
+
+## Rule 1: config.yaml is machine-managed — comments do not survive
+
+`storage.mode` is `file` and the compose mount is deliberately writable, so the
+gateway **rewrites `config.yaml` and strips every comment** the first time
+anyone saves from the UI.
+
+**Do not explain a decision in a `config.yaml` comment.** It will vanish, and
+its disappearance is silent. Put the explanation in this file or in `README.md`
+and keep the config itself to the header line.
+
+The same mechanism makes `config.yaml` a secret once the UI has been used:
+anything created there, including `llm.policies.apiKey` entries, is written back
+in plaintext. Switch `AGENTGATEWAY_STORAGE_MODE` to `hybrid` if you want an
+annotated hand-authored config and UI edits both.
+
+## Rule 2: the whole file is shell-expanded, comments included
+
+A bare `$NAME` for an unset variable aborts startup with
+`error looking key 'NAME' up` — and it does that even inside a comment. Every
+reference uses `${NAME:-}` so an unset key degrades to a 401 on that one route
+rather than taking the whole gateway down.
+
+`AGENTGATEWAY_API_KEY` is the exception: `docker-compose.yaml` uses `:?` so
+compose refuses to start with a readable message. An empty value there would
+register an empty key that `mode: strict` then happily accepts.
+
+## Rule 3: adding a provider is two edits, plus two more to make it reachable
+
+1. `llm.providers` in `config.yaml` — the credential and endpoint.
+2. `llm.models` in `config.yaml` — the route. Prefixed (`foo/*` with a
+   `stripPrefix` transformation) and/or bare-glob (`foo-*`).
+3. `docker-compose.yaml` `environment:` — **a variable the config reads but
+   compose does not pass through does not exist in the container.** This is the
+   easiest step to forget; it looks like a bad key rather than a missing one.
+4. `.env.example` — so the next person knows the variable exists.
+
+## Gemini must go through the OpenAI-compatible endpoint
+
+`provider: gemini` is **wrong for an AI Studio API key** and is the one preset
+here that does not do what its name suggests. It sends the credential as
+`Authorization: Bearer <key>` to `generativelanguage.googleapis.com`, which
+accepts that header only for an OAuth2 access token. Google answers:
+
+```
+401 {"type":"authentication_error",
+     "message":"Request had invalid authentication credentials. Expected OAuth 2
+     access token, login cookie or other valid authentication credential...",
+     "code":"UNAUTHENTICATED"}
+```
+
+The key itself is fine — the native API just wants it in `x-goog-api-key`.
+Google's OpenAI-compatible surface *does* accept a Bearer API key, so the
+provider is wired to that:
+
+```yaml
+- name: gemini
+  provider: openai
+  params:
+    baseUrl: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
+    apiKey: ${GEMINI_API_KEY:-}
+```
+
+Do not "fix" this back to `provider: gemini`. If a future agentgateway release
+sends `x-goog-api-key`, verify with the probes below before switching.
+
+Vertex AI is a different story — it genuinely wants an OAuth2 token — and is not
+configured here.
+
+## Diagnosing a 401: three probes, in order
+
+A 401 from `localhost:4000` can come from the gateway or from the vendor, and
+they look alike in a client. Separate them:
+
+**1. Is it the gateway's own auth?** A gateway rejection says so in plain text
+and never mentions the vendor:
+
+```
+api key authentication failure: no API Key found
+```
+
+Only `Authorization: Bearer` is accepted — `x-api-key` and `api-key` are not.
+
+**2. Does the key work at all, outside the gateway?**
+
+```bash
+set -a; . ./.env; set +a
+curl -s "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1" \
+  -H "x-goog-api-key: $GEMINI_API_KEY"
+```
+
+A 200 here with a 401 through the gateway means the gateway is presenting the
+key wrongly, not that the key is bad.
+
+**3. Which upstream, and what status?** The request log names both. Note that
+`config.yaml` adds `llm.prompt`/`llm.completion` to the log fields, so every
+line carries a full prompt and the log is enormous — never `docker logs` it
+unfiltered:
+
+```bash
+docker logs agentgateway --since 5m 2>&1 | grep -o 'endpoint=[^ ]*' | sort | uniq -c
+docker logs agentgateway --since 5m 2>&1 | grep generativelanguage | tail -1 | cut -c1-800
+```
+
+Google's own errors distinguish the cases precisely, which makes them worth
+reading rather than skimming:
+
+| Google says | Means |
+|---|---|
+| `Expected OAuth 2 access token, login cookie...` (401) | An `Authorization` header was sent where an API key belongs |
+| `Method doesn't allow unregistered callers` (403) | No credential reached the API at all — an empty `${VAR:-}` |
+| `API key ... used with other authentication credentials` (401) | Both `x-goog-api-key` and `Authorization` were sent |
+| `API key not valid` (400) | The key really is wrong |
+
+Two more environment traps that read as auth failures but are not: the container
+is distroless, so `docker exec agentgateway env` fails with
+`"env": executable file not found` — use
+`docker inspect agentgateway --format '{{range .Config.Env}}{{println .}}{{end}}'`
+instead. And a key edited in `.env` after `docker compose up` is **not** in the
+running container; compose reads the env file at create time.
+
+## Verify a change
+
+Validate first — it parses the config without binding ports:
+
+```bash
+docker run --rm -v "$PWD:/etc/agentgateway:ro" -w /etc/agentgateway \
+  ghcr.io/agentgateway/agentgateway:v1.5.0 --validate-only -f config.yaml
+```
+
+Then restart and exercise the route end to end. Editing `config.yaml` alone is
+not enough when the change touches `docker-compose.yaml`'s `environment:` —
+`docker compose up -d` recreates the container, `docker restart` does not pick
+up new variables.
+
+```bash
+docker compose up -d          # after an environment: change
+docker restart agentgateway   # config.yaml-only change
+
+set -a; . ./.env; set +a
+curl -s http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer $AGENTGATEWAY_API_KEY" -H 'content-type: application/json' \
+  -d '{"model":"gemini-2.5-flash","max_tokens":16,
+       "messages":[{"role":"user","content":"say ok"}]}'
+```
+
+Check **both** naming schemes when you touch a provider — the prefixed route and
+the bare glob resolve through different `llm.models` entries and can break
+independently:
+
+```bash
+for M in gemini-2.5-flash gemini/gemini-2.5-flash; do ... done
+```
+
+A vendor-level error (`no credits remaining`, an unknown model) still proves
+routing worked: the request reached the vendor. A gateway error names the model
+or the route instead.
+
+## Do not commit
+
+- `.env` — real keys (gitignored, keep it that way).
+- `config.yaml` **if the UI has written keys into it** — check
+  `llm.policies.apiKey` before staging.
+- Recordings of the UI. The repo-root rule applies: GIFs and screen captures go
+  on a release, and `.githooks/check-large-files` enforces a 1 MiB cap.

--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -362,11 +362,16 @@ These each cost a debugging cycle when this config was built.
   error, so cost data silently goes missing.
 - **The UI is on `:4000/ui`**, served by the gateway itself. The admin listener
   on `:15000` binds to localhost inside the container and is not the UI.
-- **Gemini uses `provider: openai`, not `provider: gemini`.** The `gemini`
-  preset presents the key as `Authorization: Bearer`, which
+- **Gemini is a `custom` provider, not the `gemini` preset.** The preset
+  presents the key as `Authorization: Bearer`, which
   generativelanguage.googleapis.com accepts only for OAuth2 tokens; an AI Studio
   API key gets a 401 that reads as a bad key but is not one. The provider points
-  at Google's OpenAI-compatible endpoint instead. See `CLAUDE.md`.
+  at Google's OpenAI-compatible endpoint instead, and keeps
+  `providerOverride: gcp.gemini` so the cost catalog still resolves — without it
+  requests succeed but log no cost at all. See `CLAUDE.md`.
+- **Gemini 3.x needs its `thought_signature` echoed back** on replayed tool
+  calls, or the second turn of any tool conversation is a 400. A client that
+  drops unknown `tool_calls` fields cannot use Gemini 3; 2.5 is unaffected.
 - **`localhost` inside a container is the container.** The compose file points
   `OLLAMA_BASE_URL` at `host.docker.internal` and adds the `host-gateway` entry
   that Linux needs.

--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -362,6 +362,11 @@ These each cost a debugging cycle when this config was built.
   error, so cost data silently goes missing.
 - **The UI is on `:4000/ui`**, served by the gateway itself. The admin listener
   on `:15000` binds to localhost inside the container and is not the UI.
+- **Gemini uses `provider: openai`, not `provider: gemini`.** The `gemini`
+  preset presents the key as `Authorization: Bearer`, which
+  generativelanguage.googleapis.com accepts only for OAuth2 tokens; an AI Studio
+  API key gets a 401 that reads as a bad key but is not one. The provider points
+  at Google's OpenAI-compatible endpoint instead. See `CLAUDE.md`.
 - **`localhost` inside a container is the container.** The compose file points
   `OLLAMA_BASE_URL` at `host.docker.internal` and adds the `host-gateway` entry
   that Linux needs.

--- a/hack/agentgateway/base-costs.json
+++ b/hack/agentgateway/base-costs.json
@@ -10,6 +10,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "claude-haiku-4-5": {
           "rates": {
             "input": "1",
@@ -142,6 +150,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -376,6 +392,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "global.anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -877,6 +901,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "us.anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "11",
+            "output": "55",
+            "cacheRead": "0.275",
+            "cacheWrite": "13.75"
+          }
+        },
         "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
           "rates": {
             "input": "1",
@@ -1020,6 +1052,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -1354,8 +1394,8 @@
         },
         "gpt-5.6-sol": {
           "rates": {
-            "input": "5",
-            "output": "30",
+            "input": "4",
+            "output": "20",
             "cacheRead": "0.5",
             "cacheWrite": "6.25"
           },
@@ -2611,9 +2651,16 @@
       "models": {
         "accounts/fireworks/models/deepseek-v4-flash-0731": {
           "rates": {
-            "input": "0.14",
-            "output": "0.28",
-            "cacheRead": "0.028"
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "accounts/fireworks/models/deepseek-v4-flash-vision-exp": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -2641,7 +2688,7 @@
           "rates": {
             "input": "0.15",
             "output": "0.5",
-            "cacheRead": "0.029"
+            "cacheRead": "0.03"
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -2973,6 +3020,14 @@
             "inputAudio": "0.75"
           }
         },
+        "gemini-3.8-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
         "gemini-embedding-001": {
           "rates": {
             "input": "0.15",
@@ -3023,6 +3078,14 @@
     },
     "gcp.vertex_ai": {
       "models": {
+        "claude-fable-5-1@default": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "claude-fable-5@default": {
           "rates": {
             "input": "10",
@@ -3286,6 +3349,14 @@
           }
         },
         "gemini-3.7-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-3.8-flash": {
           "rates": {
             "input": "0.75",
             "output": "3.75",
@@ -4075,24 +4146,10 @@
             "cacheRead": "0.175"
           }
         },
-        "gpt-5.2-chat-latest": {
-          "rates": {
-            "input": "1.75",
-            "output": "14",
-            "cacheRead": "0.175"
-          }
-        },
         "gpt-5.2-pro": {
           "rates": {
             "input": "21",
             "output": "168"
-          }
-        },
-        "gpt-5.3-chat-latest": {
-          "rates": {
-            "input": "1.75",
-            "output": "14",
-            "cacheRead": "0.175"
           }
         },
         "gpt-5.3-codex": {
@@ -4394,6 +4451,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "anthropic/claude-fable-5.1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "anthropic/claude-haiku-4.5": {
           "rates": {
             "input": "1",
@@ -4464,14 +4529,6 @@
             }
           ]
         },
-        "anthropic/claude-opus-4.7-fast": {
-          "rates": {
-            "input": "30",
-            "output": "150",
-            "cacheRead": "3",
-            "cacheWrite": "37.5"
-          }
-        },
         "anthropic/claude-opus-4.8": {
           "rates": {
             "input": "5",
@@ -4480,28 +4537,12 @@
             "cacheWrite": "6.25"
           }
         },
-        "anthropic/claude-opus-4.8-fast": {
-          "rates": {
-            "input": "10",
-            "output": "50",
-            "cacheRead": "1",
-            "cacheWrite": "12.5"
-          }
-        },
         "anthropic/claude-opus-5": {
           "rates": {
             "input": "5",
             "output": "25",
             "cacheRead": "0.5",
             "cacheWrite": "6.25"
-          }
-        },
-        "anthropic/claude-opus-5-fast": {
-          "rates": {
-            "input": "10",
-            "output": "50",
-            "cacheRead": "1",
-            "cacheWrite": "12.5"
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -4720,9 +4761,9 @@
         },
         "deepseek/deepseek-chat-v3.1": {
           "rates": {
-            "input": "0.55",
-            "output": "1.65",
-            "cacheRead": "0.55"
+            "input": "0.25",
+            "output": "0.95",
+            "cacheRead": "0.13"
           }
         },
         "deepseek/deepseek-r1": {
@@ -4766,9 +4807,9 @@
         },
         "deepseek/deepseek-v4-flash": {
           "rates": {
-            "input": "0.08092",
-            "output": "0.16184",
-            "cacheRead": "0.016184"
+            "input": "0.088606",
+            "output": "0.177212",
+            "cacheRead": "0.017721"
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -4780,23 +4821,23 @@
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
           "rates": {
-            "input": "0.22",
-            "output": "0.66",
-            "cacheRead": "0.007"
+            "input": "0.44",
+            "output": "1.32",
+            "cacheRead": "0.014"
           }
         },
         "deepseek/deepseek-v4-pro": {
           "rates": {
-            "input": "1.6",
-            "output": "3.2",
-            "cacheRead": "0.135"
+            "input": "1.04226",
+            "output": "2.08452",
+            "cacheRead": "0.086855"
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
           "rates": {
-            "input": "0.66",
-            "output": "1.98",
-            "cacheRead": "0.022"
+            "input": "1.1154",
+            "output": "3.3462",
+            "cacheRead": "0.03718"
           }
         },
         "dots-studio/dots-3-note-preview:free": {
@@ -5025,6 +5066,15 @@
             "reasoning": "3.75"
           }
         },
+        "google/gemini-3.8-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "cacheWrite": "0.041667",
+            "reasoning": "3.75"
+          }
+        },
         "google/gemma-2-27b-it": {
           "rates": {
             "input": "0.65",
@@ -5120,6 +5170,13 @@
             "cacheRead": "0.025"
           }
         },
+        "inception/mercury-2.5-preview": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.15",
+            "cacheRead": "0.004"
+          }
+        },
         "inclusionai/ling-3.0-flash": {
           "rates": {
             "input": "0.021",
@@ -5193,9 +5250,8 @@
         },
         "meta-llama/llama-3.3-70b-instruct": {
           "rates": {
-            "input": "0.71",
-            "output": "0.71",
-            "cacheRead": "0.71"
+            "input": "0.1",
+            "output": "0.32"
           }
         },
         "meta-llama/llama-4-maverick": {
@@ -5219,7 +5275,7 @@
         "meta/muse-glimmer-30b": {
           "rates": {
             "input": "0.3",
-            "output": "1.2",
+            "output": "1.1",
             "cacheRead": "0.04"
           }
         },
@@ -5238,6 +5294,20 @@
           }
         },
         "meta/muse-spark-1.2-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "meta/muse-spark-1.3": {
+          "rates": {
+            "input": "1.25",
+            "output": "4.25",
+            "cacheRead": "0.15"
+          }
+        },
+        "meta/muse-spark-1.3-contributor": {
           "rates": {
             "input": "0.1",
             "output": "0.2",
@@ -5550,7 +5620,7 @@
           "rates": {
             "input": "0.05",
             "output": "0.2",
-            "cacheRead": "0.025"
+            "cacheRead": "0.03"
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
@@ -5573,9 +5643,9 @@
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
           "rates": {
-            "input": "0.5",
-            "output": "2.2",
-            "cacheRead": "0.1"
+            "input": "0.6",
+            "output": "2.4",
+            "cacheRead": "0.12"
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b:free": {
@@ -6487,8 +6557,9 @@
         },
         "qwen/qwen3.5-397b-a17b": {
           "rates": {
-            "input": "0.39",
-            "output": "2.34"
+            "input": "0.55",
+            "output": "3.5",
+            "cacheRead": "0.225"
           }
         },
         "qwen/qwen3.5-9b": {
@@ -7021,9 +7092,9 @@
         },
         "z-ai/glm-4.6": {
           "rates": {
-            "input": "0.43",
-            "output": "1.75",
-            "cacheRead": "0.08"
+            "input": "0.55",
+            "output": "2.2",
+            "cacheRead": "0.11"
           }
         },
         "z-ai/glm-4.6v": {
@@ -7070,9 +7141,9 @@
         },
         "z-ai/glm-5.2": {
           "rates": {
-            "input": "1.19",
-            "output": "3.74",
-            "cacheRead": "0.221"
+            "input": "0.966",
+            "output": "3.036",
+            "cacheRead": "0.1932"
           }
         },
         "z-ai/glm-5.2:free": {
@@ -7085,7 +7156,7 @@
           "rates": {
             "input": "1.4",
             "output": "4.4",
-            "cacheRead": "0.26"
+            "cacheRead": "0.14"
           }
         },
         "z-ai/glm-5.3-flash": {
@@ -7106,7 +7177,7 @@
           "rates": {
             "input": "10",
             "output": "50",
-            "cacheRead": "1",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -7219,11 +7290,18 @@
             }
           ]
         },
+        "~z-ai/glm-flash-latest": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
         "~z-ai/glm-latest": {
           "rates": {
-            "input": "1.17",
-            "output": "3.96",
-            "cacheRead": "0.234"
+            "input": "1.106",
+            "output": "3.476",
+            "cacheRead": "0.1817"
           }
         }
       }

--- a/hack/agentgateway/config.yaml
+++ b/hack/agentgateway/config.yaml
@@ -46,8 +46,9 @@ llm:
     params:
       apiKey: ${OPENAI_API_KEY:-}
   - name: gemini
-    provider: gemini
+    provider: openai
     params:
+      baseUrl: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
       apiKey: ${GEMINI_API_KEY:-}
   - name: mistral
     provider: mistral

--- a/hack/agentgateway/config.yaml
+++ b/hack/agentgateway/config.yaml
@@ -46,7 +46,11 @@ llm:
     params:
       apiKey: ${OPENAI_API_KEY:-}
   - name: gemini
-    provider: openai
+    provider:
+      custom:
+        providerOverride: gcp.gemini
+        formats:
+        - type: completions
     params:
       baseUrl: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
       apiKey: ${GEMINI_API_KEY:-}

--- a/hack/agentgateway/config.yaml
+++ b/hack/agentgateway/config.yaml
@@ -230,7 +230,7 @@ llm:
           priority: 0
         - model: openai/gpt-5.6
           priority: 1
-        - model: gemini/gemini-3-pro
+        - model: gemini/gemini-3.1-pro-preview
           priority: 2
   - name: pi-fast
     routing:

--- a/hack/agentgateway/docker-compose.yaml
+++ b/hack/agentgateway/docker-compose.yaml
@@ -22,6 +22,9 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # Google's OpenAI-compatible endpoint, not the native one — see
+      # CLAUDE.md "Gemini must go through the OpenAI-compatible endpoint".
+      GEMINI_BASE_URL: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
       MISTRAL_API_KEY: ${MISTRAL_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}

--- a/hack/agentgateway/pi-aliases.json
+++ b/hack/agentgateway/pi-aliases.json
@@ -456,6 +456,328 @@
           }
         }
       }
+    },
+    "opencode": {
+      "models": {
+        "deepseek-v4-flash": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek-v4-pro": {
+          "rates": {
+            "input": "0.66",
+            "output": "1.98",
+            "cacheRead": "0.022"
+          }
+        },
+        "glm-5": {
+          "rates": {
+            "input": "1",
+            "output": "3.2",
+            "cacheRead": "0.2"
+          }
+        },
+        "glm-5.1": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.3-flash": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
+        "gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "grok-4.5": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.3"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "0.6"
+              }
+            }
+          ]
+        },
+        "grok-4.6": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "hy3": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.58",
+            "cacheRead": "0.035"
+          }
+        },
+        "hy4-preview": {
+          "rates": {
+            "input": "0.834",
+            "output": "2.501",
+            "cacheRead": "0.042"
+          }
+        },
+        "kimi-k2.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "3",
+            "cacheRead": "0.1"
+          }
+        },
+        "kimi-k2.6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "kimi-k2.7-code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.19"
+          }
+        },
+        "kimi-k3": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3"
+          }
+        },
+        "longcat-2.0": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.006"
+          }
+        },
+        "mimo-v2-omni": {
+          "rates": {
+            "input": "0.4",
+            "output": "2",
+            "cacheRead": "0.08"
+          }
+        },
+        "mimo-v2-pro": {
+          "rates": {
+            "input": "1",
+            "output": "3",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "2",
+                "output": "6",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "mimo-v2.5": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.0028"
+          }
+        },
+        "mimo-v2.5-pro": {
+          "rates": {
+            "input": "0.435",
+            "output": "0.87",
+            "cacheRead": "0.003625"
+          }
+        },
+        "minimax-m2.5": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.03"
+          }
+        },
+        "minimax-m2.7": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "minimax-m3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          },
+          "tiers": [
+            {
+              "contextOver": 512000,
+              "rates": {
+                "input": "0.6",
+                "output": "2.4",
+                "cacheRead": "0.12"
+              }
+            }
+          ]
+        },
+        "muse-spark-1.2-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "muse-spark-1.3-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "ox-alpha-free": {
+          "rates": {
+            "input": "0",
+            "output": "0",
+            "cacheRead": "0"
+          }
+        },
+        "qwen3.5-plus": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          }
+        },
+        "qwen3.6-plus": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.05",
+            "cacheWrite": "0.625"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "2",
+                "output": "6",
+                "cacheRead": "0.2",
+                "cacheWrite": "2.5"
+              }
+            }
+          ]
+        },
+        "qwen3.7-max": {
+          "rates": {
+            "input": "2.5",
+            "output": "7.5",
+            "cacheRead": "0.5",
+            "cacheWrite": "3.125"
+          }
+        },
+        "qwen3.7-plus": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.6",
+            "cacheRead": "0.04",
+            "cacheWrite": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "1.2",
+                "output": "4.8",
+                "cacheRead": "0.12",
+                "cacheWrite": "1.5"
+              }
+            }
+          ]
+        },
+        "qwen3.8-flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.47",
+            "cacheRead": "0.016",
+            "cacheWrite": "0.2"
+          }
+        },
+        "qwen3.8-max": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.25",
+            "cacheWrite": "2.5"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

Every Gemini model returned 401 through the gateway:

```
POST http://localhost:4000/v1/chat/completions -> 401
{"type":"authentication_error",
 "message":"Request had invalid authentication credentials. Expected OAuth 2
 access token, login cookie or other valid authentication credential.",
 "code":"UNAUTHENTICATED"}
```

It reads like a bad key. It isn't one.

`provider: gemini` presents the credential as `Authorization: Bearer <key>` to
`generativelanguage.googleapis.com`, which accepts that header only for an
OAuth2 access token. An AI Studio API key belongs in `x-goog-api-key`.

## How it was isolated

All four probes use the same `GEMINI_API_KEY`, straight at Google:

| Sent | Result |
|---|---|
| `x-goog-api-key` | **200** — the key is valid |
| `Authorization: Bearer` | 401, message byte-identical to the gateway's |
| nothing | 403 `Method doesn't allow unregistered callers` — rules out an empty `${GEMINI_API_KEY:-}` |
| both headers | 401 `used with other authentication credentials` — rules out the client's `Authorization` leaking upstream |

Only the second reproduces the observed message, and the gateway log confirms
the hop: `endpoint=generativelanguage.googleapis.com:443 http.status=401
gen_ai.provider.name=gcp.gemini`.

## Fix

Google's OpenAI-compatible surface does accept a Bearer API key, so the provider
points there:

```yaml
- name: gemini
  provider:
    custom:
      providerOverride: gcp.gemini
      formats:
      - type: completions
  params:
    baseUrl: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
    apiKey: ${GEMINI_API_KEY:-}
```

`providerOverride: gcp.gemini` is load-bearing. A plain `provider: openai` with
the same `baseUrl` authenticates identically and returns 200s, but reports
`gen_ai.provider.name=openai` — so the catalog looks the model up under
`openai`, finds no `gemini-*` there, and **every Gemini request logs with no
`agw.ai.usage.cost.total` at all**. Nothing errors; the cost column just goes
blank. The second commit catches that:

```
before: http.status=200 gen_ai.provider.name=openai      (no cost field)
after:  http.status=200 gen_ai.provider.name=gcp.gemini  agw.ai.usage.cost.total=0.0000034
```

Note the upstream docs prescribe the config that 401s:

```yaml
# https://agentgateway.dev/docs/standalone/latest/llm/providers/gemini/
provider: gemini
params: {apiKey: "$GEMINI_API_KEY"}
```

v1.5.0 is the latest release, so there is no version to upgrade into. The
provider reference notes elsewhere that `auth.gcp uses Application Default
Credentials`, which fits the wire behavior: the preset is built around a GCP
OAuth token and hands an AI Studio key to the same path.

Vertex AI genuinely wants an OAuth2 token and is unaffected — it is not
configured here.

`GEMINI_BASE_URL` is forwarded in `docker-compose.yaml`. A variable the config
reads but compose does not pass through simply does not exist in the container,
and that failure also looks like a bad key.

No comment was added to `config.yaml`, deliberately: `storage.mode=file` means
the gateway rewrites that file and strips every comment on the first UI save.
The explanation goes in `README.md` and in a new `hack/agentgateway/CLAUDE.md`.

## hack/agentgateway/CLAUDE.md

New agent-facing guide for this directory, alongside the existing root one:
config-is-machine-managed and why comments vanish, whole-file shell expansion
(a bare `$NAME` in a *comment* aborts startup), the four edits adding a provider
actually needs, this Gemini trap, and 401 triage keyed on Google's four distinct
error messages — plus two environment traps that read as auth failures: the
container is distroless so `docker exec agentgateway env` fails, and a key
edited in `.env` after `compose up` is not in the running container.

## Also found, and documented rather than fixed here

Gemini 3.x rejects a replayed tool call whose `thought_signature` was dropped —
the *second* turn of any tool conversation 400s:

```
Function call is missing a thought_signature in functionCall parts.
https://ai.google.dev/gemini-api/docs/thought-signatures
```

Measured on one conversation, both ways:

| Model | Signature returned | Replay without it | Replay with it |
|---|---|---|---|
| `gemini-3.8-flash` | yes | **400** | 200 |
| `gemini-2.5-flash` | no | 200 | 200 |

The signature arrives in `tool_calls[].extra_content.google.thought_signature`
and must be echoed back verbatim. This is a client obligation — the gateway
forwards what it is given — so it is written up in `CLAUDE.md` and `README.md`,
not worked around in config. A client that strips unknown `tool_calls` fields
cannot hold a multi-turn tool conversation with any Gemini 3 model; 2.5 is
unaffected and is the fallback until the client round-trips it.

## Verification

- `--validate-only`: `Configuration is valid!`
- `gemini-3.8-flash`, `gemini/gemini-3.8-flash`, `gemini-2.5-flash` → 200
- `anthropic/claude-haiku-4-5` → 200 (no regression on other providers)
- Both naming schemes checked: the prefixed route and the bare glob resolve
  through different `llm.models` entries and can break independently.

No Go code is touched.
