### PR TITLE
fix(agentgateway): parallel tool call arguments, output-token cap, and the config mount

### DIFF
--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -167,6 +167,34 @@ The container runs as uid 65532. On macOS (Docker Desktop, OrbStack) the bind
 mount maps ownership and writes just work. On Linux the file must be writable by
 that uid — `chmod 666 config.yaml` — or every UI save fails.
 
+### The mount is the directory, not the files
+
+Compose bind-mounts `hack/agentgateway/` at `/etc/agentgateway`, rather than
+mounting `config.yaml`, `base-costs.json` and `pi-aliases.json` one by one.
+
+A single-file bind mount binds one *inode*. Replace that file on the host by
+unlink-then-create — a `git checkout` of a deleted file, many editors' save —
+and the container is left holding a mount that resolves to nothing. Every read,
+write and watch of it then fails, while the gateway carries on serving whatever
+it loaded at boot:
+
+```
+warn  failed to watch path /etc/agentgateway/base-costs.json: No path was found.
+error Failed to reload config: failed to read from file
+      `/etc/agentgateway/config.yaml`: No such file or directory (os error 2)
+failed to write to file `./base-costs.json`: No such file or directory (os error 2)
+```
+
+Replacing the file by rename-over survives, so this fails *intermittently*,
+depending on which tool touched the file last — which is why it reads as
+"refresh costs is broken today" rather than as a broken mount. A single-file
+mount also blocks the reverse: an atomic save from inside the container cannot
+rename onto its own mount point (`EBUSY`).
+
+`.env` sits in this directory and holds the keys compose reads, so it is
+shadowed with a `/dev/null` mount — the gateway has no use for it, and
+`/dev/null` is safe as a single-file mount precisely because nothing replaces it.
+
 **Anything you create in the UI lands in this file**, including API keys under
 `llm.policies.apiKey`. Those are real credentials in plaintext. Treat
 `config.yaml` as a secret once you have used the UI: do not commit it, or switch
@@ -311,14 +339,20 @@ which injects a proxy into the Electron app — out of scope for this directory.
 
 Two `config.modelCatalog` sources, merged in order — later wins.
 
-| File | Mount | Contents |
+Both arrive through the one read-write directory mount, so the "written by"
+column is about what actually touches each file, not about permissions.
+
+| File | Written by | Contents |
 |---|---|---|
-| `base-costs.json` | **read-write** | The full models.dev catalog, ~930 models across 19 providers. Machine-managed. |
-| `pi-aliases.json` | read-only | 62 hand-maintained entries: pi-go's dotted aliases (`claude-sonnet-4.5`), older OpenAI ids (`o1-mini`, `gpt-5.1-codex`), and Ollama/OpenRouter prices the base catalog lacks. |
+| `base-costs.json` | the gateway, on every refresh | The full models.dev catalog, ~930 models across 19 providers. Machine-managed. |
+| `pi-aliases.json` | you, by hand | 62 hand-maintained entries: pi-go's dotted aliases (`claude-sonnet-4.5`), older OpenAI ids (`o1-mini`, `gpt-5.1-codex`), and Ollama/OpenRouter prices the base catalog lacks. |
 
 **`base-costs.json` is mounted writable on purpose.** The UI's refresh action —
 `POST /api/costs/refresh-base` — fetches models.dev, **overwrites this file**,
