### PR TITLE
fix(agentgateway): add openrouter claude-fable-5-1 rate to pi-aliases

### DIFF
--- a/hack/agentgateway/pi-aliases.json
+++ b/hack/agentgateway/pi-aliases.json
@@ -454,6 +454,14 @@
             "output": "0.25",
             "cacheRead": "0.015"
           }
+        },
+        "anthropic/claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
         }
       }
     },


### PR DESCRIPTION
pi-go spells the model `anthropic/claude-fable-5-1` (dash), which had no rates in `pi-aliases.json`, so backfilled `request_logs` recorded its cost as 0. Add the entry with the base-costs rates so the dashboard prices it.