### PR TITLE
fix(provider): replay Gemini 3 thought signatures on tool calls

### DIFF
--- a/internal/provider/complexity_provider_test.go
+++ b/internal/provider/complexity_provider_test.go
@@ -649,7 +649,7 @@ func TestOaiToolCallMessages_SkipsCallsWithoutID(t *testing.T) {
 		{ID: "  ", Name: "blank"},
 		{ID: "keep", Name: "fn", Args: map[string]any{"a": 1}},
 	}
-	messages := oaiToolCallMessages([]string{"text"}, calls, map[string]*genai.FunctionResponse{})
+	messages := oaiToolCallMessages([]string{"text"}, calls, map[string]*genai.FunctionResponse{}, nil)
 
 	// assistant + exactly one tool message.
 	if len(messages) != 2 {

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -123,7 +123,8 @@ func oaiContentsToMessages(contents []*genai.Content, config *genai.GenerateCont
 
 		switch {
 		case len(functionCalls) > 0 && genaiIsAssistantRole(role):
-			messages = append(messages, oaiToolCallMessages(textParts, functionCalls, functionResponses)...)
+			signatures := genaiThoughtSignatures(content.Parts)
+			messages = append(messages, oaiToolCallMessages(textParts, functionCalls, functionResponses, signatures)...)
 		case len(textParts) > 0:
 			messages = append(messages, oaiTextMessage(role, strings.Join(textParts, "\n")))
 		}
@@ -138,6 +139,7 @@ func oaiToolCallMessages(
 	textParts []string,
 	functionCalls []*genai.FunctionCall,
 	functionResponses map[string]*genai.FunctionResponse,
+	signatures map[string][]byte,
 ) []openai.ChatCompletionMessageParamUnion {
 	toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(functionCalls))
 	var toolResponseMessages []openai.ChatCompletionMessageParamUnion
@@ -146,16 +148,21 @@ func oaiToolCallMessages(
 			continue
 		}
 		argsJSON, _ := json.Marshal(fc.Args)
-		toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
-			OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
-				ID:   fc.ID,
-				Type: constant.Function("function"),
-				Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
-					Name:      fc.Name,
-					Arguments: string(argsJSON),
-				},
+		call := &openai.ChatCompletionMessageFunctionToolCallParam{
+			ID:   fc.ID,
+			Type: constant.Function("function"),
+			Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+				Name:      fc.Name,
+				Arguments: string(argsJSON),
 			},
-		})
+		}
+		// Gemini 3 rejects a replayed call whose thought signature was
+		// dropped; every other provider never produced one, so the field
+		// is only ever set when the model itself sent it.
+		if extra := oaiThoughtSignatureExtraContent(signatures[fc.ID]); extra != nil {
+			call.SetExtraFields(extra)
+		}
+		toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{OfFunction: call})
 		contentStr := "No response available for this function call."
 		if fr := functionResponses[fc.ID]; fr != nil {
 			contentStr = oaiFunctionResponseContent(fr.Response)
@@ -237,6 +244,20 @@ func accumulateOaiToolCall(acc map[int64]map[string]any, idx int64, id, name, ar
 	}
 }
 
+// accumulateOaiToolCallSignature records a Gemini thought signature for a tool
+// call being streamed. It is separate from accumulateOaiToolCall because the
+// signature is not part of the OpenAI delta shape and has to be read out of
+// the chunk's raw JSON, and because it arrives whole rather than in fragments.
+func accumulateOaiToolCallSignature(acc map[int64]map[string]any, idx int64, sig []byte) {
+	if len(sig) == 0 {
+		return
+	}
+	if acc[idx] == nil {
+		acc[idx] = map[string]any{"id": "", "name": "", "arguments": ""}
+	}
+	acc[idx]["thought_signature"] = sig
+}
+
 // buildOaiFinalResponse constructs the final LLMResponse from accumulated streaming state.
 func buildOaiFinalResponse(s *oaiStreamState) *model.LLMResponse {
 	indices := make([]int64, 0, len(s.toolCalls))
@@ -269,6 +290,9 @@ func buildOaiFinalResponse(s *oaiStreamState) *model.LLMResponse {
 		if name != "" || id != "" {
 			p := genai.NewPartFromFunctionCall(name, args)
 			p.FunctionCall.ID = id
+			if sig, ok := tc["thought_signature"].([]byte); ok {
+				p.ThoughtSignature = sig
+			}
 			finalParts = append(finalParts, p)
 		}
 	}
@@ -381,6 +405,7 @@ func oaiRunStreamingHooks(ctx context.Context, client *openai.Client, params ope
 		}
 		for _, tc := range delta.ToolCalls {
 			accumulateOaiToolCall(state.toolCalls, tc.Index, tc.ID, tc.Function.Name, tc.Function.Arguments)
+			accumulateOaiToolCallSignature(state.toolCalls, tc.Index, oaiThoughtSignature(tc.RawJSON()))
 		}
 		if choice.FinishReason != "" {
 			state.finishReason = choice.FinishReason
@@ -441,6 +466,7 @@ func oaiRunNonStreamingHooks(ctx context.Context, client *openai.Client, params 
 			}
 			p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
 			p.FunctionCall.ID = tc.ID
+			p.ThoughtSignature = oaiThoughtSignature(tc.RawJSON())
 			parts = append(parts, p)
 		}
 	}

