### PR TITLE
fix(cli): ignore unavailable ollama in model list

### DIFF
--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -112,6 +112,12 @@ func runModelList(cmd *cobra.Command, args []string) error {
 		cancel()
 
 		if err != nil {
+			// Ollama is a local daemon that is often simply not running.
+			// Treat it as absent rather than as a failure: skip it silently
+			// so `model list` still succeeds for the providers that are up.
+			if p == "ollama" {
+				continue
+			}
 			fmt.Fprintf(os.Stderr, "%s: %v\n", p, err)
 			exitCode = 1
 			continue

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -531,3 +531,39 @@ func TestRunModelList_NoArgs_EnvBaseURL(t *testing.T) {
 		t.Errorf("expected openai header in output: %s", out)
 	}
 }
+
+// TestRunModelList_OllamaUnavailableIgnored pins that a failing ollama query is
+// skipped silently rather than surfacing as an error: ollama is a local daemon
+// that is often simply not running, so `model list` must still succeed for the
+// providers that are up.
+func TestRunModelList_OllamaUnavailableIgnored(t *testing.T) {
+	// A server that 500s for ollama's /api/tags but serves openai's /v1/models.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1/models") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{"id": "gpt-5.5"}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "ollama down")
+	}))
+	defer srv.Close()
+	isolateRunModelListEnv(t)
+	t.Setenv("OPENAI_BASE_URL", srv.URL)
+	t.Setenv("OPENAI_API_KEY", "testkey")
+	// Point ollama at the mock too so the no-args branch (which always queries
+	// ollama) hits the failing endpoint.
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	out, err := runModelListCapture(t)
+	if err != nil {
+		t.Fatalf("Execute: %v (ollama failure must not fail the command)", err)
+	}
+	if !strings.Contains(out, "gpt-5.5") {
+		t.Errorf("output missing gpt-5.5: %s", out)
+	}
+	if strings.Contains(out, "ollama") {
+		t.Errorf("output should not mention the unavailable ollama provider: %s", out)
+	}
+}


### PR DESCRIPTION
Ollama is a local daemon that is often simply not running. When it is
down, `pi model list` printed an error and failed the whole command even
though every other provider succeeded. Skip a failing ollama query
silently so the listing still succeeds for the providers that are up.

Signed-off-by: dimetron <dimetron@me.com>
