### PR TITLE
feat(acp): persist sessions and implement session/load, resume and list

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,21 @@ Add pi to Zed's `agent_servers` in your settings:
 Then invoke via Zed's agent panel (`⌘⇧A` / `Ctrl+Shift+A`) and select "pi". The agent runs in the current Zed project
 directory with full access to pi's tools and memory.
 
+### Sessions survive the server
+
+Every ACP session's transcript is written to the same store the terminal uses
+(`~/.pi-go/sessions/<session-id>/`, or `$PI_SESSIONS_DIR`), keyed by the ACP
+session id. The server implements the protocol's session lifecycle on top of it:
+
+| Method | What pi does |
+|---|---|
+| `session/load` | Replays the stored transcript to the client, then continues it |
+| `session/resume` | Continues the transcript without replaying it |
+| `session/list` | Lists stored sessions, newest first, optionally filtered by `cwd` |
+
+So an editor can restart pi — or the machine — and pick a thread up where it
+left off, and `pi --session <id>` reopens the same conversation from the terminal.
+
 ## kagent
 
 Run pi-go as a custom agent inside [kagent](https://kagent.dev) on Agent Substrate via the A2A

--- a/docs/kagent-harness.md
+++ b/docs/kagent-harness.md
@@ -83,6 +83,29 @@ The short version:
 5. Create an `AgentInstance` through the kagent gRPC API and confirm it reaches
    `AGENT_INSTANCE_STATE_READY`, then chat with it from the kagent UI.
 
+## Durable state: sessions survive suspend, restore and replacement
+
+Substrate checkpoints an idle actor and may restore it elsewhere, or replace it
+outright. Either way the actor comes back as a new process, and the only thing
+that carries over is the durable directory mounted at `/data`. The adapter is
+built so that is enough:
+
+- The image sets `HOME=/data`, so everything pi keeps under `~/.pi-go` — session
+  transcripts, the memory store, server logs — lands on the durable mount. A
+  home under `/home/pi` would be lost with the pod.
+- Each A2A context id is a pi session id, and its transcript is persisted under
+  `/data/.pi-go/sessions/<context-id>/` as it happens (`events.jsonl` is
+  append-on-write, so nothing is lost to a checkpoint taken between turns).
+- On the next message for a context the restarted process opens the stored
+  transcript instead of starting a fresh one, and the conversation continues.
+
+Set `PI_SESSIONS_DIR` in the Harness `spec.env` to keep transcripts somewhere
+other than the default `$HOME/.pi-go/sessions`. Each AgentInstance has its own
+durable directory, so one actor cannot read another's transcripts.
+
+The ACP server (`pi acp-server`) persists sessions the same way and exposes
+them through `session/load`, `session/resume` and `session/list`.
+
 ## Model configuration
 
 Set `PI_MODEL` and `PI_BASE_URL` in the Harness `spec.env` to point at the

--- a/internal/acp/server/adapter/toolcall.go
+++ b/internal/acp/server/adapter/toolcall.go
@@ -40,6 +40,13 @@ func toolKind(name string) acp.ToolKind {
 	}
 }
 
+// ToolKind maps a pi-go tool name to the ACP ToolKind the live stream
+// renders it with, so a replayed transcript gets the same cards as the
+// original turn did.
+func ToolKind(name string) acp.ToolKind {
+	return toolKind(name)
+}
+
 // isSubagentTool returns true for tool names that dispatch a sub-agent.
 // Sub-agents become parent "think" cards under which inner tool calls are
 // nested. pi-go's dispatch tool is named "subagent"; "agent" is kept as a

--- a/internal/acp/server/agent.go
+++ b/internal/acp/server/agent.go
@@ -65,6 +65,9 @@ type Agent struct {
 	Subagents []subagent.AgentConfig
 	// Logger is used for diagnostic output. If nil, a discard logger is used.
 	Logger *slog.Logger
+	// Sessions persists transcripts across processes and backs session/load,
+	// session/resume and session/list. Nil keeps sessions in memory only.
+	Sessions SessionStore
 
 	mu       sync.Mutex
 	conn     *acp.AgentSideConnection
@@ -128,17 +131,29 @@ func (a *Agent) Logout(context.Context, acp.LogoutRequest) (acp.LogoutResponse, 
 
 // Initialize advertises pi's baseline capabilities. EmbeddedContext is on so
 // Zed can inline file context; Image defaults to false until zed-09 wires the
-// provider gate.
+// provider gate. session/load and session/resume are always offered;
+// session/list only when a SessionStore can answer it.
 func (a *Agent) Initialize(_ context.Context, _ acp.InitializeRequest) (acp.InitializeResponse, error) {
 	info := a.info()
+	caps := acp.SessionCapabilities{Resume: &acp.SessionResumeCapabilities{}}
+	if a.store() != nil {
+		caps.List = &acp.SessionListCapabilities{}
+	}
 	return acp.InitializeResponse{
 		ProtocolVersion: acp.ProtocolVersion(acp.ProtocolVersionNumber),
 		AgentInfo:       &info,
 		AgentCapabilities: acp.AgentCapabilities{
-			LoadSession:        true,
-			PromptCapabilities: acp.PromptCapabilities{EmbeddedContext: true},
+			LoadSession:         true,
+			PromptCapabilities:  acp.PromptCapabilities{EmbeddedContext: true},
+			SessionCapabilities: caps,
 		},
 	}, nil
+}
+
+func (a *Agent) store() SessionStore {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.Sessions
 }
 
 // NewSession registers a new session and returns its identifier.
@@ -271,10 +286,39 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	return resp, nil
 }
 
-// ListSessions is not yet supported; advertise method-not-found so clients
-// can detect capability absence.
-func (a *Agent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
-	return acp.ListSessionsResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionList)
+// ListSessions reports the sessions the SessionStore has transcripts for,
+// newest first, optionally narrowed to one working directory. Without a
+// store there is nothing to list, and method-not-found tells the client so.
+func (a *Agent) ListSessions(ctx context.Context, params acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	store := a.store()
+	if store == nil {
+		return acp.ListSessionsResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionList)
+	}
+	summaries, err := store.List(ctx)
+	if err != nil {
+		return acp.ListSessionsResponse{}, err
+	}
+	sessions := make([]acp.SessionInfo, 0, len(summaries))
+	for _, s := range summaries {
+		if params.Cwd != nil && *params.Cwd != "" && s.Cwd != *params.Cwd {
+			continue
+		}
+		sessions = append(sessions, sessionInfo(s))
+	}
+	return acp.ListSessionsResponse{Sessions: sessions}, nil
+}
+
+func sessionInfo(s SessionSummary) acp.SessionInfo {
+	info := acp.SessionInfo{SessionId: acp.SessionId(s.ID), Cwd: s.Cwd}
+	if s.Title != "" {
+		title := s.Title
+		info.Title = &title
+	}
+	if !s.UpdatedAt.IsZero() {
+		updated := s.UpdatedAt.UTC().Format(time.RFC3339)
+		info.UpdatedAt = &updated
+	}
+	return info
 }
 
 // CloseSession closes a session and cancels any in-flight prompt work.
@@ -288,9 +332,62 @@ func (a *Agent) CloseSession(ctx context.Context, params acp.CloseSessionRequest
 	return acp.CloseSessionResponse{}, nil
 }
 
-// ResumeSession is not yet supported.
-func (a *Agent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
-	return acp.ResumeSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionResume)
+// ResumeSession binds an existing session id to this agent without replaying
+// its transcript — the client already shows it and only needs the next prompt
+// to continue the conversation. The pi runtime picks the persisted history up
+// under the same id on that prompt.
+func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	if _, err := a.bindSession(ctx, string(params.SessionId), params.Cwd); err != nil {
+		return acp.ResumeSessionResponse{}, err
+	}
+	return acp.ResumeSessionResponse{}, nil
+}
+
+// bindSession attaches sid to this agent with the given cwd, refreshing the
+// record when the session is already in memory, and reports whether a
+// persisted transcript exists for it. With a store, an id that is neither in
+// memory nor on disk is rejected. Without one every id is accepted: nothing
+// can be checked, and the runtime starts a transcript under that id on the
+// first prompt — which is how a client resuming an id against a fresh agent
+// process keeps working.
+func (a *Agent) bindSession(ctx context.Context, sid, cwd string) (persisted bool, err error) {
+	if strings.TrimSpace(sid) == "" {
+		return false, fmt.Errorf("session id is required")
+	}
+	a.mu.Lock()
+	_, known := a.sessions[sid]
+	store := a.Sessions
+	a.mu.Unlock()
+
+	if store != nil {
+		persisted = store.Exists(ctx, sid)
+		if !known && !persisted {
+			return false, fmt.Errorf("session %s not found", sid)
+		}
+	}
+
+	a.mu.Lock()
+	if a.sessions == nil {
+		a.sessions = make(map[string]*sessionState)
+	}
+	st, ok := a.sessions[sid]
+	if !ok {
+		st = &sessionState{}
+		a.sessions[sid] = st
+	}
+	st.cwd = cwd
+	st.commandsSent = false
+	st.commandsPending = false
+	a.mu.Unlock()
+
+	a.log().Log(ctx, slog.LevelDebug,
+		"acp-server: session bound",
+		"session_id", sid,
+		"cwd", cwd,
+		"persisted", persisted,
+	)
+	go a.sendAvailableCommands(sid)
+	return persisted, nil
 }
 
 // SetSessionConfigOption is not yet supported.

