### PR TITLE
feat: rename Azure OpenAI API key env var to AZUREOPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Set the API key for your provider as an environment variable. The provider is in
 | xAI (Grok) | `grok-*` | `XAI_API_KEY` | `XAI_BASE_URL` |
 | OpenRouter | `openrouter/<model>` | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL` |
 | agentgateway | `agentgateway/<model>` | none (optional `AGENTGATEWAY_API_KEY`) | `AGENTGATEWAY_BASE_URL` (default `http://localhost:4000`) |
-| Azure OpenAI | `azure/<deployment>` | `AZURE_OPENAI_API_KEY` | — |
+| Azure OpenAI | `azure/<deployment>` | `AZUREOPENAI_API_KEY` | — |
 | OpenCode | `opencode/<model>` | `OPENCODE_API_KEY` | `OPENCODE_BASE_URL` |
 | Ollama (local) | `ollama/<model>` | none | `OLLAMA_HOST` (default `http://localhost:11434`) |
 | Ollama Cloud | `<model>:cloud` | `OLLAMA_API_KEY` | `https://api.ollama.com`, or the local daemon when no key is set |

--- a/hack/agentgateway/README.md
+++ b/hack/agentgateway/README.md
@@ -135,7 +135,7 @@ append:
 - name: azure
   provider: azure
   params:
-    apiKey: ${AZURE_OPENAI_API_KEY:-}
+    apiKey: ${AZUREOPENAI_API_KEY:-}
     azureResourceName: ${AZURE_OPENAI_RESOURCE_NAME:-}
     azureApiVersion: ${AZURE_OPENAI_API_VERSION:-2024-10-21}
 

--- a/hack/agentgateway/docker-compose.yaml
+++ b/hack/agentgateway/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       # localhost inside a container is the container, so reach the host's
       # Ollama explicitly. Linux needs the extra_hosts entry below.
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434/v1}
-      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZUREOPENAI_API_KEY: ${AZUREOPENAI_API_KEY:-}
       AZURE_OPENAI_RESOURCE_NAME: ${AZURE_OPENAI_RESOURCE_NAME:-}
       AZURE_OPENAI_API_VERSION: ${AZURE_OPENAI_API_VERSION:-2024-10-21}
       # The config default points at localhost, which is right for run.sh but

--- a/internal/acp/server/runtime.go
+++ b/internal/acp/server/runtime.go
@@ -561,7 +561,7 @@ func providerEnvVar(p string) string {
 	case "openai":
 		return "OPENAI_API_KEY"
 	case "azure":
-		return "AZURE_OPENAI_API_KEY"
+		return "AZUREOPENAI_API_KEY"
 	case "gemini":
 		return "GEMINI_API_KEY"
 	default:

--- a/internal/acp/server/runtime_test.go
+++ b/internal/acp/server/runtime_test.go
@@ -190,7 +190,7 @@ func TestProviderEnvVar(t *testing.T) {
 	}{
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"openai", "OPENAI_API_KEY"},
-		{"azure", "AZURE_OPENAI_API_KEY"},
+		{"azure", "AZUREOPENAI_API_KEY"},
 		{"gemini", "GEMINI_API_KEY"},
 		{"unknown", "UNKNOWN_API_KEY"},
 		{"ollama", "OLLAMA_API_KEY"},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -127,7 +127,7 @@ routing you need:
   ollama/<model>           Ollama, local   none; http://localhost:11434
   <model>:cloud            Ollama Cloud    OLLAMA_API_KEY; https://api.ollama.com
                                            without a key: the local daemon
-  azure/<deployment>       Azure OpenAI    AZURE_OPENAI_API_KEY
+  azure/<deployment>       Azure OpenAI    AZUREOPENAI_API_KEY
   opencode/<model>         OpenCode        OPENCODE_API_KEY
 
 A name with no recognized prefix is rejected rather than guessed at — reach for

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1354,7 +1354,7 @@ func TestProviderEnvVarAllCases(t *testing.T) {
 		{"gemini", "GEMINI_API_KEY"},
 		{"custom", "CUSTOM_API_KEY"},
 		{"ollama", "OLLAMA_API_KEY"},
-		{"azure", "AZURE_OPENAI_API_KEY"},
+		{"azure", "AZUREOPENAI_API_KEY"},
 		{"", "_API_KEY"},
 	}
 

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -321,7 +321,7 @@ func TestRunModelList_NoArgs_AzureOnly(t *testing.T) {
 	}))
 	defer srv.Close()
 	isolateRunModelListEnv(t)
