### PR TITLE
fix(nix): drop stale grpc substitution that aborts the build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,15 @@
             # The repository currently requires Go 1.27, which is not yet
             # available in the pinned nixpkgs revision. This is only a module
             # directive compatibility patch; the source uses no newer APIs.
+            #
+            # This was once accompanied by a second substitution promoting
+            # google.golang.org/grpc out of the indirect block. main now
+            # requires it directly, so the pattern no longer matches — and
+            # because substituteInPlace uses --replace-fail, a stale pattern
+            # does not degrade to a no-op, it aborts the build.
             postPatch = ''
               substituteInPlace go.mod \
-                --replace-fail 'go 1.27.0' 'go 1.26.5' \
-                --replace-fail 'google.golang.org/grpc v1.83.1 // indirect' 'google.golang.org/grpc v1.83.1'
+                --replace-fail 'go 1.27.0' 'go 1.26.5'
             '';
 
             subPackages = [ "cmd/pi" ];


### PR DESCRIPTION
## Summary

The flake patched `go.mod` with two `--replace-fail` substitutions. The second promoted `google.golang.org/grpc` out of the indirect require block — correct when this branch was cut, but main has since made grpc a direct dependency itself, so the pattern `google.golang.org/grpc v1.83.1 // indirect` matches nothing.

Because `substituteInPlace` uses `--replace-fail`, a stale pattern does not degrade to a silent no-op — it aborts the build. This drops the stale substitution; main now does what it was compensating for. The `go 1.27.0 → 1.26.5` directive patch is kept (still matches exactly once).

## Files
- `flake.nix`

## Verification
- Nix build of the package succeeds against current main.