--- a/internal/acp/server/agent_test.go
+++ b/internal/acp/server/agent_test.go
@@ -198,8 +198,18 @@ func TestAgentCloseAndResumeSession(t *testing.T) {
 		t.Fatalf("session %q still exists after CloseSession", sess.SessionId)
 	}
 
-	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{SessionId: sess.SessionId}); err == nil {
-		t.Fatal("ResumeSession() error = nil, want method-not-found")
+	// Without a store there is nothing to check a closed id against, so
+	// resume re-binds it: the runtime starts a transcript under it on the
+	// next prompt. Rejection of unknown ids is a store's call (see
+	// TestAgentResumeSessionWithStore).
+	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{SessionId: sess.SessionId, Cwd: "/tmp"}); err != nil {
+		t.Fatalf("ResumeSession() after close error = %v, want re-bind", err)
+	}
+	a.mu.Lock()
+	_, rebound := a.sessions[string(sess.SessionId)]
+	a.mu.Unlock()
+	if !rebound {
+		t.Fatalf("session %q not re-bound by ResumeSession", sess.SessionId)
 	}
 }
 

--- a/internal/acp/server/load.go
+++ b/internal/acp/server/load.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 
 	acp "github.com/coder/acp-go-sdk"
 )
@@ -11,26 +12,28 @@ import (
 // in Initialize.
 var _ acp.AgentLoader = (*Agent)(nil)
 
-// LoadSession binds the supplied session id to this agent with the given cwd.
-// If the id is unknown (e.g. the client is resuming a persisted session id
-// against a fresh agent process), a new state record is created so subsequent
-// Prompt calls succeed. Loading is idempotent — repeated loads simply refresh
-// the session's cwd.
-func (a *Agent) LoadSession(_ context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+// LoadSession binds the supplied session id to this agent with the given cwd
+// and, when a persisted transcript exists for it, replays that transcript to
+// the client before responding — the protocol's contract for session/load, and
+// what lets an editor show the conversation it is about to continue. Loading
+// is idempotent: repeated loads refresh the session's cwd and replay again.
+// See bindSession for how unknown ids are treated with and without a store.
+func (a *Agent) LoadSession(ctx context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
 	sid := string(params.SessionId)
-	a.mu.Lock()
-	if a.sessions == nil {
-		a.sessions = make(map[string]*sessionState)
+	persisted, err := a.bindSession(ctx, sid, params.Cwd)
+	if err != nil {
+		return acp.LoadSessionResponse{}, err
 	}
-	st, ok := a.sessions[sid]
-	if !ok {
-		st = &sessionState{}
-		a.sessions[sid] = st
+	if !persisted {
+		return acp.LoadSessionResponse{}, nil
 	}
-	st.cwd = params.Cwd
-	st.commandsSent = false
-	st.commandsPending = false
-	a.mu.Unlock()
-	go a.sendAvailableCommands(sid)
+	updater := a.updater(params.SessionId)
+	if updater == nil {
+		return acp.LoadSessionResponse{}, nil
+	}
+	if err := a.store().Replay(ctx, sid, updater); err != nil {
+		a.log().Log(ctx, slog.LevelError, "acp-server: session replay failed", "session_id", sid, "err", err)
+		return acp.LoadSessionResponse{}, err
+	}
 	return acp.LoadSessionResponse{}, nil
 }

--- a/internal/acp/server/replay.go
+++ b/internal/acp/server/replay.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strconv"
+
+	acp "github.com/coder/acp-go-sdk"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+
+	piacp "github.com/dimetron/pi-go/internal/acp"
+	"github.com/dimetron/pi-go/internal/acp/server/adapter"
+)
+
+// replayEvents re-emits a persisted transcript as the session updates
+// session/load must send before it responds: user turns as user message
+// chunks, model text as agent message chunks, reasoning as thought chunks,
+// and each tool call as one completed tool_call carrying its input, followed
+// by an update carrying its output. Partial events — streaming deltas — are
+// skipped; the aggregate that follows them is what the store keeps.
+func replayEvents(ctx context.Context, events iter.Seq[*adksession.Event], updater SessionUpdater) error {
+	r := &replayer{updater: updater, lastCallByName: map[string]acp.ToolCallId{}}
+	for ev := range events {
+		if err := r.event(ctx, ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type replayer struct {
+	updater SessionUpdater
+	seq     int
+	// lastCallByName resolves a function response to its call when the
+	// provider left both ids empty: the most recent call of that name.
+	lastCallByName map[string]acp.ToolCallId
+}
+
+func (r *replayer) event(ctx context.Context, ev *adksession.Event) error {
+	if ev == nil || ev.Content == nil || ev.Partial {
+		return nil
+	}
+	user := ev.Content.Role == "user"
+	for _, part := range ev.Content.Parts {
+		update, ok := r.update(part, user)
+		if !ok {
+			continue
+		}
+		if err := r.updater.Update(ctx, update); err != nil {
+			return fmt.Errorf("replay: %w", err)
+		}
+	}
+	return nil
+}
+
+// update classifies one part into the session update that replays it,
+// reporting false for parts that carry nothing to show.
+func (r *replayer) update(part *genai.Part, user bool) (acp.SessionUpdate, bool) {
+	switch {
+	case part == nil:
+		return acp.SessionUpdate{}, false
+	case part.FunctionCall != nil:
+		return r.toolCall(part.FunctionCall), true
+	case part.FunctionResponse != nil:
+		return r.toolResult(part.FunctionResponse)
+	case part.Text == "":
+		return acp.SessionUpdate{}, false
+	case part.Thought:
+		return acp.UpdateAgentThoughtText(part.Text), true
+	case user:
+		return acp.UpdateUserMessageText(part.Text), true
+	default:
+		return acp.UpdateAgentMessageText(part.Text), true
+	}
+}
+
+// toolCall replays a function call as a tool_call that is already complete:
+// the transcript is history, and a card left in progress for a call whose
+// result never made it to disk would spin forever.
+func (r *replayer) toolCall(fc *genai.FunctionCall) acp.SessionUpdate {
+	r.seq++
+	id := acp.ToolCallId(fc.ID)
+	if id == "" {
+		id = acp.ToolCallId("replay_" + strconv.Itoa(r.seq))
+	}
+	r.lastCallByName[fc.Name] = id
+	var rawInput any
+	if len(fc.Args) > 0 {
+		rawInput = fc.Args
+	}
+	return acp.StartToolCall(id, piacp.EnrichToolCallTitle(fc.Name, rawInput),
+		acp.WithStartKind(adapter.ToolKind(fc.Name)),
+		acp.WithStartStatus(acp.ToolCallStatusCompleted),
+		acp.WithStartRawInput(rawInput),
+	)
+}
+
+// toolResult attaches a function response to the call it answers. A response
+// that cannot be paired with a call has no card to land on and is dropped.
+func (r *replayer) toolResult(fr *genai.FunctionResponse) (acp.SessionUpdate, bool) {
+	id := acp.ToolCallId(fr.ID)
+	if id == "" {
+		id = r.lastCallByName[fr.Name]
+	}
+	if id == "" {
+		return acp.SessionUpdate{}, false
+	}
+	var rawOutput any
+	if len(fr.Response) > 0 {
+		rawOutput = fr.Response
+	}
+	return acp.UpdateToolCall(id,
+		acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+		acp.WithUpdateRawOutput(rawOutput),
+	), true
+}

--- a/internal/acp/server/replay_test.go
+++ b/internal/acp/server/replay_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"slices"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// recordingUpdater captures every session update in order.
+type recordingUpdater struct {
+	updates []acp.SessionUpdate
+	failAt  int // 1-based index of the update to fail on; 0 never fails
+}
+
+func (u *recordingUpdater) Update(_ context.Context, update acp.SessionUpdate) error {
+	u.updates = append(u.updates, update)
+	if u.failAt > 0 && len(u.updates) == u.failAt {
+		return errors.New("peer gone")
+	}
+	return nil
+}
+
+func eventsOf(evs ...*adksession.Event) iter.Seq[*adksession.Event] {
+	return slices.Values(evs)
+}
+
+func userTextEvent(text string) *adksession.Event {
+	ev := &adksession.Event{Author: "user", Timestamp: time.Now()}
+	ev.Content = genai.NewContentFromText(text, genai.RoleUser)
+	return ev
+}
+
+func modelEvent(parts ...*genai.Part) *adksession.Event {
+	ev := &adksession.Event{Author: "pi", Timestamp: time.Now()}
+	ev.Content = &genai.Content{Role: genai.RoleModel, Parts: parts}
+	return ev
+}
+
+func TestReplayEventsMapsTranscriptToUpdates(t *testing.T) {
+	t.Parallel()
+
+	call := &genai.FunctionCall{ID: "fc_1", Name: "read", Args: map[string]any{"path": "main.go"}}
+	result := &genai.FunctionResponse{ID: "fc_1", Name: "read", Response: map[string]any{"content": "package main"}}
+	partial := modelEvent(genai.NewPartFromText("delta"))
+	partial.Partial = true
+
+	u := &recordingUpdater{}
+	err := replayEvents(context.Background(), eventsOf(
+		userTextEvent("open main.go"),
+		partial,
+		modelEvent(&genai.Part{Text: "let me look", Thought: true}),
+		modelEvent(&genai.Part{FunctionCall: call}),
+		&adksession.Event{Author: "user", Content: &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{{FunctionResponse: result}}}},
+		modelEvent(genai.NewPartFromText("it is a main package")),
+		nil,
+		&adksession.Event{Author: "pi"},
+	), u)
+	if err != nil {
+		t.Fatalf("replayEvents() error = %v", err)
+	}
+
+	if len(u.updates) != 5 {
+		t.Fatalf("got %d updates, want 5: %+v", len(u.updates), u.updates)
+	}
+	if got := u.updates[0].UserMessageChunk; got == nil || got.Content.Text == nil || got.Content.Text.Text != "open main.go" {
+		t.Errorf("update[0] = %+v, want user message chunk", u.updates[0])
+	}
+	if got := u.updates[1].AgentThoughtChunk; got == nil || got.Content.Text.Text != "let me look" {
+		t.Errorf("update[1] = %+v, want thought chunk", u.updates[1])
+	}
+	tc := u.updates[2].ToolCall
+	if tc == nil {
+		t.Fatalf("update[2] = %+v, want tool_call", u.updates[2])
+	}
+	if tc.ToolCallId != "fc_1" || tc.Kind != acp.ToolKindRead || tc.Status != acp.ToolCallStatusCompleted {
+		t.Errorf("tool_call = id %q kind %q status %q", tc.ToolCallId, tc.Kind, tc.Status)
+	}
+	if tc.Title != "read: main.go" {
+		t.Errorf("tool_call title = %q, want enriched with the path", tc.Title)
+	}
+	tu := u.updates[3].ToolCallUpdate
+	if tu == nil || tu.ToolCallId != "fc_1" || tu.Status == nil || *tu.Status != acp.ToolCallStatusCompleted {
+		t.Fatalf("update[3] = %+v, want completed tool_call_update for fc_1", u.updates[3])
+	}
+	if out, ok := tu.RawOutput.(map[string]any); !ok || out["content"] != "package main" {
+		t.Errorf("tool_call_update rawOutput = %#v, want the response map", tu.RawOutput)
+	}
+	if got := u.updates[4].AgentMessageChunk; got == nil || got.Content.Text.Text != "it is a main package" {
+		t.Errorf("update[4] = %+v, want agent message chunk", u.updates[4])
+	}
+}
+
+func TestReplayEventsPairsResponsesWithoutIDsByName(t *testing.T) {
+	t.Parallel()
+
+	u := &recordingUpdater{}
+	err := replayEvents(context.Background(), eventsOf(
+		modelEvent(&genai.Part{FunctionCall: &genai.FunctionCall{Name: "bash", Args: map[string]any{"command": "ls"}}}),
+		modelEvent(&genai.Part{FunctionCall: &genai.FunctionCall{Name: "bash", Args: map[string]any{"command": "pwd"}}}),
+		&adksession.Event{Content: &genai.Content{Role: genai.RoleUser, Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{Name: "bash", Response: map[string]any{"stdout": "/"}}},
+			{FunctionResponse: &genai.FunctionResponse{Name: "never-called"}},
+		}}},
+	), u)
+	if err != nil {
+		t.Fatalf("replayEvents() error = %v", err)
+	}
+	if len(u.updates) != 3 {
+		t.Fatalf("got %d updates, want 2 calls + 1 paired result: %+v", len(u.updates), u.updates)
+	}
+	first, second := u.updates[0].ToolCall, u.updates[1].ToolCall
+	if first.ToolCallId == second.ToolCallId {
+		t.Fatalf("generated ids collide: %q", first.ToolCallId)
+	}
+	if first.Kind != acp.ToolKindExecute {
+		t.Errorf("bash kind = %q, want execute", first.Kind)
+	}
+	if got := u.updates[2].ToolCallUpdate; got == nil || got.ToolCallId != second.ToolCallId {
+		t.Errorf("result paired with %v, want the most recent bash call %q", u.updates[2], second.ToolCallId)
+	}
+}
+
+func TestReplayEventsStopsAtFirstUpdateError(t *testing.T) {
+	t.Parallel()
+
+	u := &recordingUpdater{failAt: 2}
+	err := replayEvents(context.Background(), eventsOf(
+		userTextEvent("one"),
+		modelEvent(genai.NewPartFromText("two")),
+		modelEvent(genai.NewPartFromText("three")),
+	), u)
+	if err == nil {
+		t.Fatal("replayEvents() error = nil, want the updater's failure")
+	}
+	if len(u.updates) != 2 {
+		t.Errorf("replay continued past the failure: %d updates", len(u.updates))
+	}
+}
+
+func TestReplayEventsSkipsEmptyParts(t *testing.T) {
+	t.Parallel()
+
+	u := &recordingUpdater{}
+	err := replayEvents(context.Background(), eventsOf(
+		modelEvent(nil, &genai.Part{Text: ""}, &genai.Part{Text: "", Thought: true}, genai.NewPartFromText("kept")),
+	), u)
+	if err != nil {
+		t.Fatalf("replayEvents() error = %v", err)
+	}
+	if len(u.updates) != 1 {
+		t.Fatalf("got %d updates, want only the non-empty part: %+v", len(u.updates), u.updates)
+	}
+	if got := u.updates[0].AgentMessageChunk; got == nil || got.Content.Text.Text != "kept" {
+		t.Errorf("update = %+v, want the \"kept\" chunk", u.updates[0])
+	}
+}

--- a/internal/acp/server/resume_test.go
+++ b/internal/acp/server/resume_test.go
@@ -1,0 +1,374 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+	adkmodel "google.golang.org/adk/v2/model"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+
+	piagent "github.com/dimetron/pi-go/internal/agent"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+func textPart(text string) *genai.Part { return genai.NewPartFromText(text) }
+
+// fakeStore is an in-memory SessionStore keyed by ACP session id.
+type fakeStore struct {
+	transcripts map[string][]string // agent replies to replay
+	summaries   []SessionSummary
+	listErr     error
+	replayErr   error
+	replayed    []string
+}
+
+func (f *fakeStore) Exists(_ context.Context, id string) bool {
+	_, ok := f.transcripts[id]
+	return ok
+}
+
+func (f *fakeStore) Replay(ctx context.Context, id string, u SessionUpdater) error {
+	f.replayed = append(f.replayed, id)
+	if f.replayErr != nil {
+		return f.replayErr
+	}
+	for _, text := range f.transcripts[id] {
+		if err := u.Update(ctx, acp.UpdateAgentMessageText(text)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeStore) List(context.Context) ([]SessionSummary, error) {
+	return f.summaries, f.listErr
+}
+
+func TestAgentInitializeAdvertisesResumeAndList(t *testing.T) {
+	t.Parallel()
+
+	resp, err := (&Agent{}).Initialize(context.Background(), acp.InitializeRequest{})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if resp.AgentCapabilities.SessionCapabilities.Resume == nil {
+		t.Error("Resume capability not advertised without a store")
+	}
+	if resp.AgentCapabilities.SessionCapabilities.List != nil {
+		t.Error("List capability advertised without a store to answer it")
+	}
+
+	resp, err = (&Agent{Sessions: &fakeStore{}}).Initialize(context.Background(), acp.InitializeRequest{})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if resp.AgentCapabilities.SessionCapabilities.List == nil {
+		t.Error("List capability not advertised with a store")
+	}
+}
+
+func TestAgentResumeSessionWithoutStoreBindsAnyID(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+
+	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{Cwd: "/tmp"}); err == nil {
+		t.Error("ResumeSession() with an empty id error = nil, want rejection")
+	}
+
+	captured := make(chan string, 1)
+	a.Handler = func(_ context.Context, turn PromptTurn) (PromptResult, error) {
+		captured <- turn.CWD
+		return PromptResult{StopReason: acp.StopReasonEndTurn}, nil
+	}
+	const sid = "sess_resumed_fresh"
+	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{SessionId: sid, Cwd: "/tmp/resumed"}); err != nil {
+		t.Fatalf("ResumeSession() error = %v", err)
+	}
+	if _, err := a.Prompt(context.Background(), acp.PromptRequest{
+		SessionId: sid, Prompt: []acp.ContentBlock{acp.TextBlock("hi")},
+	}); err != nil {
+		t.Fatalf("Prompt() after resume error = %v", err)
+	}
+	select {
+	case got := <-captured:
+		if got != "/tmp/resumed" {
+			t.Errorf("turn.CWD = %q, want the resumed cwd", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler did not run")
+	}
+}
+
+func TestAgentResumeSessionWithStore(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{transcripts: map[string][]string{"sess_on_disk": {"earlier reply"}}}
+	a := &Agent{Sessions: store}
+
+	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{SessionId: "sess_unknown", Cwd: "/tmp"}); err == nil {
+		t.Error("ResumeSession() of an id the store lacks error = nil, want not found")
+	}
+
+	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{SessionId: "sess_on_disk", Cwd: "/tmp"}); err != nil {
+		t.Fatalf("ResumeSession() of a persisted id error = %v", err)
+	}
+	if len(store.replayed) != 0 {
+		t.Errorf("ResumeSession() replayed %v; resume must not replay the transcript", store.replayed)
+	}
+
+	// An id that only lives in memory (created by session/new, not yet
+	// prompted) resumes too: the store is consulted for unknown ids only.
+	sess, err := a.NewSession(context.Background(), acp.NewSessionRequest{Cwd: "/tmp"})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+	if _, err := a.ResumeSession(context.Background(), acp.ResumeSessionRequest{SessionId: sess.SessionId, Cwd: "/tmp/moved"}); err != nil {
+		t.Errorf("ResumeSession() of an in-memory session error = %v", err)
+	}
+}
+
+func TestAgentLoadSessionReplaysBeforeResponding(t *testing.T) {
+	clientRW, agentRW := pipePair()
+	defer clientRW.Close()
+
+	store := &fakeStore{transcripts: map[string][]string{"sess_replayed": {"first reply", "second reply"}}}
+	a := &Agent{Sessions: store}
+	defer wireAgent(t, a, agentRW)()
+
+	client := &capturingClient{}
+	clientConn := acp.NewClientSideConnection(client, clientRW, clientRW)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	initResp, err := clientConn.Initialize(ctx, acp.InitializeRequest{ProtocolVersion: acp.ProtocolVersion(acp.ProtocolVersionNumber)})
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if initResp.AgentCapabilities.SessionCapabilities.Resume == nil || initResp.AgentCapabilities.SessionCapabilities.List == nil {
+		t.Fatalf("capabilities over the wire = %+v, want resume and list", initResp.AgentCapabilities.SessionCapabilities)
+	}
+
+	if _, err := clientConn.LoadSession(ctx, acp.LoadSessionRequest{
+		SessionId: "sess_replayed", Cwd: "/tmp/rpc", McpServers: []acp.McpServer{},
+	}); err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	// The response must trail the replay, so by now every chunk has landed.
+	got := client.messages.Load()
+	if got == nil || strings.Join(*got, "|") != "first reply|second reply" {
+		t.Fatalf("replayed messages before the load response = %v, want both replies in order", got)
+	}
+
+	if _, err := clientConn.LoadSession(ctx, acp.LoadSessionRequest{
+		SessionId: "sess_never", Cwd: "/tmp/rpc", McpServers: []acp.McpServer{},
+	}); err == nil {
+		t.Error("LoadSession() of an unknown id error = nil, want not found")
+	}
+
+	if _, err := clientConn.ResumeSession(ctx, acp.ResumeSessionRequest{SessionId: "sess_replayed", Cwd: "/tmp/rpc"}); err != nil {
+		t.Errorf("ResumeSession() over the wire error = %v", err)
+	}
+}
+
+func TestAgentLoadSessionSurfacesReplayFailure(t *testing.T) {
+	clientRW, agentRW := pipePair()
+	defer clientRW.Close()
+
+	store := &fakeStore{
+		transcripts: map[string][]string{"sess_broken": {"one"}},
+		replayErr:   errors.New("events.jsonl truncated"),
+	}
+	a := &Agent{Sessions: store}
+	defer wireAgent(t, a, agentRW)()
+	go func() { _ = acp.NewClientSideConnection(&capturingClient{}, clientRW, clientRW) }()
+
+	_, err := a.LoadSession(context.Background(), acp.LoadSessionRequest{
+		SessionId: "sess_broken", Cwd: "/tmp", McpServers: []acp.McpServer{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("LoadSession() error = %v, want the replay failure surfaced", err)
+	}
+	if len(store.replayed) != 1 {
+		t.Errorf("replay attempted %d times, want 1", len(store.replayed))
+	}
+}
+
+func TestAgentListSessions(t *testing.T) {
+	t.Parallel()
+
+	if _, err := (&Agent{}).ListSessions(context.Background(), acp.ListSessionsRequest{}); !isMethodNotFound(err) {
+		t.Errorf("ListSessions() without a store err = %v, want method-not-found", err)
+	}
+
+	updated := time.Date(2026, 9, 3, 10, 0, 0, 0, time.UTC)
+	store := &fakeStore{summaries: []SessionSummary{
+		{ID: "sess_a", Cwd: "/work/a", Title: "alpha", UpdatedAt: updated},
+		{ID: "sess_b", Cwd: "/work/b"},
+	}}
+	a := &Agent{Sessions: store}
+
+	resp, err := a.ListSessions(context.Background(), acp.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if len(resp.Sessions) != 2 {
+		t.Fatalf("ListSessions() = %d sessions, want 2", len(resp.Sessions))
+	}
+	first := resp.Sessions[0]
+	if first.SessionId != "sess_a" || first.Cwd != "/work/a" || first.Title == nil || *first.Title != "alpha" {
+		t.Errorf("session[0] = %+v, want sess_a with title alpha", first)
+	}
+	if first.UpdatedAt == nil || *first.UpdatedAt != "2026-09-03T10:00:00Z" {
+		t.Errorf("session[0].UpdatedAt = %v, want RFC3339 UTC", first.UpdatedAt)
+	}
+	if second := resp.Sessions[1]; second.Title != nil || second.UpdatedAt != nil {
+		t.Errorf("session[1] = %+v, want no title or timestamp when unset", second)
+	}
+
+	cwd := "/work/b"
+	resp, err = a.ListSessions(context.Background(), acp.ListSessionsRequest{Cwd: &cwd})
+	if err != nil {
+		t.Fatalf("ListSessions(cwd) error = %v", err)
+	}
+	if len(resp.Sessions) != 1 || resp.Sessions[0].SessionId != "sess_b" {
+		t.Errorf("ListSessions(cwd=/work/b) = %+v, want only sess_b", resp.Sessions)
+	}
+
+	store.listErr = errors.New("disk gone")
+	if _, err := a.ListSessions(context.Background(), acp.ListSessionsRequest{}); err == nil {
+		t.Error("ListSessions() error = nil, want the store failure")
+	}
+}
+
+// stubLLM satisfies adkmodel.LLM without ever being called.
+type stubLLM struct{}
+
+func (stubLLM) Name() string { return "stub" }
+func (stubLLM) GenerateContent(context.Context, *adkmodel.LLMRequest, bool) iter.Seq2[*adkmodel.LLMResponse, error] {
+	return func(func(*adkmodel.LLMResponse, error) bool) {}
+}
+
+func TestOpenPiSessionPersistsUnderACPID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	inMemory, err := piagent.New(piagent.Config{Model: stubLLM{}})
+	if err != nil {
+		t.Fatalf("piagent.New: %v", err)
+	}
+	sid, resumed, err := openPiSession(ctx, RuntimeConfig{}, inMemory, "sess_acp")
+	if err != nil {
+		t.Fatalf("openPiSession() without a service error = %v", err)
+	}
+	if resumed || sid == "" || sid == "sess_acp" {
+		t.Errorf("without a service got (%q, %v), want a fresh generated id", sid, resumed)
+	}
+
+	svc, err := pisession.NewFileService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	rt := RuntimeConfig{SessionService: svc}
+	persistent, err := piagent.New(piagent.Config{Model: stubLLM{}, SessionService: svc})
+	if err != nil {
+		t.Fatalf("piagent.New: %v", err)
+	}
+	sid, resumed, err = openPiSession(ctx, rt, persistent, "sess_acp")
+	if err != nil {
+		t.Fatalf("openPiSession() first open error = %v", err)
+	}
+	if sid != "sess_acp" || resumed {
+		t.Errorf("first open = (%q, %v), want the ACP id and no history", sid, resumed)
+	}
+
+	// A second process seeing the same id opens the same transcript.
+	again, err := piagent.New(piagent.Config{Model: stubLLM{}, SessionService: svc})
+	if err != nil {
+		t.Fatalf("piagent.New: %v", err)
+	}
+	sid, resumed, err = openPiSession(ctx, rt, again, "sess_acp")
+	if err != nil {
+		t.Fatalf("openPiSession() reopen error = %v", err)
+	}
+	if sid != "sess_acp" || !resumed {
+		t.Errorf("reopen = (%q, %v), want the same id with history", sid, resumed)
+	}
+
+	sid, _, err = openPiSession(ctx, rt, again, "../escape")
+	if err != nil {
+		t.Fatalf("openPiSession() hostile id error = %v", err)
+	}
+	if !strings.HasPrefix(sid, "acp-") {
+		t.Errorf("hostile id persisted as %q, want a hashed id", sid)
+	}
+	if _, err := svc.Get(ctx, &adksession.GetRequest{AppName: piagent.AppName, UserID: piagent.DefaultUserID, SessionID: sid}); err != nil {
+		t.Errorf("hashed session not persisted: %v", err)
+	}
+}
+
+// failingSessionService makes Create and Get fail so error paths that a real
+// store reaches only on a broken disk become testable.
+type failingSessionService struct {
+	adksession.Service
+	createErr error
+}
+
+func (f failingSessionService) Get(context.Context, *adksession.GetRequest) (*adksession.GetResponse, error) {
+	return nil, errors.New("no such session")
+}
+
+func (f failingSessionService) Create(context.Context, *adksession.CreateRequest) (*adksession.CreateResponse, error) {
+	return nil, f.createErr
+}
+
+func TestOpenPiSessionSurfacesFailures(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := failingSessionService{Service: adksession.InMemoryService(), createErr: errors.New("disk full")}
+
+	ag, err := piagent.New(piagent.Config{Model: stubLLM{}, SessionService: svc})
+	if err != nil {
+		t.Fatalf("piagent.New: %v", err)
+	}
+
+	// With a service configured, the failure comes through OpenSession.
+	if _, _, err := openPiSession(ctx, RuntimeConfig{SessionService: svc}, ag, "sess_x"); err == nil ||
+		!strings.Contains(err.Error(), "opening session") {
+		t.Errorf("openPiSession() error = %v, want it wrapped with \"opening session\"", err)
+	}
+
+	// Without one, the failure comes through CreateSession instead.
+	if _, _, err := openPiSession(ctx, RuntimeConfig{}, ag, "sess_x"); err == nil ||
+		!strings.Contains(err.Error(), "creating session") {
+		t.Errorf("openPiSession() error = %v, want it wrapped with \"creating session\"", err)
+	}
+}
+
+func TestAgentLoadSessionWithoutConnectionSkipsReplay(t *testing.T) {
+	t.Parallel()
+	// No agent-side connection is wired, so there is no updater to replay
+	// through. Load must still succeed and leave the session bound.
+	store := &fakeStore{transcripts: map[string][]string{"sess_quiet": {"reply"}}}
+	a := &Agent{Sessions: store}
+
+	if _, err := a.LoadSession(context.Background(), acp.LoadSessionRequest{
+		SessionId: "sess_quiet", Cwd: "/tmp", McpServers: []acp.McpServer{},
+	}); err != nil {
+		t.Fatalf("LoadSession() error = %v", err)
+	}
+	if len(store.replayed) != 0 {
+		t.Errorf("replayed %v with no connection; want the replay skipped", store.replayed)
+	}
+	a.mu.Lock()
+	_, bound := a.sessions["sess_quiet"]
+	a.mu.Unlock()
+	if !bound {
+		t.Error("session not bound after LoadSession")
+	}
+}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -42,6 +42,13 @@ type RuntimeConfig struct {
 	System          string
 	LoadConfig      func() (config.Config, error)
 	SandboxRootFunc func(turn PromptTurn) string
+	// SessionService, when set, persists each ACP session's transcript under
+	// its ACP session id (see StoreSessionID), so a session survives the
+	// process that started it: the next process to see the same id — after
+	// an editor restart, or after Substrate replaces an actor — continues
+	// the conversation instead of starting over. Nil keeps transcripts in
+	// memory for the life of the process.
+	SessionService adksession.Service
 }
 
 // piSessionState caches the per-ACP-session pi runtime so all turns within one
@@ -182,6 +189,8 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		Tools:                res.coreTools,
 		Toolsets:             buildToolsetsFromCfg(cfg),
 		Instruction:          instruction,
+		SessionService:       rt.SessionService,
+		WorkingDir:           cwd,
 		BeforeToolCallbacks:  res.beforeCBs,
 		AfterToolCallbacks:   res.afterCBs,
 		BeforeModelCallbacks: res.beforeModelCBs,
@@ -191,11 +200,12 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		return nil, fmt.Errorf("creating agent: %w", err)
 	}
 
-	sessionID, _, err := ag.CreateSession(ctx)
+	sessionID, resumed, err := openPiSession(ctx, rt, ag, turn.SessionID)
 	if err != nil {
 		res.cleanup()
-		return nil, fmt.Errorf("creating session: %w", err)
+		return nil, err
 	}
+	span.SetAttributes(attribute.Bool("session.resumed", resumed))
 
 	return &piSessionState{
 		agent:       ag,
@@ -204,6 +214,27 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		bashSup:     res.bashSup,
 		cleanup:     res.cleanup,
 	}, nil
+}
+
+// openPiSession settles the ADK session a turn runs in and reports whether it
+// carried history. With a persistent service the transcript lives under the
+// ACP session id, so an id seen before — by an earlier process, or by the CLI
+// — resumes where it left off. Without one every ACP session starts a fresh
+// in-memory transcript.
+func openPiSession(ctx context.Context, rt RuntimeConfig, ag *piagent.Agent, acpSessionID string) (sessionID string, resumed bool, err error) {
+	if rt.SessionService == nil {
+		sid, _, err := ag.CreateSession(ctx)
+		if err != nil {
+			return "", false, fmt.Errorf("creating session: %w", err)
+		}
+		return sid, false, nil
+	}
+	sid := StoreSessionID(acpSessionID)
+	resumed, err = ag.OpenSession(ctx, sid)
+	if err != nil {
+		return "", false, fmt.Errorf("opening session: %w", err)
+	}
+	return sid, resumed, nil
 }
 
 // loadSessionConfig loads the pi config for the session's working directory and

--- a/internal/acp/server/store.go
+++ b/internal/acp/server/store.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"time"
+
+	adksession "google.golang.org/adk/v2/session"
+
+	piagent "github.com/dimetron/pi-go/internal/agent"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// SessionSummary describes one persisted session, as reported by session/list.
+type SessionSummary struct {
+	ID        string
+	Cwd       string
+	Title     string
+	UpdatedAt time.Time
+}
+
+// SessionStore is the persistence seam behind session/load, session/resume
+// and session/list. Ids are the ACP session ids the client knows; the store
+// maps them to whatever it keeps on disk (see StoreSessionID). A nil store
+// leaves the agent with in-memory sessions only: every id is accepted on
+// load and resume because there is nothing to check it against, and
+// session/list is not advertised.
+type SessionStore interface {
+	// Exists reports whether a transcript is persisted for the session.
+	Exists(ctx context.Context, sessionID string) bool
+	// Replay re-emits the persisted transcript through updater as ACP
+	// session updates, in order. session/load calls it before responding.
+	Replay(ctx context.Context, sessionID string, updater SessionUpdater) error
+	// List returns every persisted session, newest first.
+	List(ctx context.Context) ([]SessionSummary, error)
+}
+
+// sessionIDPattern accepts ids that are safe directory names: pi's own
+// sess_… ids, the UUIDs kagent assigns as A2A context ids, and the
+// yymmdd-hhmm-… ids the CLI generates.
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// StoreSessionID maps an ACP session id to the id its transcript is persisted
+// under. Safe ids pass through unchanged, so the on-disk session carries the
+// id the client knows and `pi --session <id>` can reopen it. Anything else —
+// path separators, a leading dot, control characters, an over-long string —
+// is replaced by a stable hash, so a hostile id cannot name a path outside
+// the sessions directory and the same id still resolves to the same transcript.
+func StoreSessionID(id string) string {
+	if sessionIDPattern.MatchString(id) {
+		return id
+	}
+	sum := sha256.Sum256([]byte(id))
+	return "acp-" + hex.EncodeToString(sum[:16])
+}
+
+// FileSessionStore is a SessionStore over pi's on-disk session store — the
+// same JSONL directory the CLI writes to, so a transcript an editor started
+// over ACP is resumable from the terminal and vice versa.
+type FileSessionStore struct {
+	svc *pisession.FileService
+}
+
+var _ SessionStore = (*FileSessionStore)(nil)
+
+// NewFileSessionStore wraps svc as a SessionStore.
+func NewFileSessionStore(svc *pisession.FileService) *FileSessionStore {
+	return &FileSessionStore{svc: svc}
+}
+
+// Exists implements SessionStore.
+func (s *FileSessionStore) Exists(ctx context.Context, sessionID string) bool {
+	_, err := s.get(ctx, sessionID)
+	return err == nil
+}
+
+// Replay implements SessionStore.
+func (s *FileSessionStore) Replay(ctx context.Context, sessionID string, updater SessionUpdater) error {
+	if updater == nil {
+		return nil
+	}
+	sess, err := s.get(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	return replayEvents(ctx, sess.Events().All(), updater)
+}
+
+// List implements SessionStore.
+func (s *FileSessionStore) List(_ context.Context) ([]SessionSummary, error) {
+	metas, err := s.svc.ListMeta(piagent.AppName, piagent.DefaultUserID)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions: %w", err)
+	}
+	out := make([]SessionSummary, 0, len(metas))
+	for _, m := range metas {
+		out = append(out, SessionSummary{
+			ID:        m.ID,
+			Cwd:       m.WorkDir,
+			Title:     m.Title,
+			UpdatedAt: m.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
+func (s *FileSessionStore) get(ctx context.Context, sessionID string) (adksession.Session, error) {
+	resp, err := s.svc.Get(ctx, &adksession.GetRequest{
+		AppName:   piagent.AppName,
+		UserID:    piagent.DefaultUserID,
+		SessionID: StoreSessionID(sessionID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("session %s: %w", sessionID, err)
+	}
+	return resp.Session, nil
+}

--- a/internal/acp/server/store_test.go
+++ b/internal/acp/server/store_test.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	adksession "google.golang.org/adk/v2/session"
+
+	piagent "github.com/dimetron/pi-go/internal/agent"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+func TestStoreSessionID(t *testing.T) {
+	t.Parallel()
+
+	passthrough := []string{
+		"sess_0123456789abcdef01234567",
+		"7f0c7a4e-2f0e-4b9b-9d1a-0c2a5b3f8e11", // kagent A2A context id
+		"260903-1830-ab12c-d34ef",              // CLI-generated id
+		"a.b-c_d",
+	}
+	for _, id := range passthrough {
+		if got := StoreSessionID(id); got != id {
+			t.Errorf("StoreSessionID(%q) = %q, want unchanged", id, got)
+		}
+	}
+
+	hashed := []string{
+		"",
+		"../../etc/passwd",
+		"a/b",
+		".hidden",
+		"with space",
+		"tab\tchar",
+		strings.Repeat("x", 129),
+	}
+	seen := map[string]string{}
+	for _, id := range hashed {
+		got := StoreSessionID(id)
+		if !strings.HasPrefix(got, "acp-") || len(got) != len("acp-")+32 {
+			t.Errorf("StoreSessionID(%q) = %q, want acp-<32 hex>", id, got)
+		}
+		if filepath.Base(got) != got {
+			t.Errorf("StoreSessionID(%q) = %q is not a bare path element", id, got)
+		}
+		if prev, dup := seen[got]; dup {
+			t.Errorf("StoreSessionID(%q) collides with %q", id, prev)
+		}
+		seen[got] = id
+		if again := StoreSessionID(id); again != got {
+			t.Errorf("StoreSessionID(%q) not stable: %q then %q", id, got, again)
+		}
+	}
+}
+
+// newTempFileStore opens a FileService in a temp dir and returns it with the
+// ACP-facing store over it and the directory it lives in.
+func newTempFileStore(t *testing.T) (*pisession.FileService, *FileSessionStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := pisession.NewFileService(dir)
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	return svc, NewFileSessionStore(svc), dir
+}
+
+// persistSession creates a transcript under id with one user turn and one
+// model reply.
+func persistSession(t *testing.T, svc *pisession.FileService, id string) {
+	t.Helper()
+	ctx := context.Background()
+	resp, err := svc.Create(ctx, &adksession.CreateRequest{
+		AppName: piagent.AppName, UserID: piagent.DefaultUserID, SessionID: id,
+	})
+	if err != nil {
+		t.Fatalf("Create(%s): %v", id, err)
+	}
+	for _, ev := range []*adksession.Event{userTextEvent("hello"), modelEvent(textPart("hi there"))} {
+		if err := svc.AppendEvent(ctx, resp.Session, ev); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+}
+
+func TestFileSessionStoreExistsAndReplay(t *testing.T) {
+	t.Parallel()
+	svc, store, _ := newTempFileStore(t)
+	ctx := context.Background()
+
+	const id = "sess_persisted"
+	if store.Exists(ctx, id) {
+		t.Fatal("Exists() = true before the session was created")
+	}
+	persistSession(t, svc, id)
+	if !store.Exists(ctx, id) {
+		t.Fatal("Exists() = false for a persisted session")
+	}
+	if store.Exists(ctx, "../"+id) {
+		t.Fatal("Exists() = true for a traversal id; it must hash to a different session")
+	}
+
+	u := &recordingUpdater{}
+	if err := store.Replay(ctx, id, u); err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(u.updates) != 2 {
+		t.Fatalf("Replay() sent %d updates, want 2", len(u.updates))
+	}
+	if u.updates[0].UserMessageChunk == nil || u.updates[1].AgentMessageChunk == nil {
+		t.Errorf("Replay() order = %+v, want user chunk then agent chunk", u.updates)
+	}
+
+	if err := store.Replay(ctx, "sess_missing", u); err == nil {
+		t.Error("Replay() of an unknown session error = nil, want not found")
+	}
+	if err := store.Replay(ctx, id, nil); err != nil {
+		t.Errorf("Replay() with nil updater error = %v, want a no-op", err)
+	}
+}
+
+func TestFileSessionStoreListNewestFirst(t *testing.T) {
+	t.Parallel()
+	svc, store, _ := newTempFileStore(t)
+	ctx := context.Background()
+
+	persistSession(t, svc, "sess_older")
+	persistSession(t, svc, "sess_newer")
+	if err := svc.SetSessionTitle("sess_newer", "fix the bug"); err != nil {
+		t.Fatalf("SetSessionTitle: %v", err)
+	}
+	if err := svc.SetSessionWorkDir("sess_newer", "/work/newer"); err != nil {
+		t.Fatalf("SetSessionWorkDir: %v", err)
+	}
+
+	got, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List() = %d sessions, want 2", len(got))
+	}
+	if got[0].ID != "sess_newer" {
+		t.Errorf("List()[0] = %q, want the most recently updated session first", got[0].ID)
+	}
+	if got[0].Title != "fix the bug" || got[0].Cwd != "/work/newer" || got[0].UpdatedAt.IsZero() {
+		t.Errorf("List()[0] = %+v, want title, cwd and updatedAt filled", got[0])
+	}
+}
+
+func TestFileSessionStoreListSurfacesFailure(t *testing.T) {
+	t.Parallel()
+	svc, store, dir := newTempFileStore(t)
+	persistSession(t, svc, "sess_gone")
+
+	// Remove the directory the service lists so ListMeta's read fails.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if _, err := store.List(context.Background()); err == nil {
+		t.Fatal("List() error = nil, want the read failure surfaced")
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -580,6 +580,12 @@ type titleNamer interface {
 	SetSessionTitle(sessionID, title string) error
 }
 
+// workDirRecorder is implemented by session services that can record the
+// working directory a session runs in (e.g. session.FileService).
+type workDirRecorder interface {
+	SetSessionWorkDir(sessionID, dir string) error
+}
+
 // agentContextRecorder is implemented by session services that can persist a
 // session's place in an agent tree. Declared here for the same reason as
 // titleNamer: the agent takes the capability, not the concrete service.
@@ -601,13 +607,49 @@ func (a *Agent) CreateSession(ctx context.Context) (sessionID, defaultTitle stri
 		return "", "", fmt.Errorf("creating session: %w", err)
 	}
 	sid := resp.Session.ID()
+	return sid, a.recordNewSessionMeta(sid), nil
+}
+
+// OpenSession resumes the session persisted under sessionID, creating it when
+// the session service has no record of that id. It reports whether an existing
+// transcript was found. This is how a server hosting a session for an external
+// client — an ACP editor, an A2A gateway — continues a conversation across its
+// own restarts: the client keeps the id, and the transcript lives under it.
+func (a *Agent) OpenSession(ctx context.Context, sessionID string) (resumed bool, err error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return false, fmt.Errorf("opening session: id is required")
+	}
+	if _, err := a.sessionService.Get(ctx, &session.GetRequest{
+		AppName:   AppName,
+		UserID:    DefaultUserID,
+		SessionID: sessionID,
+	}); err == nil {
+		return true, nil
+	}
+	if _, err := a.sessionService.Create(ctx, &session.CreateRequest{
+		AppName:   AppName,
+		UserID:    DefaultUserID,
+		SessionID: sessionID,
+	}); err != nil {
+		return false, fmt.Errorf("creating session %s: %w", sessionID, err)
+	}
+	a.recordNewSessionMeta(sessionID)
+	return false, nil
+}
+
+// recordNewSessionMeta writes the metadata a brand-new session starts with —
+// its place in an agent tree, the model, the working directory, and a default
+// title — through whichever optional recorder interfaces the session service
+// implements. Every write is best-effort metadata. It returns the title that
+// was applied, or "" when none was.
+func (a *Agent) recordNewSessionMeta(sid string) string {
 	// Record this process's place in an agent tree, if it has one. A spawned
 	// worker knows its coordinator, spec, slice and cycle only through the
 	// environment; writing them here is what makes a run tree a field lookup
 	// instead of an inference from workDir and title prefixes.
 	if ac, ok := a.sessionService.(agentContextRecorder); ok {
 		if actx := pisession.AgentContextFromEnv(); actx != nil {
-			_ = ac.UpdateAgentContext(sid, actx) // best-effort metadata
+			_ = ac.UpdateAgentContext(sid, actx)
 		}
 	}
 	if mn, ok := a.sessionService.(modelNamer); ok {
@@ -615,18 +657,23 @@ func (a *Agent) CreateSession(ctx context.Context) (sessionID, defaultTitle stri
 		if a.config.Model != nil {
 			modelName = a.config.Model.Name()
 		}
-		_ = mn.SetSessionModel(sid, modelName) // best-effort; meta defaults to "unknown"
+		_ = mn.SetSessionModel(sid, modelName) // meta defaults to "unknown"
+	}
+	// The service records the process cwd at creation; an explicitly
+	// configured working directory is the one the session actually runs in.
+	if wr, ok := a.sessionService.(workDirRecorder); ok && a.config.WorkingDir != "" {
+		_ = wr.SetSessionWorkDir(sid, a.config.WorkingDir)
 	}
 	// Default title: the git repo name (or CWD basename) so brand-new sessions
 	// in /sessions listings have a sensible label before the first user prompt
 	// overwrites it via the TUI's applySessionTitle / runPrint's derivePrintTitle.
 	if tn, ok := a.sessionService.(titleNamer); ok {
 		if title := defaultSessionTitle(a.config.workingDir()); title != "" {
-			_ = tn.SetSessionTitle(sid, title) // best-effort metadata
-			return sid, title, nil
+			_ = tn.SetSessionTitle(sid, title)
+			return title
 		}
 	}
-	return sid, "", nil
+	return ""
 }
 
 // gitToplevelTimeout caps the `git rev-parse --show-toplevel` subprocess so a

--- a/internal/agent/open_session_test.go
+++ b/internal/agent/open_session_test.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/adk/v2/session"
+
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+func TestOpenSession(t *testing.T) {
+	ctx := context.Background()
+	sessionsDir := t.TempDir()
+	svc, err := pisession.NewFileService(sessionsDir)
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	workDir := t.TempDir()
+	a, err := New(Config{Model: &mockLLM{name: "test-model", response: "ok"}, SessionService: svc, WorkingDir: workDir})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := a.OpenSession(ctx, "  "); err == nil {
+		t.Error("OpenSession(blank) error = nil, want rejection")
+	}
+
+	const id = "ctx-7f0c7a4e"
+	resumed, err := a.OpenSession(ctx, id)
+	if err != nil {
+		t.Fatalf("OpenSession() first error = %v", err)
+	}
+	if resumed {
+		t.Error("first OpenSession() reported resumed = true for a brand-new id")
+	}
+
+	metas, err := svc.ListMeta(AppName, DefaultUserID)
+	if err != nil {
+		t.Fatalf("ListMeta: %v", err)
+	}
+	if len(metas) != 1 || metas[0].ID != id {
+		t.Fatalf("ListMeta() = %+v, want exactly the opened session", metas)
+	}
+	if metas[0].Model != "test-model" {
+		t.Errorf("recorded model = %q, want test-model", metas[0].Model)
+	}
+	if metas[0].WorkDir != workDir {
+		t.Errorf("recorded workDir = %q, want the configured %q", metas[0].WorkDir, workDir)
+	}
+
+	resumed, err = a.OpenSession(ctx, id)
+	if err != nil {
+		t.Fatalf("OpenSession() second error = %v", err)
+	}
+	if !resumed {
+		t.Error("second OpenSession() reported resumed = false for an existing id")
+	}
+
+	// A fresh service over the same directory — a restarted process — finds it too.
+	reopened, err := pisession.NewFileService(sessionsDir)
+	if err != nil {
+		t.Fatalf("NewFileService(reopen): %v", err)
+	}
+	b, err := New(Config{Model: &mockLLM{name: "test-model", response: "ok"}, SessionService: reopened})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if resumed, err := b.OpenSession(ctx, id); err != nil || !resumed {
+		t.Errorf("OpenSession() after restart = (%v, %v), want (true, nil)", resumed, err)
+	}
+}
+
+func TestOpenSessionInMemoryService(t *testing.T) {
+	a, err := New(Config{Model: &mockLLM{name: "m", response: "ok"}, SessionService: session.InMemoryService()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if resumed, err := a.OpenSession(context.Background(), "mem-1"); err != nil || resumed {
+		t.Fatalf("first OpenSession() = (%v, %v), want (false, nil)", resumed, err)
+	}
+	if resumed, err := a.OpenSession(context.Background(), "mem-1"); err != nil || !resumed {
+		t.Fatalf("second OpenSession() = (%v, %v), want (true, nil)", resumed, err)
+	}
+}

--- a/internal/cli/a2a_server.go
+++ b/internal/cli/a2a_server.go
@@ -79,13 +79,20 @@ func runA2AServer(cmd *cobra.Command, _ []string) error {
 		system = os.Getenv("PI_SYSTEM")
 	}
 
-	handler := acpserver.NewPromptHandler(acpserver.RuntimeConfig{
+	// The A2A context id is the pi session id, and the transcript behind it
+	// is persisted, so a conversation survives Substrate replacing the actor:
+	// the next message on the same context resumes it from the durable dir.
+	rt := acpserver.RuntimeConfig{
 		Model:    model,
 		BaseURL:  baseURL,
 		Headers:  flagHeaders,
 		Insecure: flagInsecure,
 		System:   system,
-	})
+	}
+	if sessionSvc := openServerSessionStore(ctx, logger); sessionSvc != nil {
+		rt.SessionService = sessionSvc
+	}
+	handler := acpserver.NewPromptHandler(rt)
 
 	addr := flagA2AAddr
 	if addr == "" {

--- a/internal/cli/acp_server.go
+++ b/internal/cli/acp_server.go
@@ -65,17 +65,25 @@ func runACPServer(cmd *cobra.Command, _ []string) error {
 		model = "glm-5.2:cloud"
 	}
 
+	// Transcripts go to the on-disk store so session/load, session/resume
+	// and session/list work across restarts of this process.
+	sessionSvc := openServerSessionStore(ctx, logger)
+	rt := acpserver.RuntimeConfig{
+		Model:    model,
+		BaseURL:  flagURL,
+		Headers:  flagHeaders,
+		Insecure: flagInsecure,
+		System:   flagSystem,
+	}
+	if sessionSvc != nil {
+		rt.SessionService = sessionSvc
+	}
 	agent := &acpserver.Agent{
 		AgentInfo:                 acp.Implementation{Name: "pi-go", Version: Version},
 		AvailableCommandsResolver: acpserver.DiscoverAvailableCommands,
-		Handler: acpserver.NewPromptHandler(acpserver.RuntimeConfig{
-			Model:    model,
-			BaseURL:  flagURL,
-			Headers:  flagHeaders,
-			Insecure: flagInsecure,
-			System:   flagSystem,
-		}),
-		Logger: logger,
+		Handler:                   acpserver.NewPromptHandler(rt),
+		Logger:                    logger,
+		Sessions:                  serverSessionStore(sessionSvc),
 	}
 	if err := acpserver.Serve(ctx, acpserver.ServeConfig{
 		Agent: agent,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -995,8 +995,13 @@ func memoryInstructionContext(ctx context.Context, store memory.Store, cfg confi
 
 // sessionsDir is the directory FileService keeps one subdirectory per session
 // in. Startup reaches for it before any session service exists, so it cannot
-// be asked of the service itself.
+// be asked of the service itself. PI_SESSIONS_DIR overrides the default of
+// $HOME/.pi-go/sessions — a server whose home is not durable storage points
+// it at a directory that is.
 func sessionsDir() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv("PI_SESSIONS_DIR")); dir != "" {
+		return dir, nil
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("getting home dir: %w", err)

--- a/internal/cli/server_sessions.go
+++ b/internal/cli/server_sessions.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+
+	acpserver "github.com/dimetron/pi-go/internal/acp/server"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// openServerSessionStore opens the on-disk session store the ACP and A2A
+// servers persist transcripts in — the same directory the interactive CLI
+// uses, so a conversation started by an editor or a gateway can be reopened
+// from the terminal, and survives the server process that started it.
+//
+// A store that cannot be opened is reported and skipped rather than fatal:
+// the server then runs with in-memory sessions, which is how it always ran,
+// instead of refusing to start over a directory it cannot write.
+func openServerSessionStore(ctx context.Context, logger *slog.Logger) *pisession.FileService {
+	dir, err := sessionsDir()
+	if err == nil {
+		var svc *pisession.FileService
+		svc, err = pisession.NewFileService(dir)
+		if err == nil {
+			if logger != nil {
+				logger.Log(ctx, slog.LevelInfo, "server: session store opened", "dir", dir)
+			}
+			return svc
+		}
+	}
+	if logger != nil {
+		logger.Log(ctx, slog.LevelWarn, "server: session store unavailable, sessions are in-memory only", "err", err)
+	}
+	return nil
+}
+
+// serverSessionStore adapts the optional on-disk store to the ACP agent's
+// SessionStore seam. A nil service yields a nil store, which the agent treats
+// as "in-memory sessions only".
+func serverSessionStore(svc *pisession.FileService) acpserver.SessionStore {
+	if svc == nil {
+		return nil
+	}
+	return acpserver.NewFileSessionStore(svc)
+}

--- a/internal/cli/server_sessions_test.go
+++ b/internal/cli/server_sessions_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSessionsDirHonoursEnvOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	t.Setenv("PI_SESSIONS_DIR", "")
+	got, err := sessionsDir()
+	if err != nil {
+		t.Fatalf("sessionsDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".pi-go", "sessions"); got != want {
+		t.Errorf("sessionsDir() = %q, want %q", got, want)
+	}
+
+	durable := filepath.Join(t.TempDir(), "durable-sessions")
+	t.Setenv("PI_SESSIONS_DIR", " "+durable+" ")
+	got, err = sessionsDir()
+	if err != nil {
+		t.Fatalf("sessionsDir() error = %v", err)
+	}
+	if got != durable {
+		t.Errorf("sessionsDir() with PI_SESSIONS_DIR = %q, want %q", got, durable)
+	}
+}
+
+func TestOpenServerSessionStore(t *testing.T) {
+	durable := filepath.Join(t.TempDir(), "sessions")
+	t.Setenv("PI_SESSIONS_DIR", durable)
+
+	svc := openServerSessionStore(context.Background(), slog.New(slog.DiscardHandler))
+	if svc == nil {
+		t.Fatal("openServerSessionStore() = nil, want a store over PI_SESSIONS_DIR")
+	}
+	if _, err := os.Stat(durable); err != nil {
+		t.Errorf("sessions dir not created: %v", err)
+	}
+	if serverSessionStore(svc) == nil {
+		t.Error("serverSessionStore(svc) = nil, want an ACP store")
+	}
+	if serverSessionStore(nil) != nil {
+		t.Error("serverSessionStore(nil) != nil, want in-memory sessions")
+	}
+
+	// A path that cannot be a directory degrades to in-memory sessions
+	// instead of failing startup; a nil logger must be tolerated too.
+	blocker := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_SESSIONS_DIR", filepath.Join(blocker, "sessions"))
+	if svc := openServerSessionStore(context.Background(), nil); svc != nil {
+		t.Error("openServerSessionStore() over an unwritable path != nil, want nil")
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -314,6 +314,43 @@ func (s *FileService) List(_ context.Context, req *session.ListRequest) (*sessio
 	}, nil
 }
 
+// ListMeta returns the metadata of every session under baseDir for the given
+// app, newest first. It reads only meta.json, never events, so listing a large
+// store stays cheap. An empty userID matches every user. Directories without
+// readable metadata are skipped.
+func (s *FileService) ListMeta(appName, userID string) ([]Meta, error) {
+	if appName == "" {
+		return nil, fmt.Errorf("app_name is required")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading sessions dir: %w", err)
+	}
+
+	metas := make([]Meta, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		meta, err := readMeta(filepath.Join(s.baseDir, entry.Name()))
+		if err != nil || meta.AppName != appName {
+			continue
+		}
+		if userID != "" && meta.UserID != userID {
+			continue
+		}
+		metas = append(metas, *meta)
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].UpdatedAt.After(metas[j].UpdatedAt)
+	})
+	return metas, nil
+}
+
 // Archive moves the session directory under baseDir to archiveDir/yyyy/mm/dd/
 // using the current time. It removes the session from the in-memory cache.
 func (s *FileService) Archive(_ context.Context, req *session.DeleteRequest) error {
@@ -639,6 +676,28 @@ func (s *FileService) SetSessionTitle(sessionID, title string) error {
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
 	sess.meta.Title = title
+	return writeMeta(filepath.Join(s.baseDir, sessionID), &sess.meta)
+}
+
+// SetSessionWorkDir records the working directory a session runs in and
+// persists it to meta.json. Create captures the process's own cwd, which is
+// right for the CLI but not for a server that hosts sessions for directories
+// it was not started in — an ACP editor's project, an A2A actor's workspace.
+func (s *FileService) SetSessionWorkDir(sessionID, dir string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		loaded, err := s.loadSessionUnchecked(sessionID)
+		if err != nil {
+			return err
+		}
+		sess = loaded
+	}
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	sess.meta.WorkDir = dir
 	return writeMeta(filepath.Join(s.baseDir, sessionID), &sess.meta)
 }
 

--- a/internal/session/store_workdir_test.go
+++ b/internal/session/store_workdir_test.go
@@ -1,0 +1,92 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/session"
+)
+
+func TestSetSessionWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := NewFileService(dir)
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	resp, err := svc.Create(context.Background(), &session.CreateRequest{AppName: "pi-go", UserID: "local", SessionID: "wd-1"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := svc.SetSessionWorkDir(resp.Session.ID(), "/work/project"); err != nil {
+		t.Fatalf("SetSessionWorkDir: %v", err)
+	}
+
+	// A fresh service over the same directory reads it back from meta.json.
+	reopened, err := NewFileService(dir)
+	if err != nil {
+		t.Fatalf("NewFileService(reopen): %v", err)
+	}
+	metas, err := reopened.ListMeta("pi-go", "local")
+	if err != nil {
+		t.Fatalf("ListMeta: %v", err)
+	}
+	if len(metas) != 1 || metas[0].WorkDir != "/work/project" {
+		t.Fatalf("ListMeta() = %+v, want workDir /work/project", metas)
+	}
+
+	if err := reopened.SetSessionWorkDir("missing", "/x"); err == nil {
+		t.Error("SetSessionWorkDir(missing) error = nil, want not found")
+	}
+}
+
+func TestListMeta(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := NewFileService(dir)
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	ctx := context.Background()
+	for _, c := range []struct{ id, app, user string }{
+		{"older", "pi-go", "local"},
+		{"newer", "pi-go", "local"},
+		{"other-app", "not-pi", "local"},
+		{"other-user", "pi-go", "someone"},
+	} {
+		if _, err := svc.Create(ctx, &session.CreateRequest{AppName: c.app, UserID: c.user, SessionID: c.id}); err != nil {
+			t.Fatalf("Create(%s): %v", c.id, err)
+		}
+	}
+	// An event lands on "older" last, so ordering follows UpdatedAt rather
+	// than name or creation order.
+	older, err := svc.Get(ctx, &session.GetRequest{AppName: "pi-go", UserID: "local", SessionID: "older"})
+	if err != nil {
+		t.Fatalf("Get(older): %v", err)
+	}
+	if err := svc.AppendEvent(ctx, older.Session, &session.Event{Author: "user", Timestamp: time.Now().Add(time.Minute)}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	if _, err := svc.ListMeta("", ""); err == nil {
+		t.Error("ListMeta(\"\") error = nil, want app_name required")
+	}
+
+	metas, err := svc.ListMeta("pi-go", "local")
+	if err != nil {
+		t.Fatalf("ListMeta: %v", err)
+	}
+	if len(metas) != 2 {
+		t.Fatalf("ListMeta(pi-go, local) = %d sessions, want 2 (other app and user excluded): %+v", len(metas), metas)
+	}
+	if metas[0].ID != "older" || metas[1].ID != "newer" {
+		t.Errorf("ListMeta() order = [%s %s], want most recently updated first", metas[0].ID, metas[1].ID)
+	}
+
+	all, err := svc.ListMeta("pi-go", "")
+	if err != nil {
+		t.Fatalf("ListMeta(all users): %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("ListMeta(pi-go, any user) = %d sessions, want 3", len(all))
+	}
+}

--- a/specs/kagent/Dockerfile
+++ b/specs/kagent/Dockerfile
@@ -107,11 +107,18 @@ ARG GH_VERSION=v2.65.0
 RUN arkade get gh --version "${GH_VERSION}" --path /usr/local/bin --progress=false \
     && gh --version
 
-ENV PATH="${PATH}:/usr/local/go/bin:/home/pi/.arkade/bin"
+ENV PATH="${PATH}:/usr/local/go/bin:/home/pi/.arkade/bin:/data/.arkade/bin"
 
 USER pi
 
 WORKDIR /data
+
+# Everything pi keeps under ~/.pi-go — session transcripts, the memory
+# store, logs — has to land on the durable mount, or an actor that Substrate
+# checkpoints and restores elsewhere, or replaces outright, comes back with
+# no record of its conversations. HOME is the one knob all of it hangs off;
+# PI_SESSIONS_DIR alone would leave the memory store behind.
+ENV HOME=/data
 COPY --from=build /out/pi /usr/local/bin/pi
 
 # A2A HTTP/gRPC port (kagent compiler sets PORT=80; readyz stays 8081).


### PR DESCRIPTION
## Problem

ACP sessions lived only in memory:

- `session/resume` and `session/list` returned method-not-found.
- `session/load` bound an empty record and replayed nothing, so a client that loaded a session saw a blank thread.
- The pi runtime behind both `pi acp-server` and the Substrate A2A adapter created a fresh in-memory ADK transcript per session, so any restart lost the conversation.

On Substrate this was worse than it looked. `docs/kagent-harness.md` claimed durable pi state under `/data`, but the image left `HOME=/home/pi`, so nothing pi keeps under `~/.pi-go` ever reached the durable mount. An actor that Substrate checkpointed and restored, or replaced, came back with no record of its conversations.

## What changed

**Persistence.** Transcripts go to pi's existing on-disk session store, keyed by the ACP session id. `StoreSessionID` passes ids that are safe directory names straight through (pi's `sess_…` ids, the UUID context ids kagent assigns, CLI-generated ids), and hashes anything else, so a hostile id cannot name a path outside the sessions directory and still resolves stably. Because the id is preserved, a thread started in an editor reopens from the terminal with `pi --session <id>`.

**Session lifecycle.**

| Method | Behaviour |
|---|---|
| `session/load` | Replays the stored transcript as ACP updates, then continues it |
| `session/resume` | Continues without replaying; the client already shows the thread |
| `session/list` | Stored sessions, newest first, optionally filtered by `cwd` |

Replay maps the transcript back to what the live stream emits: user and agent message chunks, thought chunks, and one completed `tool_call` per call followed by an update carrying its output. Calls are replayed as already-complete, since a card left in progress for a call whose result never reached disk would spin forever.

**Capabilities** are advertised honestly. `resume` is always offered; `list` only when a store can answer it. Without a store the agent behaves as before, accepting any id, so nothing regresses for an embedder that does not want persistence.

**Substrate.** The image sets `HOME=/data` so transcripts, memory and logs all land on the durable mount. `HOME` is the single knob the rest hangs off; `PI_SESSIONS_DIR` alone would have left the memory store behind. `PI_SESSIONS_DIR` overrides the sessions directory everywhere.

## Verification

- `go test ./...` passes. The CLI and A2A listener tests fail under the sandbox with `bind: operation not permitted`, as CLAUDE.md documents, and pass outside it.
- `golangci-lint run` reports 0 issues; `go vet ./...` is clean.
- New tests cover id sanitising and traversal, replay mapping and its failure path, `load`/`resume`/`list` over a real ACP pipe, resume across a fresh service over the same directory, and the `PI_SESSIONS_DIR` override.

## Two things worth knowing

- A session created with `session/new` but never prompted has no transcript yet, so resuming it against a fresh process with a store is rejected. Clients such as Zed fall back to a new session.
- `HOME=/data` relocates all of pi's per-user state in the image, not only sessions. That is the intent, but it is a behaviour change for existing deployments.
