### PR TITLE
fix(provider): set gpt-6-astra context window to 1.05M

### DIFF
--- a/internal/provider/coverage_boost_test.go
+++ b/internal/provider/coverage_boost_test.go
@@ -31,6 +31,7 @@ func TestContextWindowSize(t *testing.T) {
 		{"gemini-3.6-flash previous stable", "gemini-3.6-flash", 1_048_576},
 		{"gemini-3.5-flash stable", "gemini-3.5-flash", 1_048_576},
 		{"gemini-3.1-flash-lite stable beats -preview prefix", "gemini-3.1-flash-lite", 1_048_576},
+		{"gpt-6-astra frontier", "gpt-6-astra", 1_050_000},
 		{"gpt-5.5 frontier", "gpt-5.5", 272_000},
 		{"gpt-5.4-mini has longer prefix", "gpt-5.4-mini", 400_000},
 		{"mistral-large tag variant", "mistral-large-2512", 256_000},

--- a/internal/provider/model_catalog_test.go
+++ b/internal/provider/model_catalog_test.go
@@ -70,6 +70,7 @@ func TestEmbeddedContextWindows(t *testing.T) {
 		prefix string
 		want   int64
 	}{
+		{"gpt-6-astra", 1_050_000},
 		{"gpt-5.6-sol", 272_000},
 		{"gpt-5.2", 1_050_000},
 		{"claude-mythos-5", 1_000_000},

--- a/internal/provider/modeldata/context-windows.json
+++ b/internal/provider/modeldata/context-windows.json
@@ -30,6 +30,7 @@
     "claude-3-haiku": 200000
   },
   "openai": {
+    "gpt-6-astra": 1050000,
     "gpt-5.6-sol": 272000,
     "gpt-5.6-terra": 272000,
     "gpt-5.6-luna": 272000,


### PR DESCRIPTION
## What

`gpt-6-astra` was missing from `internal/provider/modeldata/context-windows.json`, so `ContextWindowSize("gpt-6-astra")` returned `0` (unknown) and the model would compact at the wrong threshold.

## Change

- Add `gpt-6-astra: 1050000` to the `openai` block — OpenAI lists a **1,050,000-token** context window for gpt-6-astra.
- Pin the value in `TestContextWindowSize` and `TestEmbeddedContextWindows`.

## Verification

- `go build ./...` passes
- `TestContextWindowSize`, `TestEmbeddedContextWindows`, `TestModelNeedsResponses` all pass
- golangci-lint: 0 issues