### PR TITLE
fix(provider): route gpt-6-astra to the Responses API

### DIFF
--- a/internal/provider/openai_responses.go
+++ b/internal/provider/openai_responses.go
@@ -29,6 +29,7 @@ func modelNeedsResponses(modelName string) bool {
 		"gpt-5-codex", "gpt-5.1-codex", "gpt-5.1-codex-mini", "gpt-5.1-codex-max",
 		"gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4-codex", "gpt-5.5-codex",
 		"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra",
+		"gpt-6-astra",
 	}
 	for _, m := range responsesOnly {
 		if strings.HasPrefix(lower, m) {

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1357,6 +1357,7 @@ func TestModelNeedsResponses(t *testing.T) {
 		{"gpt-5.6-luna", true},
 		{"gpt-5.6-sol", true},
 		{"gpt-5.6-terra", true},
+		{"gpt-6-astra", true},
 		{"gpt-5.1-codex", true},
 		// Provider-prefixed forms (agentgateway virtual models forward the
 		// bare ID upstream, so the endpoint decision must match on it).


### PR DESCRIPTION
gpt-6-astra rejects function tools with reasoning_effort on
/v1/chat/completions (400 invalid_request_error). It is a
Responses-only model, so add it to modelNeedsResponses so the
endpoint decision routes it to /v1/responses.

Signed-off-by: pi <dimetron@me.com>
