### PR TITLE
feat(agentgateway): add ollama-dsf4 alias for deepseek

### DIFF
--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -92,6 +92,7 @@ a specific model. Repoint them here rather than reconfiguring every caller.
 |---|---|
 | `ollama-deepseek-balanced` | DeepSeek weighted evenly across all three Ollama Cloud accounts |
 | `ollama-deepseek` | DeepSeek on account 1, failing over to 2 then 3 |
+| `ollama-dsf4` | Alias for `ollama-deepseek` — same DeepSeek failover, short name |
 | `ollama-gemma4`, `ollama-glm-flash`, `ollama-minimax` | Failover variants of those models across the three accounts, same pattern |
 | `pi-default` | Claude Opus, failing over to GPT then Gemini |
 | `pi-fast` | Ollama Cloud DeepSeek (account 1), failing over to `gpt-5.6-luna` |

--- a/hack/agentgateway/config.yaml
+++ b/hack/agentgateway/config.yaml
@@ -224,6 +224,16 @@ llm:
           priority: 1
         - model: ollama3/deepseek-v4-flash:0731-cloud
           priority: 2
+  - name: ollama-dsf4
+    routing:
+      failover:
+        targets:
+        - model: ollama1/deepseek-v4-flash:0731-cloud
+          priority: 0
+        - model: ollama2/deepseek-v4-flash:0731-cloud
+          priority: 1
+        - model: ollama3/deepseek-v4-flash:0731-cloud
+          priority: 2
   - name: pi-default
     routing:
       failover:

--- a/hack/agentgateway/pi-aliases.json
+++ b/hack/agentgateway/pi-aliases.json
@@ -248,6 +248,13 @@
             "cacheRead": "0.007"
           }
         },
+        "ollama-dsf4": {
+          "rates": {
+            "input": "0.22",
+            "output": "0.66",
+            "cacheRead": "0.007"
+          }
+        },
         "deepseek-v4-pro:0813": {
           "rates": {
             "input": "0.66",

--- a/internal/provider/agentgateway_test.go
+++ b/internal/provider/agentgateway_test.go
@@ -103,7 +103,7 @@ func TestContextWindowSizeForAgentGatewayLayeredRoutes(t *testing.T) {
 // 0 window, which disables auto-compaction and lets the session grow unchecked
 // until the model hits its output cap.
 func TestContextWindowSizeForAgentGatewayVirtualModels(t *testing.T) {
-	for _, name := range []string{"ollama-deepseek", "ollama-deepseek-balanced", "pi-fast"} {
+	for _, name := range []string{"ollama-deepseek", "ollama-deepseek-balanced", "ollama-dsf4", "pi-fast"} {
 		if got := ContextWindowSizeFor("agentgateway", name); got != 1_000_000 {
 			t.Errorf("ContextWindowSizeFor(agentgateway, %q) = %d, want 1000000", name, got)
 		}

--- a/internal/provider/modeldata/context-windows.json
+++ b/internal/provider/modeldata/context-windows.json
@@ -140,6 +140,7 @@
     "deepseek-v4-flash:0731-cloud": 1000000,
     "ollama-deepseek": 1000000,
     "ollama-deepseek-balanced": 1000000,
+    "ollama-dsf4": 1000000,
     "pi-fast": 1000000
   }
 }


### PR DESCRIPTION
Adds `ollama-dsf4` as a short alias for `ollama-deepseek`.

## What changed

- **Routing** (`hack/agentgateway/config.yaml`): `ollama-dsf4` virtual model with the same DeepSeek failover as `ollama-deepseek` — account 1 → 2 → 3.
- **Context window** (`internal/provider/modeldata/context-windows.json`): `ollama-dsf4` → 1M, so a session naming the alias keeps auto-compaction enabled.
- **Cost rates** (`hack/agentgateway/pi-aliases.json`): `ollama-dsf4` priced identically to `deepseek-v4-flash:0731` (input 0.22 / output 0.66 / cacheRead 0.007).
- **Docs** (`hack/agentgateway/README.md`): documented the alias.
- **Test** (`internal/provider/agentgateway_test.go`): added `ollama-dsf4` to the virtual-models context-window test.

## Verification

- `go test ./internal/provider` — PASS
- `TestContextWindowSizeForAgentGatewayVirtualModels` — PASS
- golangci-lint (pre-commit hook) — 0 issues