### PR TITLE
fix(cli): run windows upgrade via powershell with the github url

### DIFF
--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -165,29 +165,19 @@ func runUpgradeShell(scriptURL string) error {
 }
 
 func runUpgradePowerShell(scriptURL string) error {
-	resp, err := http.Get(scriptURL)
-	if err != nil {
-		return fmt.Errorf("fetching install script: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("install script returned HTTP %d", resp.StatusCode)
-	}
+	cmd := runUpgradePowerShellCommand(scriptURL)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
 
-	tmp, err := os.CreateTemp("", "pi-upgrade-*.ps1")
-	if err != nil {
-		return fmt.Errorf("creating temp script: %w", err)
-	}
-	defer os.Remove(tmp.Name())
-	defer tmp.Close()
-
-	if _, err := tmp.ReadFrom(resp.Body); err != nil {
-		return fmt.Errorf("reading script: %w", err)
-	}
-
-	execCmd := exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-File", tmp.Name())
-	execCmd.Stdin = os.Stdin
-	execCmd.Stdout = os.Stdout
-	execCmd.Stderr = os.Stderr
-	return execCmd.Run()
+// runUpgradePowerShellCommand builds the PowerShell invocation that upgrades
+// pi-go on Windows. It runs the install script straight from the GitHub URL,
+// the same way the quickinstall one-liner does — iwr the script and pipe it
+// into iex — rather than downloading it to a temp file. Kept separate from
+// runUpgradePowerShell so the command shape is testable without executing it.
+func runUpgradePowerShellCommand(scriptURL string) *exec.Cmd {
+	return exec.Command("powershell.exe", "-NoProfile", "-Command",
+		fmt.Sprintf("iwr %s -UseBasicParsing | iex", scriptURL))
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -111,16 +111,27 @@ func TestIsNewerVersion(t *testing.T) {
 		})
 	}
 }
-func TestRunUpgradePowerShellFetchError(t *testing.T) {
-	if err := runUpgradePowerShell("http://127.0.0.1:1/nope.ps1"); err == nil {
-		t.Fatal("expected fetch error")
-	}
-}
 
-func TestRunUpgradePowerShellHTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.NotFoundHandler())
-	defer srv.Close()
-	if err := runUpgradePowerShell(srv.URL); err == nil {
-		t.Fatal("expected HTTP status error")
+// TestRunUpgradePowerShellCommand pins that the Windows upgrade runs PowerShell
+// with the install script URL piped into iex — the same one-liner as the
+// quickinstall command — rather than downloading the script to a temp file.
+func TestRunUpgradePowerShellCommand(t *testing.T) {
+	cmd := runUpgradePowerShellCommand("https://example.com/install.ps1")
+	if cmd == nil {
+		t.Fatal("expected a command")
+	}
+	if cmd.Path != "powershell.exe" {
+		t.Errorf("Path = %q, want powershell.exe", cmd.Path)
+	}
+	args := cmd.Args
+	if len(args) < 4 {
+		t.Fatalf("args = %v, want -NoProfile -Command <iwr ... | iex>", args)
+	}
+	if args[1] != "-NoProfile" || args[2] != "-Command" {
+		t.Errorf("args = %v, want -NoProfile -Command", args)
+	}
+	want := "iwr https://example.com/install.ps1 -UseBasicParsing | iex"
+	if args[3] != want {
+		t.Errorf("command = %q, want %q", args[3], want)
 	}
 }


### PR DESCRIPTION
The Windows upgrade path downloaded install.ps1 to a temp file and ran it
with -File. Run PowerShell with the install script URL piped into iex
instead, matching the quickinstall one-liner exactly. This avoids the
temp file and keeps upgrade identical to a fresh install.

Signed-off-by: dimetron <dimetron@me.com>