-and hot-reloads it without a restart. A read-only mount makes it fail.
+and hot-reloads it without a restart. A read-only mount makes it fail, and so
+does a stale single-file mount (see "The mount is the directory, not the files"
+above) — with a *different* error, `No such file or directory`, that looks
+nothing like a permission problem.
 
 ```bash
 curl -X POST http://localhost:4000/api/costs/refresh-base \

--- a/hack/agentgateway/docker-compose.yaml
+++ b/hack/agentgateway/docker-compose.yaml
@@ -56,20 +56,41 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
+      # The DIRECTORY, not the three files inside it. A single-file bind mount
+      # binds one inode. Replacing that file on the host by unlink-then-create
+      # — what a `git checkout` of a deleted file and many editors' save do —
+      # leaves the container holding a mount that resolves to nothing, and
+      # every read, write and watch of it fails:
+      #
+      #   warn  failed to watch path /etc/agentgateway/base-costs.json: No path was found.
+      #   error Failed to reload config: failed to read from file
+      #         `/etc/agentgateway/config.yaml`: No such file or directory (os error 2)
+      #   failed to write to file `./base-costs.json`: No such file or directory (os error 2)
+      #
+      # Replacing it by rename-over survives, so this fails intermittently
+      # depending on which tool touched the file last — and the gateway keeps
+      # serving whatever it loaded at boot, so it reads as "refresh costs is
+      # broken" rather than as a crash. A single-file mount also refuses the
+      # reverse: an atomic save from *inside* the container cannot rename onto
+      # its own mount point (EBUSY, "Device or resource busy").
+      #
+      # Mounting the directory fixes both: the container follows a replacement,
+      # and a restart is no longer the only way to pick up a host-side edit.
+      #
       # Deliberately NOT :ro — with storage.mode=file the UI saves config
-      # changes by rewriting this file, and a read-only mount makes every save
-      # fail. The container runs as uid 65532, so on Linux the file must be
-      # group/other writable (chmod 666 config.yaml) for a save to land;
-      # Docker Desktop and OrbStack on macOS map the owner and need nothing.
-      # Set AGENTGATEWAY_STORAGE_MODE=readOnly and restore :ro to lock it down.
-      - ./config.yaml:/etc/agentgateway/config.yaml
-      # Also NOT :ro. POST /api/costs/refresh-base (the UI's "refresh costs"
-      # action) rewrites this file from models.dev, then hot-reloads it.
-      # A read-only mount makes that fail with a permission error.
-      - ./base-costs.json:/etc/agentgateway/base-costs.json
-      # Hand-maintained aliases, layered after base-costs.json so a refresh
-      # cannot wipe them. Read-only: nothing in the gateway writes this.
-      - ./pi-aliases.json:/etc/agentgateway/pi-aliases.json:ro
+      # changes by rewriting config.yaml, and POST /api/costs/refresh-base (the
+      # UI's "refresh costs" action) rewrites base-costs.json from models.dev
+      # and hot-reloads it. A read-only mount makes both fail. The container
+      # runs as uid 65532, so on Linux the files must be group/other writable
+      # (chmod 666 config.yaml base-costs.json) for a save to land; Docker
+      # Desktop and OrbStack on macOS map the owner and need nothing.
+      # Set AGENTGATEWAY_STORAGE_MODE=readOnly and append :ro to lock it down.
+      - .:/etc/agentgateway
+      # Mounting the directory also exposes this directory's .env — the keys
+      # compose reads to build the environment above. The gateway has no use
+      # for the file, so shadow it with an empty one. /dev/null is safe as a
+      # single-file mount precisely because nothing ever replaces it.
+      - /dev/null:/etc/agentgateway/.env:ro
     working_dir: /etc/agentgateway
     command: ["-f", "/etc/agentgateway/config.yaml"]
     depends_on:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1897,6 +1897,7 @@ func mergeExtraHeaders(cfgHeaders map[string]string, cliHeaders []string) map[st
 // the transport settings from config. The flags are additive: none of them can
 // turn a config-enabled setting back off, matching how --header behaves.
 func applyTransportOptions(opts *provider.LLMOptions, cfg config.Config) {
+	opts.MaxOutputTokens = cfg.MaxOutputTokens
 	opts.InsecureSkipTLS = cfg.InsecureSkipTLS || flagInsecure
 	opts.CACertPath = cfg.CACertPath
 	if flagCACert != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,12 @@ type Config struct {
 	BaseURLs        map[string]string     `json:"baseURLs,omitempty"` // provider → base URL; overridden by env
 	ExtraHeaders    map[string]string     `json:"extraHeaders,omitempty"`
 	InsecureSkipTLS bool                  `json:"insecureSkipTLS,omitempty"`
+	// MaxOutputTokens caps a reply on the OpenAI-compatible provider paths,
+	// in tokens. Zero uses the provider default (64000), which is the output
+	// ceiling of the current Claude and GPT models. Lower it for a backend
+	// whose models stop below that and reject the request rather than
+	// clamping it. This is an output cap, not a context window.
+	MaxOutputTokens int64 `json:"maxOutputTokens,omitempty"`
 	// CACertPath is a PEM bundle trusted in addition to the system roots, for
 	// TLS-intercepting corporate proxies. Prefer it over insecureSkipTLS,
 	// which turns verification off for every endpoint.

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -543,7 +543,7 @@ func buildAntFinalResponse(s *antStreamState) *model.LLMResponse {
 			_ = json.Unmarshal([]byte(block.inputJSON), &args)
 		}
 		if block.name != "" || block.id != "" {
-			p := genai.NewPartFromFunctionCall(block.name, args)
+			p := newFunctionCallPart(block.name, args)
 			p.FunctionCall.ID = block.id
 			finalParts = append(finalParts, p)
 		}
@@ -697,7 +697,7 @@ func antRunNonStreaming(ctx context.Context, client *anthropic.Client, params an
 				var args map[string]any
 				inputBytes, _ := json.Marshal(toolUse.Input)
 				_ = json.Unmarshal(inputBytes, &args)
-				p := genai.NewPartFromFunctionCall(toolUse.Name, args)
+				p := newFunctionCallPart(toolUse.Name, args)
 				p.FunctionCall.ID = toolUse.ID
 				parts = append(parts, p)
 			}
@@ -885,7 +885,7 @@ func antBetaToolUsePart(block anthropic.BetaContentBlockUnion) *genai.Part {
 	if block.Input != nil {
 		_ = json.Unmarshal(block.Input, &args)
 	}
-	p := genai.NewPartFromFunctionCall(block.Name, args)
+	p := newFunctionCallPart(block.Name, args)
 	p.FunctionCall.ID = block.ID
 	return p
 }

--- a/internal/provider/complexity_cog_provider_b_test.go
+++ b/internal/provider/complexity_cog_provider_b_test.go
@@ -674,7 +674,10 @@ func TestCogProviderBBetaNonStreamingGolden(t *testing.T) {
 		t.Fatal("no response")
 	}
 
-	const wantParts = `[{"text":"hello"},{"text":"reasoning"},{"fc_name":"bash","fc_id":"toolu_1","fc_args":{"command":"ls"}},{"fc_name":"noargs","fc_id":"toolu_2","fc_nil_args":true},{"fc_name":"nested","fc_id":"toolu_3","fc_args":{"filter":{"limit":3,"since":"yesterday"},"tags":["a","b"]}},{"text":"advice payload"},{"text":"[advisor result encrypted; will be decrypted on next turn]"},{"text":"tail"}]`
+	// "noargs" carries an empty argument map rather than a nil one: a nil map
+	// replays as tool_use.input null, which Anthropic rejects for every later
+	// request in the conversation. See newFunctionCallPart.
+	const wantParts = `[{"text":"hello"},{"text":"reasoning"},{"fc_name":"bash","fc_id":"toolu_1","fc_args":{"command":"ls"}},{"fc_name":"noargs","fc_id":"toolu_2"},{"fc_name":"nested","fc_id":"toolu_3","fc_args":{"filter":{"limit":3,"since":"yesterday"},"tags":["a","b"]}},{"text":"advice payload"},{"text":"[advisor result encrypted; will be decrypted on next turn]"},{"text":"tail"}]`
 	if got := cogBMarshal(t, cogBParts(last.Content.Parts)); got != wantParts {
 		t.Errorf("parts:\n got %s\nwant %s", got, wantParts)
 	}

--- a/internal/provider/functioncall_args.go
+++ b/internal/provider/functioncall_args.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"encoding/json"
+
+	"google.golang.org/genai"
+)
+
+// marshalFunctionCallArgs serializes a replayed function call's arguments for
+// the OpenAI wire shape, rendering an absent argument map as "{}" rather than
+// "null".
+//
+// A tool call whose arguments failed to parse — a stream cut off mid-JSON at
+// the output-token cap is the usual way — reaches history with a nil Args map.
+// Marshaling that directly produces the literal `null`, and a gateway
+// translating the turn onward for Anthropic then sends `"input": null`, which
+// the API rejects:
+//
+//	400 messages.24.content.0.tool_use.input: Input should be an object
+//
+// The damage is not the one bad call: that turn is *in* the conversation, so
+// every later request replays it and fails the same way. One truncated tool
+// call bricks the session. Anthropic's own path has always substituted an
+// empty map here (see antToolUseBlocks); this gives the OpenAI-compatible
+// paths — which is how pi-go reaches agentgateway — the same floor.
+func marshalFunctionCallArgs(args map[string]any) []byte {
+	if args == nil {
+		return []byte("{}")
+	}
+	encoded, err := json.Marshal(args)
+	if err != nil || len(encoded) == 0 {
+		return []byte("{}")
+	}
+	return encoded
+}
+
+// nonNilFunctionCallArgs is marshalFunctionCallArgs' counterpart for parts
+// being built from a provider response: it keeps a nil argument map from
+// entering the conversation at all.
+func nonNilFunctionCallArgs(args map[string]any) map[string]any {
+	if args == nil {
+		return map[string]any{}
+	}
+	return args
+}
+
+// newFunctionCallPart builds a function call part whose Args map is never nil.
+func newFunctionCallPart(name string, args map[string]any) *genai.Part {
+	return genai.NewPartFromFunctionCall(name, nonNilFunctionCallArgs(args))
+}
+
+// oaiMaxOutputTokens picks the output cap for one request: what the caller
+// asked for, else the model's configured default.
+//
+// genai carries MaxOutputTokens on the request config and the
+// OpenAI-compatible paths used to drop it on the floor, so a caller that set
+// it got the server's default anyway. Honor it first — a caller who names a
+// number means it — and fall back to the model's own default (see
+// defaultOaiMaxOutputTokens).
+func oaiMaxOutputTokens(config *genai.GenerateContentConfig, fallback int64) int64 {
+	if config != nil && config.MaxOutputTokens > 0 {
+		return int64(config.MaxOutputTokens)
+	}
+	return fallback
+}

--- a/internal/provider/functioncall_args_test.go
+++ b/internal/provider/functioncall_args_test.go
@@ -1,0 +1,175 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+func TestMarshalFunctionCallArgsNeverNull(t *testing.T) {
+	if got := string(marshalFunctionCallArgs(nil)); got != "{}" {
+		t.Errorf("nil args marshaled to %q, want {}", got)
+	}
+	if got := string(marshalFunctionCallArgs(map[string]any{})); got != "{}" {
+		t.Errorf("empty args marshaled to %q, want {}", got)
+	}
+	got := string(marshalFunctionCallArgs(map[string]any{"command": "ls"}))
+	if got != `{"command":"ls"}` {
+		t.Errorf("args marshaled to %q", got)
+	}
+}
+
+func TestNewFunctionCallPartArgsNeverNil(t *testing.T) {
+	p := newFunctionCallPart("bash", nil)
+	if p.FunctionCall == nil {
+		t.Fatal("expected a FunctionCall")
+	}
+	if p.FunctionCall.Args == nil {
+		t.Error("Args is nil; a nil map replays as tool_use.input null and 400s Anthropic")
+	}
+}
+
+// TestReplayedToolCallWithNilArgsSendsEmptyObject is the regression the guard
+// exists for: a turn holding a tool call whose arguments never parsed must
+// replay as `"arguments":"{}"`, not `"arguments":"null"`. A gateway forwards
+// the latter to Anthropic as `"input": null`, which is rejected — and since
+// the bad turn stays in history, every later request fails the same way.
+func TestReplayedToolCallWithNilArgsSendsEmptyObject(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "c1", "object": "chat.completion", "model": "m",
+			"choices": []map[string]any{{
+				"index":         0,
+				"message":       map[string]any{"role": "assistant", "content": "done"},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	llm, err := NewOpenAI(context.Background(), "m", "sk-test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewOpenAI() error: %v", err)
+	}
+
+	call := &genai.Part{FunctionCall: &genai.FunctionCall{ID: "call_1", Name: "write", Args: nil}}
+	result := &genai.Part{FunctionResponse: &genai.FunctionResponse{
+		ID: "call_1", Name: "write", Response: map[string]any{"error": "file_path is required"},
+	}}
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "write a file"}}},
+		{Role: "model", Parts: []*genai.Part{call}},
+		{Role: "user", Parts: []*genai.Part{result}},
+	}}
+	for _, err := range llm.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent() error: %v", err)
+		}
+	}
+
+	var sent struct {
+		Messages []struct {
+			ToolCalls []struct {
+				Function struct {
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decoding request: %v", err)
+	}
+	var seen int
+	for _, msg := range sent.Messages {
+		for _, tc := range msg.ToolCalls {
+			seen++
+			if tc.Function.Arguments != "{}" {
+				t.Errorf("replayed arguments = %q, want {}", tc.Function.Arguments)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no tool call was replayed")
+	}
+}
+
+func TestOaiMaxOutputTokensPrefersRequestConfig(t *testing.T) {
+	if got := oaiMaxOutputTokens(nil, 64000); got != 64000 {
+		t.Errorf("nil config = %d, want the fallback 64000", got)
+	}
+	if got := oaiMaxOutputTokens(&genai.GenerateContentConfig{}, 64000); got != 64000 {
+		t.Errorf("unset MaxOutputTokens = %d, want the fallback 64000", got)
+	}
+	cfg := &genai.GenerateContentConfig{MaxOutputTokens: 1234}
+	if got := oaiMaxOutputTokens(cfg, 64000); got != 1234 {
+		t.Errorf("caller's MaxOutputTokens = %d, want 1234", got)
+	}
+}
+
+// TestChatCompletionsSendsMaxCompletionTokens pins the fix for replies cut off
+// at a server-chosen default: agentgateway in front of Anthropic settles on
+// 4096 when the client sends nothing, which truncates a long turn and, when
+// the cut lands inside a tool call's arguments, produces a call with no
+// arguments at all.
+func TestChatCompletionsSendsMaxCompletionTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *LLMOptions
+		want float64
+	}{
+		{"default", nil, float64(defaultOaiMaxOutputTokens)},
+		{"configured", &LLMOptions{MaxOutputTokens: 8192}, 8192},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id": "c1", "object": "chat.completion", "model": "m",
+					"choices": []map[string]any{{
+						"index":         0,
+						"message":       map[string]any{"role": "assistant", "content": "ok"},
+						"finish_reason": "stop",
+					}},
+				})
+			}))
+			defer srv.Close()
+
+			llm, err := NewOpenAI(context.Background(), "m", "sk-test", srv.URL, tt.opts)
+			if err != nil {
+				t.Fatalf("NewOpenAI() error: %v", err)
+			}
+			req := &model.LLMRequest{Contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+			}}
+			for _, err := range llm.GenerateContent(context.Background(), req, false) {
+				if err != nil {
+					t.Fatalf("GenerateContent() error: %v", err)
+				}
+			}
+
+			var sent map[string]any
+			if err := json.Unmarshal(body, &sent); err != nil {
+				t.Fatalf("decoding request: %v", err)
+			}
+			got, ok := sent["max_completion_tokens"].(float64)
+			if !ok {
+				t.Fatalf("request has no max_completion_tokens: %s", body)
+			}
+			if got != tt.want {
+				t.Errorf("max_completion_tokens = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -679,7 +679,7 @@ func (s *ollamaStreamState) finalParts() []*genai.Part {
 	}
 	for _, tc := range s.toolCalls {
 		args := tc.Function.Arguments.ToMap()
-		p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
+		p := newFunctionCallPart(tc.Function.Name, args)
 		p.FunctionCall.ID = tc.ID
 		finalParts = append(finalParts, p)
 	}
@@ -758,7 +758,7 @@ func ollamaRunNonStreaming(ctx context.Context, client *ollamaapi.Client, chatRe
 
 	for _, tc := range msg.ToolCalls {
 		args := tc.Function.Arguments.ToMap()
-		p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
+		p := newFunctionCallPart(tc.Function.Name, args)
 		p.FunctionCall.ID = tc.ID
 		parts = append(parts, p)
 	}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -34,10 +34,31 @@ type openaiModel struct {
 	// backend (authenticated with a codex OAuth token). Those deployments
 	// only expose /codex/responses, so chat completions must be skipped.
 	codexBackend bool
+	// maxOutputTokens caps the reply, in tokens. See
+	// defaultOaiMaxOutputTokens for why omitting it is not an option.
+	maxOutputTokens int64
 	// mu protects responseState for Responses mode multi-turn.
 	mu            sync.Mutex
 	responseState *responsesState // nil when using Chat Completions
 }
+
+// defaultOaiMaxOutputTokens caps a reply on the OpenAI-compatible paths when
+// neither the request nor the configuration asks for something else.
+//
+// Sending nothing is not the neutral choice it looks like. Every server
+// substitutes its own default, and some are small: agentgateway in front of
+// Anthropic settles on 4096, which cuts a long coding turn off mid-sentence
+// (finish_reason "length"). Worse, when the cut lands inside a tool call's
+// arguments the JSON never closes, the call reaches the tool with no arguments
+// at all, and — before marshalFunctionCallArgs — that malformed turn went into
+// the history and 400ed every request after it.
+//
+// 64000 is the output ceiling of the current Claude and GPT models, which is
+// what this path mostly carries. It is an output cap, not a context window:
+// the million-token figure quoted for these models is how much they can *read*.
+// Override it with the maxOutputTokens setting for a backend whose models stop
+// lower and reject the request rather than clamping it.
+const defaultOaiMaxOutputTokens int64 = 64000
 
 // responsesState holds state threaded across Responses API calls.
 type responsesState struct {
@@ -102,11 +123,16 @@ func NewOpenAI(_ context.Context, modelName, apiKey, baseURL string, llmOpts *LL
 	baseTransport = &errorBodyLoggingTransport{base: baseTransport}
 	opts = append(opts, option.WithHTTPClient(&http.Client{Transport: baseTransport}))
 	client := openai.NewClient(opts...)
+	maxOutputTokens := defaultOaiMaxOutputTokens
+	if llmOpts != nil && llmOpts.MaxOutputTokens > 0 {
+		maxOutputTokens = llmOpts.MaxOutputTokens
+	}
 	return &openaiModel{
-		modelName:     modelName,
-		client:        client,
-		codexBackend:  useCodexBackend,
-		responseState: nil, // determined per-call based on model
+		modelName:       modelName,
+		client:          client,
+		codexBackend:    useCodexBackend,
+		maxOutputTokens: maxOutputTokens,
+		responseState:   nil, // determined per-call based on model
 	}, nil
 }
 

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -225,6 +225,62 @@ type oaiStreamState struct {
 	promptTokens     int64
 	completionTokens int64
 	cachedTokens     int64
+
+	// Slot bookkeeping for streams that omit the tool call index; see
+	// toolCallSlot.
+	toolCallSlots    map[string]int64
+	nextToolCallSlot int64
+	lastToolCallSlot int64
+	haveToolCallSlot bool
+}
+
+// toolCallSlot resolves the accumulator key for one streamed tool call delta.
+//
+// OpenAI streams a tool call as fragments that all carry the same "index", and
+// that index is what separates one call from the next in a parallel batch.
+// Google's OpenAI-compatible endpoint — the one agentgateway puts in front of
+// Gemini — omits the field entirely and instead sends each call whole, in its
+// own chunk:
+//
+//	{"delta":{"tool_calls":[{"id":"call_1","function":{"name":"bash",
+//	  "arguments":"{\"command\":\"ls\"}"}}]},"index":0}
+//
+// The "index" there belongs to the choice, not to the tool call. Reading the
+// absent field as its zero value collapses every call in a parallel batch onto
+// slot 0, where accumulateOaiToolCall concatenates their arguments into
+// "{...}{...}" — invalid JSON, which then unmarshals to a nil argument map and
+// reaches the tool as a call with no arguments at all ("command is required").
+//
+// So: trust the index when the wire actually sent one, and otherwise give each
+// distinct tool call ID its own slot. A delta with neither index nor ID is
+// treated as a continuation of the call before it, which is the best reading
+// available and matches the fragment-stream shape.
+func (s *oaiStreamState) toolCallSlot(indexPresent bool, index int64, id string) int64 {
+	claim := func(slot int64) int64 {
+		if slot >= s.nextToolCallSlot {
+			s.nextToolCallSlot = slot + 1
+		}
+		s.lastToolCallSlot, s.haveToolCallSlot = slot, true
+		return slot
+	}
+	if indexPresent {
+		return claim(index)
+	}
+	if id == "" {
+		if s.haveToolCallSlot {
+			return s.lastToolCallSlot
+		}
+		return claim(s.nextToolCallSlot)
+	}
+	if slot, ok := s.toolCallSlots[id]; ok {
+		return claim(slot)
+	}
+	if s.toolCallSlots == nil {
+		s.toolCallSlots = make(map[string]int64)
+	}
+	slot := s.nextToolCallSlot
+	s.toolCallSlots[id] = slot
+	return claim(slot)
 }
 
 // accumulateOaiToolCall updates the tool call accumulator with a single delta chunk.
@@ -404,8 +460,9 @@ func oaiRunStreamingHooks(ctx context.Context, client *openai.Client, params ope
 			}
 		}
 		for _, tc := range delta.ToolCalls {
-			accumulateOaiToolCall(state.toolCalls, tc.Index, tc.ID, tc.Function.Name, tc.Function.Arguments)
-			accumulateOaiToolCallSignature(state.toolCalls, tc.Index, oaiThoughtSignature(tc.RawJSON()))
+			slot := state.toolCallSlot(tc.JSON.Index.Valid(), tc.Index, tc.ID)
+			accumulateOaiToolCall(state.toolCalls, slot, tc.ID, tc.Function.Name, tc.Function.Arguments)
+			accumulateOaiToolCallSignature(state.toolCalls, slot, oaiThoughtSignature(tc.RawJSON()))
 		}
 		if choice.FinishReason != "" {
 			state.finishReason = choice.FinishReason

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -25,6 +25,9 @@ func (m *openaiModel) generateChat(ctx context.Context, req *model.LLMRequest, m
 			Model:    modelName,
 			Messages: messages,
 		}
+		if maxTokens := oaiMaxOutputTokens(req.Config, m.maxOutputTokens); maxTokens > 0 {
+			params.MaxCompletionTokens = openai.Int(maxTokens)
+		}
 		if systemInstruction != "" {
 			params.Messages = append([]openai.ChatCompletionMessageParamUnion{
 				openai.SystemMessage(systemInstruction),
@@ -147,7 +150,7 @@ func oaiToolCallMessages(
 		if fc == nil || strings.TrimSpace(fc.ID) == "" {
 			continue
 		}
-		argsJSON, _ := json.Marshal(fc.Args)
+		argsJSON := marshalFunctionCallArgs(fc.Args)
 		call := &openai.ChatCompletionMessageFunctionToolCallParam{
 			ID:   fc.ID,
 			Type: constant.Function("function"),
@@ -344,7 +347,7 @@ func buildOaiFinalResponse(s *oaiStreamState) *model.LLMResponse {
 		name, _ := tc["name"].(string)
 		id, _ := tc["id"].(string)
 		if name != "" || id != "" {
-			p := genai.NewPartFromFunctionCall(name, args)
+			p := newFunctionCallPart(name, args)
 			p.FunctionCall.ID = id
 			if sig, ok := tc["thought_signature"].([]byte); ok {
 				p.ThoughtSignature = sig
@@ -521,7 +524,7 @@ func oaiRunNonStreamingHooks(ctx context.Context, client *openai.Client, params 
 			if tc.Function.Arguments != "" {
 				_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
 			}
-			p := genai.NewPartFromFunctionCall(tc.Function.Name, args)
+			p := newFunctionCallPart(tc.Function.Name, args)
 			p.FunctionCall.ID = tc.ID
 			p.ThoughtSignature = oaiThoughtSignature(tc.RawJSON())
 			parts = append(parts, p)

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -312,7 +312,7 @@ func oaiAppendResponsesItems(
 			if _, ok := responseIDs[fc.ID]; !ok {
 				continue
 			}
-			argsJSON, _ := json.Marshal(fc.Args)
+			argsJSON := marshalFunctionCallArgs(fc.Args)
 			items = append(items, responses.ResponseInputItemParamOfFunctionCall(string(argsJSON), fc.ID, fc.Name))
 		case part.FunctionResponse != nil:
 			flushText()
@@ -592,7 +592,7 @@ func buildResponsesFinalParts(s *responsesStreamState) []*genai.Part {
 			_ = json.Unmarshal([]byte(tc.arguments), &args)
 		}
 		if tc.name != "" || tc.id != "" {
-			p := genai.NewPartFromFunctionCall(tc.name, args)
+			p := newFunctionCallPart(tc.name, args)
 			p.FunctionCall.ID = tc.id
 			parts = append(parts, p)
 		}
@@ -665,7 +665,7 @@ func parseResponsesOutput(items []responses.ResponseOutputItemUnion) ([]*genai.P
 			if variant.Arguments != "" {
 				_ = json.Unmarshal([]byte(variant.Arguments), &args)
 			}
-			p := genai.NewPartFromFunctionCall(variant.Name, args)
+			p := newFunctionCallPart(variant.Name, args)
 			p.FunctionCall.ID = variant.CallID
 			parts = append(parts, p)
 

--- a/internal/provider/openai_toolcall_index_test.go
+++ b/internal/provider/openai_toolcall_index_test.go
@@ -1,0 +1,153 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// sseToolCallServer replays a fixed list of SSE data lines as a streaming chat
+// completion.
+func sseToolCallServer(t *testing.T, chunks []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, c := range chunks {
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", c)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+}
+
+// collectFunctionCalls runs one streaming turn against srv and returns the
+// function calls on the final response.
+func collectFunctionCalls(t *testing.T, srv *httptest.Server) []*genai.FunctionCall {
+	t.Helper()
+	ctx := context.Background()
+	llm, err := NewOpenAI(ctx, "gemini-3.8-flash", "sk-test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewOpenAI() error: %v", err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "go"}}}},
+	}
+	var final *model.LLMResponse
+	for resp, err := range llm.GenerateContent(ctx, req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent() error: %v", err)
+		}
+		final = resp
+	}
+	if final == nil || final.Content == nil {
+		t.Fatal("expected a final response with content")
+	}
+	var calls []*genai.FunctionCall
+	for _, p := range final.Content.Parts {
+		if p.FunctionCall != nil {
+			calls = append(calls, p.FunctionCall)
+		}
+	}
+	return calls
+}
+
+// TestOaiStreamingParallelToolCallsWithoutIndex covers the wire shape Google's
+// OpenAI-compatible endpoint emits (and that agentgateway forwards verbatim):
+// each parallel tool call arrives whole, in its own chunk, with no "index"
+// field inside the tool call — the "index" present belongs to the choice.
+//
+// Reading the missing field as its zero value collapsed all three calls onto
+// slot 0 and concatenated their arguments into invalid JSON, so every call
+// reached the tool with no arguments at all.
+func TestOaiStreamingParallelToolCallsWithoutIndex(t *testing.T) {
+	srv := sseToolCallServer(t, []string{
+		`{"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"command\":\"ls -la\"}","name":"bash"},"id":"call_1","type":"function"}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"command\":\"pwd\"}","name":"bash"},"id":"call_2","type":"function"}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"command\":\"go version\"}","name":"bash"},"id":"call_3","type":"function"}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"role":"assistant"},"finish_reason":"stop","index":0}],"object":"chat.completion.chunk","usage":{"prompt_tokens":97,"completion_tokens":45,"total_tokens":206}}`,
+	})
+	defer srv.Close()
+
+	calls := collectFunctionCalls(t, srv)
+	if len(calls) != 3 {
+		t.Fatalf("got %d function calls, want 3", len(calls))
+	}
+	wantIDs := []string{"call_1", "call_2", "call_3"}
+	wantCmds := []string{"ls -la", "pwd", "go version"}
+	for i, fc := range calls {
+		if fc.Name != "bash" {
+			t.Errorf("call %d name = %q, want bash", i, fc.Name)
+		}
+		if fc.ID != wantIDs[i] {
+			t.Errorf("call %d ID = %q, want %q", i, fc.ID, wantIDs[i])
+		}
+		cmd, _ := fc.Args["command"].(string)
+		if cmd != wantCmds[i] {
+			t.Errorf("call %d command = %q, want %q", i, cmd, wantCmds[i])
+		}
+	}
+}
+
+// TestOaiStreamingFragmentedToolCallsWithIndex is the standard OpenAI shape:
+// each call is split into fragments that share an explicit index. The index
+// stays authoritative, so fragments still reassemble into whole calls.
+func TestOaiStreamingFragmentedToolCallsWithIndex(t *testing.T) {
+	srv := sseToolCallServer(t, []string{
+		`{"choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"bash","arguments":""}}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"read","arguments":""}}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"command\":"}}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"path\":\"/tmp\"}"}}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"ls\"}"}}]},"index":0}],"object":"chat.completion.chunk"}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_calls","index":0}],"object":"chat.completion.chunk"}`,
+	})
+	defer srv.Close()
+
+	calls := collectFunctionCalls(t, srv)
+	if len(calls) != 2 {
+		t.Fatalf("got %d function calls, want 2", len(calls))
+	}
+	if calls[0].ID != "call_a" || calls[0].Name != "bash" {
+		t.Errorf("call 0 = %q/%q, want call_a/bash", calls[0].ID, calls[0].Name)
+	}
+	if cmd, _ := calls[0].Args["command"].(string); cmd != "ls" {
+		t.Errorf("call 0 command = %q, want ls", cmd)
+	}
+	if calls[1].ID != "call_b" || calls[1].Name != "read" {
+		t.Errorf("call 1 = %q/%q, want call_b/read", calls[1].ID, calls[1].Name)
+	}
+	if p, _ := calls[1].Args["path"].(string); p != "/tmp" {
+		t.Errorf("call 1 path = %q, want /tmp", p)
+	}
+}
+
+// TestOaiToolCallSlotContinuation covers a delta that carries neither an index
+// nor an ID: it continues the call before it rather than starting a new one.
+func TestOaiToolCallSlotContinuation(t *testing.T) {
+	s := &oaiStreamState{toolCalls: make(map[int64]map[string]any)}
+	first := s.toolCallSlot(false, 0, "call_1")
+	cont := s.toolCallSlot(false, 0, "")
+	second := s.toolCallSlot(false, 0, "call_2")
+	again := s.toolCallSlot(false, 0, "call_1")
+
+	if cont != first {
+		t.Errorf("continuation slot = %d, want %d", cont, first)
+	}
+	if second == first {
+		t.Errorf("second call reused slot %d", second)
+	}
+	if again != first {
+		t.Errorf("repeat of call_1 = %d, want %d", again, first)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -580,6 +580,11 @@ type LLMOptions struct {
 	// EnableXAITools opts into xAI server-side tools (web search, X search,
 	// and code interpreter) for xAI Responses API requests.
 	EnableXAITools bool
+	// MaxOutputTokens caps a reply on the OpenAI-compatible paths, in tokens.
+	// Zero uses defaultOaiMaxOutputTokens; set it for a backend whose models
+	// stop below that and reject the request rather than clamping it. A
+	// per-request genai MaxOutputTokens still wins over both.
+	MaxOutputTokens int64
 }
 
 // NewLLM creates a model.LLM for the given provider info, API key, optional base URL, thinking level, and options.


### PR DESCRIPTION
Three failures seen through agentgateway, each reproduced against the live gateway before being fixed.

## 1. Parallel tool calls lost every argument

Session `260903-1155-05261-03a94` shows `bash` called three times with no `command` at all, answering `{"error":"command is required"}`.

Google's OpenAI-compatible endpoint sends each parallel tool call **whole, in its own chunk, with no `index` field inside the tool call** — the `index` present belongs to the *choice*. Captured from the running gateway:

```
"tool_calls":[{"function":{"arguments":"{\"command\":\"ls -la\"}","name":"bash"},"id":"call_670722"}]
"tool_calls":[{"function":{"arguments":"{\"command\":\"pwd\"}","name":"bash"},"id":"call_670723"}]
```

Reading the absent field as its zero value collapsed all three onto slot 0, where `accumulateOaiToolCall` concatenated their arguments into `{...}{...}{...}` — invalid JSON, silently unmarshalled to a nil map.

The accumulator slot is now resolved per call ID when the wire omits an index; an explicit index stays authoritative, which is the shape Anthropic through the same gateway uses. Tests replay both wire shapes captured live.

## 2. Replies truncated at 4096 tokens, which then bricked the session

pi-go sent **no `max_tokens` at all** on the OpenAI-compatible path, so every server substituted its own — agentgateway in front of Anthropic settles on 4096. Reproduced: `finish_reason: length` at exactly 4096 completion tokens. `genai`'s `MaxOutputTokens` was also being dropped on the floor, so a caller who asked for more still got 4096.

When the cut lands inside a tool call's arguments the JSON never closes, the call reaches history with a nil `Args` map, and that marshals as the literal `null`. The gateway forwards it to Anthropic as `"input": null`:

```
400 messages.24.content.0.tool_use.input: Input should be an object
```

The damage is not the one bad call — that turn is *in* the conversation, so every later request replays it and fails identically. One truncated tool call ends the session. Log evidence, 285 ms apart:

```
12:16:24.565  tool_call  write  args:null
12:16:24.850  400  messages.24.content.0.tool_use.input: Input should be an object
```

Both fixed: send a cap (caller's `MaxOutputTokens`, else 64000, overridable per install with the new `maxOutputTokens` setting), and give the OpenAI-compatible paths the floor Anthropic's own path always had — an absent argument map marshals as `{}`.

Note this is an *output* cap, not a context window; the million-token figure quoted for these models is how much they can read.

## 3. `base-costs.json` writes failed with ENOENT

```
failed to write to file `./base-costs.json`: No such file or directory (os error 2)
```

A single-file bind mount binds one inode. Replacing that file on the host by unlink-then-create — a `git checkout` of a deleted file, many editors' save — leaves the container holding a mount that resolves to nothing. Demonstrated side by side:

```
after host-side unlink+create:
  file-mount write: can't create ./f.json: nonexistent directory
  dir-mount write:  ok
```

Rename-over survives, which is why it failed intermittently and read as "refresh costs is broken today" rather than as a broken mount. Compose now mounts the directory; `.env` is shadowed with `/dev/null`, which is safe as a single-file mount precisely because nothing replaces it.

## Verification

- `go build ./...`, `go vet ./internal/...` clean; `golangci-lint` 0 issues on the changed packages.
- `go test` passes for `internal/provider`, `internal/config`, `internal/cli`, `internal/agent`, `internal/tools`.
- Live: the same request that stopped at 4096 with `finish_reason: length` now returns 6541 completion tokens and `finish_reason: stop`.
- Live: `pi ping --trace-http` shows `max_completion_tokens":64000` on the wire.
- One golden updated — `TestCogProviderBBetaNonStreamingGolden` recorded the old nil args.

The mount change cannot be applied to a running gateway until this merges: doing it from a temporary worktree would make the container mount that worktree and break when it is removed.