### PR TITLE
fix(provider): send max_tokens instead of max_completion_tokens for agentgateway

### DIFF
--- a/internal/provider/agentgateway.go
+++ b/internal/provider/agentgateway.go
@@ -17,10 +17,20 @@ const agentgatewayDefaultBaseURL = "http://localhost:4000"
 // the gateway's base URL. No API key is required: NewOpenAI substitutes a
 // dummy key whenever a base URL is set, and a gateway that needs one can still
 // be given AGENTGATEWAY_API_KEY.
+//
+// UseLegacyMaxTokens is forced on because agentgateway typically routes to
+// Ollama, whose API only understands the legacy max_tokens field — the newer
+// max_completion_tokens is silently ignored, so the model runs unbounded and
+// hits Ollama's own 65536-token default. Sending max_tokens lets pi-go's cap
+// (defaultOaiMaxOutputTokens = 64000) reach the model instead.
 func NewAgentGateway(ctx context.Context, modelName, apiKey, baseURL string, opts *LLMOptions) (model.LLM, error) {
 	if baseURL == "" {
 		baseURL = agentgatewayDefaultBaseURL
 	}
+	if opts == nil {
+		opts = &LLMOptions{}
+	}
+	opts.UseLegacyMaxTokens = true
 	llm, err := NewOpenAI(ctx, modelName, apiKey, baseURL, opts)
 	if err != nil {
 		return nil, fmt.Errorf("creating agentgateway client: %w", err)

--- a/internal/provider/functioncall_args_test.go
+++ b/internal/provider/functioncall_args_test.go
@@ -173,3 +173,56 @@ func TestChatCompletionsSendsMaxCompletionTokens(t *testing.T) {
 		})
 	}
 }
