### PR TITLE
fix(cli,provider): flush CPU profile on exit and consolidate prefix stripping

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,6 +188,9 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 			startPprofServer()
 			startCPUProfile()
 		},
+		PersistentPostRun: func(*cobra.Command, []string) {
+			stopCPUProfile()
+		},
 		RunE: runRoot,
 	}
 
@@ -511,13 +514,15 @@ var pprofOnce sync.Once
 // cpuProfileOnce guards the CPU profile writer. Like pprofOnce it exists so a
 // command reached both through PersistentPreRun and directly in tests does not
 // start two writers on the same file.
-var cpuProfileOnce sync.Once
+var (
+	cpuProfileOnce sync.Once
+	cpuProfileMu   sync.Mutex
+	cpuProfileFile *os.File
+)
 
 // startCPUProfile begins writing a runtime CPU profile to flagCPUProfile when
 // set. The profile is the input PGO consumes, so it must cover a representative
-// workload (see `make record-pgo`). It is stopped by stopCPUProfile, which
-// runRoot defers; a command that never reaches runRoot (a subcommand with its
-// own RunE) leaves the profile unwritten rather than corrupting it.
+// workload (see `make record-pgo`). It is stopped and closed by stopCPUProfile.
 func startCPUProfile() {
 	if flagCPUProfile == "" {
 		return
@@ -530,17 +535,26 @@ func startCPUProfile() {
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
 			fmt.Fprintf(os.Stderr, "cpuprofile: start: %v\n", err)
-			f.Close()
+			_ = f.Close()
 			return
 		}
+		cpuProfileMu.Lock()
+		cpuProfileFile = f
+		cpuProfileMu.Unlock()
 		fmt.Fprintf(os.Stderr, "cpuprofile: writing to %s\n", flagCPUProfile)
 	})
 }
 
 // stopCPUProfile flushes and closes the CPU profile started by startCPUProfile.
-// It is safe to call when no profile was started.
+// It is safe to call when no profile was started or multiple times.
 func stopCPUProfile() {
-	pprof.StopCPUProfile()
+	cpuProfileMu.Lock()
+	defer cpuProfileMu.Unlock()
+	if cpuProfileFile != nil {
+		pprof.StopCPUProfile()
+		_ = cpuProfileFile.Close()
+		cpuProfileFile = nil
+	}
 }
 
 // startPprofServer serves net/http/pprof on --pprof-port when --pprof is set to

