### PR TITLE
fix(provider): retry rate-limited Gemini requests

### DIFF
--- a/internal/provider/complexity_provider_test.go
+++ b/internal/provider/complexity_provider_test.go
@@ -1488,28 +1488,46 @@ func TestGeminiAPIKey(t *testing.T) {
 }
 
 func TestGeminiHTTPOptions(t *testing.T) {
-	t.Run("no overrides", func(t *testing.T) {
-		opts, overridden := geminiHTTPOptions("", nil)
-		if overridden {
-			t.Error("overridden = true, want false")
-		}
-		if opts.BaseURL != "" || opts.Headers != nil {
-			t.Errorf("opts = %+v, want zero value", opts)
+	// The retry policy is the reason these options are always set: the genai
+	// SDK does no retrying at all when RetryOptions is nil.
+	t.Run("always carries a retry policy", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			baseURL string
+			opts    *LLMOptions
+		}{
+			{"no overrides", "", nil},
+			{"empty extra headers", "", &LLMOptions{ExtraHeaders: map[string]string{}}},
+			{"base url", "https://example.test", nil},
+		} {
+			got := geminiHTTPOptions(tc.baseURL, tc.opts)
+			if got.RetryOptions == nil {
+				t.Fatalf("%s: RetryOptions = nil, want a retry policy", tc.name)
+			}
+			if got.RetryOptions.Attempts == nil || *got.RetryOptions.Attempts != geminiSDKRetryAttempts {
+				t.Errorf("%s: Attempts = %v, want %d", tc.name, got.RetryOptions.Attempts, geminiSDKRetryAttempts)
+			}
 		}
 	})
 
-	t.Run("empty extra headers is not an override", func(t *testing.T) {
-		_, overridden := geminiHTTPOptions("", &LLMOptions{ExtraHeaders: map[string]string{}})
-		if overridden {
-			t.Error("overridden = true, want false for an empty header map")
+	t.Run("no overrides leaves the endpoint and headers alone", func(t *testing.T) {
+		opts := geminiHTTPOptions("", nil)
+		if opts.BaseURL != "" {
+			t.Errorf("BaseURL = %q, want empty so the SDK keeps its default", opts.BaseURL)
+		}
+		if opts.Headers != nil {
+			t.Errorf("Headers = %v, want nil", opts.Headers)
+		}
+	})
+
+	t.Run("empty extra headers adds no header map", func(t *testing.T) {
+		if opts := geminiHTTPOptions("", &LLMOptions{ExtraHeaders: map[string]string{}}); opts.Headers != nil {
+			t.Errorf("Headers = %v, want nil for an empty header map", opts.Headers)
 		}
 	})
 
 	t.Run("base url only", func(t *testing.T) {
-		opts, overridden := geminiHTTPOptions("https://example.test", nil)
-		if !overridden {
-			t.Error("overridden = false, want true")
-		}
+		opts := geminiHTTPOptions("https://example.test", nil)
 		if opts.BaseURL != "https://example.test" {
 			t.Errorf("BaseURL = %q, want %q", opts.BaseURL, "https://example.test")
 		}
@@ -1519,12 +1537,9 @@ func TestGeminiHTTPOptions(t *testing.T) {
 	})
 
 	t.Run("headers only", func(t *testing.T) {
-		opts, overridden := geminiHTTPOptions("", &LLMOptions{
+		opts := geminiHTTPOptions("", &LLMOptions{
 			ExtraHeaders: map[string]string{"X-Token": "abc"},
 		})
-		if !overridden {
-			t.Error("overridden = false, want true")
-		}
 		if opts.BaseURL != "" {
 			t.Errorf("BaseURL = %q, want empty", opts.BaseURL)
 		}
@@ -1534,12 +1549,9 @@ func TestGeminiHTTPOptions(t *testing.T) {
 	})
 
 	t.Run("both", func(t *testing.T) {
-		opts, overridden := geminiHTTPOptions("https://example.test", &LLMOptions{
+		opts := geminiHTTPOptions("https://example.test", &LLMOptions{
 			ExtraHeaders: map[string]string{"X-Token": "abc"},
 		})
-		if !overridden {
-			t.Error("overridden = false, want true")
-		}
 		if opts.BaseURL != "https://example.test" || opts.Headers.Get("X-Token") != "abc" {
 			t.Errorf("opts = %+v, want both set", opts)
 		}

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"iter"
 	"net/http"
 	"os"
 
@@ -25,9 +26,7 @@ func NewGemini(ctx context.Context, modelName, baseURL string, opts *LLMOptions)
 		cfg.APIKey = apiKey
 	}
 
-	if httpOpts, overridden := geminiHTTPOptions(baseURL, opts); overridden {
-		cfg.HTTPOptions = httpOpts
-	}
+	cfg.HTTPOptions = geminiHTTPOptions(baseURL, opts)
 	if geminiNeedsHTTPClient(opts) {
 		httpClient, err := BuildHTTPClient(opts, 0)
 		if err != nil {
@@ -41,7 +40,70 @@ func NewGemini(ctx context.Context, modelName, baseURL string, opts *LLMOptions)
 		return nil, fmt.Errorf("creating gemini model %q: %w", modelName, err)
 	}
 
-	return llm, nil
+	return geminiRetryModel{inner: llm}, nil
+}
+
+// geminiSDKRetryAttempts is how many times the genai SDK sends one HTTP
+// request, the initial call included.
+//
+// The SDK's retry is off unless RetryOptions is set, so without this a Gemini
+// request got no retry at all — not even for a dropped connection. It is set
+// low rather than at the SDK's default of 5 because it is the inner of two
+// nets and the two multiply: geminiRetryModel re-sends the whole request up to
+// five more times on top of whatever happens here.
+//
+// Three is the split that matches what each net is good at. The SDK retries
+// blind, on a fixed exponential schedule that cannot read the server's own
+// "retry in 13s" hint, so it is useful for faults that clear in a second or
+// two — a reset connection, a timeout, a 5xx blip — and close to useless for a
+// per-minute quota window. Two quick retries here cover those, and the outer
+// net, which does honor the server's window, owns the rate-limit case.
+//
+// 429 is deliberately left in the SDK's retryable set even so, because a
+// non-streaming call (commit messages, summaries) never reaches the outer net
+// and would otherwise have nothing retrying it.
+const geminiSDKRetryAttempts int32 = 3
+
+// geminiRetryModel re-sends a Gemini streaming request that failed before it
+// emitted anything, the way every other provider in this package does.
+//
+// Gemini was the one provider that reached ADK's model directly, so it had
+// neither net: the SDK's retry was disabled (see geminiSDKRetryAttempts) and
+// the per-request retry that internal/provider gives OpenAI, Anthropic,
+// Mistral, OpenRouter, xAI and Ollama was never wired up. That left only the
+// coarse per-run retry in internal/agent, which refuses once a turn has
+// yielded anything — so a rate limit arriving after the turn's first tool call
+// ended the turn, even though the error named the seconds to wait.
+type geminiRetryModel struct {
+	inner model.LLM
+}
+
+var _ model.LLM = geminiRetryModel{}
+
+func (m geminiRetryModel) Name() string { return m.inner.Name() }
+
+// GenerateContent forwards to the wrapped model, retrying a streaming request
+// that fails before producing output. A non-streaming call is passed straight
+// through: it has no partial state to protect, and the SDK's own retry already
+// covers it.
+func (m geminiRetryModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		// send performs the request once. It takes its own yield so
+		// retryStream can re-run it across attempts.
+		send := func(y func(*model.LLMResponse, error) bool) {
+			for resp, err := range m.inner.GenerateContent(ctx, req, stream) {
+				if !y(resp, err) {
+					return
+				}
+			}
+		}
+
+		if !stream {
+			send(yield)
+			return
+		}
+		retryStream(ctx, streamRetryConfig(), yield, send)
+	}
 }
 
 // geminiAPIKey reads the Gemini API key from the environment, preferring
@@ -54,24 +116,26 @@ func geminiAPIKey() string {
 	return os.Getenv("GOOGLE_API_KEY")
 }
 
-// geminiHTTPOptions builds the endpoint and header overrides for the Gemini
-// client. The second result reports whether any override was requested — when
-// false the options are left at the SDK default rather than being overwritten
-// with an empty struct.
-func geminiHTTPOptions(baseURL string, opts *LLMOptions) (genai.HTTPOptions, bool) {
-	hasExtraHeaders := opts != nil && len(opts.ExtraHeaders) > 0
-
-	httpOpts := genai.HTTPOptions{}
+// geminiHTTPOptions builds the HTTP options for the Gemini client: the retry
+// policy, which is always set because the SDK does not retry at all without
+// it, plus the endpoint and header overrides when they were asked for. An
+// empty BaseURL leaves the SDK on its default endpoint, so the struct is safe
+// to set unconditionally.
+func geminiHTTPOptions(baseURL string, opts *LLMOptions) genai.HTTPOptions {
+	attempts := geminiSDKRetryAttempts
+	httpOpts := genai.HTTPOptions{
+		RetryOptions: &genai.HTTPRetryOptions{Attempts: &attempts},
+	}
 	if baseURL != "" {
 		httpOpts.BaseURL = baseURL
 	}
-	if hasExtraHeaders {
+	if opts != nil && len(opts.ExtraHeaders) > 0 {
 		httpOpts.Headers = make(http.Header)
 		for k, v := range opts.ExtraHeaders {
 			httpOpts.Headers.Set(k, v)
 		}
 	}
-	return httpOpts, baseURL != "" || hasExtraHeaders
+	return httpOpts
 }
 
 // geminiNeedsHTTPClient reports whether opts asks for transport settings that

--- a/internal/provider/gemini_retry_test.go
+++ b/internal/provider/gemini_retry_test.go
@@ -1,0 +1,216 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/model"
+
+	"github.com/dimetron/pi-go/internal/retry"
+)
+
+// scriptedLLM replays one canned outcome per call, so a test can make the
+// first attempt fail and the next succeed.
+type scriptedLLM struct {
+	calls    int
+	outcomes [][]scriptedYield
+}
+
+type scriptedYield struct {
+	resp *model.LLMResponse
+	err  error
+}
+
+func (s *scriptedLLM) Name() string { return "scripted" }
+
+func (s *scriptedLLM) GenerateContent(context.Context, *model.LLMRequest, bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		i := s.calls
+		s.calls++
+		if i >= len(s.outcomes) {
+			return
+		}
+		for _, y := range s.outcomes[i] {
+			if !yield(y.resp, y.err) {
+				return
+			}
+		}
+	}
+}
+
+// rateLimited is the shape a Gemini per-minute quota rejection arrives in: a
+// content-less response carrying an error code, with the server naming the
+// window it reopens in.
+//
+// The message is a real one, kept verbatim, because its wording is the whole
+// difficulty. It reads like terminal billing failure ("exceeded your current
+// quota", "check your plan and billing details") while actually being a
+// per-minute token limit that clears in seconds — and the retry window it
+// names is what internal/retry keys on to tell the two apart.
+func rateLimited() *model.LLMResponse {
+	return &model.LLMResponse{
+		ErrorCode: "429",
+		ErrorMessage: "You exceeded your current quota, please check your plan and billing details. " +
+			"Quota exceeded for metric: " +
+			"generativelanguage.googleapis.com/generate_content_paid_tier_input_token_count, " +
+			"limit: 2000000, model: gemini-3.8-flash Please retry in 13.380362265s., " +
+			"Status: RESOURCE_EXHAUSTED",
+	}
+}
+
+func TestRateLimitedFixtureIsTreatedAsTransient(t *testing.T) {
+	// Guards the fixture above: if this message ever stopped being classified
+	// as transient, every retry test here would still pass while the bug they
+	// cover came back.
+	err := streamFailure(rateLimited(), nil)
+	if !retry.IsTransient(err) {
+		t.Fatalf("IsTransient(%v) = false, want true", err)
+	}
+	d, ok := retry.ServerDelay(err)
+	if !ok {
+		t.Fatal("ServerDelay found no window in the quota message")
+	}
+	if d < 13*time.Second || d > 14*time.Second {
+		t.Errorf("ServerDelay = %v, want the ~13.38s the server asked for", d)
+	}
+}
+
+func drain(t *testing.T, seq iter.Seq2[*model.LLMResponse, error]) ([]*model.LLMResponse, []error) {
+	t.Helper()
+	var resps []*model.LLMResponse
+	var errs []error
+	for r, err := range seq {
+		resps = append(resps, r)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return resps, errs
+}
+
+func TestGeminiRetryModelRetriesRateLimitBeforeOutput(t *testing.T) {
+	inner := &scriptedLLM{outcomes: [][]scriptedYield{
+		{{resp: rateLimited()}},
+		{{resp: textResponse("recovered")}},
+	}}
+	m := geminiRetryModel{inner: inner}
+
+	resps, errs := drain(t, m.GenerateContent(context.Background(), &model.LLMRequest{}, true))
+
+	if inner.calls != 2 {
+		t.Fatalf("inner called %d times, want the request re-sent once", inner.calls)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("errors = %v, want the retry to hide the rate limit", errs)
+	}
+	if len(resps) != 1 || resps[0].Content.Parts[0].Text != "recovered" {
+		t.Fatalf("responses = %+v, want only the recovered reply", resps)
+	}
+}
+
+func TestGeminiRetryModelCommitsOnceOutputIsEmitted(t *testing.T) {
+	// A failure that lands after text has reached the consumer cannot be
+	// replayed: the caller has already seen part of the answer.
+	inner := &scriptedLLM{outcomes: [][]scriptedYield{
+		{{resp: textResponse("partial")}, {resp: rateLimited()}},
+		{{resp: textResponse("must not happen")}},
+	}}
+	m := geminiRetryModel{inner: inner}
+
+	resps, _ := drain(t, m.GenerateContent(context.Background(), &model.LLMRequest{}, true))
+
+	if inner.calls != 1 {
+		t.Fatalf("inner called %d times, want no retry after partial output", inner.calls)
+	}
+	if len(resps) != 2 || resps[0].Content.Parts[0].Text != "partial" {
+		t.Fatalf("responses = %+v, want the partial reply then the failure", resps)
+	}
+	if resps[1].ErrorCode != "429" {
+		t.Errorf("second response = %+v, want the rate limit passed through", resps[1])
+	}
+}
+
+func TestGeminiRetryModelDoesNotRetryNonStreaming(t *testing.T) {
+	// A non-streaming call is left to the SDK's own retry.
+	inner := &scriptedLLM{outcomes: [][]scriptedYield{
+		{{resp: rateLimited()}},
+		{{resp: textResponse("must not happen")}},
+	}}
+	m := geminiRetryModel{inner: inner}
+
+	resps, _ := drain(t, m.GenerateContent(context.Background(), &model.LLMRequest{}, false))
+
+	if inner.calls != 1 {
+		t.Fatalf("inner called %d times, want a single non-streaming call", inner.calls)
+	}
+	if len(resps) != 1 || resps[0].ErrorCode != "429" {
+		t.Fatalf("responses = %+v, want the failure passed through", resps)
+	}
+}
+
+func TestGeminiRetryModelStopsWhenConsumerStops(t *testing.T) {
+	inner := &scriptedLLM{outcomes: [][]scriptedYield{
+		{{resp: textResponse("one")}, {resp: textResponse("two")}},
+	}}
+	m := geminiRetryModel{inner: inner}
+
+	var seen int
+	for range m.GenerateContent(context.Background(), &model.LLMRequest{}, true) {
+		seen++
+		break
+	}
+	if seen != 1 {
+		t.Fatalf("saw %d responses, want the range to stop at one", seen)
+	}
+	if inner.calls != 1 {
+		t.Errorf("inner called %d times, want one", inner.calls)
+	}
+}
+
+func TestGeminiRetryModelGivesUpAfterBudget(t *testing.T) {
+	// streamRetry is shrunk to one retry in TestMain, so two failures exhaust
+	// it and the last failure reaches the caller.
+	inner := &scriptedLLM{outcomes: [][]scriptedYield{
+		{{resp: rateLimited()}},
+		{{resp: rateLimited()}},
+		{{resp: textResponse("never reached")}},
+	}}
+	m := geminiRetryModel{inner: inner}
+
+	resps, _ := drain(t, m.GenerateContent(context.Background(), &model.LLMRequest{}, true))
+
+	if inner.calls != 2 {
+		t.Fatalf("inner called %d times, want the budget to stop at 2", inner.calls)
+	}
+	if len(resps) != 1 || resps[0].ErrorCode != "429" {
+		t.Fatalf("responses = %+v, want the final rate limit surfaced", resps)
+	}
+}
+
+func TestGeminiRetryModelPassesThroughGoErrors(t *testing.T) {
+	// A non-transient Go error is not worth re-sending.
+	want := errors.New("malformed request")
+	inner := &scriptedLLM{outcomes: [][]scriptedYield{
+		{{err: want}},
+		{{resp: textResponse("must not happen")}},
+	}}
+	m := geminiRetryModel{inner: inner}
+
+	_, errs := drain(t, m.GenerateContent(context.Background(), &model.LLMRequest{}, true))
+
+	if inner.calls != 1 {
+		t.Fatalf("inner called %d times, want no retry for a terminal error", inner.calls)
+	}
+	if len(errs) != 1 || !errors.Is(errs[0], want) {
+		t.Fatalf("errors = %v, want %v passed through", errs, want)
+	}
+}
+
+func TestGeminiRetryModelName(t *testing.T) {
+	if got := (geminiRetryModel{inner: &scriptedLLM{}}).Name(); got != "scripted" {
+		t.Errorf("Name() = %q, want the wrapped model's name", got)
+	}
+}


### PR DESCRIPTION
## Problem

A Gemini per-minute token-quota rejection killed the turn:

```
Error 429 ... You exceeded your current quota, please check your plan and billing details.
Quota exceeded for metric: ...generate_content_paid_tier_input_token_count, limit: 2000000,
model: gemini-3.8-flash  Please retry in 13.380362265s.  Status: RESOURCE_EXHAUSTED
```

surfacing as `transient error after partial response (not retrying)`.

pi-go classified that error correctly. `internal/retry` already knows this exact case: a server-supplied retry window beats the terminal-prose patterns, precisely because Gemini's per-minute limit reuses billing-failure wording verbatim while still naming when it reopens. The error was recognised as retryable and then dropped anyway, because Gemini had no net to catch it.

## Why Gemini specifically

There are two retry layers, and Gemini was in neither.

**The SDK layer was inert.** `genai`'s `retryHTTPRequest` opens with `if opts == nil { return do(req) }`, so retry only happens when `HTTPOptions.RetryOptions` is set. `NewGemini` set `HTTPOptions` only when a custom base URL or extra headers were requested, and never set `RetryOptions`. No Gemini request was retried, not even for a dropped connection.

**The provider layer was missing.** `retryStream` re-sends a streaming request that failed before emitting anything, leaving the turn's tool calls and partial text untouched. OpenAI (responses and completions), Anthropic, Mistral, OpenRouter, xAI and Ollama all use it. Gemini returned ADK's model bare, and nothing generic wraps it at construction.

That left only the coarse per-run retry in `internal/agent`, which can only replay a run that produced nothing. It cannot distinguish "this HTTP request emitted nothing" from "this turn has emitted something", so after the turn's first tool call the two are identical and the turn dies.

## What changed

**`RetryOptions` is now always set**, capped at 3 attempts rather than the SDK's default of 5. The two nets multiply, and they are good at different things. The SDK retries blind on a fixed exponential schedule and cannot read the server's `RetryInfo`, so against a 13-second window its attempts land inside the window that just rejected them. Three attempts cover what it is actually good at — a reset connection, a timeout, a 5xx blip. 429 is deliberately left in its retryable set, because a non-streaming call (commit messages, summaries) never reaches the outer net.

**The model is wrapped in `retryStream`**, matching the other seven providers. This is the layer that honors the server's window, via `internal/retry`'s classifier. Non-streaming calls pass straight through; they have no partial state to protect and the SDK covers them.

Notably, `streamRetry`'s schedule was already tuned for this exact failure — its comment cites a Gemini rejection asking for 11s — so the pacing needed no change, only wiring.

## Verification

Verified the real error end to end rather than assuming: `ServerDelay` parses it to `13.380362265s` and `IsTransient` reports true, so `retryStream` waits the requested window and re-sends.

The test fixture keeps a real rejection verbatim, with a guard asserting it is still classified as transient. Without that guard the retry tests would keep passing while the bug came back. Tests cover the retry, the commit-once-output-is-emitted boundary, the non-streaming passthrough, budget exhaustion, consumer cancellation, and terminal Go errors. `gemini.go` is at 93-100% per function.

Build, vet, `golangci-lint` (0 issues) and the full suite pass.

## Known limit

`retryStream` gives up once content has been forwarded for a request, so a 429 arriving partway through a streamed reply still ends the turn. Fixing that means resuming a stream mid-flight, which is a much larger change and probably not worth it. This closes the common mid-turn case, where the failing request itself emitted nothing.