--- a/internal/provider/openai_thought_signature.go
+++ b/internal/provider/openai_thought_signature.go
@@ -1,0 +1,110 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"google.golang.org/genai"
+)
+
+// Gemini 3 attaches an opaque "thought signature" to every function call it
+// emits and refuses to accept that call back without it:
+//
+//	400 Function call is missing a thought_signature in functionCall parts.
+//	This is required for tools to work correctly...
+//
+// The first turn of a tool conversation therefore succeeds and the second
+// fails, which reads like an intermittent fault rather than a missing field.
+// Gemini 2.x emits no signature and does not require one, so a client that
+// drops the field works everywhere until it meets a Gemini 3 model.
+//
+// Over the OpenAI Chat Completions wire shape — the one pi-go uses for
+// agentgateway, and the one Google's own OpenAI-compatible endpoint speaks —
+// the signature rides in a non-standard sibling of the tool call:
+//
+//	{"id": "...", "type": "function", "function": {...},
+//	 "extra_content": {"google": {"thought_signature": "<base64>"}}}
+//
+// openai-go models only the standard fields, so the signature survives just
+// long enough to be read out of the raw JSON. These helpers move it between
+// that wire shape and [genai.Part.ThoughtSignature], which is where the genai
+// types this package converts through already expect it to live.
+const (
+	oaiExtraContentField     = "extra_content"
+	oaiExtraContentVendor    = "google"
+	oaiThoughtSignatureField = "thought_signature"
+)
+
+// oaiExtraContent is the decoding shape for a tool call's extra_content.
+type oaiExtraContent struct {
+	ExtraContent struct {
+		Google struct {
+			ThoughtSignature string `json:"thought_signature"`
+		} `json:"google"`
+	} `json:"extra_content"`
+}
+
+// oaiThoughtSignature reads the Gemini thought signature out of one tool
+// call's raw JSON, returning nil when there is none — the ordinary case for
+// every provider that is not Gemini 3. Malformed JSON and undecodable base64
+// are treated the same way: a signature that cannot be read is one that cannot
+// be replayed, and failing the whole turn over it would be worse than the 400
+// this exists to avoid.
+func oaiThoughtSignature(rawJSON string) []byte {
+	if rawJSON == "" {
+		return nil
+	}
+	var wire oaiExtraContent
+	if err := json.Unmarshal([]byte(rawJSON), &wire); err != nil {
+		return nil
+	}
+	encoded := wire.ExtraContent.Google.ThoughtSignature
+	if encoded == "" {
+		return nil
+	}
+	sig, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil
+	}
+	return sig
+}
+
+// genaiThoughtSignatures indexes the thought signatures carried by one
+// content's function-call parts, keyed by call ID. Splitting the parts loses
+// the [genai.Part] wrapper the signature lives on, so it is collected before
+// the split rather than threaded through it — which keeps genaiSplitParts
+// shared with the Anthropic and Ollama paths, neither of which has any use for
+// a signature.
+func genaiThoughtSignatures(parts []*genai.Part) map[string][]byte {
+	var signatures map[string][]byte
+	for _, part := range parts {
+		if part == nil || part.FunctionCall == nil || len(part.ThoughtSignature) == 0 {
+			continue
+		}
+		if part.FunctionCall.ID == "" {
+			continue
+		}
+		if signatures == nil {
+			signatures = make(map[string][]byte, len(parts))
+		}
+		signatures[part.FunctionCall.ID] = part.ThoughtSignature
+	}
+	return signatures
+}
+
+// oaiThoughtSignatureExtraContent renders a signature back into the
+// extra_content object Google expects on a replayed tool call. It returns nil
+// for an empty signature so callers can set the field unconditionally without
+// sending `extra_content: null` to providers that would reject it.
+func oaiThoughtSignatureExtraContent(sig []byte) map[string]any {
+	if len(sig) == 0 {
+		return nil
+	}
+	return map[string]any{
+		oaiExtraContentField: map[string]any{
+			oaiExtraContentVendor: map[string]any{
+				oaiThoughtSignatureField: base64.StdEncoding.EncodeToString(sig),
+			},
+		},
+	}
+}