--- a/internal/cli/cli_testsupport_test.go
+++ b/internal/cli/cli_testsupport_test.go
@@ -11,16 +11,16 @@ import (
 func resetGlobalFlags(t *testing.T) {
 	t.Helper()
 	orig := struct {
-		model, mode, session, socket, url, system, pprof, pprofPort string
-		headers                                                     []string
-		cont, insecure, smol, slow, plan, memOff                    bool
-		loginModel                                                  string
-		serveAddr, serveProject, serveModel, serveURL               string
-		serveHeaders                                                []string
-		servePairing                                                time.Duration
-		serveInsecure                                               bool
+		model, mode, session, socket, url, system, pprof, pprofPort, cpuProfile string
+		headers                                                                 []string
+		cont, insecure, smol, slow, plan, memOff                                bool
+		loginModel                                                              string
+		serveAddr, serveProject, serveModel, serveURL                           string
+		serveHeaders                                                            []string
+		servePairing                                                            time.Duration
+		serveInsecure                                                           bool
 	}{
-		flagModel, flagMode, flagSession, flagSocket, flagURL, flagSystem, flagPprof, flagPprofPort,
+		flagModel, flagMode, flagSession, flagSocket, flagURL, flagSystem, flagPprof, flagPprofPort, flagCPUProfile,
 		flagHeaders,
 		flagContinue, flagInsecure, flagSmol, flagSlow, flagPlan, flagMemoryOff,
 		flagLoginModel,
@@ -38,6 +38,7 @@ func resetGlobalFlags(t *testing.T) {
 		flagSystem = orig.system
 		flagPprof = orig.pprof
 		flagPprofPort = orig.pprofPort
+		flagCPUProfile = orig.cpuProfile
 		flagHeaders = orig.headers
 		flagContinue = orig.cont
 		flagInsecure = orig.insecure
@@ -63,6 +64,7 @@ func resetGlobalFlags(t *testing.T) {
 	flagSystem = ""
 	flagPprof = ""
 	flagPprofPort = "6060"
+	flagCPUProfile = ""
 	flagHeaders = nil
 	flagContinue = false
 	flagInsecure = false

--- a/internal/cli/cpu_profile_test.go
+++ b/internal/cli/cpu_profile_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func resetCPUProfileForTest(t *testing.T) {
+	t.Helper()
+	stopCPUProfile()
+	cpuProfileMu.Lock()
+	cpuProfileOnce = sync.Once{}
+	cpuProfileMu.Unlock()
+	t.Cleanup(func() {
+		stopCPUProfile()
+		cpuProfileMu.Lock()
+		cpuProfileOnce = sync.Once{}
+		cpuProfileMu.Unlock()
+	})
+}
+
+func TestCPUProfileLifecycle(t *testing.T) {
+	resetGlobalFlags(t)
+	resetCPUProfileForTest(t)
+
+	tmpDir := t.TempDir()
+	profPath := filepath.Join(tmpDir, "test.pprof")
+	flagCPUProfile = profPath
+
+	startCPUProfile()
+
+	cpuProfileMu.Lock()
+	file := cpuProfileFile
+	cpuProfileMu.Unlock()
+	if file == nil {
+		t.Fatal("expected cpuProfileFile to be non-nil after startCPUProfile")
+	}
+
+	// Idempotent stop
+	stopCPUProfile()
+
+	cpuProfileMu.Lock()
+	closedFile := cpuProfileFile
+	cpuProfileMu.Unlock()
+	if closedFile != nil {
+		t.Errorf("expected cpuProfileFile to be nil after stopCPUProfile, got %v", closedFile)
+	}
+
+	// Calling stop again should not panic or fail
+	stopCPUProfile()
+
+	// Verify the file was created
+	info, err := os.Stat(profPath)
+	if err != nil {
+		t.Fatalf("stat profile file: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("expected profile file to have non-zero size")
+	}
+}
+
+func TestStopCPUProfileWhenNotStarted(t *testing.T) {
+	resetGlobalFlags(t)
+	resetCPUProfileForTest(t)
+
+	// Must be safe to call when flagCPUProfile is empty and startCPUProfile was not called
+	stopCPUProfile()
+}

--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -19,27 +19,11 @@ import (
 
 // modelNeedsResponses returns true for models that only support the Responses API.
 func modelNeedsResponses(modelName string) bool {
-	lower := strings.ToLower(modelName)
-	// Strip any provider prefix (e.g. "openai/gpt-5.6-luna" from an
-	// agentgateway virtual model) so the bare model ID is matched. The gateway
-	// forwards the bare ID upstream, so the endpoint decision must be made on it.
-	// Loop so nested prefixes (e.g. "agentgateway/openai/gpt-5.6-luna") collapse.
-	for {
-		stripped := false
-		for _, p := range []string{
-			"openai/", "anthropic/", "gemini/", "mistral/", "xai/", "grok/",
-			"openrouter/", "agentgateway/", "ollama/", "azure/", "opencode/",
-		} {
-			if strings.HasPrefix(lower, p) {
-				lower = strings.TrimPrefix(lower, p)
-				stripped = true
-				break
-			}
-		}
-		if !stripped {
-			break
-		}
-	}
+	// Strip any provider prefix (e.g. "openai/gpt-5.6-luna" or nested
+	// "agentgateway/openai/gpt-5.6-luna") so the bare model ID is matched. The
+	// gateway forwards the bare ID upstream, so the endpoint decision must be
+	// made on it.
+	lower := strings.ToLower(StripKnownProviderPrefixes(modelName))
 	// Responses-only model families.
 	responsesOnly := []string{
 		"gpt-5-codex", "gpt-5.1-codex", "gpt-5.1-codex-mini", "gpt-5.1-codex-max",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -278,31 +278,53 @@ func AzureDeployments() []ModelWindow {
 	return out
 }
 
+// KnownProviderPrefixes lists known vendor and gateway prefixes that may wrap
+// model names in layered routing configurations (e.g. agentgateway/openai/...).
+var KnownProviderPrefixes = []string{
+	"agentgateway/",
+	"anthropic/",
+	"openai/",
+	"gemini/",
+	"google/",
+	"mistral/",
+	"xai/",
+	"grok/",
+	"ollama/",
+	"ollama1/",
+	"ollama2/",
+	"ollama3/",
+	"ollama-cloud/",
+	"azure/",
+	"opencode/",
+	"openrouter/",
+}
+
+// StripKnownProviderPrefixes removes known provider prefix wrappers from a
+// model name iteratively (e.g. "agentgateway/openai/gpt-5.6-luna" -> "gpt-5.6-luna").
+// It preserves the casing of the un-prefixed model identifier.
+func StripKnownProviderPrefixes(modelName string) string {
+	current := modelName
+	for {
+		stripped := false
+		lower := strings.ToLower(current)
+		for _, p := range KnownProviderPrefixes {
+			if strings.HasPrefix(lower, p) {
+				current = current[len(p):]
+				stripped = true
+				break
+			}
+		}
+		if !stripped {
+			break
+		}
+	}
+	return current
+}
+
 // longestPrefixSize resolves modelName against a prefix table, preferring the
 // longest match so "gpt-5.1" beats "gpt-5" and "o1-mini" beats "o1".
 func longestPrefixSize(sizes map[string]int64, modelName string) int64 {
-	lower := strings.ToLower(modelName)
-	// Trim gateway wrapper prefix first so layered routes like
-	// agentgateway/gemini/... or agentgateway/anthropic/... unwrap cleanly.
-	lower = strings.TrimPrefix(lower, "agentgateway/")
-	for _, p := range []string{
-		"anthropic/",
-		"openai/",
-		"gemini/",
-		"google/",
-		"mistral/",
-		"xai/",
-		"ollama/",
-		"ollama1/",
-		"ollama2/",
-		"ollama3/",
-		"ollama-cloud/",
-		"azure/",
-		"opencode/",
-		"openrouter/",
-	} {
-		lower = strings.TrimPrefix(lower, p)
-	}
+	lower := strings.ToLower(StripKnownProviderPrefixes(modelName))
 	bestLen := 0
 	var bestSize int64
 	for prefix, size := range sizes {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -155,6 +155,32 @@ func TestResolveWithAnthropicPrefixCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestStripKnownProviderPrefixes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gpt-5.4", "gpt-5.4"},
+		{"openai/gpt-5.6-luna", "gpt-5.6-luna"},
+		{"OPENAI/gpt-5.6-luna", "gpt-5.6-luna"},
+		{"agentgateway/openai/gpt-5.6-luna", "gpt-5.6-luna"},
+		{"agentgateway/openrouter/anthropic/claude-3-5-sonnet", "claude-3-5-sonnet"},
+		{"agentgateway/gemini/Gemini-3.8-Flash", "Gemini-3.8-Flash"},
+		{"azure/gpt-4o", "gpt-4o"},
+		{"ollama/llama3.3", "llama3.3"},
+		{"ollama-cloud/deepseek-v3", "deepseek-v3"},
+		{"mycorp/custom-model", "mycorp/custom-model"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := StripKnownProviderPrefixes(tt.input); got != tt.want {
+				t.Errorf("StripKnownProviderPrefixes(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveMistralPrefixStripped(t *testing.T) {
 	tests := []struct {
 		model     string


### PR DESCRIPTION
## Summary
- **CPU Profile Resource Management**: Store open file handle for `--cpuprofile`, ensure `cpuProfileFile.Close()` is called alongside `pprof.StopCPUProfile()` in `stopCPUProfile()`.
- **Subcommand Profile Lifecycle**: Wire `stopCPUProfile()` into `PersistentPostRun` so profiling flushes cleanly on both root and subcommands.
- **Provider Prefix Unification**: Centralize known provider prefix list and recursive stripping into `KnownProviderPrefixes` and `StripKnownProviderPrefixes` in `internal/provider`, sharing logic across `longestPrefixSize` and `modelNeedsResponses`.
- **Tests**: Add unit tests for CPU profiling lifecycle and prefix stripping.

## Verification
- `go test ./internal/provider ./internal/cli` pass.
- `golangci-lint run` passes with 0 issues.
- `make build` succeeds.