-	t.Setenv("AZURE_OPENAI_API_KEY", "testkey")
+	t.Setenv("AZUREOPENAI_API_KEY", "testkey")
 	t.Setenv("OLLAMA_HOST", srv.URL)
 
 	out, err := runModelListCapture(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -675,7 +675,7 @@ func APIKeys() map[string]string {
 	envVars := map[string][]string{
 		"anthropic":    {"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"},
 		"openai":       {"OPENAI_API_KEY"},
-		"azure":        {"AZURE_OPENAI_API_KEY", "AZUREOPENAI_API_KEY", "AZURE_API_KEY"},
+		"azure":        {"AZUREOPENAI_API_KEY", "AZURE_OPENAI_API_KEY", "AZURE_API_KEY"},
 		"gemini":       {"GEMINI_API_KEY", "GOOGLE_API_KEY"},
 		"mistral":      {"MISTRAL_API_KEY"},
 		"xai":          {"XAI_API_KEY"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -221,8 +221,8 @@ func TestLoadFile_LegacyDefaultModel(t *testing.T) {
 func TestAPIKeys(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("OPENAI_API_KEY", "")
-	t.Setenv("AZURE_OPENAI_API_KEY", "")
 	t.Setenv("AZUREOPENAI_API_KEY", "azure-test-key")
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
 	t.Setenv("AZURE_API_KEY", "")
 	t.Setenv("OPENCODE_API_KEY", "opencode-test-key")
 	t.Setenv("OPENROUTER_API_KEY", "openrouter-test-key")

--- a/internal/provider/apikey_test.go
+++ b/internal/provider/apikey_test.go
@@ -11,7 +11,7 @@ func TestAPIKeyEnvVar(t *testing.T) {
 		// mapping exists rather than a bare strings.ToUpper.
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"openai", "OPENAI_API_KEY"},
-		{"azure", "AZURE_OPENAI_API_KEY"},
+		{"azure", "AZUREOPENAI_API_KEY"},
 		{"gemini", "GEMINI_API_KEY"},
 		// Everything else derives from the provider name.
 		{"xai", "XAI_API_KEY"},

--- a/internal/provider/azure_catalog_test.go
+++ b/internal/provider/azure_catalog_test.go
@@ -200,8 +200,8 @@ func TestAzureProbePathsEscapesDeployment(t *testing.T) {
 // config.APIKeys already reads all three, so this is not a new capability —
 // it is the fallback chain living in one place instead of two that can drift.
 func TestAzureAPIKeyFallbackChain(t *testing.T) {
-	t.Setenv("AZURE_OPENAI_API_KEY", "")
 	t.Setenv("AZUREOPENAI_API_KEY", "")
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
 	t.Setenv("AZURE_API_KEY", "third")
 	if got := AzureAPIKey(""); got != "third" {
 		t.Errorf("AzureAPIKey() = %q, want the AZURE_API_KEY fallback", got)

--- a/internal/provider/openai_azure.go
+++ b/internal/provider/openai_azure.go
@@ -29,7 +29,7 @@ func AzureAPIKey(apiKey string) string {
 	if apiKey != "" {
 		return apiKey
 	}
-	for _, env := range []string{"AZURE_OPENAI_API_KEY", "AZUREOPENAI_API_KEY", "AZURE_API_KEY"} {
+	for _, env := range []string{"AZUREOPENAI_API_KEY", "AZURE_OPENAI_API_KEY", "AZURE_API_KEY"} {
 		if v := osGetenv(env); v != "" {
 			return v
 		}
@@ -98,7 +98,7 @@ func AzureProbePaths(deployment, apiVersion, endpoint string) []string {
 }
 
 // NewAzureOpenAI creates an Azure OpenAI model.LLM.
-// It uses AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and OPENAI_API_VERSION (defaults to 2025-04-01-preview).
+// It uses AZUREOPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and OPENAI_API_VERSION (defaults to 2025-04-01-preview).
 // The deploymentName is the Azure deployment name (not the model ID).
 func NewAzureOpenAI(_ context.Context, deploymentName, apiKey, endpoint, apiVersion string, llmOpts *LLMOptions) (model.LLM, error) {
 	apiKey = AzureAPIKey(apiKey)

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1131,7 +1131,7 @@ func TestNewAzureOpenAI_MissingEndpoint(t *testing.T) {
 	t.Cleanup(func() { osGetenv = orig })
 
 	osGetenv = func(key string) string {
-		if key == "AZURE_OPENAI_API_KEY" {
+		if key == "AZUREOPENAI_API_KEY" {
 			return "test-key"
 		}
 		return ""
@@ -1149,7 +1149,7 @@ func TestNewAzureOpenAI_Success(t *testing.T) {
 
 	osGetenv = func(key string) string {
 		switch key {
-		case "AZURE_OPENAI_API_KEY":
+		case "AZUREOPENAI_API_KEY":
 			return "test-azure-key"
 		case "AZURE_OPENAI_ENDPOINT":
 			return "https://my-resource.openai.azure.com"
@@ -1177,7 +1177,7 @@ func TestNewAzureOpenAI_WithOverrides(t *testing.T) {
 
 	// Override only API key; endpoint and api-version come from arguments.
 	osGetenv = func(key string) string {
-		if key == "AZURE_OPENAI_API_KEY" {
+		if key == "AZUREOPENAI_API_KEY" {
 			return "test-azure-key"
 		}
 		return ""
@@ -1198,7 +1198,7 @@ func TestNewAzureOpenAI_AcceptsLegacyAPIKeyEnvName(t *testing.T) {
 
 	osGetenv = func(key string) string {
 		switch key {
-		case "AZUREOPENAI_API_KEY":
+		case "AZURE_OPENAI_API_KEY":
 			return "legacy-azure-key"
 		case "AZURE_OPENAI_ENDPOINT":
 			return "https://my-resource.openai.azure.com"
@@ -1208,10 +1208,10 @@ func TestNewAzureOpenAI_AcceptsLegacyAPIKeyEnvName(t *testing.T) {
 
 	llm, err := NewAzureOpenAI(context.Background(), "my-deployment", "", "", "", nil)
 	if err != nil {
-		t.Fatalf("NewAzureOpenAI() with AZUREOPENAI_API_KEY error: %v", err)
+		t.Fatalf("NewAzureOpenAI() with AZURE_OPENAI_API_KEY error: %v", err)
 	}
 	if llm == nil {
-		t.Fatal("NewAzureOpenAI() with AZUREOPENAI_API_KEY returned nil")
+		t.Fatal("NewAzureOpenAI() with AZURE_OPENAI_API_KEY returned nil")
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -724,7 +724,7 @@ func APIKeyEnvVar(providerName string) string {
 	case "openai":
 		return "OPENAI_API_KEY"
 	case "azure":
-		return "AZURE_OPENAI_API_KEY"
+		return "AZUREOPENAI_API_KEY"
 	case "gemini":
 		return "GEMINI_API_KEY"
 	default:

--- a/pimodels/README.md
+++ b/pimodels/README.md
@@ -51,7 +51,7 @@ provider handling to become a breaking change to the agent API.
 | openai | `OPENAI_API_KEY` |
 | anthropic | `ANTHROPIC_API_KEY` |
 | gemini | `GEMINI_API_KEY` |
-| azure | `AZURE_OPENAI_API_KEY` |
+| azure | `AZUREOPENAI_API_KEY` |
 | everything else | `<PROVIDER>_API_KEY` |
 
 `WithAPIKey` overrides it. A local Ollama needs neither.

--- a/pimodels/pimodels.go
+++ b/pimodels/pimodels.go
@@ -23,7 +23,7 @@
 // # API keys
 //
 // [New] reads the key from the provider's environment variable — OPENAI_API_KEY,
-// ANTHROPIC_API_KEY, GEMINI_API_KEY, AZURE_OPENAI_API_KEY, or <PROVIDER>_API_KEY
+// ANTHROPIC_API_KEY, GEMINI_API_KEY, AZUREOPENAI_API_KEY, or <PROVIDER>_API_KEY
 // for the rest. [WithAPIKey] overrides that. Providers that need no key, such as
 // a local Ollama, work with neither set.
 //

--- a/pimodels/pimodels_test.go
+++ b/pimodels/pimodels_test.go
@@ -159,7 +159,7 @@ func TestAPIKeyEnvVar(t *testing.T) {
 	tests := map[string]string{
 		"anthropic": "ANTHROPIC_API_KEY",
 		"openai":    "OPENAI_API_KEY",
-		"azure":     "AZURE_OPENAI_API_KEY",
+		"azure":     "AZUREOPENAI_API_KEY",
 		"gemini":    "GEMINI_API_KEY",
 		"xai":       "XAI_API_KEY",
 		"mistral":   "MISTRAL_API_KEY",


### PR DESCRIPTION
Make AZUREOPENAI_API_KEY the primary env var for the Azure OpenAI
provider, keeping AZURE_OPENAI_API_KEY as a backward-compatible
fallback so existing setups keep working.

Signed-off-by: pi <dimetron@me.com>
