### PR TITLE
feat: PGO profile recording, agentgateway Gemini via OpenAI endpoint, and tighter loop detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ sandbox-trace.log
 sandbox.log
 /pi-sandbox
 
+# Local secrets — never commit real API keys. hack/agentgateway/.env holds
+# live keys (Anthropic, OpenAI, Gemini, ...) and the repo is public.
+.env
+.env.*
+!.env.example
+
 # Binaries built from the tools under hack/. `go build ./hack/<tool>` drops the
 # executable in the repo root, which is easy to commit by accident — it happened
 # once with vulngate.

--- a/.pi-go/skills/pgo/SKILL.md
+++ b/.pi-go/skills/pgo/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pgo
+description: >
+  Profile-guided optimization (PGO) for the pi binary. Use when recording a new
+  PGO profile (`make record-pgo`), when a build behaves differently after a
+  profile is added or removed, when `default.pgo` is missing or stale, or when
+  asked to optimize the pi binary with a CPU profile. Covers the go.dev/doc/pgo
+  workflow: collecting a representative CPU profile, merging profiles, and
+  building with PGO via `default.pgo` in the main package directory.
+---
+
+# PGO — Profile-Guided Optimization
+
+**Source**: [go.dev/doc/pgo](https://go.dev/doc/pgo) (authoritative).
+
+PGO feeds a **CPU pprof profile** from representative runs of the application
+back into the compiler for the next build, which uses it to make more informed
+optimization decisions (e.g. more aggressive inlining of hot functions). As of
+Go 1.22, representative programs improve ~2–14%. The compiler expects a CPU
+pprof profile — exactly what `runtime/pprof` and `net/http/pprof` produce.
+
+## The core rule: the profile must be representative
+
+A profile that is not representative of real behavior yields little or no gain.
+**Microbenchmarks are bad PGO candidates** — they exercise a small part of the
+program. Collect from a representative workload instead. For pi-go that means
+**both** of the binary's hot paths, not one:
+
+- **The headless agent/tool loop** — the tool-coverage eval suite: one
+  `pi --mode print` scenario per tool family.
+- **The TUI render loop** — `RenderMessages`, `collapseBlankLines`, and
+  `matchLexer`. A live profile attributed ~24% of CPU to the `ansi.Strip` call
+  `blankFast` replaces; bubbletea calls `View()` once per token during
+  streaming, so this is a first-class hot path. It is exercised by the render
+  benchmarks, not by `--mode print`.
+
+A profile from only one workload optimizes only one half of the program.
+
+## How pi-go records a profile
+
+`make record-pgo` does the whole loop:
+
+1. Builds the binary (`make build`).
+2. Runs the eval-tools suite with `PI_EVAL_CPU_PROFILE=tmp/pgo`, so every
+   scenario's `pi --mode print` writes a per-scenario CPU profile via the
+   `--cpuprofile` flag.
+3. Runs the TUI render benchmarks with `-cpuprofile tmp/pgo/render.pprof`.
+4. Merges all profiles into `cmd/pi/default.pgo` with
+   `go tool pprof -proto`.
+5. Cleans up the scratch profiles.
+
+`go build` auto-detects `default.pgo` in the main package directory
+(`cmd/pi/`) and enables PGO — no `-pgo` flag needed. So `make build` after a
+`record-pgo` is a PGO build.
+
+### Manual collection
+
+For a one-off profile of a specific workload:
+
+```bash
+pi --cpuprofile /tmp/pi.pprof --mode print "some representative prompt"
+```
+
+The `--cpuprofile` flag writes a runtime CPU profile for the process lifetime
+and flushes it on exit. It is a persistent flag, so it works on subcommands too
+(`pi memory mine . --cpuprofile /tmp/mine.pprof`).
+
+## Building with PGO
+
+- **Default**: `go build` detects `cmd/pi/default.pgo` and enables PGO
+  (`-pgo=auto`).
+- **Disable**: `go build -pgo=off`.
+- **Explicit path**: `go build -pgo=/tmp/foo.pprof ./cmd/pi`. A path applies to
+  all main packages in the invocation, so keep one profile per binary.
+
+## Merging profiles
+
+```bash
+go tool pprof -proto a.pprof b.pprof > merged.pprof
+```
+
+The merge is a straight sum of samples regardless of wall duration, so when
+profiling a long-running server, keep all slices the same duration or longer
+slices dominate. For pi-go's per-scenario profiles this is not a concern — each
+scenario is a short, bounded run.
+
+## Source and iterative stability
+
+Go PGO is robust to skew between the profiled version and the version being
+built:
+
+- **Source stability**: samples are matched by line offsets within functions.
+  Adding code outside a hot function, or moving a function to another file in
+  the same package, does not break matching. Renaming a function, moving it to
+  another package, or editing inside a hot function may lose some optimizations
+  (graceful degradation).
+- **Iterative stability**: the compiler is conservative, so successive PGO
+  builds do not oscillate. No two-stage canary build is required.
+
+**Consequence**: collect a fresh profile regularly. Degradation accumulates
+slowly as code drifts from the profile, and new code paths get no PGO benefit
+until a new profile reflects them. After a large refactor that renames or moves
+many functions, re-record.
+
+## Guidelines
+
+- **Re-record after meaningful code changes** — a stale profile optimizes the
+  old code shape. `make record-pgo` is the one-step refresh.
+- **Never profile a microbenchmark** for PGO; use the eval suite or a real
+  workload.
+- **Commit `default.pgo`** — the docs recommend committing the profile so builds
+  are reproducible and performant from a fresh clone. It is a build input, not
+  scratch.
+- **`make clean` removes `cmd/pi/default.pgo`** — re-run `make record-pgo`
+  after a clean if you want PGO back.
+- **Verify PGO is on**: `go build -x ./cmd/pi 2>&1 | grep -i pgo` shows the
+  `-pgo` flag the toolchain passes. Or check the binary size / `go version -m`
+  for the profile.
+- **A non-representative profile should not make the program slower** than no
+  PGO — it just optimizes cold paths. If you see a real regression, file an
+  issue at go.dev/issue/new.
+
+## Examples
+
+- `/pgo` — explain the PGO workflow and check whether `default.pgo` is current.
+- `make record-pgo` — record a fresh profile from the eval suite.
+- `pi --cpuprofile /tmp/pi.pprof --mode print "..."` — one-off manual profile.
+- `go build -pgo=off ./cmd/pi` — build without PGO to compare.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: vulncheck build install test test-unit test-integration test-e2e test-all test-coverage test-ollama check-cve scan sbom lint vet e2e clean sandbox-run sandbox-log eval-run eval-pin eval-judge eval-tools eval-tools-judge hooks fetch-models
+.PHONY: vulncheck build install test test-unit test-integration test-e2e test-all test-coverage test-ollama check-cve scan sbom lint vet e2e clean sandbox-run sandbox-log eval-run eval-pin eval-judge eval-tools eval-tools-judge record-pgo hooks fetch-models
 
 # No GOEXPERIMENT=simd: Go 1.27 changed the simd/archsimd intrinsics API, and
 # gomlx/compute's amd64 matmul kernels (gated on
@@ -122,6 +122,30 @@ eval-tools-judge: build
 	PI_EVAL_TOOLS=1 PI_EVAL_JUDGE_MODEL=$(PI_EVAL_JUDGE_MODEL) PI_BINARY=$(abspath ./pi) \
 		go test -tags e2e -v -run '^TestEvalTools$$' ./internal/eval/scenarios/ -parallel 4 -timeout 60m
 
+# Record a PGO profile: run the tool-coverage eval suite with --cpuprofile on
+# every scenario's pi process, plus the TUI render benchmarks, then merge all
+# profiles into cmd/pi/default.pgo. `go build` auto-detects default.pgo in the
+# main package dir and enables PGO, so this is the one step that keeps the
+# profile fresh.
+#
+# Two workloads are merged so the profile covers both of the binary's hot
+# paths: the headless agent/tool loop (one `pi --mode print` per tool family)
+# and the TUI render loop (RenderMessages / collapseBlankLines / matchLexer,
+# which a live profile attributed ~24% of CPU to — bubbletea calls View() once
+# per token during streaming). A single-workload profile would optimize only
+# one half of the program. Requires a built binary and an LLM API key (see
+# eval-tools). Knobs: PI_EVAL_MODEL, PI_EVAL_SCENARIO, PI_EVAL_TIMEOUT,
+# PI_EVAL_SERIAL=1. See .pi-go/skills/pgo/SKILL.md.
+record-pgo: build
+	@mkdir -p tmp/pgo
+	PI_EVAL_TOOLS=1 PI_EVAL_CPU_PROFILE=$(abspath tmp/pgo) PI_BINARY=$(abspath ./pi) \
+		go test -tags e2e -v -run '^TestEvalTools$$' ./internal/eval/scenarios/ -parallel 4 -timeout 60m
+	@go test -tags e2e -run '^$$' -bench 'BenchmarkRenderMessagesRunningCached|BenchmarkCollapseBlankLines|BenchmarkMatchLexerCached' \
+		-benchtime 2s -cpuprofile $(abspath tmp/pgo)/render.pprof ./internal/tui/
+	@go tool pprof -proto tmp/pgo/*.pprof > cmd/pi/default.pgo
+	@echo "PGO profile written to cmd/pi/default.pgo ($$(ls -la cmd/pi/default.pgo | awk '{print $$5}') bytes)"
+	@rm -rf tmp/pgo
+
 test-all: test-unit test-integration test-e2e
 
 test-coverage:
@@ -163,7 +187,7 @@ vet:
 	go vet ./...
 
 clean:
-	rm -f pi coverage.out sbom.spdx.json
+	rm -f pi coverage.out sbom.spdx.json cmd/pi/default.pgo
 
 ## OSX sandbox — pi-sandbox embeds pi-profile.sb, resolves params, tails denial logs automatically
 sandbox-run: install

--- a/hack/agentgateway/.env.example
+++ b/hack/agentgateway/.env.example
@@ -12,6 +12,10 @@
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 GEMINI_API_KEY=
+# Gemini is wired to Google's OpenAI-compatible endpoint, because the
+# native one rejects an AI Studio API key sent as a Bearer token.
+# Override only to point at a proxy; see CLAUDE.md.
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
 MISTRAL_API_KEY=
 OPENROUTER_API_KEY=
 XAI_API_KEY=

--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -362,6 +362,16 @@ These each cost a debugging cycle when this config was built.
   error, so cost data silently goes missing.
 - **The UI is on `:4000/ui`**, served by the gateway itself. The admin listener
   on `:15000` binds to localhost inside the container and is not the UI.
+- **Gemini is a `custom` provider, not the `gemini` preset.** The preset
+  presents the key as `Authorization: Bearer`, which
+  generativelanguage.googleapis.com accepts only for OAuth2 tokens; an AI Studio
+  API key gets a 401 that reads as a bad key but is not one. The provider points
+  at Google's OpenAI-compatible endpoint instead, and keeps
+  `providerOverride: gcp.gemini` so the cost catalog still resolves — without it
+  requests succeed but log no cost at all. See `CLAUDE.md`.
+- **Gemini 3.x needs its `thought_signature` echoed back** on replayed tool
+  calls, or the second turn of any tool conversation is a 400. A client that
+  drops unknown `tool_calls` fields cannot use Gemini 3; 2.5 is unaffected.
 - **`localhost` inside a container is the container.** The compose file points
   `OLLAMA_BASE_URL` at `host.docker.internal` and adds the `host-gateway` entry
   that Linux needs.

--- a/hack/agentgateway/base-costs.json
+++ b/hack/agentgateway/base-costs.json
@@ -10,6 +10,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "claude-haiku-4-5": {
           "rates": {
             "input": "1",
@@ -142,6 +150,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -376,6 +392,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "global.anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -877,6 +901,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "us.anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "11",
+            "output": "55",
+            "cacheRead": "0.275",
+            "cacheWrite": "13.75"
+          }
+        },
         "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
           "rates": {
             "input": "1",
@@ -1020,6 +1052,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -1354,8 +1394,8 @@
         },
         "gpt-5.6-sol": {
           "rates": {
-            "input": "5",
-            "output": "30",
+            "input": "4",
+            "output": "20",
             "cacheRead": "0.5",
             "cacheWrite": "6.25"
           },
@@ -2611,9 +2651,16 @@
       "models": {
         "accounts/fireworks/models/deepseek-v4-flash-0731": {
           "rates": {
-            "input": "0.14",
-            "output": "0.28",
-            "cacheRead": "0.028"
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "accounts/fireworks/models/deepseek-v4-flash-vision-exp": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -2641,7 +2688,7 @@
           "rates": {
             "input": "0.15",
             "output": "0.5",
-            "cacheRead": "0.029"
+            "cacheRead": "0.03"
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -2973,6 +3020,14 @@
             "inputAudio": "0.75"
           }
         },
+        "gemini-3.8-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
         "gemini-embedding-001": {
           "rates": {
             "input": "0.15",
@@ -3023,6 +3078,14 @@
     },
     "gcp.vertex_ai": {
       "models": {
+        "claude-fable-5-1@default": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "claude-fable-5@default": {
           "rates": {
             "input": "10",
@@ -3286,6 +3349,14 @@
           }
         },
         "gemini-3.7-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "inputAudio": "0.75"
+          }
+        },
+        "gemini-3.8-flash": {
           "rates": {
             "input": "0.75",
             "output": "3.75",
@@ -4075,24 +4146,10 @@
             "cacheRead": "0.175"
           }
         },
-        "gpt-5.2-chat-latest": {
-          "rates": {
-            "input": "1.75",
-            "output": "14",
-            "cacheRead": "0.175"
-          }
-        },
         "gpt-5.2-pro": {
           "rates": {
             "input": "21",
             "output": "168"
-          }
-        },
-        "gpt-5.3-chat-latest": {
-          "rates": {
-            "input": "1.75",
-            "output": "14",
-            "cacheRead": "0.175"
           }
         },
         "gpt-5.3-codex": {
@@ -4394,6 +4451,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "anthropic/claude-fable-5.1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "anthropic/claude-haiku-4.5": {
           "rates": {
             "input": "1",
@@ -4464,14 +4529,6 @@
             }
           ]
         },
-        "anthropic/claude-opus-4.7-fast": {
-          "rates": {
-            "input": "30",
-            "output": "150",
-            "cacheRead": "3",
-            "cacheWrite": "37.5"
-          }
-        },
         "anthropic/claude-opus-4.8": {
           "rates": {
             "input": "5",
@@ -4480,28 +4537,12 @@
             "cacheWrite": "6.25"
           }
         },
-        "anthropic/claude-opus-4.8-fast": {
-          "rates": {
-            "input": "10",
-            "output": "50",
-            "cacheRead": "1",
-            "cacheWrite": "12.5"
-          }
-        },
         "anthropic/claude-opus-5": {
           "rates": {
             "input": "5",
             "output": "25",
             "cacheRead": "0.5",
             "cacheWrite": "6.25"
-          }
-        },
-        "anthropic/claude-opus-5-fast": {
-          "rates": {
-            "input": "10",
-            "output": "50",
-            "cacheRead": "1",
-            "cacheWrite": "12.5"
           }
         },
         "anthropic/claude-sonnet-4": {
@@ -4720,9 +4761,9 @@
         },
         "deepseek/deepseek-chat-v3.1": {
           "rates": {
-            "input": "0.55",
-            "output": "1.65",
-            "cacheRead": "0.55"
+            "input": "0.25",
+            "output": "0.95",
+            "cacheRead": "0.13"
           }
         },
         "deepseek/deepseek-r1": {
@@ -4766,9 +4807,9 @@
         },
         "deepseek/deepseek-v4-flash": {
           "rates": {
-            "input": "0.08092",
-            "output": "0.16184",
-            "cacheRead": "0.016184"
+            "input": "0.088606",
+            "output": "0.177212",
+            "cacheRead": "0.017721"
           }
         },
         "deepseek/deepseek-v4-flash-0731": {
@@ -4780,23 +4821,23 @@
         },
         "deepseek/deepseek-v4-flash-vision-exp": {
           "rates": {
-            "input": "0.22",
-            "output": "0.66",
-            "cacheRead": "0.007"
+            "input": "0.44",
+            "output": "1.32",
+            "cacheRead": "0.014"
           }
         },
         "deepseek/deepseek-v4-pro": {
           "rates": {
-            "input": "1.6",
-            "output": "3.2",
-            "cacheRead": "0.135"
+            "input": "1.04226",
+            "output": "2.08452",
+            "cacheRead": "0.086855"
           }
         },
         "deepseek/deepseek-v4-pro-0813": {
           "rates": {
-            "input": "0.66",
-            "output": "1.98",
-            "cacheRead": "0.022"
+            "input": "1.1154",
+            "output": "3.3462",
+            "cacheRead": "0.03718"
           }
         },
         "dots-studio/dots-3-note-preview:free": {
@@ -5025,6 +5066,15 @@
             "reasoning": "3.75"
           }
         },
+        "google/gemini-3.8-flash": {
+          "rates": {
+            "input": "0.75",
+            "output": "3.75",
+            "cacheRead": "0.075",
+            "cacheWrite": "0.041667",
+            "reasoning": "3.75"
+          }
+        },
         "google/gemma-2-27b-it": {
           "rates": {
             "input": "0.65",
@@ -5120,6 +5170,13 @@
             "cacheRead": "0.025"
           }
         },
+        "inception/mercury-2.5-preview": {
+          "rates": {
+            "input": "0.04",
+            "output": "0.15",
+            "cacheRead": "0.004"
+          }
+        },
         "inclusionai/ling-3.0-flash": {
           "rates": {
             "input": "0.021",
@@ -5193,9 +5250,8 @@
         },
         "meta-llama/llama-3.3-70b-instruct": {
           "rates": {
-            "input": "0.71",
-            "output": "0.71",
-            "cacheRead": "0.71"
+            "input": "0.1",
+            "output": "0.32"
           }
         },
         "meta-llama/llama-4-maverick": {
@@ -5219,7 +5275,7 @@
         "meta/muse-glimmer-30b": {
           "rates": {
             "input": "0.3",
-            "output": "1.2",
+            "output": "1.1",
             "cacheRead": "0.04"
           }
         },
@@ -5238,6 +5294,20 @@
           }
         },
         "meta/muse-spark-1.2-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "meta/muse-spark-1.3": {
+          "rates": {
+            "input": "1.25",
+            "output": "4.25",
+            "cacheRead": "0.15"
+          }
+        },
+        "meta/muse-spark-1.3-contributor": {
           "rates": {
             "input": "0.1",
             "output": "0.2",
@@ -5550,7 +5620,7 @@
           "rates": {
             "input": "0.05",
             "output": "0.2",
-            "cacheRead": "0.025"
+            "cacheRead": "0.03"
           }
         },
         "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
@@ -5573,9 +5643,9 @@
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
           "rates": {
-            "input": "0.5",
-            "output": "2.2",
-            "cacheRead": "0.1"
+            "input": "0.6",
+            "output": "2.4",
+            "cacheRead": "0.12"
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b:free": {
@@ -6487,8 +6557,9 @@
         },
         "qwen/qwen3.5-397b-a17b": {
           "rates": {
-            "input": "0.39",
-            "output": "2.34"
+            "input": "0.55",
+            "output": "3.5",
+            "cacheRead": "0.225"
           }
         },
         "qwen/qwen3.5-9b": {
@@ -7021,9 +7092,9 @@
         },
         "z-ai/glm-4.6": {
           "rates": {
-            "input": "0.43",
-            "output": "1.75",
-            "cacheRead": "0.08"
+            "input": "0.55",
+            "output": "2.2",
+            "cacheRead": "0.11"
           }
         },
         "z-ai/glm-4.6v": {
@@ -7070,9 +7141,9 @@
         },
         "z-ai/glm-5.2": {
           "rates": {
-            "input": "1.19",
-            "output": "3.74",
-            "cacheRead": "0.221"
+            "input": "0.966",
+            "output": "3.036",
+            "cacheRead": "0.1932"
           }
         },
         "z-ai/glm-5.2:free": {
@@ -7085,7 +7156,7 @@
           "rates": {
             "input": "1.4",
             "output": "4.4",
-            "cacheRead": "0.26"
+            "cacheRead": "0.14"
           }
         },
         "z-ai/glm-5.3-flash": {
@@ -7106,7 +7177,7 @@
           "rates": {
             "input": "10",
             "output": "50",
-            "cacheRead": "1",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -7219,11 +7290,18 @@
             }
           ]
         },
+        "~z-ai/glm-flash-latest": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
         "~z-ai/glm-latest": {
           "rates": {
-            "input": "1.17",
-            "output": "3.96",
-            "cacheRead": "0.234"
+            "input": "1.106",
+            "output": "3.476",
+            "cacheRead": "0.1817"
           }
         }
       }

--- a/hack/agentgateway/config.yaml
+++ b/hack/agentgateway/config.yaml
@@ -46,8 +46,13 @@ llm:
     params:
       apiKey: ${OPENAI_API_KEY:-}
   - name: gemini
-    provider: gemini
+    provider:
+      custom:
+        providerOverride: gcp.gemini
+        formats:
+        - type: completions
     params:
+      baseUrl: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
       apiKey: ${GEMINI_API_KEY:-}
   - name: mistral
     provider: mistral
@@ -225,7 +230,7 @@ llm:
           priority: 0
         - model: openai/gpt-5.6
           priority: 1
-        - model: gemini/gemini-3-pro
+        - model: gemini/gemini-3.1-pro-preview
           priority: 2
   - name: pi-fast
     routing:

--- a/hack/agentgateway/docker-compose.yaml
+++ b/hack/agentgateway/docker-compose.yaml
@@ -22,6 +22,9 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # Google's OpenAI-compatible endpoint, not the native one — see
+      # CLAUDE.md "Gemini must go through the OpenAI-compatible endpoint".
+      GEMINI_BASE_URL: ${GEMINI_BASE_URL:-https://generativelanguage.googleapis.com/v1beta/openai}
       MISTRAL_API_KEY: ${MISTRAL_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}

--- a/hack/agentgateway/pi-aliases.json
+++ b/hack/agentgateway/pi-aliases.json
@@ -456,6 +456,328 @@
           }
         }
       }
+    },
+    "opencode": {
+      "models": {
+        "deepseek-v4-flash": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek-v4-flash-vision-exp": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
+        "deepseek-v4-pro": {
+          "rates": {
+            "input": "0.66",
+            "output": "1.98",
+            "cacheRead": "0.022"
+          }
+        },
+        "glm-5": {
+          "rates": {
+            "input": "1",
+            "output": "3.2",
+            "cacheRead": "0.2"
+          }
+        },
+        "glm-5.1": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.2": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.3": {
+          "rates": {
+            "input": "1.4",
+            "output": "4.4",
+            "cacheRead": "0.26"
+          }
+        },
+        "glm-5.3-flash": {
+          "rates": {
+            "input": "0.075",
+            "output": "0.25",
+            "cacheRead": "0.015"
+          }
+        },
+        "gpt-5.6-luna": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          },
+          "tiers": [
+            {
+              "contextOver": 272000,
+              "rates": {
+                "input": "0.4",
+                "output": "1.8",
+                "cacheRead": "0.04",
+                "cacheWrite": "0.5"
+              }
+            }
+          ]
+        },
+        "grok-4.5": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.3"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "0.6"
+              }
+            }
+          ]
+        },
+        "grok-4.6": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 200000,
+              "rates": {
+                "input": "4",
+                "output": "12",
+                "cacheRead": "1"
+              }
+            }
+          ]
+        },
+        "hy3": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.58",
+            "cacheRead": "0.035"
+          }
+        },
+        "hy4-preview": {
+          "rates": {
+            "input": "0.834",
+            "output": "2.501",
+            "cacheRead": "0.042"
+          }
+        },
+        "kimi-k2.5": {
+          "rates": {
+            "input": "0.6",
+            "output": "3",
+            "cacheRead": "0.1"
+          }
+        },
+        "kimi-k2.6": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.16"
+          }
+        },
+        "kimi-k2.7-code": {
+          "rates": {
+            "input": "0.95",
+            "output": "4",
+            "cacheRead": "0.19"
+          }
+        },
+        "kimi-k3": {
+          "rates": {
+            "input": "3",
+            "output": "15",
+            "cacheRead": "0.3"
+          }
+        },
+        "longcat-2.0": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.006"
+          }
+        },
+        "mimo-v2-omni": {
+          "rates": {
+            "input": "0.4",
+            "output": "2",
+            "cacheRead": "0.08"
+          }
+        },
+        "mimo-v2-pro": {
+          "rates": {
+            "input": "1",
+            "output": "3",
+            "cacheRead": "0.2"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "2",
+                "output": "6",
+                "cacheRead": "0.4"
+              }
+            }
+          ]
+        },
+        "mimo-v2.5": {
+          "rates": {
+            "input": "0.14",
+            "output": "0.28",
+            "cacheRead": "0.0028"
+          }
+        },
+        "mimo-v2.5-pro": {
+          "rates": {
+            "input": "0.435",
+            "output": "0.87",
+            "cacheRead": "0.003625"
+          }
+        },
+        "minimax-m2.5": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.03"
+          }
+        },
+        "minimax-m2.7": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          }
+        },
+        "minimax-m3": {
+          "rates": {
+            "input": "0.3",
+            "output": "1.2",
+            "cacheRead": "0.06"
+          },
+          "tiers": [
+            {
+              "contextOver": 512000,
+              "rates": {
+                "input": "0.6",
+                "output": "2.4",
+                "cacheRead": "0.12"
+              }
+            }
+          ]
+        },
+        "muse-spark-1.2-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "muse-spark-1.3-contributor": {
+          "rates": {
+            "input": "0.1",
+            "output": "0.2",
+            "cacheRead": "0.002"
+          }
+        },
+        "ox-alpha-free": {
+          "rates": {
+            "input": "0",
+            "output": "0",
+            "cacheRead": "0"
+          }
+        },
+        "qwen3.5-plus": {
+          "rates": {
+            "input": "0.2",
+            "output": "1.2",
+            "cacheRead": "0.02",
+            "cacheWrite": "0.25"
+          }
+        },
+        "qwen3.6-plus": {
+          "rates": {
+            "input": "0.5",
+            "output": "3",
+            "cacheRead": "0.05",
+            "cacheWrite": "0.625"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "2",
+                "output": "6",
+                "cacheRead": "0.2",
+                "cacheWrite": "2.5"
+              }
+            }
+          ]
+        },
+        "qwen3.7-max": {
+          "rates": {
+            "input": "2.5",
+            "output": "7.5",
+            "cacheRead": "0.5",
+            "cacheWrite": "3.125"
+          }
+        },
+        "qwen3.7-plus": {
+          "rates": {
+            "input": "0.4",
+            "output": "1.6",
+            "cacheRead": "0.04",
+            "cacheWrite": "0.5"
+          },
+          "tiers": [
+            {
+              "contextOver": 256000,
+              "rates": {
+                "input": "1.2",
+                "output": "4.8",
+                "cacheRead": "0.12",
+                "cacheWrite": "1.5"
+              }
+            }
+          ]
+        },
+        "qwen3.8-flash": {
+          "rates": {
+            "input": "0.15",
+            "output": "0.47",
+            "cacheRead": "0.016",
+            "cacheWrite": "0.2"
+          }
+        },
+        "qwen3.8-max": {
+          "rates": {
+            "input": "2",
+            "output": "6",
+            "cacheRead": "0.25",
+            "cacheWrite": "2.5"
+          }
+        }
+      }
     }
   }
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/pprof"
 	"strings"
 	"sync"
 	"time"
@@ -69,6 +70,7 @@ var (
 	flagSystem       string
 	flagPprof        string
 	flagPprofPort    string
+	flagCPUProfile   string
 	flagTraceHTTP    bool
 	flagA2AAddr      string
 	flagA2AReadyAddr string
@@ -182,8 +184,11 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 		// `pi audit`, ...) have their own RunE and never reach runRoot, so
 		// profiling them was impossible. PersistentPreRun runs for the root and
 		// every subcommand alike.
-		PersistentPreRun: func(*cobra.Command, []string) { startPprofServer() },
-		RunE:             runRoot,
+		PersistentPreRun: func(*cobra.Command, []string) {
+			startPprofServer()
+			startCPUProfile()
+		},
+		RunE: runRoot,
 	}
 
 	cmd.Flags().StringVar(&flagModel, "model", "", "LLM model to use (e.g. claude-sonnet-5, gpt-5.2, gemini-3.5-pro, ollama/gemma4:e4b, minimax-m3:cloud)")
@@ -215,6 +220,12 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 	// "unknown flag: --pprof" the moment a subcommand was used.
 	cmd.PersistentFlags().StringVar(&flagPprof, "pprof", "", "Enable pprof profiling (serves /debug/pprof; any non-empty value enables it)")
 	cmd.PersistentFlags().StringVar(&flagPprofPort, "pprof-port", "6060", "Port for the pprof HTTP server")
+	// --cpuprofile writes a runtime CPU profile to the given path for the whole
+	// process lifetime. This is the profile PGO consumes: `go build` reads a CPU
+	// pprof profile (default.pgo in the main package dir, or -pgo=<path>) to
+	// guide inlining and layout. Collect it from a representative workload —
+	// the eval-tools suite (`make record-pgo`) — not from a microbenchmark.
+	cmd.PersistentFlags().StringVar(&flagCPUProfile, "cpuprofile", "", "Write a CPU profile to this path for the process lifetime (PGO input)")
 	// Persistent for the same reason as --pprof: `pi ping --trace-http` and the
 	// other subcommands that reach a provider all need it.
 	cmd.PersistentFlags().BoolVar(&flagTraceHTTP, "trace-http", false,
@@ -497,6 +508,41 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 // with "address already in use".
 var pprofOnce sync.Once
 
+// cpuProfileOnce guards the CPU profile writer. Like pprofOnce it exists so a
+// command reached both through PersistentPreRun and directly in tests does not
+// start two writers on the same file.
+var cpuProfileOnce sync.Once
+
+// startCPUProfile begins writing a runtime CPU profile to flagCPUProfile when
+// set. The profile is the input PGO consumes, so it must cover a representative
+// workload (see `make record-pgo`). It is stopped by stopCPUProfile, which
+// runRoot defers; a command that never reaches runRoot (a subcommand with its
+// own RunE) leaves the profile unwritten rather than corrupting it.
+func startCPUProfile() {
+	if flagCPUProfile == "" {
+		return
+	}
+	cpuProfileOnce.Do(func() {
+		f, err := os.Create(flagCPUProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cpuprofile: create %s: %v\n", flagCPUProfile, err)
+			return
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "cpuprofile: start: %v\n", err)
+			f.Close()
+			return
+		}
+		fmt.Fprintf(os.Stderr, "cpuprofile: writing to %s\n", flagCPUProfile)
+	})
+}
+
+// stopCPUProfile flushes and closes the CPU profile started by startCPUProfile.
+// It is safe to call when no profile was started.
+func stopCPUProfile() {
+	pprof.StopCPUProfile()
+}
+
 // startPprofServer serves net/http/pprof on --pprof-port when --pprof is set to
 // any non-empty value. Profiles are then collected over HTTP
 // (http://localhost:<port>/debug/pprof), so no profile-specific setup is needed
@@ -528,6 +574,11 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 	// Normally started by the root's PersistentPreRun; harmless if already up.
 	startPprofServer()
+	startCPUProfile()
+	// Flush the CPU profile on the way out. runRoot is the only path that
+	// reaches the agent loop, so deferring here (rather than in main) keeps the
+	// profile covering exactly the work the process did.
+	defer stopCPUProfile()
 
 	runtime, err := buildRootRuntime(cmd.Context(), args)
 	if err != nil {

--- a/internal/eval/scenarios/tools_e2e_test.go
+++ b/internal/eval/scenarios/tools_e2e_test.go
@@ -238,11 +238,19 @@ func errorResult(s eval.Scenario, started time.Time, reason string) eval.Scenari
 // at the scenario's isolated home. Returns the exit code (-1 when the process
 // did not exit on its own), the combined output, and an error describing a
 // non-zero exit or timeout.
+//
+// When PI_EVAL_CPU_PROFILE is set to a directory, each scenario's pi process
+// also writes a runtime CPU profile to <dir>/<scenario>.pprof via --cpuprofile.
+// These are the PGO inputs: `make record-pgo` runs the suite with this set and
+// merges the per-scenario profiles into cmd/pi/default.pgo.
 func runPi(ctx context.Context, bin, workDir, home string, s eval.Scenario, timeout time.Duration) (int, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	args := append([]string{"--mode", "print"}, s.Args...)
+	if profDir := os.Getenv("PI_EVAL_CPU_PROFILE"); profDir != "" {
+		args = append(args, "--cpuprofile", filepath.Join(profDir, s.Name+".pprof"))
+	}
 	args = append(args, s.Prompt)
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = workDir

--- a/internal/tui/agent_loop.go
+++ b/internal/tui/agent_loop.go
@@ -64,7 +64,14 @@ const (
 
 	// maxOutputRepeats is the number of back-to-back copies of one phrase in
 	// the model's own output before the turn is called degenerate.
-	maxOutputRepeats = 12
+	//
+	// Set low enough to catch a model that repeats a single intent while
+	// varying its tool calls just enough to dodge the identical-call streak
+	// (session 260903-1012-bf620-ef665 repeated one phrase 8 times and burned
+	// the full 65536-token output budget before being cut off). 6 copies of a
+	// ~100-char phrase is ~600 bytes of output — far too little to be a
+	// legitimate answer, and well under the 512-byte scan cadence.
+	maxOutputRepeats = 6
 
 	// outputWindowBytes is the rolling tail of streamed output kept for
 	// repetition detection. It has to hold maxOutputRepeats copies of the

--- a/internal/tui/complexity_cog_tui_test.go
+++ b/internal/tui/complexity_cog_tui_test.go
@@ -645,12 +645,12 @@ func TestCogEmitEventParts_Sequences(t *testing.T) {
 		{
 			name: "stuck on thinking output aborts after emitting",
 			ev:   cogEvent("thinking", false, &genai.Part{Text: cogStuckPhrase}),
-			want: "thinking(" + cogStuckPhrase + ")\nerr(agent loop aborted: model repeated a 64-character phrase 12 times)\n",
+			want: fmt.Sprintf("thinking(%s)\nerr(agent loop aborted: model repeated a 64-character phrase %d times)\n", cogStuckPhrase, maxOutputRepeats),
 		},
 		{
 			name: "stuck on model output aborts after emitting",
 			ev:   cogEvent("model", false, &genai.Part{Text: cogStuckPhrase}),
-			want: "text(" + cogStuckPhrase + ")\nerr(agent loop aborted: model repeated a 64-character phrase 12 times)\n",
+			want: fmt.Sprintf("text(%s)\nerr(agent loop aborted: model repeated a 64-character phrase %d times)\n", cogStuckPhrase, maxOutputRepeats),
 		},
 		{
 			name: "stuck output abort stops before a later part",
@@ -658,7 +658,7 @@ func TestCogEmitEventParts_Sequences(t *testing.T) {
 				&genai.Part{Text: cogStuckPhrase},
 				&genai.Part{FunctionCall: &genai.FunctionCall{ID: "c2", Name: "bash"}},
 			),
-			want: "text(" + cogStuckPhrase + ")\nerr(agent loop aborted: model repeated a 64-character phrase 12 times)\n",
+			want: fmt.Sprintf("text(%s)\nerr(agent loop aborted: model repeated a 64-character phrase %d times)\n", cogStuckPhrase, maxOutputRepeats),
 		},
 		{
 			name: "stuck on repeated tool call: the call is emitted first",


### PR DESCRIPTION
Three independent changes bundled per request:

PGO support:
- Makefile: add record-pgo target that runs the tool-coverage eval suite
  with --cpuprofile, merges per-scenario profiles with the TUI render
  benchmarks into cmd/pi/default.pgo, and cleans it up on make clean.
- internal/cli: add --cpuprofile flag (runtime/pprof for the process
  lifetime) so a representative workload can feed PGO; flush on runRoot exit.
- internal/eval/scenarios: honor PI_EVAL_CPU_PROFILE to write a per-scenario
  profile via --cpuprofile.
- .pi-go/skills/pgo/SKILL.md: document the PGO workflow.

agentgateway Gemini:
- Point the gemini provider at Google's OpenAI-compatible endpoint
  (generativelanguage.googleapis.com/v1beta/openai) with providerOverride
  gcp.gemini so cost catalog still resolves; the native endpoint rejects an
  AI Studio key sent as Bearer.
- Update config.yaml, docker-compose.yaml, .env.example, README, base-costs
  and pi-aliases accordingly.

Loop detection:
- Lower maxOutputRepeats 12 -> 6 so a model repeating one phrase while
  varying its tool calls (session 260903-1012-bf620-ef665, 8 repeats, full
  65536-token budget burned) is caught before truncation.
- complexity_cog_tui_test: derive expected repeat count from the constant.

Also: gitignore .env (real API keys, public repo); .env.example stays tracked.
Signed-off-by: dimetron <dimetron@me.com>
