### PR TITLE
fix(provider): scope agentgateway legacy max_tokens to Ollama routes

### DIFF
--- a/internal/provider/agentgateway.go
+++ b/internal/provider/agentgateway.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"google.golang.org/adk/v2/model"
 )
@@ -18,11 +19,14 @@ const agentgatewayDefaultBaseURL = "http://localhost:4000"
 // dummy key whenever a base URL is set, and a gateway that needs one can still
 // be given AGENTGATEWAY_API_KEY.
 //
-// UseLegacyMaxTokens is forced on because agentgateway typically routes to
-// Ollama, whose API only understands the legacy max_tokens field — the newer
-// max_completion_tokens is silently ignored, so the model runs unbounded and
-// hits Ollama's own 65536-token default. Sending max_tokens lets pi-go's cap
-// (defaultOaiMaxOutputTokens = 64000) reach the model instead.
+// UseLegacyMaxTokens is scoped to the gateway's known Ollama routes, not forced
+// provider-wide. Ollama's API only understands the legacy max_tokens field —
+// the newer max_completion_tokens is silently ignored, so the model runs
+// unbounded and hits Ollama's own 65536-token default. Sending max_tokens lets
+// pi-go's cap (defaultOaiMaxOutputTokens = 64000) reach the model instead. The
+// gateway's other routes (anthropic, openai, gemini, …) speak the modern
+// max_completion_tokens field, so they must not be downgraded to the legacy
+// one.
 func NewAgentGateway(ctx context.Context, modelName, apiKey, baseURL string, opts *LLMOptions) (model.LLM, error) {
 	if baseURL == "" {
 		baseURL = agentgatewayDefaultBaseURL
@@ -30,10 +34,41 @@ func NewAgentGateway(ctx context.Context, modelName, apiKey, baseURL string, opt
 	if opts == nil {
 		opts = &LLMOptions{}
 	}
-	opts.UseLegacyMaxTokens = true
+	if routesToOllama(modelName) {
+		opts.UseLegacyMaxTokens = true
+	}
 	llm, err := NewOpenAI(ctx, modelName, apiKey, baseURL, opts)
 	if err != nil {
 		return nil, fmt.Errorf("creating agentgateway client: %w", err)
 	}
 	return llm, nil
+}
+
+// routesToOllama reports whether an agentgateway model name resolves to one of
+// the gateway's Ollama routes. The gateway's config.yaml routes the ollama,
+// ollama1/2/3 and ollama-cloud prefixes to Ollama backends, and the virtual
+// models that fail over across them (ollama-deepseek, ollama-gemma4, …) also
+// land on Ollama. Everything else — anthropic/, openai/, gemini/, pi-default,
+// and the bare vendor model names — speaks the modern max_completion_tokens
+// field and must not be downgraded to the legacy max_tokens.
+func routesToOllama(modelName string) bool {
+	lower := strings.ToLower(strings.TrimSpace(modelName))
+	for _, prefix := range []string{
+		"ollama/", "ollama1/", "ollama2/", "ollama3/", "ollama-cloud/",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	// Virtual models that route to Ollama backends. pi-fast's primary failover
+	// target is ollama1/deepseek-v4-flash:0731-cloud, so it is Ollama-first.
+	for _, name := range []string{
+		"ollama-deepseek", "ollama-deepseek-balanced", "ollama-gemma4",
+		"ollama-glm-flash", "ollama-minimax", "pi-fast",
+	} {
+		if lower == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/functioncall_args_test.go
+++ b/internal/provider/functioncall_args_test.go
@@ -226,3 +226,52 @@ func TestAgentGatewaySendsLegacyMaxTokens(t *testing.T) {
 		t.Errorf("request has max_completion_tokens, should only send max_tokens for agentgateway")
 	}
 }
+
+// TestAgentGatewayNonOllamaRouteSendsModernMaxTokens pins that legacy mode is
+// scoped to the gateway's Ollama routes, not forced provider-wide. A route that
+// resolves to a non-Ollama backend (here anthropic/) must send the modern
+// max_completion_tokens field, not the deprecated max_tokens.
+func TestAgentGatewayNonOllamaRouteSendsModernMaxTokens(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "c1", "object": "chat.completion", "model": "m",
+			"choices": []map[string]any{{
+				"index":         0,
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+				"finish_reason": "stop",
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	llm, err := NewAgentGateway(context.Background(), "anthropic/claude-opus-5", "", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewAgentGateway() error: %v", err)
+	}
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for _, err := range llm.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent() error: %v", err)
+		}
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decoding request: %v", err)
+	}
+	// max_completion_tokens must be present (the modern field non-Ollama
+	// backends understand).
+	if _, ok := sent["max_completion_tokens"]; !ok {
+		t.Fatalf("request has no max_completion_tokens: %s", body)
+	}
+	// max_tokens must NOT be present — it is deprecated on non-Ollama backends.
+	if _, ok := sent["max_tokens"]; ok {
+		t.Errorf("request has legacy max_tokens, should only send max_completion_tokens for non-Ollama agentgateway routes")
+	}
+}


### PR DESCRIPTION
NewAgentGateway forced UseLegacyMaxTokens on for every agentgateway route,
downgrading non-Ollama backends (anthropic, openai, gemini, ...) to the
deprecated max_tokens field. Only the gateway's Ollama routes need the
legacy field; the rest speak max_completion_tokens.

Scope legacy mode to the known Ollama routes (ollama, ollama1/2/3,
ollama-cloud prefixes and the Ollama-routing virtual models) via a new
routesToOllama helper.

Signed-off-by: dimetron <dimetron@me.com>
