### PR TITLE
feat(provider): embed models.dev pricing snapshot with /model-price-refresh

### DIFF
--- a/internal/provider/pricing_test.go
+++ b/internal/provider/pricing_test.go
@@ -117,6 +117,40 @@ func TestParseModelsDevPricingEmpty(t *testing.T) {
 	}
 }
 
+func TestParseModelsDevPricingSkipsNonContextTierAndZeroModel(t *testing.T) {
+	// A tier whose type is not "context" is skipped; a model whose rates are
+	// all zero and has no tiers is dropped entirely.
+	body := `{
+		"openai": {
+			"models": {
+				"gpt-4o": {
+					"cost": {
+						"input": 2.5, "output": 10,
+						"tiers": [
+							{"input": 5, "output": 20, "tier": {"type": "context", "size": 100000}},
+							{"input": 9, "output": 30, "tier": {"type": "prompt", "size": 200000}}
+						]
+					}
+				},
+				"zero-model": {"cost": {"input": 0, "output": 0}}
+			}
+		}
+	}`
+	s, err := parseModelsDevPricing([]byte(body))
+	if err != nil {
+		t.Fatalf("parseModelsDevPricing: %v", err)
+	}
+	// Only the context tier survives.
+	got := s.Providers["openai"]["gpt-4o"]
+	if len(got.Tiers) != 1 || got.Tiers[0].ContextOver != 100000 {
+		t.Errorf("gpt-4o tiers = %+v, want only the 100k context tier", got.Tiers)
+	}
+	// The all-zero model is dropped.
+	if _, ok := s.Providers["openai"]["zero-model"]; ok {
+		t.Error("zero-model should be dropped")
+	}
+}
+
 func TestRefreshPricingFetches(t *testing.T) {
 	withTempCacheDir(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -172,5 +206,125 @@ func TestPricingCachePathUsesModelsCacheDir(t *testing.T) {
 	dir := withTempCacheDir(t)
 	if got := pricingCachePath(); got != filepath.Join(dir, pricingCacheFile) {
 		t.Errorf("pricingCachePath() = %q, want %q", got, filepath.Join(dir, pricingCacheFile))
+	}
+}
+
+func TestLoadPricingSnapshotInvalid(t *testing.T) {
+	if _, ok := loadPricingSnapshot([]byte("not json")); ok {
+		t.Error("loadPricingSnapshot(not json) should be false")
+	}
+	if _, ok := loadPricingSnapshot([]byte(`{"source":"models.dev"}`)); ok {
+		t.Error("loadPricingSnapshot with no providers should be false")
+	}
+}
+
+func TestLoadEmbeddedPricingMissing(t *testing.T) {
+	// The embedded snapshot is always present in the binary, so this exercises
+	// the error path by reading a nonexistent file name via the same helper
+	// shape. We can't remove the embedded file, so assert the happy path works
+	// and the loader returns ok for the real snapshot.
+	if _, ok := loadEmbeddedPricing(); !ok {
+		t.Error("loadEmbeddedPricing() should find the embedded snapshot")
+	}
+}
+
+func TestLoadCachedPricingMissing(t *testing.T) {
+	withTempCacheDir(t)
+	if _, ok := loadCachedPricing(); ok {
+		t.Error("loadCachedPricing() should be false with no cache file")
+	}
+}
+
+func TestPricingForPrefersCache(t *testing.T) {
+	withTempCacheDir(t)
+	// Write a cache file; pricingFor should prefer it over embedded.
+	s := pricingSnapshot{
+		Source:    "models.dev",
+		FetchedAt: time.Now().UTC().Format(time.RFC3339),
+		Providers: map[string]map[string]PricingModel{"openai": {"gpt-4o": {Input: 2.5}}},
+	}
+	b, _ := json.Marshal(s)
+	if err := os.MkdirAll(pricingCacheDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pricingCachePath(), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := pricingFor()
+	if !ok {
+		t.Fatal("pricingFor() should find the cache")
+	}
+	if _, ok := got.Providers["openai"]["gpt-4o"]; !ok {
+		t.Errorf("pricingFor() did not prefer the cache: %+v", got.Providers)
+	}
+}
+
+func TestCostForEmptyModelName(t *testing.T) {
+	withTempCacheDir(t)
+	if _, ok := CostFor("openai", ""); ok {
+		t.Error("CostFor(openai, \"\") should not be found")
+	}
+}
+
+func TestNumInvalid(t *testing.T) {
+	if got := num(json.Number("not-a-number")); got != 0 {
+		t.Errorf("num(invalid) = %v, want 0", got)
+	}
+	if got := num(json.Number("")); got != 0 {
+		t.Errorf("num(empty) = %v, want 0", got)
+	}
+}
+
+func TestFetchModelsDevPricingNon200(t *testing.T) {
+	withTempCacheDir(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	oldURL := modelsDevPricingURL
+	modelsDevPricingURL = srv.URL
+	defer func() { modelsDevPricingURL = oldURL }()
+
+	if _, err := fetchModelsDevPricing(context.Background()); err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestFetchModelsDevPricingBadBody(t *testing.T) {
+	withTempCacheDir(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	oldURL := modelsDevPricingURL
+	modelsDevPricingURL = srv.URL
+	defer func() { modelsDevPricingURL = oldURL }()
+
+	if _, err := fetchModelsDevPricing(context.Background()); err == nil {
+		t.Fatal("expected error for malformed body")
+	}
+}
+
+func TestFetchModelsDevPricingNetworkError(t *testing.T) {
+	withTempCacheDir(t)
+	// Point at a closed port so http.DefaultClient.Do fails.
+	oldURL := modelsDevPricingURL
+	modelsDevPricingURL = "http://127.0.0.1:1"
+	defer func() { modelsDevPricingURL = oldURL }()
+
+	if _, err := fetchModelsDevPricing(context.Background()); err == nil {
+		t.Fatal("expected error for unreachable endpoint")
+	}
+}
+
+func TestFetchModelsDevPricingInvalidURL(t *testing.T) {
+	withTempCacheDir(t)
+	// An invalid URL makes http.NewRequestWithContext fail.
+	oldURL := modelsDevPricingURL
+	modelsDevPricingURL = "://bad"
+	defer func() { modelsDevPricingURL = oldURL }()
+
+	if _, err := fetchModelsDevPricing(context.Background()); err == nil {
+		t.Fatal("expected error for invalid URL")
 	}
 }

--- a/internal/tui/model_price_refresh_test.go
+++ b/internal/tui/model_price_refresh_test.go
@@ -40,7 +40,9 @@ func TestHandleModelPriceRefreshDone_ReplacesPlaceholder(t *testing.T) {
 		}},
 	}
 
-	newM, _ := m.handleModelPriceRefreshDone(modelPriceRefreshDoneMsg{err: nil})
+	// Go through m.Update so the updateSession dispatch case for
+	// modelPriceRefreshDoneMsg is exercised.
+	newM, _ := m.Update(modelPriceRefreshDoneMsg{err: nil})
 	mm := newM.(*model)
 
 	if len(mm.chatModel.Messages) != 1 {
@@ -61,10 +63,33 @@ func TestHandleModelPriceRefreshDone_Error(t *testing.T) {
 		}},
 	}
 
-	newM, _ := m.handleModelPriceRefreshDone(modelPriceRefreshDoneMsg{err: context.DeadlineExceeded})
+	newM, _ := m.Update(modelPriceRefreshDoneMsg{err: context.DeadlineExceeded})
 	mm := newM.(*model)
 
 	if !strings.Contains(mm.chatModel.Messages[0].content, "✗ Model price refresh failed") {
 		t.Errorf("expected failure message, got %q", mm.chatModel.Messages[0].content)
+	}
+}
+
+func TestHandleModelPriceRefreshDone_AppendsWhenNoPlaceholder(t *testing.T) {
+	// When the last message is not a thinking placeholder, the result is
+	// appended rather than replacing.
+	m := &model{
+		chatModel: ChatModel{Messages: []message{
+			{role: "assistant", content: "previous"},
+		}},
+	}
+
+	newM, _ := m.Update(modelPriceRefreshDoneMsg{err: nil})
+	mm := newM.(*model)
+
+	if len(mm.chatModel.Messages) != 2 {
+		t.Fatalf("expected 2 messages (append), got %d", len(mm.chatModel.Messages))
+	}
+	if mm.chatModel.Messages[1].role != "assistant" {
+		t.Errorf("expected appended assistant message, got %q", mm.chatModel.Messages[1].role)
+	}
+	if !strings.Contains(mm.chatModel.Messages[1].content, "✓ Model prices refreshed") {
+		t.Errorf("expected success message, got %q", mm.chatModel.Messages[1].content)
 	}
 }


### PR DESCRIPTION
## What

Pull **https://models.dev/api.json** into a compact embedded snapshot that pi-go can use for cost estimation, surface the prices in `pi model list`, and refresh on demand via a new **`/model-price-refresh`** slash command.

## Details

- **`internal/provider/modeldata/modelsdev-pricing.json`** (~60 KiB) — compact snapshot of the models.dev API, keeping only the providers pi-go supports (`openai`, `anthropic`, `gemini`, `mistral`, `xai`, `azure`, `openrouter`) and only the per-million-token USD rate fields cost estimation needs (`input`, `output`, `cache_read`, `cache_write`, context `tiers`). The full API is ~4.4 MiB across 200+ providers, so this keeps the binary lean.
- **`internal/provider/pricing.go`** — embeds the snapshot and exposes:
  - `CostFor(provider, model)` — exact-then-prefix matching so dated model IDs (`gpt-5.6-sol`) resolve against their base entry (`gpt-5.6`).
  - `RefreshPricing(ctx)` — fetches a fresh snapshot from models.dev and persists it to the XDG cache atomically.
- **`/model-price-refresh` slash command** — fetches a fresh models.dev snapshot on demand and reports the outcome in the chat. Runs asynchronously with a 30s timeout so a slow models.dev never blocks the TUI. **No automatic refresh at startup.**
- **`pi model list` prices** — the human table shows each model's per-million-token input/output price in USD (e.g. `$5.00/$30.00 per 1M`). Local providers (ollama, agentgateway) and models absent from the snapshot show no price. The `-o json` output is unchanged, so the checked-in `models-<provider>.json` snapshots stay stable.
- **`make fetch-modelsdev-pricing`** — regenerates the embedded snapshot from models.dev (no API key needed), mirroring the existing `fetch-models` target.

## Why

The embedded `llm-prices-*.json` files only expose model **IDs** — there's no cost-estimation helper. This adds the pricing data source (models.dev) with an on-demand refresh so the data stays current without a code change, and makes it visible in the model list.

## Verification

- `go build ./...` — clean
- `go test ./internal/provider/` — pass (incl. new pricing tests)
- `go test ./internal/tui/` — pass (incl. new slash-command tests)
- `go test ./internal/cli/ -run 'TestRunModelList|TestHumanTokens|TestPriceAmount|TestModelPrice|TestPrintAzureDeployments'` — pass
- `go vet ./internal/provider/ ./internal/tui/ ./internal/cli/` — clean
- `golangci-lint` — 0 issues
- `scripts/fetch-modelsdev-pricing.sh` — regenerates the snapshot successfully

> Note: `go test ./internal/cli/` (full) hangs under the sandbox (known listener-binding trap per CLAUDE.md); targeted non-listener cli tests pass.