--- a/internal/provider/openai_thought_signature_test.go
+++ b/internal/provider/openai_thought_signature_test.go
@@ -1,0 +1,235 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// sigB64 is a stand-in for the opaque blob Gemini 3 returns. Its contents are
+// never interpreted — only that it survives the round trip byte for byte.
+var (
+	sigBytes = []byte("thought-signature-bytes")
+	sigB64   = base64.StdEncoding.EncodeToString(sigBytes)
+)
+
+func TestOaiThoughtSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []byte
+	}{
+		{
+			name: "gemini 3 tool call",
+			raw: `{"id":"c1","type":"function","function":{"name":"bash","arguments":"{}"},` +
+				`"extra_content":{"google":{"thought_signature":"` + sigB64 + `"}}}`,
+			want: sigBytes,
+		},
+		{
+			// Every provider that is not Gemini 3: no signature, no field.
+			name: "plain openai tool call",
+			raw:  `{"id":"c1","type":"function","function":{"name":"bash","arguments":"{}"}}`,
+			want: nil,
+		},
+		{
+			name: "extra_content from another vendor",
+			raw:  `{"id":"c1","extra_content":{"other":{"thought_signature":"` + sigB64 + `"}}}`,
+			want: nil,
+		},
+		{name: "empty raw json", raw: "", want: nil},
+		{name: "malformed json", raw: `{"id":`, want: nil},
+		{
+			name: "undecodable base64",
+			raw:  `{"id":"c1","extra_content":{"google":{"thought_signature":"not!base64"}}}`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := oaiThoughtSignature(tt.raw)
+			if string(got) != string(tt.want) {
+				t.Errorf("oaiThoughtSignature() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenaiThoughtSignatures(t *testing.T) {
+	signed := genai.NewPartFromFunctionCall("bash", map[string]any{"cmd": "ls"})
+	signed.FunctionCall.ID = "c1"
+	signed.ThoughtSignature = sigBytes
+
+	unsigned := genai.NewPartFromFunctionCall("read", nil)
+	unsigned.FunctionCall.ID = "c2"
+
+	// A signature with no call ID cannot be matched back to a call, so it is
+	// dropped rather than keyed under "".
+	orphan := genai.NewPartFromFunctionCall("orphan", nil)
+	orphan.ThoughtSignature = sigBytes
+
+	parts := []*genai.Part{nil, {Text: "hello"}, signed, unsigned, orphan}
+
+	got := genaiThoughtSignatures(parts)
+	if len(got) != 1 {
+		t.Fatalf("got %d signatures, want 1: %v", len(got), got)
+	}
+	if string(got["c1"]) != string(sigBytes) {
+		t.Errorf("signature for c1 = %q, want %q", got["c1"], sigBytes)
+	}
+}
+
+func TestGenaiThoughtSignatures_NoneReturnsNil(t *testing.T) {
+	p := genai.NewPartFromFunctionCall("bash", nil)
+	p.FunctionCall.ID = "c1"
+	if got := genaiThoughtSignatures([]*genai.Part{p}); got != nil {
+		t.Errorf("got %v, want nil for parts carrying no signature", got)
+	}
+}
+
+// TestOaiToolCallMessages_ReplaysThoughtSignature is the regression this whole
+// path exists for: Gemini 3 answers a replayed call with
+// "400 Function call is missing a thought_signature" unless the signature it
+// issued comes back on the assistant message.
+func TestOaiToolCallMessages_ReplaysThoughtSignature(t *testing.T) {
+	calls := []*genai.FunctionCall{
+		{ID: "c1", Name: "bash", Args: map[string]any{"cmd": "ls"}},
+		{ID: "c2", Name: "read", Args: map[string]any{"path": "/tmp"}},
+	}
+	responses := map[string]*genai.FunctionResponse{
+		"c1": {ID: "c1", Response: map[string]any{"output": "a.txt"}},
+		"c2": {ID: "c2", Response: map[string]any{"output": "ok"}},
+	}
+	// Only the first call carries a signature, so the second must marshal
+	// without an extra_content key at all.
+	signatures := map[string][]byte{"c1": sigBytes}
+
+	messages := oaiToolCallMessages(nil, calls, responses, signatures)
+	if len(messages) == 0 || messages[0].OfAssistant == nil {
+		t.Fatal("expected an assistant message first")
+	}
+	b, err := json.Marshal(messages[0])
+	if err != nil {
+		t.Fatalf("marshal assistant message: %v", err)
+	}
+
+	var got struct {
+		ToolCalls []struct {
+			ID           string `json:"id"`
+			ExtraContent *struct {
+				Google struct {
+					ThoughtSignature string `json:"thought_signature"`
+				} `json:"google"`
+			} `json:"extra_content"`
+		} `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal assistant message: %v\n%s", err, b)
+	}
+	if len(got.ToolCalls) != 2 {
+		t.Fatalf("got %d tool calls, want 2:\n%s", len(got.ToolCalls), b)
+	}
+	if got.ToolCalls[0].ExtraContent == nil {
+		t.Fatalf("c1 lost its thought signature:\n%s", b)
+	}
+	if sig := got.ToolCalls[0].ExtraContent.Google.ThoughtSignature; sig != sigB64 {
+		t.Errorf("c1 thought_signature = %q, want %q", sig, sigB64)
+	}
+	if got.ToolCalls[1].ExtraContent != nil {
+		t.Errorf("c2 gained an extra_content it was never given:\n%s", b)
+	}
+	// A provider that never sends signatures must see a byte-identical
+	// request to the one it saw before this path existed.
+	if strings.Contains(string(b), `"extra_content":null`) {
+		t.Errorf("null extra_content leaked into the request:\n%s", b)
+	}
+}
+
+func TestOaiToolCallMessages_NoSignaturesSendsNoExtraContent(t *testing.T) {
+	calls := []*genai.FunctionCall{{ID: "c1", Name: "bash", Args: map[string]any{"cmd": "ls"}}}
+	messages := oaiToolCallMessages(nil, calls, map[string]*genai.FunctionResponse{}, nil)
+	b, err := json.Marshal(messages[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "extra_content") {
+		t.Errorf("extra_content sent for a provider that issued no signature:\n%s", b)
+	}
+}
+
+func TestAccumulateOaiToolCallSignature(t *testing.T) {
+	acc := map[int64]map[string]any{}
+
+	// An empty signature must not conjure an accumulator entry: a nil-signature
+	// delta is what every non-Gemini provider streams.
+	accumulateOaiToolCallSignature(acc, 0, nil)
+	if len(acc) != 0 {
+		t.Fatalf("empty signature created an entry: %v", acc)
+	}
+
+	accumulateOaiToolCall(acc, 0, "c1", "bash", `{"cmd":"ls"}`)
+	accumulateOaiToolCallSignature(acc, 0, sigBytes)
+	if got, _ := acc[0]["thought_signature"].([]byte); string(got) != string(sigBytes) {
+		t.Errorf("thought_signature = %q, want %q", got, sigBytes)
+	}
+
+	// The signature can also arrive before any function delta for that index.
+	accumulateOaiToolCallSignature(acc, 1, sigBytes)
+	accumulateOaiToolCall(acc, 1, "c2", "read", "")
+	if got, _ := acc[1]["thought_signature"].([]byte); string(got) != string(sigBytes) {
+		t.Errorf("out-of-order signature lost: %q", got)
+	}
+	if acc[1]["id"] != "c2" {
+		t.Errorf("id = %v, want c2 (accumulator entry was clobbered)", acc[1]["id"])
+	}
+}
+
+func TestBuildOaiFinalResponse_CarriesThoughtSignature(t *testing.T) {
+	state := &oaiStreamState{toolCalls: map[int64]map[string]any{
+		0: {"id": "c1", "name": "bash", "arguments": `{"cmd":"ls"}`, "thought_signature": sigBytes},
+		1: {"id": "c2", "name": "read", "arguments": "{}"},
+	}}
+
+	resp := buildOaiFinalResponse(state)
+	if resp.Content == nil || len(resp.Content.Parts) != 2 {
+		t.Fatalf("got %v parts, want 2", resp.Content)
+	}
+	if string(resp.Content.Parts[0].ThoughtSignature) != string(sigBytes) {
+		t.Errorf("part 0 signature = %q, want %q", resp.Content.Parts[0].ThoughtSignature, sigBytes)
+	}
+	if resp.Content.Parts[1].ThoughtSignature != nil {
+		t.Errorf("part 1 gained a signature: %q", resp.Content.Parts[1].ThoughtSignature)
+	}
+}
+
+// TestThoughtSignatureRoundTrip walks the full loop the 400 happens in: a tool
+// call arrives from the model, becomes a genai part, and is replayed on the
+// next request.
+func TestThoughtSignatureRoundTrip(t *testing.T) {
+	raw := `{"id":"c1","type":"function","function":{"name":"bash","arguments":"{\"cmd\":\"ls\"}"},` +
+		`"extra_content":{"google":{"thought_signature":"` + sigB64 + `"}}}`
+
+	part := genai.NewPartFromFunctionCall("bash", map[string]any{"cmd": "ls"})
+	part.FunctionCall.ID = "c1"
+	part.ThoughtSignature = oaiThoughtSignature(raw)
+
+	contents := []*genai.Content{
+		{Role: string(genai.RoleUser), Parts: []*genai.Part{{Text: "list files"}}},
+		{Role: string(genai.RoleModel), Parts: []*genai.Part{part}},
+		{Role: string(genai.RoleUser), Parts: []*genai.Part{
+			genai.NewPartFromFunctionResponse("bash", map[string]any{"output": "a.txt"}),
+		}},
+	}
+	contents[2].Parts[0].FunctionResponse.ID = "c1"
+
+	messages, _ := oaiContentsToMessages(contents, nil)
+	b, err := json.Marshal(messages)
+	if err != nil {
+		t.Fatalf("marshal messages: %v", err)
+	}
+	if !strings.Contains(string(b), sigB64) {
+		t.Errorf("signature did not survive the round trip:\n%s", b)
+	}
+}


### PR DESCRIPTION
## Problem

Any tool conversation with a Gemini 3 model died on its **second** turn:

```
error: agent run: POST "http://localhost:4000/v1/chat/completions": 400 Bad Request
```

Upstream, that 400 is:

```
Function call is missing a thought_signature in functionCall parts. This is
required for tools to work correctly... position 2.
https://ai.google.dev/gemini-api/docs/thought-signatures
```

Gemini 3 attaches an opaque signature to every function call it emits and
refuses the call back without it. Over the Chat Completions wire shape it rides
in a non-standard sibling of the tool call:

```json
{"id": "...", "type": "function", "function": {...},
 "extra_content": {"google": {"thought_signature": "<base64>"}}}
```

`openai-go` models only the standard fields, so the signature was read, dropped,
and never replayed. The first turn always worked — which made this present as an
intermittent fault rather than a structural one.

Measured on one conversation, both ways:

| Model | Signature returned | Replay without it | Replay with it |
|---|---|---|---|
| `gemini-3.8-flash` | yes | **400** | 200 |
| `gemini-2.5-flash` | no | 200 | 200 |

## Fix

Carry it. Read out of the tool call's raw JSON, parked on
`genai.Part.ThoughtSignature` — where the genai types this package already
converts through expect it to live — and written back as `extra_content` on the
assistant message that replays the call.

Both response paths are covered: the non-streaming message, and the streaming
accumulator. The latter needs its own step (`accumulateOaiToolCallSignature`)
because the signature is not part of the OpenAI delta shape and arrives whole
rather than in argument fragments.

**Nothing changes for any other provider.** `extra_content` is set only when the
model itself sent a signature, and only Gemini 3 does. A provider that sends
none gets a byte-identical request to before — asserted directly, including that
no `"extra_content":null` leaks in.

`genaiSplitParts` is deliberately left alone: it is shared with the Anthropic and
Ollama paths, neither of which has any use for a signature. The signatures are
collected from the parts *before* the split rather than threaded through it.

## Verification

End to end against `agentgateway/gemini-3.8-flash` — two sequential tool calls
over three model turns, the exact shape that was failing:

```
before:  error: agent run: POST .../v1/chat/completions: 400 Bad Request
after:   ⚙ tool: ls  →  ⚙ tool: read  →  answer
```

Unit tests cover extraction (malformed JSON, another vendor's `extra_content`,
and undecodable base64 all degrade to *no signature* rather than failing the
turn), the streaming accumulator in both arrival orders, and the full
response-to-request round trip.

`make vet`, `make lint` (0 issues) and `make test` all clean. One pre-existing
unrelated failure, identical on `main`: `TestNewPromptHandler_NoAPIKey` reaches
the real Anthropic API when `ANTHROPIC_API_KEY` is set in the environment and
gets a 404 for a retired model.

## Related

The gateway side is #297 — it forwards `extra_content` in both directions, which
this fix depends on and which was verified separately. The two are independent:
this change is correct against Google's OpenAI-compatible endpoint directly.
