### PR TITLE
fix(auth): drop opencode login subcommand; use OPENCODE_API_KEY

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -165,24 +165,6 @@ func Providers() []Provider {
 			DeviceVerifyURL:   "https://auth.openai.com/codex/device",
 			DeviceRedirectURI: "https://auth.openai.com/deviceauth/callback",
 		},
-		{
-			// OpenCode Console (console.opencode.ai) device flow — the same
-			// RFC 8628 flow the opencode CLI runs for `opencode console
-			// login` / `/connect`. The access token returned by the device
-			// grant is the bearer credential pi-go sends to
-			// opencode.ai/zen/go/v1, so it is saved as OPENCODE_API_KEY.
-			// The console endpoints speak JSON, not form-encoded.
-			Name:           "opencode",
-			EnvVar:         "OPENCODE_API_KEY",
-			ClientID:       "opencode-cli",
-			UseDeviceFlow:  true,
-			DeviceJSONBody: true,
-			DeviceURL:      "https://console.opencode.ai/auth/device/code",
-			TokenURL:       "https://console.opencode.ai/auth/device/token",
-			TokenToKey: func(tok *TokenResponse) string {
-				return tok.AccessToken
-			},
-		},
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -489,7 +489,7 @@ func TestPollDeviceToken_Timeout(t *testing.T) {
 }
 
 func TestFindProvider(t *testing.T) {
-	for _, name := range []string{"codex", "Codex", "CODEX", "opencode", "OpenCode"} {
+	for _, name := range []string{"codex", "Codex", "CODEX"} {
 		p, ok := FindProvider(name)
 		if !ok {
 			t.Errorf("expected to find provider %q", name)
@@ -499,25 +499,7 @@ func TestFindProvider(t *testing.T) {
 		}
 	}
 
-	// opencode uses the JSON device flow against the console endpoints.
-	op, ok := FindProvider("opencode")
-	if !ok {
-		t.Fatal("expected opencode provider")
-	}
-	if !op.UseDeviceFlow || !op.DeviceJSONBody {
-		t.Errorf("opencode should use the JSON device flow, got UseDeviceFlow=%v DeviceJSONBody=%v", op.UseDeviceFlow, op.DeviceJSONBody)
-	}
-	if op.DeviceURL == "" || op.TokenURL == "" {
-		t.Errorf("opencode device endpoints not set: device=%q token=%q", op.DeviceURL, op.TokenURL)
-	}
-	if op.TokenToKey == nil {
-		t.Error("opencode TokenToKey must be set")
-	}
-	if got := op.TokenToKey(&TokenResponse{AccessToken: "jwt-token"}); got != "jwt-token" {
-		t.Errorf("opencode TokenToKey should pass access_token through, got %q", got)
-	}
-
-	for _, name := range []string{"anthropic", "openai", "gemini", "unknown"} {
+	for _, name := range []string{"anthropic", "openai", "gemini", "opencode", "unknown"} {
 		if _, ok := FindProvider(name); ok {
 			t.Errorf("should not find provider %q", name)
 		}
@@ -669,10 +651,9 @@ func TestRunTLSPreflight_NetworkError(t *testing.T) {
 }
 
 func TestProviders_TokenToKey(t *testing.T) {
-	// The codex, anthropic and opencode OAuth providers pass access_token
-	// through unchanged (the opencode console token endpoint only ever returns
-	// access_token, never an api_key field); other providers prefer api_key
-	// when present and fall back to access_token.
+	// The codex and anthropic OAuth providers pass access_token through
+	// unchanged; other providers prefer api_key when present and fall back
+	// to access_token.
 	for _, p := range Providers() {
 		t.Run(p.Name+"_accesstoken", func(t *testing.T) {
 			tok := &TokenResponse{AccessToken: "access-token"}
@@ -680,7 +661,7 @@ func TestProviders_TokenToKey(t *testing.T) {
 				t.Errorf("expected 'access-token', got %q", got)
 			}
 		})
-		if p.Name == "codex" || p.Name == "anthropic" || p.Name == "opencode" {
+		if p.Name == "codex" || p.Name == "anthropic" {
 			continue
 		}
 		t.Run(p.Name+"_apikey", func(t *testing.T) {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -24,11 +24,9 @@ func newLoginCmd() *cobra.Command {
 
 Supported providers:
   codex        ChatGPT (chatgpt.com) — device auth
-  opencode     OpenCode Console (console.opencode.ai) — device auth
 
 Examples:
   pi login codex                        # Authenticate with Codex
-  pi login opencode                     # Authenticate with OpenCode Console
   pi login                              # Interactive provider selection`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runLogin,
@@ -57,7 +55,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// Find the provider.
 	prov, ok := auth.FindProvider(providerName)
 	if !ok {
-		return fmt.Errorf("unknown provider %q — supported: codex, opencode", providerName)
+		return fmt.Errorf("unknown provider %q — supported: codex", providerName)
 	}
 
 	fmt.Printf("Logging in to %s...\n\n", prov.Name)

--- a/internal/tui/login.go
+++ b/internal/tui/login.go
@@ -27,7 +27,7 @@ type loginSSOResultMsg struct {
 
 // handleLoginCommand initiates the /login flow.
 // Usage: /login [provider]
-// Providers: codex, opencode
+// Providers: codex
 // Auto-selects the best auth flow (device code, PKCE, or manual key entry).
 func (m *model) handleLoginCommand(args []string) (tea.Model, tea.Cmd) {
 	var provName string
@@ -48,7 +48,7 @@ func (m *model) handleLoginCommand(args []string) (tea.Model, tea.Cmd) {
 		m.logLogin("unknown provider requested: %q", provName)
 		m.chatModel.Messages = append(m.chatModel.Messages, message{
 			role:    "assistant",
-			content: fmt.Sprintf("Unknown provider: `%s`. Available: codex, opencode", provName),
+			content: fmt.Sprintf("Unknown provider: `%s`. Available: codex", provName),
 		})
 		return m, nil
 	}


### PR DESCRIPTION
The opencode OAuth device flow is no longer offered as a login provider. OpenCode is configured purely via the `OPENCODE_API_KEY` env var, which the provider already reads.

- Remove the `opencode` entry from `auth.Providers()`
- Drop `pi login opencode` from the CLI help and error text
- Drop `/login opencode` from the TUI help and unknown-provider message
- Update tests accordingly