### PR TITLE
feat(autocompact): wire context compaction into every agent entry point

### DIFF
--- a/internal/acp/server/autocompact_test.go
+++ b/internal/acp/server/autocompact_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	adksession "google.golang.org/adk/v2/session"
+
+	piagent "github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/autocompact"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/guardrail"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// newTestAgent builds the smallest agent installAutoCompact can be handed. It
+// needs no model or tools: the hook is set on the agent, not exercised here.
+func newTestAgent(t *testing.T) *piagent.Agent {
+	t.Helper()
+	ag, err := piagent.New(piagent.Config{
+		Model:          nil,
+		SessionService: adksession.InMemoryService(),
+	})
+	if err != nil {
+		t.Skipf("agent.New unavailable in this environment: %v", err)
+	}
+	return ag
+}
+
+// newTracker returns a tracker with a known window, since an unknown window is
+// itself a reason the hook declines to install.
+func newTracker(t *testing.T, window int64) *guardrail.Tracker {
+	t.Helper()
+	tr := guardrail.NewWithPath(0, t.TempDir()+"/usage.json")
+	tr.SetContextWindowSize(window)
+	return tr
+}
+
+// TestInstallAutoCompact covers which ACP sessions get a compaction hook.
+//
+// The gap this closes was silent: ACP sessions are the longest-lived shape
+// pi-go runs in and had no compaction at all, so the only symptom was a
+// transcript that grew until the provider rejected it. A regression here would
+// be equally quiet, which is why the wiring is asserted rather than assumed.
+func TestInstallAutoCompact(t *testing.T) {
+	enabled, disabled := true, false
+
+	tests := []struct {
+		desc        string
+		sessionSvc  adksession.Service
+		cfg         config.Config
+		window      int64
+		wantInstall bool
+	}{
+		{
+			desc:        "file-backed session with a known window gets the hook",
+			sessionSvc:  newFileService(t),
+			cfg:         config.Config{AutoCompact: &config.AutoCompactConfig{Enabled: &enabled}},
+			window:      200_000,
+			wantInstall: true,
+		},
+		{
+			desc:        "in-memory session has no stored transcript to rewrite",
+			sessionSvc:  adksession.InMemoryService(),
+			cfg:         config.Config{AutoCompact: &config.AutoCompactConfig{Enabled: &enabled}},
+			window:      200_000,
+			wantInstall: false,
+		},
+		{
+			desc:        "no session service at all",
+			sessionSvc:  nil,
+			cfg:         config.Config{AutoCompact: &config.AutoCompactConfig{Enabled: &enabled}},
+			window:      200_000,
+			wantInstall: false,
+		},
+		{
+			desc:        "disabled by config",
+			sessionSvc:  newFileService(t),
+			cfg:         config.Config{AutoCompact: &config.AutoCompactConfig{Enabled: &disabled}},
+			window:      200_000,
+			wantInstall: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ag := newTestAgent(t)
+			installAutoCompact(
+				context.Background(),
+				RuntimeConfig{SessionService: tt.sessionSvc},
+				tt.cfg, ag, nil, newTracker(t, tt.window),
+			)
+			if got := ag.HasPreTurnHook(); got != tt.wantInstall {
+				t.Errorf("HasPreTurnHook() = %v, want %v", got, tt.wantInstall)
+			}
+		})
+	}
+}
+
+func newFileService(t *testing.T) *pisession.FileService {
+	t.Helper()
+	svc, err := pisession.NewFileService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	return svc
+}
+
+var _ autocompact.ContextMeter = (*guardrail.Tracker)(nil)

--- a/internal/acp/server/ollama_endpoint_test.go
+++ b/internal/acp/server/ollama_endpoint_test.go
@@ -24,7 +24,7 @@ func TestBuildSessionLLM_OllamaRoutesByTag(t *testing.T) {
 		},
 	}
 
-	llm, _, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
+	llm, _, _, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
 	if err != nil {
 		t.Fatalf("buildSessionLLM: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestBuildSessionLLM_OllamaHealthCheckFailureIsReported(t *testing.T) {
 		},
 	}
 
-	_, _, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
+	_, _, _, err := buildSessionLLM(context.Background(), RuntimeConfig{}, cfg)
 	if err == nil {
 		t.Fatal("expected an error when the daemon is unreachable")
 	}

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,13 +20,16 @@ import (
 
 	"github.com/dimetron/pi-go/internal/acp/server/adapter"
 	piagent "github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/autocompact"
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/ctxwindow"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/gitroot"
 	"github.com/dimetron/pi-go/internal/guardrail"
 	"github.com/dimetron/pi-go/internal/lsp"
 	"github.com/dimetron/pi-go/internal/otel"
 	"github.com/dimetron/pi-go/internal/provider"
+	pisession "github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/subagent"
 	"github.com/dimetron/pi-go/internal/tools"
 )
@@ -169,7 +173,7 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		return nil, err
 	}
 
-	llm, providerName, err := buildSessionLLM(ctx, rt, cfg)
+	llm, providerName, tokenTracker, err := buildSessionLLM(ctx, rt, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -207,6 +211,8 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 	}
 	span.SetAttributes(attribute.Bool("session.resumed", resumed))
 
+	installAutoCompact(ctx, rt, cfg, ag, llm, tokenTracker)
+
 	return &piSessionState{
 		agent:       ag,
 		sessionID:   sessionID,
@@ -214,6 +220,44 @@ func initPiSessionState(ctx context.Context, rt RuntimeConfig, turn PromptTurn) 
 		bashSup:     res.bashSup,
 		cleanup:     res.cleanup,
 	}, nil
+}
+
+// installAutoCompact wires the two-stage compaction hook onto an ACP session.
+//
+// An ACP session is the longest-lived shape pi-go runs in — an editor holds one
+// open across many turns, and every turn re-sends the whole transcript — so it
+// is the path that most needs the history rewritten out from under it. It is
+// also the path that went without: the hook used to live in internal/cli and
+// nothing outside that package could reach it.
+//
+// Compaction rewrites the persisted transcript, so it needs the file-backed
+// session service. Under an in-memory service there is no stored history to
+// rewrite and the hook is left off; BuildHook returns nil for that, and for a
+// tracker that never learned the model's context window.
+func installAutoCompact(
+	ctx context.Context,
+	rt RuntimeConfig,
+	cfg config.Config,
+	ag *piagent.Agent,
+	llm adkmodel.LLM,
+	tracker *guardrail.Tracker,
+) {
+	svc, _ := rt.SessionService.(*pisession.FileService)
+	hook := autocompact.BuildHook(autocompact.Deps{
+		SessionSvc:    svc,
+		Tracker:       tracker,
+		Cfg:           autocompact.ConfigFrom(cfg),
+		SummarizerLLM: llm,
+		// No session logger on this path, and stdout belongs to the ACP wire
+		// protocol, so the notice goes to slog like the rest of the server's
+		// diagnostics.
+		Notify: func(msg string) {
+			slog.InfoContext(ctx, "acp-server: auto-compact", "outcome", msg)
+		},
+	})
+	if hook != nil {
+		ag.SetPreTurnHook(hook)
+	}
 }
 
 // openPiSession settles the ADK session a turn runs in and reports whether it
