### PR TITLE
fix(agentgateway): bind compose port to loopback only

### DIFF
--- a/hack/agentgateway/docker-compose.yaml
+++ b/hack/agentgateway/docker-compose.yaml
@@ -17,7 +17,10 @@ services:
     container_name: agentgateway
     restart: unless-stopped
     ports:
-      - "4000:4000"
+      # Loopback only: publishing on 0.0.0.0 collides with Tailscale's
+      # 100.x.y.z interface, which makes the gateway unreachable from the
+      # tailnet and can confuse other local services.
+      - "127.0.0.1:4000:4000"
     environment:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}


### PR DESCRIPTION
Publishing 4000 on 0.0.0.0 collides with Tailscale's 100.x.y.z
interface, making the gateway unreachable from the tailnet. Bind to
127.0.0.1 so the LLM endpoint and UI stay local-only.

Signed-off-by: pi <dimetron@me.com>
