### PR TITLE
fix(kagent): copy vendored go-ordered-map in harness image build

### DIFF
--- a/specs/kagent/Dockerfile
+++ b/specs/kagent/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /src
 # Cache module downloads first.
 COPY go.mod go.sum ./
 COPY third_party/acp-go-sdk ./third_party/acp-go-sdk
+COPY third_party/go-ordered-map ./third_party/go-ordered-map
 RUN go mod download
 
 # Build the pure-Go pi binary for the target architecture (TARGETARCH is set


### PR DESCRIPTION
## Problem

The **Docker image** job in the [v0.0.91 release run](https://github.com/dimetron/pi-go/actions/runs/33753797441/job/100649017398) failed at the *Build and push the kagent harness image* step.

`go mod download` exited non-zero:

```
go: github.com/wk8/go-ordered-map/v2@v2.1.8 (replaced by ./third_party/go-ordered-map): reading third_party/go-ordered-map/go.mod: open /src/third_party/go-ordered-map/go.mod: no such file or directory
```

## Root cause

Commit `667a5f2` vendored the `go-ordered-map/v2` fork into `third_party/go-ordered-map` and added a `replace` directive in `go.mod`. But the kagent Dockerfile's module-cache step only copies `third_party/acp-go-sdk` (the other replace target), so inside the container the vendored directory is missing when `go mod download` resolves the replace.

## Fix

Copy `third_party/go-ordered-map` alongside the existing replace target in `specs/kagent/Dockerfile`.

Verified locally: the `go mod download` step (the exact failing step) now passes; the build proceeds past it to `go build`. (A separate, unrelated local-disk-full condition stopped my sandbox build later — not hit by CI.)

Also updated: none.

## Verification

- `golangci-lint`: 0 issues
- `go mod download` in a local buildkit build no longer errors on the vendored replace