### PR TITLE
feat(ratelimit): expose RPM/TPM quota metrics over Prometheus

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -575,6 +575,11 @@ func stopCPUProfile() {
 // any non-empty value. Profiles are then collected over HTTP
 // (http://localhost:<port>/debug/pprof), so no profile-specific setup is needed
 // here — the value is only echoed back so the user can see what they asked for.
+//
+// Diagnostics go through slog, not fmt: this starts from PersistentPreRun and
+// the interactive TUI may already own the terminal by the time the listener
+// fails, and a raw stdout or stderr write would render as garbage over the
+// alternate screen (see CLAUDE.md).
 func startPprofServer() {
 	if flagPprof == "" {
 		return
@@ -582,10 +587,12 @@ func startPprofServer() {
 	pprofOnce.Do(func() {
 		addr := ":" + flagPprofPort
 		go func() {
-			fmt.Printf("pprof server listening on %s (profile: %s)\n", addr, flagPprof)
-			fmt.Println("collect with: go tool pprof http://localhost:" + flagPprofPort + "/debug/pprof/heap")
+			slog.Info("pprof server listening",
+				"addr", addr,
+				"profile", flagPprof,
+				"collect_with", "go tool pprof http://localhost:"+flagPprofPort+"/debug/pprof/heap")
 			if err := http.ListenAndServe(addr, nil); err != nil {
-				fmt.Fprintf(os.Stderr, "pprof server error: %v\n", err)
+				slog.Error("pprof server error", "error", err)
 			}
 		}()
 	})

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dimetron/pi-go/internal/palace"
 	"github.com/dimetron/pi-go/internal/pirpc"
 	"github.com/dimetron/pi-go/internal/provider"
+	"github.com/dimetron/pi-go/internal/ratelimit"
 	"github.com/dimetron/pi-go/internal/retry"
 	pisession "github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/subagent"
@@ -70,6 +71,8 @@ var (
 	flagSystem       string
 	flagPprof        string
 	flagPprofPort    string
+	flagMetrics      bool
+	flagMetricsPort  string
 	flagCPUProfile   string
 	flagTraceHTTP    bool
 	flagA2AAddr      string
@@ -186,6 +189,7 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 		// every subcommand alike.
 		PersistentPreRun: func(*cobra.Command, []string) {
 			startPprofServer()
+			startMetricsServer()
 			startCPUProfile()
 		},
 		PersistentPostRun: func(*cobra.Command, []string) {
@@ -223,6 +227,16 @@ Set a default in ~/.pi-go/config.json so --model is only needed to deviate;
 	// "unknown flag: --pprof" the moment a subcommand was used.
 	cmd.PersistentFlags().StringVar(&flagPprof, "pprof", "", "Enable pprof profiling (serves /debug/pprof; any non-empty value enables it)")
 	cmd.PersistentFlags().StringVar(&flagPprofPort, "pprof-port", "6060", "Port for the pprof HTTP server")
+	// A separate flag and server from --pprof on purpose: pprof is a profiling
+	// tool a user turns on for one debugging session, while rate-limit metrics
+	// are an ops signal someone may want scraped continuously. Tying it to
+	// --pprof would mean either enabling CPU/heap profiling overhead just to
+	// see quota headroom, or never exposing the quota view without it; a
+	// dedicated mux also keeps /debug/pprof off this port when only metrics
+	// were asked for. 9464 is OpenTelemetry's own default Prometheus exporter
+	// port, so a scraper config aimed at "the usual place" finds it.
+	cmd.PersistentFlags().BoolVar(&flagMetrics, "metrics", false, "Serve rate-limit usage metrics in Prometheus text format at /metrics (see --metrics-port)")
+	cmd.PersistentFlags().StringVar(&flagMetricsPort, "metrics-port", "9464", "Port for the rate-limit metrics HTTP server")
 	// --cpuprofile writes a runtime CPU profile to the given path for the whole
 	// process lifetime. This is the profile PGO consumes: `go build` reads a CPU
 	// pprof profile (default.pgo in the main package dir, or -pgo=<path>) to
@@ -572,6 +586,36 @@ func startPprofServer() {
 			fmt.Println("collect with: go tool pprof http://localhost:" + flagPprofPort + "/debug/pprof/heap")
 			if err := http.ListenAndServe(addr, nil); err != nil {
 				fmt.Fprintf(os.Stderr, "pprof server error: %v\n", err)
+			}
+		}()
+	})
+}
+
+// metricsOnce guards the metrics listener the same way pprofOnce guards the
+// pprof one: PersistentPreRun fires once per command, including subcommands.
+var metricsOnce sync.Once
+
+// startMetricsServer serves internal/ratelimit's Prometheus-format /metrics
+// endpoint on --metrics-port when --metrics is set.
+//
+// It runs on its own ServeMux rather than sharing pprof's DefaultServeMux
+// (or listening on the same address): the two flags are independent, and a
+// user who asked only for --metrics should not also get /debug/pprof for
+// free, or vice versa. Diagnostics go through slog rather than fmt/stdout —
+// this can start while the interactive TUI already owns the terminal, and a
+// raw stdout write from here would corrupt its display (see CLAUDE.md).
+func startMetricsServer() {
+	if !flagMetrics {
+		return
+	}
+	metricsOnce.Do(func() {
+		addr := ":" + flagMetricsPort
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", ratelimit.MetricsHandler())
+		go func() {
+			slog.Info("rate-limit metrics server listening", "addr", addr, "path", "/metrics")
+			if err := http.ListenAndServe(addr, mux); err != nil {
+				slog.Error("rate-limit metrics server error", "error", err)
 			}
 		}()
 	})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -79,6 +79,8 @@ func BuildTransport(opts *LLMOptions) (http.RoundTripper, error) {
 		base = &ratelimit.Transport{
 			Base:    base,
 			Limiter: ratelimit.Shared(opts.RateLimitScope, opts.RateLimit),
+			Scope:   opts.RateLimitScope,
+			Limits:  opts.RateLimit,
 		}
 	}
 	return base, nil

--- a/internal/ratelimit/metrics.go
+++ b/internal/ratelimit/metrics.go
@@ -1,0 +1,293 @@
+package ratelimit
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// This file mirrors, for observability, the two per-minute figures Google AI
+// Studio's quota dashboard shows for a Gemini model: "Peak requests per
+// minute" and "Peak input tokens per minute". It exists so a user can see
+// locally, while a turn is running, what the provider console only shows
+// after the fact.
+//
+// It deliberately keeps its own rolling-window ledger rather than reading
+// Limiter's internal admission state. Limiter's own bookkeeping for the token
+// budget has changed shape before (a token bucket, then a rolling window; see
+// fix/ratelimit-rolling-window) and the request budget has never had a ledger
+// at all — RequestsPerMinute is paced with a plain token-bucket rate.Limiter,
+// which has nothing to report a rolling *count* from. A metrics path wired to
+// either representation would have to change every time admission logic does,
+// or would have no ledger to read at all. Recording independently, at the one
+// point every provider's requests already pass through (Transport.RoundTrip,
+// right after Wait grants admission), gets the same numbers the provider
+// counts without coupling to how admission happens to be implemented.
+
+// metricsWindow is the width of the rolling window these metrics are computed
+// over. It matches window in ratelimit.go: both describe the same per-minute
+// quota the provider enforces, so a scraper's numbers describe the same 60
+// seconds a 429 would name.
+const metricsWindow = time.Minute
+
+// tokenSample is one admitted request's token charge, timestamped so it can
+// be dropped once it falls out of the rolling window.
+type tokenSample struct {
+	at     time.Time
+	tokens int
+}
+
+// scopeMetrics accumulates the rolling-window request and token counters for
+// one provider+model scope (see ScopeFor), plus the high-water mark observed
+// for each since the process started.
+type scopeMetrics struct {
+	provider, model string
+	limits          Limits
+
+	mu           sync.Mutex
+	requestTimes []time.Time
+	peakRequests int
+	tokenEvents  []tokenSample
+	peakTokens   int
+}
+
+// record admits one request charging inputTokens into the rolling window and
+// updates the peak counters if this admission set a new high.
+//
+// The peak only needs checking on insertion: the rolling sum (or count) never
+// increases except when a new event is appended, so its maximum over time is
+// always reached immediately after an insertion, never after an expiry.
+func (m *scopeMetrics) record(inputTokens int) {
+	now := time.Now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.requestTimes = append(m.requestTimes, now)
+	m.requestTimes = dropBefore(m.requestTimes, now.Add(-metricsWindow))
+	m.peakRequests = max(m.peakRequests, len(m.requestTimes))
+
+	if inputTokens > 0 {
+		m.tokenEvents = append(m.tokenEvents, tokenSample{at: now, tokens: inputTokens})
+	}
+	m.tokenEvents = dropExpiredTokens(m.tokenEvents, now.Add(-metricsWindow))
+	m.peakTokens = max(m.peakTokens, sumTokens(m.tokenEvents))
+}
+
+// snapshot reports the current rolling-window values and the peaks observed
+// so far. It prunes entries that have fallen out of the window since the last
+// record, so a scrape between requests still reads the true current value
+// rather than a stale one left over from the last admission.
+func (m *scopeMetrics) snapshot() ScopeMetrics {
+	now := time.Now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.requestTimes = dropBefore(m.requestTimes, now.Add(-metricsWindow))
+	m.tokenEvents = dropExpiredTokens(m.tokenEvents, now.Add(-metricsWindow))
+
+	return ScopeMetrics{
+		Provider: m.provider,
+		Model:    m.model,
+
+		RequestsPerMinute:     len(m.requestTimes),
+		PeakRequestsPerMinute: m.peakRequests,
+		RequestsLimit:         m.limits.RequestsPerMinute,
+
+		InputTokensPerMinute:     sumTokens(m.tokenEvents),
+		PeakInputTokensPerMinute: m.peakTokens,
+		InputTokensLimit:         m.limits.InputTokensPerMinute,
+	}
+}
+
+// dropBefore drops the leading run of times older than cutoff. requestTimes
+// is append-only and therefore already sorted, so a linear scan from the
+// front is sufficient — no need to search or resort.
+func dropBefore(times []time.Time, cutoff time.Time) []time.Time {
+	keep := 0
+	for keep < len(times) && times[keep].Before(cutoff) {
+		keep++
+	}
+	return times[keep:]
+}
+
+// dropExpiredTokens is dropBefore's counterpart for tokenSample, which is
+// also append-only and therefore already ordered by at.
+func dropExpiredTokens(events []tokenSample, cutoff time.Time) []tokenSample {
+	keep := 0
+	for keep < len(events) && events[keep].at.Before(cutoff) {
+		keep++
+	}
+	return events[keep:]
+}
+
+func sumTokens(events []tokenSample) int {
+	sum := 0
+	for _, e := range events {
+		sum += e.tokens
+	}
+	return sum
+}
+
+// ScopeMetrics is a rendered snapshot of one provider+model scope's
+// rate-limit metrics: the current rolling-60s value and the peak observed
+// since the process started, for both requests and input tokens, alongside
+// the configured budget each is paced against.
+type ScopeMetrics struct {
+	Provider string
+	Model    string
+
+	// RequestsPerMinute is the request count admitted in the trailing 60s.
+	RequestsPerMinute int
+	// PeakRequestsPerMinute is the highest RequestsPerMinute has been since
+	// the process started.
+	PeakRequestsPerMinute int
+	// RequestsLimit is the configured requests-per-minute budget. Zero means
+	// unlimited.
+	RequestsLimit int
+
+	// InputTokensPerMinute is the input tokens admitted in the trailing 60s.
+	InputTokensPerMinute int
+	// PeakInputTokensPerMinute is the highest InputTokensPerMinute has been
+	// since the process started.
+	PeakInputTokensPerMinute int
+	// InputTokensLimit is the configured input-tokens-per-minute budget. Zero
+	// means unlimited.
+	InputTokensLimit int
+}
+
+var (
+	metricsMu      sync.Mutex
+	metricsByScope = map[string]*scopeMetrics{}
+)
+
+// recordAdmitted records one admitted request against scope's rolling-window
+// metrics, creating the scope's counters on first use.
+//
+// Like Shared, the first caller for a scope wins: if a later Transport for
+// the same scope somehow disagreed on limits, the metrics would still be
+// read against the budget the scope was first observed with, matching the
+// one Limiter every caller on that scope actually shares.
+func recordAdmitted(scope, provider, model string, limits Limits, inputTokens int) {
+	metricsMu.Lock()
+	m, ok := metricsByScope[scope]
+	if !ok {
+		m = &scopeMetrics{provider: provider, model: model, limits: limits}
+		metricsByScope[scope] = m
+	}
+	metricsMu.Unlock()
+	m.record(inputTokens)
+}
+
+// MetricsSnapshot returns the current rolling-window and peak values for
+// every provider+model scope that has admitted at least one request, sorted
+// by provider then model for stable output.
+func MetricsSnapshot() []ScopeMetrics {
+	metricsMu.Lock()
+	scopes := make([]*scopeMetrics, 0, len(metricsByScope))
+	for _, m := range metricsByScope {
+		scopes = append(scopes, m)
+	}
+	metricsMu.Unlock()
+
+	out := make([]ScopeMetrics, len(scopes))
+	for i, m := range scopes {
+		out[i] = m.snapshot()
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Model < out[j].Model
+	})
+	return out
+}
+
+// resetMetrics drops every recorded scope. Tests only: metricsByScope is
+// process-wide by design, which would otherwise leak state between cases.
+func resetMetrics() {
+	metricsMu.Lock()
+	defer metricsMu.Unlock()
+	metricsByScope = map[string]*scopeMetrics{}
+}
+
+// Prometheus gauge names this package exposes. All six carry the
+// {provider="...",model="..."} label pair; none carry the base URL — the
+// dashboard being mirrored groups by model, not by endpoint, and a base URL
+// can embed a hostname or path a user would not want in scraped metric
+// labels.
+const (
+	metricRequests      = "pi_ratelimit_requests_per_minute"
+	metricRequestsPeak  = "pi_ratelimit_requests_per_minute_peak"
+	metricRequestsLimit = "pi_ratelimit_requests_per_minute_limit"
+	metricTokens        = "pi_ratelimit_input_tokens_per_minute"
+	metricTokensPeak    = "pi_ratelimit_input_tokens_per_minute_peak"
+	metricTokensLimit   = "pi_ratelimit_input_tokens_per_minute_limit"
+)
+
+// gauge is one Prometheus gauge family this package exposes: a name, its HELP
+// text, and how to read its value out of a ScopeMetrics.
+type gauge struct {
+	name string
+	help string
+	val  func(ScopeMetrics) int
+}
+
+// gauges lists every metric WriteMetrics renders, in the order they appear in
+// the exposition. Order does not matter to Prometheus, but a stable order
+// makes curl output and diffs readable.
+var gauges = []gauge{
+	{metricRequests, "Requests admitted in the trailing 60s, per provider+model.",
+		func(s ScopeMetrics) int { return s.RequestsPerMinute }},
+	{metricRequestsPeak, "Peak requests admitted in any trailing 60s window, per provider+model, since process start.",
+		func(s ScopeMetrics) int { return s.PeakRequestsPerMinute }},
+	{metricRequestsLimit, "Configured requests-per-minute budget, per provider+model. 0 means unlimited.",
+		func(s ScopeMetrics) int { return s.RequestsLimit }},
+	{metricTokens, "Input tokens admitted in the trailing 60s, per provider+model.",
+		func(s ScopeMetrics) int { return s.InputTokensPerMinute }},
+	{metricTokensPeak, "Peak input tokens admitted in any trailing 60s window, per provider+model, since process start.",
+		func(s ScopeMetrics) int { return s.PeakInputTokensPerMinute }},
+	{metricTokensLimit, "Configured input-tokens-per-minute budget, per provider+model. 0 means unlimited.",
+		func(s ScopeMetrics) int { return s.InputTokensLimit }},
+}
+
+// WriteMetrics renders every scope in scopes as Prometheus text exposition
+// format (https://prometheus.io/docs/instrumenting/exposition_formats/): six
+// gauge families, each with one HELP/TYPE header followed by one sample line
+// per scope.
+//
+// Reporting both the current rolling value and its peak is the point: the
+// dashboard being mirrored is a peak view precisely because a point-in-time
+// gauge alone hides the bursts that trip a 429 — see the package-level
+// comment in ratelimit.go. The limit gauges let a scraper compute headroom
+// the same way the dashboard's red line does.
+func WriteMetrics(w io.Writer, scopes []ScopeMetrics) error {
+	for _, g := range gauges {
+		if _, err := fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", g.name, g.help, g.name); err != nil {
+			return err
+		}
+		for _, s := range scopes {
+			_, err := fmt.Fprintf(w, "%s{provider=%s,model=%s} %d\n",
+				g.name, strconv.Quote(s.Provider), strconv.Quote(s.Model), g.val(s))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// MetricsHandler serves every provider+model scope's rate-limit metrics in
+// Prometheus text exposition format. Mount it at whatever path the caller
+// chooses (e.g. "/metrics"); it does not register itself anywhere.
+func MetricsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		// A ResponseWriter write failure means the client is already gone;
+		// nothing useful can be done with the error here.
+		_ = WriteMetrics(w, MetricsSnapshot())
+	})
+}

--- a/internal/ratelimit/metrics_test.go
+++ b/internal/ratelimit/metrics_test.go
@@ -1,0 +1,249 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDropBefore(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	times := []time.Time{now.Add(-3 * time.Minute), now.Add(-90 * time.Second), now.Add(-10 * time.Second), now}
+	tests := []struct {
+		name   string
+		cutoff time.Time
+		want   int
+	}{
+		{"nothing expired", now.Add(-4 * time.Minute), 4},
+		{"everything expired", now.Add(time.Second), 0},
+		{"drops the two oldest", now.Add(-time.Minute), 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := dropBefore(times, tt.cutoff); len(got) != tt.want {
+				t.Errorf("dropBefore(%v) len = %d, want %d", tt.cutoff, len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestSumTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		events []tokenSample
+		want   int
+	}{
+		{"empty", nil, 0},
+		{"one", []tokenSample{{tokens: 100}}, 100},
+		{"several", []tokenSample{{tokens: 100}, {tokens: 250}, {tokens: 1}}, 351},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sumTokens(tt.events); got != tt.want {
+				t.Errorf("sumTokens = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopeMetricsRecordAndSnapshot(t *testing.T) {
+	t.Parallel()
+	m := &scopeMetrics{
+		provider: "gemini",
+		model:    "gemini-3.8-flash",
+		limits:   Limits{RequestsPerMinute: 1000, InputTokensPerMinute: 2_000_000},
+	}
+
+	m.record(500_000)
+	m.record(600_000)
+	m.record(700_000)
+
+	got := m.snapshot()
+	want := ScopeMetrics{
+		Provider: "gemini",
+		Model:    "gemini-3.8-flash",
+
+		RequestsPerMinute:     3,
+		PeakRequestsPerMinute: 3,
+		RequestsLimit:         1000,
+
+		InputTokensPerMinute:     1_800_000,
+		PeakInputTokensPerMinute: 1_800_000,
+		InputTokensLimit:         2_000_000,
+	}
+	if got != want {
+		t.Fatalf("snapshot = %+v, want %+v", got, want)
+	}
+}
+
+// The dashboard being mirrored is a peak view: once the window rolls forward
+// and the current value drops, the peak observed earlier must still be
+// reported, not overwritten by the lower current reading.
+func TestScopeMetricsPeakSurvivesWindowExpiry(t *testing.T) {
+	t.Parallel()
+	m := &scopeMetrics{limits: Limits{InputTokensPerMinute: 2_000_000}}
+
+	m.record(2_000_000)
+	if peak := m.snapshot().PeakInputTokensPerMinute; peak != 2_000_000 {
+		t.Fatalf("peak after first burst = %d, want 2_000_000", peak)
+	}
+
+	// Age the recorded event past the window without a real sleep, the same
+	// way ratelimit_test.go backdates spend entries: grab the lock and rewrite
+	// the timestamp.
+	m.mu.Lock()
+	for i := range m.tokenEvents {
+		m.tokenEvents[i].at = time.Now().Add(-2 * time.Minute)
+	}
+	for i := range m.requestTimes {
+		m.requestTimes[i] = time.Now().Add(-2 * time.Minute)
+	}
+	m.mu.Unlock()
+
+	got := m.snapshot()
+	if got.InputTokensPerMinute != 0 {
+		t.Fatalf("current tokens after expiry = %d, want 0", got.InputTokensPerMinute)
+	}
+	if got.PeakInputTokensPerMinute != 2_000_000 {
+		t.Fatalf("peak after expiry = %d, want 2_000_000 (peaks must not decay)", got.PeakInputTokensPerMinute)
+	}
+	if got.RequestsPerMinute != 0 {
+		t.Fatalf("current requests after expiry = %d, want 0", got.RequestsPerMinute)
+	}
+	if got.PeakRequestsPerMinute != 1 {
+		t.Fatalf("peak requests after expiry = %d, want 1", got.PeakRequestsPerMinute)
+	}
+}
+
+// A request with no measurable body (chunked, ContentLength unknown) charges
+// no tokens but must still count toward the request-rate metric.
+func TestScopeMetricsZeroTokenRequestStillCountsAsRequest(t *testing.T) {
+	t.Parallel()
+	m := &scopeMetrics{}
+	m.record(0)
+	got := m.snapshot()
+	if got.RequestsPerMinute != 1 {
+		t.Fatalf("RequestsPerMinute = %d, want 1", got.RequestsPerMinute)
+	}
+	if got.InputTokensPerMinute != 0 {
+		t.Fatalf("InputTokensPerMinute = %d, want 0", got.InputTokensPerMinute)
+	}
+}
+
+func TestRecordAdmittedAndMetricsSnapshot(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+
+	recordAdmitted("gemini|gemini-3.8-flash|", "gemini", "gemini-3.8-flash",
+		Limits{InputTokensPerMinute: 2_000_000}, 900_000)
+	recordAdmitted("gemini|gemini-3.8-flash|", "gemini", "gemini-3.8-flash",
+		Limits{InputTokensPerMinute: 2_000_000}, 1_200_000)
+	recordAdmitted("openai|gpt-5.2|", "openai", "gpt-5.2",
+		Limits{RequestsPerMinute: 500}, 100)
+
+	got := MetricsSnapshot()
+	if len(got) != 2 {
+		t.Fatalf("MetricsSnapshot returned %d scopes, want 2", len(got))
+	}
+	// Sorted by provider then model: gemini before openai.
+	if got[0].Provider != "gemini" || got[0].Model != "gemini-3.8-flash" {
+		t.Fatalf("got[0] = %+v, want gemini/gemini-3.8-flash first", got[0])
+	}
+	if got[0].InputTokensPerMinute != 2_100_000 {
+		t.Fatalf("gemini InputTokensPerMinute = %d, want 2_100_000", got[0].InputTokensPerMinute)
+	}
+	if got[0].RequestsPerMinute != 2 {
+		t.Fatalf("gemini RequestsPerMinute = %d, want 2", got[0].RequestsPerMinute)
+	}
+	if got[1].Provider != "openai" || got[1].RequestsLimit != 500 {
+		t.Fatalf("got[1] = %+v, want openai/gpt-5.2 with RequestsLimit 500", got[1])
+	}
+}
+
+// The first caller's limits win, mirroring Shared's "first caller wins" rule
+// for the Limiter itself: every client on one scope shares one budget, so a
+// later, differently-configured caller must not silently rewrite it.
+func TestRecordAdmittedFirstLimitsWin(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+
+	recordAdmitted("scope", "p", "m", Limits{InputTokensPerMinute: 111}, 1)
+	recordAdmitted("scope", "p", "m", Limits{InputTokensPerMinute: 999}, 1)
+
+	got := MetricsSnapshot()
+	if len(got) != 1 || got[0].InputTokensLimit != 111 {
+		t.Fatalf("MetricsSnapshot = %+v, want a single scope with InputTokensLimit 111", got)
+	}
+}
+
+func TestWriteMetricsFormat(t *testing.T) {
+	t.Parallel()
+	scopes := []ScopeMetrics{
+		{
+			Provider: "gemini", Model: "gemini-3.8-flash",
+			RequestsPerMinute: 12, PeakRequestsPerMinute: 40, RequestsLimit: 1000,
+			InputTokensPerMinute: 1_900_000, PeakInputTokensPerMinute: 2_005_778, InputTokensLimit: 2_000_000,
+		},
+	}
+	var sb strings.Builder
+	if err := WriteMetrics(&sb, scopes); err != nil {
+		t.Fatalf("WriteMetrics: %v", err)
+	}
+	out := sb.String()
+
+	for _, want := range []string{
+		"# TYPE pi_ratelimit_requests_per_minute gauge",
+		`pi_ratelimit_requests_per_minute{provider="gemini",model="gemini-3.8-flash"} 12`,
+		`pi_ratelimit_requests_per_minute_peak{provider="gemini",model="gemini-3.8-flash"} 40`,
+		`pi_ratelimit_requests_per_minute_limit{provider="gemini",model="gemini-3.8-flash"} 1000`,
+		`pi_ratelimit_input_tokens_per_minute{provider="gemini",model="gemini-3.8-flash"} 1900000`,
+		`pi_ratelimit_input_tokens_per_minute_peak{provider="gemini",model="gemini-3.8-flash"} 2005778`,
+		`pi_ratelimit_input_tokens_per_minute_limit{provider="gemini",model="gemini-3.8-flash"} 2000000`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// Label values are quoted the way the Prometheus text format requires, so a
+// provider or model name containing a quote cannot break the exposition.
+func TestWriteMetricsEscapesLabels(t *testing.T) {
+	t.Parallel()
+	scopes := []ScopeMetrics{{Provider: `weird"provider`, Model: "m"}}
+	var sb strings.Builder
+	if err := WriteMetrics(&sb, scopes); err != nil {
+		t.Fatalf("WriteMetrics: %v", err)
+	}
+	if !strings.Contains(sb.String(), `provider="weird\"provider"`) {
+		t.Fatalf("output does not escape the embedded quote:\n%s", sb.String())
+	}
+}
+
+// httptest.NewRecorder is safe here (unlike httptest.NewServer): it fakes an
+// http.ResponseWriter without binding a local listener, so it does not hit
+// the sandbox trap documented in CLAUDE.md.
+func TestMetricsHandlerServesExpositionFormat(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+	recordAdmitted("gemini|gemini-3.8-flash|", "gemini", "gemini-3.8-flash",
+		Limits{InputTokensPerMinute: 2_000_000}, 500_000)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	MetricsHandler().ServeHTTP(rec, req)
+
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("Content-Type = %q, want text/plain prefix", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `pi_ratelimit_input_tokens_per_minute{provider="gemini",model="gemini-3.8-flash"} 500000`) {
+		t.Fatalf("handler body missing recorded scope:\n%s", body)
+	}
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -32,6 +32,7 @@ package ratelimit
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -247,6 +248,19 @@ func Shared(scope string, l Limits) *Limiter {
 // different accounts.
 func ScopeFor(provider, model, baseURL string) string {
 	return provider + "|" + model + "|" + baseURL
+}
+
+// splitScope recovers the provider and model labels from a scope string built
+// by ScopeFor, for use as metrics labels (see metrics.go). The base URL
+// segment is dropped: metrics are labeled by provider+model only, matching
+// how the dashboard being mirrored groups usage by model rather than by
+// endpoint.
+func splitScope(scope string) (provider, model string) {
+	parts := strings.SplitN(scope, "|", 3)
+	if len(parts) < 2 {
+		return scope, ""
+	}
+	return parts[0], parts[1]
 }
 
 // resetRegistry drops every shared limiter. Tests only: the registry is

--- a/internal/ratelimit/transport.go
+++ b/internal/ratelimit/transport.go
@@ -55,6 +55,16 @@ const hintBodyLimit = 8 << 10
 type Transport struct {
 	Base    http.RoundTripper
 	Limiter *Limiter
+
+	// Scope names the budget this transport paces against (see ScopeFor). A
+	// non-empty Scope also turns on metrics: each admitted request is counted
+	// against it for the /metrics endpoint (see MetricsHandler). Left empty,
+	// a caller that does not want metrics is unaffected.
+	Scope string
+	// Limits is the configured budget for Scope, recorded as-is so a scraper
+	// can read it back as the pi_ratelimit_*_limit gauges. Ignored when Scope
+	// is empty.
+	Limits Limits
 }
 
 // RoundTrip waits for budget, sends, and records any cooldown the server asked
@@ -64,8 +74,15 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	if err := t.Limiter.Wait(req.Context(), estimateRequestTokens(req)); err != nil {
+	tokens := estimateRequestTokens(req)
+	if err := t.Limiter.Wait(req.Context(), tokens); err != nil {
 		return nil, err
+	}
+	// Recorded here, once admission succeeds, so the count matches what the
+	// provider actually saw rather than what pi-go merely attempted.
+	if t.Scope != "" {
+		provider, model := splitScope(t.Scope)
+		recordAdmitted(t.Scope, provider, model, t.Limits, tokens)
 	}
 
 	resp, err := base.RoundTrip(req)

--- a/internal/ratelimit/transport_test.go
+++ b/internal/ratelimit/transport_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -325,5 +326,140 @@ func TestEstimateCatchesTheRejectedMinute(t *testing.T) {
 	if est <= budget {
 		t.Fatalf("the rejected minute (%d bytes) estimates at %d tokens, inside the %d budget: "+
 			"the limiter would pace nothing and the 429 would recur", wireBytes, est, budget)
+	}
+}
+
+// A Transport with no Scope is the pre-metrics configuration and must not
+// record anything, so existing callers that never set the field see no
+// behavior change.
+func TestTransportEmptyScopeRecordsNoMetrics(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+	stub := &stubRoundTripper{resp: response(http.StatusOK, nil, "")}
+	tr := &Transport{Base: stub, Limiter: New(Limits{InputTokensPerMinute: 1_000_000})}
+
+	if _, err := tr.RoundTrip(newRequest(t, strings.Repeat("x", 270))); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if got := MetricsSnapshot(); len(got) != 0 {
+		t.Fatalf("MetricsSnapshot = %+v, want no scopes recorded", got)
+	}
+}
+
+// The point of wiring metrics into Transport: an admitted request shows up
+// under its provider+model scope, charged for the same tokens the Limiter
+// paced it against.
+func TestTransportRecordsAdmittedRequestMetrics(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+	stub := &stubRoundTripper{resp: response(http.StatusOK, nil, "")}
+	scope := ScopeFor("gemini", "gemini-3.8-flash", "https://generativelanguage.googleapis.com")
+	tr := &Transport{
+		Base:    stub,
+		Limiter: New(Limits{InputTokensPerMinute: 2_000_000}),
+		Scope:   scope,
+		Limits:  Limits{InputTokensPerMinute: 2_000_000},
+	}
+
+	// 270 bytes / 2.7 bytes-per-token = 100 tokens.
+	if _, err := tr.RoundTrip(newRequest(t, strings.Repeat("x", 270))); err != nil {
+		t.Fatalf("first RoundTrip: %v", err)
+	}
+	if _, err := tr.RoundTrip(newRequest(t, strings.Repeat("x", 270))); err != nil {
+		t.Fatalf("second RoundTrip: %v", err)
+	}
+
+	got := MetricsSnapshot()
+	if len(got) != 1 {
+		t.Fatalf("MetricsSnapshot returned %d scopes, want 1: %+v", len(got), got)
+	}
+	want := ScopeMetrics{
+		Provider: "gemini", Model: "gemini-3.8-flash",
+		RequestsPerMinute: 2, PeakRequestsPerMinute: 2,
+		InputTokensPerMinute: 200, PeakInputTokensPerMinute: 200, InputTokensLimit: 2_000_000,
+	}
+	if got[0] != want {
+		t.Fatalf("MetricsSnapshot[0] = %+v, want %+v", got[0], want)
+	}
+}
+
+// A request rejected by admission (context canceled while waiting) must not
+// be counted — the counters are meant to mirror what the provider actually
+// saw, and a request that never went out was never charged by anyone.
+func TestTransportDoesNotRecordUnadmittedRequests(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+	stub := &stubRoundTripper{resp: response(http.StatusOK, nil, "")}
+	scope := ScopeFor("gemini", "gemini-3.8-flash", "")
+	lim := New(Limits{InputTokensPerMinute: 100})
+	tr := &Transport{Base: stub, Limiter: lim, Scope: scope, Limits: Limits{InputTokensPerMinute: 100}}
+
+	body := strings.Repeat("x", 400) // ~148 tokens, exceeds the 100-token budget's burst
+	if _, err := tr.RoundTrip(newRequest(t, body)); err != nil {
+		t.Fatalf("first RoundTrip: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := tr.RoundTrip(newRequest(t, body).WithContext(ctx)); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second RoundTrip err = %v, want it held and then time out", err)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("stub saw %d calls, want 1", stub.calls)
+	}
+
+	got := MetricsSnapshot()
+	if len(got) != 1 || got[0].RequestsPerMinute != 1 {
+		t.Fatalf("MetricsSnapshot = %+v, want exactly the one admitted request counted", got)
+	}
+}
+
+// Concurrent requests across several scopes must not race: the counters are
+// written from request goroutines and read by the metrics HTTP handler.
+// Run with -race.
+func TestTransportMetricsConcurrentSafe(t *testing.T) {
+	resetMetrics()
+	t.Cleanup(resetMetrics)
+
+	const goroutines = 20
+	const perGoroutine = 50
+	scopes := []string{
+		ScopeFor("gemini", "gemini-3.8-flash", ""),
+		ScopeFor("openai", "gpt-5.2", ""),
+	}
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		scope := scopes[g%len(scopes)]
+		tr := &Transport{
+			Base:    &stubRoundTripper{resp: response(http.StatusOK, nil, "")},
+			Limiter: New(Limits{InputTokensPerMinute: 100_000_000}),
+			Scope:   scope,
+			Limits:  Limits{InputTokensPerMinute: 100_000_000},
+		}
+		wg.Go(func() {
+			for range perGoroutine {
+				if _, err := tr.RoundTrip(newRequest(t, "x")); err != nil {
+					t.Errorf("RoundTrip: %v", err)
+				}
+			}
+		})
+	}
+	// Read concurrently with the writers too, exercising the handler's read
+	// path against live writers.
+	wg.Go(func() {
+		for range 50 {
+			_ = MetricsSnapshot()
+		}
+	})
+	wg.Wait()
+
+	got := MetricsSnapshot()
+	total := 0
+	for _, s := range got {
+		total += s.RequestsPerMinute
+	}
+	if want := goroutines * perGoroutine; total != want {
+		t.Fatalf("total RequestsPerMinute across scopes = %d, want %d", total, want)
 	}
 }


### PR DESCRIPTION
## Why

Gemini 429s (#315) are only visible after the fact, in Google AI Studio's
quota dashboard. This exposes the same two per-minute numbers locally, so the
approach to a limit is observable while it is happening rather than in a
console the next day.

Mirrors the dashboard's "Peak usage trends" panels for RPM and input TPM,
including the limit as its own gauge so a scraper can compute headroom the way
the red line does. RPD is deliberately not built.

## What

Six gauges, labeled `{provider,model}` — no base URL, so hostnames and paths
never reach a label:

```
pi_ratelimit_requests_per_minute{provider,model}
pi_ratelimit_requests_per_minute_peak{provider,model}
pi_ratelimit_requests_per_minute_limit{provider,model}
pi_ratelimit_input_tokens_per_minute{provider,model}
pi_ratelimit_input_tokens_per_minute_peak{provider,model}
pi_ratelimit_input_tokens_per_minute_limit{provider,model}
```

- **Current** is the live rolling-60s value, recomputed at scrape time with
  expired entries pruned, so a scrape between requests reads true current
  state rather than a stale bucket.
- **Peak** is the high-water mark since process start. It can only rise on an
  insertion and never on an expiry, so sampling after each insertion gives an
  exact peak, not an approximation.
- **Limit** is the configured budget (0 = unlimited).

Recording happens immediately after `Limiter.Wait` grants admission
(`transport.go:78-85`), so the counts match what the provider actually saw —
a request the limiter holds or cancels is not counted
(`TestTransportDoesNotRecordUnadmittedRequests`).

Served at `/metrics` behind a new `--metrics` flag on `--metrics-port`
(default 9464, OTel's own Prometheus default). Its own flag, server and mux
rather than folded into `--pprof`: the two have independent lifecycles, and
asking for always-on quota visibility should not also mean paying profiling
overhead, or vice versa. `internal/otel/` wires traces only today, so a small
dependency-free text encoder was preferred over pulling in a metrics SDK for
six gauges.

Reuses the existing token estimate (`bytesPerToken = 2.7`) and admission
point rather than adding a second estimator.

## Relationship to #316

Built alongside the rolling-window limiter but deliberately not coupled to it.
The recorder keeps its own rolling ledger instead of reading that branch's
internal `spend []spendEvent`, for two reasons: the *request* budget is a
plain token bucket with no ledger to report a rolling count from, so RPM
needed independent bookkeeping regardless; and coupling metrics to an internal
representation still in flux would mean re-deriving the windowed value
whichever shape wins. No file overlap in the admission/ledger logic — merge
order between the branches does not matter.

## Also here

`startPprofServer` wrote to stdout/stderr directly. It starts from
`PersistentPreRun` and its `ListenAndServe` error surfaces from a goroutine,
so the write can land while the interactive TUI owns the alternate screen —
the corruption CLAUDE.md prohibits. Now on `slog`, like the new metrics
server. The remaining stderr writes in that file are startup-time and
sequential, ahead of the TUI; this one was the async outlier.

## Verification

`make build`, `make vet`, `make lint` (0 issues), `go test -race` over
`internal/ratelimit`, `internal/provider` and `internal/cli`, and the full
suite outside the sandbox. Endpoint exercised live against a stub transport:

```
pi_ratelimit_requests_per_minute{provider="gemini",model="gemini-3.8-flash"} 15
pi_ratelimit_requests_per_minute_peak{provider="gemini",model="gemini-3.8-flash"} 15
pi_ratelimit_requests_per_minute_limit{provider="gemini",model="gemini-3.8-flash"} 1000
pi_ratelimit_input_tokens_per_minute{provider="gemini",model="gemini-3.8-flash"} 1350000
pi_ratelimit_input_tokens_per_minute_peak{provider="gemini",model="gemini-3.8-flash"} 1350000
pi_ratelimit_input_tokens_per_minute_limit{provider="gemini",model="gemini-3.8-flash"} 2000000
```

Peak equals current there because the driver fires faster than the window
decays; `TestScopeMetricsPeakSurvivesWindowExpiry` covers the diverging case.

Refs #315