+
+// TestAgentGatewaySendsLegacyMaxTokens pins the fix for Ollama ignoring
+// max_completion_tokens: the agentgateway provider must send max_tokens
+// (the legacy field) instead, or Ollama runs unbounded and hits its own
+// 65536-token default — which is what truncated session 260906-1320.
+func TestAgentGatewaySendsLegacyMaxTokens(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "c1", "object": "chat.completion", "model": "m",
+			"choices": []map[string]any{{
+				"index":         0,
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+				"finish_reason": "stop",
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	llm, err := NewAgentGateway(context.Background(), "ollama-deepseek", "", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewAgentGateway() error: %v", err)
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for _, err := range llm.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent() error: %v", err)
+		}
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decoding request: %v", err)
+	}
+	// max_tokens must be present (the legacy field Ollama understands).
+	got, ok := sent["max_tokens"].(float64)
+	if !ok {
+		t.Fatalf("request has no max_tokens (Ollama would run unbounded): %s", body)
+	}
+	if got != float64(defaultOaiMaxOutputTokens) {
+		t.Errorf("max_tokens = %v, want %v", got, defaultOaiMaxOutputTokens)
+	}
+	// max_completion_tokens must NOT be present — Ollama ignores it, and
+	// sending both is at best redundant and at worst ambiguous.
+	if _, ok := sent["max_completion_tokens"]; ok {
+		t.Errorf("request has max_completion_tokens, should only send max_tokens for agentgateway")
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -37,6 +37,13 @@ type openaiModel struct {
 	// maxOutputTokens caps the reply, in tokens. See
 	// defaultOaiMaxOutputTokens for why omitting it is not an option.
 	maxOutputTokens int64
+	// useLegacyMaxTokens sends max_tokens instead of max_completion_tokens
+	// on the Chat Completions wire. Ollama only understands max_tokens — the
+	// newer max_completion_tokens field is silently ignored, so the model
+	// runs unbounded and hits its own 65536 default (see agentgateway). The
+	// OpenAI API itself accepts both but deprecated max_tokens in favor of
+	// max_completion_tokens, so this only matters for Ollama-class backends.
+	useLegacyMaxTokens bool
 	// mu protects responseState for Responses mode multi-turn.
 	mu            sync.Mutex
 	responseState *responsesState // nil when using Chat Completions
@@ -128,11 +135,12 @@ func NewOpenAI(_ context.Context, modelName, apiKey, baseURL string, llmOpts *LL
 		maxOutputTokens = llmOpts.MaxOutputTokens
 	}
 	return &openaiModel{
-		modelName:       modelName,
-		client:          client,
-		codexBackend:    useCodexBackend,
-		maxOutputTokens: maxOutputTokens,
-		responseState:   nil, // determined per-call based on model
+		modelName:          modelName,
+		client:             client,
+		codexBackend:       useCodexBackend,
+		maxOutputTokens:    maxOutputTokens,
+		useLegacyMaxTokens: llmOpts != nil && llmOpts.UseLegacyMaxTokens,
+		responseState:      nil, // determined per-call based on model
 	}, nil
 }
 

--- a/internal/provider/openai_completions.go
+++ b/internal/provider/openai_completions.go
@@ -26,7 +26,11 @@ func (m *openaiModel) generateChat(ctx context.Context, req *model.LLMRequest, m
 			Messages: messages,
 		}
 		if maxTokens := oaiMaxOutputTokens(req.Config, m.maxOutputTokens); maxTokens > 0 {
-			params.MaxCompletionTokens = openai.Int(maxTokens)
+			if m.useLegacyMaxTokens {
+				params.MaxTokens = openai.Int(maxTokens)
+			} else {
+				params.MaxCompletionTokens = openai.Int(maxTokens)
+			}
 		}
 		if systemInstruction != "" {
 			params.Messages = append([]openai.ChatCompletionMessageParamUnion{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -647,6 +647,11 @@ type LLMOptions struct {
 	// stop below that and reject the request rather than clamping it. A
 	// per-request genai MaxOutputTokens still wins over both.
 	MaxOutputTokens int64
+	// UseLegacyMaxTokens sends max_tokens instead of max_completion_tokens on
+	// the Chat Completions wire. Ollama only understands the legacy field; the
+	// newer max_completion_tokens is silently ignored, leaving the model
+	// unbounded. Set for agentgateway (which routes to Ollama).
+	UseLegacyMaxTokens bool
 	// RateLimit paces outbound requests so a turn stays inside the provider's
 	// per-minute quota rather than being rejected by it. A zero value sends at
 	// whatever rate the caller manages. Resolved from config by


### PR DESCRIPTION
## Summary

Ollama only understands the legacy `max_tokens` field; the newer `max_completion_tokens` (which the openai-go SDK sends by default) is silently ignored. When pi-go sends `max_completion_tokens=64000` through agentgateway to an Ollama-backed model, Ollama falls back to its own 65536-token default, truncating long turns at a different limit than the one pi-go asked for — and the cut can land mid-generation with no content at all.

**Session 260906-1320** was the reported case: `ollama-deepseek` via agentgateway, 116K prompt tokens, 65536 output tokens, empty `parts: []`, `finishReason: MAX_TOKENS`. The model hit Ollama's 65536 default because pi-go's 64000 cap was sent in a field Ollama doesn't read.

## Fix

Add `useLegacyMaxTokens` to `openaiModel`, set it for the agentgateway provider, and send `MaxTokens` (`max_tokens`) instead of `MaxCompletionTokens` (`max_completion_tokens`) on the Chat Completions wire when it is set.

No agentgateway config change needed — the gateway already forwards `max_tokens` correctly; the issue was entirely that pi-go was not sending the field Ollama reads.

## Files changed

- `internal/provider/provider.go` — add `UseLegacyMaxTokens` to `LLMOptions`
- `internal/provider/openai.go` — add `useLegacyMaxTokens` field, wire from `LLMOptions`
- `internal/provider/openai_completions.go` — send `params.MaxTokens` when set, `params.MaxCompletionTokens` otherwise
- `internal/provider/agentgateway.go` — force `UseLegacyMaxTokens = true`
- `internal/provider/functioncall_args_test.go` — new test `TestAgentGatewaySendsLegacyMaxTokens`

## Verification

- `go build ./...` ✅
- `go vet ./internal/provider/...` ✅
- `golangci-lint` ✅ (0 issues)
- `go test ./internal/provider/...` ✅ (all tests pass including new test)