### PR TITLE
fix(ratelimit): pace Gemini input tokens against a rolling window, not a bucket

### DIFF
--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -84,6 +84,15 @@ type spendEvent struct {
 	tokens int
 }
 
+// waiter is one request queued for token capacity. Waiters are served in FIFO
+// order so a large request cannot be starved by a stream of small ones.
+type waiter struct {
+	charge int
+	// ready is closed when this waiter becomes the head and should re-check
+	// whether it can be admitted.
+	ready chan struct{}
+}
+
 // Limiter paces requests against a rolling input-token window and/or a
 // request-per-minute budget, and absorbs server-ordered cooldowns.
 //
@@ -100,6 +109,8 @@ type Limiter struct {
 	tokenBurst int
 	// spend holds the token charges still inside the window, oldest first.
 	spend []spendEvent
+	// waiters is the FIFO queue of requests waiting for token capacity.
+	waiters []*waiter
 
 	mu        sync.Mutex
 	coolUntil time.Time
@@ -159,39 +170,118 @@ func (l *Limiter) Wait(ctx context.Context, inputTokens int) error {
 // text. Clamp its charge to a full window and let the server answer instead:
 // its 429 names the quota and the model, which is the message the user
 // actually needs. The window is then full, so later requests wait.
+//
+// Waiters are served in FIFO order. Without ordering, a large request queued
+// behind a stream of small ones could be leapfrogged at every window expiry
+// and starve; the queue guarantees each waiter is admitted before any that
+// arrived after it.
 func (l *Limiter) waitTokenWindow(ctx context.Context, inputTokens int) error {
 	charge := inputTokens
 	if charge > l.tokenLimit {
 		charge = l.tokenLimit
 	}
-	for {
-		l.mu.Lock()
-		now := time.Now()
-		// Drop charges that have fallen out of the window: they no longer
-		// count against the server's rolling window.
-		cutoff := now.Add(-window)
-		keep := 0
-		for keep < len(l.spend) && l.spend[keep].at.Before(cutoff) {
-			keep++
-		}
-		l.spend = l.spend[keep:]
 
-		sum := 0
-		for _, e := range l.spend {
-			sum += e.tokens
+	// Fast path: no one is waiting and the charge fits, admit immediately.
+	// A canceled context must not record a charge for a request that will
+	// never be sent.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	// Enqueue behind any existing waiters, or admit immediately when the queue
+	// is empty and the charge fits.
+	w := &waiter{charge: charge, ready: make(chan struct{})}
+	l.mu.Lock()
+	if len(l.waiters) == 0 && l.windowSumLocked() <= l.tokenLimit-charge {
+		l.spend = append(l.spend, spendEvent{at: time.Now(), tokens: charge})
+		l.mu.Unlock()
+		return nil
+	}
+	l.waiters = append(l.waiters, w)
+	head := len(l.waiters) == 1
+	l.mu.Unlock()
+
+	// Wait until this waiter is at the head of the queue, then try to admit.
+	// The head waiter proceeds immediately; later waiters wait to be woken by
+	// the waiter ahead of them being admitted or removed.
+	for {
+		if !head {
+			select {
+			case <-ctx.Done():
+				l.removeWaiter(w)
+				return ctx.Err()
+			case <-w.ready:
+				head = true
+			}
 		}
-		if sum+charge <= l.tokenLimit {
+
+		l.mu.Lock()
+		if l.waiters[0] != w {
+			// Not head yet; a predecessor is still ahead. Wait to be woken.
+			head = false
+			l.mu.Unlock()
+			continue
+		}
+		now := time.Now()
+		l.dropExpiredLocked(now)
+		if l.windowSumLocked() <= l.tokenLimit-charge {
+			// Admit and dequeue.
 			l.spend = append(l.spend, spendEvent{at: now, tokens: charge})
+			l.waiters = l.waiters[1:]
+			l.wakeNextLocked()
 			l.mu.Unlock()
 			return nil
 		}
-
-		// The window is full. Wait until the oldest charge falls out of it,
-		// then re-check — a concurrent caller may have spent in the meantime.
+		// Head but the window is full. Wait until the oldest charge falls out,
+		// then re-check.
 		wait := l.spend[0].at.Add(window).Sub(now)
 		l.mu.Unlock()
 		if !sleepCtx(ctx, wait) {
+			l.removeWaiter(w)
 			return ctx.Err()
+		}
+	}
+}
+
+// windowSumLocked returns the sum of token charges still inside the window.
+// Caller must hold l.mu.
+func (l *Limiter) windowSumLocked() int {
+	sum := 0
+	for _, e := range l.spend {
+		sum += e.tokens
+	}
+	return sum
+}
+
+// dropExpiredLocked removes charges that have fallen out of the window.
+// Caller must hold l.mu.
+func (l *Limiter) dropExpiredLocked(now time.Time) {
+	cutoff := now.Add(-window)
+	keep := 0
+	for keep < len(l.spend) && l.spend[keep].at.Before(cutoff) {
+		keep++
+	}
+	l.spend = l.spend[keep:]
+}
+
+// wakeNextLocked signals the next waiter in line, if any, that it may re-check.
+// Caller must hold l.mu.
+func (l *Limiter) wakeNextLocked() {
+	if len(l.waiters) > 0 {
+		close(l.waiters[0].ready)
+	}
+}
+
+// removeWaiter drops w from the queue, waking the next waiter if w was head.
+func (l *Limiter) removeWaiter(w *waiter) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, c := range l.waiters {
+		if c == w {
+			l.waiters = append(l.waiters[:i], l.waiters[i+1:]...)
+			if i == 0 && len(l.waiters) > 0 {
+				close(l.waiters[0].ready)
+			}
+			return
 		}
 	}
 }

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -27,6 +27,15 @@
 //     holding its own model.LLM. A limiter owned by one client would not have
 //     seen the others' spend, so limiters are looked up from a process-wide
 //     registry keyed by endpoint (see Shared).
+//
+// The token budget is a *rolling window*, not a token bucket. The server's
+// quota is a rolling 60-second window: a burst at t=0 still counts against the
+// window at t=59 and only falls out at t=60. A token bucket with a full-window
+// burst lets a client dump a whole window's worth instantly and again a minute
+// later, which the server counts as two windows' worth in one — the bursty
+// failure mode that produced mid-stream 429s after the original fix. The
+// rolling window here delays a request until its input tokens fit in the last
+// window, so a second full burst is held rather than sent and rejected.
 package ratelimit
 
 import (
@@ -64,18 +73,33 @@ func (l Limits) Enabled() bool {
 // would let a misconfigured gateway freeze a turn indefinitely.
 const maxCooldown = 60 * time.Second
 
-// Limiter paces requests against a token-per-minute and/or
+// window is how long a token charge stays in the rolling window. It matches
+// the server's own per-minute quota window.
+const window = time.Minute
+
+// spendEvent records one admitted request's token charge and when it was
+// admitted, so the rolling window can drop it once it falls out.
+type spendEvent struct {
+	at     time.Time
+	tokens int
+}
+
+// Limiter paces requests against a rolling input-token window and/or a
 // request-per-minute budget, and absorbs server-ordered cooldowns.
 //
 // The zero value is not usable; a nil *Limiter is, and does nothing — that is
 // how "no limits configured" is represented at call sites.
 type Limiter struct {
-	// requests and tokens are nil when that budget is unlimited.
+	// requests is nil when the RPM budget is unlimited.
 	requests *rate.Limiter
-	tokens   *rate.Limiter
-	// tokenBurst mirrors tokens' burst so Wait can clamp to it without
-	// reaching back into the rate.Limiter.
+
+	// tokenLimit is the max input tokens admitted in any window; tokenBurst
+	// mirrors it so Wait can clamp an oversize request without reaching back
+	// into the ledger. Both are zero when the token budget is unlimited.
+	tokenLimit int
 	tokenBurst int
+	// spend holds the token charges still inside the window, oldest first.
+	spend []spendEvent
 
 	mu        sync.Mutex
 	coolUntil time.Time
@@ -83,11 +107,10 @@ type Limiter struct {
 
 // New builds a Limiter for the given budget, or nil when nothing is limited.
 //
-// Each bucket's burst is a full window's worth rather than 1. Smoothing to a
-// single unit would serialize an agent turn that legitimately fans out several
-// small requests at once, and it would make the token bucket reject any
-// request larger than one token. A full-window burst matches the shape of the
-// server's own limit: spend it all at once if you like, then wait.
+// The RPM budget is a token bucket with a full-window burst, so a turn that
+// legitimately fans out several small requests at once is not serialized. The
+// token budget is a rolling window instead — see the package comment for why a
+// bucket is the wrong shape for a per-minute quota.
 func New(l Limits) *Limiter {
 	if !l.Enabled() {
 		return nil
@@ -97,7 +120,7 @@ func New(l Limits) *Limiter {
 		lim.requests = rate.NewLimiter(rate.Limit(float64(l.RequestsPerMinute)/60), l.RequestsPerMinute)
 	}
 	if l.InputTokensPerMinute > 0 {
-		lim.tokens = rate.NewLimiter(rate.Limit(float64(l.InputTokensPerMinute)/60), l.InputTokensPerMinute)
+		lim.tokenLimit = l.InputTokensPerMinute
 		lim.tokenBurst = l.InputTokensPerMinute
 	}
 	return lim
@@ -120,22 +143,57 @@ func (l *Limiter) Wait(ctx context.Context, inputTokens int) error {
 			return waitErr(ctx, err)
 		}
 	}
-	if l.tokens != nil && inputTokens > 0 {
-		// Clamp to the burst. A request bigger than the whole per-minute
-		// budget can never be admitted, and rate.WaitN reports that as an
-		// error — which would turn an over-large prompt into a local failure
-		// with no useful text. Drain the bucket and let the server answer
-		// instead: its 429 names the quota and the model, which is the message
-		// the user actually needs.
-		n := inputTokens
-		if n > l.tokenBurst {
-			n = l.tokenBurst
-		}
-		if err := l.tokens.WaitN(ctx, n); err != nil {
-			return waitErr(ctx, err)
+	if l.tokenLimit > 0 && inputTokens > 0 {
+		if err := l.waitTokenWindow(ctx, inputTokens); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// waitTokenWindow holds a request until its token charge fits in the rolling
+// window, then records the charge.
+//
+// A request larger than the whole window can never be admitted, and blocking
+// on it would turn an over-large prompt into a local failure with no useful
+// text. Clamp its charge to a full window and let the server answer instead:
+// its 429 names the quota and the model, which is the message the user
+// actually needs. The window is then full, so later requests wait.
+func (l *Limiter) waitTokenWindow(ctx context.Context, inputTokens int) error {
+	charge := inputTokens
+	if charge > l.tokenLimit {
+		charge = l.tokenLimit
+	}
+	for {
+		l.mu.Lock()
+		now := time.Now()
+		// Drop charges that have fallen out of the window: they no longer
+		// count against the server's rolling window.
+		cutoff := now.Add(-window)
+		keep := 0
+		for keep < len(l.spend) && l.spend[keep].at.Before(cutoff) {
+			keep++
+		}
+		l.spend = l.spend[keep:]
+
+		sum := 0
+		for _, e := range l.spend {
+			sum += e.tokens
+		}
+		if sum+charge <= l.tokenLimit {
+			l.spend = append(l.spend, spendEvent{at: now, tokens: charge})
+			l.mu.Unlock()
+			return nil
+		}
+
+		// The window is full. Wait until the oldest charge falls out of it,
+		// then re-check — a concurrent caller may have spent in the meantime.
+		wait := l.spend[0].at.Add(window).Sub(now)
+		l.mu.Unlock()
+		if !sleepCtx(ctx, wait) {
+			return ctx.Err()
+		}
+	}
 }
 
 // waitErr translates a rate.Limiter refusal into the vocabulary the rest of
@@ -193,15 +251,24 @@ func (l *Limiter) waitCooldown(ctx context.Context) error {
 		if d <= 0 {
 			return nil
 		}
-		timer := time.NewTimer(d)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
+		if !sleepCtx(ctx, d) {
 			return ctx.Err()
-		case <-timer.C:
-			// Loop rather than return: a concurrent Backoff may have pushed
-			// coolUntil further out while this caller was asleep.
 		}
+	}
+}
+
+// sleepCtx waits for d, reporting false if ctx was canceled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -105,6 +105,30 @@ func TestLimiterHoldsSecondFullBurst(t *testing.T) {
 	}
 }
 
+// This is the case that distinguishes the rolling window from the old token
+// bucket. A token bucket refills continuously, so at t=59s it has ~983 tokens
+// back and would admit a 100-token request. The rolling window still counts
+// the full 1000-token burst at t=59, so it must reject the same request. The
+// old bucket would pass this test; the rolling window is what makes it fail.
+func TestLimiterRollingWindowRejectsPartialChargeBeforeExpiry(t *testing.T) {
+	t.Parallel()
+	lim := New(Limits{InputTokensPerMinute: 1000})
+	if err := lim.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+
+	// At t=59s the full burst is still in the window, so even a small charge
+	// must be held. A token bucket would have refilled and admitted it.
+	lim.mu.Lock()
+	lim.spend[0].at = time.Now().Add(-59 * time.Second)
+	lim.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := lim.Wait(ctx, 100); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Wait(100) at t=59 err = %v, want it held by the rolling window", err)
+	}
+}
+
 // A charge admitted at t=0 still counts against the window at t=59 and only
 // falls out at t=60. This is the property a token bucket does not model.
 func TestLimiterRollingWindowExpiry(t *testing.T) {
@@ -130,6 +154,62 @@ func TestLimiterRollingWindowExpiry(t *testing.T) {
 	lim.mu.Unlock()
 	if err := lim.Wait(context.Background(), 1000); err != nil {
 		t.Fatalf("Wait after window expiry: %v", err)
+	}
+}
+
+// A canceled context must not record a charge for a request that will never be
+// sent. The old rate.WaitN rejected a pre-canceled context; the rolling window
+// must too, or it would charge budget for a request that never goes out.
+func TestLimiterPreCanceledContextDoesNotCharge(t *testing.T) {
+	t.Parallel()
+	lim := New(Limits{InputTokensPerMinute: 1000})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := lim.Wait(ctx, 100); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait with canceled ctx err = %v, want context.Canceled", err)
+	}
+
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	if len(lim.spend) != 0 {
+		t.Fatalf("canceled request recorded %d charges, want none", len(lim.spend))
+	}
+}
+
+// A large request queued behind a stream of small ones must not be starved.
+// Without FIFO ordering, a small request arriving after the large one could
+// consume the freed capacity and leapfrog it. Here the large request is queued
+// first and the small one second; neither may be admitted while the window is
+// full, and the small one must not slip ahead of the large one.
+func TestLimiterFIFOOrderingPreventsStarvation(t *testing.T) {
+	t.Parallel()
+	lim := New(Limits{InputTokensPerMinute: 1000})
+	if err := lim.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("fill Wait: %v", err)
+	}
+
+	// Queue a large request first, then a small one. Both must be held while
+	// the window is full.
+	largeDone := make(chan error, 1)
+	go func() {
+		largeDone <- lim.Wait(context.Background(), 1000)
+	}()
+	// Give the large request a moment to enqueue before the small one.
+	time.Sleep(20 * time.Millisecond)
+	smallDone := make(chan error, 1)
+	go func() {
+		smallDone <- lim.Wait(context.Background(), 100)
+	}()
+
+	// Neither may complete while the window is full.
+	select {
+	case err := <-largeDone:
+		t.Fatalf("large request admitted while window full: %v", err)
+	case err := <-smallDone:
+		t.Fatalf("small request admitted ahead of the queued large one: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		// Both correctly held.
 	}
 }
 

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -84,6 +84,55 @@ func TestLimiterBlocksOnRequestBudget(t *testing.T) {
 	}
 }
 
+// The regression this package was reworked for: a second full burst, sent a
+// minute after the first, must be held rather than admitted. The server's
+// rolling window still counts the first burst when the second lands, so a
+// token bucket with a full-window burst would over-spend and 429. The rolling
+// window delays the second burst until the first falls out.
+func TestLimiterHoldsSecondFullBurst(t *testing.T) {
+	t.Parallel()
+	lim := New(Limits{InputTokensPerMinute: 1000})
+	if err := lim.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("first burst Wait: %v", err)
+	}
+
+	// A second full burst immediately must wait for the first to fall out of
+	// the window, not be admitted.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := lim.Wait(ctx, 1000); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second full burst err = %v, want it held by the rolling window", err)
+	}
+}
+
+// A charge admitted at t=0 still counts against the window at t=59 and only
+// falls out at t=60. This is the property a token bucket does not model.
+func TestLimiterRollingWindowExpiry(t *testing.T) {
+	t.Parallel()
+	lim := New(Limits{InputTokensPerMinute: 1000})
+	if err := lim.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("first Wait: %v", err)
+	}
+
+	// Just before the window closes, the budget is still spent.
+	lim.mu.Lock()
+	lim.spend[0].at = time.Now().Add(-59 * time.Second)
+	lim.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := lim.Wait(ctx, 1000); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Wait at t=59 err = %v, want it still held", err)
+	}
+
+	// Once the charge falls out of the window, the budget is free again.
+	lim.mu.Lock()
+	lim.spend[0].at = time.Now().Add(-61 * time.Second)
+	lim.mu.Unlock()
+	if err := lim.Wait(context.Background(), 1000); err != nil {
+		t.Fatalf("Wait after window expiry: %v", err)
+	}
+}
+
 // A request larger than the whole per-minute budget must still be sent: the
 // server's 429 names the quota, whereas a local rate.WaitN error would say
 // nothing useful and would never clear.


### PR DESCRIPTION
## Problem

`internal/ratelimit` paces Gemini traffic to stay under the published
`generate_content_paid_tier_input_token_count` quota (2,000,000 input
tokens/min). The token budget was a `rate.Limiter` with a **full-window burst**
— the comment in `New` said "spend it all at once if you like, then wait."

That is the wrong shape for a **rolling** 60-second window. A burst at t=0 still
counts at t=59 and only falls out at t=60, so a second full burst a minute later
lands while the first is still counted — 3.6M tokens in one window — and Gemini
answers with a mid-stream 429:

```
transient error after partial response (not retrying): Error 429 ...
Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_paid_tier_input_token_count,
limit: 2000000, model: gemini-3.8-flash
```

A mid-stream 429 is unrecoverable: `agent/retry.go` refuses to re-run a turn
once it has yielded anything. The 10% haircut (1.8M default) only covers the
refill, not a second full burst.

## Fix

Replace the token bucket with a **rolling-window ledger** in
`internal/ratelimit`:

- Each admitted request records its token charge and admission time.
- Charges older than the window are dropped (they've fallen out of the server's
  rolling window).
- A request is **delayed** until its charge fits the remaining window — a second
  full burst is held until the first falls out, turning the mid-stream 429 into
  a controlled delay at admission.

The RPM budget stays a token bucket (a full-window burst is fine for request
*count*), and server-ordered `Backoff` is unchanged.

## Tests

- `TestLimiterHoldsSecondFullBurst` — the exact failure: a second full burst a
  minute after the first is now held, not admitted.
- `TestLimiterRollingWindowExpiry` — a charge at t=0 still counts at t=59, falls
  out at t=60.

All existing ratelimit/config/provider tests pass; `go build ./...` and
`go vet` are clean.

Fixes #315