@@ -260,26 +304,31 @@ func loadSessionConfig(rt RuntimeConfig, cwd string) (config.Config, error) {
 // buildSessionLLM resolves the default role to a provider and returns a
 // token-guarded LLM for it, along with the name of the provider it resolved to
 // — callbacks built alongside the agent need it to know what the wire format
-// can carry.
-func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (adkmodel.LLM, string, error) {
+// can carry — and the guardrail tracker guarding it.
+//
+// The tracker is returned rather than kept private because auto-compaction
+// reads the live context size from it. An ACP session that dropped it on the
+// floor could still meter tokens, but nothing could tell when the transcript
+// had outgrown the window.
+func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (adkmodel.LLM, string, *guardrail.Tracker, error) {
 	modelName, providerName, advisorModel, advisorMaxUses, advisorCaching, err := cfg.ResolveRole("default")
 	if err != nil {
-		return nil, "", fmt.Errorf("resolving model role: %w", err)
+		return nil, "", nil, fmt.Errorf("resolving model role: %w", err)
 	}
 
 	info, baseURL, err := resolveSessionProvider(cfg, rt.BaseURL, modelName, providerName)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	apiKey := config.APIKeys()[info.Provider]
 	if err := checkProviderCredentials(info, apiKey, baseURL); err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	baseURL, err = resolveOllamaBaseURL(info, apiKey, baseURL)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	llm, err := provider.NewLLM(ctx, info, apiKey, baseURL, cfg.ThinkingLevel, &provider.LLMOptions{
@@ -295,12 +344,12 @@ func buildSessionLLM(ctx context.Context, rt RuntimeConfig, cfg config.Config) (
 		RateLimit: cfg.ResolveRateLimits(info.Provider, info.Model),
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("creating LLM provider: %w", err)
+		return nil, "", nil, fmt.Errorf("creating LLM provider: %w", err)
 	}
 
 	tokenTracker := guardrail.New(cfg.MaxDailyTokens)
-	tokenTracker.SetContextWindowSize(sessionContextWindow(ctx, info, baseURL))
-	return guardrail.WrapModel(llm, tokenTracker), info.Provider, nil
+	tokenTracker.SetContextWindowSize(ctxwindow.Resolve(ctx, cfg, info, baseURL))
+	return guardrail.WrapModel(llm, tokenTracker), info.Provider, tokenTracker, nil
 }
 
 // checkProviderCredentials rejects a provider that needs an API key and has
@@ -362,23 +411,6 @@ func resolveSessionProvider(cfg config.Config, flagBaseURL, modelName, providerN
 		return provider.Info{}, "", fmt.Errorf("model validation: %w", err)
 	}
 	return info, baseURL, nil
-}
-
-// sessionContextWindow returns the model's context window, preferring the size
-// a running Ollama reports or the OpenRouter listing publishes over the static
-// table.
-func sessionContextWindow(ctx context.Context, info provider.Info, baseURL string) int64 {
-	if info.Ollama {
-		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
-			return n
-		}
-	}
-	if info.Provider == "openrouter" {
-		if n := provider.OpenRouterContextWindowSize(ctx, baseURL, info.Model); n > 0 {
-			return n
-		}
-	}
-	return provider.ContextWindowSizeFor(info.Provider, info.Model)
 }
 
 // sessionResources holds the tools and callbacks a session runs with, plus the

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -391,6 +391,14 @@ func (a *Agent) SetPreTurnHook(h PreTurnHook) {
 	a.preTurn = h
 }
 
+// HasPreTurnHook reports whether a pre-turn hook is installed. It exists so a
+// caller can assert that compaction was actually wired: every entry point
+// installs the hook conditionally, and an entry point that quietly declined to
+// would show no symptom until a transcript outgrew its context window.
+func (a *Agent) HasPreTurnHook() bool {
+	return a.preTurn != nil
+}
+
 // runPreTurn invokes the hook if one is installed.
 func (a *Agent) runPreTurn(ctx context.Context, sessionID string) error {
 	if a.preTurn == nil {

--- a/internal/autocompact/config.go
+++ b/internal/autocompact/config.go
@@ -1,0 +1,33 @@
+package autocompact
+
+import (
+	"github.com/dimetron/pi-go/internal/config"
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// ConfigFrom maps the user's config.json settings onto an AutoCompactConfig,
+// leaving any field the user did not set at its default. Every numeric field
+// is guarded by its own zero-check, so an unset field keeps its default rather
+// than compacting at 0%.
+func ConfigFrom(cfg config.Config) pisession.AutoCompactConfig {
+	acCfg := pisession.DefaultAutoCompactConfig()
+	if cfg.AutoCompact == nil {
+		return acCfg
+	}
+	if cfg.AutoCompact.Enabled != nil {
+		acCfg.Enabled = *cfg.AutoCompact.Enabled
+	}
+	if cfg.AutoCompact.ShedPercent > 0 {
+		acCfg.ShedPercent = cfg.AutoCompact.ShedPercent
+	}
+	if cfg.AutoCompact.SummarizePercent > 0 {
+		acCfg.SummarizePercent = cfg.AutoCompact.SummarizePercent
+	}
+	if cfg.AutoCompact.KeepUserMessageTokens > 0 {
+		acCfg.KeepUserMessageTokens = cfg.AutoCompact.KeepUserMessageTokens
+	}
+	if cfg.AutoCompact.KeepRecentEvents > 0 {
+		acCfg.KeepRecentEvents = cfg.AutoCompact.KeepRecentEvents
+	}
+	return acCfg
+}

--- a/internal/autocompact/config_test.go
+++ b/internal/autocompact/config_test.go
@@ -1,4 +1,4 @@
-package cli
+package autocompact
 
 import (
 	"testing"
@@ -84,9 +84,9 @@ func TestAutoCompactConfigFrom(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			got := autoCompactConfigFrom(tc.in)
+			got := ConfigFrom(tc.in)
 			if got != tc.want {
-				t.Fatalf("autoCompactConfigFrom() = %+v, want %+v", got, tc.want)
+				t.Fatalf("ConfigFrom() = %+v, want %+v", got, tc.want)
 			}
 		})
 	}
@@ -119,12 +119,12 @@ func newTempLogger(t *testing.T) *logger.Logger {
 // this test or any parent has called t.Parallel.
 func TestAutoCompactDepsReport(t *testing.T) {
 	t.Run("both sinks nil does not panic", func(t *testing.T) {
-		autoCompactDeps{}.report("no sinks")
+		Deps{}.report("no sinks")
 	})
 
 	t.Run("Notify receives the message verbatim", func(t *testing.T) {
 		var got []string
-		d := autoCompactDeps{Notify: func(m string) { got = append(got, m) }}
+		d := Deps{Notify: func(m string) { got = append(got, m) }}
 		d.report("shed 3 results")
 		if len(got) != 1 || got[0] != "shed 3 results" {
 			t.Fatalf("Notify got %q, want exactly [\"shed 3 results\"]", got)
@@ -133,13 +133,13 @@ func TestAutoCompactDepsReport(t *testing.T) {
 
 	// The Log sink writes to ~/.pi-go/log, so these point HOME at a temp dir.
 	t.Run("Log alone does not panic and does not need Notify", func(t *testing.T) {
-		d := autoCompactDeps{Log: newTempLogger(t)}
+		d := Deps{Log: newTempLogger(t)}
 		d.report("logged only")
 	})
 
 	t.Run("both sinks each receive the message", func(t *testing.T) {
 		var got []string
-		d := autoCompactDeps{
+		d := Deps{
 			Log:    newTempLogger(t),
 			Notify: func(m string) { got = append(got, m) },
 		}

--- a/internal/autocompact/hook.go
+++ b/internal/autocompact/hook.go
@@ -1,11 +1,19 @@
-package cli
+// Package autocompact installs pi-go's two-stage context compaction as a
+// pre-turn hook: shed superseded tool results at the lower threshold,
+// summarize at the upper one.
+//
+// It lives outside internal/cli so that every agent entry point can install
+// the same hook — the interactive TUI, the one-shot CLI, the ACP server and
+// the piagent SDK. A long agent session re-sends its whole transcript on every
+// turn, so an entry point without compaction pays that growth in full.
+package autocompact
 
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/dimetron/pi-go/internal/agent"
-	"github.com/dimetron/pi-go/internal/guardrail"
 	"github.com/dimetron/pi-go/internal/logger"
 	pisession "github.com/dimetron/pi-go/internal/session"
 	"github.com/dimetron/pi-go/internal/tools"
@@ -13,10 +21,24 @@ import (
 	llmmodel "google.golang.org/adk/v2/model"
 )
 
-// autoCompactDeps are the pieces a pre-turn compaction pass needs.
-type autoCompactDeps struct {
+// ContextMeter reports how much of the model's context window the live
+// transcript occupies. *guardrail.Tracker satisfies it, and so does [Meter];
+// the interface is what keeps this package off internal/guardrail, which
+// piagent may not reach even transitively.
+//
+// BodyTokens is the figure the thresholds are measured against: tokens after
+// the stable cached prefix, so a large but fully-cached system prompt never
+// pushes a session toward compaction on its own.
+type ContextMeter interface {
+	BodyTokens() int64
+	ContextWindowSize() int64
+	SetLastPromptTokens(int64)
+}
+
+// Deps are the pieces a pre-turn compaction pass needs.
+type Deps struct {
 	SessionSvc *pisession.FileService
-	Tracker    *guardrail.Tracker
+	Tracker    ContextMeter
 	Deduper    *tools.ResultDeduper
 	Cfg        pisession.AutoCompactConfig
 	Log        *logger.Logger
@@ -31,18 +53,25 @@ type autoCompactDeps struct {
 	Notify func(string)
 }
 
-// buildAutoCompactHook returns a pre-turn hook that runs the two-stage
-// compaction. It reads the body size — context after the stable cached prefix —
+// BuildHook returns a pre-turn hook that runs the two-stage compaction.
+// It returns nil when compaction cannot run — no session service, no token
+// tracker, or disabled by config — so a caller can install the result
+// unconditionally. It reads the body size — context after the stable cached prefix —
 // from the token tracker, so a large but fully cached system prompt and tool
 // block never trigger compaction on their own.
 //
 // The hook never aborts a turn on compaction failure: being unable to reclaim
 // context is a degraded state, not a reason to refuse the user's request. The
 // error is reported and the turn proceeds.
-func buildAutoCompactHook(deps autoCompactDeps) agent.PreTurnHook {
+func BuildHook(deps Deps) agent.PreTurnHook {
 	if deps.SessionSvc == nil || deps.Tracker == nil || !deps.Cfg.Enabled {
 		return nil
 	}
+
+	// An unknown window is reported once rather than every turn: the hook is
+	// inert for the whole session in that state, and repeating it each turn
+	// would bury the notice it is trying to deliver.
+	var warnUnknownWindow sync.Once
 
 	return func(ctx context.Context, sessionID string) error {
 		if sessionID == "" {
@@ -51,6 +80,15 @@ func buildAutoCompactHook(deps autoCompactDeps) agent.PreTurnHook {
 
 		body := deps.Tracker.BodyTokens()
 		window := deps.Tracker.ContextWindowSize()
+		if window <= 0 {
+			// Compaction has no denominator, so it can never fire. Saying so
+			// beats the alternative, which is a transcript that grows until
+			// the provider rejects it with nothing having warned anyone.
+			warnUnknownWindow.Do(func() {
+				deps.report("context window unknown for this model — auto-compaction is off; set context_window in ~/.pi-go/config.json")
+			})
+			return nil
+		}
 		if deps.Cfg.Decide(body, window) == pisession.CompactionNone {
 			return nil
 		}
@@ -98,7 +136,7 @@ func buildAutoCompactHook(deps autoCompactDeps) agent.PreTurnHook {
 	}
 }
 
-func (d autoCompactDeps) report(msg string) {
+func (d Deps) report(msg string) {
 	if d.Log != nil {
 		d.Log.Info("auto-compact: " + msg)
 	}

--- a/internal/autocompact/hook_test.go
+++ b/internal/autocompact/hook_test.go
@@ -1,0 +1,87 @@
+package autocompact
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pisession "github.com/dimetron/pi-go/internal/session"
+)
+
+// TestBuildHookDeclines covers the shapes that cannot compact at all, where
+// returning nil lets a caller install the result unconditionally.
+func TestBuildHookDeclines(t *testing.T) {
+	t.Parallel()
+
+	svc, err := pisession.NewFileService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	on := pisession.DefaultAutoCompactConfig()
+	on.Enabled = true
+	off := on
+	off.Enabled = false
+
+	tests := []struct {
+		desc     string
+		deps     Deps
+		wantHook bool
+	}{
+		{desc: "nothing wired", deps: Deps{}},
+		{desc: "no session service", deps: Deps{Tracker: NewMeter(), Cfg: on}},
+		{desc: "no meter", deps: Deps{SessionSvc: svc, Cfg: on}},
+		{desc: "disabled by config", deps: Deps{SessionSvc: svc, Tracker: NewMeter(), Cfg: off}},
+		{desc: "fully wired", deps: Deps{SessionSvc: svc, Tracker: NewMeter(), Cfg: on}, wantHook: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := BuildHook(tt.deps) != nil; got != tt.wantHook {
+				t.Errorf("BuildHook() non-nil = %v, want %v", got, tt.wantHook)
+			}
+		})
+	}
+}
+
+// TestHookReportsUnknownWindowOnce covers the state that used to be silent: a
+// model whose context window pi-go cannot resolve makes compaction inert, and
+// a session can then grow until the provider rejects it with nothing having
+// said so. The notice fires once, not once per turn, or it would bury itself.
+func TestHookReportsUnknownWindowOnce(t *testing.T) {
+	t.Parallel()
+
+	svc, err := pisession.NewFileService(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileService: %v", err)
+	}
+	cfg := pisession.DefaultAutoCompactConfig()
+	cfg.Enabled = true
+
+	meter := NewMeter() // window deliberately left unknown
+	meter.Observe(500_000)
+
+	var notices []string
+	hook := BuildHook(Deps{
+		SessionSvc: svc,
+		Tracker:    meter,
+		Cfg:        cfg,
+		Notify:     func(m string) { notices = append(notices, m) },
+	})
+	if hook == nil {
+		t.Fatal("BuildHook returned nil for a fully-wired Deps")
+	}
+
+	for range 5 {
+		if err := hook(context.Background(), "session-1"); err != nil {
+			t.Fatalf("hook: %v", err)
+		}
+	}
+
+	if len(notices) != 1 {
+		t.Fatalf("got %d notices %q, want exactly 1", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "context window unknown") {
+		t.Errorf("notice = %q, want it to name the unknown context window", notices[0])
+	}
+}

--- a/internal/autocompact/meter.go
+++ b/internal/autocompact/meter.go
@@ -1,0 +1,102 @@
+package autocompact
+
+import (
+	"sync"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	adkmodel "google.golang.org/adk/v2/model"
+)
+
+// Meter is a standalone [ContextMeter] for callers that have no guardrail
+// tracker to read — piagent, which is barred from importing internal/guardrail
+// and in any case wants none of the daily-budget half of it.
+//
+// It measures and never enforces: nothing here can refuse a request. Feed it
+// with [MeterCallback].
+type Meter struct {
+	mu                sync.Mutex
+	contextWindowSize int64
+	lastPromptTokens  int64
+
+	// cachePrefixTokens is the stable, already-cached prefix of the current
+	// window — system prompt, tool declarations, initial context. The first
+	// request of a window establishes it, and BodyTokens subtracts it. It
+	// mirrors guardrail.Tracker's rule deliberately: the two must agree, or
+	// compaction would fire at different points depending on which entry
+	// point the session ran through.
+	cachePrefixTokens int64
+}
+
+// NewMeter returns a meter with an unknown context window. Compaction stays
+// off until [Meter.SetContextWindowSize] is given a positive size, which is
+// the same thing an unresolvable window means everywhere else.
+func NewMeter() *Meter { return &Meter{} }
+
+// SetContextWindowSize records the model's context window, in tokens.
+func (m *Meter) SetContextWindowSize(size int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.contextWindowSize = size
+}
+
+// ContextWindowSize reports the model's context window, or 0 if unknown.
+func (m *Meter) ContextWindowSize() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.contextWindowSize
+}
+
+// BodyTokens reports the tokens accumulated after the stable cached prefix.
+func (m *Meter) BodyTokens() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	body := m.lastPromptTokens - m.cachePrefixTokens
+	if body < 0 {
+		return 0
+	}
+	return body
+}
+
+// SetLastPromptTokens overwrites the prompt-token baseline, and clears the
+// prefix baseline with it. A compaction pass calls this because it knows the
+// post-pass count exactly; the rewritten window has a new stable prefix by
+// definition, so the old one no longer applies.
+//
+// A non-positive n clears the prefix without setting a new count.
+func (m *Meter) SetLastPromptTokens(n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if n > 0 {
+		m.lastPromptTokens = n
+	}
+	m.cachePrefixTokens = 0
+}
+
+// Observe records the prompt-token count of one LLM response. promptTokens is
+// inclusive of cache reads, as every provider reports it.
+func (m *Meter) Observe(promptTokens int64) {
+	if promptTokens <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastPromptTokens = promptTokens
+	if m.cachePrefixTokens == 0 {
+		m.cachePrefixTokens = promptTokens
+	}
+}
+
+// MeterCallback returns an ADK after-model callback that feeds m from each
+// response's usage metadata. It never rewrites the response.
+//
+// A streaming turn yields many responses and the callback sees each one; the
+// last prompt count wins, which is the one describing the whole request.
+func MeterCallback(m *Meter) llmagent.AfterModelCallback {
+	return func(_ agent.Context, resp *adkmodel.LLMResponse, _ error) (*adkmodel.LLMResponse, error) {
+		if m != nil && resp != nil && resp.UsageMetadata != nil {
+			m.Observe(int64(resp.UsageMetadata.PromptTokenCount))
+		}
+		return nil, nil
+	}
+}

--- a/internal/autocompact/meter_test.go
+++ b/internal/autocompact/meter_test.go
@@ -1,0 +1,141 @@
+package autocompact
+
+import (
+	"sync"
+	"testing"
+
+	"google.golang.org/genai"
+
+	adkmodel "google.golang.org/adk/v2/model"
+)
+
+// TestMeterBodyTokens covers the prefix rule. The failure it guards against is
+// silent: a meter that counted the cached system prompt as body would compact
+// a session that had barely started, and one that never established a prefix
+// would never compact at all.
+func TestMeterBodyTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		observe  []int64
+		wantBody int64
+	}{
+		{desc: "no observations means no body", observe: nil, wantBody: 0},
+		{desc: "first observation is all prefix", observe: []int64{11_045}, wantBody: 0},
+		{desc: "growth after the prefix is body", observe: []int64{11_045, 40_000}, wantBody: 28_955},
+		{desc: "a shrinking prompt never reports negative body", observe: []int64{40_000, 10_000}, wantBody: 0},
+		{desc: "non-positive counts are ignored", observe: []int64{11_045, 0, -5, 20_000}, wantBody: 8_955},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			m := NewMeter()
+			for _, n := range tt.observe {
+				m.Observe(n)
+			}
+			if got := m.BodyTokens(); got != tt.wantBody {
+				t.Errorf("BodyTokens() = %d, want %d", got, tt.wantBody)
+			}
+		})
+	}
+}
+
+// TestMeterContextWindow pins the contract BuildHook relies on: an unset
+// window reads as 0, which Decide treats as "never compact".
+func TestMeterContextWindow(t *testing.T) {
+	t.Parallel()
+
+	m := NewMeter()
+	if got := m.ContextWindowSize(); got != 0 {
+		t.Fatalf("fresh meter ContextWindowSize() = %d, want 0", got)
+	}
+	m.SetContextWindowSize(1_048_576)
+	if got := m.ContextWindowSize(); got != 1_048_576 {
+		t.Errorf("ContextWindowSize() = %d, want 1048576", got)
+	}
+}
+
+// TestMeterSetLastPromptTokens covers the post-compaction reset: the rewritten
+// window has a new prefix, so the old one must not carry over and make the
+// fresh window look empty.
+func TestMeterSetLastPromptTokens(t *testing.T) {
+	t.Parallel()
+
+	m := NewMeter()
+	m.Observe(50_000)
+	m.Observe(120_000)
+
+	m.SetLastPromptTokens(18_000)
+	if got := m.BodyTokens(); got != 18_000 {
+		t.Fatalf("BodyTokens() after reset = %d, want 18000", got)
+	}
+
+	// The first request after compaction re-establishes the prefix, exactly as
+	// the first request of any window does, so the fresh window reads as empty
+	// until it grows again. guardrail.Tracker does the same; see
+	// TestTrackerAndMeterAgreeOnBodyTokens.
+	m.Observe(25_000)
+	if got := m.BodyTokens(); got != 0 {
+		t.Errorf("BodyTokens() = %d, want 0 — the post-compaction request is the new prefix", got)
+	}
+	m.Observe(33_000)
+	if got := m.BodyTokens(); got != 8_000 {
+		t.Errorf("BodyTokens() = %d, want 8000 — growth past the new prefix", got)
+	}
+}
+
+// TestMeterCallback covers the wiring, including the shapes that arrive when a
+// response carries no usage at all. A callback that panicked on one of these
+// would take the turn down with it.
+func TestMeterCallback(t *testing.T) {
+	t.Parallel()
+
+	m := NewMeter()
+	cb := MeterCallback(m)
+
+	for _, resp := range []*adkmodel.LLMResponse{
+		nil,
+		{},
+		{UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 9_000}},
+		{UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 31_000}},
+	} {
+		got, err := cb(nil, resp, nil)
+		if err != nil {
+			t.Fatalf("callback returned error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("callback rewrote the response (%v); it must observe only", got)
+		}
+	}
+
+	if got := m.BodyTokens(); got != 22_000 {
+		t.Errorf("BodyTokens() = %d, want 22000", got)
+	}
+
+	// A nil meter is the shape a caller gets from an un-wired Deps; the
+	// callback must tolerate it rather than panic mid-turn.
+	if _, err := MeterCallback(nil)(nil, &adkmodel.LLMResponse{
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1},
+	}, nil); err != nil {
+		t.Errorf("nil-meter callback returned error: %v", err)
+	}
+}
+
+// TestMeterConcurrentAccess exists for the race detector: a streaming turn
+// writes from the model goroutine while the pre-turn hook reads.
+func TestMeterConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	m := NewMeter()
+	m.SetContextWindowSize(200_000)
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(2)
+		go func() { defer wg.Done(); m.Observe(int64(1_000 + i)) }()
+		go func() { defer wg.Done(); _ = m.BodyTokens(); _ = m.ContextWindowSize() }()
+	}
+	wg.Wait()
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,9 @@ import (
 	adktool "google.golang.org/adk/v2/tool"
 
 	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/autocompact"
 	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/ctxwindow"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/gitroot"
 	"github.com/dimetron/pi-go/internal/guardrail"
@@ -401,29 +403,6 @@ func applyRuntimeOllamaEndpoint(info *provider.Info, apiKey, baseURL string) (st
 	return baseURL, nil
 }
 
-// resolveRuntimeContextWindow picks the context window to budget against: the
-// catalog size, overridden by what a live Ollama daemon reports, overridden in
-// turn by an explicit config value.
-func resolveRuntimeContextWindow(ctx context.Context, cfg config.Config, info provider.Info, baseURL string) int64 {
-	ctxWindowSize := provider.ContextWindowSizeFor(info.Provider, info.Model)
-	if info.Ollama {
-		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
-			ctxWindowSize = n
-		}
-	}
-	if info.Provider == "openrouter" {
-		if n := provider.OpenRouterContextWindowSize(ctx, baseURL, info.Model); n > 0 {
-			ctxWindowSize = n
-		}
-	}
-	// An explicit config value wins: the embedded catalog does not cover every
-	// provider's models, and auto-compaction needs a real window to work from.
-	if cfg.ContextWindow > 0 {
-		ctxWindowSize = cfg.ContextWindow
-	}
-	return ctxWindowSize
-}
-
 func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 	cfg, err := loadRootConfig()
 	if err != nil {
@@ -476,7 +455,7 @@ func buildRootRuntime(ctx context.Context, args []string) (rootRuntime, error) {
 	}
 
 	tokenTracker := guardrail.New(cfg.MaxDailyTokens)
-	tokenTracker.SetContextWindowSize(resolveRuntimeContextWindow(ctx, cfg, info, baseURL))
+	tokenTracker.SetContextWindowSize(ctxwindow.Resolve(ctx, cfg, info, baseURL))
 	llm = guardrail.WrapModel(llm, tokenTracker)
 
 	cwd, err := os.Getwd()
@@ -858,11 +837,11 @@ func runNonInteractive(
 	// Two-stage auto-compaction: shed superseded tool results at the lower
 	// threshold, summarize at the upper one. Installed as a pre-turn hook so it
 	// only ever rewrites history between turns.
-	if hook := buildAutoCompactHook(autoCompactDeps{
+	if hook := autocompact.BuildHook(autocompact.Deps{
 		SessionSvc:    sessionSvc,
 		Tracker:       tokenTracker,
 		Deduper:       resultDeduper,
-		Cfg:           autoCompactConfigFrom(cfg),
+		Cfg:           autocompact.ConfigFrom(cfg),
 		Log:           sessionLog,
 		SummarizerLLM: llm,
 		Notify:        func(msg string) { fmt.Fprintf(os.Stderr, "pi-go: %s\n", msg) },
@@ -1308,31 +1287,6 @@ func compactorConfigFrom(cfg config.Config) tools.CompactorConfig {
 		compactorCfg.MaxLines = cfg.Compactor.MaxLines
 	}
 	return compactorCfg
-}
-
-// autoCompactConfigFrom resolves the two-stage auto-compaction settings,
-// falling back to the session package's defaults for anything unset.
-func autoCompactConfigFrom(cfg config.Config) pisession.AutoCompactConfig {
-	acCfg := pisession.DefaultAutoCompactConfig()
-	if cfg.AutoCompact == nil {
-		return acCfg
-	}
-	if cfg.AutoCompact.Enabled != nil {
-		acCfg.Enabled = *cfg.AutoCompact.Enabled
-	}
-	if cfg.AutoCompact.ShedPercent > 0 {
-		acCfg.ShedPercent = cfg.AutoCompact.ShedPercent
-	}
-	if cfg.AutoCompact.SummarizePercent > 0 {
-		acCfg.SummarizePercent = cfg.AutoCompact.SummarizePercent
-	}
-	if cfg.AutoCompact.KeepUserMessageTokens > 0 {
-		acCfg.KeepUserMessageTokens = cfg.AutoCompact.KeepUserMessageTokens
-	}
-	if cfg.AutoCompact.KeepRecentEvents > 0 {
-		acCfg.KeepRecentEvents = cfg.AutoCompact.KeepRecentEvents
-	}
-	return acCfg
 }
 
 // memoryObservationCallback records each successful tool call as a raw

--- a/internal/cli/complexity_core_test.go
+++ b/internal/cli/complexity_core_test.go
@@ -292,33 +292,6 @@ func TestApplyRuntimeOllamaEndpoint(t *testing.T) {
 	})
 }
 
-func TestResolveRuntimeContextWindow(t *testing.T) {
-	t.Parallel()
-
-	info := provider.Info{Provider: "anthropic", Model: "claude-sonnet-4-6"}
-	catalog := provider.ContextWindowSizeFor(info.Provider, info.Model)
-
-	tests := []struct {
-		name string
-		cfg  config.Config
-		want int64
-	}{
-		{name: "catalog size when config says nothing", cfg: config.Config{}, want: catalog},
-		{name: "explicit config value wins", cfg: config.Config{ContextWindow: 4242}, want: 4242},
-		{name: "zero config value does not override", cfg: config.Config{ContextWindow: 0}, want: catalog},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := resolveRuntimeContextWindow(context.Background(), tt.cfg, info, "")
-			if got != tt.want {
-				t.Errorf("resolveRuntimeContextWindow = %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
-
 // --- cli.go: runNonInteractive helpers ------------------------------------
 
 func TestAppendNonInteractiveMemoryTools(t *testing.T) {

--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -16,6 +16,7 @@ import (
 	adktool "google.golang.org/adk/v2/tool"
 
 	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/autocompact"
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/guardrail"
@@ -325,11 +326,11 @@ func deferredInit(
 	// only ever rewritten between turns. It shares the caller's notice channel
 	// — a buffered, non-blocking send, so a compaction notice never blocks the
 	// turn if the TUI is momentarily busy.
-	if hook := buildAutoCompactHook(autoCompactDeps{
+	if hook := autocompact.BuildHook(autocompact.Deps{
 		SessionSvc:    sessionSvc,
 		Tracker:       tokenTracker,
 		Deduper:       cbs.deduper,
-		Cfg:           autoCompactConfigFrom(cfg),
+		Cfg:           autocompact.ConfigFrom(cfg),
 		Log:           sessionLog,
 		SummarizerLLM: llm,
 		Notify: func(msg string) {

--- a/internal/ctxwindow/ctxwindow.go
+++ b/internal/ctxwindow/ctxwindow.go
@@ -1,0 +1,43 @@
+// Package ctxwindow resolves the context window of the model a session runs
+// against, which is the denominator every compaction threshold is measured in.
+//
+// It is deliberately separate from internal/autocompact, which consumes the
+// number: resolving a window means asking internal/provider, and piagent is
+// barred by TestPiagentStaysIsolated from reaching provider construction even
+// transitively. Keeping the two apart lets piagent install the same compaction
+// hook as the CLI without acquiring that dependency.
+package ctxwindow
+
+import (
+	"context"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/provider"
+)
+
+// Resolve reports the context window the running model actually
+// has, in tokens. It starts from the embedded catalog and lets the two
+// providers that can be asked at runtime — Ollama and OpenRouter — correct it.
+//
+// A zero result means the window is unknown, and compaction then never fires:
+// AutoCompactConfig.Decide treats an unknown window as CompactionNone rather
+// than guessing a percentage of nothing. Setting context_window in config.json
+// is the escape hatch, and it wins over every other source, because the
+// embedded catalog does not cover every provider's models.
+func Resolve(ctx context.Context, cfg config.Config, info provider.Info, baseURL string) int64 {
+	ctxWindowSize := provider.ContextWindowSizeFor(info.Provider, info.Model)
+	if info.Ollama {
+		if n := provider.OllamaContextWindowSize(ctx, baseURL, info.Model); n > 0 {
+			ctxWindowSize = n
+		}
+	}
+	if info.Provider == "openrouter" {
+		if n := provider.OpenRouterContextWindowSize(ctx, baseURL, info.Model); n > 0 {
+			ctxWindowSize = n
+		}
+	}
+	if cfg.ContextWindow > 0 {
+		ctxWindowSize = cfg.ContextWindow
+	}
+	return ctxWindowSize
+}

--- a/internal/ctxwindow/ctxwindow_test.go
+++ b/internal/ctxwindow/ctxwindow_test.go
@@ -1,0 +1,36 @@
+package ctxwindow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/provider"
+)
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	info := provider.Info{Provider: "anthropic", Model: "claude-sonnet-4-6"}
+	catalog := provider.ContextWindowSizeFor(info.Provider, info.Model)
+
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want int64
+	}{
+		{name: "catalog size when config says nothing", cfg: config.Config{}, want: catalog},
+		{name: "explicit config value wins", cfg: config.Config{ContextWindow: 4242}, want: 4242},
+		{name: "zero config value does not override", cfg: config.Config{ContextWindow: 0}, want: catalog},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Resolve(context.Background(), tt.cfg, info, "")
+			if got != tt.want {
+				t.Errorf("Resolve = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/guardrail/contextmeter_test.go
+++ b/internal/guardrail/contextmeter_test.go
@@ -1,0 +1,61 @@
+package guardrail_test
+
+import (
+	"testing"
+
+	"github.com/dimetron/pi-go/internal/autocompact"
+	"github.com/dimetron/pi-go/internal/guardrail"
+)
+
+// Auto-compaction reads the live context size through autocompact.ContextMeter
+// rather than through this package, so that piagent — which may not import
+// internal/guardrail, see TestPiagentStaysIsolated — can install the same hook.
+// That indirection means nothing in the compiler forces the two halves to stay
+// compatible; this assertion does.
+var _ autocompact.ContextMeter = (*guardrail.Tracker)(nil)
+
+// TestTrackerAndMeterAgreeOnBodyTokens pins the rule both implementations
+// encode: the first request of a window establishes the cached prefix, and
+// body tokens are what accumulated after it. Two entry points measuring the
+// same session differently would compact at different points.
+func TestTrackerAndMeterAgreeOnBodyTokens(t *testing.T) {
+	t.Parallel()
+
+	steps := []struct {
+		desc   string
+		prompt int32
+		want   int64
+	}{
+		{desc: "first request establishes the prefix, so no body yet", prompt: 12_000, want: 0},
+		{desc: "growth after the prefix is body", prompt: 30_000, want: 18_000},
+		{desc: "further growth accumulates", prompt: 109_498, want: 97_498},
+	}
+
+	tracker := guardrail.NewWithPath(0, t.TempDir()+"/usage.json")
+	meter := autocompact.NewMeter()
+
+	for _, step := range steps {
+		if err := tracker.AddWithCache(step.prompt, 100, 0); err != nil {
+			t.Fatalf("%s: AddWithCache: %v", step.desc, err)
+		}
+		meter.Observe(int64(step.prompt))
+
+		if got := tracker.BodyTokens(); got != step.want {
+			t.Errorf("%s: tracker.BodyTokens() = %d, want %d", step.desc, got, step.want)
+		}
+		if got := meter.BodyTokens(); got != step.want {
+			t.Errorf("%s: meter.BodyTokens() = %d, want %d", step.desc, got, step.want)
+		}
+	}
+
+	// Compaction rewrites the window, so both must re-establish a prefix from
+	// the next request rather than keeping the old one.
+	tracker.SetLastPromptTokens(20_000)
+	meter.SetLastPromptTokens(20_000)
+	if got := tracker.BodyTokens(); got != 20_000 {
+		t.Errorf("after compaction tracker.BodyTokens() = %d, want 20000", got)
+	}
+	if got := meter.BodyTokens(); got != 20_000 {
+		t.Errorf("after compaction meter.BodyTokens() = %d, want 20000", got)
+	}
+}

--- a/piagent/agent.go
+++ b/piagent/agent.go
@@ -17,6 +17,7 @@ import (
 	adktool "google.golang.org/adk/v2/tool"
 
 	"github.com/dimetron/pi-go/internal/agent"
+	"github.com/dimetron/pi-go/internal/autocompact"
 	"github.com/dimetron/pi-go/internal/config"
 	"github.com/dimetron/pi-go/internal/extension"
 	"github.com/dimetron/pi-go/internal/logger"
@@ -46,9 +47,13 @@ type Agent struct {
 	// onNewSession arms the subsystems that can only be told a session ID
 	// after the session exists — memory recording and the ACP event log.
 	onNewSession func(sessionID string)
-	beforeTurn   []BeforeTurnFunc
-	afterTurn    []AfterTurnFunc
-	closers      []func() error
+	// meter is what auto-compaction reads the live context size from. It is
+	// fed by an after-model callback rather than by a model wrapper, because
+	// wrapping the model is guardrail's job and guardrail is out of reach.
+	meter      *autocompact.Meter
+	beforeTurn []BeforeTurnFunc
+	afterTurn  []AfterTurnFunc
+	closers    []func() error
 }
 
 // ErrNoModel is returned by [New] when no model was supplied. piagent does not
@@ -87,12 +92,21 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 
 	llm := o.model
 	providerName := providerOf(llm)
+
+	// Measures, never enforces: nothing here caps an embedder's spend, and
+	// the CLI's guardrail is out of reach anyway (see the isolation test).
+	// The meter exists so auto-compaction can tell how much of the context
+	// window the transcript is using; it is fed by an after-model callback.
+	contextMeter := autocompact.NewMeter()
+	contextMeter.SetContextWindowSize(contextWindowFor(cfg, o))
+
 	a := &Agent{
 		workDir:    workDir,
 		modelName:  llm.Name(),
 		provider:   providerName,
 		beforeTurn: o.beforeTurn,
 		afterTurn:  o.afterTurn,
+		meter:      contextMeter,
 	}
 
 	rt, err := a.buildRuntime(ctx, o, &cfg, providerName)
@@ -124,7 +138,13 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 	// memSessionID is only known once a session exists; the memory callback
 	// reads it through the pointer, so recording starts from that point.
 	var memSessionID string
+	// Held rather than created inline: a summarizing compaction rebuilds the
+	// transcript, which invalidates every pointer the deduper holds into the
+	// old one, so the hook has to be able to reset it.
+	resultDeduper := tools.NewResultDeduper()
 	before, after := buildCallbacks(callbackDeps{
+		deduper:   resultDeduper,
+		meter:     contextMeter,
 		cfg:       cfg,
 		sandbox:   rt.sandbox,
 		lspMgr:    rt.lspMgr,
@@ -152,6 +172,24 @@ func New(ctx context.Context, opts ...Option) (*Agent, error) {
 		return nil, a.abort(fmt.Errorf("creating agent: %w", err))
 	}
 	a.inner = inner
+	// Auto-compaction, on the same terms as the CLI and the ACP server. An
+	// embedded agent is no less prone to outgrowing its window than an
+	// interactive one — it re-sends the whole transcript every turn just the
+	// same — and before this it was the one entry point with no defense.
+	if hook := autocompact.BuildHook(autocompact.Deps{
+		SessionSvc:    sessionSvc,
+		Tracker:       contextMeter,
+		Deduper:       resultDeduper,
+		Cfg:           autocompact.ConfigFrom(cfg),
+		Log:           sessionLog,
+		SummarizerLLM: llm,
+		// No terminal to notify: an embedder reads the outcome in the session
+		// log, and writing it anywhere else would be output it never asked
+		// for.
+		Notify: nil,
+	}); hook != nil {
+		inner.SetPreTurnHook(hook)
+	}
 	a.onNewSession = func(sessionID string) {
 		memSessionID = sessionID
 		rt.orch.SetACPLogPath(filepath.Join(sessionDir, sessionID, "acp.jsonl"))
@@ -378,6 +416,27 @@ type providerNamer interface{ Provider() string }
 // and both degrade quietly on a miss — the OTel gen_ai.provider.name span
 // attribute (which falls back to the raw string) and the Gemini grounding tool
 // (which simply does not register).
+// contextWindowFor reports the model's context window in tokens, which is the
+// denominator auto-compaction measures its thresholds against.
+//
+// It cannot consult the model catalog the way the CLI does: looking a model up
+// means importing internal/provider, and that is exactly the dependency
+// TestPiagentStaysIsolated exists to prevent. So the window is stated rather
+// than inferred — [WithContextWindow] first, then context_window in
+// ~/.pi-go/config.json.
+//
+// A zero result leaves compaction off rather than guessing, which is what an
+// unknown window means everywhere else in pi-go. An embedder using pimodels
+// can pass provider.ContextWindowSizeFor's answer straight into
+// [WithContextWindow]; that composition belongs in the caller, which is the
+// whole point of the split.
+func contextWindowFor(cfg config.Config, o options) int64 {
+	if o.contextWindow > 0 {
+		return o.contextWindow
+	}
+	return cfg.ContextWindow
+}
+
 func providerOf(m model.LLM) string {
 	if pn, ok := m.(providerNamer); ok {
 		if name := pn.Provider(); name != "" {
@@ -420,6 +479,8 @@ type callbackDeps struct {
 	worker    *memory.Worker
 	project   string
 	sessionID *string
+	deduper   *tools.ResultDeduper
+	meter     *autocompact.Meter
 	opts      options
 }
 
@@ -459,11 +520,15 @@ func buildCallbacks(d callbackDeps) (callbackSet, afterCallbackSet) {
 	afterTool = append(afterTool,
 		lsp.BuildLSPAfterToolCallback(d.lspMgr),
 		tools.BuildCompactorCallback(compactorConfig(d.cfg), tools.NewCompactMetrics()),
-		tools.BuildDedupCallback(tools.NewResultDeduper()))
+		tools.BuildDedupCallback(d.deduper))
 
 	if d.worker != nil {
 		afterTool = append(afterTool, memoryObservationCallback(d.worker, d.cfg, d.project, d.sessionID))
 	}
+
+	// Ahead of the embedder's callbacks: the meter reports what the provider
+	// actually billed for, which is not the embedder's to alter.
+	afterModel = append(afterModel, autocompact.MeterCallback(d.meter))
 
 	// The embedder's callbacks run last, so they observe the compacted and
 	// deduplicated result rather than the raw one.

--- a/piagent/autocompact_test.go
+++ b/piagent/autocompact_test.go
@@ -1,0 +1,136 @@
+package piagent
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genai"
+
+	adkmodel "google.golang.org/adk/v2/model"
+
+	"github.com/dimetron/pi-go/internal/autocompact"
+	"github.com/dimetron/pi-go/internal/config"
+	"github.com/dimetron/pi-go/internal/testenv"
+)
+
+// newEmbeddedAgent builds an agent the way an embedder would, rooted in temp
+// directories so the test never touches the developer's real ~/.pi-go.
+func newEmbeddedAgent(t *testing.T, opts ...Option) *Agent {
+	t.Helper()
+	testenv.SetHome(t, t.TempDir())
+
+	base := []Option{
+		WithModel(&fakeLLM{name: "test-model"}),
+		WithWorkingDir(t.TempDir()),
+		WithSessionDir(t.TempDir()),
+	}
+	ag, err := New(context.Background(), append(base, opts...)...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = ag.Close() })
+	return ag
+}
+
+// TestAutoCompactWiredForEmbedders covers the wiring an embedder gets. Before
+// this, piagent was the one entry point with no compaction at all: an embedded
+// agent re-sends its whole transcript every turn exactly as the CLI does, and
+// nothing reclaimed it.
+//
+// The hook is installed either way. What the stated window decides is whether
+// it can do anything: with no window there is no denominator, and the hook
+// reports that once instead of silently no-opping forever.
+func TestAutoCompactWiredForEmbedders(t *testing.T) {
+	tests := []struct {
+		desc       string
+		opts       []Option
+		wantWindow int64
+	}{
+		{
+			desc:       "no window stated leaves compaction inert",
+			wantWindow: 0,
+		},
+		{
+			desc:       "WithContextWindow states it",
+			opts:       []Option{WithContextWindow(200_000)},
+			wantWindow: 200_000,
+		},
+		{
+			desc:       "a non-positive window is not a window",
+			opts:       []Option{WithContextWindow(0)},
+			wantWindow: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ag := newEmbeddedAgent(t, tt.opts...)
+			if !ag.inner.HasPreTurnHook() {
+				t.Error("HasPreTurnHook() = false; every embedded agent gets the hook")
+			}
+			if got := ag.meter.ContextWindowSize(); got != tt.wantWindow {
+				t.Errorf("meter.ContextWindowSize() = %d, want %d", got, tt.wantWindow)
+			}
+		})
+	}
+}
+
+// TestMeterIsFedByTheModelCallback pins the half that is easy to leave out: a
+// meter nothing writes to reports zero forever, and compaction that reads zero
+// never fires. It asserts through the assembled agent's callback chain rather
+// than by calling the meter directly, because the wiring is what breaks.
+func TestMeterIsFedByTheModelCallback(t *testing.T) {
+	ag := newEmbeddedAgent(t, WithContextWindow(200_000))
+
+	feed := func(promptTokens int32) {
+		t.Helper()
+		cb := autocompact.MeterCallback(ag.meter)
+		if _, err := cb(nil, &adkmodel.LLMResponse{
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: promptTokens},
+		}, nil); err != nil {
+			t.Fatalf("meter callback: %v", err)
+		}
+	}
+
+	feed(11_045)
+	if got := ag.meter.BodyTokens(); got != 0 {
+		t.Errorf("BodyTokens() after the first response = %d, want 0 — it is all prefix", got)
+	}
+	feed(109_498)
+	if got := ag.meter.BodyTokens(); got != 98_453 {
+		t.Errorf("BodyTokens() = %d, want 98453 — growth past the prefix", got)
+	}
+}
+
+// TestContextWindowFor covers the precedence between the option and
+// config.json. The option wins: an embedder who states a window in Go has said
+// something more specific than a file the user happens to have.
+func TestContextWindowFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		cfg  config.Config
+		opts options
+		want int64
+	}{
+		{desc: "neither set means unknown", want: 0},
+		{desc: "config alone", cfg: config.Config{ContextWindow: 128_000}, want: 128_000},
+		{desc: "option alone", opts: options{contextWindow: 200_000}, want: 200_000},
+		{
+			desc: "option beats config",
+			cfg:  config.Config{ContextWindow: 128_000},
+			opts: options{contextWindow: 1_048_576},
+			want: 1_048_576,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := contextWindowFor(tt.cfg, tt.opts); got != tt.want {
+				t.Errorf("contextWindowFor() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/piagent/doc.go
+++ b/piagent/doc.go
@@ -137,10 +137,6 @@
 // credential option exists here, because each one would drag provider
 // resolution into this package's public surface.
 //
-// The CLI's two-stage auto-compaction pre-turn hook, which lives in
-// internal/cli and would have to be extracted first; embedders that need it
-// can install their own via ADK.
-//
 // A process-global HTTP trace sink, because a library has no business
 // claiming one.
 //
@@ -150,7 +146,24 @@
 // [WithAfterToolCallbacks] do the same work without the fork.
 //
 // The daily-token guardrail, which wraps the model rather than the agent and
-// so belongs with whoever built the model.
+// so belongs with whoever built the model. piagent does wrap the model in an
+// unlimited tracker, but only to measure: nothing here caps an embedder's
+// spend.
+//
+// # Auto-compaction
+//
+// The two-stage compaction the CLI runs — shed superseded tool results at the
+// lower threshold, summarize the transcript at the upper one — is installed
+// here too, as a pre-turn hook. An embedded agent re-sends its whole
+// transcript on every turn exactly as an interactive one does, so a long
+// session outgrows its context window just as fast.
+//
+// It reads its thresholds from the auto_compact block of ~/.pi-go/config.json
+// and is on by default. Two things switch it off: setting auto_compact.enabled
+// to false, and a context window that cannot be resolved. The window comes
+// from the embedded model catalog, because piagent is handed a finished model
+// and never learns its base URL; set context_window in config.json when the
+// catalog does not know the model.
 //
 // # Finding the provider behind a model
 //

--- a/piagent/options.go
+++ b/piagent/options.go
@@ -50,6 +50,7 @@ type options struct {
 	skillsEnabled   bool
 	subagentEnabled bool
 	onAgentEvent    AgentEventFunc
+	contextWindow   int64
 }
 
 // defaultOptions splits pi-go's conventions along one line: reading them is on
@@ -232,4 +233,25 @@ func WithSubagents(enabled bool) Option {
 // Without one those events are discarded.
 func WithAgentEvents(fn AgentEventFunc) Option {
 	return func(o *options) { o.onAgentEvent = fn }
+}
+
+// WithContextWindow states the model's context window in tokens, which is what
+// switches auto-compaction on.
+//
+// piagent cannot look this up. Resolving a window means consulting pi-go's
+// model catalog, and this package is deliberately kept off provider
+// construction — so the number is stated by whoever built the model. An
+// embedder using pimodels has it to hand:
+//
+//	m, _ := pimodels.New(ctx, "gemini-3.8-flash")
+//	ag, _ := piagent.New(ctx,
+//		piagent.WithModel(m),
+//		piagent.WithContextWindow(provider.ContextWindowSizeFor("gemini", m.Name())),
+//	)
+//
+// Without it, and without context_window in ~/.pi-go/config.json, the window
+// is unknown and compaction never fires — the transcript grows until the
+// provider rejects it. A non-positive size is ignored.
+func WithContextWindow(tokens int64) Option {
+	return func(o *options) { o.contextWindow = tokens }
 }


### PR DESCRIPTION
## Why

Auto-compaction ran on two of pi-go's four agent entry points. The interactive
TUI (`interactive.go:342`) and the one-shot CLI (`cli.go:870`) installed the
pre-turn hook. The ACP server and the `piagent` SDK did not — and could not:
`buildAutoCompactHook` was an unexported member of `internal/cli`, so nothing
outside that package could reach it. `piagent/doc.go` recorded the gap as a
known omission.

The gap is expensive. Every turn re-sends the whole transcript, so prompt
tokens grow monotonically across a session. A measured Gemini session (#315)
ran 11,045 → 109,498 across 89 responses — 6.17M input tokens in ~21 minutes,
peaking at 1.27M inside a single 60s window against a 2M/min quota. ACP is the
path editors and subagents run on, so it holds the longest-lived transcripts
of any entry point, and it was the one with no defense at all.

## What

`internal/autocompact` owns the hook; `internal/cli` becomes a caller.

**ACP.** `buildSessionLLM` was building a guardrail tracker and dropping it on
the floor, so nothing downstream could install a hook against it. It now
returns the tracker, and `initPiSessionState` installs the hook. Compaction
rewrites a *stored* transcript, so it requires the file-backed session
service; an in-memory session has nothing to rewrite and correctly gets none.

**piagent.** Installed, but fed by a new standalone `Meter` rather than a
guardrail tracker. `TestPiagentStaysIsolated` bars that package from
`internal/guardrail` and `internal/provider` even transitively, and it is a
`go list -deps` assertion, so this was not negotiable. Two consequences, both
deliberate: the meter measures and never enforces — nothing here caps an
embedder's spend — and the context window has to be *stated*, via the new
`WithContextWindow` option or `context_window` in config.json, because looking
it up means importing provider construction.

Two splits fall out of that boundary:

- `Deps.Tracker` becomes a `ContextMeter` interface, so `autocompact` imports
  neither forbidden package. `*guardrail.Tracker` satisfies it structurally. A
  compile-time assertion plus a shared behavioural test keep `*Tracker` and
  `*Meter` agreeing on the cached-prefix rule — otherwise the two would drift
  and entry points would compact at different points with nothing noticing.
- Window resolution moves to `internal/ctxwindow`, absorbing ACP's
  near-duplicate `sessionContextWindow`. That copy silently ignored the user's
  `context_window` setting — a real defect, fixed by the consolidation.

**Unknown windows are no longer silent.** An unresolvable context window makes
compaction inert, because `Decide` treats a zero window as "never compact".
The hook now says so once per session instead of no-opping forever. That state
is precisely how a transcript grows until the provider rejects it with nothing
having warned anyone.

## What this does not fix

Compaction remains **pre-turn only**. `Agent.Run`/`RunStreaming` call the hook
once at dispatch (`internal/agent/agent.go:765,774`); the comment there gives
the reason, that rewriting history mid-turn would orphan a tool call from its
result.

That bounds the benefit. The 11K → 109K growth above happened across 89 model
responses inside a handful of user turns, so a pre-turn hook never fires during
the burst that blows the quota. Codex solves this by compacting mid-turn —
after each sampling it checks the limit and, if the loop will make another
request, rolls the window over and continues, sidestepping the orphaning
problem by re-injecting context before the last user message. That is a change
to `internal/agent`'s loop and is not in this PR; it is written up on #315.

## Verification

`make build`, `make vet`, `make lint` (0 issues), the full `go test ./...`
outside the sandbox, and `go test -race` over every touched package.

New tests cover: which ACP sessions get a hook and which correctly do not;
piagent's window precedence and that its meter is actually fed by the
after-model callback; the meter's prefix rule including the post-compaction
reset and concurrent access; the once-per-session unknown-window notice; and
the `*Tracker`/`*Meter` conformance.

Refs #315
